### PR TITLE
Import new tokens - 2026-07-06-1447

### DIFF
--- a/duckduckgo.pot
+++ b/duckduckgo.pot
@@ -1384,6 +1384,12 @@ msgid "Address is incorrect"
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Adjust the servings"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. as in multiple advertisements
 msgid "Ads"
 msgstr ""
@@ -1592,6 +1598,14 @@ msgstr ""
 #. Heading shown on the empty chat screen. The text between the two %s markers is displayed inside a clickable privacy button. First %s renders a shield icon, second %s is an invisible end marker. Keep the word 'private' between both %s markers.
 msgctxt "Empty state heading in Duck.ai chat mode"
 msgid "All chats are %sprivate%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Paragraph in the Privacy & Terms section of the About & Legal page in Duck.ai settings, summarizing how chats are anonymized and are not stored or used to train chat models.
+msgctxt "Privacy & Terms section description on the Duck.ai settings page"
+msgid ""
+"All chats are anonymized by DuckDuckGo, and your conversations are not used "
+"to train chat models by DuckDuckGo or the model providers"
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -1846,6 +1860,13 @@ msgstr ""
 #. Confirmation message after location service is enabled.
 msgctxt "precise_user_location"
 msgid "Anonymous location enabled"
+msgstr ""
+
+# smartling.placeholder_format=C
+msgctxt "settings"
+msgid ""
+"Anonymously generates answers for search queries based on web content. "
+"Choose how often you want it to appear, or disable it completely."
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -2116,6 +2137,12 @@ msgstr ""
 # smartling.placeholder_format=C
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse
 msgid "Ask a follow-up with Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
+msgctxt "Page suggestion chip label"
+msgid "Ask about this page"
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -2508,6 +2535,12 @@ msgid "Barcode"
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Based on this page, is this course worth taking?"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Basic"
 msgstr ""
@@ -2545,6 +2578,14 @@ msgstr ""
 #. Placeholder text displayed while the assistant waits for the user to choose an action.
 msgctxt "Assistant response placeholder"
 msgid "Before continuing..."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Explains that before storing the report, DuckDuckGo will anonymize the conversation by removing PII like names, email addresses, and identifying metadata.
+msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
+msgid ""
+"Before storing this report, DuckDuckGo will anonymize your conversation by "
+"removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -2861,6 +2902,12 @@ msgstr ""
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Break Points Won"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Break this down into clear, numbered steps."
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -3296,6 +3343,12 @@ msgstr ""
 #. Text of a button that performs a search for the cast of a particular movie or tv show
 msgctxt "Movie/TV Show Title instant answer"
 msgid "Cast"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Cast & Crew"
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -4952,6 +5005,12 @@ msgid "Create Image"
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Create a shopping list with quantities from this recipe."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text displayed in the input field when starting a new image generation session.
 msgctxt "Placeholder text for the image generation input field"
 msgid "Create an image of a cute duck..."
@@ -5588,6 +5647,11 @@ msgid "Dictation limit reached"
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
+msgid "Dictation temporarily unavailable"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
@@ -5886,6 +5950,22 @@ msgid "Done"
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Message shown in a modal after DuckDuckGo browser users disable AI features in Settings. The first two placeholders bold noai.duckduckgo.com. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
+"filtered out. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
+"and AI images filtered out. %sLearn more%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Double Faults"
@@ -5993,6 +6073,18 @@ msgctxt "Full sentence for writing an email"
 msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Draft a cover letter"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Draft a cover letter for this job."
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -6160,6 +6252,15 @@ msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
+msgctxt "About section description on the Duck.ai settings page"
+msgid ""
+"Duck.ai is created by DuckDuckGo. We're an independent online protection "
+"company for anyone who wants to take back control of their personal "
+"information."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
 msgctxt "duckai_migration"
 msgid "Duck.ai is moving domains"
@@ -6198,6 +6299,13 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
+msgstr ""
+
+# smartling.placeholder_format=C
+msgctxt "settings"
+msgid ""
+"Duck.ai lets you chat privately with popular AI models. Disabling it hides "
+"Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -7110,6 +7218,18 @@ msgid "Eritrea"
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Estimate the nutrition"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Estimate the nutritional information for this recipe."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Estonia"
 msgstr ""
 
@@ -7164,10 +7284,58 @@ msgid "Expires in 1 day"
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain the accepted answer in simple terms."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain the top answer"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this in simple, plain language."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this paper"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this repo"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this research paper in plain language."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this simply"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain what this repository does and how to use it."
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -7446,6 +7614,12 @@ msgid ""
 msgstr ""
 
 # smartling.placeholder_format=C
+msgctxt "settings"
+msgid ""
+"Filters out known AI spam sites from image search results. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the final score of a sporting event.
 msgid "Final"
 msgstr ""
@@ -7496,6 +7670,12 @@ msgstr ""
 #. Short description shown below the 'Web Search' label in the Tools dropdown.
 msgctxt "Subtitle for the Web Search tool entry in the Tools dropdown menu"
 msgid "Find current information"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Find me alternatives"
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -7967,6 +8147,12 @@ msgid "Generate More"
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Generate a shopping list"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
 msgid "Generate a short answer from the web"
 msgstr ""
@@ -8249,6 +8435,12 @@ msgstr ""
 #. Text for a button inviting users to give it a try for the Duck.ai product. On click, they're taken to the Duck.ai page.
 msgctxt "Onboarding welcome screen button text"
 msgid "Give it a Try"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Give me a quick background on this person."
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -8691,6 +8883,18 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Link to a page with information about sharing DuckDuckGo with friends.
 msgid "Help Spread Privacy"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Help me prep for the interview"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Help me tailor my resume for this job."
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -9196,6 +9400,14 @@ msgstr ""
 #. Text displayed on the button on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
 msgctxt "Onboarding terms screen button text"
 msgid "I Agree"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Text for the button that takes the user to the external DuckDuckGo login subscription page.
+msgctxt ""
+"Text for the I already have a subscription button in the Duck.ai settings "
+"page"
+msgid "I Already Have a Subscription"
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -9746,6 +9958,12 @@ msgid "Install Mac Browser"
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
+msgctxt "settings"
+msgid "Install Now"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of a button to install the DuckDuckGo app
 msgctxt "Serp footer content"
 msgid "Install Our App"
@@ -9843,9 +10061,41 @@ msgid "Is deleted data really deleted?"
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is it worth taking?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this place any good?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"Is this place any good? Summarize its reputation based on reviews and "
+"ratings."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "Is this video helpful?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this worth watching?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Is this worth watching? Give me a spoiler-free take."
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -10451,6 +10701,12 @@ msgid "Links:"
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "List the tools, materials, or prerequisites I need for this."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
 msgid "Listen"
 msgstr ""
@@ -10854,6 +11110,12 @@ msgstr ""
 #. Label for linke navigating to site exclusion feature on Settings page
 msgctxt "Exclusion message manage sites button"
 msgid "Manage blocked sites"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
+msgctxt "setting"
+msgid "Manage in Browser Settings"
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -13642,6 +13904,12 @@ msgstr ""
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
+msgid "Please describe why the chat response is harmful or illegal. (optional)"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
+msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
 msgstr ""
 
@@ -13663,6 +13931,14 @@ msgctxt "Modal disclaimer text"
 msgid ""
 "Please note: starting a new chat with any model will delete your current "
 "chat session."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
+msgctxt "Feedback prompt"
+msgid ""
+"Please paste your prompt and the problematic output (with any personal "
+"information removed) and describe why the content is harmful or illegal."
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -14129,6 +14405,12 @@ msgid "Privacy"
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
+msgctxt "Section heading on the Duck.ai settings page"
+msgid "Privacy & Terms"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Privacy Blog"
 msgstr ""
 
@@ -14195,6 +14477,12 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Text used in other strings to link to the Privacy Policy and Terms of Service content.
 msgctxt "Copy used to compose link in sentences"
+msgid "Privacy Policy and Terms of Service"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Text for a button that links to the terms of use and privacy policy page.
+msgctxt "Secondary button text in active privacy modal"
 msgid "Privacy Policy and Terms of Service"
 msgstr ""
 
@@ -14689,6 +14977,30 @@ msgid "Recommend a book"
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar books"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar books."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar movies or shows."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar titles"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
 msgid "Recording failed. Please try again."
 msgstr ""
@@ -15073,6 +15385,15 @@ msgid "Republic of Moldova"
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Note indicating that sharing the conversation is mandatory when reporting harmful or illegal content. Rendered alongside the standard share label (DUCKCHAT_RESPONSE_FEEDBACK_SHARE_PROMPT_RESPONSE_LABEL), not replacing it.
+msgctxt ""
+"Note shown under the share-content switch label on the Duck.ai response "
+"feedback form when the user has selected Harmful or Illegal as the feedback "
+"reason"
+msgid "Required for harmful or illegal reports"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
 msgctxt "Description for extended reasoning mode in Duck.ai"
 msgid "Researches before responding"
@@ -15294,6 +15615,12 @@ msgstr ""
 #. Label above a list of customer reviews of a business.
 msgctxt "maps_places"
 msgid "Reviews"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Rewrite this recipe scaled for a different number of servings."
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -16567,6 +16894,12 @@ msgid "Set Up Now"
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
+msgctxt "Encrypted storage setup button shown in native browsers"
+msgid "Set Up Sync & Backup"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
 msgctxt "Title for the Sync & Backup intro screen"
 msgid "Set Up Sync & Backup"
@@ -16738,6 +17071,13 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
+msgctxt ""
+"Label beside the share-content switch on the Duck.ai response feedback form"
+msgid "Share this conversation with DuckDuckGo"
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -17966,6 +18306,24 @@ msgid "Suggest a title for a blog post"
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest related articles or topics worth exploring next."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Suggest related articles to explore"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest some alternatives to this product."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
 msgctxt "directions"
 msgid "Suggestions:"
@@ -17977,9 +18335,99 @@ msgid "Suggestions:"
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Sum up the reviews"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A short title for the a message asking the AI to summarize a text.
 msgctxt "Title for the summarize message"
 msgid "Summarize"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize the Q&As"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the background and notable work of this person."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the key details of this event."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the questions and answers on this page."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize their background"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this book"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this book."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this discussion"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this discussion thread."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this page"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this page."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this video"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this video."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize what the reviews say."
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -18284,6 +18732,12 @@ msgid "Syria"
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Text for a button that enables the theme to follow the operating system's color scheme preference.
+msgctxt "System theme button for theme selector"
+msgid "System"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Abbreviation indicating this is the total score for a game
 msgctxt "Sports module"
 msgid "T"
@@ -18309,6 +18763,12 @@ msgstr ""
 #. The name of the Tahitian language
 msgctxt "language_name"
 msgid "Tahitian"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Tailor my resume"
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -18338,6 +18798,13 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Take control of your personal data!"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Description for the Feedback section of the Duck.ai settings page, asking the user to take an anonymous survey to let us know how we can make Duck.ai better.
+msgctxt "Feedback section description on the Duck.ai settings page"
+msgid ""
+"Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -18631,6 +19098,12 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Title for the theme menu:
 #. https://duck.co/media/files/theme.png
+msgid "Theme"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Text for the theme selector label that allows users to switch between Light and dark theme.
+msgctxt "Label for the theme selector feature"
 msgid "Theme"
 msgstr ""
 
@@ -19409,6 +19882,18 @@ msgid ""
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Translate this page"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
+msgctxt "Page suggestion prompt"
+msgid "Translate this page into %s."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text for a region that will display translated text.
 msgctxt "translations_module"
 msgid "Translation"
@@ -19547,6 +20032,12 @@ msgstr ""
 #. Call-to-action button for the subscription promo in the SERP sidemenu.
 msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
+msgctxt "settings"
+msgid "Try It Now"
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -19779,6 +20270,22 @@ msgstr ""
 #. Response a user can select in a feedback form, indicating that they're trying DuckDuckGo again.
 msgctxt "new user poll"
 msgid "Trying DuckDuckGo again"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Message shown in a modal after supported third-party browser users disable AI features in Settings. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -20512,6 +21019,12 @@ msgid "Uruguay"
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
+msgctxt "Navigation label on the Duck.ai settings page"
+msgid "Usage"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A feedback suggestion
 msgctxt "Feedback prompt"
 msgid "Usage limit"
@@ -20931,6 +21444,12 @@ msgid "Wales"
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Walk me through the steps"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for walking directions on a map.
 msgctxt "directions"
 msgid "Walking"
@@ -21038,6 +21557,17 @@ msgstr ""
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
+msgctxt ""
+"Inline warning shown below the share-content toggle when the user selects "
+"Harmful or Illegal but has not enabled sharing"
+msgid ""
+"We can only fix what we can see. To report a harmful or illegal response, "
+"please share this conversation with DuckDuckGo so we can investigate and "
+"address the issue."
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -21535,6 +22065,103 @@ msgid ""
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the counterarguments?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the hours & location?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key contributions of this paper?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key contributions?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key details?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key points covered in this video?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key points?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key takeaways from this article?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key takeaways?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key things I will learn from this course?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main counterarguments or criticisms of this?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main questions this page answers?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the must-try dishes here?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"What are the opening hours, location, and contact details for this place?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the pros and cons of this product?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the pros and cons?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
 msgctxt "feedback form"
 msgid "What bothered you most?"
@@ -21635,6 +22262,12 @@ msgid "What does atria mean in the context of a medical article?"
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What does this answer?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
@@ -21644,6 +22277,12 @@ msgstr ""
 #. Header above a list of types of information that gets saved by the cloud save feature.
 msgctxt "cloudsave"
 msgid "What information gets saved?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What interview questions might come up for this role?"
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -21658,6 +22297,12 @@ msgstr ""
 #. Text for a prompt suggestion for looking up the capital city of Albania.
 msgctxt "Full sentence for looking up basic facts"
 msgid "What is the capital city of Albania?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What is the overall verdict and rating for this?"
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -21683,6 +22328,12 @@ msgid "What people say:"
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What should I order?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
 msgctxt "feedback form"
 msgid "What stood out?"
@@ -21692,6 +22343,18 @@ msgstr ""
 #. Question on a feedback form for a negative feedback response.
 msgctxt "feedback form"
 msgid "What was wrong with the response? (optional)"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I learn?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I need?"
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -21709,6 +22372,12 @@ msgstr ""
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
 msgctxt "SERP footer content"
 msgid "What's New"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What's the verdict?"
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -21760,6 +22429,12 @@ msgid "Which features are missing? (Optional)"
 msgstr ""
 
 # smartling.placeholder_format=C
+#. An invitation for users to leave feedback
+msgctxt "Feedback prompt"
+msgid "Which features are missing? (optional)"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
 msgid "White"
 msgstr ""
@@ -21773,6 +22448,18 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Link to an about us page.
 msgid "Who We Are"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Who are the main cast and crew, and what else are they known for?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Who is this person?"
 msgstr ""
 
 # smartling.placeholder_format=C

--- a/locales/af_ZA/LC_MESSAGES/duckduckgo.po
+++ b/locales/af_ZA/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: af_ZA\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -22,7 +22,8 @@ msgstr "!Knal-soeksnelsleutels"
 msgctxt ""
 "Body copy for the Remove Device confirmation modal; %s is the device name"
 msgid "\"%s\" will no longer be able to access your synced data."
-msgstr "\"%1$s\" sal nie meer toegang tot jou gesinkroniseerde data kan kry nie."
+msgstr ""
+"\"%1$s\" sal nie meer toegang tot jou gesinkroniseerde data kan kry nie."
 
 # smartling.placeholder_format=C
 #. Used to specify the rank of a team/player in a specific ranking in short form. This should be interpreted as 'Ranked number <rankNumber> in the <rankingName> ranking. Here you only need to translate the # symbol for ranked number. If your language doesn't provide a single-letter convention, please leave #.
@@ -416,7 +417,8 @@ msgstr "%1$s woorde"
 #. Instructions on which buttons and options the user has to click in order to add the DuckDuckGo extension to their browser.
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
-msgstr "%1$sKlik op %2$sVoeg by%3$sMerk %4$sLaat toe%5$s en klik dan op %6$sGoed%7$s"
+msgstr ""
+"%1$sKlik op %2$sVoeg by%3$sMerk %4$sLaat toe%5$s en klik dan op %6$sGoed%7$s"
 
 # Firefox, obsolete
 # smartling.placeholder_format=C
@@ -479,7 +481,8 @@ msgstr ""
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "%sLearn more%s about how chats are stored privately on your device."
-msgstr "%1$sKom meer te wete%2$s oor hoe kletse privaat op jou toestel gestoor word."
+msgstr ""
+"%1$sKom meer te wete%2$s oor hoe kletse privaat op jou toestel gestoor word."
 
 # smartling.placeholder_format=C
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
@@ -810,7 +813,8 @@ msgstr "6-uur-gebruikslimiet is bereik."
 #. Displayed when the user has reached a fixed 6-hour Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "6-hour usage limit reached. You can continue this chat after %s."
-msgstr "6-uur-gebruikslimiet is bereik. Jy kan hierdie kletsgesprek voortsit ná %1$s."
+msgstr ""
+"6-uur-gebruikslimiet is bereik. Jy kan hierdie kletsgesprek voortsit ná %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable 6-hour Duck.ai usage limit and can opt in to continue using the daily limit.
@@ -1279,7 +1283,8 @@ msgstr "Voeg DuckDuckGo-uitbreiding by"
 # smartling.placeholder_format=C
 msgid ""
 "Add DuckDuckGo Privacy Essentials to your browser for free with one download:"
-msgstr "Voeg DuckDuckGo Privacy Essentials gratis by jou blaaier met een aflaai:"
+msgstr ""
+"Voeg DuckDuckGo Privacy Essentials gratis by jou blaaier met een aflaai:"
 
 #  IE default search engine instruction
 # smartling.placeholder_format=C
@@ -1432,6 +1437,12 @@ msgstr "Adresbalk:"
 msgctxt "feedback form"
 msgid "Address is incorrect"
 msgstr "Adres is verkeerd"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Adjust the servings"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. as in multiple advertisements
@@ -1647,6 +1658,14 @@ msgid "All chats are %sprivate%s"
 msgstr "Alle kletsgesprekke is %1$sprivaat%2$s"
 
 # smartling.placeholder_format=C
+#. Paragraph in the Privacy & Terms section of the About & Legal page in Duck.ai settings, summarizing how chats are anonymized and are not stored or used to train chat models.
+msgctxt "Privacy & Terms section description on the Duck.ai settings page"
+msgid ""
+"All chats are anonymized by DuckDuckGo, and your conversations are not used "
+"to train chat models by DuckDuckGo or the model providers"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
 msgctxt "Privacy modal header in Duck.ai chat"
 msgid "All chats are private"
@@ -1676,7 +1695,8 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "All model providers are prevented from training their AI on your "
 "conversations."
-msgstr "Alle modelverskaffers word verhoed om hul KI met jou gesprekke op te lei."
+msgstr ""
+"Alle modelverskaffers word verhoed om hul KI met jou gesprekke op te lei."
 
 # smartling.placeholder_format=C
 #. Text displayed in the subheader of the modal that allows the user to pick an AI chat model.
@@ -1735,7 +1755,8 @@ msgstr "Laat advertensies toe wat privaatheid respekteer"
 # smartling.placeholder_format=C
 #. Title in a dialog informing the user how to disable their ad blocker for DuckDuckGo
 msgid "Allow privacy-respecting ads on DuckDuckGo Private Search"
-msgstr "Laat advertensies toe wat privaatheid respekteer op DuckDuckGo Private Search"
+msgstr ""
+"Laat advertensies toe wat privaatheid respekteer op DuckDuckGo Private Search"
 
 # smartling.placeholder_format=C
 #. Description explaining privacy implications of enabling web search on encrypted models. The first two placeholders are the full model name (e.g. 'gpt-oss 120B'). The third and fourth placeholders wrap a clickable link reading 'zero provider visibility' that opens the privacy modal, please keep those around the link text in your translation. An example full sentence would be: Allows gpt-oss 120B to search the web to improve responses to relevant prompts. Only sends AI-generated queries to a search engine with limited data retention. Prompts and responses with gpt-oss 120B still have zero provider visibility.
@@ -1915,6 +1936,13 @@ msgid "Anonymous location enabled"
 msgstr "Anonieme ligging is geaktiveer"
 
 # smartling.placeholder_format=C
+msgctxt "settings"
+msgid ""
+"Anonymously generates answers for search queries based on web content. "
+"Choose how often you want it to appear, or disable it completely."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Instant Answer tab name
 msgid "Answer"
 msgstr "Antwoord"
@@ -2059,7 +2087,8 @@ msgstr "Is jy nog daar?"
 msgctxt "Body text for clear all chats confirmation modal"
 msgid ""
 "Are you sure you want to clear all of your chats? This cannot be undone."
-msgstr "Is jy seker jy wil al jou kletse skoonmaak? Dit kan nie ontdoen word nie."
+msgstr ""
+"Is jy seker jy wil al jou kletse skoonmaak? Dit kan nie ontdoen word nie."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that asks the user if they want to clear the conversation.
@@ -2193,6 +2222,12 @@ msgid "Ask a follow-up with Duck.ai"
 msgstr "Vra 'n opvolgvraag met Duck.ai"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
+msgctxt "Page suggestion chip label"
+msgid "Ask about this page"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
 msgctxt "Title for the page context onboarding modal"
 msgid "Ask about this page"
@@ -2259,8 +2294,8 @@ msgstr ""
 "verskyn: Nooit (verwyder Assist UI heeltemal uit soekresultate), Op aanvraag "
 "(wys slegs KI-gesteunde antwoorde as jy op die Assist-knoppie klik), Soms "
 "(wys slegs KI-gesteunde antwoorde wanneer dit baie relevant is) of Dikwels "
-"(wys meer gereeld op 'n wyer verskeidenheid soektogte). Vir nou is "
-"KI-gesteunde antwoorde slegs beskikbaar in die Amerikaanse (Engels) streek."
+"(wys meer gereeld op 'n wyer verskeidenheid soektogte). Vir nou is KI-"
+"gesteunde antwoorde slegs beskikbaar in die Amerikaanse (Engels) streek."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2366,7 +2401,8 @@ msgstr ""
 #. Description in consent disclaimer informing that audio from the voice chat session is not stored by us or by OpenAI after the voice chat ends.
 msgctxt "voice chat"
 msgid "Audio is not stored by us or by OpenAI after the chat ends."
-msgstr "Klank word nie deur ons of deur OpenAI gestoor nadat die klets eindig nie."
+msgstr ""
+"Klank word nie deur ons of deur OpenAI gestoor nadat die klets eindig nie."
 
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
@@ -2414,7 +2450,8 @@ msgstr "Outo-antwoord"
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid "Auto-generated based on listed sources. May contain inaccuracies."
-msgstr "Outomaties gegenereer gebaseer op gelyste bronne. Mag onakkuraathede bevat."
+msgstr ""
+"Outomaties gegenereer gebaseer op gelyste bronne. Mag onakkuraathede bevat."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
@@ -2610,6 +2647,12 @@ msgid "Barcode"
 msgstr "Strepieskode"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Based on this page, is this course worth taking?"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Basic"
 msgstr "Basies"
@@ -2648,6 +2691,14 @@ msgstr "Kolwer"
 msgctxt "Assistant response placeholder"
 msgid "Before continuing..."
 msgstr "Voordat jy voortgaan ..."
+
+# smartling.placeholder_format=C
+#. Explains that before storing the report, DuckDuckGo will anonymize the conversation by removing PII like names, email addresses, and identifying metadata.
+msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
+msgid ""
+"Before storing this report, DuckDuckGo will anonymize your conversation by "
+"removing PII like names, email addresses, and identifying metadata."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -2964,6 +3015,12 @@ msgstr "Brasilië"
 msgctxt "Sports module"
 msgid "Break Points Won"
 msgstr "Breekpunte gewen"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Break this down into clear, numbered steps."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -3421,6 +3478,12 @@ msgid "Cast"
 msgstr "Rolverdeling"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Cast & Crew"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
 msgctxt "Tone option label for Casual"
 msgid "Casual"
@@ -3505,7 +3568,8 @@ msgstr "Verander hoe resultaat-URL'e vertoon word"
 #. This is the description of a user setting
 msgctxt "settings"
 msgid "Changes how the header is displayed and its behavior as you scroll"
-msgstr "Verander hoe die opskrif vertoon word en die gedrag daarvan terwyl jy rollees"
+msgstr ""
+"Verander hoe die opskrif vertoon word en die gedrag daarvan terwyl jy rollees"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/mcZdcaF.png
@@ -3657,10 +3721,10 @@ msgid ""
 msgstr ""
 "Met Chat (via ons Duck.ai-diens) kan jy anonieme gesprekke voer met "
 "derdeparty-KI-kletsmodelle, wat modelle van OpenAI, Anthropic en meer "
-"ondersteun. As jy hierdie instelling afskakel, sal die Chat-knoppies en "
-"-skakels op DuckDuckGo Search verberg word. Jy kan egter steeds toegang tot "
-"Chat kry wanneer hierdie instelling afgeskakel is, deur "
-"%1$shttps://duck.ai%2$s direk te besoek."
+"ondersteun. As jy hierdie instelling afskakel, sal die Chat-knoppies en -"
+"skakels op DuckDuckGo Search verberg word. Jy kan egter steeds toegang tot "
+"Chat kry wanneer hierdie instelling afgeskakel is, deur %1$shttps://duck."
+"ai%2$s direk te besoek."
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -3715,14 +3779,16 @@ msgstr "Gesels privaat"
 #. Mobile variant of DUCKCHAT_BROWSER_UPSELL_PROMO_TEXT. Shorter version for the promotional card encouraging third-party browser users to download the DuckDuckGo browser.
 msgctxt "Promotional text (mobile)"
 msgid "Chat privately on any website with Duck.ai built into our free browser."
-msgstr "Gesels privaat op enige webwerf met Duck.ai ingebou in ons gratis blaaier."
+msgstr ""
+"Gesels privaat op enige webwerf met Duck.ai ingebou in ons gratis blaaier."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card encouraging third-party browser users to download the DuckDuckGo browser. Not shown in the DuckDuckGo browser or on Linux.
 msgctxt "Promotional text"
 msgid ""
 "Chat privately on any website with the Duck.ai sidebar in our free browser."
-msgstr "Gesels privaat op enige webwerf met die Duck.ai-sybalk in ons gratis blaaier."
+msgstr ""
+"Gesels privaat op enige webwerf met die Duck.ai-sybalk in ons gratis blaaier."
 
 # smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
@@ -3785,9 +3851,9 @@ msgid ""
 "Chats are stored locally on your device instead of on DuckDuckGo servers or "
 "remote servers. Disabling chat history will delete pinned chats."
 msgstr ""
-"Kletse word plaaslik op jou toestel gestoor in plaas van op "
-"DuckDuckGo-bedieners of afgeleë bedieners. As jy kletsgeskiedenis "
-"deaktiveer, sal vasgespelde kletse uitgevee word."
+"Kletse word plaaslik op jou toestel gestoor in plaas van op DuckDuckGo-"
+"bedieners of afgeleë bedieners. As jy kletsgeskiedenis deaktiveer, sal "
+"vasgespelde kletse uitgevee word."
 
 # smartling.placeholder_format=C
 #. Text explaining how the Chat History feature stores the user's chats locally to their device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection. Also explains that disabling chat history will delete pinned chats.
@@ -4304,7 +4370,8 @@ msgstr "Klik %1$sJa%2$s"
 # smartling.placeholder_format=C
 #. Tells the user where to click to open their browser's settings menu.
 msgid "Click %ssettings/hamburger icon %s on the Chrome toolbar (top right)."
-msgstr "Klik %1$sinstellings/hamburgerikoon %2$s in die Chrome-taakbalk (regs bo)."
+msgstr ""
+"Klik %1$sinstellings/hamburgerikoon %2$s in die Chrome-taakbalk (regs bo)."
 
 #  Maxthon default search engine instruction
 # smartling.placeholder_format=C
@@ -5079,7 +5146,8 @@ msgstr "Costa Rica"
 #. Inline error shown on the recovery code screen when exportSyncSettings rejects.
 msgctxt "Error message when the recovery code fails to generate"
 msgid "Couldn't load your recovery code. Please close this and try again."
-msgstr "Kon nie jou herstelkode laai nie. Maak dit asseblief toe en probeer weer."
+msgstr ""
+"Kon nie jou herstelkode laai nie. Maak dit asseblief toe en probeer weer."
 
 # smartling.placeholder_format=C
 #. Pairs with a Retry button. Shown after two consecutive failed attempts to load the device list.
@@ -5123,6 +5191,12 @@ msgstr "Skep prent"
 msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr "Skep prent"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Create a shopping list with quantities from this recipe."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed in the input field when starting a new image generation session.
@@ -5648,7 +5722,8 @@ msgstr "Wil jy oudste kletsgesprekke skrap om stoorplek te maak?"
 #. Title shown when user has reached the file storage sync quota (5GB).
 msgctxt "Sync file storage limit modal title"
 msgid "Delete oldest chats with attachments to free up storage?"
-msgstr "Wil jy oudste kletsgesprekke met aanhangsels skrap om stoorplek te maak?"
+msgstr ""
+"Wil jy oudste kletsgesprekke met aanhangsels skrap om stoorplek te maak?"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to delete all recent chats.
@@ -5694,7 +5769,8 @@ msgstr "Beskryf veranderinge gebaseer op die beeld"
 #. Placeholder text displayed in the input field when the user can make follow-up edits to a generated image.
 msgctxt "Placeholder text for the image generation input field for follow-ups"
 msgid "Describe changes to continue editing this image"
-msgstr "Beskryf veranderinge om voort te gaan met die redigering van hierdie beeld"
+msgstr ""
+"Beskryf veranderinge om voort te gaan met die redigering van hierdie beeld"
 
 # smartling.placeholder_format=C
 #. Title shown when the user first enters Image Generation mode, prompting them to describe the image they want to create.
@@ -5765,6 +5841,11 @@ msgstr ""
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
 msgid "Dictation limit reached"
 msgstr "Diktasielimiet is bereik"
+
+# smartling.placeholder_format=C
+#. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
+msgid "Dictation temporarily unavailable"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
@@ -5958,7 +6039,8 @@ msgstr "Vertoon taal"
 #. This is the description of a user setting
 msgctxt "settings"
 msgid "Displays a checkmark to the left of results you've visited"
-msgstr "Vertoon 'n regmerkie aan die linkerkant van resultate wat jy besoek het"
+msgstr ""
+"Vertoon 'n regmerkie aan die linkerkant van resultate wat jy besoek het"
 
 # smartling.placeholder_format=C
 #. This is the description of a user setting
@@ -6065,6 +6147,22 @@ msgstr "Klaar"
 msgctxt "precise_user_location"
 msgid "Done"
 msgstr "Klaar"
+
+# smartling.placeholder_format=C
+#. Message shown in a modal after DuckDuckGo browser users disable AI features in Settings. The first two placeholders bold noai.duckduckgo.com. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
+"filtered out. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
+"and AI images filtered out. %sLearn more%s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6179,6 +6277,18 @@ msgid ""
 msgstr ""
 "Stel 'n bondige en gedetailleerde e-pos op aan 'n verkoper waarin 'n "
 "kwotasie vir yskashersteldienste tuis aangevra word."
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Draft a cover letter"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Draft a cover letter for this job."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -6357,6 +6467,15 @@ msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
 msgstr "Duck.ai werk die beste in ons privaat en gratis DuckDuckGo-blaaier!"
 
 # smartling.placeholder_format=C
+#. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
+msgctxt "About section description on the Duck.ai settings page"
+msgid ""
+"Duck.ai is created by DuckDuckGo. We're an independent online protection "
+"company for anyone who wants to take back control of their personal "
+"information."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
 msgctxt "duckai_migration"
 msgid "Duck.ai is moving domains"
@@ -6402,6 +6521,13 @@ msgstr ""
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
 msgstr "Duck.ai is tydelik onbeskikbaar. Probeer asseblief weer later."
+
+# smartling.placeholder_format=C
+msgctxt "settings"
+msgid ""
+"Duck.ai lets you chat privately with popular AI models. Disabling it hides "
+"Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6475,9 +6601,9 @@ msgid ""
 "AI chat no sign up, OpenAI, Anthropic, Llama, Mistral, open source AI "
 "models, privacy focused AI, no account AI chat"
 msgstr ""
-"Duck.ai, DuckDuckGo KI, private KI-kletsbot, gratis KI-klets, anonieme "
-"KI-klets, KI-klets geen aanmelding, OpenAI, Anthropic, Llama, Mistral, "
-"oopbron KI-modelle, privaatheidsgefokusde KI, KI-klets geen rekening"
+"Duck.ai, DuckDuckGo KI, private KI-kletsbot, gratis KI-klets, anonieme KI-"
+"klets, KI-klets geen aanmelding, OpenAI, Anthropic, Llama, Mistral, oopbron "
+"KI-modelle, privaatheidsgefokusde KI, KI-klets geen rekening"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -6646,7 +6772,8 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr "DuckDuckGo AI Chat is tydelik onbeskikbaar. Probeer asseblief weer later."
+msgstr ""
+"DuckDuckGo AI Chat is tydelik onbeskikbaar. Probeer asseblief weer later."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -6765,8 +6892,8 @@ msgid ""
 "DuckDuckGo anonymizes these reports by automatically removing PII like "
 "names, email addresses, phone numbers, and identifying metadata."
 msgstr ""
-"DuckDuckGo anonimiseer hierdie aanmeldings deur outomaties PII, soos name, "
-"e-posadresse, telefoonnommers en identifiserende metadata, te verwyder."
+"DuckDuckGo anonimiseer hierdie aanmeldings deur outomaties PII, soos name, e-"
+"posadresse, telefoonnommers en identifiserende metadata, te verwyder."
 
 # smartling.placeholder_format=C
 #. The first %s is the agree button label ('Agree'). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. The leading sentence mirrors the drawer-style inline disclaimer (DUCKCHAT_TOS_INLINE_DISCLAIMER).
@@ -6866,7 +6993,8 @@ msgctxt ""
 "Description of the DuckDuckGo subscription setting when it is not available "
 "in the user region"
 msgid "DuckDuckGo subscriptions are not available to purchase in this region."
-msgstr "DuckDuckGo-intekeninge is nie in hierdie streek beskikbaar om te koop nie."
+msgstr ""
+"DuckDuckGo-intekeninge is nie in hierdie streek beskikbaar om te koop nie."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use 'ducky' tone in its responses. When this option is selected, the AI assistant speaks like a duck.
@@ -7133,7 +7261,8 @@ msgstr "Aktiveer diktasie in Duck.ai"
 #. Prompt to enable location service so that search results can be displayed near the user's current location.
 msgctxt "precise_user_location"
 msgid "Enable location settings on your device to use anonymous location"
-msgstr "Aktiveer liggingsinstellings op jou toestel om anonieme ligging te gebruik"
+msgstr ""
+"Aktiveer liggingsinstellings op jou toestel om anonieme ligging te gebruik"
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -7397,6 +7526,18 @@ msgid "Eritrea"
 msgstr "Eritrea"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Estimate the nutrition"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Estimate the nutritional information for this recipe."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Estonia"
 msgstr "Estland"
 
@@ -7430,7 +7571,8 @@ msgstr "Vou kaart uit"
 #. Subtitle for the Collaborations promotional card at the bottom of search results. Describes the branded merchandise line. 'Give a duck' is a wordplay on the DuckDuckGo brand name.
 msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
-msgstr "Kundig vervaardigde produkte vir mense wat 'n \"duck\" omgee vir privaatheid."
+msgstr ""
+"Kundig vervaardigde produkte vir mense wat 'n \"duck\" omgee vir privaatheid."
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
@@ -7451,11 +7593,59 @@ msgid "Expires in 1 day"
 msgstr "Verval oor 1 dag"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain the accepted answer in simple terms."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
 msgstr "Verduidelik die grondbeginsels van swart gate aan my op hoërskoolvlak."
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain the top answer"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this in simple, plain language."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this paper"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this repo"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this research paper in plain language."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this simply"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain what this repository does and how to use it."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label to show if song lyrics contain explicit content
@@ -7633,8 +7823,8 @@ msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and improvements."
 msgstr ""
-"Terugvoer soos joune het 'n direkte invloed op ons produkbywerkings en "
-"-verbeterings."
+"Terugvoer soos joune het 'n direkte invloed op ons produkbywerkings en -"
+"verbeterings."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -7643,8 +7833,8 @@ msgid ""
 "Feedback like yours directly influences our product updates and "
 "improvements. Hopefully we can address the issue you shared too."
 msgstr ""
-"Terugvoer soos joune het 'n direkte invloed op ons produkbywerkings en "
-"-verbeterings. Hopelik kan ons ook die probleem aanspreek wat jy gedeel het."
+"Terugvoer soos joune het 'n direkte invloed op ons produkbywerkings en -"
+"verbeterings. Hopelik kan ons ook die probleem aanspreek wat jy gedeel het."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box
@@ -7741,6 +7931,12 @@ msgstr ""
 "wete%2$s"
 
 # smartling.placeholder_format=C
+msgctxt "settings"
+msgid ""
+"Filters out known AI spam sites from image search results. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the final score of a sporting event.
 msgid "Final"
 msgstr "Finaal"
@@ -7779,7 +7975,8 @@ msgstr "Vind <b>%1$s</b> in jou aflaaivouer"
 # smartling.placeholder_format=C
 #. Tells users how to change their default search engine to DuckDuckGo.
 msgid "Find DuckDuckGo in the displayed list and click %sMake Default%s"
-msgstr "Spoor DuckDuckGo op in die lys wat vertoon word en klik%1$sMaak verstek%2$s"
+msgstr ""
+"Spoor DuckDuckGo op in die lys wat vertoon word en klik%1$sMaak verstek%2$s"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for finding a better word.
@@ -7792,6 +7989,12 @@ msgstr "Vind 'n beter woord"
 msgctxt "Subtitle for the Web Search tool entry in the Tools dropdown menu"
 msgid "Find current information"
 msgstr "Kry die nuutste inligting"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Find me alternatives"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button that searches for results closer to the user's current location.
@@ -7810,7 +8013,8 @@ msgstr "Vind resultate nader aan jou."
 msgctxt "Precise user location overlay"
 msgid ""
 "Find results near you. %sYour location stays private, secure, and anonymous."
-msgstr "Vind resultate naby jou. %1$sJou ligging bly privaat, veilig en anoniem."
+msgstr ""
+"Vind resultate naby jou. %1$sJou ligging bly privaat, veilig en anoniem."
 
 # smartling.placeholder_format=C
 #. Loading message shown while generating explore more follow-up questions
@@ -7986,7 +8190,8 @@ msgstr "Gratis en privaat geselsies, geanonimiseer deur ons"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr "Gratis en privaat geselsies, geanonimiseer deur ons. Geen rekening nodig nie."
+msgstr ""
+"Gratis en privaat geselsies, geanonimiseer deur ons. Geen rekening nodig nie."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -8099,8 +8304,8 @@ msgid ""
 "<strong>Check for Updates...</strong>, then select <strong>Install Update</"
 "strong>."
 msgstr ""
-"Kies <strong>DuckDuckGo</strong> &gt; <strong>Kyk of daar opdaterings is "
-"...</strong> op die app se kieslysbalk op Mac. Kies dan <strong>Installeer "
+"Kies <strong>DuckDuckGo</strong> &gt; <strong>Kyk of daar opdaterings is ..."
+"</strong> op die app se kieslysbalk op Mac. Kies dan <strong>Installeer "
 "opdatering</strong>."
 
 # smartling.placeholder_format=C
@@ -8267,6 +8472,12 @@ msgstr "Genereer beeld"
 #. Text for the button that generates more of an answer from duckassist when the answer has come from a collapsed state
 msgid "Generate More"
 msgstr "Genereer meer"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Generate a shopping list"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
@@ -8459,8 +8670,8 @@ msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"Kry toegang tot gevorderde KI-modelle in Duck.ai met 'n "
-"DuckDuckGo-intekening, wat ook ons VPN en ander premium "
+"Kry toegang tot gevorderde KI-modelle in Duck.ai met 'n DuckDuckGo-"
+"intekening, wat ook ons VPN en ander premium "
 "privaatheidsbeskermingsmaatreëls insluit."
 
 # smartling.placeholder_format=C
@@ -8495,7 +8706,8 @@ msgstr "Kry ons blaaier om nooit jou instellings te verloor nie."
 # smartling.placeholder_format=C
 msgid ""
 "Get seamless privacy protection on your browser for free with one download:"
-msgstr "Kry gratis probleemvrye privaatheidsbeskerming op jou blaaier met een aflaai:"
+msgstr ""
+"Kry gratis probleemvrye privaatheidsbeskerming op jou blaaier met een aflaai:"
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo app when clicked
@@ -8558,6 +8770,12 @@ msgstr "Probeer dit"
 msgctxt "Onboarding welcome screen button text"
 msgid "Give it a Try"
 msgstr "Probeer dit"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Give me a quick background on this person."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9006,6 +9224,18 @@ msgid "Help Spread Privacy"
 msgstr "Help om privaatheid te versprei"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Help me prep for the interview"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Help me tailor my resume for this job."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title of a SERP popup that invites users to take a survey (desktop only)
 msgctxt "User survey popup"
 msgid "Help us improve DuckDuckGo"
@@ -9073,7 +9303,8 @@ msgstr "Help jou vriende en familie om by die Duck-kant aan te sluit!"
 #. Text description for the Spread card in the SERP footer
 msgctxt "footer_card"
 msgid "Help your friends and family take back their privacy!"
-msgstr "Help jou vriende en familie om weer beheer oor hul privaatheid terug te neem!"
+msgstr ""
+"Help jou vriende en familie om weer beheer oor hul privaatheid terug te neem!"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -9204,7 +9435,8 @@ msgstr "Versteek jou e-posadres"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Hides search term from being shown in browser tab/history"
-msgstr "Dit verhoed die soekterm om in jou blaaier se oortjie/geskiedenis te vertoon"
+msgstr ""
+"Dit verhoed die soekterm om in jou blaaier se oortjie/geskiedenis te vertoon"
 
 # smartling.placeholder_format=C
 #. The highest stock price in a day
@@ -9452,7 +9684,8 @@ msgstr "Hoe dikwels wil jy KI-gesteunde antwoorde sien?"
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
 msgctxt "Duck.ai settings usage section"
 msgid "How much of your daily and weekly limits you've used so far."
-msgstr "Hoeveel van jou daaglikse en weeklikse limiete jy tot dusver gebruik het."
+msgstr ""
+"Hoeveel van jou daaglikse en weeklikse limiete jy tot dusver gebruik het."
 
 # smartling.placeholder_format=C
 #. A header for the feedback form in the assist negative feedback flow. The user is being asked to update how often they want AI-assisted answers to appear.
@@ -9519,6 +9752,14 @@ msgstr "Orkaan"
 msgctxt "Onboarding terms screen button text"
 msgid "I Agree"
 msgstr "Ek stem saam"
+
+# smartling.placeholder_format=C
+#. Text for the button that takes the user to the external DuckDuckGo login subscription page.
+msgctxt ""
+"Text for the I already have a subscription button in the Duck.ai settings "
+"page"
+msgid "I Already Have a Subscription"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the button that takes the user to the login subscription page.
@@ -9687,7 +9928,8 @@ msgstr ""
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
-msgstr "Indien jy ons steeds wil ondersteun, %1$shelp om DuckDuckGo te versprei%2$s"
+msgstr ""
+"Indien jy ons steeds wil ondersteun, %1$shelp om DuckDuckGo te versprei%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -9836,8 +10078,8 @@ msgctxt "settings"
 msgid ""
 "Improves result legibility with updated URL format, placement, and color"
 msgstr ""
-"Verbeter leesbaarheid van resultaat met bygewerkte URL-formaat, -plasing en "
-"-kleur"
+"Verbeter leesbaarheid van resultaat met bygewerkte URL-formaat, -plasing en -"
+"kleur"
 
 # smartling.placeholder_format=C
 #. A label that appears in front of the name of a company that DuckDuckGo has partnered with. For example, 'In partnership with Wikipedia'
@@ -10095,6 +10337,12 @@ msgid "Install Mac Browser"
 msgstr "Installeer Mac-blaaier"
 
 # smartling.placeholder_format=C
+#. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
+msgctxt "settings"
+msgid "Install Now"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of a button to install the DuckDuckGo app
 msgctxt "Serp footer content"
 msgid "Install Our App"
@@ -10192,10 +10440,42 @@ msgid "Is deleted data really deleted?"
 msgstr "Is geskrapte data werklik geskrap?"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is it worth taking?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this place any good?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"Is this place any good? Summarize its reputation based on reviews and "
+"ratings."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "Is this video helpful?"
 msgstr "Is hierdie video nuttig?"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this worth watching?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Is this worth watching? Give me a spoiler-free take."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -10227,7 +10507,8 @@ msgstr "Dit is vinnig, gratis en gee jou selfs meer aanlyn beskerming."
 msgctxt "settings"
 msgid ""
 "It's okay to (very infrequently) ask me about my experience using DuckDuckGo"
-msgstr "Jy mag my (baie ongereeld) vra oor my ervaring met die gebruik van DuckDuckGo"
+msgstr ""
+"Jy mag my (baie ongereeld) vra oor my ervaring met die gebruik van DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. The name of the Italian language
@@ -10806,6 +11087,12 @@ msgid "Links:"
 msgstr "Skakels:"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "List the tools, materials, or prerequisites I need for this."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
 msgid "Listen"
 msgstr "Luister"
@@ -11212,6 +11499,12 @@ msgid "Manage blocked sites"
 msgstr "Bestuur geblokkeerde webwerwe"
 
 # smartling.placeholder_format=C
+#. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
+msgctxt "setting"
+msgid "Manage in Browser Settings"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to the site exclusion settings page
 msgctxt "Organic result context menu"
 msgid "Manage sites you've blocked"
@@ -11434,7 +11727,8 @@ msgstr "Mikronesië"
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
 msgid ""
 "Microphone access was denied. Please allow microphone access and try again."
-msgstr "Mikrofoontoegang is geweier. Gee asseblief mikrofoontoegang en probeer weer."
+msgstr ""
+"Mikrofoontoegang is geweier. Gee asseblief mikrofoontoegang en probeer weer."
 
 # smartling.placeholder_format=C
 #. The Microsoft brand name.
@@ -12186,11 +12480,11 @@ msgid ""
 "internet connection. Disabling chat history will delete pinned chats, and "
 "disable the temporary storage of new prompts and responses."
 msgstr ""
-"Nuwe aanporrings en antwoorde word geënkripteer en tydelik op ’n "
-"DuckDuckGo-bediener gestoor nadat dit gestuur is om te help om ’n klets te "
-"herstel as jy jou internetverbinding verloor. As jy kletsgeskiedenis "
-"deaktiveer, sal vasgespelde kletse uitgevee word en die tydelike berging van "
-"nuwe aanporrings en antwoorde deaktiveer."
+"Nuwe aanporrings en antwoorde word geënkripteer en tydelik op ’n DuckDuckGo-"
+"bediener gestoor nadat dit gestuur is om te help om ’n klets te herstel as "
+"jy jou internetverbinding verloor. As jy kletsgeskiedenis deaktiveer, sal "
+"vasgespelde kletse uitgevee word en die tydelike berging van nuwe "
+"aanporrings en antwoorde deaktiveer."
 
 # smartling.placeholder_format=C
 #. Question in a feedback form.
@@ -12499,7 +12793,8 @@ msgstr "Geen resultate gevind nie."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the recording contains no audible speech.
 msgid "No speech detected. Please try again and speak into your microphone."
-msgstr "Geen spraak is bespeur nie. Probeer asseblief weer en praat in jou mikrofoon."
+msgstr ""
+"Geen spraak is bespeur nie. Probeer asseblief weer en praat in jou mikrofoon."
 
 # smartling.placeholder_format=C
 #. Button that dismisses a feedback form.
@@ -13290,7 +13585,8 @@ msgstr "Maak die paneel oop oor hoe Duck.ai werk."
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open the Safari menu and select %sSettings for DuckDuckGo...%s"
-msgstr "Maak die Safari-kieslys oop en kies %1$sInstellings vir DuckDuckGo...%2$s"
+msgstr ""
+"Maak die Safari-kieslys oop en kies %1$sInstellings vir DuckDuckGo...%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the time a business opens. For example: 'Opens at 10am'
@@ -13891,8 +14187,8 @@ msgid ""
 msgstr ""
 "As jy jou soektog as 'n vraag en in 'n volsin fraseer, sal DuckAssist meer "
 "geneig wees om outomaties te verskyn en dikwels beter antwoorde lewer. Om "
-"dit af te skakel en die Assist-knoppie te verberg, kan jy na "
-"%1$sDuckAssist-instellings%2$s gaan."
+"dit af te skakel en die Assist-knoppie te verberg, kan jy na %1$sDuckAssist-"
+"instellings%2$s gaan."
 
 # smartling.placeholder_format=C
 #. Button that allows users to manually select a location on a map.
@@ -14047,6 +14343,12 @@ msgstr ""
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
+msgid "Please describe why the chat response is harmful or illegal. (optional)"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
+msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
 msgstr ""
 "Beskryf asseblief waarom die kletsreaksie onwettig of skadelik is. "
@@ -14073,6 +14375,14 @@ msgid ""
 msgstr ""
 "Neem asseblief kennis: Om 'n nuwe klets met enige model te begin, sal jou "
 "huidige kletssessie uitwis."
+
+# smartling.placeholder_format=C
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
+msgctxt "Feedback prompt"
+msgid ""
+"Please paste your prompt and the problematic output (with any personal "
+"information removed) and describe why the content is harmful or illegal."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -14543,6 +14853,12 @@ msgid "Privacy"
 msgstr "Privaatheid"
 
 # smartling.placeholder_format=C
+#. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
+msgctxt "Section heading on the Duck.ai settings page"
+msgid "Privacy & Terms"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Privacy Blog"
 msgstr "Privaatheidsblog"
 
@@ -14611,6 +14927,12 @@ msgstr "Privaatheidsbeleid en Gebruiksvoorwaardes"
 msgctxt "Copy used to compose link in sentences"
 msgid "Privacy Policy and Terms of Service"
 msgstr "Privaatheidsbeleid en diensvoorwaardes"
+
+# smartling.placeholder_format=C
+#. Text for a button that links to the terms of use and privacy policy page.
+msgctxt "Secondary button text in active privacy modal"
+msgid "Privacy Policy and Terms of Service"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title displayed on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
@@ -14784,7 +15106,8 @@ msgstr "Vra my"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Prompt me to use my approximate location to get nearby results."
-msgstr "Vra my om my geskatte ligging te gebruik om resultate in die omgewing te kry."
+msgstr ""
+"Vra my om my geskatte ligging te gebruik om resultate in die omgewing te kry."
 
 # smartling.placeholder_format=C
 #. DuckDuckGo Email Protection removes trackers from emails
@@ -15111,6 +15434,30 @@ msgstr "Resepte vir %1$s%2$s%3$s"
 msgctxt "Brief for recommending a book"
 msgid "Recommend a book"
 msgstr "Beveel 'n boek aan"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar books"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar books."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar movies or shows."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar titles"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
@@ -15514,6 +15861,15 @@ msgid "Republic of Moldova"
 msgstr "Republiek van Moldawië"
 
 # smartling.placeholder_format=C
+#. Note indicating that sharing the conversation is mandatory when reporting harmful or illegal content. Rendered alongside the standard share label (DUCKCHAT_RESPONSE_FEEDBACK_SHARE_PROMPT_RESPONSE_LABEL), not replacing it.
+msgctxt ""
+"Note shown under the share-content switch label on the Duck.ai response "
+"feedback form when the user has selected Harmful or Illegal as the feedback "
+"reason"
+msgid "Required for harmful or illegal reports"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
 msgctxt "Description for extended reasoning mode in Duck.ai"
 msgid "Researches before responding"
@@ -15748,6 +16104,12 @@ msgstr "Resensies"
 msgctxt "maps_places"
 msgid "Reviews"
 msgstr "Resensies"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Rewrite this recipe scaled for a different number of servings."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Romania"
@@ -16034,8 +16396,8 @@ msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
 msgstr ""
-"Stoor jou Duck.ai-kletsgesprekke op jou verskillende toestelle met "
-"end-tot-end-enkripsie."
+"Stoor jou Duck.ai-kletsgesprekke op jou verskillende toestelle met end-tot-"
+"end-enkripsie."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -16194,7 +16556,8 @@ msgstr "Rol af en soek %1$sjou blaaier%2$s op die lys."
 #. Tells users which setting to change to enable location service.
 msgctxt "precise_user_location"
 msgid "Scroll down to %sDuckDuckGo%s and allow it to use your location."
-msgstr "Rol af na %1$sDuckDuckGo%2$s en laat dit toe om jou ligging te gebruik."
+msgstr ""
+"Rol af na %1$sDuckDuckGo%2$s en laat dit toe om jou ligging te gebruik."
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -16424,8 +16787,8 @@ msgctxt "settings"
 msgid ""
 "Search queries are included in URL (if off, searches will use POST requests)"
 msgstr ""
-"Soeknavrae word by bronadres ingesluit (indien af, sal soektogte "
-"POST-versoeke gebruik)"
+"Soeknavrae word by bronadres ingesluit (indien af, sal soektogte POST-"
+"versoeke gebruik)"
 
 # smartling.placeholder_format=C
 #. Describes how cookies are used to store user settings privately and securely.
@@ -16568,8 +16931,8 @@ msgid ""
 "Securely store your chats on our server using end-to-end encryption, and "
 "access them from all your devices."
 msgstr ""
-"Stoor jou gesprekke veilig op ons bediener met behulp van "
-"punt-tot-punt-enkripsie, en verkry toegang daartoe vanaf al jou toestelle."
+"Stoor jou gesprekke veilig op ons bediener met behulp van punt-tot-punt-"
+"enkripsie, en verkry toegang daartoe vanaf al jou toestelle."
 
 # smartling.placeholder_format=C
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
@@ -16696,7 +17059,8 @@ msgstr "Kyk na 'n paar van ons nuutste opdaterings"
 #. Link to a page with more information about how user settings are stored in a URL.
 msgctxt "settings"
 msgid "See the %sURL Parameter Reference page%s for more details."
-msgstr "Raadpleeg die %1$sURL-parameterverwysingsblad%2$s vir meer besonderhede."
+msgstr ""
+"Raadpleeg die %1$sURL-parameterverwysingsblad%2$s vir meer besonderhede."
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the context menu of a chat in chat history, that allows the user to select the chat and begin batch selection mode.
@@ -16723,7 +17087,8 @@ msgstr "Kies %1$s%2$s%3$s, dan %4$sSoekenjin%5$s"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %s'Setting for this Website...'%s from the Safari menu."
-msgstr "Kies %1$s'Instelling vir hierdie webwerf...'%2$s op die Safari-kieslys."
+msgstr ""
+"Kies %1$s'Instelling vir hierdie webwerf...'%2$s op die Safari-kieslys."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -16878,7 +17243,8 @@ msgstr ""
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %syour browser%s in the list and %sallow%s location access"
-msgstr "Kies %1$sjou blaaier%2$s in die lys en %3$slaat%4$s liggingstoegang toe"
+msgstr ""
+"Kies %1$sjou blaaier%2$s in die lys en %3$slaat%4$s liggingstoegang toe"
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the modal for deleting all recent chats, that allows the user to select the chats to delete.
@@ -17072,6 +17438,12 @@ msgid "Set Up Now"
 msgstr "Stel nou op"
 
 # smartling.placeholder_format=C
+#. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
+msgctxt "Encrypted storage setup button shown in native browsers"
+msgid "Set Up Sync & Backup"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
 msgctxt "Title for the Sync & Backup intro screen"
 msgid "Set Up Sync & Backup"
@@ -17107,7 +17479,8 @@ msgstr ""
 #. Prompt for the user to indicate their location on a map, to enable more relevant search results.
 msgctxt "precise_user_location"
 msgid "Set your location manually, or ensure Location Services is enabled."
-msgstr "Stel jou ligging handmatig in, of sorg dat liggingsdienste geaktiveer is."
+msgstr ""
+"Stel jou ligging handmatig in, of sorg dat liggingsdienste geaktiveer is."
 
 # smartling.placeholder_format=C
 #. In the top dropdown menu  ("More" > "Settings")
@@ -17188,8 +17561,8 @@ msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
 msgstr ""
-"Deel 'n ligging op stadsvlak met KI-modelle om relevansie te verbeter. "
-"Duck.ai verklap nooit jou presiese ligging aan ons of KI-modelle nie."
+"Deel 'n ligging op stadsvlak met KI-modelle om relevansie te verbeter. Duck."
+"ai verklap nooit jou presiese ligging aan ons of KI-modelle nie."
 
 # smartling.placeholder_format=C
 #. Menu option to share feedback about a result
@@ -17248,6 +17621,13 @@ msgstr "Deel bladsy-URL"
 msgctxt "feedback form"
 msgid "Share positive feedback"
 msgstr "Deel positiewe terugvoer"
+
+# smartling.placeholder_format=C
+#. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
+msgctxt ""
+"Label beside the share-content switch on the Duck.ai response feedback form"
+msgid "Share this conversation with DuckDuckGo"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -17386,7 +17766,8 @@ msgstr "Wys DuckAssist <sup>BETA</sup>"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show DuckAssist more often. (You can also completely %sturn it off%s.)"
-msgstr "Wys DuckAssist meer gereeld. (Jy kan dit ook heeltemal %1$safskakel%2$s.)"
+msgstr ""
+"Wys DuckAssist meer gereeld. (Jy kan dit ook heeltemal %1$safskakel%2$s.)"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
@@ -17684,7 +18065,8 @@ msgstr "Wys voorstelle onder die soekkassie soos jy tik"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows the privacy benefits of using DuckDuckGo on the homepage"
-msgstr "Wys die privaatheidsvoordele van die gebruik van DuckDuckGo op die tuisblad"
+msgstr ""
+"Wys die privaatheidsvoordele van die gebruik van DuckDuckGo op die tuisblad"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -17699,7 +18081,8 @@ msgstr "Wys verwelkomingsboodskap bo-aan die bladsy met soekresultate"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message to EU Android preference menu users"
-msgstr "Wys verwelkomingsboodskap vir gebruikers wat die EU Android-kieslys verkies"
+msgstr ""
+"Wys verwelkomingsboodskap vir gebruikers wat die EU Android-kieslys verkies"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers sometimes.
@@ -17771,7 +18154,8 @@ msgstr "Webwerfname"
 #. A message saying that site filters are not currently working
 msgctxt "Site filter message"
 msgid "Site search is temporarily unavailable. We are working on a fix."
-msgstr "Webwerfsoektog is tydelik onbeskikbaar. Ons is besig om 'n oplossing te vind."
+msgstr ""
+"Webwerfsoektog is tydelik onbeskikbaar. Ons is besig om 'n oplossing te vind."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -17915,7 +18299,8 @@ msgstr "Iets het skeefgeloop"
 #. Error message indicating that the user's settings weren't able to be saved.
 msgctxt "cloudsave"
 msgid "Something went wrong saving to the server, please try again."
-msgstr "Iets het skeefgeloop toe na die bediener gestoor is; probeer asseblief weer."
+msgstr ""
+"Iets het skeefgeloop toe na die bediener gestoor is; probeer asseblief weer."
 
 # smartling.placeholder_format=C
 #. Body copy displayed under the Set Up Now button when the sync setup call fails.
@@ -17947,7 +18332,8 @@ msgstr "Soms"
 #. Generic error message shown when the image generation model cannot process the user's request.
 msgctxt "Error message from the image generation model"
 msgid "Sorry I can't help, please describe your image in a different way."
-msgstr "Jammer, ek kan nie help nie. Beskryf asseblief jou beeld op ’n ander manier."
+msgstr ""
+"Jammer, ek kan nie help nie. Beskryf asseblief jou beeld op ’n ander manier."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -18004,8 +18390,8 @@ msgstr ""
 msgid ""
 "Sorry, we couldn't generate a richer answer. You can try asking Duck.ai."
 msgstr ""
-"Jammer, ons kon nie 'n ryker antwoord genereer nie. Jy kan probeer om "
-"Duck.ai te vra."
+"Jammer, ons kon nie 'n ryker antwoord genereer nie. Jy kan probeer om Duck."
+"ai te vra."
 
 # smartling.placeholder_format=C
 #. Inform the users that "something" went wrong and that they could try to refresh the page to resolve the error. Placeholders are for markup, please ignore.
@@ -18021,7 +18407,8 @@ msgstr ""
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr "Jammer, ons kon nie jou terugvoer indien nie. Probeer asseblief weer later."
+msgstr ""
+"Jammer, ons kon nie jou terugvoer indien nie. Probeer asseblief weer later."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -18499,6 +18886,24 @@ msgid "Suggest a title for a blog post"
 msgstr "Stel 'n titel vir 'n blogplasing voor"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest related articles or topics worth exploring next."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Suggest related articles to explore"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest some alternatives to this product."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
 msgctxt "directions"
 msgid "Suggestions:"
@@ -18510,10 +18915,100 @@ msgid "Suggestions:"
 msgstr "Voorstelle:"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Sum up the reviews"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A short title for the a message asking the AI to summarize a text.
 msgctxt "Title for the summarize message"
 msgid "Summarize"
 msgstr "Som op"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize the Q&As"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the background and notable work of this person."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the key details of this event."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the questions and answers on this page."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize their background"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this book"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this book."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this discussion"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this discussion thread."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this page"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this page."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this video"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this video."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize what the reviews say."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -18730,7 +19225,8 @@ msgstr "Sync & Backup is geaktiveer!"
 #. Notice shown under the recovery code explaining that backup data has an inactivity expiration.
 msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
-msgstr "Sync & Backup-data kan nie herwin word ná 18 maande van onaktiwiteit nie."
+msgstr ""
+"Sync & Backup-data kan nie herwin word ná 18 maande van onaktiwiteit nie."
 
 # smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
@@ -18779,8 +19275,8 @@ msgid ""
 msgstr ""
 "Sinkronisasieherstelkode\n"
 "\n"
-"Die herstelkode stel jou in staat om jou wagwoorde, outovuldata en "
-"Duck.ai-kletsgesprekke oor verskillende toestelle te sinkroniseer, en jou "
+"Die herstelkode stel jou in staat om jou wagwoorde, outovuldata en Duck.ai-"
+"kletsgesprekke oor verskillende toestelle te sinkroniseer, en jou "
 "gesinkroniseerde data terug te kry as jy toegang tot ’n toestel verloor.\n"
 "\n"
 "Hou hierdie inligting veilig en seker.\n"
@@ -18840,6 +19336,12 @@ msgid "Syria"
 msgstr "Sirië"
 
 # smartling.placeholder_format=C
+#. Text for a button that enables the theme to follow the operating system's color scheme preference.
+msgctxt "System theme button for theme selector"
+msgid "System"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Abbreviation indicating this is the total score for a game
 msgctxt "Sports module"
 msgid "T"
@@ -18866,6 +19368,12 @@ msgstr "TV"
 msgctxt "language_name"
 msgid "Tahitian"
 msgstr "Tahitiaans"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Tailor my resume"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Taiwan"
@@ -18895,6 +19403,13 @@ msgstr "Neem beheer van jou persoonlike data oor"
 msgctxt "homepage ATB modal"
 msgid "Take control of your personal data!"
 msgstr "Neem beheer van jou persoonlike data oor!"
+
+# smartling.placeholder_format=C
+#. Description for the Feedback section of the Duck.ai settings page, asking the user to take an anonymous survey to let us know how we can make Duck.ai better.
+msgctxt "Feedback section description on the Duck.ai settings page"
+msgid ""
+"Take this anonymous survey to let us know how we can make Duck.ai better."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -19143,7 +19658,8 @@ msgstr "Die aangehegte lêers oorskry die totale groottelimiet van %1$s MB."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the server rejects corrupt or unrecognized audio.
 msgid "The audio could not be processed. Please try recording again."
-msgstr "Die klank kon nie verwerk word nie. Probeer asseblief om weer op te neem."
+msgstr ""
+"Die klank kon nie verwerk word nie. Probeer asseblief om weer op te neem."
 
 # smartling.placeholder_format=C
 #. Second paragraph explaining where the encryption key is stored on the entry screen.
@@ -19168,7 +19684,8 @@ msgstr ""
 #. Description explaining that the AI model provider does not store any chat data on their servers.
 msgctxt "Privacy claim description in Duck.ai chat"
 msgid "The model provider does not save this chat on their servers."
-msgstr "Die modelverskaffer stoor nie hierdie kletsgesprek op die bedieners nie."
+msgstr ""
+"Die modelverskaffer stoor nie hierdie kletsgesprek op die bedieners nie."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers.
@@ -19201,6 +19718,12 @@ msgstr "Die bediener het 'n fout teëgekom en kon nie jou versoek voltooi nie."
 #. https://duck.co/media/files/theme.png
 msgid "Theme"
 msgstr "Tema"
+
+# smartling.placeholder_format=C
+#. Text for the theme selector label that allows users to switch between Light and dark theme.
+msgctxt "Label for the theme selector feature"
+msgid "Theme"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/LpFhb1e.png
@@ -19253,7 +19776,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Error message for explore more questions when a retryable error occurs (timeout, network)
 msgid "There's been an issue loading this answer. Please try again."
-msgstr "Daar was 'n probleem met die laai van hierdie antwoord. Probeer gerus weer."
+msgstr ""
+"Daar was 'n probleem met die laai van hierdie antwoord. Probeer gerus weer."
 
 # smartling.placeholder_format=C
 #. Instant Answer Tab Name
@@ -19325,7 +19849,8 @@ msgstr ""
 #. Appears below a type of search results called 'Instant Answers'
 msgctxt "attribution"
 msgid "This Instant Answer was made by the %sDuckDuckHack%s Community."
-msgstr "Hierdie kitsantwoord is deur die %1$sDuckDuckHack%2$s-gemeenskap geskep."
+msgstr ""
+"Hierdie kitsantwoord is deur die %1$sDuckDuckHack%2$s-gemeenskap geskep."
 
 # smartling.placeholder_format=C
 #. Label for the monthly usage row in the Usage section of Duck.ai settings.
@@ -19414,7 +19939,8 @@ msgctxt ""
 "Error message when an uploaded file type is not supported, with list ending "
 "in or"
 msgid "This file type is not supported, please attach a %s or %s"
-msgstr "Hierdie lêertipe word nie gesteun nie, heg asseblief 'n %1$s of %2$s aan"
+msgstr ""
+"Hierdie lêertipe word nie gesteun nie, heg asseblief 'n %1$s of %2$s aan"
 
 # smartling.placeholder_format=C
 #. Error message for unsupported file type when multiple types are accepted. First placeholder is a comma-separated list of all accepted types except the last (e.g. PNG, JPG, WebP, GIF). Second placeholder is the last accepted type (e.g. PDF). Full example: This file type is not supported, please attach a PNG, JPG, WebP, GIF or PDF
@@ -19422,7 +19948,8 @@ msgctxt ""
 "Error message when an uploaded file type is not supported, with list ending "
 "in or"
 msgid "This file type is not supported, please attach a %s or %s."
-msgstr "Hierdie lêertipe word nie gesteun nie; heg asseblief 'n %1$s of %2$s aan."
+msgstr ""
+"Hierdie lêertipe word nie gesteun nie; heg asseblief 'n %1$s of %2$s aan."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to upload an unsupported file type and we know which types are accepted. Placeholder is a single accepted type. E.g. This file type is not supported, please attach a PDF
@@ -19517,7 +20044,8 @@ msgstr "Hierdie bladsy vereis Javascript om te funksioneer."
 #. Information tooltip text explaining that the current page's content will be included with the chat message.
 msgctxt "Tooltip explaining that page content will be sent to Duck.ai"
 msgid "This page's content will be sent with your message to Duck.ai"
-msgstr "Hierdie bladsy se inhoud sal saam met jou boodskap na Duck.ai gestuur word."
+msgstr ""
+"Hierdie bladsy se inhoud sal saam met jou boodskap na Duck.ai gestuur word."
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -19548,9 +20076,8 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again."
 msgstr ""
-"Hierdie instelling word in jou blaaier gestoor, wat beteken as jy "
-"duckduckgo.com-blaaierdata skoonmaak, kan jy dalk weer KI-gesteunde "
-"antwoorde sien."
+"Hierdie instelling word in jou blaaier gestoor, wat beteken as jy duckduckgo."
+"com-blaaierdata skoonmaak, kan jy dalk weer KI-gesteunde antwoorde sien."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -19560,10 +20087,10 @@ msgid ""
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
 msgstr ""
-"Hierdie instelling word in jou blaaier gestoor, wat beteken as jy "
-"duckduckgo.com-blaaierdata skoonmaak, kan jy dalk weer KI-gesteunde "
-"antwoorde sien. Ons het egter ook 'n beginbladsy wat nooit KI-gesteunde "
-"antwoorde by %1$s wys nie."
+"Hierdie instelling word in jou blaaier gestoor, wat beteken as jy duckduckgo."
+"com-blaaierdata skoonmaak, kan jy dalk weer KI-gesteunde antwoorde sien. Ons "
+"het egter ook 'n beginbladsy wat nooit KI-gesteunde antwoorde by %1$s wys "
+"nie."
 
 # smartling.placeholder_format=C
 #. User feedback indicating that a translation is helpful
@@ -19634,7 +20161,8 @@ msgstr "Dit sal alle instellings wis. Gaan voort?"
 #. Confirmation message asking if the user is sure they want to reset all of their settings.
 msgctxt "settings"
 msgid "This will reset your saved settings to default values. Continue?"
-msgstr "Dit sal jou bewaarde instellings na die verstekwaardes terugstel. Gaan voort?"
+msgstr ""
+"Dit sal jou bewaarde instellings na die verstekwaardes terugstel. Gaan voort?"
 
 # smartling.placeholder_format=C
 #. Golf leaderboard column: holes completed in current round
@@ -19747,7 +20275,8 @@ msgstr "Om voort te gaan, moet jy instem tot Duck.ai se %1$s en %2$s"
 msgctxt ""
 "Copy stating agreement to AI Chat Privacy Policy and Terms of Service."
 msgid "To continue, you must agree to DuckDuckGo AI Chat’s %s and %s"
-msgstr "Om voort te gaan, moet jy instem tot DuckDuckGo AI Chat se %1$s en %2$s"
+msgstr ""
+"Om voort te gaan, moet jy instem tot DuckDuckGo AI Chat se %1$s en %2$s"
 
 # smartling.placeholder_format=C
 #. Instructions for how to print driving directions.
@@ -19779,8 +20308,8 @@ msgid ""
 "To transfer your chat history to Duck.ai, please update your DuckDuckGo "
 "browser to the latest version and try again."
 msgstr ""
-"Om jou kletsgeskiedenis na Duck.ai oor te dra, werk asseblief jou "
-"DuckDuckGo-blaaier by tot die nuutste weergawe en probeer weer."
+"Om jou kletsgeskiedenis na Duck.ai oor te dra, werk asseblief jou DuckDuckGo-"
+"blaaier by tot die nuutste weergawe en probeer weer."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
@@ -20042,6 +20571,18 @@ msgstr ""
 "uit?”"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Translate this page"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
+msgctxt "Page suggestion prompt"
+msgid "Translate this page into %s."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text for a region that will display translated text.
 msgctxt "translations_module"
 msgid "Translation"
@@ -20183,6 +20724,12 @@ msgid "Try Free"
 msgstr "Probeer gratis"
 
 # smartling.placeholder_format=C
+#. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
+msgctxt "settings"
+msgid "Try It Now"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
 msgctxt "Promotional CTA for new AI models"
 msgid "Try Now"
@@ -20253,7 +20800,8 @@ msgstr "Probeer om anonieme ligging te aktiveer vir meer akkurate resultate."
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr "Probeer eksperimenteer met elke model – hulle sal verskillende antwoorde gee."
+msgstr ""
+"Probeer eksperimenteer met elke model – hulle sal verskillende antwoorde gee."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
@@ -20419,6 +20967,22 @@ msgid "Trying DuckDuckGo again"
 msgstr "Probeer DuckDuckGo tans weer"
 
 # smartling.placeholder_format=C
+#. Message shown in a modal after supported third-party browser users disable AI features in Settings. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
 msgctxt "Assistant response placeholder"
 msgid "Trying with %s"
@@ -20523,7 +21087,8 @@ msgstr "Skakel %1$s\"Presiese Ligging\"%2$s aan vir meer akkurate resultate"
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
-msgstr "Skakel Duck Player aan om YouTube te kyk sonder geteikende advertensies"
+msgstr ""
+"Skakel Duck Player aan om YouTube te kyk sonder geteikende advertensies"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service.
@@ -20728,13 +21293,14 @@ msgstr ""
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
 msgstr ""
-"Onder %1$sAan die begin%2$s, kies %3$sTuisblad%4$s en voer in "
-"https://duckduckgo.com"
+"Onder %1$sAan die begin%2$s, kies %3$sTuisblad%4$s en voer in https://"
+"duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sOpen with%s select %sA specific page or pages%s"
-msgstr "Onder %1$sMaak oop met%2$s, kies %3$s’n spesifieke bladsy of bladsye%4$s"
+msgstr ""
+"Onder %1$sMaak oop met%2$s, kies %3$s’n spesifieke bladsy of bladsye%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -20761,7 +21327,8 @@ msgstr "Onder %1$sSoek%2$s-afdeling, klik %3$sBestuur soekenjins …%4$s"
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under On startup select %sOpen a specific page or set of pages%s"
-msgstr "Onder Aan die begin, kies %1$sMaak ’n spesifieke blad of stel blaaie oop%2$s"
+msgstr ""
+"Onder Aan die begin, kies %1$sMaak ’n spesifieke blad of stel blaaie oop%2$s"
 
 #  Opera default search engine instruction
 # smartling.placeholder_format=C
@@ -20867,7 +21434,8 @@ msgstr "Ontsluit met 'n DuckDuckGo-intekening"
 msgctxt "voice chat limit modal"
 msgid ""
 "Unlock advanced AI models and higher limits with a DuckDuckGo Subscription"
-msgstr "Ontsluit gevorderde KI-modelle en hoër limiete met 'n DuckDuckGo-intekening"
+msgstr ""
+"Ontsluit gevorderde KI-modelle en hoër limiete met 'n DuckDuckGo-intekening"
 
 # smartling.placeholder_format=C
 #. Text informing the user that advanced AI models can be unlocked with a subscription. The variable is used to insert a link that opens the subscription modal. Example: Unlock advanced AI models with a DuckDuckGo subscription.
@@ -20918,7 +21486,8 @@ msgstr "Onbevestigde inligting"
 #. Text explaining the limit on the number of recent chats that can be stored. Example: 'Up to 30 of your most recent chats can be saved at a time.'
 msgctxt "Information about the limit of recent chats that can be saved"
 msgid "Up to %s of your most recent chats can be saved at a time."
-msgstr "Tot en met %1$s van jou mees onlangse kletse kan op 'n slag gestoor word."
+msgstr ""
+"Tot en met %1$s van jou mees onlangse kletse kan op 'n slag gestoor word."
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -21162,6 +21731,12 @@ msgid "Uruguay"
 msgstr "Uruguay"
 
 # smartling.placeholder_format=C
+#. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
+msgctxt "Navigation label on the Duck.ai settings page"
+msgid "Usage"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A feedback suggestion
 msgctxt "Feedback prompt"
 msgid "Usage limit"
@@ -21390,7 +21965,8 @@ msgstr "Bekyk pryse vir jou verblyf"
 # smartling.placeholder_format=C
 #. A description for the ads tooltip that explains that viewing ads is privacy protected by DuckDuckGo.
 msgid "Viewing ads is privacy protected by DuckDuckGo."
-msgstr "Jou privaatheid word deur DuckDuckGo beskerm as jy na advertensies kyk."
+msgstr ""
+"Jou privaatheid word deur DuckDuckGo beskerm as jy na advertensies kyk."
 
 # smartling.placeholder_format=C
 msgctxt "Ads GDPR, internal use only. Do not change"
@@ -21440,7 +22016,8 @@ msgctxt "mobile promotion on desktop"
 msgid ""
 "Visit %sDuckDuckGo.com%s on your tablet or phone and follow the provided "
 "instructions."
-msgstr "Besoek %1$sDuckDuckGo.com%2$s op jou tablet of foon en volg die aanwysings."
+msgstr ""
+"Besoek %1$sDuckDuckGo.com%2$s op jou tablet of foon en volg die aanwysings."
 
 # smartling.placeholder_format=C
 #. Primary button to visit Duck.ai.
@@ -21491,9 +22068,9 @@ msgid ""
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
 msgstr ""
-"Besoek Duck.ai in jou ander blaaier of die DuckDuckGo-app en maak "
-"Duck.ai-instellings oop. Kies “Skakel aan” onder Sync & Backup en kies "
-"“Sinkroniseer met ’n ander toestel”. Of skandeer die QR op jou Herstel-PDF."
+"Besoek Duck.ai in jou ander blaaier of die DuckDuckGo-app en maak Duck.ai-"
+"instellings oop. Kies “Skakel aan” onder Sync & Backup en kies “Sinkroniseer "
+"met ’n ander toestel”. Of skandeer die QR op jou Herstel-PDF."
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -21606,6 +22183,12 @@ msgstr "Wag tans vir ligging ..."
 # smartling.placeholder_format=C
 msgid "Wales"
 msgstr "Wallis"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Walk me through the steps"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for walking directions on a map.
@@ -21726,6 +22309,17 @@ msgstr ""
 "te wys."
 
 # smartling.placeholder_format=C
+#. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
+msgctxt ""
+"Inline warning shown below the share-content toggle when the user selects "
+"Harmful or Illegal but has not enabled sharing"
+msgid ""
+"We can only fix what we can see. To report a harmful or illegal response, "
+"please share this conversation with DuckDuckGo so we can investigate and "
+"address the issue."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
 msgctxt ""
 "Inline warning shown below the share-content toggle when the user selects "
@@ -21772,7 +22366,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don't store your personal info or track you. Ever."
-msgstr "Ons bewaar nie jou persoonlike inligting, of spoor jou na nie. Nooit nie."
+msgstr ""
+"Ons bewaar nie jou persoonlike inligting, of spoor jou na nie. Nooit nie."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -21990,7 +22585,8 @@ msgctxt "duckai_migration"
 msgid ""
 "We're sorry for this inconvenience. We’re working hard to make your "
 "experience better."
-msgstr "Ons is jammer vir die ongerief. Ons werk hard om jou ervaring te verbeter."
+msgstr ""
+"Ons is jammer vir die ongerief. Ons werk hard om jou ervaring te verbeter."
 
 # smartling.placeholder_format=C
 #. Body text explaining the service update requires a page reload.
@@ -22240,7 +22836,8 @@ msgstr ""
 #. Text for a prompt suggestion for considering factors when purchasing a computer monitor.
 msgctxt "Full sentence for preparing for a purchase"
 msgid "What are some factors to consider when purchasing a computer monitor?"
-msgstr "Wat is 'n paar faktore om te oorweeg vir die aankoop van 'n rekenaarmonitor?"
+msgstr ""
+"Wat is 'n paar faktore om te oorweeg vir die aankoop van 'n rekenaarmonitor?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for asking about must-see attractions in Paris for a first-time visitor.
@@ -22278,11 +22875,107 @@ msgid ""
 "experience."
 msgstr ""
 "Wat is die voordele daarvan om die DuckDuckGo-blaaier af te laai vir iemand "
-"wat belangstel om Duck.ai te gebruik? Verwys slegs na amptelike "
-"DuckDuckGo-bronne. Verdeel die antwoord in duidelike afdelings met titels, "
-"met ’n fokus op Duck.ai-integrasies en privaatheidsbeskerming. Hou dit kort, "
-"eenvoudig en maklik om te verstaan vir mense met of sonder veel KI- of "
-"tegniese ervaring."
+"wat belangstel om Duck.ai te gebruik? Verwys slegs na amptelike DuckDuckGo-"
+"bronne. Verdeel die antwoord in duidelike afdelings met titels, met ’n fokus "
+"op Duck.ai-integrasies en privaatheidsbeskerming. Hou dit kort, eenvoudig en "
+"maklik om te verstaan vir mense met of sonder veel KI- of tegniese ervaring."
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the counterarguments?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the hours & location?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key contributions of this paper?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key contributions?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key details?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key points covered in this video?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key points?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key takeaways from this article?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key takeaways?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key things I will learn from this course?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main counterarguments or criticisms of this?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main questions this page answers?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the must-try dishes here?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"What are the opening hours, location, and contact details for this place?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the pros and cons of this product?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the pros and cons?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
@@ -22385,6 +23078,12 @@ msgid "What does atria mean in the context of a medical article?"
 msgstr "Wat beteken \"atria\" in die konteks van 'n mediese artikel?"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What does this answer?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
@@ -22397,20 +23096,32 @@ msgid "What information gets saved?"
 msgstr "Watter inligting word gestoor?"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What interview questions might come up for this role?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
 msgid ""
 "What is the Cloud Save bookmarklet and how does it differ from the URL "
 "parameter bookmarklet?"
 msgstr ""
-"Wat is die Cloud Save-boekmerkie en hoe verskil dit van die URL "
-"parameter-boekmerkie?"
+"Wat is die Cloud Save-boekmerkie en hoe verskil dit van die URL parameter-"
+"boekmerkie?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for looking up the capital city of Albania.
 msgctxt "Full sentence for looking up basic facts"
 msgid "What is the capital city of Albania?"
 msgstr "Wat is die hoofstad van Albanië?"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What is the overall verdict and rating for this?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to a page with additional information.
@@ -22435,6 +23146,12 @@ msgid "What people say:"
 msgstr "Wat mense te sê het:"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What should I order?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
 msgctxt "feedback form"
 msgid "What stood out?"
@@ -22445,6 +23162,18 @@ msgstr "Wat het uitgestaan?"
 msgctxt "feedback form"
 msgid "What was wrong with the response? (optional)"
 msgstr "Wat was fout met die antwoord? (opsioneel)"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I learn?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I need?"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -22466,6 +23195,12 @@ msgid "What's New"
 msgstr "Wat is nuut"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What's the verdict?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to a page featuring the most recent updates from DuckDuckGo.
 msgid "What’s New"
 msgstr "Wat is nuut"
@@ -22483,7 +23218,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "When enabled, Duck.ai will show instant answers in the chat."
-msgstr "Wanneer dit geaktiveer is, sal Duck.ai kitsantwoorde in die kletsgesprek wys."
+msgstr ""
+"Wanneer dit geaktiveer is, sal Duck.ai kitsantwoorde in die kletsgesprek wys."
 
 # smartling.placeholder_format=C
 #. Text of a button that performs a search for the available streaming services that show a particular movie or tv show
@@ -22516,6 +23252,12 @@ msgid "Which features are missing? (Optional)"
 msgstr "Watter kenmerke ontbreek? (Opsioneel)"
 
 # smartling.placeholder_format=C
+#. An invitation for users to leave feedback
+msgctxt "Feedback prompt"
+msgid "Which features are missing? (optional)"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
 msgid "White"
 msgstr "Wit"
@@ -22530,6 +23272,18 @@ msgstr "Wit"
 #. Link to an about us page.
 msgid "Who We Are"
 msgstr "Wie ons is"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Who are the main cast and crew, and what else are they known for?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Who is this person?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Header above a collection of privacy-related links.
@@ -22900,7 +23654,8 @@ msgstr "Ja, nuwe gebruiker!"
 msgctxt "cloudsave"
 msgid ""
 "Yes, we throw away data when you’re done with it, and it cannot be recovered."
-msgstr "Ja, ons gooi data weg as jy daarmee klaar is en dit kan nie herwin word nie."
+msgstr ""
+"Ja, ons gooi data weg as jy daarmee klaar is en dit kan nie herwin word nie."
 
 # smartling.placeholder_format=C
 #. Option for the filter-by-date search.
@@ -22960,7 +23715,8 @@ msgstr ""
 
 # smartling.placeholder_format=C
 msgid "You can also use %sDuck.ai%s to answer questions or summarize text."
-msgstr "Jy kan ook %1$sDuck.ai%2$s gebruik om vrae te beantwoord of teks op te som."
+msgstr ""
+"Jy kan ook %1$sDuck.ai%2$s gebruik om vrae te beantwoord of teks op te som."
 
 # smartling.placeholder_format=C
 msgid ""
@@ -23022,7 +23778,8 @@ msgstr "Jykan hierdie herinnering verberg by %1$sSoekinstellings%2$s"
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
-msgstr "Jy kan nou tot 100 kletsgesprekke op hierdie toestel stoor. Gesels gerus!"
+msgstr ""
+"Jy kan nou tot 100 kletsgesprekke op hierdie toestel stoor. Gesels gerus!"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -23116,7 +23873,8 @@ msgstr "Jy kan oor begin op hierdie nuwe domein (duck.ai)."
 #. Text explaining the benefits of the cloud save feature.
 msgctxt "cloudsave"
 msgid "You can store several sets of settings for different purposes."
-msgstr "Jy kan verskillende stelle instellings stoor vir verskillende doeleindes."
+msgstr ""
+"Jy kan verskillende stelle instellings stoor vir verskillende doeleindes."
 
 # smartling.placeholder_format=C
 #. Instructions for user once they've failed the bot challenge
@@ -23191,7 +23949,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
 msgid "You won't see this message again unless you clear your browser data."
-msgstr "Jy sal hierdie boodskap nie weer sien nie tensy jy jou blaaierdata skoonmaak."
+msgstr ""
+"Jy sal hierdie boodskap nie weer sien nie tensy jy jou blaaierdata skoonmaak."
 
 # smartling.placeholder_format=C
 #. The second paragraph of a pop up where we explain how to update the browser manually.
@@ -23283,7 +24042,8 @@ msgstr "Jy het die maksimum stemkletsduur vir een sessie bereik."
 msgctxt "voice chat limit modal"
 msgid ""
 "You've reached the voice chat limit for today. Please try again tomorrow."
-msgstr "Jy het die stemkletslimiet vir vandag bereik. Probeer asseblief weer môre."
+msgstr ""
+"Jy het die stemkletslimiet vir vandag bereik. Probeer asseblief weer môre."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
@@ -23449,7 +24209,8 @@ msgstr ""
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never used to train AI models"
-msgstr "Jou geselsies is privaat en word nooit gebruik om KI-modelle op te lei nie"
+msgstr ""
+"Jou geselsies is privaat en word nooit gebruik om KI-modelle op te lei nie"
 
 # smartling.placeholder_format=C
 #. Text for a description of the active privacy protection for DuckDuckGo's AI Chat feature.
@@ -23457,8 +24218,8 @@ msgctxt "Active Privacy protection description"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
 msgstr ""
-"Jou geselsies is privaat, word deur ons geanonimiseer en nie gebruik om "
-"KI-modelle op te lei nie."
+"Jou geselsies is privaat, word deur ons geanonimiseer en nie gebruik om KI-"
+"modelle op te lei nie."
 
 # smartling.placeholder_format=C
 #. Text explaining that user chats are private and not used for AI (Artificial Intelligence) training.
@@ -23466,8 +24227,8 @@ msgctxt "Body text for privacy protection modal"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
 msgstr ""
-"Jou geselsies is privaat, word deur ons geanonimiseer en nie gebruik om "
-"KI-modelle op te lei nie."
+"Jou geselsies is privaat, word deur ons geanonimiseer en nie gebruik om KI-"
+"modelle op te lei nie."
 
 # smartling.placeholder_format=C
 #. Text for a menu item that describes the privacy protection feature.
@@ -23559,7 +24320,8 @@ msgctxt ""
 "Subtitle of the one-time popover shown above the thumbs up/down buttons on "
 "an AI response"
 msgid "Your feedback is anonymized and not used to train AI."
-msgstr "Jou terugvoer word geanonimiseer en word nie gebruik om KI op te lei nie."
+msgstr ""
+"Jou terugvoer word geanonimiseer en word nie gebruik om KI op te lei nie."
 
 # smartling.placeholder_format=C
 #. Explains that the User's Location is always private to DuckDuckGo.
@@ -23588,8 +24350,8 @@ msgid ""
 "browser. We save the settings file using the key as the name. DuckDuckGo "
 "never knows your passphrase."
 msgstr ""
-"Jou kenfrase skep 'n 512-bissleutel deur middel van die Secure "
-"Hash-algoritme, ook bekend as %1$sSHA-2%2$s. Slegs die sleutel en gekoppelde "
+"Jou kenfrase skep 'n 512-bissleutel deur middel van die Secure Hash-"
+"algoritme, ook bekend as %1$sSHA-2%2$s. Slegs die sleutel en gekoppelde "
 "instellingslêer verlaat jou blaaier. Ons stoor die instellingslêer deur die "
 "sleutel as naam te gebruik. DuckDuckGo ken nooit jou kenfrase nie."
 
@@ -23804,7 +24566,8 @@ msgstr "deur %1$s"
 #. Trust line shown at the bottom of the explainer panel, summarizing DuckDuckGo's reputation for online protection.
 msgctxt "Footer banner text in the How Duck.ai Works panel"
 msgid "by DuckDuckGo — online protection trusted by millions every day."
-msgstr "deur DuckDuckGo – aanlyn beskerming wat elke dag deur miljoene vertrou word."
+msgstr ""
+"deur DuckDuckGo – aanlyn beskerming wat elke dag deur miljoene vertrou word."
 
 # smartling.placeholder_format=C
 #. An abreviated unit of time indicating an age, e.g. "2d"

--- a/locales/af_ZA/LC_MESSAGES/duckduckgo.po
+++ b/locales/af_ZA/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: af_ZA\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -22,8 +22,7 @@ msgstr "!Knal-soeksnelsleutels"
 msgctxt ""
 "Body copy for the Remove Device confirmation modal; %s is the device name"
 msgid "\"%s\" will no longer be able to access your synced data."
-msgstr ""
-"\"%1$s\" sal nie meer toegang tot jou gesinkroniseerde data kan kry nie."
+msgstr "\"%1$s\" sal nie meer toegang tot jou gesinkroniseerde data kan kry nie."
 
 # smartling.placeholder_format=C
 #. Used to specify the rank of a team/player in a specific ranking in short form. This should be interpreted as 'Ranked number <rankNumber> in the <rankingName> ranking. Here you only need to translate the # symbol for ranked number. If your language doesn't provide a single-letter convention, please leave #.
@@ -417,8 +416,7 @@ msgstr "%1$s woorde"
 #. Instructions on which buttons and options the user has to click in order to add the DuckDuckGo extension to their browser.
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
-msgstr ""
-"%1$sKlik op %2$sVoeg by%3$sMerk %4$sLaat toe%5$s en klik dan op %6$sGoed%7$s"
+msgstr "%1$sKlik op %2$sVoeg by%3$sMerk %4$sLaat toe%5$s en klik dan op %6$sGoed%7$s"
 
 # Firefox, obsolete
 # smartling.placeholder_format=C
@@ -481,8 +479,7 @@ msgstr ""
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "%sLearn more%s about how chats are stored privately on your device."
-msgstr ""
-"%1$sKom meer te wete%2$s oor hoe kletse privaat op jou toestel gestoor word."
+msgstr "%1$sKom meer te wete%2$s oor hoe kletse privaat op jou toestel gestoor word."
 
 # smartling.placeholder_format=C
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
@@ -813,8 +810,7 @@ msgstr "6-uur-gebruikslimiet is bereik."
 #. Displayed when the user has reached a fixed 6-hour Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "6-hour usage limit reached. You can continue this chat after %s."
-msgstr ""
-"6-uur-gebruikslimiet is bereik. Jy kan hierdie kletsgesprek voortsit ná %1$s."
+msgstr "6-uur-gebruikslimiet is bereik. Jy kan hierdie kletsgesprek voortsit ná %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable 6-hour Duck.ai usage limit and can opt in to continue using the daily limit.
@@ -1283,8 +1279,7 @@ msgstr "Voeg DuckDuckGo-uitbreiding by"
 # smartling.placeholder_format=C
 msgid ""
 "Add DuckDuckGo Privacy Essentials to your browser for free with one download:"
-msgstr ""
-"Voeg DuckDuckGo Privacy Essentials gratis by jou blaaier met een aflaai:"
+msgstr "Voeg DuckDuckGo Privacy Essentials gratis by jou blaaier met een aflaai:"
 
 #  IE default search engine instruction
 # smartling.placeholder_format=C
@@ -1442,7 +1437,7 @@ msgstr "Adres is verkeerd"
 #. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Adjust the servings"
-msgstr ""
+msgstr "Pas die porsies aan"
 
 # smartling.placeholder_format=C
 #. as in multiple advertisements
@@ -1664,6 +1659,9 @@ msgid ""
 "All chats are anonymized by DuckDuckGo, and your conversations are not used "
 "to train chat models by DuckDuckGo or the model providers"
 msgstr ""
+"Alle kletsgesprekke word deur DuckDuckGo geanonimiseer, en jou gesprekke "
+"word nie gebruik om kletsmodelle deur DuckDuckGo of die modelverskaffers op "
+"te lei nie"
 
 # smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1695,8 +1693,7 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "All model providers are prevented from training their AI on your "
 "conversations."
-msgstr ""
-"Alle modelverskaffers word verhoed om hul KI met jou gesprekke op te lei."
+msgstr "Alle modelverskaffers word verhoed om hul KI met jou gesprekke op te lei."
 
 # smartling.placeholder_format=C
 #. Text displayed in the subheader of the modal that allows the user to pick an AI chat model.
@@ -1755,8 +1752,7 @@ msgstr "Laat advertensies toe wat privaatheid respekteer"
 # smartling.placeholder_format=C
 #. Title in a dialog informing the user how to disable their ad blocker for DuckDuckGo
 msgid "Allow privacy-respecting ads on DuckDuckGo Private Search"
-msgstr ""
-"Laat advertensies toe wat privaatheid respekteer op DuckDuckGo Private Search"
+msgstr "Laat advertensies toe wat privaatheid respekteer op DuckDuckGo Private Search"
 
 # smartling.placeholder_format=C
 #. Description explaining privacy implications of enabling web search on encrypted models. The first two placeholders are the full model name (e.g. 'gpt-oss 120B'). The third and fourth placeholders wrap a clickable link reading 'zero provider visibility' that opens the privacy modal, please keep those around the link text in your translation. An example full sentence would be: Allows gpt-oss 120B to search the web to improve responses to relevant prompts. Only sends AI-generated queries to a search engine with limited data retention. Prompts and responses with gpt-oss 120B still have zero provider visibility.
@@ -1941,6 +1937,8 @@ msgid ""
 "Anonymously generates answers for search queries based on web content. "
 "Choose how often you want it to appear, or disable it completely."
 msgstr ""
+"Genereer anoniem antwoorde op soeknavrae gebaseer op webinhoud. Kies hoe "
+"gereeld jy wil hê dit moet verskyn, of deaktiveer dit heeltemal."
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -2087,8 +2085,7 @@ msgstr "Is jy nog daar?"
 msgctxt "Body text for clear all chats confirmation modal"
 msgid ""
 "Are you sure you want to clear all of your chats? This cannot be undone."
-msgstr ""
-"Is jy seker jy wil al jou kletse skoonmaak? Dit kan nie ontdoen word nie."
+msgstr "Is jy seker jy wil al jou kletse skoonmaak? Dit kan nie ontdoen word nie."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that asks the user if they want to clear the conversation.
@@ -2225,7 +2222,7 @@ msgstr "Vra 'n opvolgvraag met Duck.ai"
 #. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
 msgctxt "Page suggestion chip label"
 msgid "Ask about this page"
-msgstr ""
+msgstr "Vra oor hierdie bladsy"
 
 # smartling.placeholder_format=C
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2294,8 +2291,8 @@ msgstr ""
 "verskyn: Nooit (verwyder Assist UI heeltemal uit soekresultate), Op aanvraag "
 "(wys slegs KI-gesteunde antwoorde as jy op die Assist-knoppie klik), Soms "
 "(wys slegs KI-gesteunde antwoorde wanneer dit baie relevant is) of Dikwels "
-"(wys meer gereeld op 'n wyer verskeidenheid soektogte). Vir nou is KI-"
-"gesteunde antwoorde slegs beskikbaar in die Amerikaanse (Engels) streek."
+"(wys meer gereeld op 'n wyer verskeidenheid soektogte). Vir nou is "
+"KI-gesteunde antwoorde slegs beskikbaar in die Amerikaanse (Engels) streek."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2401,8 +2398,7 @@ msgstr ""
 #. Description in consent disclaimer informing that audio from the voice chat session is not stored by us or by OpenAI after the voice chat ends.
 msgctxt "voice chat"
 msgid "Audio is not stored by us or by OpenAI after the chat ends."
-msgstr ""
-"Klank word nie deur ons of deur OpenAI gestoor nadat die klets eindig nie."
+msgstr "Klank word nie deur ons of deur OpenAI gestoor nadat die klets eindig nie."
 
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
@@ -2450,8 +2446,7 @@ msgstr "Outo-antwoord"
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid "Auto-generated based on listed sources. May contain inaccuracies."
-msgstr ""
-"Outomaties gegenereer gebaseer op gelyste bronne. Mag onakkuraathede bevat."
+msgstr "Outomaties gegenereer gebaseer op gelyste bronne. Mag onakkuraathede bevat."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
@@ -2650,7 +2645,7 @@ msgstr "Strepieskode"
 #. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Based on this page, is this course worth taking?"
-msgstr ""
+msgstr "Gebaseer op hierdie bladsy, is hierdie kursus die moeite werd om te volg?"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2699,6 +2694,9 @@ msgid ""
 "Before storing this report, DuckDuckGo will anonymize your conversation by "
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
+"Voordat hierdie verslag gestoor word, sal DuckDuckGo jou kletsgesprek "
+"anonimiseer deur PII, soos name, e-posadresse en identifiserende metadata, "
+"te verwyder."
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -3020,7 +3018,7 @@ msgstr "Breekpunte gewen"
 #. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Break this down into clear, numbered steps."
-msgstr ""
+msgstr "Breek dit op in duidelike, genommerde stappe."
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -3481,7 +3479,7 @@ msgstr "Rolverdeling"
 #. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Cast & Crew"
-msgstr ""
+msgstr "Rolverdeling & Span"
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -3568,8 +3566,7 @@ msgstr "Verander hoe resultaat-URL'e vertoon word"
 #. This is the description of a user setting
 msgctxt "settings"
 msgid "Changes how the header is displayed and its behavior as you scroll"
-msgstr ""
-"Verander hoe die opskrif vertoon word en die gedrag daarvan terwyl jy rollees"
+msgstr "Verander hoe die opskrif vertoon word en die gedrag daarvan terwyl jy rollees"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/mcZdcaF.png
@@ -3721,10 +3718,10 @@ msgid ""
 msgstr ""
 "Met Chat (via ons Duck.ai-diens) kan jy anonieme gesprekke voer met "
 "derdeparty-KI-kletsmodelle, wat modelle van OpenAI, Anthropic en meer "
-"ondersteun. As jy hierdie instelling afskakel, sal die Chat-knoppies en -"
-"skakels op DuckDuckGo Search verberg word. Jy kan egter steeds toegang tot "
-"Chat kry wanneer hierdie instelling afgeskakel is, deur %1$shttps://duck."
-"ai%2$s direk te besoek."
+"ondersteun. As jy hierdie instelling afskakel, sal die Chat-knoppies en "
+"-skakels op DuckDuckGo Search verberg word. Jy kan egter steeds toegang tot "
+"Chat kry wanneer hierdie instelling afgeskakel is, deur "
+"%1$shttps://duck.ai%2$s direk te besoek."
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -3779,16 +3776,14 @@ msgstr "Gesels privaat"
 #. Mobile variant of DUCKCHAT_BROWSER_UPSELL_PROMO_TEXT. Shorter version for the promotional card encouraging third-party browser users to download the DuckDuckGo browser.
 msgctxt "Promotional text (mobile)"
 msgid "Chat privately on any website with Duck.ai built into our free browser."
-msgstr ""
-"Gesels privaat op enige webwerf met Duck.ai ingebou in ons gratis blaaier."
+msgstr "Gesels privaat op enige webwerf met Duck.ai ingebou in ons gratis blaaier."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card encouraging third-party browser users to download the DuckDuckGo browser. Not shown in the DuckDuckGo browser or on Linux.
 msgctxt "Promotional text"
 msgid ""
 "Chat privately on any website with the Duck.ai sidebar in our free browser."
-msgstr ""
-"Gesels privaat op enige webwerf met die Duck.ai-sybalk in ons gratis blaaier."
+msgstr "Gesels privaat op enige webwerf met die Duck.ai-sybalk in ons gratis blaaier."
 
 # smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
@@ -3851,9 +3846,9 @@ msgid ""
 "Chats are stored locally on your device instead of on DuckDuckGo servers or "
 "remote servers. Disabling chat history will delete pinned chats."
 msgstr ""
-"Kletse word plaaslik op jou toestel gestoor in plaas van op DuckDuckGo-"
-"bedieners of afgeleë bedieners. As jy kletsgeskiedenis deaktiveer, sal "
-"vasgespelde kletse uitgevee word."
+"Kletse word plaaslik op jou toestel gestoor in plaas van op "
+"DuckDuckGo-bedieners of afgeleë bedieners. As jy kletsgeskiedenis "
+"deaktiveer, sal vasgespelde kletse uitgevee word."
 
 # smartling.placeholder_format=C
 #. Text explaining how the Chat History feature stores the user's chats locally to their device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection. Also explains that disabling chat history will delete pinned chats.
@@ -4370,8 +4365,7 @@ msgstr "Klik %1$sJa%2$s"
 # smartling.placeholder_format=C
 #. Tells the user where to click to open their browser's settings menu.
 msgid "Click %ssettings/hamburger icon %s on the Chrome toolbar (top right)."
-msgstr ""
-"Klik %1$sinstellings/hamburgerikoon %2$s in die Chrome-taakbalk (regs bo)."
+msgstr "Klik %1$sinstellings/hamburgerikoon %2$s in die Chrome-taakbalk (regs bo)."
 
 #  Maxthon default search engine instruction
 # smartling.placeholder_format=C
@@ -5146,8 +5140,7 @@ msgstr "Costa Rica"
 #. Inline error shown on the recovery code screen when exportSyncSettings rejects.
 msgctxt "Error message when the recovery code fails to generate"
 msgid "Couldn't load your recovery code. Please close this and try again."
-msgstr ""
-"Kon nie jou herstelkode laai nie. Maak dit asseblief toe en probeer weer."
+msgstr "Kon nie jou herstelkode laai nie. Maak dit asseblief toe en probeer weer."
 
 # smartling.placeholder_format=C
 #. Pairs with a Retry button. Shown after two consecutive failed attempts to load the device list.
@@ -5196,7 +5189,7 @@ msgstr "Skep prent"
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
-msgstr ""
+msgstr "Skep ’n inkopielys met hoeveelhede uit hierdie resep."
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed in the input field when starting a new image generation session.
@@ -5722,8 +5715,7 @@ msgstr "Wil jy oudste kletsgesprekke skrap om stoorplek te maak?"
 #. Title shown when user has reached the file storage sync quota (5GB).
 msgctxt "Sync file storage limit modal title"
 msgid "Delete oldest chats with attachments to free up storage?"
-msgstr ""
-"Wil jy oudste kletsgesprekke met aanhangsels skrap om stoorplek te maak?"
+msgstr "Wil jy oudste kletsgesprekke met aanhangsels skrap om stoorplek te maak?"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to delete all recent chats.
@@ -5769,8 +5761,7 @@ msgstr "Beskryf veranderinge gebaseer op die beeld"
 #. Placeholder text displayed in the input field when the user can make follow-up edits to a generated image.
 msgctxt "Placeholder text for the image generation input field for follow-ups"
 msgid "Describe changes to continue editing this image"
-msgstr ""
-"Beskryf veranderinge om voort te gaan met die redigering van hierdie beeld"
+msgstr "Beskryf veranderinge om voort te gaan met die redigering van hierdie beeld"
 
 # smartling.placeholder_format=C
 #. Title shown when the user first enters Image Generation mode, prompting them to describe the image they want to create.
@@ -5845,7 +5836,7 @@ msgstr "Diktasielimiet is bereik"
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
 msgid "Dictation temporarily unavailable"
-msgstr ""
+msgstr "Diktee is tydelik onbeskikbaar"
 
 # smartling.placeholder_format=C
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
@@ -6039,8 +6030,7 @@ msgstr "Vertoon taal"
 #. This is the description of a user setting
 msgctxt "settings"
 msgid "Displays a checkmark to the left of results you've visited"
-msgstr ""
-"Vertoon 'n regmerkie aan die linkerkant van resultate wat jy besoek het"
+msgstr "Vertoon 'n regmerkie aan die linkerkant van resultate wat jy besoek het"
 
 # smartling.placeholder_format=C
 #. This is the description of a user setting
@@ -6155,6 +6145,8 @@ msgid ""
 "Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
 "filtered out. %sLearn More%s"
 msgstr ""
+"Wil jy nie KI hê nie? %1$snoai.duckduckgo.com%2$s bied geen KI-kenmerke nie "
+"en KI-beelde is verwyder. %3$sKom meer te wete%4$s"
 
 # smartling.placeholder_format=C
 #. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
@@ -6163,6 +6155,8 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
+"Wil jy nie KI hê nie? Besoek %1$snoai.duckduckgo.com%2$s om te soek sonder "
+"KI-funksies en met KI-beelde wat verwyder is. %3$sKom meer te wete%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6282,13 +6276,13 @@ msgstr ""
 #. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Draft a cover letter"
-msgstr ""
+msgstr "Stel ’n dekbrief op"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Draft a cover letter for this job."
-msgstr ""
+msgstr "Stel ’n dekbrief vir hierdie pos op."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -6474,6 +6468,9 @@ msgid ""
 "company for anyone who wants to take back control of their personal "
 "information."
 msgstr ""
+"Duck.ai is deur DuckDuckGo geskep. Ons is ’n onafhanklike aanlyn "
+"beskermingsmaatskappy vir enigiemand wat weer beheer oor hul persoonlike "
+"inligting wil neem."
 
 # smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
@@ -6528,6 +6525,9 @@ msgid ""
 "Duck.ai lets you chat privately with popular AI models. Disabling it hides "
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
+"Duck.ai laat jou privaat met gewilde KI-modelle gesels. As jy dit afskakel, "
+"word Duck.ai-knoppies en -skakels verberg, maar jy kan steeds "
+"%1$sduck.ai%2$s direk besoek."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6601,9 +6601,9 @@ msgid ""
 "AI chat no sign up, OpenAI, Anthropic, Llama, Mistral, open source AI "
 "models, privacy focused AI, no account AI chat"
 msgstr ""
-"Duck.ai, DuckDuckGo KI, private KI-kletsbot, gratis KI-klets, anonieme KI-"
-"klets, KI-klets geen aanmelding, OpenAI, Anthropic, Llama, Mistral, oopbron "
-"KI-modelle, privaatheidsgefokusde KI, KI-klets geen rekening"
+"Duck.ai, DuckDuckGo KI, private KI-kletsbot, gratis KI-klets, anonieme "
+"KI-klets, KI-klets geen aanmelding, OpenAI, Anthropic, Llama, Mistral, "
+"oopbron KI-modelle, privaatheidsgefokusde KI, KI-klets geen rekening"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -6772,8 +6772,7 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr ""
-"DuckDuckGo AI Chat is tydelik onbeskikbaar. Probeer asseblief weer later."
+msgstr "DuckDuckGo AI Chat is tydelik onbeskikbaar. Probeer asseblief weer later."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -6892,8 +6891,8 @@ msgid ""
 "DuckDuckGo anonymizes these reports by automatically removing PII like "
 "names, email addresses, phone numbers, and identifying metadata."
 msgstr ""
-"DuckDuckGo anonimiseer hierdie aanmeldings deur outomaties PII, soos name, e-"
-"posadresse, telefoonnommers en identifiserende metadata, te verwyder."
+"DuckDuckGo anonimiseer hierdie aanmeldings deur outomaties PII, soos name, "
+"e-posadresse, telefoonnommers en identifiserende metadata, te verwyder."
 
 # smartling.placeholder_format=C
 #. The first %s is the agree button label ('Agree'). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. The leading sentence mirrors the drawer-style inline disclaimer (DUCKCHAT_TOS_INLINE_DISCLAIMER).
@@ -6993,8 +6992,7 @@ msgctxt ""
 "Description of the DuckDuckGo subscription setting when it is not available "
 "in the user region"
 msgid "DuckDuckGo subscriptions are not available to purchase in this region."
-msgstr ""
-"DuckDuckGo-intekeninge is nie in hierdie streek beskikbaar om te koop nie."
+msgstr "DuckDuckGo-intekeninge is nie in hierdie streek beskikbaar om te koop nie."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use 'ducky' tone in its responses. When this option is selected, the AI assistant speaks like a duck.
@@ -7261,8 +7259,7 @@ msgstr "Aktiveer diktasie in Duck.ai"
 #. Prompt to enable location service so that search results can be displayed near the user's current location.
 msgctxt "precise_user_location"
 msgid "Enable location settings on your device to use anonymous location"
-msgstr ""
-"Aktiveer liggingsinstellings op jou toestel om anonieme ligging te gebruik"
+msgstr "Aktiveer liggingsinstellings op jou toestel om anonieme ligging te gebruik"
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -7529,13 +7526,13 @@ msgstr "Eritrea"
 #. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Estimate the nutrition"
-msgstr ""
+msgstr "Beraam die voedingswaarde"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Estimate the nutritional information for this recipe."
-msgstr ""
+msgstr "Beraam die voedingswaarde-inligting vir hierdie resep."
 
 # smartling.placeholder_format=C
 msgid "Estonia"
@@ -7571,8 +7568,7 @@ msgstr "Vou kaart uit"
 #. Subtitle for the Collaborations promotional card at the bottom of search results. Describes the branded merchandise line. 'Give a duck' is a wordplay on the DuckDuckGo brand name.
 msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
-msgstr ""
-"Kundig vervaardigde produkte vir mense wat 'n \"duck\" omgee vir privaatheid."
+msgstr "Kundig vervaardigde produkte vir mense wat 'n \"duck\" omgee vir privaatheid."
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
@@ -7596,7 +7592,7 @@ msgstr "Verval oor 1 dag"
 #. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain the accepted answer in simple terms."
-msgstr ""
+msgstr "Verduidelik die aanvaarde antwoord in eenvoudige terme."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
@@ -7609,43 +7605,43 @@ msgstr "Verduidelik die grondbeginsels van swart gate aan my op hoërskoolvlak."
 #. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain the top answer"
-msgstr ""
+msgstr "Verduidelik die topantwoord"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain this in simple, plain language."
-msgstr ""
+msgstr "Verduidelik dit in eenvoudige, duidelike taal."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain this paper"
-msgstr ""
+msgstr "Verduidelik hierdie artikel"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain this repo"
-msgstr ""
+msgstr "Verduidelik hierdie argief"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain this research paper in plain language."
-msgstr ""
+msgstr "Verduidelik hierdie navorsingsartikel in eenvoudige taal."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain this simply"
-msgstr ""
+msgstr "Verduidelik dit eenvoudig"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain what this repository does and how to use it."
-msgstr ""
+msgstr "Verduidelik wat hierdie argief doen en hoe om dit te gebruik."
 
 # smartling.placeholder_format=C
 #. Label to show if song lyrics contain explicit content
@@ -7823,8 +7819,8 @@ msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and improvements."
 msgstr ""
-"Terugvoer soos joune het 'n direkte invloed op ons produkbywerkings en -"
-"verbeterings."
+"Terugvoer soos joune het 'n direkte invloed op ons produkbywerkings en "
+"-verbeterings."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -7833,8 +7829,8 @@ msgid ""
 "Feedback like yours directly influences our product updates and "
 "improvements. Hopefully we can address the issue you shared too."
 msgstr ""
-"Terugvoer soos joune het 'n direkte invloed op ons produkbywerkings en -"
-"verbeterings. Hopelik kan ons ook die probleem aanspreek wat jy gedeel het."
+"Terugvoer soos joune het 'n direkte invloed op ons produkbywerkings en "
+"-verbeterings. Hopelik kan ons ook die probleem aanspreek wat jy gedeel het."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box
@@ -7935,6 +7931,8 @@ msgctxt "settings"
 msgid ""
 "Filters out known AI spam sites from image search results. %sLearn More%s"
 msgstr ""
+"Verwyder bekende KI-rommelwerwe uit beeldsoekresultate. %1$sKom meer te "
+"wete%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the final score of a sporting event.
@@ -7975,8 +7973,7 @@ msgstr "Vind <b>%1$s</b> in jou aflaaivouer"
 # smartling.placeholder_format=C
 #. Tells users how to change their default search engine to DuckDuckGo.
 msgid "Find DuckDuckGo in the displayed list and click %sMake Default%s"
-msgstr ""
-"Spoor DuckDuckGo op in die lys wat vertoon word en klik%1$sMaak verstek%2$s"
+msgstr "Spoor DuckDuckGo op in die lys wat vertoon word en klik%1$sMaak verstek%2$s"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for finding a better word.
@@ -7994,7 +7991,7 @@ msgstr "Kry die nuutste inligting"
 #. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Find me alternatives"
-msgstr ""
+msgstr "Vind vir my alternatiewe"
 
 # smartling.placeholder_format=C
 #. Button that searches for results closer to the user's current location.
@@ -8013,8 +8010,7 @@ msgstr "Vind resultate nader aan jou."
 msgctxt "Precise user location overlay"
 msgid ""
 "Find results near you. %sYour location stays private, secure, and anonymous."
-msgstr ""
-"Vind resultate naby jou. %1$sJou ligging bly privaat, veilig en anoniem."
+msgstr "Vind resultate naby jou. %1$sJou ligging bly privaat, veilig en anoniem."
 
 # smartling.placeholder_format=C
 #. Loading message shown while generating explore more follow-up questions
@@ -8190,8 +8186,7 @@ msgstr "Gratis en privaat geselsies, geanonimiseer deur ons"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr ""
-"Gratis en privaat geselsies, geanonimiseer deur ons. Geen rekening nodig nie."
+msgstr "Gratis en privaat geselsies, geanonimiseer deur ons. Geen rekening nodig nie."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -8304,8 +8299,8 @@ msgid ""
 "<strong>Check for Updates...</strong>, then select <strong>Install Update</"
 "strong>."
 msgstr ""
-"Kies <strong>DuckDuckGo</strong> &gt; <strong>Kyk of daar opdaterings is ..."
-"</strong> op die app se kieslysbalk op Mac. Kies dan <strong>Installeer "
+"Kies <strong>DuckDuckGo</strong> &gt; <strong>Kyk of daar opdaterings is "
+"...</strong> op die app se kieslysbalk op Mac. Kies dan <strong>Installeer "
 "opdatering</strong>."
 
 # smartling.placeholder_format=C
@@ -8477,7 +8472,7 @@ msgstr "Genereer meer"
 #. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Generate a shopping list"
-msgstr ""
+msgstr "Genereer ’n inkopielys"
 
 # smartling.placeholder_format=C
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
@@ -8670,8 +8665,8 @@ msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"Kry toegang tot gevorderde KI-modelle in Duck.ai met 'n DuckDuckGo-"
-"intekening, wat ook ons VPN en ander premium "
+"Kry toegang tot gevorderde KI-modelle in Duck.ai met 'n "
+"DuckDuckGo-intekening, wat ook ons VPN en ander premium "
 "privaatheidsbeskermingsmaatreëls insluit."
 
 # smartling.placeholder_format=C
@@ -8706,8 +8701,7 @@ msgstr "Kry ons blaaier om nooit jou instellings te verloor nie."
 # smartling.placeholder_format=C
 msgid ""
 "Get seamless privacy protection on your browser for free with one download:"
-msgstr ""
-"Kry gratis probleemvrye privaatheidsbeskerming op jou blaaier met een aflaai:"
+msgstr "Kry gratis probleemvrye privaatheidsbeskerming op jou blaaier met een aflaai:"
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo app when clicked
@@ -8775,7 +8769,7 @@ msgstr "Probeer dit"
 #. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Give me a quick background on this person."
-msgstr ""
+msgstr "Gee vir my ’n vinnige agtergrond van hierdie persoon."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9227,13 +9221,13 @@ msgstr "Help om privaatheid te versprei"
 #. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Help me prep for the interview"
-msgstr ""
+msgstr "Help my voorberei vir die onderhoud"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Help me tailor my resume for this job."
-msgstr ""
+msgstr "Help my om my CV vir hierdie pos aan te pas."
 
 # smartling.placeholder_format=C
 #. Title of a SERP popup that invites users to take a survey (desktop only)
@@ -9303,8 +9297,7 @@ msgstr "Help jou vriende en familie om by die Duck-kant aan te sluit!"
 #. Text description for the Spread card in the SERP footer
 msgctxt "footer_card"
 msgid "Help your friends and family take back their privacy!"
-msgstr ""
-"Help jou vriende en familie om weer beheer oor hul privaatheid terug te neem!"
+msgstr "Help jou vriende en familie om weer beheer oor hul privaatheid terug te neem!"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -9435,8 +9428,7 @@ msgstr "Versteek jou e-posadres"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Hides search term from being shown in browser tab/history"
-msgstr ""
-"Dit verhoed die soekterm om in jou blaaier se oortjie/geskiedenis te vertoon"
+msgstr "Dit verhoed die soekterm om in jou blaaier se oortjie/geskiedenis te vertoon"
 
 # smartling.placeholder_format=C
 #. The highest stock price in a day
@@ -9684,8 +9676,7 @@ msgstr "Hoe dikwels wil jy KI-gesteunde antwoorde sien?"
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
 msgctxt "Duck.ai settings usage section"
 msgid "How much of your daily and weekly limits you've used so far."
-msgstr ""
-"Hoeveel van jou daaglikse en weeklikse limiete jy tot dusver gebruik het."
+msgstr "Hoeveel van jou daaglikse en weeklikse limiete jy tot dusver gebruik het."
 
 # smartling.placeholder_format=C
 #. A header for the feedback form in the assist negative feedback flow. The user is being asked to update how often they want AI-assisted answers to appear.
@@ -9759,7 +9750,7 @@ msgctxt ""
 "Text for the I already have a subscription button in the Duck.ai settings "
 "page"
 msgid "I Already Have a Subscription"
-msgstr ""
+msgstr "Ek het reeds ’n intekening"
 
 # smartling.placeholder_format=C
 #. Text for the button that takes the user to the login subscription page.
@@ -9928,8 +9919,7 @@ msgstr ""
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
-msgstr ""
-"Indien jy ons steeds wil ondersteun, %1$shelp om DuckDuckGo te versprei%2$s"
+msgstr "Indien jy ons steeds wil ondersteun, %1$shelp om DuckDuckGo te versprei%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -10078,8 +10068,8 @@ msgctxt "settings"
 msgid ""
 "Improves result legibility with updated URL format, placement, and color"
 msgstr ""
-"Verbeter leesbaarheid van resultaat met bygewerkte URL-formaat, -plasing en -"
-"kleur"
+"Verbeter leesbaarheid van resultaat met bygewerkte URL-formaat, -plasing en "
+"-kleur"
 
 # smartling.placeholder_format=C
 #. A label that appears in front of the name of a company that DuckDuckGo has partnered with. For example, 'In partnership with Wikipedia'
@@ -10340,7 +10330,7 @@ msgstr "Installeer Mac-blaaier"
 #. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
 msgctxt "settings"
 msgid "Install Now"
-msgstr ""
+msgstr "Installeer nou"
 
 # smartling.placeholder_format=C
 #. Text of a button to install the DuckDuckGo app
@@ -10443,13 +10433,13 @@ msgstr "Is geskrapte data werklik geskrap?"
 #. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Is it worth taking?"
-msgstr ""
+msgstr "Is dit die moeite werd om dit te neem?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Is this place any good?"
-msgstr ""
+msgstr "Is hierdie plek enigsins goed?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
@@ -10458,6 +10448,8 @@ msgid ""
 "Is this place any good? Summarize its reputation based on reviews and "
 "ratings."
 msgstr ""
+"Is hierdie plek enigsins goed? Gee ’n opsomming van sy reputasie gebaseer op "
+"resensies en graderings."
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -10469,13 +10461,13 @@ msgstr "Is hierdie video nuttig?"
 #. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Is this worth watching?"
-msgstr ""
+msgstr "Is dit die moeite werd om te kyk?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Is this worth watching? Give me a spoiler-free take."
-msgstr ""
+msgstr "Is dit die moeite werd om te kyk? Gee my ’n opinie sonder bederwers."
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -10507,8 +10499,7 @@ msgstr "Dit is vinnig, gratis en gee jou selfs meer aanlyn beskerming."
 msgctxt "settings"
 msgid ""
 "It's okay to (very infrequently) ask me about my experience using DuckDuckGo"
-msgstr ""
-"Jy mag my (baie ongereeld) vra oor my ervaring met die gebruik van DuckDuckGo"
+msgstr "Jy mag my (baie ongereeld) vra oor my ervaring met die gebruik van DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. The name of the Italian language
@@ -11090,7 +11081,7 @@ msgstr "Skakels:"
 #. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
-msgstr ""
+msgstr "Gee die gereedskap, materiale of voorvereistes wat ek hiervoor benodig."
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -11502,7 +11493,7 @@ msgstr "Bestuur geblokkeerde webwerwe"
 #. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
 msgctxt "setting"
 msgid "Manage in Browser Settings"
-msgstr ""
+msgstr "Bestuur in blaaierinstellings"
 
 # smartling.placeholder_format=C
 #. Link to the site exclusion settings page
@@ -11727,8 +11718,7 @@ msgstr "Mikronesië"
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
 msgid ""
 "Microphone access was denied. Please allow microphone access and try again."
-msgstr ""
-"Mikrofoontoegang is geweier. Gee asseblief mikrofoontoegang en probeer weer."
+msgstr "Mikrofoontoegang is geweier. Gee asseblief mikrofoontoegang en probeer weer."
 
 # smartling.placeholder_format=C
 #. The Microsoft brand name.
@@ -12480,11 +12470,11 @@ msgid ""
 "internet connection. Disabling chat history will delete pinned chats, and "
 "disable the temporary storage of new prompts and responses."
 msgstr ""
-"Nuwe aanporrings en antwoorde word geënkripteer en tydelik op ’n DuckDuckGo-"
-"bediener gestoor nadat dit gestuur is om te help om ’n klets te herstel as "
-"jy jou internetverbinding verloor. As jy kletsgeskiedenis deaktiveer, sal "
-"vasgespelde kletse uitgevee word en die tydelike berging van nuwe "
-"aanporrings en antwoorde deaktiveer."
+"Nuwe aanporrings en antwoorde word geënkripteer en tydelik op ’n "
+"DuckDuckGo-bediener gestoor nadat dit gestuur is om te help om ’n klets te "
+"herstel as jy jou internetverbinding verloor. As jy kletsgeskiedenis "
+"deaktiveer, sal vasgespelde kletse uitgevee word en die tydelike berging van "
+"nuwe aanporrings en antwoorde deaktiveer."
 
 # smartling.placeholder_format=C
 #. Question in a feedback form.
@@ -12793,8 +12783,7 @@ msgstr "Geen resultate gevind nie."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the recording contains no audible speech.
 msgid "No speech detected. Please try again and speak into your microphone."
-msgstr ""
-"Geen spraak is bespeur nie. Probeer asseblief weer en praat in jou mikrofoon."
+msgstr "Geen spraak is bespeur nie. Probeer asseblief weer en praat in jou mikrofoon."
 
 # smartling.placeholder_format=C
 #. Button that dismisses a feedback form.
@@ -13585,8 +13574,7 @@ msgstr "Maak die paneel oop oor hoe Duck.ai werk."
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open the Safari menu and select %sSettings for DuckDuckGo...%s"
-msgstr ""
-"Maak die Safari-kieslys oop en kies %1$sInstellings vir DuckDuckGo...%2$s"
+msgstr "Maak die Safari-kieslys oop en kies %1$sInstellings vir DuckDuckGo...%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the time a business opens. For example: 'Opens at 10am'
@@ -14187,8 +14175,8 @@ msgid ""
 msgstr ""
 "As jy jou soektog as 'n vraag en in 'n volsin fraseer, sal DuckAssist meer "
 "geneig wees om outomaties te verskyn en dikwels beter antwoorde lewer. Om "
-"dit af te skakel en die Assist-knoppie te verberg, kan jy na %1$sDuckAssist-"
-"instellings%2$s gaan."
+"dit af te skakel en die Assist-knoppie te verberg, kan jy na "
+"%1$sDuckAssist-instellings%2$s gaan."
 
 # smartling.placeholder_format=C
 #. Button that allows users to manually select a location on a map.
@@ -14345,6 +14333,8 @@ msgstr ""
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is harmful or illegal. (optional)"
 msgstr ""
+"Beskryf asseblief waarom die kletsgesprekantwoord skadelik of onwettig is. "
+"(opsioneel)"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
@@ -14383,6 +14373,9 @@ msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is harmful or illegal."
 msgstr ""
+"Plak asseblief jou aanwysings en die problematiese afvoer (met enige "
+"persoonlike inligting verwyder) en beskryf waarom die inhoud skadelik of "
+"onwettig is."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -14856,7 +14849,7 @@ msgstr "Privaatheid"
 #. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
 msgctxt "Section heading on the Duck.ai settings page"
 msgid "Privacy & Terms"
-msgstr ""
+msgstr "Privaatheid & Bepalings"
 
 # smartling.placeholder_format=C
 msgid "Privacy Blog"
@@ -14932,7 +14925,7 @@ msgstr "Privaatheidsbeleid en diensvoorwaardes"
 #. Text for a button that links to the terms of use and privacy policy page.
 msgctxt "Secondary button text in active privacy modal"
 msgid "Privacy Policy and Terms of Service"
-msgstr ""
+msgstr "Privaatheidsbeleid en diensvoorwaardes"
 
 # smartling.placeholder_format=C
 #. Title displayed on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
@@ -15106,8 +15099,7 @@ msgstr "Vra my"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Prompt me to use my approximate location to get nearby results."
-msgstr ""
-"Vra my om my geskatte ligging te gebruik om resultate in die omgewing te kry."
+msgstr "Vra my om my geskatte ligging te gebruik om resultate in die omgewing te kry."
 
 # smartling.placeholder_format=C
 #. DuckDuckGo Email Protection removes trackers from emails
@@ -15439,25 +15431,25 @@ msgstr "Beveel 'n boek aan"
 #. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Recommend similar books"
-msgstr ""
+msgstr "Beveel soortgelyke boeke aan"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Recommend similar books."
-msgstr ""
+msgstr "Beveel soortgelyke boeke aan."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Recommend similar movies or shows."
-msgstr ""
+msgstr "Beveel soortgelyke flieks of programme aan."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Recommend similar titles"
-msgstr ""
+msgstr "Beveel soortgelyke titels aan"
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
@@ -15867,7 +15859,7 @@ msgctxt ""
 "feedback form when the user has selected Harmful or Illegal as the feedback "
 "reason"
 msgid "Required for harmful or illegal reports"
-msgstr ""
+msgstr "Vereis vir verslae oor skadelike of onwettige inhoud"
 
 # smartling.placeholder_format=C
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
@@ -16109,7 +16101,7 @@ msgstr "Resensies"
 #. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Rewrite this recipe scaled for a different number of servings."
-msgstr ""
+msgstr "Herskryf hierdie resep aangepas vir ’n ander hoeveelheid porsies."
 
 # smartling.placeholder_format=C
 msgid "Romania"
@@ -16396,8 +16388,8 @@ msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
 msgstr ""
-"Stoor jou Duck.ai-kletsgesprekke op jou verskillende toestelle met end-tot-"
-"end-enkripsie."
+"Stoor jou Duck.ai-kletsgesprekke op jou verskillende toestelle met "
+"end-tot-end-enkripsie."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -16556,8 +16548,7 @@ msgstr "Rol af en soek %1$sjou blaaier%2$s op die lys."
 #. Tells users which setting to change to enable location service.
 msgctxt "precise_user_location"
 msgid "Scroll down to %sDuckDuckGo%s and allow it to use your location."
-msgstr ""
-"Rol af na %1$sDuckDuckGo%2$s en laat dit toe om jou ligging te gebruik."
+msgstr "Rol af na %1$sDuckDuckGo%2$s en laat dit toe om jou ligging te gebruik."
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -16787,8 +16778,8 @@ msgctxt "settings"
 msgid ""
 "Search queries are included in URL (if off, searches will use POST requests)"
 msgstr ""
-"Soeknavrae word by bronadres ingesluit (indien af, sal soektogte POST-"
-"versoeke gebruik)"
+"Soeknavrae word by bronadres ingesluit (indien af, sal soektogte "
+"POST-versoeke gebruik)"
 
 # smartling.placeholder_format=C
 #. Describes how cookies are used to store user settings privately and securely.
@@ -16931,8 +16922,8 @@ msgid ""
 "Securely store your chats on our server using end-to-end encryption, and "
 "access them from all your devices."
 msgstr ""
-"Stoor jou gesprekke veilig op ons bediener met behulp van punt-tot-punt-"
-"enkripsie, en verkry toegang daartoe vanaf al jou toestelle."
+"Stoor jou gesprekke veilig op ons bediener met behulp van "
+"punt-tot-punt-enkripsie, en verkry toegang daartoe vanaf al jou toestelle."
 
 # smartling.placeholder_format=C
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
@@ -17059,8 +17050,7 @@ msgstr "Kyk na 'n paar van ons nuutste opdaterings"
 #. Link to a page with more information about how user settings are stored in a URL.
 msgctxt "settings"
 msgid "See the %sURL Parameter Reference page%s for more details."
-msgstr ""
-"Raadpleeg die %1$sURL-parameterverwysingsblad%2$s vir meer besonderhede."
+msgstr "Raadpleeg die %1$sURL-parameterverwysingsblad%2$s vir meer besonderhede."
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the context menu of a chat in chat history, that allows the user to select the chat and begin batch selection mode.
@@ -17087,8 +17077,7 @@ msgstr "Kies %1$s%2$s%3$s, dan %4$sSoekenjin%5$s"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %s'Setting for this Website...'%s from the Safari menu."
-msgstr ""
-"Kies %1$s'Instelling vir hierdie webwerf...'%2$s op die Safari-kieslys."
+msgstr "Kies %1$s'Instelling vir hierdie webwerf...'%2$s op die Safari-kieslys."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -17243,8 +17232,7 @@ msgstr ""
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %syour browser%s in the list and %sallow%s location access"
-msgstr ""
-"Kies %1$sjou blaaier%2$s in die lys en %3$slaat%4$s liggingstoegang toe"
+msgstr "Kies %1$sjou blaaier%2$s in die lys en %3$slaat%4$s liggingstoegang toe"
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the modal for deleting all recent chats, that allows the user to select the chats to delete.
@@ -17441,7 +17429,7 @@ msgstr "Stel nou op"
 #. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
 msgctxt "Encrypted storage setup button shown in native browsers"
 msgid "Set Up Sync & Backup"
-msgstr ""
+msgstr "Stel Sync & Backup op"
 
 # smartling.placeholder_format=C
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
@@ -17479,8 +17467,7 @@ msgstr ""
 #. Prompt for the user to indicate their location on a map, to enable more relevant search results.
 msgctxt "precise_user_location"
 msgid "Set your location manually, or ensure Location Services is enabled."
-msgstr ""
-"Stel jou ligging handmatig in, of sorg dat liggingsdienste geaktiveer is."
+msgstr "Stel jou ligging handmatig in, of sorg dat liggingsdienste geaktiveer is."
 
 # smartling.placeholder_format=C
 #. In the top dropdown menu  ("More" > "Settings")
@@ -17561,8 +17548,8 @@ msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
 msgstr ""
-"Deel 'n ligging op stadsvlak met KI-modelle om relevansie te verbeter. Duck."
-"ai verklap nooit jou presiese ligging aan ons of KI-modelle nie."
+"Deel 'n ligging op stadsvlak met KI-modelle om relevansie te verbeter. "
+"Duck.ai verklap nooit jou presiese ligging aan ons of KI-modelle nie."
 
 # smartling.placeholder_format=C
 #. Menu option to share feedback about a result
@@ -17627,7 +17614,7 @@ msgstr "Deel positiewe terugvoer"
 msgctxt ""
 "Label beside the share-content switch on the Duck.ai response feedback form"
 msgid "Share this conversation with DuckDuckGo"
-msgstr ""
+msgstr "Deel hierdie kletsgesprek met DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -17766,8 +17753,7 @@ msgstr "Wys DuckAssist <sup>BETA</sup>"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show DuckAssist more often. (You can also completely %sturn it off%s.)"
-msgstr ""
-"Wys DuckAssist meer gereeld. (Jy kan dit ook heeltemal %1$safskakel%2$s.)"
+msgstr "Wys DuckAssist meer gereeld. (Jy kan dit ook heeltemal %1$safskakel%2$s.)"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
@@ -18065,8 +18051,7 @@ msgstr "Wys voorstelle onder die soekkassie soos jy tik"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows the privacy benefits of using DuckDuckGo on the homepage"
-msgstr ""
-"Wys die privaatheidsvoordele van die gebruik van DuckDuckGo op die tuisblad"
+msgstr "Wys die privaatheidsvoordele van die gebruik van DuckDuckGo op die tuisblad"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18081,8 +18066,7 @@ msgstr "Wys verwelkomingsboodskap bo-aan die bladsy met soekresultate"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message to EU Android preference menu users"
-msgstr ""
-"Wys verwelkomingsboodskap vir gebruikers wat die EU Android-kieslys verkies"
+msgstr "Wys verwelkomingsboodskap vir gebruikers wat die EU Android-kieslys verkies"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers sometimes.
@@ -18154,8 +18138,7 @@ msgstr "Webwerfname"
 #. A message saying that site filters are not currently working
 msgctxt "Site filter message"
 msgid "Site search is temporarily unavailable. We are working on a fix."
-msgstr ""
-"Webwerfsoektog is tydelik onbeskikbaar. Ons is besig om 'n oplossing te vind."
+msgstr "Webwerfsoektog is tydelik onbeskikbaar. Ons is besig om 'n oplossing te vind."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18299,8 +18282,7 @@ msgstr "Iets het skeefgeloop"
 #. Error message indicating that the user's settings weren't able to be saved.
 msgctxt "cloudsave"
 msgid "Something went wrong saving to the server, please try again."
-msgstr ""
-"Iets het skeefgeloop toe na die bediener gestoor is; probeer asseblief weer."
+msgstr "Iets het skeefgeloop toe na die bediener gestoor is; probeer asseblief weer."
 
 # smartling.placeholder_format=C
 #. Body copy displayed under the Set Up Now button when the sync setup call fails.
@@ -18332,8 +18314,7 @@ msgstr "Soms"
 #. Generic error message shown when the image generation model cannot process the user's request.
 msgctxt "Error message from the image generation model"
 msgid "Sorry I can't help, please describe your image in a different way."
-msgstr ""
-"Jammer, ek kan nie help nie. Beskryf asseblief jou beeld op ’n ander manier."
+msgstr "Jammer, ek kan nie help nie. Beskryf asseblief jou beeld op ’n ander manier."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -18390,8 +18371,8 @@ msgstr ""
 msgid ""
 "Sorry, we couldn't generate a richer answer. You can try asking Duck.ai."
 msgstr ""
-"Jammer, ons kon nie 'n ryker antwoord genereer nie. Jy kan probeer om Duck."
-"ai te vra."
+"Jammer, ons kon nie 'n ryker antwoord genereer nie. Jy kan probeer om "
+"Duck.ai te vra."
 
 # smartling.placeholder_format=C
 #. Inform the users that "something" went wrong and that they could try to refresh the page to resolve the error. Placeholders are for markup, please ignore.
@@ -18407,8 +18388,7 @@ msgstr ""
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr ""
-"Jammer, ons kon nie jou terugvoer indien nie. Probeer asseblief weer later."
+msgstr "Jammer, ons kon nie jou terugvoer indien nie. Probeer asseblief weer later."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -18890,18 +18870,20 @@ msgstr "Stel 'n titel vir 'n blogplasing voor"
 msgctxt "Page suggestion prompt"
 msgid "Suggest related articles or topics worth exploring next."
 msgstr ""
+"Stel verwante artikels of onderwerpe voor wat die moeite werd is om volgende "
+"te ondersoek."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Suggest related articles to explore"
-msgstr ""
+msgstr "Stel verwante artikels voor om te lees"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Suggest some alternatives to this product."
-msgstr ""
+msgstr "Stel ’n paar alternatiewe vir hierdie produk voor."
 
 # smartling.placeholder_format=C
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
@@ -18918,7 +18900,7 @@ msgstr "Voorstelle:"
 #. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Sum up the reviews"
-msgstr ""
+msgstr "Som die resensies op"
 
 # smartling.placeholder_format=C
 #. A short title for the a message asking the AI to summarize a text.
@@ -18930,85 +18912,85 @@ msgstr "Som op"
 #. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize the Q&As"
-msgstr ""
+msgstr "Vat die Vrae en Antwoorde saam"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the background and notable work of this person."
-msgstr ""
+msgstr "Som hierdie persoon se agtergrond en noemenswaardige werk op."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the key details of this event."
-msgstr ""
+msgstr "Som die belangrikste besonderhede van hierdie gebeurtenis op."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the questions and answers on this page."
-msgstr ""
+msgstr "Som die vrae en antwoorde op hierdie bladsy op."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize their background"
-msgstr ""
+msgstr "Som hul agtergrond op"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this book"
-msgstr ""
+msgstr "Som hierdie boek op"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this book."
-msgstr ""
+msgstr "Som hierdie boek op."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this discussion"
-msgstr ""
+msgstr "Som hierdie bespreking op"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this discussion thread."
-msgstr ""
+msgstr "Som hierdie besprekingsrygdraad op."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this page"
-msgstr ""
+msgstr "Som hierdie bladsy op"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this page."
-msgstr ""
+msgstr "Som hierdie bladsy op."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this video"
-msgstr ""
+msgstr "Som hierdie video op"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this video."
-msgstr ""
+msgstr "Som hierdie video op."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize what the reviews say."
-msgstr ""
+msgstr "Som op wat die resensies sê."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -19225,8 +19207,7 @@ msgstr "Sync & Backup is geaktiveer!"
 #. Notice shown under the recovery code explaining that backup data has an inactivity expiration.
 msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
-msgstr ""
-"Sync & Backup-data kan nie herwin word ná 18 maande van onaktiwiteit nie."
+msgstr "Sync & Backup-data kan nie herwin word ná 18 maande van onaktiwiteit nie."
 
 # smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
@@ -19275,8 +19256,8 @@ msgid ""
 msgstr ""
 "Sinkronisasieherstelkode\n"
 "\n"
-"Die herstelkode stel jou in staat om jou wagwoorde, outovuldata en Duck.ai-"
-"kletsgesprekke oor verskillende toestelle te sinkroniseer, en jou "
+"Die herstelkode stel jou in staat om jou wagwoorde, outovuldata en "
+"Duck.ai-kletsgesprekke oor verskillende toestelle te sinkroniseer, en jou "
 "gesinkroniseerde data terug te kry as jy toegang tot ’n toestel verloor.\n"
 "\n"
 "Hou hierdie inligting veilig en seker.\n"
@@ -19339,7 +19320,7 @@ msgstr "Sirië"
 #. Text for a button that enables the theme to follow the operating system's color scheme preference.
 msgctxt "System theme button for theme selector"
 msgid "System"
-msgstr ""
+msgstr "Stelsel"
 
 # smartling.placeholder_format=C
 #. Abbreviation indicating this is the total score for a game
@@ -19373,7 +19354,7 @@ msgstr "Tahitiaans"
 #. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Tailor my resume"
-msgstr ""
+msgstr "Pas my CV aan"
 
 # smartling.placeholder_format=C
 msgid "Taiwan"
@@ -19410,6 +19391,8 @@ msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
+"Voltooi hierdie anonieme opname om ons te laat weet hoe ons Duck.ai beter "
+"kan maak."
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -19658,8 +19641,7 @@ msgstr "Die aangehegte lêers oorskry die totale groottelimiet van %1$s MB."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the server rejects corrupt or unrecognized audio.
 msgid "The audio could not be processed. Please try recording again."
-msgstr ""
-"Die klank kon nie verwerk word nie. Probeer asseblief om weer op te neem."
+msgstr "Die klank kon nie verwerk word nie. Probeer asseblief om weer op te neem."
 
 # smartling.placeholder_format=C
 #. Second paragraph explaining where the encryption key is stored on the entry screen.
@@ -19684,8 +19666,7 @@ msgstr ""
 #. Description explaining that the AI model provider does not store any chat data on their servers.
 msgctxt "Privacy claim description in Duck.ai chat"
 msgid "The model provider does not save this chat on their servers."
-msgstr ""
-"Die modelverskaffer stoor nie hierdie kletsgesprek op die bedieners nie."
+msgstr "Die modelverskaffer stoor nie hierdie kletsgesprek op die bedieners nie."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers.
@@ -19723,7 +19704,7 @@ msgstr "Tema"
 #. Text for the theme selector label that allows users to switch between Light and dark theme.
 msgctxt "Label for the theme selector feature"
 msgid "Theme"
-msgstr ""
+msgstr "Tema"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/LpFhb1e.png
@@ -19776,8 +19757,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Error message for explore more questions when a retryable error occurs (timeout, network)
 msgid "There's been an issue loading this answer. Please try again."
-msgstr ""
-"Daar was 'n probleem met die laai van hierdie antwoord. Probeer gerus weer."
+msgstr "Daar was 'n probleem met die laai van hierdie antwoord. Probeer gerus weer."
 
 # smartling.placeholder_format=C
 #. Instant Answer Tab Name
@@ -19849,8 +19829,7 @@ msgstr ""
 #. Appears below a type of search results called 'Instant Answers'
 msgctxt "attribution"
 msgid "This Instant Answer was made by the %sDuckDuckHack%s Community."
-msgstr ""
-"Hierdie kitsantwoord is deur die %1$sDuckDuckHack%2$s-gemeenskap geskep."
+msgstr "Hierdie kitsantwoord is deur die %1$sDuckDuckHack%2$s-gemeenskap geskep."
 
 # smartling.placeholder_format=C
 #. Label for the monthly usage row in the Usage section of Duck.ai settings.
@@ -19939,8 +19918,7 @@ msgctxt ""
 "Error message when an uploaded file type is not supported, with list ending "
 "in or"
 msgid "This file type is not supported, please attach a %s or %s"
-msgstr ""
-"Hierdie lêertipe word nie gesteun nie, heg asseblief 'n %1$s of %2$s aan"
+msgstr "Hierdie lêertipe word nie gesteun nie, heg asseblief 'n %1$s of %2$s aan"
 
 # smartling.placeholder_format=C
 #. Error message for unsupported file type when multiple types are accepted. First placeholder is a comma-separated list of all accepted types except the last (e.g. PNG, JPG, WebP, GIF). Second placeholder is the last accepted type (e.g. PDF). Full example: This file type is not supported, please attach a PNG, JPG, WebP, GIF or PDF
@@ -19948,8 +19926,7 @@ msgctxt ""
 "Error message when an uploaded file type is not supported, with list ending "
 "in or"
 msgid "This file type is not supported, please attach a %s or %s."
-msgstr ""
-"Hierdie lêertipe word nie gesteun nie; heg asseblief 'n %1$s of %2$s aan."
+msgstr "Hierdie lêertipe word nie gesteun nie; heg asseblief 'n %1$s of %2$s aan."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to upload an unsupported file type and we know which types are accepted. Placeholder is a single accepted type. E.g. This file type is not supported, please attach a PDF
@@ -20044,8 +20021,7 @@ msgstr "Hierdie bladsy vereis Javascript om te funksioneer."
 #. Information tooltip text explaining that the current page's content will be included with the chat message.
 msgctxt "Tooltip explaining that page content will be sent to Duck.ai"
 msgid "This page's content will be sent with your message to Duck.ai"
-msgstr ""
-"Hierdie bladsy se inhoud sal saam met jou boodskap na Duck.ai gestuur word."
+msgstr "Hierdie bladsy se inhoud sal saam met jou boodskap na Duck.ai gestuur word."
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -20076,8 +20052,9 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again."
 msgstr ""
-"Hierdie instelling word in jou blaaier gestoor, wat beteken as jy duckduckgo."
-"com-blaaierdata skoonmaak, kan jy dalk weer KI-gesteunde antwoorde sien."
+"Hierdie instelling word in jou blaaier gestoor, wat beteken as jy "
+"duckduckgo.com-blaaierdata skoonmaak, kan jy dalk weer KI-gesteunde "
+"antwoorde sien."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -20087,10 +20064,10 @@ msgid ""
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
 msgstr ""
-"Hierdie instelling word in jou blaaier gestoor, wat beteken as jy duckduckgo."
-"com-blaaierdata skoonmaak, kan jy dalk weer KI-gesteunde antwoorde sien. Ons "
-"het egter ook 'n beginbladsy wat nooit KI-gesteunde antwoorde by %1$s wys "
-"nie."
+"Hierdie instelling word in jou blaaier gestoor, wat beteken as jy "
+"duckduckgo.com-blaaierdata skoonmaak, kan jy dalk weer KI-gesteunde "
+"antwoorde sien. Ons het egter ook 'n beginbladsy wat nooit KI-gesteunde "
+"antwoorde by %1$s wys nie."
 
 # smartling.placeholder_format=C
 #. User feedback indicating that a translation is helpful
@@ -20161,8 +20138,7 @@ msgstr "Dit sal alle instellings wis. Gaan voort?"
 #. Confirmation message asking if the user is sure they want to reset all of their settings.
 msgctxt "settings"
 msgid "This will reset your saved settings to default values. Continue?"
-msgstr ""
-"Dit sal jou bewaarde instellings na die verstekwaardes terugstel. Gaan voort?"
+msgstr "Dit sal jou bewaarde instellings na die verstekwaardes terugstel. Gaan voort?"
 
 # smartling.placeholder_format=C
 #. Golf leaderboard column: holes completed in current round
@@ -20275,8 +20251,7 @@ msgstr "Om voort te gaan, moet jy instem tot Duck.ai se %1$s en %2$s"
 msgctxt ""
 "Copy stating agreement to AI Chat Privacy Policy and Terms of Service."
 msgid "To continue, you must agree to DuckDuckGo AI Chat’s %s and %s"
-msgstr ""
-"Om voort te gaan, moet jy instem tot DuckDuckGo AI Chat se %1$s en %2$s"
+msgstr "Om voort te gaan, moet jy instem tot DuckDuckGo AI Chat se %1$s en %2$s"
 
 # smartling.placeholder_format=C
 #. Instructions for how to print driving directions.
@@ -20308,8 +20283,8 @@ msgid ""
 "To transfer your chat history to Duck.ai, please update your DuckDuckGo "
 "browser to the latest version and try again."
 msgstr ""
-"Om jou kletsgeskiedenis na Duck.ai oor te dra, werk asseblief jou DuckDuckGo-"
-"blaaier by tot die nuutste weergawe en probeer weer."
+"Om jou kletsgeskiedenis na Duck.ai oor te dra, werk asseblief jou "
+"DuckDuckGo-blaaier by tot die nuutste weergawe en probeer weer."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
@@ -20574,13 +20549,13 @@ msgstr ""
 #. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Translate this page"
-msgstr ""
+msgstr "Vertaal hierdie bladsy"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
 msgctxt "Page suggestion prompt"
 msgid "Translate this page into %s."
-msgstr ""
+msgstr "Vertaal hierdie bladsy na %1$s."
 
 # smartling.placeholder_format=C
 #. Placeholder text for a region that will display translated text.
@@ -20727,7 +20702,7 @@ msgstr "Probeer gratis"
 #. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
 msgctxt "settings"
 msgid "Try It Now"
-msgstr ""
+msgstr "Probeer dit nou"
 
 # smartling.placeholder_format=C
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -20800,8 +20775,7 @@ msgstr "Probeer om anonieme ligging te aktiveer vir meer akkurate resultate."
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr ""
-"Probeer eksperimenteer met elke model – hulle sal verskillende antwoorde gee."
+msgstr "Probeer eksperimenteer met elke model – hulle sal verskillende antwoorde gee."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
@@ -20973,6 +20947,8 @@ msgid ""
 "Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
+"Probeer jy om KI-funksies te deaktiveer? Installeer die %1$sDuckDuckGo No "
+"AI%2$s-soekuitbreiding om jou instellings te onthou. %3$sKom meer te wete%4$s"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -20981,6 +20957,8 @@ msgid ""
 "Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
+"Probeer jy om KI-funksies te deaktiveer? Skakel oor na die %1$sDuckDuckGo No "
+"AI%2$s-soekuitbreiding om jou instellings te onthou. %3$sKom meer te wete%4$s"
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -21087,8 +21065,7 @@ msgstr "Skakel %1$s\"Presiese Ligging\"%2$s aan vir meer akkurate resultate"
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
-msgstr ""
-"Skakel Duck Player aan om YouTube te kyk sonder geteikende advertensies"
+msgstr "Skakel Duck Player aan om YouTube te kyk sonder geteikende advertensies"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service.
@@ -21293,14 +21270,13 @@ msgstr ""
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
 msgstr ""
-"Onder %1$sAan die begin%2$s, kies %3$sTuisblad%4$s en voer in https://"
-"duckduckgo.com"
+"Onder %1$sAan die begin%2$s, kies %3$sTuisblad%4$s en voer in "
+"https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sOpen with%s select %sA specific page or pages%s"
-msgstr ""
-"Onder %1$sMaak oop met%2$s, kies %3$s’n spesifieke bladsy of bladsye%4$s"
+msgstr "Onder %1$sMaak oop met%2$s, kies %3$s’n spesifieke bladsy of bladsye%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -21327,8 +21303,7 @@ msgstr "Onder %1$sSoek%2$s-afdeling, klik %3$sBestuur soekenjins …%4$s"
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under On startup select %sOpen a specific page or set of pages%s"
-msgstr ""
-"Onder Aan die begin, kies %1$sMaak ’n spesifieke blad of stel blaaie oop%2$s"
+msgstr "Onder Aan die begin, kies %1$sMaak ’n spesifieke blad of stel blaaie oop%2$s"
 
 #  Opera default search engine instruction
 # smartling.placeholder_format=C
@@ -21434,8 +21409,7 @@ msgstr "Ontsluit met 'n DuckDuckGo-intekening"
 msgctxt "voice chat limit modal"
 msgid ""
 "Unlock advanced AI models and higher limits with a DuckDuckGo Subscription"
-msgstr ""
-"Ontsluit gevorderde KI-modelle en hoër limiete met 'n DuckDuckGo-intekening"
+msgstr "Ontsluit gevorderde KI-modelle en hoër limiete met 'n DuckDuckGo-intekening"
 
 # smartling.placeholder_format=C
 #. Text informing the user that advanced AI models can be unlocked with a subscription. The variable is used to insert a link that opens the subscription modal. Example: Unlock advanced AI models with a DuckDuckGo subscription.
@@ -21486,8 +21460,7 @@ msgstr "Onbevestigde inligting"
 #. Text explaining the limit on the number of recent chats that can be stored. Example: 'Up to 30 of your most recent chats can be saved at a time.'
 msgctxt "Information about the limit of recent chats that can be saved"
 msgid "Up to %s of your most recent chats can be saved at a time."
-msgstr ""
-"Tot en met %1$s van jou mees onlangse kletse kan op 'n slag gestoor word."
+msgstr "Tot en met %1$s van jou mees onlangse kletse kan op 'n slag gestoor word."
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -21734,7 +21707,7 @@ msgstr "Uruguay"
 #. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
 msgctxt "Navigation label on the Duck.ai settings page"
 msgid "Usage"
-msgstr ""
+msgstr "Gebruik"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -21965,8 +21938,7 @@ msgstr "Bekyk pryse vir jou verblyf"
 # smartling.placeholder_format=C
 #. A description for the ads tooltip that explains that viewing ads is privacy protected by DuckDuckGo.
 msgid "Viewing ads is privacy protected by DuckDuckGo."
-msgstr ""
-"Jou privaatheid word deur DuckDuckGo beskerm as jy na advertensies kyk."
+msgstr "Jou privaatheid word deur DuckDuckGo beskerm as jy na advertensies kyk."
 
 # smartling.placeholder_format=C
 msgctxt "Ads GDPR, internal use only. Do not change"
@@ -22016,8 +21988,7 @@ msgctxt "mobile promotion on desktop"
 msgid ""
 "Visit %sDuckDuckGo.com%s on your tablet or phone and follow the provided "
 "instructions."
-msgstr ""
-"Besoek %1$sDuckDuckGo.com%2$s op jou tablet of foon en volg die aanwysings."
+msgstr "Besoek %1$sDuckDuckGo.com%2$s op jou tablet of foon en volg die aanwysings."
 
 # smartling.placeholder_format=C
 #. Primary button to visit Duck.ai.
@@ -22068,9 +22039,9 @@ msgid ""
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
 msgstr ""
-"Besoek Duck.ai in jou ander blaaier of die DuckDuckGo-app en maak Duck.ai-"
-"instellings oop. Kies “Skakel aan” onder Sync & Backup en kies “Sinkroniseer "
-"met ’n ander toestel”. Of skandeer die QR op jou Herstel-PDF."
+"Besoek Duck.ai in jou ander blaaier of die DuckDuckGo-app en maak "
+"Duck.ai-instellings oop. Kies “Skakel aan” onder Sync & Backup en kies "
+"“Sinkroniseer met ’n ander toestel”. Of skandeer die QR op jou Herstel-PDF."
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -22188,7 +22159,7 @@ msgstr "Wallis"
 #. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Walk me through the steps"
-msgstr ""
+msgstr "Lei my deur die stappe"
 
 # smartling.placeholder_format=C
 #. Label for walking directions on a map.
@@ -22318,6 +22289,9 @@ msgid ""
 "please share this conversation with DuckDuckGo so we can investigate and "
 "address the issue."
 msgstr ""
+"Ons kan slegs regmaak wat ons kan sien. Om ’n skadelike of onwettige "
+"antwoord aan te meld, deel asseblief hierdie gesprek met DuckDuckGo sodat "
+"ons die probleem kan ondersoek en aanspreek."
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -22366,8 +22340,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don't store your personal info or track you. Ever."
-msgstr ""
-"Ons bewaar nie jou persoonlike inligting, of spoor jou na nie. Nooit nie."
+msgstr "Ons bewaar nie jou persoonlike inligting, of spoor jou na nie. Nooit nie."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -22585,8 +22558,7 @@ msgctxt "duckai_migration"
 msgid ""
 "We're sorry for this inconvenience. We’re working hard to make your "
 "experience better."
-msgstr ""
-"Ons is jammer vir die ongerief. Ons werk hard om jou ervaring te verbeter."
+msgstr "Ons is jammer vir die ongerief. Ons werk hard om jou ervaring te verbeter."
 
 # smartling.placeholder_format=C
 #. Body text explaining the service update requires a page reload.
@@ -22836,8 +22808,7 @@ msgstr ""
 #. Text for a prompt suggestion for considering factors when purchasing a computer monitor.
 msgctxt "Full sentence for preparing for a purchase"
 msgid "What are some factors to consider when purchasing a computer monitor?"
-msgstr ""
-"Wat is 'n paar faktore om te oorweeg vir die aankoop van 'n rekenaarmonitor?"
+msgstr "Wat is 'n paar faktore om te oorweeg vir die aankoop van 'n rekenaarmonitor?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for asking about must-see attractions in Paris for a first-time visitor.
@@ -22875,107 +22846,108 @@ msgid ""
 "experience."
 msgstr ""
 "Wat is die voordele daarvan om die DuckDuckGo-blaaier af te laai vir iemand "
-"wat belangstel om Duck.ai te gebruik? Verwys slegs na amptelike DuckDuckGo-"
-"bronne. Verdeel die antwoord in duidelike afdelings met titels, met ’n fokus "
-"op Duck.ai-integrasies en privaatheidsbeskerming. Hou dit kort, eenvoudig en "
-"maklik om te verstaan vir mense met of sonder veel KI- of tegniese ervaring."
+"wat belangstel om Duck.ai te gebruik? Verwys slegs na amptelike "
+"DuckDuckGo-bronne. Verdeel die antwoord in duidelike afdelings met titels, "
+"met ’n fokus op Duck.ai-integrasies en privaatheidsbeskerming. Hou dit kort, "
+"eenvoudig en maklik om te verstaan vir mense met of sonder veel KI- of "
+"tegniese ervaring."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the counterarguments?"
-msgstr ""
+msgstr "Wat is die teenargumente?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the hours & location?"
-msgstr ""
+msgstr "Wat is die tye en ligging?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key contributions of this paper?"
-msgstr ""
+msgstr "Wat is die belangrikste bydraes van hierdie artikel?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key contributions?"
-msgstr ""
+msgstr "Wat is die belangrikste bydraes?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key details?"
-msgstr ""
+msgstr "Wat is die belangrikste besonderhede?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key points covered in this video?"
-msgstr ""
+msgstr "Wat is die kernpunte wat in hierdie video gedek word?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key points?"
-msgstr ""
+msgstr "Wat is die belangrikste punte?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key takeaways from this article?"
-msgstr ""
+msgstr "Wat is die belangrikste idees om te onthou van hierdie artikel?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key takeaways?"
-msgstr ""
+msgstr "Wat is die belangrikste idees?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key things I will learn from this course?"
-msgstr ""
+msgstr "Wat is die belangrikste dinge wat ek uit hierdie kursus gaan leer?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the main counterarguments or criticisms of this?"
-msgstr ""
+msgstr "Wat is die vernaamste teenargumente of kritiek van dit?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the main questions this page answers?"
-msgstr ""
+msgstr "Wat is die hoofvrae wat hierdie bladsy beantwoord?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the must-try dishes here?"
-msgstr ""
+msgstr "Wat is die beste geregte wat jy hier kan probeer?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid ""
 "What are the opening hours, location, and contact details for this place?"
-msgstr ""
+msgstr "Wat is die openingstye, ligging en kontakbesonderhede van hierdie plek?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the pros and cons of this product?"
-msgstr ""
+msgstr "Wat is die voor- en nadele van hierdie produk?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the pros and cons?"
-msgstr ""
+msgstr "Wat is die voor- en nadele?"
 
 # smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
@@ -23081,7 +23053,7 @@ msgstr "Wat beteken \"atria\" in die konteks van 'n mediese artikel?"
 #. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What does this answer?"
-msgstr ""
+msgstr "Wat beantwoord dit?"
 
 # smartling.placeholder_format=C
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
@@ -23099,7 +23071,7 @@ msgstr "Watter inligting word gestoor?"
 #. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What interview questions might come up for this role?"
-msgstr ""
+msgstr "Watter onderhoudsvrae gaan moontlik gevra word oor hierdie rol?"
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -23108,8 +23080,8 @@ msgid ""
 "What is the Cloud Save bookmarklet and how does it differ from the URL "
 "parameter bookmarklet?"
 msgstr ""
-"Wat is die Cloud Save-boekmerkie en hoe verskil dit van die URL parameter-"
-"boekmerkie?"
+"Wat is die Cloud Save-boekmerkie en hoe verskil dit van die URL "
+"parameter-boekmerkie?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for looking up the capital city of Albania.
@@ -23121,7 +23093,7 @@ msgstr "Wat is die hoofstad van Albanië?"
 #. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What is the overall verdict and rating for this?"
-msgstr ""
+msgstr "Wat is die algehele uitspraak en evaluering hiervoor?"
 
 # smartling.placeholder_format=C
 #. Link to a page with additional information.
@@ -23149,7 +23121,7 @@ msgstr "Wat mense te sê het:"
 #. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What should I order?"
-msgstr ""
+msgstr "Wat moet ek bestel?"
 
 # smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
@@ -23167,13 +23139,13 @@ msgstr "Wat was fout met die antwoord? (opsioneel)"
 #. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What will I learn?"
-msgstr ""
+msgstr "Wat gaan ek leer?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What will I need?"
-msgstr ""
+msgstr "Wat sal ek nodig hê?"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -23198,7 +23170,7 @@ msgstr "Wat is nuut"
 #. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What's the verdict?"
-msgstr ""
+msgstr "Wat is die uitspraak?"
 
 # smartling.placeholder_format=C
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -23218,8 +23190,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "When enabled, Duck.ai will show instant answers in the chat."
-msgstr ""
-"Wanneer dit geaktiveer is, sal Duck.ai kitsantwoorde in die kletsgesprek wys."
+msgstr "Wanneer dit geaktiveer is, sal Duck.ai kitsantwoorde in die kletsgesprek wys."
 
 # smartling.placeholder_format=C
 #. Text of a button that performs a search for the available streaming services that show a particular movie or tv show
@@ -23255,7 +23226,7 @@ msgstr "Watter kenmerke ontbreek? (Opsioneel)"
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Which features are missing? (optional)"
-msgstr ""
+msgstr "Watter funksionaliteite ontbreek? (opsioneel)"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
@@ -23277,13 +23248,13 @@ msgstr "Wie ons is"
 #. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Who are the main cast and crew, and what else are they known for?"
-msgstr ""
+msgstr "Wie is die hoofrolspelers en span, en waarvoor is hulle nog bekend?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Who is this person?"
-msgstr ""
+msgstr "Wie is hierdie persoon?"
 
 # smartling.placeholder_format=C
 #. Header above a collection of privacy-related links.
@@ -23654,8 +23625,7 @@ msgstr "Ja, nuwe gebruiker!"
 msgctxt "cloudsave"
 msgid ""
 "Yes, we throw away data when you’re done with it, and it cannot be recovered."
-msgstr ""
-"Ja, ons gooi data weg as jy daarmee klaar is en dit kan nie herwin word nie."
+msgstr "Ja, ons gooi data weg as jy daarmee klaar is en dit kan nie herwin word nie."
 
 # smartling.placeholder_format=C
 #. Option for the filter-by-date search.
@@ -23715,8 +23685,7 @@ msgstr ""
 
 # smartling.placeholder_format=C
 msgid "You can also use %sDuck.ai%s to answer questions or summarize text."
-msgstr ""
-"Jy kan ook %1$sDuck.ai%2$s gebruik om vrae te beantwoord of teks op te som."
+msgstr "Jy kan ook %1$sDuck.ai%2$s gebruik om vrae te beantwoord of teks op te som."
 
 # smartling.placeholder_format=C
 msgid ""
@@ -23778,8 +23747,7 @@ msgstr "Jykan hierdie herinnering verberg by %1$sSoekinstellings%2$s"
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
-msgstr ""
-"Jy kan nou tot 100 kletsgesprekke op hierdie toestel stoor. Gesels gerus!"
+msgstr "Jy kan nou tot 100 kletsgesprekke op hierdie toestel stoor. Gesels gerus!"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -23873,8 +23841,7 @@ msgstr "Jy kan oor begin op hierdie nuwe domein (duck.ai)."
 #. Text explaining the benefits of the cloud save feature.
 msgctxt "cloudsave"
 msgid "You can store several sets of settings for different purposes."
-msgstr ""
-"Jy kan verskillende stelle instellings stoor vir verskillende doeleindes."
+msgstr "Jy kan verskillende stelle instellings stoor vir verskillende doeleindes."
 
 # smartling.placeholder_format=C
 #. Instructions for user once they've failed the bot challenge
@@ -23949,8 +23916,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
 msgid "You won't see this message again unless you clear your browser data."
-msgstr ""
-"Jy sal hierdie boodskap nie weer sien nie tensy jy jou blaaierdata skoonmaak."
+msgstr "Jy sal hierdie boodskap nie weer sien nie tensy jy jou blaaierdata skoonmaak."
 
 # smartling.placeholder_format=C
 #. The second paragraph of a pop up where we explain how to update the browser manually.
@@ -24042,8 +24008,7 @@ msgstr "Jy het die maksimum stemkletsduur vir een sessie bereik."
 msgctxt "voice chat limit modal"
 msgid ""
 "You've reached the voice chat limit for today. Please try again tomorrow."
-msgstr ""
-"Jy het die stemkletslimiet vir vandag bereik. Probeer asseblief weer môre."
+msgstr "Jy het die stemkletslimiet vir vandag bereik. Probeer asseblief weer môre."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
@@ -24209,8 +24174,7 @@ msgstr ""
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never used to train AI models"
-msgstr ""
-"Jou geselsies is privaat en word nooit gebruik om KI-modelle op te lei nie"
+msgstr "Jou geselsies is privaat en word nooit gebruik om KI-modelle op te lei nie"
 
 # smartling.placeholder_format=C
 #. Text for a description of the active privacy protection for DuckDuckGo's AI Chat feature.
@@ -24218,8 +24182,8 @@ msgctxt "Active Privacy protection description"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
 msgstr ""
-"Jou geselsies is privaat, word deur ons geanonimiseer en nie gebruik om KI-"
-"modelle op te lei nie."
+"Jou geselsies is privaat, word deur ons geanonimiseer en nie gebruik om "
+"KI-modelle op te lei nie."
 
 # smartling.placeholder_format=C
 #. Text explaining that user chats are private and not used for AI (Artificial Intelligence) training.
@@ -24227,8 +24191,8 @@ msgctxt "Body text for privacy protection modal"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
 msgstr ""
-"Jou geselsies is privaat, word deur ons geanonimiseer en nie gebruik om KI-"
-"modelle op te lei nie."
+"Jou geselsies is privaat, word deur ons geanonimiseer en nie gebruik om "
+"KI-modelle op te lei nie."
 
 # smartling.placeholder_format=C
 #. Text for a menu item that describes the privacy protection feature.
@@ -24320,8 +24284,7 @@ msgctxt ""
 "Subtitle of the one-time popover shown above the thumbs up/down buttons on "
 "an AI response"
 msgid "Your feedback is anonymized and not used to train AI."
-msgstr ""
-"Jou terugvoer word geanonimiseer en word nie gebruik om KI op te lei nie."
+msgstr "Jou terugvoer word geanonimiseer en word nie gebruik om KI op te lei nie."
 
 # smartling.placeholder_format=C
 #. Explains that the User's Location is always private to DuckDuckGo.
@@ -24350,8 +24313,8 @@ msgid ""
 "browser. We save the settings file using the key as the name. DuckDuckGo "
 "never knows your passphrase."
 msgstr ""
-"Jou kenfrase skep 'n 512-bissleutel deur middel van die Secure Hash-"
-"algoritme, ook bekend as %1$sSHA-2%2$s. Slegs die sleutel en gekoppelde "
+"Jou kenfrase skep 'n 512-bissleutel deur middel van die Secure "
+"Hash-algoritme, ook bekend as %1$sSHA-2%2$s. Slegs die sleutel en gekoppelde "
 "instellingslêer verlaat jou blaaier. Ons stoor die instellingslêer deur die "
 "sleutel as naam te gebruik. DuckDuckGo ken nooit jou kenfrase nie."
 
@@ -24566,8 +24529,7 @@ msgstr "deur %1$s"
 #. Trust line shown at the bottom of the explainer panel, summarizing DuckDuckGo's reputation for online protection.
 msgctxt "Footer banner text in the How Duck.ai Works panel"
 msgid "by DuckDuckGo — online protection trusted by millions every day."
-msgstr ""
-"deur DuckDuckGo – aanlyn beskerming wat elke dag deur miljoene vertrou word."
+msgstr "deur DuckDuckGo – aanlyn beskerming wat elke dag deur miljoene vertrou word."
 
 # smartling.placeholder_format=C
 #. An abreviated unit of time indicating an age, e.g. "2d"

--- a/locales/ar_DZ/LC_MESSAGES/duckduckgo.po
+++ b/locales/ar_DZ/LC_MESSAGES/duckduckgo.po
@@ -1160,6 +1160,11 @@ msgctxt "feedback form"
 msgid "Address is incorrect"
 msgstr ""
 
+#. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Adjust the servings"
+msgstr ""
+
 #. as in multiple advertisements
 msgid "Ads"
 msgstr ""
@@ -1331,6 +1336,13 @@ msgstr ""
 #. Heading shown on the empty chat screen. The text between the two %s markers is displayed inside a clickable privacy button. First %s renders a shield icon, second %s is an invisible end marker. Keep the word 'private' between both %s markers.
 msgctxt "Empty state heading in Duck.ai chat mode"
 msgid "All chats are %sprivate%s"
+msgstr ""
+
+#. Paragraph in the Privacy & Terms section of the About & Legal page in Duck.ai settings, summarizing how chats are anonymized and are not stored or used to train chat models.
+msgctxt "Privacy & Terms section description on the Duck.ai settings page"
+msgid ""
+"All chats are anonymized by DuckDuckGo, and your conversations are not used "
+"to train chat models by DuckDuckGo or the model providers"
 msgstr ""
 
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1543,6 +1555,12 @@ msgstr ""
 #. Confirmation message after location service is enabled.
 msgctxt "precise_user_location"
 msgid "Anonymous location enabled"
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Anonymously generates answers for search queries based on web content. "
+"Choose how often you want it to appear, or disable it completely."
 msgstr ""
 
 #. Instant Answer tab name
@@ -1765,6 +1783,11 @@ msgstr ""
 
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse
 msgid "Ask a follow-up with Duck.ai"
+msgstr ""
+
+#. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
+msgctxt "Page suggestion chip label"
+msgid "Ask about this page"
 msgstr ""
 
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2089,6 +2112,11 @@ msgstr ""
 msgid "Barcode"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Based on this page, is this course worth taking?"
+msgstr ""
+
 msgctxt "settings"
 msgid "Basic"
 msgstr "أساسي"
@@ -2120,6 +2148,13 @@ msgstr ""
 #. Placeholder text displayed while the assistant waits for the user to choose an action.
 msgctxt "Assistant response placeholder"
 msgid "Before continuing..."
+msgstr ""
+
+#. Explains that before storing the report, DuckDuckGo will anonymize the conversation by removing PII like names, email addresses, and identifying metadata.
+msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
+msgid ""
+"Before storing this report, DuckDuckGo will anonymize your conversation by "
+"removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
 #. Label that's displayed next to a past start date below a web search result.
@@ -2378,6 +2413,11 @@ msgstr "البرازيل"
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Break Points Won"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Break this down into clear, numbered steps."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -2737,6 +2777,11 @@ msgstr "الوظائف"
 #. Text of a button that performs a search for the cast of a particular movie or tv show
 msgctxt "Movie/TV Show Title instant answer"
 msgid "Cast"
+msgstr ""
+
+#. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Cast & Crew"
 msgstr ""
 
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -4086,6 +4131,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Create a shopping list with quantities from this recipe."
+msgstr ""
+
 #. Placeholder text displayed in the input field when starting a new image generation session.
 msgctxt "Placeholder text for the image generation input field"
 msgid "Create an image of a cute duck..."
@@ -4612,6 +4662,10 @@ msgstr ""
 msgid "Dictation limit reached"
 msgstr ""
 
+#. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
+msgid "Dictation temporarily unavailable"
+msgstr ""
+
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
@@ -4856,6 +4910,20 @@ msgctxt "precise_user_location"
 msgid "Done"
 msgstr ""
 
+#. Message shown in a modal after DuckDuckGo browser users disable AI features in Settings. The first two placeholders bold noai.duckduckgo.com. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
+"filtered out. %sLearn More%s"
+msgstr ""
+
+#. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
+"and AI images filtered out. %sLearn more%s"
+msgstr ""
+
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Double Faults"
@@ -4946,6 +5014,16 @@ msgctxt "Full sentence for writing an email"
 msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
+msgstr ""
+
+#. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Draft a cover letter"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Draft a cover letter for this job."
 msgstr ""
 
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -5085,6 +5163,14 @@ msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
 msgstr ""
 
+#. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
+msgctxt "About section description on the Duck.ai settings page"
+msgid ""
+"Duck.ai is created by DuckDuckGo. We're an independent online protection "
+"company for anyone who wants to take back control of their personal "
+"information."
+msgstr ""
+
 #. Title shown when an update is required before proceeding.
 msgctxt "duckai_migration"
 msgid "Duck.ai is moving domains"
@@ -5118,6 +5204,12 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Duck.ai lets you chat privately with popular AI models. Disabling it hides "
+"Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
 
 msgctxt "settings"
@@ -5889,6 +5981,16 @@ msgstr ""
 msgid "Eritrea"
 msgstr ""
 
+#. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Estimate the nutrition"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Estimate the nutritional information for this recipe."
+msgstr ""
+
 msgid "Estonia"
 msgstr "إستونيا"
 
@@ -5933,10 +6035,50 @@ msgctxt "merchant promotion product ad extension"
 msgid "Expires in 1 day"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain the accepted answer in simple terms."
+msgstr ""
+
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
+msgstr ""
+
+#. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain the top answer"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this in simple, plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this paper"
+msgstr ""
+
+#. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this repo"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this research paper in plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this simply"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain what this repository does and how to use it."
 msgstr ""
 
 #. Label to show if song lyrics contain explicit content
@@ -6165,6 +6307,11 @@ msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
 msgstr ""
 
+msgctxt "settings"
+msgid ""
+"Filters out known AI spam sites from image search results. %sLearn More%s"
+msgstr ""
+
 #. Label for the final score of a sporting event.
 msgid "Final"
 msgstr ""
@@ -6204,6 +6351,11 @@ msgstr ""
 #. Short description shown below the 'Web Search' label in the Tools dropdown.
 msgctxt "Subtitle for the Web Search tool entry in the Tools dropdown menu"
 msgid "Find current information"
+msgstr ""
+
+#. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Find me alternatives"
 msgstr ""
 
 #. Button that searches for results closer to the user's current location.
@@ -6594,6 +6746,11 @@ msgstr ""
 msgid "Generate More"
 msgstr ""
 
+#. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Generate a shopping list"
+msgstr ""
+
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
 msgid "Generate a short answer from the web"
 msgstr ""
@@ -6828,6 +6985,11 @@ msgstr ""
 #. Text for a button inviting users to give it a try for the Duck.ai product. On click, they're taken to the Duck.ai page.
 msgctxt "Onboarding welcome screen button text"
 msgid "Give it a Try"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Give me a quick background on this person."
 msgstr ""
 
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -7190,6 +7352,16 @@ msgstr ""
 
 #. Link to a page with information about sharing DuckDuckGo with friends.
 msgid "Help Spread Privacy"
+msgstr ""
+
+#. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Help me prep for the interview"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Help me tailor my resume for this job."
 msgstr ""
 
 #. Title of a SERP popup that invites users to take a survey (desktop only)
@@ -7609,6 +7781,13 @@ msgstr ""
 #. Text displayed on the button on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
 msgctxt "Onboarding terms screen button text"
 msgid "I Agree"
+msgstr ""
+
+#. Text for the button that takes the user to the external DuckDuckGo login subscription page.
+msgctxt ""
+"Text for the I already have a subscription button in the Duck.ai settings "
+"page"
+msgid "I Already Have a Subscription"
 msgstr ""
 
 #. Text for the button that takes the user to the login subscription page.
@@ -8065,6 +8244,11 @@ msgctxt "Sidemenu browser promo"
 msgid "Install Mac Browser"
 msgstr ""
 
+#. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
+msgctxt "settings"
+msgid "Install Now"
+msgstr ""
+
 #. Text of a button to install the DuckDuckGo app
 msgctxt "Serp footer content"
 msgid "Install Our App"
@@ -8144,9 +8328,36 @@ msgctxt "cloudsave"
 msgid "Is deleted data really deleted?"
 msgstr "هل المعلومات المحذوفة هي حقاً محذوفة؟"
 
+#. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is it worth taking?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this place any good?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"Is this place any good? Summarize its reputation based on reviews and "
+"ratings."
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "Is this video helpful?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this worth watching?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Is this worth watching? Give me a spoiler-free take."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -8643,6 +8854,11 @@ msgstr "بنط الرابط"
 msgid "Links:"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "List the tools, materials, or prerequisites I need for this."
+msgstr ""
+
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
 msgid "Listen"
 msgstr "استـمـع"
@@ -8975,6 +9191,11 @@ msgstr ""
 #. Label for linke navigating to site exclusion feature on Settings page
 msgctxt "Exclusion message manage sites button"
 msgid "Manage blocked sites"
+msgstr ""
+
+#. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
+msgctxt "setting"
+msgid "Manage in Browser Settings"
 msgstr ""
 
 #. Link to the site exclusion settings page
@@ -11276,6 +11497,11 @@ msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
+msgid "Please describe why the chat response is harmful or illegal. (optional)"
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
+msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
 msgstr ""
 
@@ -11294,6 +11520,13 @@ msgctxt "Modal disclaimer text"
 msgid ""
 "Please note: starting a new chat with any model will delete your current "
 "chat session."
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
+msgctxt "Feedback prompt"
+msgid ""
+"Please paste your prompt and the problematic output (with any personal "
+"information removed) and describe why the content is harmful or illegal."
 msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -11678,6 +11911,11 @@ msgctxt "settings"
 msgid "Privacy"
 msgstr ""
 
+#. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
+msgctxt "Section heading on the Duck.ai settings page"
+msgid "Privacy & Terms"
+msgstr ""
+
 msgid "Privacy Blog"
 msgstr ""
 
@@ -11731,6 +11969,11 @@ msgstr ""
 
 #. Text used in other strings to link to the Privacy Policy and Terms of Service content.
 msgctxt "Copy used to compose link in sentences"
+msgid "Privacy Policy and Terms of Service"
+msgstr ""
+
+#. Text for a button that links to the terms of use and privacy policy page.
+msgctxt "Secondary button text in active privacy modal"
 msgid "Privacy Policy and Terms of Service"
 msgstr ""
 
@@ -12139,6 +12382,26 @@ msgctxt "Brief for recommending a book"
 msgid "Recommend a book"
 msgstr ""
 
+#. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar books"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar books."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar movies or shows."
+msgstr ""
+
+#. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar titles"
+msgstr ""
+
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
 msgid "Recording failed. Please try again."
 msgstr ""
@@ -12458,6 +12721,14 @@ msgstr ""
 msgid "Republic of Moldova"
 msgstr ""
 
+#. Note indicating that sharing the conversation is mandatory when reporting harmful or illegal content. Rendered alongside the standard share label (DUCKCHAT_RESPONSE_FEEDBACK_SHARE_PROMPT_RESPONSE_LABEL), not replacing it.
+msgctxt ""
+"Note shown under the share-content switch label on the Duck.ai response "
+"feedback form when the user has selected Harmful or Illegal as the feedback "
+"reason"
+msgid "Required for harmful or illegal reports"
+msgstr ""
+
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
 msgctxt "Description for extended reasoning mode in Duck.ai"
 msgid "Researches before responding"
@@ -12643,6 +12914,11 @@ msgstr "التـعـليـقـات"
 #. Label above a list of customer reviews of a business.
 msgctxt "maps_places"
 msgid "Reviews"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Rewrite this recipe scaled for a different number of servings."
 msgstr ""
 
 msgid "Romania"
@@ -13682,6 +13958,11 @@ msgctxt "Setup button for native sync flow"
 msgid "Set Up Now"
 msgstr ""
 
+#. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
+msgctxt "Encrypted storage setup button shown in native browsers"
+msgid "Set Up Sync & Backup"
+msgstr ""
+
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
 msgctxt "Title for the Sync & Backup intro screen"
 msgid "Set Up Sync & Backup"
@@ -13824,6 +14105,12 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
+msgctxt ""
+"Label beside the share-content switch on the Duck.ai response feedback form"
+msgid "Share this conversation with DuckDuckGo"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -14838,6 +15125,21 @@ msgctxt "Brief for suggesting a blog post title"
 msgid "Suggest a title for a blog post"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest related articles or topics worth exploring next."
+msgstr ""
+
+#. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Suggest related articles to explore"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest some alternatives to this product."
+msgstr ""
+
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
 msgctxt "directions"
 msgid "Suggestions:"
@@ -14847,9 +15149,84 @@ msgctxt "noresults"
 msgid "Suggestions:"
 msgstr ""
 
+#. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Sum up the reviews"
+msgstr ""
+
 #. A short title for the a message asking the AI to summarize a text.
 msgctxt "Title for the summarize message"
 msgid "Summarize"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize the Q&As"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the background and notable work of this person."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the key details of this event."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the questions and answers on this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize their background"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this book"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this book."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this discussion"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this discussion thread."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this video"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this video."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize what the reviews say."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -15106,6 +15483,11 @@ msgstr ""
 msgid "Syria"
 msgstr ""
 
+#. Text for a button that enables the theme to follow the operating system's color scheme preference.
+msgctxt "System theme button for theme selector"
+msgid "System"
+msgstr ""
+
 #. Abbreviation indicating this is the total score for a game
 msgctxt "Sports module"
 msgid "T"
@@ -15129,6 +15511,11 @@ msgctxt "language_name"
 msgid "Tahitian"
 msgstr ""
 
+#. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Tailor my resume"
+msgstr ""
+
 msgid "Taiwan"
 msgstr "تايوان"
 
@@ -15150,6 +15537,12 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "Take control of your personal data!"
+msgstr ""
+
+#. Description for the Feedback section of the Duck.ai settings page, asking the user to take an anonymous survey to let us know how we can make Duck.ai better.
+msgctxt "Feedback section description on the Duck.ai settings page"
+msgid ""
+"Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
 
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -15392,6 +15785,11 @@ msgstr ""
 
 #. Title for the theme menu:
 #. https://duck.co/media/files/theme.png
+msgid "Theme"
+msgstr ""
+
+#. Text for the theme selector label that allows users to switch between Light and dark theme.
+msgctxt "Label for the theme selector feature"
 msgid "Theme"
 msgstr ""
 
@@ -16045,6 +16443,16 @@ msgid ""
 "movie theatre?”"
 msgstr ""
 
+#. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Translate this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
+msgctxt "Page suggestion prompt"
+msgid "Translate this page into %s."
+msgstr ""
+
 #. Placeholder text for a region that will display translated text.
 msgctxt "translations_module"
 msgid "Translation"
@@ -16159,6 +16567,11 @@ msgstr ""
 #. Call-to-action button for the subscription promo in the SERP sidemenu.
 msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
+msgstr ""
+
+#. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
+msgctxt "settings"
+msgid "Try It Now"
 msgstr ""
 
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -16352,6 +16765,20 @@ msgstr "%s حـاول:"
 #. Response a user can select in a feedback form, indicating that they're trying DuckDuckGo again.
 msgctxt "new user poll"
 msgid "Trying DuckDuckGo again"
+msgstr ""
+
+#. Message shown in a modal after supported third-party browser users disable AI features in Settings. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+#. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
 msgstr ""
 
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -16952,6 +17379,11 @@ msgstr ""
 msgid "Uruguay"
 msgstr ""
 
+#. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
+msgctxt "Navigation label on the Duck.ai settings page"
+msgid "Usage"
+msgstr ""
+
 #. A feedback suggestion
 msgctxt "Feedback prompt"
 msgid "Usage limit"
@@ -17300,6 +17732,11 @@ msgstr ""
 msgid "Wales"
 msgstr ""
 
+#. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Walk me through the steps"
+msgstr ""
+
 #. Label for walking directions on a map.
 msgctxt "directions"
 msgid "Walking"
@@ -17390,6 +17827,16 @@ msgstr ""
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
+msgstr ""
+
+#. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
+msgctxt ""
+"Inline warning shown below the share-content toggle when the user selects "
+"Harmful or Illegal but has not enabled sharing"
+msgid ""
+"We can only fix what we can see. To report a harmful or illegal response, "
+"please share this conversation with DuckDuckGo so we can investigate and "
+"address the issue."
 msgstr ""
 
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -17811,6 +18258,87 @@ msgid ""
 "experience."
 msgstr ""
 
+#. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the counterarguments?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the hours & location?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key contributions of this paper?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key contributions?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key details?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key points covered in this video?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key points?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key takeaways from this article?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key takeaways?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key things I will learn from this course?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main counterarguments or criticisms of this?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main questions this page answers?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the must-try dishes here?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"What are the opening hours, location, and contact details for this place?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the pros and cons of this product?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the pros and cons?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
 msgctxt "feedback form"
 msgid "What bothered you most?"
@@ -17894,6 +18422,11 @@ msgctxt "Full sentence for defining a term"
 msgid "What does atria mean in the context of a medical article?"
 msgstr ""
 
+#. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What does this answer?"
+msgstr ""
+
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
@@ -17903,6 +18436,11 @@ msgstr ""
 msgctxt "cloudsave"
 msgid "What information gets saved?"
 msgstr "ما هي المعلومات التي تسجل؟"
+
+#. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What interview questions might come up for this role?"
+msgstr ""
 
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
@@ -17914,6 +18452,11 @@ msgstr ""
 #. Text for a prompt suggestion for looking up the capital city of Albania.
 msgctxt "Full sentence for looking up basic facts"
 msgid "What is the capital city of Albania?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What is the overall verdict and rating for this?"
 msgstr ""
 
 #. Link to a page with additional information.
@@ -17934,6 +18477,11 @@ msgctxt "maps_places"
 msgid "What people say:"
 msgstr ""
 
+#. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What should I order?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
 msgctxt "feedback form"
 msgid "What stood out?"
@@ -17942,6 +18490,16 @@ msgstr ""
 #. Question on a feedback form for a negative feedback response.
 msgctxt "feedback form"
 msgid "What was wrong with the response? (optional)"
+msgstr ""
+
+#. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I learn?"
+msgstr ""
+
+#. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I need?"
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -17956,6 +18514,11 @@ msgstr ""
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
 msgctxt "SERP footer content"
 msgid "What's New"
+msgstr ""
+
+#. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What's the verdict?"
 msgstr ""
 
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -17997,6 +18560,11 @@ msgctxt "Feedback prompt"
 msgid "Which features are missing? (Optional)"
 msgstr ""
 
+#. An invitation for users to leave feedback
+msgctxt "Feedback prompt"
+msgid "Which features are missing? (optional)"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
 msgid "White"
 msgstr ""
@@ -18008,6 +18576,16 @@ msgstr ""
 
 #. Link to an about us page.
 msgid "Who We Are"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Who are the main cast and crew, and what else are they known for?"
+msgstr ""
+
+#. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Who is this person?"
 msgstr ""
 
 #. Header above a collection of privacy-related links.

--- a/locales/ar_EG/LC_MESSAGES/duckduckgo.po
+++ b/locales/ar_EG/LC_MESSAGES/duckduckgo.po
@@ -1162,6 +1162,11 @@ msgctxt "feedback form"
 msgid "Address is incorrect"
 msgstr ""
 
+#. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Adjust the servings"
+msgstr ""
+
 #. as in multiple advertisements
 msgid "Ads"
 msgstr ""
@@ -1333,6 +1338,13 @@ msgstr ""
 #. Heading shown on the empty chat screen. The text between the two %s markers is displayed inside a clickable privacy button. First %s renders a shield icon, second %s is an invisible end marker. Keep the word 'private' between both %s markers.
 msgctxt "Empty state heading in Duck.ai chat mode"
 msgid "All chats are %sprivate%s"
+msgstr ""
+
+#. Paragraph in the Privacy & Terms section of the About & Legal page in Duck.ai settings, summarizing how chats are anonymized and are not stored or used to train chat models.
+msgctxt "Privacy & Terms section description on the Duck.ai settings page"
+msgid ""
+"All chats are anonymized by DuckDuckGo, and your conversations are not used "
+"to train chat models by DuckDuckGo or the model providers"
 msgstr ""
 
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1547,6 +1559,12 @@ msgstr ""
 #. Confirmation message after location service is enabled.
 msgctxt "precise_user_location"
 msgid "Anonymous location enabled"
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Anonymously generates answers for search queries based on web content. "
+"Choose how often you want it to appear, or disable it completely."
 msgstr ""
 
 #. Instant Answer tab name
@@ -1769,6 +1787,11 @@ msgstr ""
 
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse
 msgid "Ask a follow-up with Duck.ai"
+msgstr ""
+
+#. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
+msgctxt "Page suggestion chip label"
+msgid "Ask about this page"
 msgstr ""
 
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2093,6 +2116,11 @@ msgstr ""
 msgid "Barcode"
 msgstr "باركود"
 
+#. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Based on this page, is this course worth taking?"
+msgstr ""
+
 msgctxt "settings"
 msgid "Basic"
 msgstr "أساسي"
@@ -2124,6 +2152,13 @@ msgstr ""
 #. Placeholder text displayed while the assistant waits for the user to choose an action.
 msgctxt "Assistant response placeholder"
 msgid "Before continuing..."
+msgstr ""
+
+#. Explains that before storing the report, DuckDuckGo will anonymize the conversation by removing PII like names, email addresses, and identifying metadata.
+msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
+msgid ""
+"Before storing this report, DuckDuckGo will anonymize your conversation by "
+"removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
 #. Label that's displayed next to a past start date below a web search result.
@@ -2382,6 +2417,11 @@ msgstr ""
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Break Points Won"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Break this down into clear, numbered steps."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -2741,6 +2781,11 @@ msgstr ""
 #. Text of a button that performs a search for the cast of a particular movie or tv show
 msgctxt "Movie/TV Show Title instant answer"
 msgid "Cast"
+msgstr ""
+
+#. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Cast & Crew"
 msgstr ""
 
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -4093,6 +4138,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Create a shopping list with quantities from this recipe."
+msgstr ""
+
 #. Placeholder text displayed in the input field when starting a new image generation session.
 msgctxt "Placeholder text for the image generation input field"
 msgid "Create an image of a cute duck..."
@@ -4619,6 +4669,10 @@ msgstr ""
 msgid "Dictation limit reached"
 msgstr ""
 
+#. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
+msgid "Dictation temporarily unavailable"
+msgstr ""
+
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
@@ -4863,6 +4917,20 @@ msgctxt "precise_user_location"
 msgid "Done"
 msgstr ""
 
+#. Message shown in a modal after DuckDuckGo browser users disable AI features in Settings. The first two placeholders bold noai.duckduckgo.com. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
+"filtered out. %sLearn More%s"
+msgstr ""
+
+#. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
+"and AI images filtered out. %sLearn more%s"
+msgstr ""
+
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Double Faults"
@@ -4953,6 +5021,16 @@ msgctxt "Full sentence for writing an email"
 msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
+msgstr ""
+
+#. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Draft a cover letter"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Draft a cover letter for this job."
 msgstr ""
 
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -5092,6 +5170,14 @@ msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
 msgstr ""
 
+#. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
+msgctxt "About section description on the Duck.ai settings page"
+msgid ""
+"Duck.ai is created by DuckDuckGo. We're an independent online protection "
+"company for anyone who wants to take back control of their personal "
+"information."
+msgstr ""
+
 #. Title shown when an update is required before proceeding.
 msgctxt "duckai_migration"
 msgid "Duck.ai is moving domains"
@@ -5125,6 +5211,12 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Duck.ai lets you chat privately with popular AI models. Disabling it hides "
+"Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
 
 msgctxt "settings"
@@ -5908,6 +6000,16 @@ msgstr ""
 msgid "Eritrea"
 msgstr ""
 
+#. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Estimate the nutrition"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Estimate the nutritional information for this recipe."
+msgstr ""
+
 msgid "Estonia"
 msgstr ""
 
@@ -5952,10 +6054,50 @@ msgctxt "merchant promotion product ad extension"
 msgid "Expires in 1 day"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain the accepted answer in simple terms."
+msgstr ""
+
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
+msgstr ""
+
+#. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain the top answer"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this in simple, plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this paper"
+msgstr ""
+
+#. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this repo"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this research paper in plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this simply"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain what this repository does and how to use it."
 msgstr ""
 
 #. Label to show if song lyrics contain explicit content
@@ -6186,6 +6328,11 @@ msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
 msgstr ""
 
+msgctxt "settings"
+msgid ""
+"Filters out known AI spam sites from image search results. %sLearn More%s"
+msgstr ""
+
 #. Label for the final score of a sporting event.
 msgid "Final"
 msgstr ""
@@ -6225,6 +6372,11 @@ msgstr ""
 #. Short description shown below the 'Web Search' label in the Tools dropdown.
 msgctxt "Subtitle for the Web Search tool entry in the Tools dropdown menu"
 msgid "Find current information"
+msgstr ""
+
+#. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Find me alternatives"
 msgstr ""
 
 #. Button that searches for results closer to the user's current location.
@@ -6615,6 +6767,11 @@ msgstr ""
 msgid "Generate More"
 msgstr ""
 
+#. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Generate a shopping list"
+msgstr ""
+
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
 msgid "Generate a short answer from the web"
 msgstr ""
@@ -6849,6 +7006,11 @@ msgstr ""
 #. Text for a button inviting users to give it a try for the Duck.ai product. On click, they're taken to the Duck.ai page.
 msgctxt "Onboarding welcome screen button text"
 msgid "Give it a Try"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Give me a quick background on this person."
 msgstr ""
 
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -7211,6 +7373,16 @@ msgstr ""
 
 #. Link to a page with information about sharing DuckDuckGo with friends.
 msgid "Help Spread Privacy"
+msgstr ""
+
+#. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Help me prep for the interview"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Help me tailor my resume for this job."
 msgstr ""
 
 #. Title of a SERP popup that invites users to take a survey (desktop only)
@@ -7630,6 +7802,13 @@ msgstr ""
 #. Text displayed on the button on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
 msgctxt "Onboarding terms screen button text"
 msgid "I Agree"
+msgstr ""
+
+#. Text for the button that takes the user to the external DuckDuckGo login subscription page.
+msgctxt ""
+"Text for the I already have a subscription button in the Duck.ai settings "
+"page"
+msgid "I Already Have a Subscription"
 msgstr ""
 
 #. Text for the button that takes the user to the login subscription page.
@@ -8087,6 +8266,11 @@ msgctxt "Sidemenu browser promo"
 msgid "Install Mac Browser"
 msgstr ""
 
+#. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
+msgctxt "settings"
+msgid "Install Now"
+msgstr ""
+
 #. Text of a button to install the DuckDuckGo app
 msgctxt "Serp footer content"
 msgid "Install Our App"
@@ -8166,9 +8350,36 @@ msgctxt "cloudsave"
 msgid "Is deleted data really deleted?"
 msgstr "هل البيانات المحذوفة تحذف حقاً؟"
 
+#. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is it worth taking?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this place any good?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"Is this place any good? Summarize its reputation based on reviews and "
+"ratings."
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "Is this video helpful?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this worth watching?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Is this worth watching? Give me a spoiler-free take."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -8665,6 +8876,11 @@ msgstr "خط رابط:"
 msgid "Links:"
 msgstr "روابط:"
 
+#. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "List the tools, materials, or prerequisites I need for this."
+msgstr ""
+
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
 msgid "Listen"
 msgstr "استمع"
@@ -8997,6 +9213,11 @@ msgstr ""
 #. Label for linke navigating to site exclusion feature on Settings page
 msgctxt "Exclusion message manage sites button"
 msgid "Manage blocked sites"
+msgstr ""
+
+#. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
+msgctxt "setting"
+msgid "Manage in Browser Settings"
 msgstr ""
 
 #. Link to the site exclusion settings page
@@ -11296,6 +11517,11 @@ msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
+msgid "Please describe why the chat response is harmful or illegal. (optional)"
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
+msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
 msgstr ""
 
@@ -11314,6 +11540,13 @@ msgctxt "Modal disclaimer text"
 msgid ""
 "Please note: starting a new chat with any model will delete your current "
 "chat session."
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
+msgctxt "Feedback prompt"
+msgid ""
+"Please paste your prompt and the problematic output (with any personal "
+"information removed) and describe why the content is harmful or illegal."
 msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -11698,6 +11931,11 @@ msgctxt "settings"
 msgid "Privacy"
 msgstr "الخصوصية"
 
+#. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
+msgctxt "Section heading on the Duck.ai settings page"
+msgid "Privacy & Terms"
+msgstr ""
+
 msgid "Privacy Blog"
 msgstr ""
 
@@ -11751,6 +11989,11 @@ msgstr ""
 
 #. Text used in other strings to link to the Privacy Policy and Terms of Service content.
 msgctxt "Copy used to compose link in sentences"
+msgid "Privacy Policy and Terms of Service"
+msgstr ""
+
+#. Text for a button that links to the terms of use and privacy policy page.
+msgctxt "Secondary button text in active privacy modal"
 msgid "Privacy Policy and Terms of Service"
 msgstr ""
 
@@ -12159,6 +12402,26 @@ msgctxt "Brief for recommending a book"
 msgid "Recommend a book"
 msgstr ""
 
+#. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar books"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar books."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar movies or shows."
+msgstr ""
+
+#. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar titles"
+msgstr ""
+
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
 msgid "Recording failed. Please try again."
 msgstr ""
@@ -12478,6 +12741,14 @@ msgstr ""
 msgid "Republic of Moldova"
 msgstr ""
 
+#. Note indicating that sharing the conversation is mandatory when reporting harmful or illegal content. Rendered alongside the standard share label (DUCKCHAT_RESPONSE_FEEDBACK_SHARE_PROMPT_RESPONSE_LABEL), not replacing it.
+msgctxt ""
+"Note shown under the share-content switch label on the Duck.ai response "
+"feedback form when the user has selected Harmful or Illegal as the feedback "
+"reason"
+msgid "Required for harmful or illegal reports"
+msgstr ""
+
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
 msgctxt "Description for extended reasoning mode in Duck.ai"
 msgid "Researches before responding"
@@ -12663,6 +12934,11 @@ msgstr "مراجعات"
 #. Label above a list of customer reviews of a business.
 msgctxt "maps_places"
 msgid "Reviews"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Rewrite this recipe scaled for a different number of servings."
 msgstr ""
 
 msgid "Romania"
@@ -13704,6 +13980,11 @@ msgctxt "Setup button for native sync flow"
 msgid "Set Up Now"
 msgstr ""
 
+#. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
+msgctxt "Encrypted storage setup button shown in native browsers"
+msgid "Set Up Sync & Backup"
+msgstr ""
+
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
 msgctxt "Title for the Sync & Backup intro screen"
 msgid "Set Up Sync & Backup"
@@ -13846,6 +14127,12 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
+msgctxt ""
+"Label beside the share-content switch on the Duck.ai response feedback form"
+msgid "Share this conversation with DuckDuckGo"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -14860,6 +15147,21 @@ msgctxt "Brief for suggesting a blog post title"
 msgid "Suggest a title for a blog post"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest related articles or topics worth exploring next."
+msgstr ""
+
+#. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Suggest related articles to explore"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest some alternatives to this product."
+msgstr ""
+
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
 msgctxt "directions"
 msgid "Suggestions:"
@@ -14869,9 +15171,84 @@ msgctxt "noresults"
 msgid "Suggestions:"
 msgstr ""
 
+#. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Sum up the reviews"
+msgstr ""
+
 #. A short title for the a message asking the AI to summarize a text.
 msgctxt "Title for the summarize message"
 msgid "Summarize"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize the Q&As"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the background and notable work of this person."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the key details of this event."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the questions and answers on this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize their background"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this book"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this book."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this discussion"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this discussion thread."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this video"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this video."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize what the reviews say."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -15126,6 +15503,11 @@ msgstr ""
 msgid "Syria"
 msgstr ""
 
+#. Text for a button that enables the theme to follow the operating system's color scheme preference.
+msgctxt "System theme button for theme selector"
+msgid "System"
+msgstr ""
+
 #. Abbreviation indicating this is the total score for a game
 msgctxt "Sports module"
 msgid "T"
@@ -15149,6 +15531,11 @@ msgctxt "language_name"
 msgid "Tahitian"
 msgstr ""
 
+#. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Tailor my resume"
+msgstr ""
+
 msgid "Taiwan"
 msgstr ""
 
@@ -15170,6 +15557,12 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "Take control of your personal data!"
+msgstr ""
+
+#. Description for the Feedback section of the Duck.ai settings page, asking the user to take an anonymous survey to let us know how we can make Duck.ai better.
+msgctxt "Feedback section description on the Duck.ai settings page"
+msgid ""
+"Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
 
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -15414,6 +15807,11 @@ msgstr ""
 #. https://duck.co/media/files/theme.png
 msgid "Theme"
 msgstr "مظهر"
+
+#. Text for the theme selector label that allows users to switch between Light and dark theme.
+msgctxt "Label for the theme selector feature"
+msgid "Theme"
+msgstr ""
 
 #. http://i.imgur.com/LpFhb1e.png
 msgctxt "settings"
@@ -16065,6 +16463,16 @@ msgid ""
 "movie theatre?”"
 msgstr ""
 
+#. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Translate this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
+msgctxt "Page suggestion prompt"
+msgid "Translate this page into %s."
+msgstr ""
+
 #. Placeholder text for a region that will display translated text.
 msgctxt "translations_module"
 msgid "Translation"
@@ -16179,6 +16587,11 @@ msgstr ""
 #. Call-to-action button for the subscription promo in the SERP sidemenu.
 msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
+msgstr ""
+
+#. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
+msgctxt "settings"
+msgid "Try It Now"
 msgstr ""
 
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -16372,6 +16785,20 @@ msgstr "جرب %s"
 #. Response a user can select in a feedback form, indicating that they're trying DuckDuckGo again.
 msgctxt "new user poll"
 msgid "Trying DuckDuckGo again"
+msgstr ""
+
+#. Message shown in a modal after supported third-party browser users disable AI features in Settings. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+#. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
 msgstr ""
 
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -16972,6 +17399,11 @@ msgstr ""
 msgid "Uruguay"
 msgstr ""
 
+#. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
+msgctxt "Navigation label on the Duck.ai settings page"
+msgid "Usage"
+msgstr ""
+
 #. A feedback suggestion
 msgctxt "Feedback prompt"
 msgid "Usage limit"
@@ -17320,6 +17752,11 @@ msgstr ""
 msgid "Wales"
 msgstr ""
 
+#. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Walk me through the steps"
+msgstr ""
+
 #. Label for walking directions on a map.
 msgctxt "directions"
 msgid "Walking"
@@ -17410,6 +17847,16 @@ msgstr ""
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
+msgstr ""
+
+#. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
+msgctxt ""
+"Inline warning shown below the share-content toggle when the user selects "
+"Harmful or Illegal but has not enabled sharing"
+msgid ""
+"We can only fix what we can see. To report a harmful or illegal response, "
+"please share this conversation with DuckDuckGo so we can investigate and "
+"address the issue."
 msgstr ""
 
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -17829,6 +18276,87 @@ msgid ""
 "experience."
 msgstr ""
 
+#. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the counterarguments?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the hours & location?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key contributions of this paper?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key contributions?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key details?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key points covered in this video?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key points?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key takeaways from this article?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key takeaways?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key things I will learn from this course?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main counterarguments or criticisms of this?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main questions this page answers?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the must-try dishes here?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"What are the opening hours, location, and contact details for this place?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the pros and cons of this product?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the pros and cons?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
 msgctxt "feedback form"
 msgid "What bothered you most?"
@@ -17912,6 +18440,11 @@ msgctxt "Full sentence for defining a term"
 msgid "What does atria mean in the context of a medical article?"
 msgstr ""
 
+#. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What does this answer?"
+msgstr ""
+
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
@@ -17921,6 +18454,11 @@ msgstr ""
 msgctxt "cloudsave"
 msgid "What information gets saved?"
 msgstr "ما المعلومات التي تحفظ؟"
+
+#. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What interview questions might come up for this role?"
+msgstr ""
 
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
@@ -17932,6 +18470,11 @@ msgstr ""
 #. Text for a prompt suggestion for looking up the capital city of Albania.
 msgctxt "Full sentence for looking up basic facts"
 msgid "What is the capital city of Albania?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What is the overall verdict and rating for this?"
 msgstr ""
 
 #. Link to a page with additional information.
@@ -17952,6 +18495,11 @@ msgctxt "maps_places"
 msgid "What people say:"
 msgstr ""
 
+#. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What should I order?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
 msgctxt "feedback form"
 msgid "What stood out?"
@@ -17960,6 +18508,16 @@ msgstr ""
 #. Question on a feedback form for a negative feedback response.
 msgctxt "feedback form"
 msgid "What was wrong with the response? (optional)"
+msgstr ""
+
+#. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I learn?"
+msgstr ""
+
+#. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I need?"
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -17974,6 +18532,11 @@ msgstr ""
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
 msgctxt "SERP footer content"
 msgid "What's New"
+msgstr ""
+
+#. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What's the verdict?"
 msgstr ""
 
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -18015,6 +18578,11 @@ msgctxt "Feedback prompt"
 msgid "Which features are missing? (Optional)"
 msgstr ""
 
+#. An invitation for users to leave feedback
+msgctxt "Feedback prompt"
+msgid "Which features are missing? (optional)"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
 msgid "White"
 msgstr "أبيض"
@@ -18026,6 +18594,16 @@ msgstr ""
 
 #. Link to an about us page.
 msgid "Who We Are"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Who are the main cast and crew, and what else are they known for?"
+msgstr ""
+
+#. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Who is this person?"
 msgstr ""
 
 #. Header above a collection of privacy-related links.

--- a/locales/ar_JO/LC_MESSAGES/duckduckgo.po
+++ b/locales/ar_JO/LC_MESSAGES/duckduckgo.po
@@ -1162,6 +1162,11 @@ msgctxt "feedback form"
 msgid "Address is incorrect"
 msgstr ""
 
+#. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Adjust the servings"
+msgstr ""
+
 #. as in multiple advertisements
 msgid "Ads"
 msgstr ""
@@ -1333,6 +1338,13 @@ msgstr ""
 #. Heading shown on the empty chat screen. The text between the two %s markers is displayed inside a clickable privacy button. First %s renders a shield icon, second %s is an invisible end marker. Keep the word 'private' between both %s markers.
 msgctxt "Empty state heading in Duck.ai chat mode"
 msgid "All chats are %sprivate%s"
+msgstr ""
+
+#. Paragraph in the Privacy & Terms section of the About & Legal page in Duck.ai settings, summarizing how chats are anonymized and are not stored or used to train chat models.
+msgctxt "Privacy & Terms section description on the Duck.ai settings page"
+msgid ""
+"All chats are anonymized by DuckDuckGo, and your conversations are not used "
+"to train chat models by DuckDuckGo or the model providers"
 msgstr ""
 
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1545,6 +1557,12 @@ msgstr ""
 #. Confirmation message after location service is enabled.
 msgctxt "precise_user_location"
 msgid "Anonymous location enabled"
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Anonymously generates answers for search queries based on web content. "
+"Choose how often you want it to appear, or disable it completely."
 msgstr ""
 
 #. Instant Answer tab name
@@ -1767,6 +1785,11 @@ msgstr ""
 
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse
 msgid "Ask a follow-up with Duck.ai"
+msgstr ""
+
+#. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
+msgctxt "Page suggestion chip label"
+msgid "Ask about this page"
 msgstr ""
 
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2091,6 +2114,11 @@ msgstr ""
 msgid "Barcode"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Based on this page, is this course worth taking?"
+msgstr ""
+
 msgctxt "settings"
 msgid "Basic"
 msgstr ""
@@ -2122,6 +2150,13 @@ msgstr ""
 #. Placeholder text displayed while the assistant waits for the user to choose an action.
 msgctxt "Assistant response placeholder"
 msgid "Before continuing..."
+msgstr ""
+
+#. Explains that before storing the report, DuckDuckGo will anonymize the conversation by removing PII like names, email addresses, and identifying metadata.
+msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
+msgid ""
+"Before storing this report, DuckDuckGo will anonymize your conversation by "
+"removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
 #. Label that's displayed next to a past start date below a web search result.
@@ -2380,6 +2415,11 @@ msgstr ""
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Break Points Won"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Break this down into clear, numbered steps."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -2739,6 +2779,11 @@ msgstr ""
 #. Text of a button that performs a search for the cast of a particular movie or tv show
 msgctxt "Movie/TV Show Title instant answer"
 msgid "Cast"
+msgstr ""
+
+#. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Cast & Crew"
 msgstr ""
 
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -4090,6 +4135,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Create a shopping list with quantities from this recipe."
+msgstr ""
+
 #. Placeholder text displayed in the input field when starting a new image generation session.
 msgctxt "Placeholder text for the image generation input field"
 msgid "Create an image of a cute duck..."
@@ -4616,6 +4666,10 @@ msgstr ""
 msgid "Dictation limit reached"
 msgstr ""
 
+#. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
+msgid "Dictation temporarily unavailable"
+msgstr ""
+
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
@@ -4860,6 +4914,20 @@ msgctxt "precise_user_location"
 msgid "Done"
 msgstr ""
 
+#. Message shown in a modal after DuckDuckGo browser users disable AI features in Settings. The first two placeholders bold noai.duckduckgo.com. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
+"filtered out. %sLearn More%s"
+msgstr ""
+
+#. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
+"and AI images filtered out. %sLearn more%s"
+msgstr ""
+
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Double Faults"
@@ -4950,6 +5018,16 @@ msgctxt "Full sentence for writing an email"
 msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
+msgstr ""
+
+#. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Draft a cover letter"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Draft a cover letter for this job."
 msgstr ""
 
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -5089,6 +5167,14 @@ msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
 msgstr ""
 
+#. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
+msgctxt "About section description on the Duck.ai settings page"
+msgid ""
+"Duck.ai is created by DuckDuckGo. We're an independent online protection "
+"company for anyone who wants to take back control of their personal "
+"information."
+msgstr ""
+
 #. Title shown when an update is required before proceeding.
 msgctxt "duckai_migration"
 msgid "Duck.ai is moving domains"
@@ -5122,6 +5208,12 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Duck.ai lets you chat privately with popular AI models. Disabling it hides "
+"Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
 
 msgctxt "settings"
@@ -5905,6 +5997,16 @@ msgstr ""
 msgid "Eritrea"
 msgstr ""
 
+#. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Estimate the nutrition"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Estimate the nutritional information for this recipe."
+msgstr ""
+
 msgid "Estonia"
 msgstr ""
 
@@ -5949,10 +6051,50 @@ msgctxt "merchant promotion product ad extension"
 msgid "Expires in 1 day"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain the accepted answer in simple terms."
+msgstr ""
+
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
+msgstr ""
+
+#. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain the top answer"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this in simple, plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this paper"
+msgstr ""
+
+#. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this repo"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this research paper in plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this simply"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain what this repository does and how to use it."
 msgstr ""
 
 #. Label to show if song lyrics contain explicit content
@@ -6181,6 +6323,11 @@ msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
 msgstr ""
 
+msgctxt "settings"
+msgid ""
+"Filters out known AI spam sites from image search results. %sLearn More%s"
+msgstr ""
+
 #. Label for the final score of a sporting event.
 msgid "Final"
 msgstr ""
@@ -6220,6 +6367,11 @@ msgstr ""
 #. Short description shown below the 'Web Search' label in the Tools dropdown.
 msgctxt "Subtitle for the Web Search tool entry in the Tools dropdown menu"
 msgid "Find current information"
+msgstr ""
+
+#. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Find me alternatives"
 msgstr ""
 
 #. Button that searches for results closer to the user's current location.
@@ -6610,6 +6762,11 @@ msgstr ""
 msgid "Generate More"
 msgstr ""
 
+#. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Generate a shopping list"
+msgstr ""
+
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
 msgid "Generate a short answer from the web"
 msgstr ""
@@ -6844,6 +7001,11 @@ msgstr ""
 #. Text for a button inviting users to give it a try for the Duck.ai product. On click, they're taken to the Duck.ai page.
 msgctxt "Onboarding welcome screen button text"
 msgid "Give it a Try"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Give me a quick background on this person."
 msgstr ""
 
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -7206,6 +7368,16 @@ msgstr ""
 
 #. Link to a page with information about sharing DuckDuckGo with friends.
 msgid "Help Spread Privacy"
+msgstr ""
+
+#. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Help me prep for the interview"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Help me tailor my resume for this job."
 msgstr ""
 
 #. Title of a SERP popup that invites users to take a survey (desktop only)
@@ -7625,6 +7797,13 @@ msgstr ""
 #. Text displayed on the button on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
 msgctxt "Onboarding terms screen button text"
 msgid "I Agree"
+msgstr ""
+
+#. Text for the button that takes the user to the external DuckDuckGo login subscription page.
+msgctxt ""
+"Text for the I already have a subscription button in the Duck.ai settings "
+"page"
+msgid "I Already Have a Subscription"
 msgstr ""
 
 #. Text for the button that takes the user to the login subscription page.
@@ -8077,6 +8256,11 @@ msgctxt "Sidemenu browser promo"
 msgid "Install Mac Browser"
 msgstr ""
 
+#. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
+msgctxt "settings"
+msgid "Install Now"
+msgstr ""
+
 #. Text of a button to install the DuckDuckGo app
 msgctxt "Serp footer content"
 msgid "Install Our App"
@@ -8156,9 +8340,36 @@ msgctxt "cloudsave"
 msgid "Is deleted data really deleted?"
 msgstr "هل تحذف المعلومات فعلا؟"
 
+#. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is it worth taking?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this place any good?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"Is this place any good? Summarize its reputation based on reviews and "
+"ratings."
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "Is this video helpful?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this worth watching?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Is this worth watching? Give me a spoiler-free take."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -8655,6 +8866,11 @@ msgstr "خط الرابط:"
 msgid "Links:"
 msgstr "الروابط."
 
+#. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "List the tools, materials, or prerequisites I need for this."
+msgstr ""
+
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
 msgid "Listen"
 msgstr "إستمع"
@@ -8987,6 +9203,11 @@ msgstr ""
 #. Label for linke navigating to site exclusion feature on Settings page
 msgctxt "Exclusion message manage sites button"
 msgid "Manage blocked sites"
+msgstr ""
+
+#. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
+msgctxt "setting"
+msgid "Manage in Browser Settings"
 msgstr ""
 
 #. Link to the site exclusion settings page
@@ -11284,6 +11505,11 @@ msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
+msgid "Please describe why the chat response is harmful or illegal. (optional)"
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
+msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
 msgstr ""
 
@@ -11302,6 +11528,13 @@ msgctxt "Modal disclaimer text"
 msgid ""
 "Please note: starting a new chat with any model will delete your current "
 "chat session."
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
+msgctxt "Feedback prompt"
+msgid ""
+"Please paste your prompt and the problematic output (with any personal "
+"information removed) and describe why the content is harmful or illegal."
 msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -11686,6 +11919,11 @@ msgctxt "settings"
 msgid "Privacy"
 msgstr ""
 
+#. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
+msgctxt "Section heading on the Duck.ai settings page"
+msgid "Privacy & Terms"
+msgstr ""
+
 msgid "Privacy Blog"
 msgstr ""
 
@@ -11739,6 +11977,11 @@ msgstr ""
 
 #. Text used in other strings to link to the Privacy Policy and Terms of Service content.
 msgctxt "Copy used to compose link in sentences"
+msgid "Privacy Policy and Terms of Service"
+msgstr ""
+
+#. Text for a button that links to the terms of use and privacy policy page.
+msgctxt "Secondary button text in active privacy modal"
 msgid "Privacy Policy and Terms of Service"
 msgstr ""
 
@@ -12147,6 +12390,26 @@ msgctxt "Brief for recommending a book"
 msgid "Recommend a book"
 msgstr ""
 
+#. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar books"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar books."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar movies or shows."
+msgstr ""
+
+#. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar titles"
+msgstr ""
+
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
 msgid "Recording failed. Please try again."
 msgstr ""
@@ -12466,6 +12729,14 @@ msgstr ""
 msgid "Republic of Moldova"
 msgstr ""
 
+#. Note indicating that sharing the conversation is mandatory when reporting harmful or illegal content. Rendered alongside the standard share label (DUCKCHAT_RESPONSE_FEEDBACK_SHARE_PROMPT_RESPONSE_LABEL), not replacing it.
+msgctxt ""
+"Note shown under the share-content switch label on the Duck.ai response "
+"feedback form when the user has selected Harmful or Illegal as the feedback "
+"reason"
+msgid "Required for harmful or illegal reports"
+msgstr ""
+
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
 msgctxt "Description for extended reasoning mode in Duck.ai"
 msgid "Researches before responding"
@@ -12651,6 +12922,11 @@ msgstr "إنتقادات"
 #. Label above a list of customer reviews of a business.
 msgctxt "maps_places"
 msgid "Reviews"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Rewrite this recipe scaled for a different number of servings."
 msgstr ""
 
 msgid "Romania"
@@ -13688,6 +13964,11 @@ msgctxt "Setup button for native sync flow"
 msgid "Set Up Now"
 msgstr ""
 
+#. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
+msgctxt "Encrypted storage setup button shown in native browsers"
+msgid "Set Up Sync & Backup"
+msgstr ""
+
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
 msgctxt "Title for the Sync & Backup intro screen"
 msgid "Set Up Sync & Backup"
@@ -13830,6 +14111,12 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
+msgctxt ""
+"Label beside the share-content switch on the Duck.ai response feedback form"
+msgid "Share this conversation with DuckDuckGo"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -14844,6 +15131,21 @@ msgctxt "Brief for suggesting a blog post title"
 msgid "Suggest a title for a blog post"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest related articles or topics worth exploring next."
+msgstr ""
+
+#. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Suggest related articles to explore"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest some alternatives to this product."
+msgstr ""
+
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
 msgctxt "directions"
 msgid "Suggestions:"
@@ -14853,9 +15155,84 @@ msgctxt "noresults"
 msgid "Suggestions:"
 msgstr ""
 
+#. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Sum up the reviews"
+msgstr ""
+
 #. A short title for the a message asking the AI to summarize a text.
 msgctxt "Title for the summarize message"
 msgid "Summarize"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize the Q&As"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the background and notable work of this person."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the key details of this event."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the questions and answers on this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize their background"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this book"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this book."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this discussion"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this discussion thread."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this video"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this video."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize what the reviews say."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -15110,6 +15487,11 @@ msgstr ""
 msgid "Syria"
 msgstr ""
 
+#. Text for a button that enables the theme to follow the operating system's color scheme preference.
+msgctxt "System theme button for theme selector"
+msgid "System"
+msgstr ""
+
 #. Abbreviation indicating this is the total score for a game
 msgctxt "Sports module"
 msgid "T"
@@ -15133,6 +15515,11 @@ msgctxt "language_name"
 msgid "Tahitian"
 msgstr ""
 
+#. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Tailor my resume"
+msgstr ""
+
 msgid "Taiwan"
 msgstr ""
 
@@ -15154,6 +15541,12 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "Take control of your personal data!"
+msgstr ""
+
+#. Description for the Feedback section of the Duck.ai settings page, asking the user to take an anonymous survey to let us know how we can make Duck.ai better.
+msgctxt "Feedback section description on the Duck.ai settings page"
+msgid ""
+"Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
 
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -15396,6 +15789,11 @@ msgstr ""
 
 #. Title for the theme menu:
 #. https://duck.co/media/files/theme.png
+msgid "Theme"
+msgstr ""
+
+#. Text for the theme selector label that allows users to switch between Light and dark theme.
+msgctxt "Label for the theme selector feature"
 msgid "Theme"
 msgstr ""
 
@@ -16049,6 +16447,16 @@ msgid ""
 "movie theatre?”"
 msgstr ""
 
+#. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Translate this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
+msgctxt "Page suggestion prompt"
+msgid "Translate this page into %s."
+msgstr ""
+
 #. Placeholder text for a region that will display translated text.
 msgctxt "translations_module"
 msgid "Translation"
@@ -16163,6 +16571,11 @@ msgstr ""
 #. Call-to-action button for the subscription promo in the SERP sidemenu.
 msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
+msgstr ""
+
+#. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
+msgctxt "settings"
+msgid "Try It Now"
 msgstr ""
 
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -16356,6 +16769,20 @@ msgstr "أعد المحاولة باستخدام: %s"
 #. Response a user can select in a feedback form, indicating that they're trying DuckDuckGo again.
 msgctxt "new user poll"
 msgid "Trying DuckDuckGo again"
+msgstr ""
+
+#. Message shown in a modal after supported third-party browser users disable AI features in Settings. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+#. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
 msgstr ""
 
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -16956,6 +17383,11 @@ msgstr ""
 msgid "Uruguay"
 msgstr ""
 
+#. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
+msgctxt "Navigation label on the Duck.ai settings page"
+msgid "Usage"
+msgstr ""
+
 #. A feedback suggestion
 msgctxt "Feedback prompt"
 msgid "Usage limit"
@@ -17304,6 +17736,11 @@ msgstr ""
 msgid "Wales"
 msgstr ""
 
+#. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Walk me through the steps"
+msgstr ""
+
 #. Label for walking directions on a map.
 msgctxt "directions"
 msgid "Walking"
@@ -17394,6 +17831,16 @@ msgstr ""
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
+msgstr ""
+
+#. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
+msgctxt ""
+"Inline warning shown below the share-content toggle when the user selects "
+"Harmful or Illegal but has not enabled sharing"
+msgid ""
+"We can only fix what we can see. To report a harmful or illegal response, "
+"please share this conversation with DuckDuckGo so we can investigate and "
+"address the issue."
 msgstr ""
 
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -17813,6 +18260,87 @@ msgid ""
 "experience."
 msgstr ""
 
+#. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the counterarguments?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the hours & location?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key contributions of this paper?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key contributions?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key details?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key points covered in this video?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key points?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key takeaways from this article?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key takeaways?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key things I will learn from this course?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main counterarguments or criticisms of this?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main questions this page answers?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the must-try dishes here?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"What are the opening hours, location, and contact details for this place?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the pros and cons of this product?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the pros and cons?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
 msgctxt "feedback form"
 msgid "What bothered you most?"
@@ -17896,6 +18424,11 @@ msgctxt "Full sentence for defining a term"
 msgid "What does atria mean in the context of a medical article?"
 msgstr ""
 
+#. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What does this answer?"
+msgstr ""
+
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
@@ -17905,6 +18438,11 @@ msgstr ""
 msgctxt "cloudsave"
 msgid "What information gets saved?"
 msgstr "الحفظ السحابي"
+
+#. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What interview questions might come up for this role?"
+msgstr ""
 
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
@@ -17916,6 +18454,11 @@ msgstr ""
 #. Text for a prompt suggestion for looking up the capital city of Albania.
 msgctxt "Full sentence for looking up basic facts"
 msgid "What is the capital city of Albania?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What is the overall verdict and rating for this?"
 msgstr ""
 
 #. Link to a page with additional information.
@@ -17936,6 +18479,11 @@ msgctxt "maps_places"
 msgid "What people say:"
 msgstr ""
 
+#. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What should I order?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
 msgctxt "feedback form"
 msgid "What stood out?"
@@ -17944,6 +18492,16 @@ msgstr ""
 #. Question on a feedback form for a negative feedback response.
 msgctxt "feedback form"
 msgid "What was wrong with the response? (optional)"
+msgstr ""
+
+#. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I learn?"
+msgstr ""
+
+#. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I need?"
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -17958,6 +18516,11 @@ msgstr ""
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
 msgctxt "SERP footer content"
 msgid "What's New"
+msgstr ""
+
+#. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What's the verdict?"
 msgstr ""
 
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -17999,6 +18562,11 @@ msgctxt "Feedback prompt"
 msgid "Which features are missing? (Optional)"
 msgstr ""
 
+#. An invitation for users to leave feedback
+msgctxt "Feedback prompt"
+msgid "Which features are missing? (optional)"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
 msgid "White"
 msgstr "أبيض"
@@ -18010,6 +18578,16 @@ msgstr ""
 
 #. Link to an about us page.
 msgid "Who We Are"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Who are the main cast and crew, and what else are they known for?"
+msgstr ""
+
+#. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Who is this person?"
 msgstr ""
 
 #. Header above a collection of privacy-related links.

--- a/locales/ar_SA/LC_MESSAGES/duckduckgo.po
+++ b/locales/ar_SA/LC_MESSAGES/duckduckgo.po
@@ -1164,6 +1164,11 @@ msgctxt "feedback form"
 msgid "Address is incorrect"
 msgstr ""
 
+#. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Adjust the servings"
+msgstr ""
+
 #. as in multiple advertisements
 msgid "Ads"
 msgstr ""
@@ -1335,6 +1340,13 @@ msgstr ""
 #. Heading shown on the empty chat screen. The text between the two %s markers is displayed inside a clickable privacy button. First %s renders a shield icon, second %s is an invisible end marker. Keep the word 'private' between both %s markers.
 msgctxt "Empty state heading in Duck.ai chat mode"
 msgid "All chats are %sprivate%s"
+msgstr ""
+
+#. Paragraph in the Privacy & Terms section of the About & Legal page in Duck.ai settings, summarizing how chats are anonymized and are not stored or used to train chat models.
+msgctxt "Privacy & Terms section description on the Duck.ai settings page"
+msgid ""
+"All chats are anonymized by DuckDuckGo, and your conversations are not used "
+"to train chat models by DuckDuckGo or the model providers"
 msgstr ""
 
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1547,6 +1559,12 @@ msgstr ""
 #. Confirmation message after location service is enabled.
 msgctxt "precise_user_location"
 msgid "Anonymous location enabled"
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Anonymously generates answers for search queries based on web content. "
+"Choose how often you want it to appear, or disable it completely."
 msgstr ""
 
 #. Instant Answer tab name
@@ -1769,6 +1787,11 @@ msgstr ""
 
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse
 msgid "Ask a follow-up with Duck.ai"
+msgstr ""
+
+#. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
+msgctxt "Page suggestion chip label"
+msgid "Ask about this page"
 msgstr ""
 
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2093,6 +2116,11 @@ msgstr ""
 msgid "Barcode"
 msgstr "الباركود"
 
+#. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Based on this page, is this course worth taking?"
+msgstr ""
+
 msgctxt "settings"
 msgid "Basic"
 msgstr "أساسي"
@@ -2124,6 +2152,13 @@ msgstr ""
 #. Placeholder text displayed while the assistant waits for the user to choose an action.
 msgctxt "Assistant response placeholder"
 msgid "Before continuing..."
+msgstr ""
+
+#. Explains that before storing the report, DuckDuckGo will anonymize the conversation by removing PII like names, email addresses, and identifying metadata.
+msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
+msgid ""
+"Before storing this report, DuckDuckGo will anonymize your conversation by "
+"removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
 #. Label that's displayed next to a past start date below a web search result.
@@ -2382,6 +2417,11 @@ msgstr "البرازيل"
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Break Points Won"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Break this down into clear, numbered steps."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -2741,6 +2781,11 @@ msgstr "المهن"
 #. Text of a button that performs a search for the cast of a particular movie or tv show
 msgctxt "Movie/TV Show Title instant answer"
 msgid "Cast"
+msgstr ""
+
+#. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Cast & Crew"
 msgstr ""
 
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -4095,6 +4140,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Create a shopping list with quantities from this recipe."
+msgstr ""
+
 #. Placeholder text displayed in the input field when starting a new image generation session.
 msgctxt "Placeholder text for the image generation input field"
 msgid "Create an image of a cute duck..."
@@ -4621,6 +4671,10 @@ msgstr ""
 msgid "Dictation limit reached"
 msgstr ""
 
+#. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
+msgid "Dictation temporarily unavailable"
+msgstr ""
+
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
@@ -4865,6 +4919,20 @@ msgctxt "precise_user_location"
 msgid "Done"
 msgstr ""
 
+#. Message shown in a modal after DuckDuckGo browser users disable AI features in Settings. The first two placeholders bold noai.duckduckgo.com. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
+"filtered out. %sLearn More%s"
+msgstr ""
+
+#. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
+"and AI images filtered out. %sLearn more%s"
+msgstr ""
+
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Double Faults"
@@ -4955,6 +5023,16 @@ msgctxt "Full sentence for writing an email"
 msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
+msgstr ""
+
+#. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Draft a cover letter"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Draft a cover letter for this job."
 msgstr ""
 
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -5094,6 +5172,14 @@ msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
 msgstr ""
 
+#. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
+msgctxt "About section description on the Duck.ai settings page"
+msgid ""
+"Duck.ai is created by DuckDuckGo. We're an independent online protection "
+"company for anyone who wants to take back control of their personal "
+"information."
+msgstr ""
+
 #. Title shown when an update is required before proceeding.
 msgctxt "duckai_migration"
 msgid "Duck.ai is moving domains"
@@ -5127,6 +5213,12 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Duck.ai lets you chat privately with popular AI models. Disabling it hides "
+"Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
 
 msgctxt "settings"
@@ -5899,6 +5991,16 @@ msgstr ""
 msgid "Eritrea"
 msgstr ""
 
+#. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Estimate the nutrition"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Estimate the nutritional information for this recipe."
+msgstr ""
+
 msgid "Estonia"
 msgstr "يستونيا"
 
@@ -5943,10 +6045,50 @@ msgctxt "merchant promotion product ad extension"
 msgid "Expires in 1 day"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain the accepted answer in simple terms."
+msgstr ""
+
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
+msgstr ""
+
+#. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain the top answer"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this in simple, plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this paper"
+msgstr ""
+
+#. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this repo"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this research paper in plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this simply"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain what this repository does and how to use it."
 msgstr ""
 
 #. Label to show if song lyrics contain explicit content
@@ -6176,6 +6318,11 @@ msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
 msgstr ""
 
+msgctxt "settings"
+msgid ""
+"Filters out known AI spam sites from image search results. %sLearn More%s"
+msgstr ""
+
 #. Label for the final score of a sporting event.
 msgid "Final"
 msgstr "النهائي "
@@ -6215,6 +6362,11 @@ msgstr ""
 #. Short description shown below the 'Web Search' label in the Tools dropdown.
 msgctxt "Subtitle for the Web Search tool entry in the Tools dropdown menu"
 msgid "Find current information"
+msgstr ""
+
+#. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Find me alternatives"
 msgstr ""
 
 #. Button that searches for results closer to the user's current location.
@@ -6605,6 +6757,11 @@ msgstr ""
 msgid "Generate More"
 msgstr ""
 
+#. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Generate a shopping list"
+msgstr ""
+
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
 msgid "Generate a short answer from the web"
 msgstr ""
@@ -6839,6 +6996,11 @@ msgstr ""
 #. Text for a button inviting users to give it a try for the Duck.ai product. On click, they're taken to the Duck.ai page.
 msgctxt "Onboarding welcome screen button text"
 msgid "Give it a Try"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Give me a quick background on this person."
 msgstr ""
 
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -7201,6 +7363,16 @@ msgstr ""
 
 #. Link to a page with information about sharing DuckDuckGo with friends.
 msgid "Help Spread Privacy"
+msgstr ""
+
+#. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Help me prep for the interview"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Help me tailor my resume for this job."
 msgstr ""
 
 #. Title of a SERP popup that invites users to take a survey (desktop only)
@@ -7620,6 +7792,13 @@ msgstr ""
 #. Text displayed on the button on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
 msgctxt "Onboarding terms screen button text"
 msgid "I Agree"
+msgstr ""
+
+#. Text for the button that takes the user to the external DuckDuckGo login subscription page.
+msgctxt ""
+"Text for the I already have a subscription button in the Duck.ai settings "
+"page"
+msgid "I Already Have a Subscription"
 msgstr ""
 
 #. Text for the button that takes the user to the login subscription page.
@@ -8076,6 +8255,11 @@ msgctxt "Sidemenu browser promo"
 msgid "Install Mac Browser"
 msgstr ""
 
+#. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
+msgctxt "settings"
+msgid "Install Now"
+msgstr ""
+
 #. Text of a button to install the DuckDuckGo app
 msgctxt "Serp footer content"
 msgid "Install Our App"
@@ -8155,9 +8339,36 @@ msgctxt "cloudsave"
 msgid "Is deleted data really deleted?"
 msgstr "هل البيانات المحذوفه فعلا حذفت؟"
 
+#. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is it worth taking?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this place any good?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"Is this place any good? Summarize its reputation based on reviews and "
+"ratings."
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "Is this video helpful?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this worth watching?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Is this worth watching? Give me a spoiler-free take."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -8654,6 +8865,11 @@ msgstr "الخط المستخدم للروابط:"
 msgid "Links:"
 msgstr "روابط"
 
+#. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "List the tools, materials, or prerequisites I need for this."
+msgstr ""
+
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
 msgid "Listen"
 msgstr "استمع"
@@ -8986,6 +9202,11 @@ msgstr ""
 #. Label for linke navigating to site exclusion feature on Settings page
 msgctxt "Exclusion message manage sites button"
 msgid "Manage blocked sites"
+msgstr ""
+
+#. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
+msgctxt "setting"
+msgid "Manage in Browser Settings"
 msgstr ""
 
 #. Link to the site exclusion settings page
@@ -11290,6 +11511,11 @@ msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
+msgid "Please describe why the chat response is harmful or illegal. (optional)"
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
+msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
 msgstr ""
 
@@ -11308,6 +11534,13 @@ msgctxt "Modal disclaimer text"
 msgid ""
 "Please note: starting a new chat with any model will delete your current "
 "chat session."
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
+msgctxt "Feedback prompt"
+msgid ""
+"Please paste your prompt and the problematic output (with any personal "
+"information removed) and describe why the content is harmful or illegal."
 msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -11692,6 +11925,11 @@ msgctxt "settings"
 msgid "Privacy"
 msgstr "خصوصية"
 
+#. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
+msgctxt "Section heading on the Duck.ai settings page"
+msgid "Privacy & Terms"
+msgstr ""
+
 msgid "Privacy Blog"
 msgstr ""
 
@@ -11745,6 +11983,11 @@ msgstr ""
 
 #. Text used in other strings to link to the Privacy Policy and Terms of Service content.
 msgctxt "Copy used to compose link in sentences"
+msgid "Privacy Policy and Terms of Service"
+msgstr ""
+
+#. Text for a button that links to the terms of use and privacy policy page.
+msgctxt "Secondary button text in active privacy modal"
 msgid "Privacy Policy and Terms of Service"
 msgstr ""
 
@@ -12153,6 +12396,26 @@ msgctxt "Brief for recommending a book"
 msgid "Recommend a book"
 msgstr ""
 
+#. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar books"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar books."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar movies or shows."
+msgstr ""
+
+#. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar titles"
+msgstr ""
+
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
 msgid "Recording failed. Please try again."
 msgstr ""
@@ -12472,6 +12735,14 @@ msgstr ""
 msgid "Republic of Moldova"
 msgstr ""
 
+#. Note indicating that sharing the conversation is mandatory when reporting harmful or illegal content. Rendered alongside the standard share label (DUCKCHAT_RESPONSE_FEEDBACK_SHARE_PROMPT_RESPONSE_LABEL), not replacing it.
+msgctxt ""
+"Note shown under the share-content switch label on the Duck.ai response "
+"feedback form when the user has selected Harmful or Illegal as the feedback "
+"reason"
+msgid "Required for harmful or illegal reports"
+msgstr ""
+
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
 msgctxt "Description for extended reasoning mode in Duck.ai"
 msgid "Researches before responding"
@@ -12657,6 +12928,11 @@ msgstr "مراجعات"
 #. Label above a list of customer reviews of a business.
 msgctxt "maps_places"
 msgid "Reviews"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Rewrite this recipe scaled for a different number of servings."
 msgstr ""
 
 msgid "Romania"
@@ -13700,6 +13976,11 @@ msgctxt "Setup button for native sync flow"
 msgid "Set Up Now"
 msgstr ""
 
+#. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
+msgctxt "Encrypted storage setup button shown in native browsers"
+msgid "Set Up Sync & Backup"
+msgstr ""
+
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
 msgctxt "Title for the Sync & Backup intro screen"
 msgid "Set Up Sync & Backup"
@@ -13842,6 +14123,12 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
+msgctxt ""
+"Label beside the share-content switch on the Duck.ai response feedback form"
+msgid "Share this conversation with DuckDuckGo"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -14856,6 +15143,21 @@ msgctxt "Brief for suggesting a blog post title"
 msgid "Suggest a title for a blog post"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest related articles or topics worth exploring next."
+msgstr ""
+
+#. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Suggest related articles to explore"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest some alternatives to this product."
+msgstr ""
+
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
 msgctxt "directions"
 msgid "Suggestions:"
@@ -14865,9 +15167,84 @@ msgctxt "noresults"
 msgid "Suggestions:"
 msgstr ""
 
+#. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Sum up the reviews"
+msgstr ""
+
 #. A short title for the a message asking the AI to summarize a text.
 msgctxt "Title for the summarize message"
 msgid "Summarize"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize the Q&As"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the background and notable work of this person."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the key details of this event."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the questions and answers on this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize their background"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this book"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this book."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this discussion"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this discussion thread."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this video"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this video."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize what the reviews say."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -15124,6 +15501,11 @@ msgstr ""
 msgid "Syria"
 msgstr ""
 
+#. Text for a button that enables the theme to follow the operating system's color scheme preference.
+msgctxt "System theme button for theme selector"
+msgid "System"
+msgstr ""
+
 #. Abbreviation indicating this is the total score for a game
 msgctxt "Sports module"
 msgid "T"
@@ -15147,6 +15529,11 @@ msgctxt "language_name"
 msgid "Tahitian"
 msgstr ""
 
+#. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Tailor my resume"
+msgstr ""
+
 msgid "Taiwan"
 msgstr "تايوان"
 
@@ -15168,6 +15555,12 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "Take control of your personal data!"
+msgstr ""
+
+#. Description for the Feedback section of the Duck.ai settings page, asking the user to take an anonymous survey to let us know how we can make Duck.ai better.
+msgctxt "Feedback section description on the Duck.ai settings page"
+msgid ""
+"Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
 
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -15412,6 +15805,11 @@ msgstr ""
 #. https://duck.co/media/files/theme.png
 msgid "Theme"
 msgstr "المظهر"
+
+#. Text for the theme selector label that allows users to switch between Light and dark theme.
+msgctxt "Label for the theme selector feature"
+msgid "Theme"
+msgstr ""
 
 #. http://i.imgur.com/LpFhb1e.png
 msgctxt "settings"
@@ -16063,6 +16461,16 @@ msgid ""
 "movie theatre?”"
 msgstr ""
 
+#. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Translate this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
+msgctxt "Page suggestion prompt"
+msgid "Translate this page into %s."
+msgstr ""
+
 #. Placeholder text for a region that will display translated text.
 msgctxt "translations_module"
 msgid "Translation"
@@ -16177,6 +16585,11 @@ msgstr ""
 #. Call-to-action button for the subscription promo in the SERP sidemenu.
 msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
+msgstr ""
+
+#. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
+msgctxt "settings"
+msgid "Try It Now"
 msgstr ""
 
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -16370,6 +16783,20 @@ msgstr "جرب: %s"
 #. Response a user can select in a feedback form, indicating that they're trying DuckDuckGo again.
 msgctxt "new user poll"
 msgid "Trying DuckDuckGo again"
+msgstr ""
+
+#. Message shown in a modal after supported third-party browser users disable AI features in Settings. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+#. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
 msgstr ""
 
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -16974,6 +17401,11 @@ msgstr ""
 msgid "Uruguay"
 msgstr ""
 
+#. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
+msgctxt "Navigation label on the Duck.ai settings page"
+msgid "Usage"
+msgstr ""
+
 #. A feedback suggestion
 msgctxt "Feedback prompt"
 msgid "Usage limit"
@@ -17322,6 +17754,11 @@ msgstr ""
 msgid "Wales"
 msgstr ""
 
+#. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Walk me through the steps"
+msgstr ""
+
 #. Label for walking directions on a map.
 msgctxt "directions"
 msgid "Walking"
@@ -17412,6 +17849,16 @@ msgstr ""
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
+msgstr ""
+
+#. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
+msgctxt ""
+"Inline warning shown below the share-content toggle when the user selects "
+"Harmful or Illegal but has not enabled sharing"
+msgid ""
+"We can only fix what we can see. To report a harmful or illegal response, "
+"please share this conversation with DuckDuckGo so we can investigate and "
+"address the issue."
 msgstr ""
 
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -17833,6 +18280,87 @@ msgid ""
 "experience."
 msgstr ""
 
+#. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the counterarguments?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the hours & location?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key contributions of this paper?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key contributions?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key details?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key points covered in this video?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key points?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key takeaways from this article?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key takeaways?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key things I will learn from this course?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main counterarguments or criticisms of this?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main questions this page answers?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the must-try dishes here?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"What are the opening hours, location, and contact details for this place?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the pros and cons of this product?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the pros and cons?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
 msgctxt "feedback form"
 msgid "What bothered you most?"
@@ -17916,6 +18444,11 @@ msgctxt "Full sentence for defining a term"
 msgid "What does atria mean in the context of a medical article?"
 msgstr ""
 
+#. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What does this answer?"
+msgstr ""
+
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
@@ -17925,6 +18458,11 @@ msgstr ""
 msgctxt "cloudsave"
 msgid "What information gets saved?"
 msgstr "ما هيا المعلومات الحفظ , سحابة الحفظ"
+
+#. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What interview questions might come up for this role?"
+msgstr ""
 
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
@@ -17936,6 +18474,11 @@ msgstr ""
 #. Text for a prompt suggestion for looking up the capital city of Albania.
 msgctxt "Full sentence for looking up basic facts"
 msgid "What is the capital city of Albania?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What is the overall verdict and rating for this?"
 msgstr ""
 
 #. Link to a page with additional information.
@@ -17958,6 +18501,11 @@ msgctxt "maps_places"
 msgid "What people say:"
 msgstr ""
 
+#. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What should I order?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
 msgctxt "feedback form"
 msgid "What stood out?"
@@ -17966,6 +18514,16 @@ msgstr ""
 #. Question on a feedback form for a negative feedback response.
 msgctxt "feedback form"
 msgid "What was wrong with the response? (optional)"
+msgstr ""
+
+#. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I learn?"
+msgstr ""
+
+#. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I need?"
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -17980,6 +18538,11 @@ msgstr ""
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
 msgctxt "SERP footer content"
 msgid "What's New"
+msgstr ""
+
+#. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What's the verdict?"
 msgstr ""
 
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -18021,6 +18584,11 @@ msgctxt "Feedback prompt"
 msgid "Which features are missing? (Optional)"
 msgstr ""
 
+#. An invitation for users to leave feedback
+msgctxt "Feedback prompt"
+msgid "Which features are missing? (optional)"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
 msgid "White"
 msgstr "أبيض"
@@ -18032,6 +18600,16 @@ msgstr "ابيض"
 
 #. Link to an about us page.
 msgid "Who We Are"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Who are the main cast and crew, and what else are they known for?"
+msgstr ""
+
+#. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Who is this person?"
 msgstr ""
 
 #. Header above a collection of privacy-related links.

--- a/locales/ast_ES/LC_MESSAGES/duckduckgo.po
+++ b/locales/ast_ES/LC_MESSAGES/duckduckgo.po
@@ -1156,6 +1156,11 @@ msgctxt "feedback form"
 msgid "Address is incorrect"
 msgstr ""
 
+#. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Adjust the servings"
+msgstr ""
+
 #. as in multiple advertisements
 msgid "Ads"
 msgstr ""
@@ -1327,6 +1332,13 @@ msgstr ""
 #. Heading shown on the empty chat screen. The text between the two %s markers is displayed inside a clickable privacy button. First %s renders a shield icon, second %s is an invisible end marker. Keep the word 'private' between both %s markers.
 msgctxt "Empty state heading in Duck.ai chat mode"
 msgid "All chats are %sprivate%s"
+msgstr ""
+
+#. Paragraph in the Privacy & Terms section of the About & Legal page in Duck.ai settings, summarizing how chats are anonymized and are not stored or used to train chat models.
+msgctxt "Privacy & Terms section description on the Duck.ai settings page"
+msgid ""
+"All chats are anonymized by DuckDuckGo, and your conversations are not used "
+"to train chat models by DuckDuckGo or the model providers"
 msgstr ""
 
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1539,6 +1551,12 @@ msgstr ""
 #. Confirmation message after location service is enabled.
 msgctxt "precise_user_location"
 msgid "Anonymous location enabled"
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Anonymously generates answers for search queries based on web content. "
+"Choose how often you want it to appear, or disable it completely."
 msgstr ""
 
 #. Instant Answer tab name
@@ -1761,6 +1779,11 @@ msgstr ""
 
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse
 msgid "Ask a follow-up with Duck.ai"
+msgstr ""
+
+#. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
+msgctxt "Page suggestion chip label"
+msgid "Ask about this page"
 msgstr ""
 
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2085,6 +2108,11 @@ msgstr ""
 msgid "Barcode"
 msgstr "Códigu de barres"
 
+#. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Based on this page, is this course worth taking?"
+msgstr ""
+
 msgctxt "settings"
 msgid "Basic"
 msgstr ""
@@ -2116,6 +2144,13 @@ msgstr ""
 #. Placeholder text displayed while the assistant waits for the user to choose an action.
 msgctxt "Assistant response placeholder"
 msgid "Before continuing..."
+msgstr ""
+
+#. Explains that before storing the report, DuckDuckGo will anonymize the conversation by removing PII like names, email addresses, and identifying metadata.
+msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
+msgid ""
+"Before storing this report, DuckDuckGo will anonymize your conversation by "
+"removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
 #. Label that's displayed next to a past start date below a web search result.
@@ -2374,6 +2409,11 @@ msgstr "Brasil"
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Break Points Won"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Break this down into clear, numbered steps."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -2736,6 +2776,11 @@ msgstr ""
 #. Text of a button that performs a search for the cast of a particular movie or tv show
 msgctxt "Movie/TV Show Title instant answer"
 msgid "Cast"
+msgstr ""
+
+#. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Cast & Crew"
 msgstr ""
 
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -4085,6 +4130,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Create a shopping list with quantities from this recipe."
+msgstr ""
+
 #. Placeholder text displayed in the input field when starting a new image generation session.
 msgctxt "Placeholder text for the image generation input field"
 msgid "Create an image of a cute duck..."
@@ -4611,6 +4661,10 @@ msgstr ""
 msgid "Dictation limit reached"
 msgstr ""
 
+#. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
+msgid "Dictation temporarily unavailable"
+msgstr ""
+
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
@@ -4855,6 +4909,20 @@ msgctxt "precise_user_location"
 msgid "Done"
 msgstr ""
 
+#. Message shown in a modal after DuckDuckGo browser users disable AI features in Settings. The first two placeholders bold noai.duckduckgo.com. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
+"filtered out. %sLearn More%s"
+msgstr ""
+
+#. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
+"and AI images filtered out. %sLearn more%s"
+msgstr ""
+
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Double Faults"
@@ -4945,6 +5013,16 @@ msgctxt "Full sentence for writing an email"
 msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
+msgstr ""
+
+#. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Draft a cover letter"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Draft a cover letter for this job."
 msgstr ""
 
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -5084,6 +5162,14 @@ msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
 msgstr ""
 
+#. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
+msgctxt "About section description on the Duck.ai settings page"
+msgid ""
+"Duck.ai is created by DuckDuckGo. We're an independent online protection "
+"company for anyone who wants to take back control of their personal "
+"information."
+msgstr ""
+
 #. Title shown when an update is required before proceeding.
 msgctxt "duckai_migration"
 msgid "Duck.ai is moving domains"
@@ -5117,6 +5203,12 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Duck.ai lets you chat privately with popular AI models. Disabling it hides "
+"Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
 
 msgctxt "settings"
@@ -5882,6 +5974,16 @@ msgstr ""
 msgid "Eritrea"
 msgstr ""
 
+#. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Estimate the nutrition"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Estimate the nutritional information for this recipe."
+msgstr ""
+
 msgid "Estonia"
 msgstr "Estonia"
 
@@ -5926,10 +6028,50 @@ msgctxt "merchant promotion product ad extension"
 msgid "Expires in 1 day"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain the accepted answer in simple terms."
+msgstr ""
+
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
+msgstr ""
+
+#. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain the top answer"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this in simple, plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this paper"
+msgstr ""
+
+#. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this repo"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this research paper in plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this simply"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain what this repository does and how to use it."
 msgstr ""
 
 #. Label to show if song lyrics contain explicit content
@@ -6158,6 +6300,11 @@ msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
 msgstr ""
 
+msgctxt "settings"
+msgid ""
+"Filters out known AI spam sites from image search results. %sLearn More%s"
+msgstr ""
+
 #. Label for the final score of a sporting event.
 msgid "Final"
 msgstr ""
@@ -6197,6 +6344,11 @@ msgstr ""
 #. Short description shown below the 'Web Search' label in the Tools dropdown.
 msgctxt "Subtitle for the Web Search tool entry in the Tools dropdown menu"
 msgid "Find current information"
+msgstr ""
+
+#. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Find me alternatives"
 msgstr ""
 
 #. Button that searches for results closer to the user's current location.
@@ -6587,6 +6739,11 @@ msgstr ""
 msgid "Generate More"
 msgstr ""
 
+#. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Generate a shopping list"
+msgstr ""
+
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
 msgid "Generate a short answer from the web"
 msgstr ""
@@ -6821,6 +6978,11 @@ msgstr ""
 #. Text for a button inviting users to give it a try for the Duck.ai product. On click, they're taken to the Duck.ai page.
 msgctxt "Onboarding welcome screen button text"
 msgid "Give it a Try"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Give me a quick background on this person."
 msgstr ""
 
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -7183,6 +7345,16 @@ msgstr ""
 
 #. Link to a page with information about sharing DuckDuckGo with friends.
 msgid "Help Spread Privacy"
+msgstr ""
+
+#. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Help me prep for the interview"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Help me tailor my resume for this job."
 msgstr ""
 
 #. Title of a SERP popup that invites users to take a survey (desktop only)
@@ -7602,6 +7774,13 @@ msgstr ""
 #. Text displayed on the button on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
 msgctxt "Onboarding terms screen button text"
 msgid "I Agree"
+msgstr ""
+
+#. Text for the button that takes the user to the external DuckDuckGo login subscription page.
+msgctxt ""
+"Text for the I already have a subscription button in the Duck.ai settings "
+"page"
+msgid "I Already Have a Subscription"
 msgstr ""
 
 #. Text for the button that takes the user to the login subscription page.
@@ -8054,6 +8233,11 @@ msgctxt "Sidemenu browser promo"
 msgid "Install Mac Browser"
 msgstr ""
 
+#. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
+msgctxt "settings"
+msgid "Install Now"
+msgstr ""
+
 #. Text of a button to install the DuckDuckGo app
 msgctxt "Serp footer content"
 msgid "Install Our App"
@@ -8133,9 +8317,36 @@ msgctxt "cloudsave"
 msgid "Is deleted data really deleted?"
 msgstr "¿Desaníciense daveres los datos?"
 
+#. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is it worth taking?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this place any good?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"Is this place any good? Summarize its reputation based on reviews and "
+"ratings."
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "Is this video helpful?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this worth watching?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Is this worth watching? Give me a spoiler-free take."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -8632,6 +8843,11 @@ msgstr ""
 msgid "Links:"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "List the tools, materials, or prerequisites I need for this."
+msgstr ""
+
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
 msgid "Listen"
 msgstr ""
@@ -8964,6 +9180,11 @@ msgstr ""
 #. Label for linke navigating to site exclusion feature on Settings page
 msgctxt "Exclusion message manage sites button"
 msgid "Manage blocked sites"
+msgstr ""
+
+#. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
+msgctxt "setting"
+msgid "Manage in Browser Settings"
 msgstr ""
 
 #. Link to the site exclusion settings page
@@ -11265,6 +11486,11 @@ msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
+msgid "Please describe why the chat response is harmful or illegal. (optional)"
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
+msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
 msgstr ""
 
@@ -11283,6 +11509,13 @@ msgctxt "Modal disclaimer text"
 msgid ""
 "Please note: starting a new chat with any model will delete your current "
 "chat session."
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
+msgctxt "Feedback prompt"
+msgid ""
+"Please paste your prompt and the problematic output (with any personal "
+"information removed) and describe why the content is harmful or illegal."
 msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -11667,6 +11900,11 @@ msgctxt "settings"
 msgid "Privacy"
 msgstr "Privacidá"
 
+#. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
+msgctxt "Section heading on the Duck.ai settings page"
+msgid "Privacy & Terms"
+msgstr ""
+
 msgid "Privacy Blog"
 msgstr ""
 
@@ -11720,6 +11958,11 @@ msgstr ""
 
 #. Text used in other strings to link to the Privacy Policy and Terms of Service content.
 msgctxt "Copy used to compose link in sentences"
+msgid "Privacy Policy and Terms of Service"
+msgstr ""
+
+#. Text for a button that links to the terms of use and privacy policy page.
+msgctxt "Secondary button text in active privacy modal"
 msgid "Privacy Policy and Terms of Service"
 msgstr ""
 
@@ -12128,6 +12371,26 @@ msgctxt "Brief for recommending a book"
 msgid "Recommend a book"
 msgstr ""
 
+#. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar books"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar books."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar movies or shows."
+msgstr ""
+
+#. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar titles"
+msgstr ""
+
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
 msgid "Recording failed. Please try again."
 msgstr ""
@@ -12447,6 +12710,14 @@ msgstr ""
 msgid "Republic of Moldova"
 msgstr ""
 
+#. Note indicating that sharing the conversation is mandatory when reporting harmful or illegal content. Rendered alongside the standard share label (DUCKCHAT_RESPONSE_FEEDBACK_SHARE_PROMPT_RESPONSE_LABEL), not replacing it.
+msgctxt ""
+"Note shown under the share-content switch label on the Duck.ai response "
+"feedback form when the user has selected Harmful or Illegal as the feedback "
+"reason"
+msgid "Required for harmful or illegal reports"
+msgstr ""
+
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
 msgctxt "Description for extended reasoning mode in Duck.ai"
 msgid "Researches before responding"
@@ -12632,6 +12903,11 @@ msgstr ""
 #. Label above a list of customer reviews of a business.
 msgctxt "maps_places"
 msgid "Reviews"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Rewrite this recipe scaled for a different number of servings."
 msgstr ""
 
 msgid "Romania"
@@ -13667,6 +13943,11 @@ msgctxt "Setup button for native sync flow"
 msgid "Set Up Now"
 msgstr ""
 
+#. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
+msgctxt "Encrypted storage setup button shown in native browsers"
+msgid "Set Up Sync & Backup"
+msgstr ""
+
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
 msgctxt "Title for the Sync & Backup intro screen"
 msgid "Set Up Sync & Backup"
@@ -13810,6 +14091,12 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
+msgctxt ""
+"Label beside the share-content switch on the Duck.ai response feedback form"
+msgid "Share this conversation with DuckDuckGo"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -14824,6 +15111,21 @@ msgctxt "Brief for suggesting a blog post title"
 msgid "Suggest a title for a blog post"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest related articles or topics worth exploring next."
+msgstr ""
+
+#. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Suggest related articles to explore"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest some alternatives to this product."
+msgstr ""
+
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
 msgctxt "directions"
 msgid "Suggestions:"
@@ -14833,9 +15135,84 @@ msgctxt "noresults"
 msgid "Suggestions:"
 msgstr "Suxerencies"
 
+#. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Sum up the reviews"
+msgstr ""
+
 #. A short title for the a message asking the AI to summarize a text.
 msgctxt "Title for the summarize message"
 msgid "Summarize"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize the Q&As"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the background and notable work of this person."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the key details of this event."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the questions and answers on this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize their background"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this book"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this book."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this discussion"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this discussion thread."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this video"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this video."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize what the reviews say."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -15090,6 +15467,11 @@ msgstr ""
 msgid "Syria"
 msgstr ""
 
+#. Text for a button that enables the theme to follow the operating system's color scheme preference.
+msgctxt "System theme button for theme selector"
+msgid "System"
+msgstr ""
+
 #. Abbreviation indicating this is the total score for a game
 msgctxt "Sports module"
 msgid "T"
@@ -15113,6 +15495,11 @@ msgctxt "language_name"
 msgid "Tahitian"
 msgstr ""
 
+#. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Tailor my resume"
+msgstr ""
+
 msgid "Taiwan"
 msgstr ""
 
@@ -15134,6 +15521,12 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "Take control of your personal data!"
+msgstr ""
+
+#. Description for the Feedback section of the Duck.ai settings page, asking the user to take an anonymous survey to let us know how we can make Duck.ai better.
+msgctxt "Feedback section description on the Duck.ai settings page"
+msgid ""
+"Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
 
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -15378,6 +15771,11 @@ msgstr ""
 #. https://duck.co/media/files/theme.png
 msgid "Theme"
 msgstr "Estilu"
+
+#. Text for the theme selector label that allows users to switch between Light and dark theme.
+msgctxt "Label for the theme selector feature"
+msgid "Theme"
+msgstr ""
 
 #. http://i.imgur.com/LpFhb1e.png
 msgctxt "settings"
@@ -16029,6 +16427,16 @@ msgid ""
 "movie theatre?”"
 msgstr ""
 
+#. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Translate this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
+msgctxt "Page suggestion prompt"
+msgid "Translate this page into %s."
+msgstr ""
+
 #. Placeholder text for a region that will display translated text.
 msgctxt "translations_module"
 msgid "Translation"
@@ -16143,6 +16551,11 @@ msgstr ""
 #. Call-to-action button for the subscription promo in the SERP sidemenu.
 msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
+msgstr ""
+
+#. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
+msgctxt "settings"
+msgid "Try It Now"
 msgstr ""
 
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -16336,6 +16749,20 @@ msgstr ""
 #. Response a user can select in a feedback form, indicating that they're trying DuckDuckGo again.
 msgctxt "new user poll"
 msgid "Trying DuckDuckGo again"
+msgstr ""
+
+#. Message shown in a modal after supported third-party browser users disable AI features in Settings. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+#. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
 msgstr ""
 
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -16936,6 +17363,11 @@ msgstr ""
 msgid "Uruguay"
 msgstr ""
 
+#. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
+msgctxt "Navigation label on the Duck.ai settings page"
+msgid "Usage"
+msgstr ""
+
 #. A feedback suggestion
 msgctxt "Feedback prompt"
 msgid "Usage limit"
@@ -17284,6 +17716,11 @@ msgstr ""
 msgid "Wales"
 msgstr ""
 
+#. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Walk me through the steps"
+msgstr ""
+
 #. Label for walking directions on a map.
 msgctxt "directions"
 msgid "Walking"
@@ -17374,6 +17811,16 @@ msgstr ""
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
+msgstr ""
+
+#. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
+msgctxt ""
+"Inline warning shown below the share-content toggle when the user selects "
+"Harmful or Illegal but has not enabled sharing"
+msgid ""
+"We can only fix what we can see. To report a harmful or illegal response, "
+"please share this conversation with DuckDuckGo so we can investigate and "
+"address the issue."
 msgstr ""
 
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -17793,6 +18240,87 @@ msgid ""
 "experience."
 msgstr ""
 
+#. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the counterarguments?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the hours & location?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key contributions of this paper?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key contributions?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key details?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key points covered in this video?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key points?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key takeaways from this article?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key takeaways?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key things I will learn from this course?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main counterarguments or criticisms of this?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main questions this page answers?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the must-try dishes here?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"What are the opening hours, location, and contact details for this place?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the pros and cons of this product?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the pros and cons?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
 msgctxt "feedback form"
 msgid "What bothered you most?"
@@ -17876,6 +18404,11 @@ msgctxt "Full sentence for defining a term"
 msgid "What does atria mean in the context of a medical article?"
 msgstr ""
 
+#. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What does this answer?"
+msgstr ""
+
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
@@ -17885,6 +18418,11 @@ msgstr ""
 msgctxt "cloudsave"
 msgid "What information gets saved?"
 msgstr "¿Qué información se guarda?"
+
+#. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What interview questions might come up for this role?"
+msgstr ""
 
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
@@ -17896,6 +18434,11 @@ msgstr ""
 #. Text for a prompt suggestion for looking up the capital city of Albania.
 msgctxt "Full sentence for looking up basic facts"
 msgid "What is the capital city of Albania?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What is the overall verdict and rating for this?"
 msgstr ""
 
 #. Link to a page with additional information.
@@ -17916,6 +18459,11 @@ msgctxt "maps_places"
 msgid "What people say:"
 msgstr ""
 
+#. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What should I order?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
 msgctxt "feedback form"
 msgid "What stood out?"
@@ -17924,6 +18472,16 @@ msgstr ""
 #. Question on a feedback form for a negative feedback response.
 msgctxt "feedback form"
 msgid "What was wrong with the response? (optional)"
+msgstr ""
+
+#. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I learn?"
+msgstr ""
+
+#. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I need?"
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -17938,6 +18496,11 @@ msgstr ""
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
 msgctxt "SERP footer content"
 msgid "What's New"
+msgstr ""
+
+#. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What's the verdict?"
 msgstr ""
 
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -17979,6 +18542,11 @@ msgctxt "Feedback prompt"
 msgid "Which features are missing? (Optional)"
 msgstr ""
 
+#. An invitation for users to leave feedback
+msgctxt "Feedback prompt"
+msgid "Which features are missing? (optional)"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
 msgid "White"
 msgstr "Blancu"
@@ -17991,6 +18559,16 @@ msgstr "Blancu"
 #. Link to an about us page.
 msgid "Who We Are"
 msgstr "Quién somos"
+
+#. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Who are the main cast and crew, and what else are they known for?"
+msgstr ""
+
+#. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Who is this person?"
+msgstr ""
 
 #. Header above a collection of privacy-related links.
 msgid "Why Privacy"

--- a/locales/az_AZ/LC_MESSAGES/duckduckgo.po
+++ b/locales/az_AZ/LC_MESSAGES/duckduckgo.po
@@ -1159,6 +1159,11 @@ msgctxt "feedback form"
 msgid "Address is incorrect"
 msgstr ""
 
+#. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Adjust the servings"
+msgstr ""
+
 #. as in multiple advertisements
 msgid "Ads"
 msgstr ""
@@ -1332,6 +1337,13 @@ msgstr ""
 #. Heading shown on the empty chat screen. The text between the two %s markers is displayed inside a clickable privacy button. First %s renders a shield icon, second %s is an invisible end marker. Keep the word 'private' between both %s markers.
 msgctxt "Empty state heading in Duck.ai chat mode"
 msgid "All chats are %sprivate%s"
+msgstr ""
+
+#. Paragraph in the Privacy & Terms section of the About & Legal page in Duck.ai settings, summarizing how chats are anonymized and are not stored or used to train chat models.
+msgctxt "Privacy & Terms section description on the Duck.ai settings page"
+msgid ""
+"All chats are anonymized by DuckDuckGo, and your conversations are not used "
+"to train chat models by DuckDuckGo or the model providers"
 msgstr ""
 
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1545,6 +1557,12 @@ msgstr ""
 #. Confirmation message after location service is enabled.
 msgctxt "precise_user_location"
 msgid "Anonymous location enabled"
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Anonymously generates answers for search queries based on web content. "
+"Choose how often you want it to appear, or disable it completely."
 msgstr ""
 
 #. Instant Answer tab name
@@ -1767,6 +1785,11 @@ msgstr ""
 
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse
 msgid "Ask a follow-up with Duck.ai"
+msgstr ""
+
+#. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
+msgctxt "Page suggestion chip label"
+msgid "Ask about this page"
 msgstr ""
 
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2091,6 +2114,11 @@ msgstr ""
 msgid "Barcode"
 msgstr "Barkod"
 
+#. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Based on this page, is this course worth taking?"
+msgstr ""
+
 msgctxt "settings"
 msgid "Basic"
 msgstr "Əsas"
@@ -2122,6 +2150,13 @@ msgstr ""
 #. Placeholder text displayed while the assistant waits for the user to choose an action.
 msgctxt "Assistant response placeholder"
 msgid "Before continuing..."
+msgstr ""
+
+#. Explains that before storing the report, DuckDuckGo will anonymize the conversation by removing PII like names, email addresses, and identifying metadata.
+msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
+msgid ""
+"Before storing this report, DuckDuckGo will anonymize your conversation by "
+"removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
 #. Label that's displayed next to a past start date below a web search result.
@@ -2380,6 +2415,11 @@ msgstr "Brazilya"
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Break Points Won"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Break this down into clear, numbered steps."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -2739,6 +2779,11 @@ msgstr "Karyera"
 #. Text of a button that performs a search for the cast of a particular movie or tv show
 msgctxt "Movie/TV Show Title instant answer"
 msgid "Cast"
+msgstr ""
+
+#. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Cast & Crew"
 msgstr ""
 
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -4093,6 +4138,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Create a shopping list with quantities from this recipe."
+msgstr ""
+
 #. Placeholder text displayed in the input field when starting a new image generation session.
 msgctxt "Placeholder text for the image generation input field"
 msgid "Create an image of a cute duck..."
@@ -4619,6 +4669,10 @@ msgstr ""
 msgid "Dictation limit reached"
 msgstr ""
 
+#. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
+msgid "Dictation temporarily unavailable"
+msgstr ""
+
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
@@ -4863,6 +4917,20 @@ msgctxt "precise_user_location"
 msgid "Done"
 msgstr ""
 
+#. Message shown in a modal after DuckDuckGo browser users disable AI features in Settings. The first two placeholders bold noai.duckduckgo.com. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
+"filtered out. %sLearn More%s"
+msgstr ""
+
+#. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
+"and AI images filtered out. %sLearn more%s"
+msgstr ""
+
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Double Faults"
@@ -4953,6 +5021,16 @@ msgctxt "Full sentence for writing an email"
 msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
+msgstr ""
+
+#. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Draft a cover letter"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Draft a cover letter for this job."
 msgstr ""
 
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -5092,6 +5170,14 @@ msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
 msgstr ""
 
+#. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
+msgctxt "About section description on the Duck.ai settings page"
+msgid ""
+"Duck.ai is created by DuckDuckGo. We're an independent online protection "
+"company for anyone who wants to take back control of their personal "
+"information."
+msgstr ""
+
 #. Title shown when an update is required before proceeding.
 msgctxt "duckai_migration"
 msgid "Duck.ai is moving domains"
@@ -5125,6 +5211,12 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Duck.ai lets you chat privately with popular AI models. Disabling it hides "
+"Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
 
 msgctxt "settings"
@@ -5890,6 +5982,16 @@ msgstr ""
 msgid "Eritrea"
 msgstr ""
 
+#. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Estimate the nutrition"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Estimate the nutritional information for this recipe."
+msgstr ""
+
 msgid "Estonia"
 msgstr "Estoniya‎"
 
@@ -5934,10 +6036,50 @@ msgctxt "merchant promotion product ad extension"
 msgid "Expires in 1 day"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain the accepted answer in simple terms."
+msgstr ""
+
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
+msgstr ""
+
+#. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain the top answer"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this in simple, plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this paper"
+msgstr ""
+
+#. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this repo"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this research paper in plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this simply"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain what this repository does and how to use it."
 msgstr ""
 
 #. Label to show if song lyrics contain explicit content
@@ -6168,6 +6310,11 @@ msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
 msgstr ""
 
+msgctxt "settings"
+msgid ""
+"Filters out known AI spam sites from image search results. %sLearn More%s"
+msgstr ""
+
 #. Label for the final score of a sporting event.
 msgid "Final"
 msgstr ""
@@ -6207,6 +6354,11 @@ msgstr ""
 #. Short description shown below the 'Web Search' label in the Tools dropdown.
 msgctxt "Subtitle for the Web Search tool entry in the Tools dropdown menu"
 msgid "Find current information"
+msgstr ""
+
+#. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Find me alternatives"
 msgstr ""
 
 #. Button that searches for results closer to the user's current location.
@@ -6597,6 +6749,11 @@ msgstr ""
 msgid "Generate More"
 msgstr ""
 
+#. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Generate a shopping list"
+msgstr ""
+
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
 msgid "Generate a short answer from the web"
 msgstr ""
@@ -6831,6 +6988,11 @@ msgstr ""
 #. Text for a button inviting users to give it a try for the Duck.ai product. On click, they're taken to the Duck.ai page.
 msgctxt "Onboarding welcome screen button text"
 msgid "Give it a Try"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Give me a quick background on this person."
 msgstr ""
 
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -7193,6 +7355,16 @@ msgstr ""
 
 #. Link to a page with information about sharing DuckDuckGo with friends.
 msgid "Help Spread Privacy"
+msgstr ""
+
+#. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Help me prep for the interview"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Help me tailor my resume for this job."
 msgstr ""
 
 #. Title of a SERP popup that invites users to take a survey (desktop only)
@@ -7612,6 +7784,13 @@ msgstr ""
 #. Text displayed on the button on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
 msgctxt "Onboarding terms screen button text"
 msgid "I Agree"
+msgstr ""
+
+#. Text for the button that takes the user to the external DuckDuckGo login subscription page.
+msgctxt ""
+"Text for the I already have a subscription button in the Duck.ai settings "
+"page"
+msgid "I Already Have a Subscription"
 msgstr ""
 
 #. Text for the button that takes the user to the login subscription page.
@@ -8068,6 +8247,11 @@ msgctxt "Sidemenu browser promo"
 msgid "Install Mac Browser"
 msgstr ""
 
+#. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
+msgctxt "settings"
+msgid "Install Now"
+msgstr ""
+
 #. Text of a button to install the DuckDuckGo app
 msgctxt "Serp footer content"
 msgid "Install Our App"
@@ -8147,9 +8331,36 @@ msgctxt "cloudsave"
 msgid "Is deleted data really deleted?"
 msgstr "Silinən məlumatlar həqiqətən silinirmi?"
 
+#. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is it worth taking?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this place any good?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"Is this place any good? Summarize its reputation based on reviews and "
+"ratings."
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "Is this video helpful?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this worth watching?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Is this worth watching? Give me a spoiler-free take."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -8646,6 +8857,11 @@ msgstr "Keçid yazı tipi:"
 msgid "Links:"
 msgstr "Keçidlər:"
 
+#. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "List the tools, materials, or prerequisites I need for this."
+msgstr ""
+
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
 msgid "Listen"
 msgstr "Dinlə"
@@ -8978,6 +9194,11 @@ msgstr ""
 #. Label for linke navigating to site exclusion feature on Settings page
 msgctxt "Exclusion message manage sites button"
 msgid "Manage blocked sites"
+msgstr ""
+
+#. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
+msgctxt "setting"
+msgid "Manage in Browser Settings"
 msgstr ""
 
 #. Link to the site exclusion settings page
@@ -11281,6 +11502,11 @@ msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
+msgid "Please describe why the chat response is harmful or illegal. (optional)"
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
+msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
 msgstr ""
 
@@ -11299,6 +11525,13 @@ msgctxt "Modal disclaimer text"
 msgid ""
 "Please note: starting a new chat with any model will delete your current "
 "chat session."
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
+msgctxt "Feedback prompt"
+msgid ""
+"Please paste your prompt and the problematic output (with any personal "
+"information removed) and describe why the content is harmful or illegal."
 msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -11683,6 +11916,11 @@ msgctxt "settings"
 msgid "Privacy"
 msgstr "Məxfilik"
 
+#. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
+msgctxt "Section heading on the Duck.ai settings page"
+msgid "Privacy & Terms"
+msgstr ""
+
 msgid "Privacy Blog"
 msgstr ""
 
@@ -11736,6 +11974,11 @@ msgstr ""
 
 #. Text used in other strings to link to the Privacy Policy and Terms of Service content.
 msgctxt "Copy used to compose link in sentences"
+msgid "Privacy Policy and Terms of Service"
+msgstr ""
+
+#. Text for a button that links to the terms of use and privacy policy page.
+msgctxt "Secondary button text in active privacy modal"
 msgid "Privacy Policy and Terms of Service"
 msgstr ""
 
@@ -12144,6 +12387,26 @@ msgctxt "Brief for recommending a book"
 msgid "Recommend a book"
 msgstr ""
 
+#. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar books"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar books."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar movies or shows."
+msgstr ""
+
+#. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar titles"
+msgstr ""
+
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
 msgid "Recording failed. Please try again."
 msgstr ""
@@ -12463,6 +12726,14 @@ msgstr ""
 msgid "Republic of Moldova"
 msgstr ""
 
+#. Note indicating that sharing the conversation is mandatory when reporting harmful or illegal content. Rendered alongside the standard share label (DUCKCHAT_RESPONSE_FEEDBACK_SHARE_PROMPT_RESPONSE_LABEL), not replacing it.
+msgctxt ""
+"Note shown under the share-content switch label on the Duck.ai response "
+"feedback form when the user has selected Harmful or Illegal as the feedback "
+"reason"
+msgid "Required for harmful or illegal reports"
+msgstr ""
+
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
 msgctxt "Description for extended reasoning mode in Duck.ai"
 msgid "Researches before responding"
@@ -12648,6 +12919,11 @@ msgstr "Rəylər"
 #. Label above a list of customer reviews of a business.
 msgctxt "maps_places"
 msgid "Reviews"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Rewrite this recipe scaled for a different number of servings."
 msgstr ""
 
 msgid "Romania"
@@ -13685,6 +13961,11 @@ msgctxt "Setup button for native sync flow"
 msgid "Set Up Now"
 msgstr ""
 
+#. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
+msgctxt "Encrypted storage setup button shown in native browsers"
+msgid "Set Up Sync & Backup"
+msgstr ""
+
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
 msgctxt "Title for the Sync & Backup intro screen"
 msgid "Set Up Sync & Backup"
@@ -13828,6 +14109,12 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
+msgctxt ""
+"Label beside the share-content switch on the Duck.ai response feedback form"
+msgid "Share this conversation with DuckDuckGo"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -14842,6 +15129,21 @@ msgctxt "Brief for suggesting a blog post title"
 msgid "Suggest a title for a blog post"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest related articles or topics worth exploring next."
+msgstr ""
+
+#. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Suggest related articles to explore"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest some alternatives to this product."
+msgstr ""
+
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
 msgctxt "directions"
 msgid "Suggestions:"
@@ -14851,9 +15153,84 @@ msgctxt "noresults"
 msgid "Suggestions:"
 msgstr ""
 
+#. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Sum up the reviews"
+msgstr ""
+
 #. A short title for the a message asking the AI to summarize a text.
 msgctxt "Title for the summarize message"
 msgid "Summarize"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize the Q&As"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the background and notable work of this person."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the key details of this event."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the questions and answers on this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize their background"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this book"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this book."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this discussion"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this discussion thread."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this video"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this video."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize what the reviews say."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -15108,6 +15485,11 @@ msgstr ""
 msgid "Syria"
 msgstr ""
 
+#. Text for a button that enables the theme to follow the operating system's color scheme preference.
+msgctxt "System theme button for theme selector"
+msgid "System"
+msgstr ""
+
 #. Abbreviation indicating this is the total score for a game
 msgctxt "Sports module"
 msgid "T"
@@ -15131,6 +15513,11 @@ msgctxt "language_name"
 msgid "Tahitian"
 msgstr ""
 
+#. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Tailor my resume"
+msgstr ""
+
 msgid "Taiwan"
 msgstr "Tayvan"
 
@@ -15152,6 +15539,12 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "Take control of your personal data!"
+msgstr ""
+
+#. Description for the Feedback section of the Duck.ai settings page, asking the user to take an anonymous survey to let us know how we can make Duck.ai better.
+msgctxt "Feedback section description on the Duck.ai settings page"
+msgid ""
+"Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
 
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -15396,6 +15789,11 @@ msgstr ""
 #. https://duck.co/media/files/theme.png
 msgid "Theme"
 msgstr "Tema"
+
+#. Text for the theme selector label that allows users to switch between Light and dark theme.
+msgctxt "Label for the theme selector feature"
+msgid "Theme"
+msgstr ""
 
 #. http://i.imgur.com/LpFhb1e.png
 msgctxt "settings"
@@ -16047,6 +16445,16 @@ msgid ""
 "movie theatre?”"
 msgstr ""
 
+#. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Translate this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
+msgctxt "Page suggestion prompt"
+msgid "Translate this page into %s."
+msgstr ""
+
 #. Placeholder text for a region that will display translated text.
 msgctxt "translations_module"
 msgid "Translation"
@@ -16161,6 +16569,11 @@ msgstr ""
 #. Call-to-action button for the subscription promo in the SERP sidemenu.
 msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
+msgstr ""
+
+#. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
+msgctxt "settings"
+msgid "Try It Now"
 msgstr ""
 
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -16354,6 +16767,20 @@ msgstr "%s yoxla"
 #. Response a user can select in a feedback form, indicating that they're trying DuckDuckGo again.
 msgctxt "new user poll"
 msgid "Trying DuckDuckGo again"
+msgstr ""
+
+#. Message shown in a modal after supported third-party browser users disable AI features in Settings. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+#. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
 msgstr ""
 
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -16956,6 +17383,11 @@ msgstr ""
 msgid "Uruguay"
 msgstr ""
 
+#. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
+msgctxt "Navigation label on the Duck.ai settings page"
+msgid "Usage"
+msgstr ""
+
 #. A feedback suggestion
 msgctxt "Feedback prompt"
 msgid "Usage limit"
@@ -17304,6 +17736,11 @@ msgstr ""
 msgid "Wales"
 msgstr ""
 
+#. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Walk me through the steps"
+msgstr ""
+
 #. Label for walking directions on a map.
 msgctxt "directions"
 msgid "Walking"
@@ -17394,6 +17831,16 @@ msgstr ""
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
+msgstr ""
+
+#. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
+msgctxt ""
+"Inline warning shown below the share-content toggle when the user selects "
+"Harmful or Illegal but has not enabled sharing"
+msgid ""
+"We can only fix what we can see. To report a harmful or illegal response, "
+"please share this conversation with DuckDuckGo so we can investigate and "
+"address the issue."
 msgstr ""
 
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -17815,6 +18262,87 @@ msgid ""
 "experience."
 msgstr ""
 
+#. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the counterarguments?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the hours & location?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key contributions of this paper?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key contributions?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key details?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key points covered in this video?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key points?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key takeaways from this article?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key takeaways?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key things I will learn from this course?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main counterarguments or criticisms of this?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main questions this page answers?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the must-try dishes here?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"What are the opening hours, location, and contact details for this place?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the pros and cons of this product?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the pros and cons?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
 msgctxt "feedback form"
 msgid "What bothered you most?"
@@ -17898,6 +18426,11 @@ msgctxt "Full sentence for defining a term"
 msgid "What does atria mean in the context of a medical article?"
 msgstr ""
 
+#. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What does this answer?"
+msgstr ""
+
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
@@ -17907,6 +18440,11 @@ msgstr ""
 msgctxt "cloudsave"
 msgid "What information gets saved?"
 msgstr "Hansı məlumatlar saxlanılır?"
+
+#. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What interview questions might come up for this role?"
+msgstr ""
 
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
@@ -17918,6 +18456,11 @@ msgstr ""
 #. Text for a prompt suggestion for looking up the capital city of Albania.
 msgctxt "Full sentence for looking up basic facts"
 msgid "What is the capital city of Albania?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What is the overall verdict and rating for this?"
 msgstr ""
 
 #. Link to a page with additional information.
@@ -17938,6 +18481,11 @@ msgctxt "maps_places"
 msgid "What people say:"
 msgstr ""
 
+#. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What should I order?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
 msgctxt "feedback form"
 msgid "What stood out?"
@@ -17946,6 +18494,16 @@ msgstr ""
 #. Question on a feedback form for a negative feedback response.
 msgctxt "feedback form"
 msgid "What was wrong with the response? (optional)"
+msgstr ""
+
+#. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I learn?"
+msgstr ""
+
+#. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I need?"
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -17960,6 +18518,11 @@ msgstr ""
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
 msgctxt "SERP footer content"
 msgid "What's New"
+msgstr ""
+
+#. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What's the verdict?"
 msgstr ""
 
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -18002,6 +18565,11 @@ msgctxt "Feedback prompt"
 msgid "Which features are missing? (Optional)"
 msgstr ""
 
+#. An invitation for users to leave feedback
+msgctxt "Feedback prompt"
+msgid "Which features are missing? (optional)"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
 msgid "White"
 msgstr "Ağ"
@@ -18013,6 +18581,16 @@ msgstr "Ağ"
 
 #. Link to an about us page.
 msgid "Who We Are"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Who are the main cast and crew, and what else are they known for?"
+msgstr ""
+
+#. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Who is this person?"
 msgstr ""
 
 #. Header above a collection of privacy-related links.

--- a/locales/be_BY/LC_MESSAGES/duckduckgo.po
+++ b/locales/be_BY/LC_MESSAGES/duckduckgo.po
@@ -2,16 +2,15 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: be_BY\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
-"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 
 # smartling.gettext_line_width = normalized : 79
 # smartling.placeholder_format=C
@@ -467,8 +466,8 @@ msgstr "%1$sДаведацца больш%2$s."
 msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
 msgstr ""
-"%1$sДаведайцеся, як мы захоўваем прыватнасць даных вашага месцазнаходжання."
-"%2$s"
+"%1$sДаведайцеся, як мы захоўваем прыватнасць даных вашага "
+"месцазнаходжання.%2$s"
 
 # smartling.placeholder_format=C
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
@@ -491,8 +490,7 @@ msgstr ""
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "%sLong-press%s the DuckDuckGo app icon on the home screen"
-msgstr ""
-"%1$sДоўгае націсканне%2$s значка праграмы DuckDuckGo на галоўным экране"
+msgstr "%1$sДоўгае націсканне%2$s значка праграмы DuckDuckGo на галоўным экране"
 
 # smartling.placeholder_format=C
 #. A message displayed when there is an error loading content or no results on requery
@@ -1000,10 +998,10 @@ msgid ""
 "models from OpenAI, and Anthropic, and more."
 msgstr ""
 "У цяперашні час ў адказах з дапамогай штучнага інтэлекту не падтрымліваюцца "
-"непасрэдна дадатковыя пытанні. Аднак мы таксама прапануем сэрвіс %1$sDuck."
-"ai%2$s для дадатковых пытанняў і часта спасылаемся на яго. Гэта наш прыватны "
-"чат на базе штучнага інтэлекту, які падтрымлівае мадэлі чата ад OpenAI, "
-"Anthropic і іншых."
+"непасрэдна дадатковыя пытанні. Аднак мы таксама прапануем сэрвіс "
+"%1$sDuck.ai%2$s для дадатковых пытанняў і часта спасылаемся на яго. Гэта наш "
+"прыватны чат на базе штучнага інтэлекту, які падтрымлівае мадэлі чата ад "
+"OpenAI, Anthropic і іншых."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has turned off AI features and will no longer see AI-assisted answers.
@@ -1445,7 +1443,7 @@ msgstr "Адрас няправільны"
 #. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Adjust the servings"
-msgstr ""
+msgstr "Наладзь порцыі"
 
 # smartling.placeholder_format=C
 #. as in multiple advertisements
@@ -1667,6 +1665,8 @@ msgid ""
 "All chats are anonymized by DuckDuckGo, and your conversations are not used "
 "to train chat models by DuckDuckGo or the model providers"
 msgstr ""
+"Усе чаты ананімізуюцца DuckDuckGo, а вашы размовы не выкарыстоўваюцца для "
+"навучання мадэляў чатаў DuckDuckGo або пастаўшчыкамі мадэляў"
 
 # smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1698,8 +1698,7 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "All model providers are prevented from training their AI on your "
 "conversations."
-msgstr ""
-"Усім пастаўшчыкам мадэляў забаронена навучаць свой AI на вашых размовах."
+msgstr "Усім пастаўшчыкам мадэляў забаронена навучаць свой AI на вашых размовах."
 
 # smartling.placeholder_format=C
 #. Text displayed in the subheader of the modal that allows the user to pick an AI chat model.
@@ -1810,8 +1809,7 @@ msgstr "Ужо сінхранізавана."
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Also search privately on your iPad, iPhone, or Android!"
-msgstr ""
-"Таксама захоўвайце сваю прыватнасць падчас пошуку на iPad, iPhone ці Android!"
+msgstr "Таксама захоўвайце сваю прыватнасць падчас пошуку на iPad, iPhone ці Android!"
 
 # smartling.placeholder_format=C
 #. Keyboard shortcut for Duck.ai
@@ -1944,6 +1942,9 @@ msgid ""
 "Anonymously generates answers for search queries based on web content. "
 "Choose how often you want it to appear, or disable it completely."
 msgstr ""
+"Ананімна генерыруе адказы на пошукавыя запыты на аснове вэб-змесціва. "
+"Выберыце, як часта вы хочаце, каб яны з'яўляліся, або цалкам адключыце гэту "
+"функцыю."
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -2110,8 +2111,7 @@ msgctxt "Body text for disable chat history confirmation modal"
 msgid ""
 "Are you sure you want to disable history? This will delete all chats, "
 "including pinned chats."
-msgstr ""
-"Сапраўды адключыць гісторыю? Гэта выдаліць усе чаты, у тым ліку замацаваныя."
+msgstr "Сапраўды адключыць гісторыю? Гэта выдаліць усе чаты, у тым ліку замацаваныя."
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to disable recent chats, with a warning that it will also delete currently saved chats.
@@ -2227,7 +2227,7 @@ msgstr "Задайце ўдакладняльнае пытанне ў Duck.ai"
 #. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
 msgctxt "Page suggestion chip label"
 msgid "Ask about this page"
-msgstr ""
+msgstr "Спытайцеся пра гэту старонку"
 
 # smartling.placeholder_format=C
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2652,7 +2652,7 @@ msgstr "Штрыхкод"
 #. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Based on this page, is this course worth taking?"
-msgstr ""
+msgstr "Зыходзячы з гэтай старонкі, ці варта праходзіць гэты курс?"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2701,6 +2701,9 @@ msgid ""
 "Before storing this report, DuckDuckGo will anonymize your conversation by "
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
+"Перад захаваннем гэтай справаздачы DuckDuckGo ананімізуе вашу размову, "
+"выдаляючы асабістыя даныя, напрыклад імёны, адрасы электроннай пошты і "
+"метаданыя, якія дазваляюць ідэнтыфікаваць асобу."
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -2828,8 +2831,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. A disclaimer about AI-generated images in search results
 msgid "Block list is not exhaustive and may contain inaccuracies."
-msgstr ""
-"Спіс блакіроўкі не з'яўляецца вычарпальным і можа ўтрымліваць недакладнасці."
+msgstr "Спіс блакіроўкі не з'яўляецца вычарпальным і можа ўтрымліваць недакладнасці."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -3025,7 +3027,7 @@ msgstr "Выйграныя брэйк-пойнты"
 #. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Break this down into clear, numbered steps."
-msgstr ""
+msgstr "Разбіце гэта на зразумелыя пранумараваныя крокі."
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -3485,7 +3487,7 @@ msgstr "Акцёры"
 #. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Cast & Crew"
-msgstr ""
+msgstr "Акцёры і здымачная група"
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -3591,8 +3593,7 @@ msgstr "Змяняе колер фону на ўсім сайце"
 msgctxt "settings"
 msgid ""
 "Changes the background color of results on hover, modules, and dropdown menus"
-msgstr ""
-"Змяняе фонавы колер вынікаў пры навядзенні курсорам, модуляў і выпадных меню"
+msgstr "Змяняе фонавы колер вынікаў пры навядзенні курсорам, модуляў і выпадных меню"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/NdpkbY0.png
@@ -3725,8 +3726,8 @@ msgstr ""
 "мадэлямі чата на базе штучнага інтэлекту, якімі падтрымліваюцца мадэлі "
 "OpenAI, Anthropic і іншыя. Адключэнне гэтай налады схавае кнопкі і спасылкі "
 "чата ў DuckDuckGo Search. Тым не менш, можна атрымаць доступ да чата, калі "
-"гэты параметр выключаны. Для гэтага трэба перайсці на сайт %1$shttps://duck."
-"ai%2$s ."
+"гэты параметр выключаны. Для гэтага трэба перайсці на сайт "
+"%1$shttps://duck.ai%2$s ."
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -3791,8 +3792,8 @@ msgctxt "Promotional text"
 msgid ""
 "Chat privately on any website with the Duck.ai sidebar in our free browser."
 msgstr ""
-"Размаўляйце ў чаце прыватна на любым сайце з дапамогай бакавой панэлі Duck."
-"ai ў нашым бясплатным браўзеры."
+"Размаўляйце ў чаце прыватна на любым сайце з дапамогай бакавой панэлі "
+"Duck.ai ў нашым бясплатным браўзеры."
 
 # smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
@@ -3956,8 +3957,7 @@ msgstr ""
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
 msgctxt "noresults"
 msgid "Check the status page for updates on this outage."
-msgstr ""
-"Праверце старонку стану, каб даведацца пра абнаўленні наконт гэтага збою."
+msgstr "Праверце старонку стану, каб даведацца пра абнаўленні наконт гэтага збою."
 
 # smartling.placeholder_format=C
 #. Title shown to the host device (the one that is logged in) after it sends the pairing code. The host can't confirm the peer applied it, so this is a title-only screen (no body) prompting the user to finish on the other device.
@@ -4016,8 +4016,7 @@ msgstr "Выбар мадэляў штучнага інтэлекту, у тым
 # smartling.placeholder_format=C
 #. As in 'Choose to keep DuckDuckGo as your default search engine'. Placeholders are for markup, you can ignore them.
 msgid "Choose %skeep it%s to continue protecting your privacy."
-msgstr ""
-"Націсніце %1$sЗахаваць%2$s, каб мы і надалей абаранялі вашу прыватнасць."
+msgstr "Націсніце %1$sЗахаваць%2$s, каб мы і надалей абаранялі вашу прыватнасць."
 
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
@@ -4421,8 +4420,7 @@ msgstr "Націсніце на %1$sПастаўшчыкі пошуку%2$s па
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click on the %sTools icon%s in the top-right of the browser"
-msgstr ""
-"Націсніце на %1$sзначок інструментаў%2$s у правым верхнім куце браўзера"
+msgstr "Націсніце на %1$sзначок інструментаў%2$s у правым верхнім куце браўзера"
 
 #  Firefox default search engine instruction
 # smartling.placeholder_format=C
@@ -5206,7 +5204,7 @@ msgstr "Стварыце відарыс"
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
-msgstr ""
+msgstr "Стварыце спіс пакупак з колькасцю інгрэдыентаў з гэтага рэцэпта."
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed in the input field when starting a new image generation session.
@@ -5853,7 +5851,7 @@ msgstr "Ліміт дыктавання вычарпаны"
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
 msgid "Dictation temporarily unavailable"
-msgstr ""
+msgstr "Дыктаванне часова недаступнае"
 
 # smartling.placeholder_format=C
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
@@ -6163,6 +6161,8 @@ msgid ""
 "Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
 "filtered out. %sLearn More%s"
 msgstr ""
+"Не хочаце выкарыстоўваць AI? %1$snoai.duckduckgo.com%2$s не прапануе функцыі "
+"AI, а AI-відарысы фільтруюцца. %3$sДаведацца больш%4$s"
 
 # smartling.placeholder_format=C
 #. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
@@ -6171,6 +6171,9 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
+"Не хочаце выкарыстоўваць AI? Наведайце %1$snoai.duckduckgo.com%2$s, каб "
+"шукаць без функцый AI і з адфільтраванымі AI-відарысамі. %3$sДаведацца "
+"больш%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6290,13 +6293,13 @@ msgstr ""
 #. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Draft a cover letter"
-msgstr ""
+msgstr "Ствары суправаджальны ліст"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Draft a cover letter for this job."
-msgstr ""
+msgstr "Ствары суправаджальны ліст для гэтай вакансіі."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -6482,6 +6485,9 @@ msgid ""
 "company for anyone who wants to take back control of their personal "
 "information."
 msgstr ""
+"Duck.ai створаны кампаніяй DuckDuckGo. Мы — незалежная кампанія па "
+"забеспячэнні прыватнасці ў інтэрнэце для ўсіх, хто хоча вярнуць кантроль над "
+"сваёй асабістай інфармацыяй."
 
 # smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
@@ -6534,6 +6540,9 @@ msgid ""
 "Duck.ai lets you chat privately with popular AI models. Disabling it hides "
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
+"Duck.ai дазваляе вам прыватна размаўляць з папулярнымі мадэлямі штучнага "
+"інтэлекту. Адключэнне схавае кнопкі і спасылкі Duck.ai, але вы ўсё яшчэ "
+"можаце наведаць %1$sduck.ai%2$s напрамую."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6597,8 +6606,7 @@ msgstr "Duck.ai абноўлены!"
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
-msgstr ""
-"Duck.ai найлепш працуе ў нашай прыватнай і бясплатнай праграме DuckDuckGo!"
+msgstr "Duck.ai найлепш працуе ў нашай прыватнай і бясплатнай праграме DuckDuckGo!"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -6608,10 +6616,10 @@ msgid ""
 "AI chat no sign up, OpenAI, Anthropic, Llama, Mistral, open source AI "
 "models, privacy focused AI, no account AI chat"
 msgstr ""
-"Duck.ai, DuckDuckGo AI, прыватны чат-бот AI, бясплатны AI-чат, ананімны AI-"
-"чат, AI-чат без рэгістрацыі, OpenAI, Anthropic, Llama, Mistral, мадэлі AI з "
-"адкрытым зыходным кодам, арыентаваны на прыватнасць AI, AI-чат без уліковага "
-"запісу"
+"Duck.ai, DuckDuckGo AI, прыватны чат-бот AI, бясплатны AI-чат, ананімны "
+"AI-чат, AI-чат без рэгістрацыі, OpenAI, Anthropic, Llama, Mistral, мадэлі AI "
+"з адкрытым зыходным кодам, арыентаваны на прыватнасць AI, AI-чат без "
+"уліковага запісу"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -6777,8 +6785,7 @@ msgctxt "Error message for VQD error"
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. Please refresh the page and "
 "try again."
-msgstr ""
-"DuckDuckGo AI Chat часова недаступны. Абнавіце старонку і паўтарыце спробу."
+msgstr "DuckDuckGo AI Chat часова недаступны. Абнавіце старонку і паўтарыце спробу."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -7385,8 +7392,7 @@ msgstr "Падабаецца Duck.ai?"
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure %s'Allow'%s is selected for the 'Location' setting."
-msgstr ""
-"Упэўніцеся, што для налады \"Месцазнаходжанне\" выбрана %1$sДазволіць%2$s."
+msgstr "Упэўніцеся, што для налады \"Месцазнаходжанне\" выбрана %1$sДазволіць%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
@@ -7398,22 +7404,19 @@ msgstr "Упэўніцеся, што %1$sўключана%2$s налада \"С�
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location' is set to %sallow%s"
-msgstr ""
-"Упэўніцеся, што для налады \"Месцазнаходжанне\" выбрана %1$sДазволіць%2$s"
+msgstr "Упэўніцеся, што для налады \"Месцазнаходжанне\" выбрана %1$sДазволіць%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location' is set to %sallow%s."
-msgstr ""
-"Упэўніцеся, што для налады \"Месцазнаходжанне\" выбрана %1$sдазволіць%2$s."
+msgstr "Упэўніцеся, што для налады \"Месцазнаходжанне\" выбрана %1$sдазволіць%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure Location is set to %sAllow%s"
-msgstr ""
-"Упэўніцеся, што для налады \"Месцазнаходжанне\" выбрана %1$sДазволіць%2$s"
+msgstr "Упэўніцеся, што для налады \"Месцазнаходжанне\" выбрана %1$sДазволіць%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
@@ -7431,8 +7434,7 @@ msgstr "Упэўніцеся, што %1$sдазволены%2$s доступ д�
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed %slocation access%s"
-msgstr ""
-"Упэўніцеся, што ў браўзеры дазволены %1$sдоступ да месцазнаходжання%2$s"
+msgstr "Упэўніцеся, што ў браўзеры дазволены %1$sдоступ да месцазнаходжання%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service.
@@ -7540,8 +7542,7 @@ msgstr "Экватарыяльная Гвінея"
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Erase your browsing data in a flash with our %sFire Button%s"
-msgstr ""
-"Імгненна выдаляйце даныя прагляду з дапамогай кнопкі %1$sFire Button%2$s"
+msgstr "Імгненна выдаляйце даныя прагляду з дапамогай кнопкі %1$sFire Button%2$s"
 
 # smartling.placeholder_format=C
 msgid "Eritrea"
@@ -7551,13 +7552,13 @@ msgstr "Эрытрэя"
 #. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Estimate the nutrition"
-msgstr ""
+msgstr "Ацані спажыўнасць"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Estimate the nutritional information for this recipe."
-msgstr ""
+msgstr "Ацані спажыўную каштоўнасць гэтага рэцэпта."
 
 # smartling.placeholder_format=C
 msgid "Estonia"
@@ -7593,8 +7594,7 @@ msgstr "Разгарнуць карту"
 #. Subtitle for the Collaborations promotional card at the bottom of search results. Describes the branded merchandise line. 'Give a duck' is a wordplay on the DuckDuckGo brand name.
 msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
-msgstr ""
-"Прафесійна распрацаваныя вырабы для людзей, якім неабыякавая прыватнасць."
+msgstr "Прафесійна распрацаваныя вырабы для людзей, якім неабыякавая прыватнасць."
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
@@ -7618,7 +7618,7 @@ msgstr "Тэрмін дзеяння заканчваецца праз 1 дзен
 #. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain the accepted answer in simple terms."
-msgstr ""
+msgstr "Растлумач прыняты адказ простымі словамі."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
@@ -7631,43 +7631,43 @@ msgstr "Растлумач асноўныя паняцці чорных дзір
 #. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain the top answer"
-msgstr ""
+msgstr "Растлумач найлепшы адказ"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain this in simple, plain language."
-msgstr ""
+msgstr "Растлумач гэта простай і зразумелай мовай."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain this paper"
-msgstr ""
+msgstr "Растлумач гэты артыкул"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain this repo"
-msgstr ""
+msgstr "Растлумач гэты рэпазіторый"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain this research paper in plain language."
-msgstr ""
+msgstr "Растлумач гэты навуковы артыкул простай мовай."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain this simply"
-msgstr ""
+msgstr "Растлумач гэта простымі словамі"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain what this repository does and how to use it."
-msgstr ""
+msgstr "Растлумач, што робіць гэты рэпазіторый і як ім карыстацца."
 
 # smartling.placeholder_format=C
 #. Label to show if song lyrics contain explicit content
@@ -7943,8 +7943,7 @@ msgstr "Фільтры неэфектыўныя"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Filters out AI-generated images from image search results"
-msgstr ""
-"Фільтруе відарысы, створаныя штучным інтэлектам, з вынікаў пошуку відарысаў"
+msgstr "Фільтруе відарысы, створаныя штучным інтэлектам, з вынікаў пошуку відарысаў"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -7959,6 +7958,8 @@ msgctxt "settings"
 msgid ""
 "Filters out known AI spam sites from image search results. %sLearn More%s"
 msgstr ""
+"Фільтруе вядомыя сайты са спамам, створаныя штучным інтэлектам, з вынікаў "
+"пошуку відарысаў. %1$sДаведацца больш%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the final score of a sporting event.
@@ -8019,7 +8020,7 @@ msgstr "Знайдзіце актуальную інфармацыю"
 #. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Find me alternatives"
-msgstr ""
+msgstr "Знайдзі мне альтэрнатывы"
 
 # smartling.placeholder_format=C
 #. Button that searches for results closer to the user's current location.
@@ -8248,8 +8249,7 @@ msgstr "Можна абагульваць і выкарыстоўваць у к�
 #. Description text explaining how to free up sync storage. Pinned chats are chats the user has explicitly marked to keep.
 msgctxt "Sync limit modal description"
 msgid "Free up space by deleting your chats. Pinned chats will not be deleted."
-msgstr ""
-"Вызваліце месца, выдаліўшы свае чаты. Замацаваныя чаты не будуць выдалены."
+msgstr "Вызваліце месца, выдаліўшы свае чаты. Замацаваныя чаты не будуць выдалены."
 
 # smartling.placeholder_format=C
 #. Indicates that this streaming service is free to watch but shows ads
@@ -8503,7 +8503,7 @@ msgstr "Згенерыраваць яшчэ"
 #. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Generate a shopping list"
-msgstr ""
+msgstr "Ствары спіс пакупак"
 
 # smartling.placeholder_format=C
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
@@ -8731,8 +8731,7 @@ msgstr "Усталюйце наш браўзер, каб ніколі не гу�
 # smartling.placeholder_format=C
 msgid ""
 "Get seamless privacy protection on your browser for free with one download:"
-msgstr ""
-"У адной спампоўцы вы бясплатна атрымліваеце комплексную абарону прыватнасці:"
+msgstr "У адной спампоўцы вы бясплатна атрымліваеце комплексную абарону прыватнасці:"
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo app when clicked
@@ -8778,8 +8777,7 @@ msgstr "Атрымаць гэту песню на:"
 # smartling.placeholder_format=C
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
-msgstr ""
-"Запрасіце сваіх сяброў перайсці да нас і тым самым дапамагчы нам расці!"
+msgstr "Запрасіце сваіх сяброў перайсці да нас і тым самым дапамагчы нам расці!"
 
 # smartling.placeholder_format=C
 msgid "Ghana"
@@ -8801,7 +8799,7 @@ msgstr "Паспрабуйце"
 #. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Give me a quick background on this person."
-msgstr ""
+msgstr "Дай мне кароткую даведку пра гэтага чалавека."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9254,13 +9252,13 @@ msgstr "Дапамажыце пашырыць прыватнасць"
 #. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Help me prep for the interview"
-msgstr ""
+msgstr "Дапамажы мне падрыхтавацца да інтэрв'ю"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Help me tailor my resume for this job."
-msgstr ""
+msgstr "Дапамажы мне адаптаваць маё рэзюмэ пад гэтую вакансію."
 
 # smartling.placeholder_format=C
 #. Title of a SERP popup that invites users to take a survey (desktop only)
@@ -9711,8 +9709,7 @@ msgstr ""
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
 msgctxt "Duck.ai settings usage section"
 msgid "How much of your daily and weekly limits you've used so far."
-msgstr ""
-"Колькі з вашых дзённых і тыднёвых лімітаў вы выкарысталі да гэтага часу."
+msgstr "Колькі з вашых дзённых і тыднёвых лімітаў вы выкарысталі да гэтага часу."
 
 # smartling.placeholder_format=C
 #. A header for the feedback form in the assist negative feedback flow. The user is being asked to update how often they want AI-assisted answers to appear.
@@ -9786,7 +9783,7 @@ msgctxt ""
 "Text for the I already have a subscription button in the Duck.ai settings "
 "page"
 msgid "I Already Have a Subscription"
-msgstr ""
+msgstr "У мяне ўжо ёсць падпіска"
 
 # smartling.placeholder_format=C
 #. Text for the button that takes the user to the login subscription page.
@@ -10371,7 +10368,7 @@ msgstr "Усталюйце браўзер для Mac"
 #. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
 msgctxt "settings"
 msgid "Install Now"
-msgstr ""
+msgstr "Усталяваць зараз"
 
 # smartling.placeholder_format=C
 #. Text of a button to install the DuckDuckGo app
@@ -10474,13 +10471,13 @@ msgstr "Выдаленыя даныя на самой справе выдале�
 #. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Is it worth taking?"
-msgstr ""
+msgstr "Ці варта гэта браць?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Is this place any good?"
-msgstr ""
+msgstr "Ці вартае гэта месца ўвагі?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
@@ -10489,6 +10486,8 @@ msgid ""
 "Is this place any good? Summarize its reputation based on reviews and "
 "ratings."
 msgstr ""
+"Ці вартае гэта месца ўвагі? Зрабі рэзюмэ яго рэпутацыі на аснове водгукаў і "
+"ацэнак."
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -10500,13 +10499,13 @@ msgstr "Ці было гэта відэа карысным?"
 #. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Is this worth watching?"
-msgstr ""
+msgstr "Гэта варта глядзець?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Is this worth watching? Give me a spoiler-free take."
-msgstr ""
+msgstr "Гэта варта глядзець? Раскажы без спойлераў."
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -11124,7 +11123,7 @@ msgstr "Спасылкі:"
 #. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
-msgstr ""
+msgstr "Пералічы інструменты, матэрыялы або тое, што мне трэба для гэтага."
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -11415,8 +11414,7 @@ msgstr "Пераканайцеся, што ўсе словы напісаны п
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Make sure to check %s\"Make this my default search provider\"%s"
-msgstr ""
-"Не забудзьцеся пазначыць %1$s\"Зрабіць стандартнай пошукавай сістэмай\"%2$s"
+msgstr "Не забудзьцеся пазначыць %1$s\"Зрабіць стандартнай пошукавай сістэмай\"%2$s"
 
 # smartling.placeholder_format=C
 #. Message prompting users to check the spelling of their search term.
@@ -11537,7 +11535,7 @@ msgstr "Кіраванне заблакіраванымі сайтамі"
 #. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
 msgctxt "setting"
 msgid "Manage in Browser Settings"
-msgstr ""
+msgstr "Кіраваць у наладах браўзера"
 
 # smartling.placeholder_format=C
 #. Link to the site exclusion settings page
@@ -12826,8 +12824,7 @@ msgstr "Вынікі не знойдзены."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the recording contains no audible speech.
 msgid "No speech detected. Please try again and speak into your microphone."
-msgstr ""
-"Маўленне не выяўлена. Калі ласка, паспрабуйце яшчэ раз і гаварыце ў мікрафон."
+msgstr "Маўленне не выяўлена. Калі ласка, паспрабуйце яшчэ раз і гаварыце ў мікрафон."
 
 # smartling.placeholder_format=C
 #. Button that dismisses a feedback form.
@@ -13296,8 +13293,7 @@ msgstr "Аман"
 #. http://i.imgur.com/zQWKLIm.png
 msgctxt "settings"
 msgid "Omits objectionable (mostly adult) material"
-msgstr ""
-"Апускае спрэчнае змесціва (галоўным чынам, прызначанае \"для дарослых\")"
+msgstr "Апускае спрэчнае змесціва (галоўным чынам, прызначанае \"для дарослых\")"
 
 # smartling.placeholder_format=C
 msgid "On"
@@ -14362,8 +14358,7 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this prompt was made by a "
 "human."
-msgstr ""
-"Выканайце наступнае заданне, каб пацвердзіць, што запыт выкананы чалавекам."
+msgstr "Выканайце наступнае заданне, каб пацвердзіць, што запыт выкананы чалавекам."
 
 # smartling.placeholder_format=C
 #. Bot challenge explanation
@@ -14371,14 +14366,15 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this search was made by a "
 "human."
-msgstr ""
-"Выканайце наступнае заданне, каб пацвердзіць, што пошук выкананы чалавекам."
+msgstr "Выканайце наступнае заданне, каб пацвердзіць, што пошук выкананы чалавекам."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is harmful or illegal. (optional)"
 msgstr ""
+"Калі ласка, растлумачце, чаму адказ у чаце з'яўляецца шкодным або "
+"незаконным. (неабавязкова)"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
@@ -14398,8 +14394,7 @@ msgstr "Калі ласка, увядзіце кодавую фразу"
 #. Body copy shown when a scanned or pasted pairing payload fails schema validation.
 msgctxt "Description for the wrong code error screen"
 msgid "Please make sure the correct code was entered or scanned."
-msgstr ""
-"Калі ласка, пераканайцеся, што быў уведзены або адсканаваны сапраўдны код."
+msgstr "Калі ласка, пераканайцеся, што быў уведзены або адсканаваны сапраўдны код."
 
 # smartling.placeholder_format=C
 #. Disclaimer text displayed in a modal that informs the user that starting a new chat with any AI model will delete their current chat session.
@@ -14418,6 +14413,8 @@ msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is harmful or illegal."
 msgstr ""
+"Устаўце свой запыт і праблемны вынік (без асабістай інфармацыі) і "
+"патлумачце, чаму змесціва з'яўляецца шкодным або незаконным."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -14890,7 +14887,7 @@ msgstr "Прыватнасць"
 #. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
 msgctxt "Section heading on the Duck.ai settings page"
 msgid "Privacy & Terms"
-msgstr ""
+msgstr "Прыватнасць і ўмовы"
 
 # smartling.placeholder_format=C
 msgid "Privacy Blog"
@@ -14966,7 +14963,7 @@ msgstr "Палітыка прыватнасці і Умовы выкарыста
 #. Text for a button that links to the terms of use and privacy policy page.
 msgctxt "Secondary button text in active privacy modal"
 msgid "Privacy Policy and Terms of Service"
-msgstr ""
+msgstr "Палітыка прыватнасці і Умовы выкарыстання"
 
 # smartling.placeholder_format=C
 #. Title displayed on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
@@ -15473,25 +15470,25 @@ msgstr "Парэкамендуй кнігу"
 #. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Recommend similar books"
-msgstr ""
+msgstr "Парэкамендуй падобныя кнігі"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Recommend similar books."
-msgstr ""
+msgstr "Парэкамендуй падобныя кнігі."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Recommend similar movies or shows."
-msgstr ""
+msgstr "Парэкамендуй падобныя фільмы ці шоу."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Recommend similar titles"
-msgstr ""
+msgstr "Парэкамендуй падобныя загалоўкі"
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
@@ -15706,8 +15703,8 @@ msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
 msgstr ""
-"Перазагрузіце DuckDuckGo, выконваючы інструкцыі або націснуўшы кнопку &quot;"
-"Абнавіць&quot; ці &quot;Перазагрузіць&quot; у браўзеры."
+"Перазагрузіце DuckDuckGo, выконваючы інструкцыі або націснуўшы кнопку "
+"&quot;Абнавіць&quot; ці &quot;Перазагрузіць&quot; у браўзеры."
 
 # smartling.placeholder_format=C
 #. checkbox label that allows the user to save the setting
@@ -15903,7 +15900,7 @@ msgctxt ""
 "feedback form when the user has selected Harmful or Illegal as the feedback "
 "reason"
 msgid "Required for harmful or illegal reports"
-msgstr ""
+msgstr "Патрабуецца для паведамленняў аб шкодным або незаконным змесціве"
 
 # smartling.placeholder_format=C
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
@@ -16146,7 +16143,7 @@ msgstr "Водгукі"
 #. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Rewrite this recipe scaled for a different number of servings."
-msgstr ""
+msgstr "Перапішы гэты рэцэпт з улікам іншай колькасці порцый."
 
 # smartling.placeholder_format=C
 msgid "Romania"
@@ -16223,8 +16220,7 @@ msgstr "SE"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "SERP promotion for desktop browsers has been dismissed"
-msgstr ""
-"Рэклама браўзераў для камп'ютара на старонцы з вынікамі пошуку была закрыта"
+msgstr "Рэклама браўзераў для камп'ютара на старонцы з вынікамі пошуку была закрыта"
 
 # smartling.placeholder_format=C
 #. Abbreviation indicating that a game is in shootouts, e.g. in NHL (hockey)
@@ -16755,8 +16751,7 @@ msgstr "Бачнасць пошуку"
 # smartling.placeholder_format=C
 #. Message prompting users to download the DuckDuckGo app.
 msgid "Search and browse privately with the DuckDuckGo app."
-msgstr ""
-"Шукайце і праглядайце інфармацыю ў прыватным рэжыме ў праграме DuckDuckGo."
+msgstr "Шукайце і праглядайце інфармацыю ў прыватным рэжыме ў праграме DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Category a user can select on a feedback form.
@@ -16831,8 +16826,8 @@ msgctxt "settings"
 msgid ""
 "Search queries are included in URL (if off, searches will use POST requests)"
 msgstr ""
-"Пошукавыя запыты ўключаны ў URL (калі выкл., пошук будзе выкарыстоўваць POST-"
-"запыты)"
+"Пошукавыя запыты ўключаны ў URL (калі выкл., пошук будзе выкарыстоўваць "
+"POST-запыты)"
 
 # smartling.placeholder_format=C
 #. Describes how cookies are used to store user settings privately and securely.
@@ -17108,8 +17103,7 @@ msgstr "Паглядзіце апошнія абнаўленні"
 #. Link to a page with more information about how user settings are stored in a URL.
 msgctxt "settings"
 msgid "See the %sURL Parameter Reference page%s for more details."
-msgstr ""
-"Дадатковую інфармацыю глядзіце на старонцы %1$sПараметры URL-адраса%2$s ."
+msgstr "Дадатковую інфармацыю глядзіце на старонцы %1$sПараметры URL-адраса%2$s ."
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the context menu of a chat in chat history, that allows the user to select the chat and begin batch selection mode.
@@ -17188,8 +17182,7 @@ msgstr "Выберыце %1$sDuckDuckGo%2$s у спісе сайтаў пошу�
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s under the%sDefault Search Engine%s section"
-msgstr ""
-"Выберыце %1$sDuckDuckGo%2$s у раздзеле %3$sСтандартная пошукавая сістэма%4$s"
+msgstr "Выберыце %1$sDuckDuckGo%2$s у раздзеле %3$sСтандартная пошукавая сістэма%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user were in the settings menu they can change their default search engine.
@@ -17370,8 +17363,7 @@ msgstr "Выбраны тэкст з %1$s"
 #. Displayed when the user's text selection exceeds the maximum message size for AI tools (summary, translation, etc.).
 msgctxt "Error message for selection input limit"
 msgid "Selected text is too long. Try again with a shorter selection."
-msgstr ""
-"Вылучаны тэкст занадта доўгі. Выберыце карацейшы ўрывак і паўтарыце спробу."
+msgstr "Вылучаны тэкст занадта доўгі. Выберыце карацейшы ўрывак і паўтарыце спробу."
 
 # smartling.placeholder_format=C
 #. Label for the semi-finals knockout stage in e.g. the soccer World Cup
@@ -17495,7 +17487,7 @@ msgstr "Наладзіць зараз"
 #. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
 msgctxt "Encrypted storage setup button shown in native browsers"
 msgid "Set Up Sync & Backup"
-msgstr ""
+msgstr "Наладзіць Sync & Backup"
 
 # smartling.placeholder_format=C
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
@@ -17683,7 +17675,7 @@ msgstr "Абагуліць станоўчы водгук"
 msgctxt ""
 "Label beside the share-content switch on the Duck.ai response feedback form"
 msgid "Share this conversation with DuckDuckGo"
-msgstr ""
+msgstr "Абагуліць гэтую размову з DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -18215,8 +18207,7 @@ msgstr "Пошук па сайце часова недаступны. Мы пр�
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Sites you block will be hidden from all your search results"
-msgstr ""
-"Сайты, якія вы заблакіруеце, будуць схаваныя ва ўсіх вашых вынікаў пошуку"
+msgstr "Сайты, якія вы заблакіруеце, будуць схаваныя ва ўсіх вашых вынікаў пошуку"
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes full name (tooltip)
@@ -18355,8 +18346,7 @@ msgstr "Адбылася памылка"
 #. Error message indicating that the user's settings weren't able to be saved.
 msgctxt "cloudsave"
 msgid "Something went wrong saving to the server, please try again."
-msgstr ""
-"Штосьці пайшло не так з запісам на сервер. Калі ласка, паўтарыце спробу."
+msgstr "Штосьці пайшло не так з запісам на сервер. Калі ласка, паўтарыце спробу."
 
 # smartling.placeholder_format=C
 #. Body copy displayed under the Set Up Now button when the sync setup call fails.
@@ -18723,15 +18713,13 @@ msgstr ""
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletters."
-msgstr ""
-"Заставайцеся абароненымі і інфармаванымі праз нашу рассылку пра прыватнасць."
+msgstr "Заставайцеся абароненымі і інфармаванымі праз нашу рассылку пра прыватнасць."
 
 # smartling.placeholder_format=C
 #. Text on the page where users can subscribe to DuckDuckGo's privacy newsletter
 msgctxt "showcase_newsletter"
 msgid "Stay protected and informed with our privacy newsletters."
-msgstr ""
-"Заставайцеся абароненымі і інфармаванымі праз нашу рассылку пра прыватнасць."
+msgstr "Заставайцеся абароненымі і інфармаванымі праз нашу рассылку пра прыватнасць."
 
 # smartling.placeholder_format=C
 #. Loading message shown when image generation is taking longer than usual.
@@ -18864,8 +18852,8 @@ msgid ""
 "Subscribe to DuckDuckGo to unlock higher limits in Duck.ai, or come back "
 "later to create more images."
 msgstr ""
-"Падпішыцеся на DuckDuckGo, каб разблакіраваць больш высокія ліміты ў Duck."
-"ai, або вярніцеся пазней, каб стварыць больш відарысаў."
+"Падпішыцеся на DuckDuckGo, каб разблакіраваць больш высокія ліміты ў "
+"Duck.ai, або вярніцеся пазней, каб стварыць больш відарысаў."
 
 # smartling.placeholder_format=C
 #. Description shown to free users who have reached their image generation limit, encouraging them to subscribe.
@@ -18947,19 +18935,19 @@ msgstr "Прапануй назву для публікацыі ў блогу"
 #. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Suggest related articles or topics worth exploring next."
-msgstr ""
+msgstr "Прапануй звязаныя артыкулы ці тэмы, якія варта вывучаць далей."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Suggest related articles to explore"
-msgstr ""
+msgstr "Прапануй звязаныя артыкулы для вывучэння"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Suggest some alternatives to this product."
-msgstr ""
+msgstr "Прапануй некалькі альтэрнатыў да гэтага прадукту."
 
 # smartling.placeholder_format=C
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
@@ -18976,7 +18964,7 @@ msgstr "Прапановы:"
 #. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Sum up the reviews"
-msgstr ""
+msgstr "Падсумуй водгукі"
 
 # smartling.placeholder_format=C
 #. A short title for the a message asking the AI to summarize a text.
@@ -18988,85 +18976,85 @@ msgstr "Зрабіць рэзюмэ"
 #. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize the Q&As"
-msgstr ""
+msgstr "Зрабі рэзюмэ пытанняў і адказаў"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the background and notable work of this person."
-msgstr ""
+msgstr "Зрабі рэзюмэ біяграфіі і значных прац гэтага чалавека."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the key details of this event."
-msgstr ""
+msgstr "Зрабі рэзюмэ ключавых дэталяў гэтай падзеі."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the questions and answers on this page."
-msgstr ""
+msgstr "Падсумуй пытанні і адказы на гэтай старонцы."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize their background"
-msgstr ""
+msgstr "Зрабі рэзюмэ іх біяграфіі"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this book"
-msgstr ""
+msgstr "Зрабі рэзюмэ гэтай кнігі"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this book."
-msgstr ""
+msgstr "Зрабі рэзюмэ гэтай кнігі."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this discussion"
-msgstr ""
+msgstr "Зрабі рэзюмэ гэтай дыскусіі"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this discussion thread."
-msgstr ""
+msgstr "Зрабі рэзюмэ гэтай галінкі абмеркавання."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this page"
-msgstr ""
+msgstr "Зрабі рэзюмэ гэтай старонкі"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this page."
-msgstr ""
+msgstr "Зрабі рэзюмэ гэтай старонкі."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this video"
-msgstr ""
+msgstr "Зрабі рэзюмэ гэтага відэа"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this video."
-msgstr ""
+msgstr "Зрабі рэзюмэ гэтага відэа."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize what the reviews say."
-msgstr ""
+msgstr "Падсумуй, што кажуць у водгуках."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -19397,7 +19385,7 @@ msgstr "Сірыя"
 #. Text for a button that enables the theme to follow the operating system's color scheme preference.
 msgctxt "System theme button for theme selector"
 msgid "System"
-msgstr ""
+msgstr "Сістэма"
 
 # smartling.placeholder_format=C
 #. Abbreviation indicating this is the total score for a game
@@ -19431,7 +19419,7 @@ msgstr "Таіцянская"
 #. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Tailor my resume"
-msgstr ""
+msgstr "Адаптуй маё рэзюмэ"
 
 # smartling.placeholder_format=C
 msgid "Taiwan"
@@ -19468,6 +19456,8 @@ msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
+"Прайдзіце гэта ананімнае апытанне, каб паведаміць нам, як мы можам палепшыць "
+"Duck.ai."
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -19778,7 +19768,7 @@ msgstr "Тэма"
 #. Text for the theme selector label that allows users to switch between Light and dark theme.
 msgctxt "Label for the theme selector feature"
 msgid "Theme"
-msgstr ""
+msgstr "Тэма"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/LpFhb1e.png
@@ -20096,8 +20086,7 @@ msgstr "Для работы гэтай старонкі патрабуецца J
 #. Information tooltip text explaining that the current page's content will be included with the chat message.
 msgctxt "Tooltip explaining that page content will be sent to Duck.ai"
 msgid "This page's content will be sent with your message to Duck.ai"
-msgstr ""
-"Змесціва гэтай старонкі будзе адпраўлена разам з паведамленнем у Duck.ai"
+msgstr "Змесціва гэтай старонкі будзе адпраўлена разам з паведамленнем у Duck.ai"
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -20167,15 +20156,13 @@ msgstr "Гэты пераклад няправільны"
 # smartling.placeholder_format=C
 #. Label indicating that the video can't be played on the current page, and only on the website that owns the vide. The placeholder is the name of the website that owns the video.
 msgid "This video is not yet able to be watched here. You can watch it on %s."
-msgstr ""
-"Відэа пакуль што нельга паглядзець тут. Вы можаце яго паглядзець на %1$s."
+msgstr "Відэа пакуль што нельга паглядзець тут. Вы можаце яго паглядзець на %1$s."
 
 # smartling.placeholder_format=C
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr ""
-"На гэтай старонцы не выкарыстоўваецца бяспечнае шыфраванае злучэнне (HTTPS)."
+msgstr "На гэтай старонцы не выкарыстоўваецца бяспечнае шыфраванае злучэнне (HTTPS)."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -20314,8 +20301,7 @@ msgstr "Падкрэсліванне загалоўка"
 # smartling.placeholder_format=C
 #. Informative header on a list of steps for the user to take to disable their adblocker
 msgid "To allowlist DuckDuckGo in other ad blocker extensions:"
-msgstr ""
-"Каб дадаць DuckDuckGo у белы спіс у іншых пашырэннях для блакіроўкі рэкламы:"
+msgstr "Каб дадаць DuckDuckGo у белы спіс у іншых пашырэннях для блакіроўкі рэкламы:"
 
 # smartling.placeholder_format=C
 #. Text stating agreement to Duck.ai Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'To continue, you must agree to Duck.ai’s Privacy Policy and Terms of Service'
@@ -20340,8 +20326,8 @@ msgid ""
 "To print directions:%sGo back to the map.%sSelect the route you want to "
 "print.%sClick the print icon.%s"
 msgstr ""
-"Як раздрукаваць маршрут:%1$sВярніцеся на карту.%2$sВыберыце патрэбны маршрут."
-"%3$sНацісніце на значок друку.%4$s"
+"Як раздрукаваць маршрут:%1$sВярніцеся на карту.%2$sВыберыце патрэбны "
+"маршрут.%3$sНацісніце на значок друку.%4$s"
 
 # smartling.placeholder_format=C
 #. Explains where the user can find their recovery code. Figma frame 3703-44420.
@@ -20565,8 +20551,8 @@ msgid ""
 "Tracking attempts blocked by DuckDuckGo appear here. Keep browsing to see "
 "how many we block."
 msgstr ""
-"Тут паказваюцца звесткі пра спробы адсочвання, заблакіраваныя DuckDuckGo."
-"Спіс будзе абнаўляцца па меры вашага выкарыстання."
+"Тут паказваюцца звесткі пра спробы адсочвання, заблакіраваныя "
+"DuckDuckGo.Спіс будзе абнаўляцца па меры вашага выкарыстання."
 
 # smartling.placeholder_format=C
 #. Placeholder for when we cannot report any blocked trackers yet
@@ -20631,13 +20617,13 @@ msgstr ""
 #. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Translate this page"
-msgstr ""
+msgstr "Перакладзі гэтую старонку"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
 msgctxt "Page suggestion prompt"
 msgid "Translate this page into %s."
-msgstr ""
+msgstr "Перакладзі гэтую старонку на наступную мову: %1$s."
 
 # smartling.placeholder_format=C
 #. Placeholder text for a region that will display translated text.
@@ -20784,7 +20770,7 @@ msgstr "Паспрабаваць бясплатна"
 #. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
 msgctxt "settings"
 msgid "Try It Now"
-msgstr ""
+msgstr "Паспрабаваць"
 
 # smartling.placeholder_format=C
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -20850,16 +20836,14 @@ msgstr ""
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
 msgctxt "precise_user_location"
 msgid "Try enabling anonymous location for more accurate results."
-msgstr ""
-"Для больш дакладных вынікаў паспрабуйце ўключыць ананімнае месцазнаходжанне."
+msgstr "Для больш дакладных вынікаў паспрабуйце ўключыць ананімнае месцазнаходжанне."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the screen of the onboarding where the user picks a chat model.
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr ""
-"Паспрабуйце паэксперыментаваць з кожнай мадэллю — яны дадуць розныя адказы."
+msgstr "Паспрабуйце паэксперыментаваць з кожнай мадэллю — яны дадуць розныя адказы."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
@@ -20916,8 +20900,7 @@ msgstr "Паспрабуйце наш браўзер,"
 # smartling.placeholder_format=C
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
-msgstr ""
-"Паспрабуйце нашу хатнюю старонку, якая ніколі не паказвае гэтыя паведамленні:"
+msgstr "Паспрабуйце нашу хатнюю старонку, якая ніколі не паказвае гэтыя паведамленні:"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with different words to get more results.
@@ -20986,15 +20969,13 @@ msgstr "Паспрабуйце новы прыватны галасавы чат
 #. Text for a promotional card that encourages users to try the recently added open-source AI models. The placeholders are the names of AI models like 'Try the recently added open-source Llama 3.1 and Mistral.'
 msgctxt "Promotional text for new AI models"
 msgid "Try the recently added open-source %s and %s"
-msgstr ""
-"Паспрабуйце нядаўна дададзеныя мадэлі з адкрытым зыходным кодам: %1$s і %2$s"
+msgstr "Паспрабуйце нядаўна дададзеныя мадэлі з адкрытым зыходным кодам: %1$s і %2$s"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that encourages users to try the recently added open-source AI models Llama 3.1 and Mixtral.
 msgctxt "Promotional text for new AI models"
 msgid "Try the recently added open-source Llama 3.1 and Mixtral"
-msgstr ""
-"Паспрабуйце нядаўна дададзеныя Llama 3.1 і Mixtral з адкрытым зыходным кодам"
+msgstr "Паспрабуйце нядаўна дададзеныя Llama 3.1 і Mixtral з адкрытым зыходным кодам"
 
 # smartling.placeholder_format=C
 #. Message displayed to suggest the user to try the provided prompts or enter their own.
@@ -21034,6 +21015,8 @@ msgid ""
 "Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
+"Хочаце адключыць функцыі штучнага інтэлекту? Усталюйце пашырэнне для пошуку "
+"%1$sDuckDuckGo No AI%2$s, каб захаваць вашы налады. %3$sДаведацца больш%4$s"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -21042,6 +21025,9 @@ msgid ""
 "Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
+"Хочаце адключыць функцыі штучнага інтэлекту? Пераключыцеся на пашырэнне для "
+"пошуку %1$sDuckDuckGo No AI%2$s, каб захаваць вашы налады. %3$sДаведацца "
+"больш%4$s"
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -21386,8 +21372,8 @@ msgstr ""
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
 msgstr ""
-"Пад раздзелам %1$sПошук%2$s націсніце %3$sКіраваць пошукавымі сістэмамі..."
-"%4$s"
+"Пад раздзелам %1$sПошук%2$s націсніце %3$sКіраваць пошукавымі "
+"сістэмамі...%4$s"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -21511,15 +21497,13 @@ msgstr ""
 msgctxt ""
 "Text that shows users they can unlock advanced AI models with a subscription."
 msgid "Unlock advanced AI models with a %s"
-msgstr ""
-"Адкрыйце доступ да перадавых мадэляў штучнага інтэлекту з падпіскай (%1$s)"
+msgstr "Адкрыйце доступ да перадавых мадэляў штучнага інтэлекту з падпіскай (%1$s)"
 
 # smartling.placeholder_format=C
 #. Tooltip text shown when the user hovers over the free badge telling the user that they can unlock advanced AI (Artificial Intelligence) models with a DuckDuckGo subscription.
 msgctxt "Tooltip for the free badge"
 msgid "Unlock advanced AI models with a DuckDuckGo subscription"
-msgstr ""
-"Разблакіруйце перадавыя мадэлі штучнага інтэлекту з падпіскай DuckDuckGo"
+msgstr "Разблакіруйце перадавыя мадэлі штучнага інтэлекту з падпіскай DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. A link to a blog post explaining the new AI benefits to a subscription. Please keep translations to 50 characters or less.
@@ -21531,8 +21515,7 @@ msgstr "Атрымайце доступ да перадавога штучнаг
 #. Upsell message shown in the voice chat duration limit modal for free users.
 msgctxt "voice chat duration limit modal"
 msgid "Unlock longer voice chats with a DuckDuckGo Subscription"
-msgstr ""
-"Разблакіруйце больш працяглыя галасавыя чаты, аформіўшы падпіску DuckDuckGo"
+msgstr "Разблакіруйце больш працяглыя галасавыя чаты, аформіўшы падпіску DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Text informing the user that more capable AI models can be unlocked with a subscription, with a trailing call-to-action link. %s is replaced with either the 'Try for free' link (for unauthenticated users) or the 'Learn more' link (for authenticated users). The link opens the subscription modal. Example: Unlock more capable AI models with a DuckDuckGo subscription. Try for free
@@ -21755,8 +21738,7 @@ msgstr ""
 #. Upsell message shown in the voice chat limit and duration limit modals for Plus subscribers, encouraging them to upgrade to Pro.
 msgctxt "voice chat limit modal"
 msgid "Upgrade to Pro to unlock 2x higher usage limits than Plus"
-msgstr ""
-"Абнавіцеся да Pro, каб адкрыць удвая большыя ліміты выкарыстання, чым у Plus"
+msgstr "Абнавіцеся да Pro, каб адкрыць удвая большыя ліміты выкарыстання, чым у Plus"
 
 # smartling.placeholder_format=C
 #. Heading in a promotion for a desktop web browser
@@ -21808,7 +21790,7 @@ msgstr "Уругвай"
 #. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
 msgctxt "Navigation label on the Duck.ai settings page"
 msgid "Usage"
-msgstr ""
+msgstr "Выкарыстанне"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -21866,8 +21848,7 @@ msgstr "Выкарыстаць прыватны пошук DuckDuckGo"
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Use DuckDuckGo private search on your iPad, iPhone, or Android!"
-msgstr ""
-"Скарыстайце DuckDuckGo для асабістага пошуку на iPad, iPhone ці Android!"
+msgstr "Скарыстайце DuckDuckGo для асабістага пошуку на iPad, iPhone ці Android!"
 
 # smartling.placeholder_format=C
 #. User clicks this button to share their device's location
@@ -21904,8 +21885,7 @@ msgstr ""
 #. Prompt to ask the user if they want to use their approximate location for more accurate results
 msgctxt "DuckChat location prompt"
 msgid "Use your approximate location for more accurate results?"
-msgstr ""
-"Выкарыстоўваць ваша прыблізнае месцазнаходжанне для больш дакладных вынікаў?"
+msgstr "Выкарыстоўваць ваша прыблізнае месцазнаходжанне для больш дакладных вынікаў?"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes before every user message in the downloaded file, indicating which message it is out of the total number of messages. Example: 'User prompt 3 of 5'
@@ -22108,8 +22088,8 @@ msgid ""
 "Visit Duck.ai in your other browser and go to %sDuck.ai Settings%s > %sSync "
 "& Backup%s > %sManage%s then select %sSync With Another Device%s."
 msgstr ""
-"Наведайце Duck.ai ў іншым браўзеры і перайдзіце ў раздзел %1$sНалады Duck."
-"ai%2$s > %3$sSync & Backup%4$s > %5$sКіраванне%6$s, а затым выберыце "
+"Наведайце Duck.ai ў іншым браўзеры і перайдзіце ў раздзел %1$sНалады "
+"Duck.ai%2$s > %3$sSync & Backup%4$s > %5$sКіраванне%6$s, а затым выберыце "
 "%7$sСінхранізаваць з іншай прыладай%8$s."
 
 # smartling.placeholder_format=C
@@ -22265,7 +22245,7 @@ msgstr "Уэльс"
 #. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Walk me through the steps"
-msgstr ""
+msgstr "Правядзі мяне праз усе крокі"
 
 # smartling.placeholder_format=C
 #. Label for walking directions on a map.
@@ -22394,6 +22374,9 @@ msgid ""
 "please share this conversation with DuckDuckGo so we can investigate and "
 "address the issue."
 msgstr ""
+"Мы можам выправіць толькі тое, што бачым. Каб паведаміць пра шкодны або "
+"незаконны адказ, падзяліцеся гэтай размовай з DuckDuckGo, каб мы маглі "
+"разабрацца і вырашыць праблему."
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -22422,8 +22405,7 @@ msgstr ""
 msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
-msgstr ""
-"Мы не можам прачытаць далучаныя файлы, бо прынамсі адзін з іх зашыфраваны."
+msgstr "Мы не можам прачытаць далучаныя файлы, бо прынамсі адзін з іх зашыфраваны."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -22625,8 +22607,8 @@ msgstr ""
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
 msgstr ""
-"Мы блакіруем трэкеры, якія спрабуюць збіраць вашы даныя падчас прагляду вэб-"
-"старонак."
+"Мы блакіруем трэкеры, якія спрабуюць збіраць вашы даныя падчас прагляду "
+"вэб-старонак."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -22660,8 +22642,7 @@ msgctxt "duckai_migration"
 msgid ""
 "We're sorry for this inconvenience. We’re working hard to make your "
 "experience better."
-msgstr ""
-"Прабачце за гэтыя нязручнасці. Мы старанна працуем, каб палепшыць ваш досвед."
+msgstr "Прабачце за гэтыя нязручнасці. Мы старанна працуем, каб палепшыць ваш досвед."
 
 # smartling.placeholder_format=C
 #. Body text explaining the service update requires a page reload.
@@ -22915,8 +22896,7 @@ msgstr "Якія фактары варта ўлічваць пры куплі м
 #. Text for a prompt suggestion for asking about must-see attractions in Paris for a first-time visitor.
 msgctxt "Full sentence for planning a trip"
 msgid "What are some must-see attractions in Paris for a first-time visitor?"
-msgstr ""
-"Якія славутасці Парыжа трэба абавязкова наведаць тым, хто прыязджае ўпершыню?"
+msgstr "Якія славутасці Парыжа трэба абавязкова наведаць тым, хто прыязджае ўпершыню?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for finding options for the word 'better' in a specific context.
@@ -22924,8 +22904,7 @@ msgctxt "Full sentence for finding a better word"
 msgid ""
 "What are some options for the word ‘better’ in the context of “We really "
 "need to do better.”"
-msgstr ""
-"Якія варыянты слова \"лепш\" у кантэксце \"Нам сапраўды трэба зрабіць лепш\"."
+msgstr "Якія варыянты слова \"лепш\" у кантэксце \"Нам сапраўды трэба зрабіць лепш\"."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
@@ -22955,98 +22934,98 @@ msgstr ""
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the counterarguments?"
-msgstr ""
+msgstr "Якія ёсць контраргументы?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the hours & location?"
-msgstr ""
+msgstr "Якія гадзіны працы і месцазнаходжанне?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key contributions of this paper?"
-msgstr ""
+msgstr "Які асноўны ўклад гэтага артыкула?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key contributions?"
-msgstr ""
+msgstr "Які асноўны ўклад?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key details?"
-msgstr ""
+msgstr "Якія асноўныя дэталі?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key points covered in this video?"
-msgstr ""
+msgstr "Якія асноўныя пункты асвятляюцца ў гэтым відэа?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key points?"
-msgstr ""
+msgstr "Якія асноўныя пункты?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key takeaways from this article?"
-msgstr ""
+msgstr "Якія асноўныя высновы з гэтага артыкула?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key takeaways?"
-msgstr ""
+msgstr "Якія асноўныя высновы?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key things I will learn from this course?"
-msgstr ""
+msgstr "Што галоўнае я даведаюся з гэтага курса?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the main counterarguments or criticisms of this?"
-msgstr ""
+msgstr "Якія асноўныя контраргументы або крытычныя заўвагі на гэты конт?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the main questions this page answers?"
-msgstr ""
+msgstr "На якія асноўныя пытанні адказвае гэтая старонка?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the must-try dishes here?"
-msgstr ""
+msgstr "Якія стравы тут варта паспрабаваць?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid ""
 "What are the opening hours, location, and contact details for this place?"
-msgstr ""
+msgstr "Якія гадзіны працы, месцазнаходжанне і кантактныя даныя гэтага месца?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the pros and cons of this product?"
-msgstr ""
+msgstr "Якія плюсы і мінусы гэтага прадукту?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the pros and cons?"
-msgstr ""
+msgstr "Якія плюсы і мінусы?"
 
 # smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
@@ -23152,7 +23131,7 @@ msgstr "Што значыць \"перадсэрдзе\" ў кантэксце �
 #. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What does this answer?"
-msgstr ""
+msgstr "На што гэта адказвае?"
 
 # smartling.placeholder_format=C
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
@@ -23170,7 +23149,7 @@ msgstr "Якая інфармацыя будзе захавана?"
 #. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What interview questions might come up for this role?"
-msgstr ""
+msgstr "Якія пытанні на інтэрв'ю для гэтай вакансіі могуць быць зададзены?"
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -23192,7 +23171,7 @@ msgstr "Якая сталіца Албаніі?"
 #. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What is the overall verdict and rating for this?"
-msgstr ""
+msgstr "Які выніковы вердыкт і рэйтынг?"
 
 # smartling.placeholder_format=C
 #. Link to a page with additional information.
@@ -23220,7 +23199,7 @@ msgstr "Што кажуць людзі:"
 #. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What should I order?"
-msgstr ""
+msgstr "Што мне замовіць?"
 
 # smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
@@ -23238,13 +23217,13 @@ msgstr "У чым была памылка ў адказе? (неабавязко
 #. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What will I learn?"
-msgstr ""
+msgstr "Чаму я навучуся?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What will I need?"
-msgstr ""
+msgstr "Што мне спатрэбіцца?"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -23269,7 +23248,7 @@ msgstr "Што новага"
 #. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What's the verdict?"
-msgstr ""
+msgstr "Які вердыкт?"
 
 # smartling.placeholder_format=C
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -23327,7 +23306,7 @@ msgstr "Якіх функцый не хапае? (Неабавязкова)"
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Which features are missing? (optional)"
-msgstr ""
+msgstr "Якіх функцый бракуе? (неабавязкова)"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
@@ -23350,12 +23329,14 @@ msgstr "Хто мы"
 msgctxt "Page suggestion prompt"
 msgid "Who are the main cast and crew, and what else are they known for?"
 msgstr ""
+"Хто ўваходзіць у асноўны акцёрскі склад і здымачную групу і чым яшчэ яны "
+"вядомыя?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Who is this person?"
-msgstr ""
+msgstr "Хто гэты чалавек?"
 
 # smartling.placeholder_format=C
 #. Header above a collection of privacy-related links.
@@ -24106,16 +24087,14 @@ msgstr ""
 #. Description shown when the user has reached the maximum voice chat duration.
 msgctxt "voice chat duration limit modal"
 msgid "You've reached the maximum voice chat duration for a single session."
-msgstr ""
-"Вы дасягнулі максімальнай працягласці галасавога чата для аднаго сеансу."
+msgstr "Вы дасягнулі максімальнай працягласці галасавога чата для аднаго сеансу."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the daily voice chat limit.
 msgctxt "voice chat limit modal"
 msgid ""
 "You've reached the voice chat limit for today. Please try again tomorrow."
-msgstr ""
-"Вы дасягнулі на сёння ліміту галасавога чата. Паспрабуйце яшчэ раз заўтра."
+msgstr "Вы дасягнулі на сёння ліміту галасавога чата. Паспрабуйце яшчэ раз заўтра."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
@@ -24345,8 +24324,8 @@ msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
 msgstr ""
-"Вашы чаты былі імпартаваны. Працягвайце з таго месца, дзе спыніліся, у Duck."
-"ai."
+"Вашы чаты былі імпартаваны. Працягвайце з таго месца, дзе спыніліся, у "
+"Duck.ai."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.

--- a/locales/be_BY/LC_MESSAGES/duckduckgo.po
+++ b/locales/be_BY/LC_MESSAGES/duckduckgo.po
@@ -2,15 +2,16 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: be_BY\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 
 # smartling.gettext_line_width = normalized : 79
 # smartling.placeholder_format=C
@@ -466,8 +467,8 @@ msgstr "%1$sДаведацца больш%2$s."
 msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
 msgstr ""
-"%1$sДаведайцеся, як мы захоўваем прыватнасць даных вашага "
-"месцазнаходжання.%2$s"
+"%1$sДаведайцеся, як мы захоўваем прыватнасць даных вашага месцазнаходжання."
+"%2$s"
 
 # smartling.placeholder_format=C
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
@@ -490,7 +491,8 @@ msgstr ""
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "%sLong-press%s the DuckDuckGo app icon on the home screen"
-msgstr "%1$sДоўгае націсканне%2$s значка праграмы DuckDuckGo на галоўным экране"
+msgstr ""
+"%1$sДоўгае націсканне%2$s значка праграмы DuckDuckGo на галоўным экране"
 
 # smartling.placeholder_format=C
 #. A message displayed when there is an error loading content or no results on requery
@@ -998,10 +1000,10 @@ msgid ""
 "models from OpenAI, and Anthropic, and more."
 msgstr ""
 "У цяперашні час ў адказах з дапамогай штучнага інтэлекту не падтрымліваюцца "
-"непасрэдна дадатковыя пытанні. Аднак мы таксама прапануем сэрвіс "
-"%1$sDuck.ai%2$s для дадатковых пытанняў і часта спасылаемся на яго. Гэта наш "
-"прыватны чат на базе штучнага інтэлекту, які падтрымлівае мадэлі чата ад "
-"OpenAI, Anthropic і іншых."
+"непасрэдна дадатковыя пытанні. Аднак мы таксама прапануем сэрвіс %1$sDuck."
+"ai%2$s для дадатковых пытанняў і часта спасылаемся на яго. Гэта наш прыватны "
+"чат на базе штучнага інтэлекту, які падтрымлівае мадэлі чата ад OpenAI, "
+"Anthropic і іншых."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has turned off AI features and will no longer see AI-assisted answers.
@@ -1440,6 +1442,12 @@ msgid "Address is incorrect"
 msgstr "Адрас няправільны"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Adjust the servings"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. as in multiple advertisements
 msgid "Ads"
 msgstr "Рэклама"
@@ -1653,6 +1661,14 @@ msgid "All chats are %sprivate%s"
 msgstr "Усе чаты %1$sпрыватныя%2$s"
 
 # smartling.placeholder_format=C
+#. Paragraph in the Privacy & Terms section of the About & Legal page in Duck.ai settings, summarizing how chats are anonymized and are not stored or used to train chat models.
+msgctxt "Privacy & Terms section description on the Duck.ai settings page"
+msgid ""
+"All chats are anonymized by DuckDuckGo, and your conversations are not used "
+"to train chat models by DuckDuckGo or the model providers"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
 msgctxt "Privacy modal header in Duck.ai chat"
 msgid "All chats are private"
@@ -1682,7 +1698,8 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "All model providers are prevented from training their AI on your "
 "conversations."
-msgstr "Усім пастаўшчыкам мадэляў забаронена навучаць свой AI на вашых размовах."
+msgstr ""
+"Усім пастаўшчыкам мадэляў забаронена навучаць свой AI на вашых размовах."
 
 # smartling.placeholder_format=C
 #. Text displayed in the subheader of the modal that allows the user to pick an AI chat model.
@@ -1793,7 +1810,8 @@ msgstr "Ужо сінхранізавана."
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Also search privately on your iPad, iPhone, or Android!"
-msgstr "Таксама захоўвайце сваю прыватнасць падчас пошуку на iPad, iPhone ці Android!"
+msgstr ""
+"Таксама захоўвайце сваю прыватнасць падчас пошуку на iPad, iPhone ці Android!"
 
 # smartling.placeholder_format=C
 #. Keyboard shortcut for Duck.ai
@@ -1919,6 +1937,13 @@ msgstr ""
 msgctxt "precise_user_location"
 msgid "Anonymous location enabled"
 msgstr "Уключана ананімнае месцазнаходжанне"
+
+# smartling.placeholder_format=C
+msgctxt "settings"
+msgid ""
+"Anonymously generates answers for search queries based on web content. "
+"Choose how often you want it to appear, or disable it completely."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -2085,7 +2110,8 @@ msgctxt "Body text for disable chat history confirmation modal"
 msgid ""
 "Are you sure you want to disable history? This will delete all chats, "
 "including pinned chats."
-msgstr "Сапраўды адключыць гісторыю? Гэта выдаліць усе чаты, у тым ліку замацаваныя."
+msgstr ""
+"Сапраўды адключыць гісторыю? Гэта выдаліць усе чаты, у тым ліку замацаваныя."
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to disable recent chats, with a warning that it will also delete currently saved chats.
@@ -2196,6 +2222,12 @@ msgstr "Задайце ўдакладняльнае пытанне"
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse
 msgid "Ask a follow-up with Duck.ai"
 msgstr "Задайце ўдакладняльнае пытанне ў Duck.ai"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
+msgctxt "Page suggestion chip label"
+msgid "Ask about this page"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2617,6 +2649,12 @@ msgid "Barcode"
 msgstr "Штрыхкод"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Based on this page, is this course worth taking?"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Basic"
 msgstr "Базавая"
@@ -2655,6 +2693,14 @@ msgstr "Бэтэр"
 msgctxt "Assistant response placeholder"
 msgid "Before continuing..."
 msgstr "Перад тым, як працягнуць..."
+
+# smartling.placeholder_format=C
+#. Explains that before storing the report, DuckDuckGo will anonymize the conversation by removing PII like names, email addresses, and identifying metadata.
+msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
+msgid ""
+"Before storing this report, DuckDuckGo will anonymize your conversation by "
+"removing PII like names, email addresses, and identifying metadata."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -2782,7 +2828,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. A disclaimer about AI-generated images in search results
 msgid "Block list is not exhaustive and may contain inaccuracies."
-msgstr "Спіс блакіроўкі не з'яўляецца вычарпальным і можа ўтрымліваць недакладнасці."
+msgstr ""
+"Спіс блакіроўкі не з'яўляецца вычарпальным і можа ўтрымліваць недакладнасці."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -2973,6 +3020,12 @@ msgstr "Бразілія"
 msgctxt "Sports module"
 msgid "Break Points Won"
 msgstr "Выйграныя брэйк-пойнты"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Break this down into clear, numbered steps."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -3429,6 +3482,12 @@ msgid "Cast"
 msgstr "Акцёры"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Cast & Crew"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
 msgctxt "Tone option label for Casual"
 msgid "Casual"
@@ -3532,7 +3591,8 @@ msgstr "Змяняе колер фону на ўсім сайце"
 msgctxt "settings"
 msgid ""
 "Changes the background color of results on hover, modules, and dropdown menus"
-msgstr "Змяняе фонавы колер вынікаў пры навядзенні курсорам, модуляў і выпадных меню"
+msgstr ""
+"Змяняе фонавы колер вынікаў пры навядзенні курсорам, модуляў і выпадных меню"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/NdpkbY0.png
@@ -3665,8 +3725,8 @@ msgstr ""
 "мадэлямі чата на базе штучнага інтэлекту, якімі падтрымліваюцца мадэлі "
 "OpenAI, Anthropic і іншыя. Адключэнне гэтай налады схавае кнопкі і спасылкі "
 "чата ў DuckDuckGo Search. Тым не менш, можна атрымаць доступ да чата, калі "
-"гэты параметр выключаны. Для гэтага трэба перайсці на сайт "
-"%1$shttps://duck.ai%2$s ."
+"гэты параметр выключаны. Для гэтага трэба перайсці на сайт %1$shttps://duck."
+"ai%2$s ."
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -3731,8 +3791,8 @@ msgctxt "Promotional text"
 msgid ""
 "Chat privately on any website with the Duck.ai sidebar in our free browser."
 msgstr ""
-"Размаўляйце ў чаце прыватна на любым сайце з дапамогай бакавой панэлі "
-"Duck.ai ў нашым бясплатным браўзеры."
+"Размаўляйце ў чаце прыватна на любым сайце з дапамогай бакавой панэлі Duck."
+"ai ў нашым бясплатным браўзеры."
 
 # smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
@@ -3896,7 +3956,8 @@ msgstr ""
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
 msgctxt "noresults"
 msgid "Check the status page for updates on this outage."
-msgstr "Праверце старонку стану, каб даведацца пра абнаўленні наконт гэтага збою."
+msgstr ""
+"Праверце старонку стану, каб даведацца пра абнаўленні наконт гэтага збою."
 
 # smartling.placeholder_format=C
 #. Title shown to the host device (the one that is logged in) after it sends the pairing code. The host can't confirm the peer applied it, so this is a title-only screen (no body) prompting the user to finish on the other device.
@@ -3955,7 +4016,8 @@ msgstr "Выбар мадэляў штучнага інтэлекту, у тым
 # smartling.placeholder_format=C
 #. As in 'Choose to keep DuckDuckGo as your default search engine'. Placeholders are for markup, you can ignore them.
 msgid "Choose %skeep it%s to continue protecting your privacy."
-msgstr "Націсніце %1$sЗахаваць%2$s, каб мы і надалей абаранялі вашу прыватнасць."
+msgstr ""
+"Націсніце %1$sЗахаваць%2$s, каб мы і надалей абаранялі вашу прыватнасць."
 
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
@@ -4359,7 +4421,8 @@ msgstr "Націсніце на %1$sПастаўшчыкі пошуку%2$s па
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click on the %sTools icon%s in the top-right of the browser"
-msgstr "Націсніце на %1$sзначок інструментаў%2$s у правым верхнім куце браўзера"
+msgstr ""
+"Націсніце на %1$sзначок інструментаў%2$s у правым верхнім куце браўзера"
 
 #  Firefox default search engine instruction
 # smartling.placeholder_format=C
@@ -5140,6 +5203,12 @@ msgid "Create Image"
 msgstr "Стварыце відарыс"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Create a shopping list with quantities from this recipe."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text displayed in the input field when starting a new image generation session.
 msgctxt "Placeholder text for the image generation input field"
 msgid "Create an image of a cute duck..."
@@ -5782,6 +5851,11 @@ msgid "Dictation limit reached"
 msgstr "Ліміт дыктавання вычарпаны"
 
 # smartling.placeholder_format=C
+#. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
+msgid "Dictation temporarily unavailable"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
@@ -6083,6 +6157,22 @@ msgid "Done"
 msgstr "Гатова"
 
 # smartling.placeholder_format=C
+#. Message shown in a modal after DuckDuckGo browser users disable AI features in Settings. The first two placeholders bold noai.duckduckgo.com. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
+"filtered out. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
+"and AI images filtered out. %sLearn more%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Double Faults"
@@ -6195,6 +6285,18 @@ msgid ""
 msgstr ""
 "Напішы сціслы і падрабязны электронны ліст майстру з запытам цаны на рамонт "
 "халадзільніка."
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Draft a cover letter"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Draft a cover letter for this job."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -6373,6 +6475,15 @@ msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
 msgstr "Duck.ai найлепшы ў нашым прыватным і бясплатным браўзеры DuckDuckGo!"
 
 # smartling.placeholder_format=C
+#. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
+msgctxt "About section description on the Duck.ai settings page"
+msgid ""
+"Duck.ai is created by DuckDuckGo. We're an independent online protection "
+"company for anyone who wants to take back control of their personal "
+"information."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
 msgctxt "duckai_migration"
 msgid "Duck.ai is moving domains"
@@ -6416,6 +6527,13 @@ msgstr "Duck.ai часова недаступны. Абнавіце старон
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
 msgstr "Duck.ai часова недаступны. Паўтарыце спробу пазней."
+
+# smartling.placeholder_format=C
+msgctxt "settings"
+msgid ""
+"Duck.ai lets you chat privately with popular AI models. Disabling it hides "
+"Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6479,7 +6597,8 @@ msgstr "Duck.ai абноўлены!"
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
-msgstr "Duck.ai найлепш працуе ў нашай прыватнай і бясплатнай праграме DuckDuckGo!"
+msgstr ""
+"Duck.ai найлепш працуе ў нашай прыватнай і бясплатнай праграме DuckDuckGo!"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -6489,10 +6608,10 @@ msgid ""
 "AI chat no sign up, OpenAI, Anthropic, Llama, Mistral, open source AI "
 "models, privacy focused AI, no account AI chat"
 msgstr ""
-"Duck.ai, DuckDuckGo AI, прыватны чат-бот AI, бясплатны AI-чат, ананімны "
-"AI-чат, AI-чат без рэгістрацыі, OpenAI, Anthropic, Llama, Mistral, мадэлі AI "
-"з адкрытым зыходным кодам, арыентаваны на прыватнасць AI, AI-чат без "
-"уліковага запісу"
+"Duck.ai, DuckDuckGo AI, прыватны чат-бот AI, бясплатны AI-чат, ананімны AI-"
+"чат, AI-чат без рэгістрацыі, OpenAI, Anthropic, Llama, Mistral, мадэлі AI з "
+"адкрытым зыходным кодам, арыентаваны на прыватнасць AI, AI-чат без уліковага "
+"запісу"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -6658,7 +6777,8 @@ msgctxt "Error message for VQD error"
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. Please refresh the page and "
 "try again."
-msgstr "DuckDuckGo AI Chat часова недаступны. Абнавіце старонку і паўтарыце спробу."
+msgstr ""
+"DuckDuckGo AI Chat часова недаступны. Абнавіце старонку і паўтарыце спробу."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -7265,7 +7385,8 @@ msgstr "Падабаецца Duck.ai?"
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure %s'Allow'%s is selected for the 'Location' setting."
-msgstr "Упэўніцеся, што для налады \"Месцазнаходжанне\" выбрана %1$sДазволіць%2$s."
+msgstr ""
+"Упэўніцеся, што для налады \"Месцазнаходжанне\" выбрана %1$sДазволіць%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
@@ -7277,19 +7398,22 @@ msgstr "Упэўніцеся, што %1$sўключана%2$s налада \"С�
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location' is set to %sallow%s"
-msgstr "Упэўніцеся, што для налады \"Месцазнаходжанне\" выбрана %1$sДазволіць%2$s"
+msgstr ""
+"Упэўніцеся, што для налады \"Месцазнаходжанне\" выбрана %1$sДазволіць%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location' is set to %sallow%s."
-msgstr "Упэўніцеся, што для налады \"Месцазнаходжанне\" выбрана %1$sдазволіць%2$s."
+msgstr ""
+"Упэўніцеся, што для налады \"Месцазнаходжанне\" выбрана %1$sдазволіць%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure Location is set to %sAllow%s"
-msgstr "Упэўніцеся, што для налады \"Месцазнаходжанне\" выбрана %1$sДазволіць%2$s"
+msgstr ""
+"Упэўніцеся, што для налады \"Месцазнаходжанне\" выбрана %1$sДазволіць%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
@@ -7307,7 +7431,8 @@ msgstr "Упэўніцеся, што %1$sдазволены%2$s доступ д�
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed %slocation access%s"
-msgstr "Упэўніцеся, што ў браўзеры дазволены %1$sдоступ да месцазнаходжання%2$s"
+msgstr ""
+"Упэўніцеся, што ў браўзеры дазволены %1$sдоступ да месцазнаходжання%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service.
@@ -7415,11 +7540,24 @@ msgstr "Экватарыяльная Гвінея"
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Erase your browsing data in a flash with our %sFire Button%s"
-msgstr "Імгненна выдаляйце даныя прагляду з дапамогай кнопкі %1$sFire Button%2$s"
+msgstr ""
+"Імгненна выдаляйце даныя прагляду з дапамогай кнопкі %1$sFire Button%2$s"
 
 # smartling.placeholder_format=C
 msgid "Eritrea"
 msgstr "Эрытрэя"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Estimate the nutrition"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Estimate the nutritional information for this recipe."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Estonia"
@@ -7455,7 +7593,8 @@ msgstr "Разгарнуць карту"
 #. Subtitle for the Collaborations promotional card at the bottom of search results. Describes the branded merchandise line. 'Give a duck' is a wordplay on the DuckDuckGo brand name.
 msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
-msgstr "Прафесійна распрацаваныя вырабы для людзей, якім неабыякавая прыватнасць."
+msgstr ""
+"Прафесійна распрацаваныя вырабы для людзей, якім неабыякавая прыватнасць."
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
@@ -7476,11 +7615,59 @@ msgid "Expires in 1 day"
 msgstr "Тэрмін дзеяння заканчваецца праз 1 дзень"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain the accepted answer in simple terms."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
 msgstr "Растлумач асноўныя паняцці чорных дзірак на ўзроўні сярэдняй школы."
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain the top answer"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this in simple, plain language."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this paper"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this repo"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this research paper in plain language."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this simply"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain what this repository does and how to use it."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label to show if song lyrics contain explicit content
@@ -7756,7 +7943,8 @@ msgstr "Фільтры неэфектыўныя"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Filters out AI-generated images from image search results"
-msgstr "Фільтруе відарысы, створаныя штучным інтэлектам, з вынікаў пошуку відарысаў"
+msgstr ""
+"Фільтруе відарысы, створаныя штучным інтэлектам, з вынікаў пошуку відарысаў"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -7765,6 +7953,12 @@ msgid ""
 msgstr ""
 "Фільтруе відарысы, створаныя штучным інтэлектам, з вынікаў пошуку відарысаў. "
 "%1$sДаведацца больш%2$s"
+
+# smartling.placeholder_format=C
+msgctxt "settings"
+msgid ""
+"Filters out known AI spam sites from image search results. %sLearn More%s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the final score of a sporting event.
@@ -7820,6 +8014,12 @@ msgstr "Знайдзі лепшае слова"
 msgctxt "Subtitle for the Web Search tool entry in the Tools dropdown menu"
 msgid "Find current information"
 msgstr "Знайдзіце актуальную інфармацыю"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Find me alternatives"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button that searches for results closer to the user's current location.
@@ -8048,7 +8248,8 @@ msgstr "Можна абагульваць і выкарыстоўваць у к�
 #. Description text explaining how to free up sync storage. Pinned chats are chats the user has explicitly marked to keep.
 msgctxt "Sync limit modal description"
 msgid "Free up space by deleting your chats. Pinned chats will not be deleted."
-msgstr "Вызваліце месца, выдаліўшы свае чаты. Замацаваныя чаты не будуць выдалены."
+msgstr ""
+"Вызваліце месца, выдаліўшы свае чаты. Замацаваныя чаты не будуць выдалены."
 
 # smartling.placeholder_format=C
 #. Indicates that this streaming service is free to watch but shows ads
@@ -8299,6 +8500,12 @@ msgid "Generate More"
 msgstr "Згенерыраваць яшчэ"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Generate a shopping list"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
 msgid "Generate a short answer from the web"
 msgstr "Стварыць кароткі адказ з інтэрнэту"
@@ -8524,7 +8731,8 @@ msgstr "Усталюйце наш браўзер, каб ніколі не гу�
 # smartling.placeholder_format=C
 msgid ""
 "Get seamless privacy protection on your browser for free with one download:"
-msgstr "У адной спампоўцы вы бясплатна атрымліваеце комплексную абарону прыватнасці:"
+msgstr ""
+"У адной спампоўцы вы бясплатна атрымліваеце комплексную абарону прыватнасці:"
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo app when clicked
@@ -8570,7 +8778,8 @@ msgstr "Атрымаць гэту песню на:"
 # smartling.placeholder_format=C
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
-msgstr "Запрасіце сваіх сяброў перайсці да нас і тым самым дапамагчы нам расці!"
+msgstr ""
+"Запрасіце сваіх сяброў перайсці да нас і тым самым дапамагчы нам расці!"
 
 # smartling.placeholder_format=C
 msgid "Ghana"
@@ -8587,6 +8796,12 @@ msgstr "Паспрабуйце"
 msgctxt "Onboarding welcome screen button text"
 msgid "Give it a Try"
 msgstr "Паспрабуйце"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Give me a quick background on this person."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9034,6 +9249,18 @@ msgstr "Дапамагчы ў распаўсюджанні DuckDuckGo!"
 #. Link to a page with information about sharing DuckDuckGo with friends.
 msgid "Help Spread Privacy"
 msgstr "Дапамажыце пашырыць прыватнасць"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Help me prep for the interview"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Help me tailor my resume for this job."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title of a SERP popup that invites users to take a survey (desktop only)
@@ -9484,7 +9711,8 @@ msgstr ""
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
 msgctxt "Duck.ai settings usage section"
 msgid "How much of your daily and weekly limits you've used so far."
-msgstr "Колькі з вашых дзённых і тыднёвых лімітаў вы выкарысталі да гэтага часу."
+msgstr ""
+"Колькі з вашых дзённых і тыднёвых лімітаў вы выкарысталі да гэтага часу."
 
 # smartling.placeholder_format=C
 #. A header for the feedback form in the assist negative feedback flow. The user is being asked to update how often they want AI-assisted answers to appear.
@@ -9551,6 +9779,14 @@ msgstr "Ураган"
 msgctxt "Onboarding terms screen button text"
 msgid "I Agree"
 msgstr "Я згаджаюся"
+
+# smartling.placeholder_format=C
+#. Text for the button that takes the user to the external DuckDuckGo login subscription page.
+msgctxt ""
+"Text for the I already have a subscription button in the Duck.ai settings "
+"page"
+msgid "I Already Have a Subscription"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the button that takes the user to the login subscription page.
@@ -10132,6 +10368,12 @@ msgid "Install Mac Browser"
 msgstr "Усталюйце браўзер для Mac"
 
 # smartling.placeholder_format=C
+#. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
+msgctxt "settings"
+msgid "Install Now"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of a button to install the DuckDuckGo app
 msgctxt "Serp footer content"
 msgid "Install Our App"
@@ -10229,10 +10471,42 @@ msgid "Is deleted data really deleted?"
 msgstr "Выдаленыя даныя на самой справе выдалены?"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is it worth taking?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this place any good?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"Is this place any good? Summarize its reputation based on reviews and "
+"ratings."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "Is this video helpful?"
 msgstr "Ці было гэта відэа карысным?"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this worth watching?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Is this worth watching? Give me a spoiler-free take."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -10847,6 +11121,12 @@ msgid "Links:"
 msgstr "Спасылкі:"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "List the tools, materials, or prerequisites I need for this."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
 msgid "Listen"
 msgstr "Слухаць"
@@ -11135,7 +11415,8 @@ msgstr "Пераканайцеся, што ўсе словы напісаны п
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Make sure to check %s\"Make this my default search provider\"%s"
-msgstr "Не забудзьцеся пазначыць %1$s\"Зрабіць стандартнай пошукавай сістэмай\"%2$s"
+msgstr ""
+"Не забудзьцеся пазначыць %1$s\"Зрабіць стандартнай пошукавай сістэмай\"%2$s"
 
 # smartling.placeholder_format=C
 #. Message prompting users to check the spelling of their search term.
@@ -11251,6 +11532,12 @@ msgstr "Кіраванне падпіскай"
 msgctxt "Exclusion message manage sites button"
 msgid "Manage blocked sites"
 msgstr "Кіраванне заблакіраванымі сайтамі"
+
+# smartling.placeholder_format=C
+#. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
+msgctxt "setting"
+msgid "Manage in Browser Settings"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to the site exclusion settings page
@@ -12539,7 +12826,8 @@ msgstr "Вынікі не знойдзены."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the recording contains no audible speech.
 msgid "No speech detected. Please try again and speak into your microphone."
-msgstr "Маўленне не выяўлена. Калі ласка, паспрабуйце яшчэ раз і гаварыце ў мікрафон."
+msgstr ""
+"Маўленне не выяўлена. Калі ласка, паспрабуйце яшчэ раз і гаварыце ў мікрафон."
 
 # smartling.placeholder_format=C
 #. Button that dismisses a feedback form.
@@ -13008,7 +13296,8 @@ msgstr "Аман"
 #. http://i.imgur.com/zQWKLIm.png
 msgctxt "settings"
 msgid "Omits objectionable (mostly adult) material"
-msgstr "Апускае спрэчнае змесціва (галоўным чынам, прызначанае \"для дарослых\")"
+msgstr ""
+"Апускае спрэчнае змесціва (галоўным чынам, прызначанае \"для дарослых\")"
 
 # smartling.placeholder_format=C
 msgid "On"
@@ -14073,7 +14362,8 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this prompt was made by a "
 "human."
-msgstr "Выканайце наступнае заданне, каб пацвердзіць, што запыт выкананы чалавекам."
+msgstr ""
+"Выканайце наступнае заданне, каб пацвердзіць, што запыт выкананы чалавекам."
 
 # smartling.placeholder_format=C
 #. Bot challenge explanation
@@ -14081,7 +14371,14 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this search was made by a "
 "human."
-msgstr "Выканайце наступнае заданне, каб пацвердзіць, што пошук выкананы чалавекам."
+msgstr ""
+"Выканайце наступнае заданне, каб пацвердзіць, што пошук выкананы чалавекам."
+
+# smartling.placeholder_format=C
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
+msgctxt "Feedback prompt"
+msgid "Please describe why the chat response is harmful or illegal. (optional)"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
@@ -14101,7 +14398,8 @@ msgstr "Калі ласка, увядзіце кодавую фразу"
 #. Body copy shown when a scanned or pasted pairing payload fails schema validation.
 msgctxt "Description for the wrong code error screen"
 msgid "Please make sure the correct code was entered or scanned."
-msgstr "Калі ласка, пераканайцеся, што быў уведзены або адсканаваны сапраўдны код."
+msgstr ""
+"Калі ласка, пераканайцеся, што быў уведзены або адсканаваны сапраўдны код."
 
 # smartling.placeholder_format=C
 #. Disclaimer text displayed in a modal that informs the user that starting a new chat with any AI model will delete their current chat session.
@@ -14112,6 +14410,14 @@ msgid ""
 msgstr ""
 "Звярніце ўвагу: пачатак новага чата з любой мадэллю выдаліць ваш бягучы "
 "сеанс чата."
+
+# smartling.placeholder_format=C
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
+msgctxt "Feedback prompt"
+msgid ""
+"Please paste your prompt and the problematic output (with any personal "
+"information removed) and describe why the content is harmful or illegal."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -14581,6 +14887,12 @@ msgid "Privacy"
 msgstr "Прыватнасць"
 
 # smartling.placeholder_format=C
+#. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
+msgctxt "Section heading on the Duck.ai settings page"
+msgid "Privacy & Terms"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Privacy Blog"
 msgstr "Блог пра прыватнасць"
 
@@ -14649,6 +14961,12 @@ msgstr "Палітыка прыватнасці і ўмовы выкарыста
 msgctxt "Copy used to compose link in sentences"
 msgid "Privacy Policy and Terms of Service"
 msgstr "Палітыка прыватнасці і Умовы выкарыстання"
+
+# smartling.placeholder_format=C
+#. Text for a button that links to the terms of use and privacy policy page.
+msgctxt "Secondary button text in active privacy modal"
+msgid "Privacy Policy and Terms of Service"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title displayed on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
@@ -15152,6 +15470,30 @@ msgid "Recommend a book"
 msgstr "Парэкамендуй кнігу"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar books"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar books."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar movies or shows."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar titles"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
 msgid "Recording failed. Please try again."
 msgstr "Запіс не ўдаўся. Паўтарыце спробу."
@@ -15364,8 +15706,8 @@ msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
 msgstr ""
-"Перазагрузіце DuckDuckGo, выконваючы інструкцыі або націснуўшы кнопку "
-"&quot;Абнавіць&quot; ці &quot;Перазагрузіць&quot; у браўзеры."
+"Перазагрузіце DuckDuckGo, выконваючы інструкцыі або націснуўшы кнопку &quot;"
+"Абнавіць&quot; ці &quot;Перазагрузіць&quot; у браўзеры."
 
 # smartling.placeholder_format=C
 #. checkbox label that allows the user to save the setting
@@ -15553,6 +15895,15 @@ msgstr ""
 # smartling.placeholder_format=C
 msgid "Republic of Moldova"
 msgstr "Рэспубліка Малдова"
+
+# smartling.placeholder_format=C
+#. Note indicating that sharing the conversation is mandatory when reporting harmful or illegal content. Rendered alongside the standard share label (DUCKCHAT_RESPONSE_FEEDBACK_SHARE_PROMPT_RESPONSE_LABEL), not replacing it.
+msgctxt ""
+"Note shown under the share-content switch label on the Duck.ai response "
+"feedback form when the user has selected Harmful or Illegal as the feedback "
+"reason"
+msgid "Required for harmful or illegal reports"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
@@ -15792,6 +16143,12 @@ msgid "Reviews"
 msgstr "Водгукі"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Rewrite this recipe scaled for a different number of servings."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Romania"
 msgstr "Румынія"
 
@@ -15866,7 +16223,8 @@ msgstr "SE"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "SERP promotion for desktop browsers has been dismissed"
-msgstr "Рэклама браўзераў для камп'ютара на старонцы з вынікамі пошуку была закрыта"
+msgstr ""
+"Рэклама браўзераў для камп'ютара на старонцы з вынікамі пошуку была закрыта"
 
 # smartling.placeholder_format=C
 #. Abbreviation indicating that a game is in shootouts, e.g. in NHL (hockey)
@@ -16397,7 +16755,8 @@ msgstr "Бачнасць пошуку"
 # smartling.placeholder_format=C
 #. Message prompting users to download the DuckDuckGo app.
 msgid "Search and browse privately with the DuckDuckGo app."
-msgstr "Шукайце і праглядайце інфармацыю ў прыватным рэжыме ў праграме DuckDuckGo."
+msgstr ""
+"Шукайце і праглядайце інфармацыю ў прыватным рэжыме ў праграме DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Category a user can select on a feedback form.
@@ -16472,8 +16831,8 @@ msgctxt "settings"
 msgid ""
 "Search queries are included in URL (if off, searches will use POST requests)"
 msgstr ""
-"Пошукавыя запыты ўключаны ў URL (калі выкл., пошук будзе выкарыстоўваць "
-"POST-запыты)"
+"Пошукавыя запыты ўключаны ў URL (калі выкл., пошук будзе выкарыстоўваць POST-"
+"запыты)"
 
 # smartling.placeholder_format=C
 #. Describes how cookies are used to store user settings privately and securely.
@@ -16749,7 +17108,8 @@ msgstr "Паглядзіце апошнія абнаўленні"
 #. Link to a page with more information about how user settings are stored in a URL.
 msgctxt "settings"
 msgid "See the %sURL Parameter Reference page%s for more details."
-msgstr "Дадатковую інфармацыю глядзіце на старонцы %1$sПараметры URL-адраса%2$s ."
+msgstr ""
+"Дадатковую інфармацыю глядзіце на старонцы %1$sПараметры URL-адраса%2$s ."
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the context menu of a chat in chat history, that allows the user to select the chat and begin batch selection mode.
@@ -16828,7 +17188,8 @@ msgstr "Выберыце %1$sDuckDuckGo%2$s у спісе сайтаў пошу�
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s under the%sDefault Search Engine%s section"
-msgstr "Выберыце %1$sDuckDuckGo%2$s у раздзеле %3$sСтандартная пошукавая сістэма%4$s"
+msgstr ""
+"Выберыце %1$sDuckDuckGo%2$s у раздзеле %3$sСтандартная пошукавая сістэма%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user were in the settings menu they can change their default search engine.
@@ -17009,7 +17370,8 @@ msgstr "Выбраны тэкст з %1$s"
 #. Displayed when the user's text selection exceeds the maximum message size for AI tools (summary, translation, etc.).
 msgctxt "Error message for selection input limit"
 msgid "Selected text is too long. Try again with a shorter selection."
-msgstr "Вылучаны тэкст занадта доўгі. Выберыце карацейшы ўрывак і паўтарыце спробу."
+msgstr ""
+"Вылучаны тэкст занадта доўгі. Выберыце карацейшы ўрывак і паўтарыце спробу."
 
 # smartling.placeholder_format=C
 #. Label for the semi-finals knockout stage in e.g. the soccer World Cup
@@ -17128,6 +17490,12 @@ msgstr "Наладзьце зараз"
 msgctxt "Setup button for native sync flow"
 msgid "Set Up Now"
 msgstr "Наладзіць зараз"
+
+# smartling.placeholder_format=C
+#. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
+msgctxt "Encrypted storage setup button shown in native browsers"
+msgid "Set Up Sync & Backup"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
@@ -17309,6 +17677,13 @@ msgstr "Абагуліць URL-адрасы старонкі"
 msgctxt "feedback form"
 msgid "Share positive feedback"
 msgstr "Абагуліць станоўчы водгук"
+
+# smartling.placeholder_format=C
+#. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
+msgctxt ""
+"Label beside the share-content switch on the Duck.ai response feedback form"
+msgid "Share this conversation with DuckDuckGo"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -17840,7 +18215,8 @@ msgstr "Пошук па сайце часова недаступны. Мы пр�
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Sites you block will be hidden from all your search results"
-msgstr "Сайты, якія вы заблакіруеце, будуць схаваныя ва ўсіх вашых вынікаў пошуку"
+msgstr ""
+"Сайты, якія вы заблакіруеце, будуць схаваныя ва ўсіх вашых вынікаў пошуку"
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes full name (tooltip)
@@ -17979,7 +18355,8 @@ msgstr "Адбылася памылка"
 #. Error message indicating that the user's settings weren't able to be saved.
 msgctxt "cloudsave"
 msgid "Something went wrong saving to the server, please try again."
-msgstr "Штосьці пайшло не так з запісам на сервер. Калі ласка, паўтарыце спробу."
+msgstr ""
+"Штосьці пайшло не так з запісам на сервер. Калі ласка, паўтарыце спробу."
 
 # smartling.placeholder_format=C
 #. Body copy displayed under the Set Up Now button when the sync setup call fails.
@@ -18346,13 +18723,15 @@ msgstr ""
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletters."
-msgstr "Заставайцеся абароненымі і інфармаванымі праз нашу рассылку пра прыватнасць."
+msgstr ""
+"Заставайцеся абароненымі і інфармаванымі праз нашу рассылку пра прыватнасць."
 
 # smartling.placeholder_format=C
 #. Text on the page where users can subscribe to DuckDuckGo's privacy newsletter
 msgctxt "showcase_newsletter"
 msgid "Stay protected and informed with our privacy newsletters."
-msgstr "Заставайцеся абароненымі і інфармаванымі праз нашу рассылку пра прыватнасць."
+msgstr ""
+"Заставайцеся абароненымі і інфармаванымі праз нашу рассылку пра прыватнасць."
 
 # smartling.placeholder_format=C
 #. Loading message shown when image generation is taking longer than usual.
@@ -18485,8 +18864,8 @@ msgid ""
 "Subscribe to DuckDuckGo to unlock higher limits in Duck.ai, or come back "
 "later to create more images."
 msgstr ""
-"Падпішыцеся на DuckDuckGo, каб разблакіраваць больш высокія ліміты ў "
-"Duck.ai, або вярніцеся пазней, каб стварыць больш відарысаў."
+"Падпішыцеся на DuckDuckGo, каб разблакіраваць больш высокія ліміты ў Duck."
+"ai, або вярніцеся пазней, каб стварыць больш відарысаў."
 
 # smartling.placeholder_format=C
 #. Description shown to free users who have reached their image generation limit, encouraging them to subscribe.
@@ -18565,6 +18944,24 @@ msgid "Suggest a title for a blog post"
 msgstr "Прапануй назву для публікацыі ў блогу"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest related articles or topics worth exploring next."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Suggest related articles to explore"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest some alternatives to this product."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
 msgctxt "directions"
 msgid "Suggestions:"
@@ -18576,10 +18973,100 @@ msgid "Suggestions:"
 msgstr "Прапановы:"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Sum up the reviews"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A short title for the a message asking the AI to summarize a text.
 msgctxt "Title for the summarize message"
 msgid "Summarize"
 msgstr "Зрабіць рэзюмэ"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize the Q&As"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the background and notable work of this person."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the key details of this event."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the questions and answers on this page."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize their background"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this book"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this book."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this discussion"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this discussion thread."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this page"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this page."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this video"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this video."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize what the reviews say."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -18907,6 +19394,12 @@ msgid "Syria"
 msgstr "Сірыя"
 
 # smartling.placeholder_format=C
+#. Text for a button that enables the theme to follow the operating system's color scheme preference.
+msgctxt "System theme button for theme selector"
+msgid "System"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Abbreviation indicating this is the total score for a game
 msgctxt "Sports module"
 msgid "T"
@@ -18933,6 +19426,12 @@ msgstr "ТБ"
 msgctxt "language_name"
 msgid "Tahitian"
 msgstr "Таіцянская"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Tailor my resume"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Taiwan"
@@ -18962,6 +19461,13 @@ msgstr "Толькі вы будзеце кантраляваць свае ас�
 msgctxt "homepage ATB modal"
 msgid "Take control of your personal data!"
 msgstr "Толькі вы будзеце кантраляваць свае асабістыя даныя!"
+
+# smartling.placeholder_format=C
+#. Description for the Feedback section of the Duck.ai settings page, asking the user to take an anonymous survey to let us know how we can make Duck.ai better.
+msgctxt "Feedback section description on the Duck.ai settings page"
+msgid ""
+"Take this anonymous survey to let us know how we can make Duck.ai better."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -19267,6 +19773,12 @@ msgstr "Адбылася памылка. Сервер не змог выкана
 #. https://duck.co/media/files/theme.png
 msgid "Theme"
 msgstr "Тэма"
+
+# smartling.placeholder_format=C
+#. Text for the theme selector label that allows users to switch between Light and dark theme.
+msgctxt "Label for the theme selector feature"
+msgid "Theme"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/LpFhb1e.png
@@ -19584,7 +20096,8 @@ msgstr "Для работы гэтай старонкі патрабуецца J
 #. Information tooltip text explaining that the current page's content will be included with the chat message.
 msgctxt "Tooltip explaining that page content will be sent to Duck.ai"
 msgid "This page's content will be sent with your message to Duck.ai"
-msgstr "Змесціва гэтай старонкі будзе адпраўлена разам з паведамленнем у Duck.ai"
+msgstr ""
+"Змесціва гэтай старонкі будзе адпраўлена разам з паведамленнем у Duck.ai"
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -19654,13 +20167,15 @@ msgstr "Гэты пераклад няправільны"
 # smartling.placeholder_format=C
 #. Label indicating that the video can't be played on the current page, and only on the website that owns the vide. The placeholder is the name of the website that owns the video.
 msgid "This video is not yet able to be watched here. You can watch it on %s."
-msgstr "Відэа пакуль што нельга паглядзець тут. Вы можаце яго паглядзець на %1$s."
+msgstr ""
+"Відэа пакуль што нельга паглядзець тут. Вы можаце яго паглядзець на %1$s."
 
 # smartling.placeholder_format=C
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr "На гэтай старонцы не выкарыстоўваецца бяспечнае шыфраванае злучэнне (HTTPS)."
+msgstr ""
+"На гэтай старонцы не выкарыстоўваецца бяспечнае шыфраванае злучэнне (HTTPS)."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -19799,7 +20314,8 @@ msgstr "Падкрэсліванне загалоўка"
 # smartling.placeholder_format=C
 #. Informative header on a list of steps for the user to take to disable their adblocker
 msgid "To allowlist DuckDuckGo in other ad blocker extensions:"
-msgstr "Каб дадаць DuckDuckGo у белы спіс у іншых пашырэннях для блакіроўкі рэкламы:"
+msgstr ""
+"Каб дадаць DuckDuckGo у белы спіс у іншых пашырэннях для блакіроўкі рэкламы:"
 
 # smartling.placeholder_format=C
 #. Text stating agreement to Duck.ai Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'To continue, you must agree to Duck.ai’s Privacy Policy and Terms of Service'
@@ -19824,8 +20340,8 @@ msgid ""
 "To print directions:%sGo back to the map.%sSelect the route you want to "
 "print.%sClick the print icon.%s"
 msgstr ""
-"Як раздрукаваць маршрут:%1$sВярніцеся на карту.%2$sВыберыце патрэбны "
-"маршрут.%3$sНацісніце на значок друку.%4$s"
+"Як раздрукаваць маршрут:%1$sВярніцеся на карту.%2$sВыберыце патрэбны маршрут."
+"%3$sНацісніце на значок друку.%4$s"
 
 # smartling.placeholder_format=C
 #. Explains where the user can find their recovery code. Figma frame 3703-44420.
@@ -20049,8 +20565,8 @@ msgid ""
 "Tracking attempts blocked by DuckDuckGo appear here. Keep browsing to see "
 "how many we block."
 msgstr ""
-"Тут паказваюцца звесткі пра спробы адсочвання, заблакіраваныя "
-"DuckDuckGo.Спіс будзе абнаўляцца па меры вашага выкарыстання."
+"Тут паказваюцца звесткі пра спробы адсочвання, заблакіраваныя DuckDuckGo."
+"Спіс будзе абнаўляцца па меры вашага выкарыстання."
 
 # smartling.placeholder_format=C
 #. Placeholder for when we cannot report any blocked trackers yet
@@ -20110,6 +20626,18 @@ msgid ""
 msgstr ""
 "Перакладзі з беларускай мовы на англійскую: \"Як дабрацца да бліжэйшага "
 "кінатэатра?\""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Translate this page"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
+msgctxt "Page suggestion prompt"
+msgid "Translate this page into %s."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder text for a region that will display translated text.
@@ -20253,6 +20781,12 @@ msgid "Try Free"
 msgstr "Паспрабаваць бясплатна"
 
 # smartling.placeholder_format=C
+#. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
+msgctxt "settings"
+msgid "Try It Now"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
 msgctxt "Promotional CTA for new AI models"
 msgid "Try Now"
@@ -20316,14 +20850,16 @@ msgstr ""
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
 msgctxt "precise_user_location"
 msgid "Try enabling anonymous location for more accurate results."
-msgstr "Для больш дакладных вынікаў паспрабуйце ўключыць ананімнае месцазнаходжанне."
+msgstr ""
+"Для больш дакладных вынікаў паспрабуйце ўключыць ананімнае месцазнаходжанне."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the screen of the onboarding where the user picks a chat model.
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr "Паспрабуйце паэксперыментаваць з кожнай мадэллю — яны дадуць розныя адказы."
+msgstr ""
+"Паспрабуйце паэксперыментаваць з кожнай мадэллю — яны дадуць розныя адказы."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
@@ -20380,7 +20916,8 @@ msgstr "Паспрабуйце наш браўзер,"
 # smartling.placeholder_format=C
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
-msgstr "Паспрабуйце нашу хатнюю старонку, якая ніколі не паказвае гэтыя паведамленні:"
+msgstr ""
+"Паспрабуйце нашу хатнюю старонку, якая ніколі не паказвае гэтыя паведамленні:"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with different words to get more results.
@@ -20449,13 +20986,15 @@ msgstr "Паспрабуйце новы прыватны галасавы чат
 #. Text for a promotional card that encourages users to try the recently added open-source AI models. The placeholders are the names of AI models like 'Try the recently added open-source Llama 3.1 and Mistral.'
 msgctxt "Promotional text for new AI models"
 msgid "Try the recently added open-source %s and %s"
-msgstr "Паспрабуйце нядаўна дададзеныя мадэлі з адкрытым зыходным кодам: %1$s і %2$s"
+msgstr ""
+"Паспрабуйце нядаўна дададзеныя мадэлі з адкрытым зыходным кодам: %1$s і %2$s"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that encourages users to try the recently added open-source AI models Llama 3.1 and Mixtral.
 msgctxt "Promotional text for new AI models"
 msgid "Try the recently added open-source Llama 3.1 and Mixtral"
-msgstr "Паспрабуйце нядаўна дададзеныя Llama 3.1 і Mixtral з адкрытым зыходным кодам"
+msgstr ""
+"Паспрабуйце нядаўна дададзеныя Llama 3.1 і Mixtral з адкрытым зыходным кодам"
 
 # smartling.placeholder_format=C
 #. Message displayed to suggest the user to try the provided prompts or enter their own.
@@ -20487,6 +21026,22 @@ msgstr "Паспрабуйце: %1$s"
 msgctxt "new user poll"
 msgid "Trying DuckDuckGo again"
 msgstr "Паспрабуйце DuckDuckGo яшчэ раз"
+
+# smartling.placeholder_format=C
+#. Message shown in a modal after supported third-party browser users disable AI features in Settings. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -20831,8 +21386,8 @@ msgstr ""
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
 msgstr ""
-"Пад раздзелам %1$sПошук%2$s націсніце %3$sКіраваць пошукавымі "
-"сістэмамі...%4$s"
+"Пад раздзелам %1$sПошук%2$s націсніце %3$sКіраваць пошукавымі сістэмамі..."
+"%4$s"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -20956,13 +21511,15 @@ msgstr ""
 msgctxt ""
 "Text that shows users they can unlock advanced AI models with a subscription."
 msgid "Unlock advanced AI models with a %s"
-msgstr "Адкрыйце доступ да перадавых мадэляў штучнага інтэлекту з падпіскай (%1$s)"
+msgstr ""
+"Адкрыйце доступ да перадавых мадэляў штучнага інтэлекту з падпіскай (%1$s)"
 
 # smartling.placeholder_format=C
 #. Tooltip text shown when the user hovers over the free badge telling the user that they can unlock advanced AI (Artificial Intelligence) models with a DuckDuckGo subscription.
 msgctxt "Tooltip for the free badge"
 msgid "Unlock advanced AI models with a DuckDuckGo subscription"
-msgstr "Разблакіруйце перадавыя мадэлі штучнага інтэлекту з падпіскай DuckDuckGo"
+msgstr ""
+"Разблакіруйце перадавыя мадэлі штучнага інтэлекту з падпіскай DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. A link to a blog post explaining the new AI benefits to a subscription. Please keep translations to 50 characters or less.
@@ -20974,7 +21531,8 @@ msgstr "Атрымайце доступ да перадавога штучнаг
 #. Upsell message shown in the voice chat duration limit modal for free users.
 msgctxt "voice chat duration limit modal"
 msgid "Unlock longer voice chats with a DuckDuckGo Subscription"
-msgstr "Разблакіруйце больш працяглыя галасавыя чаты, аформіўшы падпіску DuckDuckGo"
+msgstr ""
+"Разблакіруйце больш працяглыя галасавыя чаты, аформіўшы падпіску DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Text informing the user that more capable AI models can be unlocked with a subscription, with a trailing call-to-action link. %s is replaced with either the 'Try for free' link (for unauthenticated users) or the 'Learn more' link (for authenticated users). The link opens the subscription modal. Example: Unlock more capable AI models with a DuckDuckGo subscription. Try for free
@@ -21197,7 +21755,8 @@ msgstr ""
 #. Upsell message shown in the voice chat limit and duration limit modals for Plus subscribers, encouraging them to upgrade to Pro.
 msgctxt "voice chat limit modal"
 msgid "Upgrade to Pro to unlock 2x higher usage limits than Plus"
-msgstr "Абнавіцеся да Pro, каб адкрыць удвая большыя ліміты выкарыстання, чым у Plus"
+msgstr ""
+"Абнавіцеся да Pro, каб адкрыць удвая большыя ліміты выкарыстання, чым у Plus"
 
 # smartling.placeholder_format=C
 #. Heading in a promotion for a desktop web browser
@@ -21244,6 +21803,12 @@ msgstr "Урду"
 # smartling.placeholder_format=C
 msgid "Uruguay"
 msgstr "Уругвай"
+
+# smartling.placeholder_format=C
+#. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
+msgctxt "Navigation label on the Duck.ai settings page"
+msgid "Usage"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -21301,7 +21866,8 @@ msgstr "Выкарыстаць прыватны пошук DuckDuckGo"
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Use DuckDuckGo private search on your iPad, iPhone, or Android!"
-msgstr "Скарыстайце DuckDuckGo для асабістага пошуку на iPad, iPhone ці Android!"
+msgstr ""
+"Скарыстайце DuckDuckGo для асабістага пошуку на iPad, iPhone ці Android!"
 
 # smartling.placeholder_format=C
 #. User clicks this button to share their device's location
@@ -21338,7 +21904,8 @@ msgstr ""
 #. Prompt to ask the user if they want to use their approximate location for more accurate results
 msgctxt "DuckChat location prompt"
 msgid "Use your approximate location for more accurate results?"
-msgstr "Выкарыстоўваць ваша прыблізнае месцазнаходжанне для больш дакладных вынікаў?"
+msgstr ""
+"Выкарыстоўваць ваша прыблізнае месцазнаходжанне для больш дакладных вынікаў?"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes before every user message in the downloaded file, indicating which message it is out of the total number of messages. Example: 'User prompt 3 of 5'
@@ -21541,8 +22108,8 @@ msgid ""
 "Visit Duck.ai in your other browser and go to %sDuck.ai Settings%s > %sSync "
 "& Backup%s > %sManage%s then select %sSync With Another Device%s."
 msgstr ""
-"Наведайце Duck.ai ў іншым браўзеры і перайдзіце ў раздзел %1$sНалады "
-"Duck.ai%2$s > %3$sSync & Backup%4$s > %5$sКіраванне%6$s, а затым выберыце "
+"Наведайце Duck.ai ў іншым браўзеры і перайдзіце ў раздзел %1$sНалады Duck."
+"ai%2$s > %3$sSync & Backup%4$s > %5$sКіраванне%6$s, а затым выберыце "
 "%7$sСінхранізаваць з іншай прыладай%8$s."
 
 # smartling.placeholder_format=C
@@ -21695,6 +22262,12 @@ msgid "Wales"
 msgstr "Уэльс"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Walk me through the steps"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for walking directions on a map.
 msgctxt "directions"
 msgid "Walking"
@@ -21812,6 +22385,17 @@ msgstr ""
 "паказу вынікаў паблізу ад вас."
 
 # smartling.placeholder_format=C
+#. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
+msgctxt ""
+"Inline warning shown below the share-content toggle when the user selects "
+"Harmful or Illegal but has not enabled sharing"
+msgid ""
+"We can only fix what we can see. To report a harmful or illegal response, "
+"please share this conversation with DuckDuckGo so we can investigate and "
+"address the issue."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
 msgctxt ""
 "Inline warning shown below the share-content toggle when the user selects "
@@ -21838,7 +22422,8 @@ msgstr ""
 msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
-msgstr "Мы не можам прачытаць далучаныя файлы, бо прынамсі адзін з іх зашыфраваны."
+msgstr ""
+"Мы не можам прачытаць далучаныя файлы, бо прынамсі адзін з іх зашыфраваны."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -22040,8 +22625,8 @@ msgstr ""
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
 msgstr ""
-"Мы блакіруем трэкеры, якія спрабуюць збіраць вашы даныя падчас прагляду "
-"вэб-старонак."
+"Мы блакіруем трэкеры, якія спрабуюць збіраць вашы даныя падчас прагляду вэб-"
+"старонак."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -22075,7 +22660,8 @@ msgctxt "duckai_migration"
 msgid ""
 "We're sorry for this inconvenience. We’re working hard to make your "
 "experience better."
-msgstr "Прабачце за гэтыя нязручнасці. Мы старанна працуем, каб палепшыць ваш досвед."
+msgstr ""
+"Прабачце за гэтыя нязручнасці. Мы старанна працуем, каб палепшыць ваш досвед."
 
 # smartling.placeholder_format=C
 #. Body text explaining the service update requires a page reload.
@@ -22329,7 +22915,8 @@ msgstr "Якія фактары варта ўлічваць пры куплі м
 #. Text for a prompt suggestion for asking about must-see attractions in Paris for a first-time visitor.
 msgctxt "Full sentence for planning a trip"
 msgid "What are some must-see attractions in Paris for a first-time visitor?"
-msgstr "Якія славутасці Парыжа трэба абавязкова наведаць тым, хто прыязджае ўпершыню?"
+msgstr ""
+"Якія славутасці Парыжа трэба абавязкова наведаць тым, хто прыязджае ўпершыню?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for finding options for the word 'better' in a specific context.
@@ -22337,7 +22924,8 @@ msgctxt "Full sentence for finding a better word"
 msgid ""
 "What are some options for the word ‘better’ in the context of “We really "
 "need to do better.”"
-msgstr "Якія варыянты слова \"лепш\" у кантэксце \"Нам сапраўды трэба зрабіць лепш\"."
+msgstr ""
+"Якія варыянты слова \"лепш\" у кантэксце \"Нам сапраўды трэба зрабіць лепш\"."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
@@ -22362,6 +22950,103 @@ msgstr ""
 "абарону прыватнасці. Зрабіце яго даволі кароткім, простым і зразумелым для "
 "людзей з вялікім досведам працы са штучным інтэлектам або тэхнічным досведам "
 "ці без яго."
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the counterarguments?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the hours & location?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key contributions of this paper?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key contributions?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key details?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key points covered in this video?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key points?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key takeaways from this article?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key takeaways?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key things I will learn from this course?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main counterarguments or criticisms of this?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main questions this page answers?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the must-try dishes here?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"What are the opening hours, location, and contact details for this place?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the pros and cons of this product?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the pros and cons?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
@@ -22464,6 +23149,12 @@ msgid "What does atria mean in the context of a medical article?"
 msgstr "Што значыць \"перадсэрдзе\" ў кантэксце медыцынскага артыкула?"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What does this answer?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
@@ -22474,6 +23165,12 @@ msgstr "Якую функцыю вы хацелі б дадаць? (неабав
 msgctxt "cloudsave"
 msgid "What information gets saved?"
 msgstr "Якая інфармацыя будзе захавана?"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What interview questions might come up for this role?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -22490,6 +23187,12 @@ msgstr ""
 msgctxt "Full sentence for looking up basic facts"
 msgid "What is the capital city of Albania?"
 msgstr "Якая сталіца Албаніі?"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What is the overall verdict and rating for this?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to a page with additional information.
@@ -22514,6 +23217,12 @@ msgid "What people say:"
 msgstr "Што кажуць людзі:"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What should I order?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
 msgctxt "feedback form"
 msgid "What stood out?"
@@ -22524,6 +23233,18 @@ msgstr "Што асабліва спадабалася?"
 msgctxt "feedback form"
 msgid "What was wrong with the response? (optional)"
 msgstr "У чым была памылка ў адказе? (неабавязкова)"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I learn?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I need?"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -22543,6 +23264,12 @@ msgstr ""
 msgctxt "SERP footer content"
 msgid "What's New"
 msgstr "Што новага"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What's the verdict?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -22597,6 +23324,12 @@ msgid "Which features are missing? (Optional)"
 msgstr "Якіх функцый не хапае? (Неабавязкова)"
 
 # smartling.placeholder_format=C
+#. An invitation for users to leave feedback
+msgctxt "Feedback prompt"
+msgid "Which features are missing? (optional)"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
 msgid "White"
 msgstr "Белы"
@@ -22611,6 +23344,18 @@ msgstr "Белы"
 #. Link to an about us page.
 msgid "Who We Are"
 msgstr "Хто мы"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Who are the main cast and crew, and what else are they known for?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Who is this person?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Header above a collection of privacy-related links.
@@ -23361,14 +24106,16 @@ msgstr ""
 #. Description shown when the user has reached the maximum voice chat duration.
 msgctxt "voice chat duration limit modal"
 msgid "You've reached the maximum voice chat duration for a single session."
-msgstr "Вы дасягнулі максімальнай працягласці галасавога чата для аднаго сеансу."
+msgstr ""
+"Вы дасягнулі максімальнай працягласці галасавога чата для аднаго сеансу."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the daily voice chat limit.
 msgctxt "voice chat limit modal"
 msgid ""
 "You've reached the voice chat limit for today. Please try again tomorrow."
-msgstr "Вы дасягнулі на сёння ліміту галасавога чата. Паспрабуйце яшчэ раз заўтра."
+msgstr ""
+"Вы дасягнулі на сёння ліміту галасавога чата. Паспрабуйце яшчэ раз заўтра."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
@@ -23598,8 +24345,8 @@ msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
 msgstr ""
-"Вашы чаты былі імпартаваны. Працягвайце з таго месца, дзе спыніліся, у "
-"Duck.ai."
+"Вашы чаты былі імпартаваны. Працягвайце з таго месца, дзе спыніліся, у Duck."
+"ai."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.

--- a/locales/bg_BG/LC_MESSAGES/duckduckgo.po
+++ b/locales/bg_BG/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: bg_BG\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -468,8 +468,7 @@ msgstr "%1$sНаучи повече%2$s."
 #. Link to a page with more information about how anonymous location works.
 msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
-msgstr ""
-"%1$sНаучете как запазваме поверителността на вашето местоположение%2$s."
+msgstr "%1$sНаучете как запазваме поверителността на вашето местоположение%2$s."
 
 # smartling.placeholder_format=C
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
@@ -944,8 +943,8 @@ msgstr ""
 "AI Chat ви позволява да провеждате анонимни разговори с модели за чат с "
 "изкуствен интелект на трети страни. Изключването на това ще скрие функцията "
 "AI Chat в DuckDuckGo Search. Все още можете да получите достъп до AI Chat, "
-"когато тази настройка е изключена, като посетите %1$sduckduckgo.com/"
-"aichat%2$s."
+"когато тази настройка е изключена, като посетите "
+"%1$sduckduckgo.com/aichat%2$s."
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -1452,7 +1451,7 @@ msgstr "Грешен адрес"
 #. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Adjust the servings"
-msgstr ""
+msgstr "Промени порциите"
 
 # smartling.placeholder_format=C
 #. as in multiple advertisements
@@ -1674,6 +1673,9 @@ msgid ""
 "All chats are anonymized by DuckDuckGo, and your conversations are not used "
 "to train chat models by DuckDuckGo or the model providers"
 msgstr ""
+"Всички чатове се анонимизират от DuckDuckGo, а разговорите Ви не се "
+"използват за обучение на чат модели от DuckDuckGo или от доставчиците на "
+"моделите"
 
 # smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1951,6 +1953,9 @@ msgid ""
 "Anonymously generates answers for search queries based on web content. "
 "Choose how often you want it to appear, or disable it completely."
 msgstr ""
+"Генерира анонимно отговори на заявки за търсене въз основа на уеб "
+"съдържание. Изберете колко често искате да се показва или го изключете "
+"напълно."
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -2105,8 +2110,7 @@ msgstr ""
 #. Body text of the modal that asks the user if they want to clear the conversation.
 msgctxt "Modal body for clearing conversation"
 msgid "Are you sure you want to clear this conversation and start a new one?"
-msgstr ""
-"Сигурни ли сте, че искате да изчистите този разговор и да започнете нов?"
+msgstr "Сигурни ли сте, че искате да изчистите този разговор и да започнете нов?"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to delete their current chat, explaining that this action cannot be undone.
@@ -2240,7 +2244,7 @@ msgstr "Задайте последващи въпроси на Duck.ai"
 #. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
 msgctxt "Page suggestion chip label"
 msgid "Ask about this page"
-msgstr ""
+msgstr "Попитайте за тази страница"
 
 # smartling.placeholder_format=C
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2420,8 +2424,7 @@ msgstr "След приключване на чата аудиото не се �
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat is transcribed."
-msgstr ""
-"След транскрибиране на чата аудиото не се съхранява от нас или от OpenAI."
+msgstr "След транскрибиране на чата аудиото не се съхранява от нас или от OpenAI."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when MediaRecorder API is unavailable.
@@ -2663,7 +2666,7 @@ msgstr "Баркод"
 #. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Based on this page, is this course worth taking?"
-msgstr ""
+msgstr "Въз основа на тази страница, струва ли си да курсът да бъде завършен?"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2712,6 +2715,9 @@ msgid ""
 "Before storing this report, DuckDuckGo will anonymize your conversation by "
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
+"Преди да съхрани този отчет, DuckDuckGo ще анонимизира разговора, като "
+"премахне личната информация, като имена, имейл адреси и идентифициращи "
+"метаданни."
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -3033,7 +3039,7 @@ msgstr "Брейк точки"
 #. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Break this down into clear, numbered steps."
-msgstr ""
+msgstr "Раздели това на отделни ясни и номерирани стъпки."
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -3494,7 +3500,7 @@ msgstr "Актьорски състав"
 #. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Cast & Crew"
-msgstr ""
+msgstr "Актьорски състав и екип"
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -3616,8 +3622,7 @@ msgstr "Променя фоновия цвят, когато курсорът б
 #. Description of a setting managing the color of search result snippet text.
 msgctxt "settings"
 msgid "Changes the color of descriptive content shown for results"
-msgstr ""
-"Променя цвета на описателното съдържание, което се показва с резултатите"
+msgstr "Променя цвета на описателното съдържание, което се показва с резултатите"
 
 # smartling.placeholder_format=C
 #. This is the description of a user setting
@@ -3963,8 +3968,7 @@ msgstr "Проверете правописа"
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
 msgctxt "noresults"
 msgid "Check the DuckDuckGo subreddit for updates on this outage."
-msgstr ""
-"Проверка на subreddit в DuckDuckGo за актуализации относно това прекъсване."
+msgstr "Проверка на subreddit в DuckDuckGo за актуализации относно това прекъсване."
 
 # smartling.placeholder_format=C
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
@@ -4351,8 +4355,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click %sPrivacy and Services%s in the left sidebar."
-msgstr ""
-"Щракнете върху %1$sПоверителност и услуги%2$s в лявата странична лента."
+msgstr "Щракнете върху %1$sПоверителност и услуги%2$s в лявата странична лента."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -4419,8 +4422,7 @@ msgstr "Щракнете върху %1$sБраузър%2$s в странично
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click on %sChange Search Settings%s in the dropdown menu"
-msgstr ""
-"Щракнете върху %1$sПромяна на настройките за търсене%2$s в падащото меню"
+msgstr "Щракнете върху %1$sПромяна на настройките за търсене%2$s в падащото меню"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -4438,8 +4440,7 @@ msgstr "Щракнете върху %1$sТърсачки%2$s под Видове
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click on the %sTools icon%s in the top-right of the browser"
-msgstr ""
-"Щракнете върху %1$sиконата Настройки%2$s в горния десен ъгъл на браузъра"
+msgstr "Щракнете върху %1$sиконата Настройки%2$s в горния десен ъгъл на браузъра"
 
 #  Firefox default search engine instruction
 # smartling.placeholder_format=C
@@ -4514,8 +4515,7 @@ msgstr "Щракнете върху %1$sиконата за разрешения
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to search using DuckDuckGo.
 msgid "Click the Duck icon at the top of your browser to search!"
-msgstr ""
-"Щракнете върху иконата с пате в горната част на браузъра си, за да търсите!"
+msgstr "Щракнете върху иконата с пате в горната част на браузъра си, за да търсите!"
 
 #  UC Browser on Android
 # smartling.placeholder_format=C
@@ -5103,8 +5103,7 @@ msgstr "Копиране"
 # smartling.placeholder_format=C
 #. Instructions on how to change the default search engine
 msgid "Copy &amp; paste %sabout:preferences#search%s into the address bar"
-msgstr ""
-"Копирайте и поставете %1$sabout:preferences#search%2$s в адресната лента"
+msgstr "Копирайте и поставете %1$sabout:preferences#search%2$s в адресната лента"
 
 # smartling.placeholder_format=C
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
@@ -5174,8 +5173,7 @@ msgstr "Коста Рика"
 #. Inline error shown on the recovery code screen when exportSyncSettings rejects.
 msgctxt "Error message when the recovery code fails to generate"
 msgid "Couldn't load your recovery code. Please close this and try again."
-msgstr ""
-"Неуспешно зареждане на кода. Затворете този прозорец и опитайте отново."
+msgstr "Неуспешно зареждане на кода. Затворете този прозорец и опитайте отново."
 
 # smartling.placeholder_format=C
 #. Pairs with a Retry button. Shown after two consecutive failed attempts to load the device list.
@@ -5224,7 +5222,7 @@ msgstr "Създаване на изображение"
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
-msgstr ""
+msgstr "Създай списък за пазаруване с количествата от тази рецепта."
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed in the input field when starting a new image generation session.
@@ -5873,7 +5871,7 @@ msgstr "Достигнат лимит за диктовка"
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
 msgid "Dictation temporarily unavailable"
-msgstr ""
+msgstr "Диктуването е временно недостъпно"
 
 # smartling.placeholder_format=C
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
@@ -5962,8 +5960,7 @@ msgstr "Деактивиране и изключване"
 #. Title of a modal that asks the user if they want to turn off chat history and disconnect from Sync & Backup.
 msgctxt "Modal header for disabling chat history and disconnecting sync"
 msgid "Disable chat history and disconnect from Sync & Backup?"
-msgstr ""
-"Деактивиране на историята на чата и прекъсване на връзката със Sync & Backup?"
+msgstr "Деактивиране на историята на чата и прекъсване на връзката със Sync & Backup?"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to turn off the chat history feature.
@@ -6151,8 +6148,7 @@ msgstr "Не виждате DuckDuckGo в списъка?"
 #. Link to download a file again if the user can't find it on their computer.
 msgctxt "install-extension"
 msgid "Don't see it? %s%s%sClick here to re-download%s"
-msgstr ""
-"Не го виждате? %1$s%2$s%3$sНатиснете тук, за да го изтеглите отново%4$s"
+msgstr "Не го виждате? %1$s%2$s%3$sНатиснете тук, за да го изтеглите отново%4$s"
 
 #  IE < 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -6184,6 +6180,8 @@ msgid ""
 "Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
 "filtered out. %sLearn More%s"
 msgstr ""
+"Не искате AI? %1$snoai.duckduckgo.com%2$s не предлага AI функции и AI "
+"изображенията са филтрирани. %3$sНаучете повече%4$s"
 
 # smartling.placeholder_format=C
 #. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
@@ -6192,6 +6190,8 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
+"Не искате AI? Влезте в %1$snoai.duckduckgo.com%2$s за търсене без AI функции "
+"и с филтрирани AI изображения. %3$sНаучете повече%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6311,13 +6311,13 @@ msgstr ""
 #. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Draft a cover letter"
-msgstr ""
+msgstr "Напиши мотивационно писмо"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Draft a cover letter for this job."
-msgstr ""
+msgstr "Напиши мотивационно писмо за тази работа."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -6453,8 +6453,7 @@ msgstr "Условия за ползване на Duck.ai"
 #. The HTML <title> for Duck.ai.
 msgctxt "duckai_seo"
 msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
-msgstr ""
-"Duck.ai от DuckDuckGo. Поверителен чат с изкуствен интелект. Безплатен."
+msgstr "Duck.ai от DuckDuckGo. Поверителен чат с изкуствен интелект. Безплатен."
 
 # smartling.placeholder_format=C
 #. Description explaining how the page context feature works in Duck.ai sidebar.
@@ -6494,8 +6493,7 @@ msgstr ""
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
-msgstr ""
-"Duck.ai е най-добър в нашия поверителен и безплатен браузър DuckDuckGo!"
+msgstr "Duck.ai е най-добър в нашия поверителен и безплатен браузър DuckDuckGo!"
 
 # smartling.placeholder_format=C
 #. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
@@ -6505,6 +6503,8 @@ msgid ""
 "company for anyone who wants to take back control of their personal "
 "information."
 msgstr ""
+"Duck.ai е създаден от DuckDuckGo. Ние сме независима компания за онлайн "
+"защита за всеки, който иска да си върне контрола върху личната информация."
 
 # smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
@@ -6543,8 +6543,7 @@ msgstr ""
 msgctxt "Error message for VQD error"
 msgid ""
 "Duck.ai is temporarily unavailable. Please refresh the page and try again."
-msgstr ""
-"Duck.ai е временно недостъпен. Моля, опреснете страницата и опитайте отново."
+msgstr "Duck.ai е временно недостъпен. Моля, опреснете страницата и опитайте отново."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -6558,6 +6557,9 @@ msgid ""
 "Duck.ai lets you chat privately with popular AI models. Disabling it hides "
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
+"Duck.ai осигурява поверителен чат с популярни AI модели. Когато го "
+"изключите, бутоните и връзките на Duck.ai се скриват, но въпреки това можете "
+"да влезете в %1$sduck.ai%2$s директно."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6572,8 +6574,8 @@ msgstr ""
 "интелект на трети страни, включително модели от OpenAI, Anthropic и други. "
 "Ако изключите тази настройка, бутоните и връзките на Duck.ai в DuckDuckGo "
 "Search ще се скрият. Въпреки това можете да получите достъп до Duck.ai, "
-"когато тази настройка е изключена, като посетите директно %1$shttps://duck."
-"ai%2$s ."
+"когато тази настройка е изключена, като посетите директно "
+"%1$shttps://duck.ai%2$s ."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
@@ -6807,8 +6809,8 @@ msgstr ""
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
 msgstr ""
-"Функцията DuckDuckGo AI Chat е временно недостъпна. Моля, опитайте отново по-"
-"късно."
+"Функцията DuckDuckGo AI Chat е временно недостъпна. Моля, опитайте отново "
+"по-късно."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -7417,15 +7419,13 @@ msgstr ""
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location Services' is %senabled%s."
-msgstr ""
-"Уверете се, че функцията \"Услуги за местоположение\" е %1$sактивирана%2$s."
+msgstr "Уверете се, че функцията \"Услуги за местоположение\" е %1$sактивирана%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location' is set to %sallow%s"
-msgstr ""
-"Уверете се, че функцията „Местоположение“ е зададена на %1$s„разрешаване“%2$s"
+msgstr "Уверете се, че функцията „Местоположение“ е зададена на %1$s„разрешаване“%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service.
@@ -7455,15 +7455,13 @@ msgstr "Уверете се, че достъпът до местоположен
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed %slocation access%s"
-msgstr ""
-"Уверете се, че на браузъра е разрешен %1$sдостъпът до местоположението%2$s"
+msgstr "Уверете се, че на браузъра е разрешен %1$sдостъпът до местоположението%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed %slocation access%s."
-msgstr ""
-"Уверете се, че браузърът има разрешен %1$sдостъп до местоположение%2$s."
+msgstr "Уверете се, че браузърът има разрешен %1$sдостъп до местоположение%2$s."
 
 # smartling.placeholder_format=C
 #. Tells how to enable location service. Part of a list of instructions on how to enable location service.
@@ -7563,8 +7561,7 @@ msgstr "Екваториална Гвинея"
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Erase your browsing data in a flash with our %sFire Button%s"
-msgstr ""
-"Изтрийте светкавично данните за сърфирането с нашия %1$sбутон Fire Button%2$s"
+msgstr "Изтрийте светкавично данните за сърфирането с нашия %1$sбутон Fire Button%2$s"
 
 # smartling.placeholder_format=C
 msgid "Eritrea"
@@ -7574,13 +7571,13 @@ msgstr "Еритрея"
 #. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Estimate the nutrition"
-msgstr ""
+msgstr "Изчисли хранителната стойност"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Estimate the nutritional information for this recipe."
-msgstr ""
+msgstr "Изчисли хранителната стойност на тази рецепта."
 
 # smartling.placeholder_format=C
 msgid "Estonia"
@@ -7642,57 +7639,56 @@ msgstr "Изтича след 1 ден"
 #. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain the accepted answer in simple terms."
-msgstr ""
+msgstr "Обясни приетия отговор с прости думи."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
-msgstr ""
-"Обясни ми основните принципи на черните дупки на ниво гимназиален етап."
+msgstr "Обясни ми основните принципи на черните дупки на ниво гимназиален етап."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain the top answer"
-msgstr ""
+msgstr "Обясни най-горния отговор"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain this in simple, plain language."
-msgstr ""
+msgstr "Обясни това на прост и ясен език."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain this paper"
-msgstr ""
+msgstr "Обясни тази статия"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain this repo"
-msgstr ""
+msgstr "Обясни това хранилище"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain this research paper in plain language."
-msgstr ""
+msgstr "Обясни тази научна статия на достъпен език."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain this simply"
-msgstr ""
+msgstr "Обясни това по-просто"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain what this repository does and how to use it."
-msgstr ""
+msgstr "Обясни какво прави това хранилище и как да се използва."
 
 # smartling.placeholder_format=C
 #. Label to show if song lyrics contain explicit content
@@ -7716,8 +7712,7 @@ msgstr "Нецензуриран текст на песен"
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
-msgstr ""
-"Разгледайте най-новите актуализации на продукти и функции на DuckDuckGo."
+msgstr "Разгледайте най-новите актуализации на продукти и функции на DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Links to a page that provides a list of DuckDuckGo product updates
@@ -7986,6 +7981,8 @@ msgctxt "settings"
 msgid ""
 "Filters out known AI spam sites from image search results. %sLearn More%s"
 msgstr ""
+"Филтрира известни спам AI сайтове в резултатите от търсенето на изображения. "
+"%1$sНаучете повече%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the final score of a sporting event.
@@ -8014,8 +8011,7 @@ msgstr "Финансов консултант"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Find %sDuckDuckGo%s and click%sMake default%s"
-msgstr ""
-"Намерете %1$sDuckDuckGo%2$s и щракнете върху%3$sНаправи по подразбиране%4$s"
+msgstr "Намерете %1$sDuckDuckGo%2$s и щракнете върху%3$sНаправи по подразбиране%4$s"
 
 # smartling.placeholder_format=C
 #. Sentence shown after export, includes a placeholder for one or more filenames with bold formatting for the filename(s).
@@ -8047,7 +8043,7 @@ msgstr "Намиране на актуална информация"
 #. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Find me alternatives"
-msgstr ""
+msgstr "Намери ми алтернативи"
 
 # smartling.placeholder_format=C
 #. Button that searches for results closer to the user's current location.
@@ -8244,8 +8240,7 @@ msgstr "Безплатни и поверителни чатове, аноним�
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr ""
-"Безплатни и поверителни чатове, анонимизирани от нас. Не е необходим акаунт."
+msgstr "Безплатни и поверителни чатове, анонимизирани от нас. Не е необходим акаунт."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -8491,15 +8486,13 @@ msgstr "Общо предназначение"
 #. Text with short description for an AI (Artificial Intelligence) Model that has a high moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "General purpose AI with high built-in moderation"
-msgstr ""
-"Изкуствен интелект с общо предназначение с високо ниво на вградена модерация"
+msgstr "Изкуствен интелект с общо предназначение с високо ниво на вградена модерация"
 
 # smartling.placeholder_format=C
 #. Text with short description for an AI (Artificial Intelligence) Model that has a low moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "General purpose AI with low built-in moderation"
-msgstr ""
-"Изкуствен интелект с общо предназначение с ниско ниво на вградена модерация"
+msgstr "Изкуствен интелект с общо предназначение с ниско ниво на вградена модерация"
 
 # smartling.placeholder_format=C
 #. Text with short description for an AI (Artificial Intelligence) Model that has a medium moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
@@ -8535,7 +8528,7 @@ msgstr "Генерирай повече"
 #. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Generate a shopping list"
-msgstr ""
+msgstr "Генерирай списък за пазаруване"
 
 # smartling.placeholder_format=C
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
@@ -8834,14 +8827,13 @@ msgstr "Изпробвайте"
 #. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Give me a quick background on this person."
-msgstr ""
+msgstr "Дай ми кратка информация за този човек."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
-msgstr ""
-"Отидете на %1$s„Поверителност и сигурност > Услуги за местоположение“%2$s"
+msgstr "Отидете на %1$s„Поверителност и сигурност > Услуги за местоположение“%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9288,13 +9280,13 @@ msgstr "Помогнете да разпространим поверителн�
 #. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Help me prep for the interview"
-msgstr ""
+msgstr "Помогни ми да се подготвя за интервюто"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Help me tailor my resume for this job."
-msgstr ""
+msgstr "Помогни ми да адаптирам автобиографията си за тази работа."
 
 # smartling.placeholder_format=C
 #. Title of a SERP popup that invites users to take a survey (desktop only)
@@ -9495,8 +9487,7 @@ msgstr "Скриване на Вашия имейл адрес"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Hides search term from being shown in browser tab/history"
-msgstr ""
-"Скрива търсената дума, за да не се показва в раздела/историята на браузъра"
+msgstr "Скрива търсената дума, за да не се показва в раздела/историята на браузъра"
 
 # smartling.placeholder_format=C
 #. The highest stock price in a day
@@ -9758,8 +9749,7 @@ msgstr "Колко често искате да виждате отговори�
 #. A header for the feedback form in the assist negative feedback flow. The user is being asked to update how often they want AI-assisted answers to appear.
 msgctxt "duckassist"
 msgid "How often do you want to see AI-assisted answers?"
-msgstr ""
-"Колко често искаш да виждаш отговори, подпомогнати от изкуствен интелект?"
+msgstr "Колко често искаш да виждаш отговори, подпомогнати от изкуствен интелект?"
 
 # smartling.placeholder_format=C
 #. Section title above the frequency radio options in the Search Assist settings modal.
@@ -9821,7 +9811,7 @@ msgctxt ""
 "Text for the I already have a subscription button in the Duck.ai settings "
 "page"
 msgid "I Already Have a Subscription"
-msgstr ""
+msgstr "Вече имам абонамент"
 
 # smartling.placeholder_format=C
 #. Text for the button that takes the user to the login subscription page.
@@ -9897,8 +9887,8 @@ msgid ""
 "I like the book Name of the Wind. What are some other good books/series most "
 "like it and why?"
 msgstr ""
-"Харесва ми книгата „Името на вятъра“. Кажи ми какви други добри книги/"
-"поредици има, които приличат най-много на нея, и защо?"
+"Харесва ми книгата „Името на вятъра“. Кажи ми какви други добри "
+"книги/поредици има, които приличат най-много на нея, и защо?"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the user needs more help or information on how to use the chat.
@@ -10407,7 +10397,7 @@ msgstr "Инсталиране на браузъра на Mac"
 #. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
 msgctxt "settings"
 msgid "Install Now"
-msgstr ""
+msgstr "Инсталирай сега"
 
 # smartling.placeholder_format=C
 #. Text of a button to install the DuckDuckGo app
@@ -10510,13 +10500,13 @@ msgstr "Изтритите данни наистина ли са изтрити?
 #. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Is it worth taking?"
-msgstr ""
+msgstr "Струва ли си да бъде завършен?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Is this place any good?"
-msgstr ""
+msgstr "Това място добро ли е?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
@@ -10524,7 +10514,7 @@ msgctxt "Page suggestion prompt"
 msgid ""
 "Is this place any good? Summarize its reputation based on reviews and "
 "ratings."
-msgstr ""
+msgstr "Това място добро ли е? Обобщи репутацията му въз основа на отзиви и оценки."
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -10536,13 +10526,13 @@ msgstr "Полезно ли е това видео?"
 #. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Is this worth watching?"
-msgstr ""
+msgstr "Струва ли си да се гледа?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Is this worth watching? Give me a spoiler-free take."
-msgstr ""
+msgstr "Струва ли си да се гледа? Дай ми мнение без спойлери."
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -10574,8 +10564,7 @@ msgstr "Той е бърз, безплатен и осигурява още по
 msgctxt "settings"
 msgid ""
 "It's okay to (very infrequently) ask me about my experience using DuckDuckGo"
-msgstr ""
-"Няма проблем (много рядко) да ме питате за мнението ми относно DuckDuckGo"
+msgstr "Няма проблем (много рядко) да ме питате за мнението ми относно DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. The name of the Italian language
@@ -11131,8 +11120,7 @@ msgstr "Ограничено съхранение на данни за този 
 #. Description of a setting managing the length of search result snippet text.
 msgctxt "settings"
 msgid "Limits the amount of descriptive content shown for results"
-msgstr ""
-"Ограничава количеството описателно съдържание, което се показва с резултатите"
+msgstr "Ограничава количеството описателно съдържание, което се показва с резултатите"
 
 # smartling.placeholder_format=C
 #. i.e. a type of image comprised of lines without gradiations in shade or hue
@@ -11161,6 +11149,8 @@ msgstr "Линкове:"
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
 msgstr ""
+"Изброй инструментите, материалите или предпоставките, които са ми необходими "
+"за това."
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -11271,8 +11261,7 @@ msgstr "Зареждане на още резултати с изображен�
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Loads more results in Images, Videos, and Shopping when scrolling"
-msgstr ""
-"При превъртане зарежда повече резултати в изображения, видео и пазаруване"
+msgstr "При превъртане зарежда повече резултати в изображения, видео и пазаруване"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/WTkvs9I.png
@@ -11301,8 +11290,7 @@ msgstr "Местоположение"
 #. Message informing users that location-based search is private.
 msgctxt "precise_user_location"
 msgid "Location information is stored only on your device."
-msgstr ""
-"Информацията за местоположението се съхранява само на вашето устройство."
+msgstr "Информацията за местоположението се съхранява само на вашето устройство."
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -11576,7 +11564,7 @@ msgstr "Управление на блокирани сайтове"
 #. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
 msgctxt "setting"
 msgid "Manage in Browser Settings"
-msgstr ""
+msgstr "Управление в настройките на браузъра"
 
 # smartling.placeholder_format=C
 #. Link to the site exclusion settings page
@@ -13661,8 +13649,7 @@ msgstr "Отваряне на панела Как работи Duck.ai"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open the Safari menu and select %sSettings for DuckDuckGo...%s"
-msgstr ""
-"Отворете менюто на Safari и изберете %1$s„Настройки за DuckDuckGo“...%2$s"
+msgstr "Отворете менюто на Safari и изберете %1$s„Настройки за DuckDuckGo“...%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the time a business opens. For example: 'Opens at 10am'
@@ -14248,9 +14235,9 @@ msgid ""
 "DuckAssist more likely to appear and often yields better answers. To adjust "
 "how this feature works, or to turn it off, visit %sDuckAssist Settings%s."
 msgstr ""
-"Ако формулирате своето търсене като въпрос и в пълно изречение, е по-"
-"вероятно DuckAssist да се появи и често допринася за по-добри отговори. За "
-"да настроите как да работи тази функция или да я изключите, отидете на "
+"Ако формулирате своето търсене като въпрос и в пълно изречение, е "
+"по-вероятно DuckAssist да се появи и често допринася за по-добри отговори. "
+"За да настроите как да работи тази функция или да я изключите, отидете на "
 "%1$sНастройки на DuckAssist%2$s."
 
 # smartling.placeholder_format=C
@@ -14420,7 +14407,7 @@ msgstr ""
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is harmful or illegal. (optional)"
-msgstr ""
+msgstr "Опишете защо отговорът в чата е вреден или незаконен. (По избор)"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
@@ -14457,6 +14444,8 @@ msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is harmful or illegal."
 msgstr ""
+"Копирайте и поставете подканата и проблемния резултат (с премахната лична "
+"информация) и опишете защо съдържанието е вредно или незаконно."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -14929,7 +14918,7 @@ msgstr "Поверителност"
 #. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
 msgctxt "Section heading on the Duck.ai settings page"
 msgid "Privacy & Terms"
-msgstr ""
+msgstr "Поверителност и Условия"
 
 # smartling.placeholder_format=C
 msgid "Privacy Blog"
@@ -15005,7 +14994,7 @@ msgstr "Политика за поверителност и Условия на 
 #. Text for a button that links to the terms of use and privacy policy page.
 msgctxt "Secondary button text in active privacy modal"
 msgid "Privacy Policy and Terms of Service"
-msgstr ""
+msgstr "Политика за поверителност и Условия на услугата"
 
 # smartling.placeholder_format=C
 #. Title displayed on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
@@ -15513,25 +15502,25 @@ msgstr "Препоръчай книга"
 #. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Recommend similar books"
-msgstr ""
+msgstr "Препоръчай подобни книги"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Recommend similar books."
-msgstr ""
+msgstr "Препоръчай подобни книги."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Recommend similar movies or shows."
-msgstr ""
+msgstr "Препоръчай подобни филми или предавания."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Recommend similar titles"
-msgstr ""
+msgstr "Препоръчай подобни заглавия"
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
@@ -15757,8 +15746,7 @@ msgstr "Запомни моя избор"
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings
 msgid "Remember my choice (this can be changed in %s%s%sSettings%s)"
-msgstr ""
-"Запомни моя избор (това може да бъде променено в %1$s%2$s%3$sНастройки%4$s)"
+msgstr "Запомни моя избор (това може да бъде променено в %1$s%2$s%3$sНастройки%4$s)"
 
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
@@ -15943,7 +15931,7 @@ msgctxt ""
 "feedback form when the user has selected Harmful or Illegal as the feedback "
 "reason"
 msgid "Required for harmful or illegal reports"
-msgstr ""
+msgstr "Задължително за докладване на вредно или незаконно съдържание"
 
 # smartling.placeholder_format=C
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
@@ -16186,7 +16174,7 @@ msgstr "Рецензии"
 #. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Rewrite this recipe scaled for a different number of servings."
-msgstr ""
+msgstr "Пренапиши тази рецепта за различен брой порции."
 
 # smartling.placeholder_format=C
 msgid "Romania"
@@ -16590,15 +16578,13 @@ msgstr "Шотландия"
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Scroll down and click %sView advanced settings%s"
-msgstr ""
-"Превъртете надолу и щракнете върху %1$sПреглед на разширените настройки%2$s"
+msgstr "Превъртете надолу и щракнете върху %1$sПреглед на разширените настройки%2$s"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down and click %sView advanced settings%s."
-msgstr ""
-"Превъртете надолу и щракнете върху %1$sПреглед на разширените настройки%2$s."
+msgstr "Превъртете надолу и щракнете върху %1$sПреглед на разширените настройки%2$s."
 
 #  Edge Legacy default search engine instruction, obsolete?
 # smartling.placeholder_format=C
@@ -17025,8 +17011,7 @@ msgstr ""
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
 msgctxt "Sync feature benefit description"
 msgid "Securely stored on DuckDuckGo's server with end-to-end encryption."
-msgstr ""
-"Съхранява се сигурно на сървъра на DuckDuckGo с криптиране от край до край."
+msgstr "Съхранява се сигурно на сървъра на DuckDuckGo с криптиране от край до край."
 
 # smartling.placeholder_format=C
 #. List item explaining that synced chats are stored with end-to-end encryption on DuckDuckGo's server and only the user can access them.
@@ -17147,8 +17132,7 @@ msgstr "Вижте някои от най-новите ни актуализац
 #. Link to a page with more information about how user settings are stored in a URL.
 msgctxt "settings"
 msgid "See the %sURL Parameter Reference page%s for more details."
-msgstr ""
-"За повече подробности вижте %1$sстраницата за справка за URL параметър%2$s."
+msgstr "За повече подробности вижте %1$sстраницата за справка за URL параметър%2$s."
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the context menu of a chat in chat history, that allows the user to select the chat and begin batch selection mode.
@@ -17188,8 +17172,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
-msgstr ""
-"Изберете %1$sDuckDuckGo%2$s и натиснете %3$sДобавяне по подразбиране%4$s!"
+msgstr "Изберете %1$sDuckDuckGo%2$s и натиснете %3$sДобавяне по подразбиране%4$s!"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
@@ -17210,8 +17193,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Select %sDuckDuckGo%s in the Default Search Engine drop down"
-msgstr ""
-"Изберете %1$sDuckDuckGo%2$s в падащия списък като търсачка по подразбиране"
+msgstr "Изберете %1$sDuckDuckGo%2$s в падащия списък като търсачка по подразбиране"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
@@ -17538,7 +17520,7 @@ msgstr "Настройване сега"
 #. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
 msgctxt "Encrypted storage setup button shown in native browsers"
 msgid "Set Up Sync & Backup"
-msgstr ""
+msgstr "Настройка на Sync & Backup"
 
 # smartling.placeholder_format=C
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
@@ -17661,8 +17643,8 @@ msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
 msgstr ""
-"Споделете местоположение на ниво град с AI моделите, за да получавате по-"
-"подходящи отговори. Duck.ai никога не разкрива точното Ви местоположение "
+"Споделете местоположение на ниво град с AI моделите, за да получавате "
+"по-подходящи отговори. Duck.ai никога не разкрива точното Ви местоположение "
 "нито на нас, нито на AI моделите."
 
 # smartling.placeholder_format=C
@@ -17728,7 +17710,7 @@ msgstr "Споделяне на положителен отзив"
 msgctxt ""
 "Label beside the share-content switch on the Duck.ai response feedback form"
 msgid "Share this conversation with DuckDuckGo"
-msgstr ""
+msgstr "Споделете този разговор с DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -18138,8 +18120,7 @@ msgstr "Показва периодично напомняне за добавя
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr ""
-"Показва периодично напомняне за добавяне на DuckDuckGo към устройствата ви"
+msgstr "Показва периодично напомняне за добавяне на DuckDuckGo към устройствата ви"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18157,8 +18138,7 @@ msgstr "Показва номерата на страниците в края н
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows sign-up form for the DuckDuckGo privacy newsletters"
-msgstr ""
-"Показва формуляр за регистриране за бюлетините за поверителност на DuckDuckGo"
+msgstr "Показва формуляр за регистриране за бюлетините за поверителност на DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/94erFcS.png
@@ -18181,14 +18161,12 @@ msgstr "Показва фона на бутона за търсене"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message on top of the search results page"
-msgstr ""
-"Показва приветствие в горната част на страницата с резултати от търсенето"
+msgstr "Показва приветствие в горната част на страницата с резултати от търсенето"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message to EU Android preference menu users"
-msgstr ""
-"Показва приветствие за потребителите с меню за предпочитания за Android в ЕС"
+msgstr "Показва приветствие за потребителите с меню за предпочитания за Android в ЕС"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers sometimes.
@@ -18260,14 +18238,12 @@ msgstr "Имена на сайтове"
 #. A message saying that site filters are not currently working
 msgctxt "Site filter message"
 msgid "Site search is temporarily unavailable. We are working on a fix."
-msgstr ""
-"Търсенето в сайта е временно недостъпно. Работим за разрешаване на проблема."
+msgstr "Търсенето в сайта е временно недостъпно. Работим за разрешаване на проблема."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Sites you block will be hidden from all your search results"
-msgstr ""
-"Сайтовете, които блокирате, ще бъдат скрити от всички резултати от търсенето."
+msgstr "Сайтовете, които блокирате, ще бъдат скрити от всички резултати от търсенето."
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes full name (tooltip)
@@ -18412,8 +18388,7 @@ msgstr "Нещо се обърка при запазването на сървъ
 #. Body copy displayed under the Set Up Now button when the sync setup call fails.
 msgctxt "Generic error shown when sync setup fails"
 msgid "Something went wrong while enabling Sync & Backup. Please try again."
-msgstr ""
-"Нещо се обърка при активирането на Sync & Backup. Моля, опитайте отново."
+msgstr "Нещо се обърка при активирането на Sync & Backup. Моля, опитайте отново."
 
 # smartling.placeholder_format=C
 #. Displayed when the voice chat session ends with an unknown error.
@@ -18437,8 +18412,7 @@ msgstr "Понякога"
 #. Generic error message shown when the image generation model cannot process the user's request.
 msgctxt "Error message from the image generation model"
 msgid "Sorry I can't help, please describe your image in a different way."
-msgstr ""
-"Съжалявам, не мога да помогна, моля, опишете изображението по друг начин."
+msgstr "Съжалявам, не мога да помогна, моля, опишете изображението по друг начин."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -18513,8 +18487,8 @@ msgstr ""
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
 msgstr ""
-"За съжаление, не успяхме да подадем вашия отзив. Моля, опитайте отново по-"
-"късно."
+"За съжаление, не успяхме да подадем вашия отзив. Моля, опитайте отново "
+"по-късно."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -18824,8 +18798,7 @@ msgstr "Спрете скритите тракери, които се спота
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop most hidden trackers lurking on other websites."
-msgstr ""
-"Спрете повечето от скритите тракери, които се спотайват в други уебсайтове."
+msgstr "Спрете повечето от скритите тракери, които се спотайват в други уебсайтове."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18999,18 +18972,20 @@ msgstr "Предложи заглавие на публикация в блог"
 msgctxt "Page suggestion prompt"
 msgid "Suggest related articles or topics worth exploring next."
 msgstr ""
+"Предложи сродни статии или теми, които си струва да бъдат разгледани след "
+"това."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Suggest related articles to explore"
-msgstr ""
+msgstr "Предложи сродни статии за преглед"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Suggest some alternatives to this product."
-msgstr ""
+msgstr "Предложи алтернативи на този продукт."
 
 # smartling.placeholder_format=C
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
@@ -19027,7 +19002,7 @@ msgstr "Предложения:"
 #. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Sum up the reviews"
-msgstr ""
+msgstr "Обобщи рецензиите"
 
 # smartling.placeholder_format=C
 #. A short title for the a message asking the AI to summarize a text.
@@ -19039,85 +19014,85 @@ msgstr "Направи обобщение"
 #. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize the Q&As"
-msgstr ""
+msgstr "Обобщи въпросите и отговорите"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the background and notable work of this person."
-msgstr ""
+msgstr "Обобщи биографията и значимите постижения на това лице."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the key details of this event."
-msgstr ""
+msgstr "Обобщи основните подробности за това събитие."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the questions and answers on this page."
-msgstr ""
+msgstr "Обобщи въпросите и отговорите на тази страница."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize their background"
-msgstr ""
+msgstr "Обобщи биографията"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this book"
-msgstr ""
+msgstr "Обобщи тази книга"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this book."
-msgstr ""
+msgstr "Обобщи тази книга."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this discussion"
-msgstr ""
+msgstr "Обобщи тази дискусия"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this discussion thread."
-msgstr ""
+msgstr "Обобщи тази тема във форума."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this page"
-msgstr ""
+msgstr "Обобщи тази страница"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this page."
-msgstr ""
+msgstr "Обобщи тази страница."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this video"
-msgstr ""
+msgstr "Обобщи това видео"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this video."
-msgstr ""
+msgstr "Обобщи това видео."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize what the reviews say."
-msgstr ""
+msgstr "Обобщи мненията в отзивите."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -19451,7 +19426,7 @@ msgstr "Сирия"
 #. Text for a button that enables the theme to follow the operating system's color scheme preference.
 msgctxt "System theme button for theme selector"
 msgid "System"
-msgstr ""
+msgstr "Системна"
 
 # smartling.placeholder_format=C
 #. Abbreviation indicating this is the total score for a game
@@ -19485,7 +19460,7 @@ msgstr "Таитянски"
 #. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Tailor my resume"
-msgstr ""
+msgstr "Адаптирай автобиографията ми"
 
 # smartling.placeholder_format=C
 msgid "Taiwan"
@@ -19522,6 +19497,8 @@ msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
+"Попълнете тази анонимна анкета, за да ни кажете как можем да подобрим "
+"Duck.ai."
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -19832,7 +19809,7 @@ msgstr "Тема"
 #. Text for the theme selector label that allows users to switch between Light and dark theme.
 msgctxt "Label for the theme selector feature"
 msgid "Theme"
-msgstr ""
+msgstr "Тема"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/LpFhb1e.png
@@ -19885,8 +19862,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Error message for explore more questions when a retryable error occurs (timeout, network)
 msgid "There's been an issue loading this answer. Please try again."
-msgstr ""
-"Възникна проблем при зареждането на този отговор. Моля, опитайте отново."
+msgstr "Възникна проблем при зареждането на този отговор. Моля, опитайте отново."
 
 # smartling.placeholder_format=C
 #. Instant Answer Tab Name
@@ -19940,8 +19916,7 @@ msgctxt "AI Chat: Error message for when a model is removed"
 msgid ""
 "This AI model is no longer available. Try starting a new chat with a "
 "different model."
-msgstr ""
-"Този AI модел вече не е наличен. Опитайте да започнете нов чат с друг модел."
+msgstr "Този AI модел вече не е наличен. Опитайте да започнете нов чат с друг модел."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is no longer supported because it has been upgraded to a newest version.
@@ -19957,8 +19932,7 @@ msgstr ""
 #. Appears below a type of search results called 'Instant Answers'
 msgctxt "attribution"
 msgid "This Instant Answer was made by the %sDuckDuckHack%s Community."
-msgstr ""
-"Този незабавен отговор бе създаден от общността на %1$sDuckDuckHack%2$s."
+msgstr "Този незабавен отговор бе създаден от общността на %1$sDuckDuckHack%2$s."
 
 # smartling.placeholder_format=C
 #. Label for the monthly usage row in the Usage section of Duck.ai settings.
@@ -20219,8 +20193,7 @@ msgstr "Този превод е грешен"
 # smartling.placeholder_format=C
 #. Label indicating that the video can't be played on the current page, and only on the website that owns the vide. The placeholder is the name of the website that owns the video.
 msgid "This video is not yet able to be watched here. You can watch it on %s."
-msgstr ""
-"Все още не можете да гледате това видео тук. Можете да го гледате в %1$s."
+msgstr "Все още не можете да гледате това видео тук. Можете да го гледате в %1$s."
 
 # smartling.placeholder_format=C
 #. Message indicating that a website is not using an encrypted connection and is not secure.
@@ -20666,8 +20639,8 @@ msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
 msgstr ""
-"Преведи това изречение от английски на френски: „Как да стигна до най-"
-"близкото кино?“"
+"Преведи това изречение от английски на френски: „Как да стигна до "
+"най-близкото кино?“"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for translating a sentence into another language. Translate the whole sentence and please use target language instead of 'English' and modify the sentence to translate into 'English' instead of 'French'. Example: 'Translate this {target language} sentence into English: “How do I get to the nearest movie theatre?”'
@@ -20676,20 +20649,20 @@ msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
 msgstr ""
-"Преведи това изречение от български на английски: „Как да стигна до най-"
-"близкото кино?“"
+"Преведи това изречение от български на английски: „Как да стигна до "
+"най-близкото кино?“"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Translate this page"
-msgstr ""
+msgstr "Преведи тази страница"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
 msgctxt "Page suggestion prompt"
 msgid "Translate this page into %s."
-msgstr ""
+msgstr "Преведи тази страница на %1$s."
 
 # smartling.placeholder_format=C
 #. Placeholder text for a region that will display translated text.
@@ -20795,8 +20768,7 @@ msgstr "Изпробвайте %1$s — първият ни модел с нул
 
 # smartling.placeholder_format=C
 msgid "Try %sDuck.ai%s, our private AI chat service:"
-msgstr ""
-"Опитайте %1$sDuck.ai%2$s, нашата частна услуга за чат с изкуствен интелект:"
+msgstr "Опитайте %1$sDuck.ai%2$s, нашата частна услуга за чат с изкуствен интелект:"
 
 # smartling.placeholder_format=C
 #. Button text to retry loading an explore more question that failed
@@ -20837,7 +20809,7 @@ msgstr "Пробвайте безплатно"
 #. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
 msgctxt "settings"
 msgid "Try It Now"
-msgstr ""
+msgstr "Изпробвайте го сега"
 
 # smartling.placeholder_format=C
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -20971,8 +20943,7 @@ msgstr "Изпробвайте нашия браузър"
 # smartling.placeholder_format=C
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
-msgstr ""
-"Опитайте нашата начална страница, която никога не показва тези съобщения:"
+msgstr "Опитайте нашата начална страница, която никога не показва тези съобщения:"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with different words to get more results.
@@ -21089,6 +21060,9 @@ msgid ""
 "Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
+"Опитвате се да деактивирате функциите на изкуствения интелект? Инсталирайте "
+"разширението за търсене %1$sDuckDuckGo No AI%2$s, за да запаметите "
+"настройките си. %3$sНаучете повече%4$s"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -21097,6 +21071,9 @@ msgid ""
 "Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
+"Опитвате се да деактивирате функциите на изкуствения интелект? Превключете "
+"към разширението за търсене %1$sDuckDuckGo No AI%2$s, за да запаметите "
+"настройките си. %3$sНаучете повече%4$s"
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -21421,8 +21398,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
-msgstr ""
-"Под %1$sСТАРТИРАНЕ > Начална страница%2$s въведете: https://duckduckgo.com"
+msgstr "Под %1$sСТАРТИРАНЕ > Начална страница%2$s въведете: https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -21440,8 +21416,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
-msgstr ""
-"В раздела %1$sТърсене%2$s щракнете върху %3$sУправляване на търсачките...%4$s"
+msgstr "В раздела %1$sТърсене%2$s щракнете върху %3$sУправляване на търсачките...%4$s"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -21857,7 +21832,7 @@ msgstr "Уругвай"
 #. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
 msgctxt "Navigation label on the Duck.ai settings page"
 msgid "Usage"
-msgstr ""
+msgstr "Употреба"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -21954,8 +21929,7 @@ msgstr ""
 #. Prompt to ask the user if they want to use their approximate location for more accurate results
 msgctxt "DuckChat location prompt"
 msgid "Use your approximate location for more accurate results?"
-msgstr ""
-"Да се използва приблизителното Ви местоположение за по-точни резултати?"
+msgstr "Да се използва приблизителното Ви местоположение за по-точни резултати?"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes before every user message in the downloaded file, indicating which message it is out of the total number of messages. Example: 'User prompt 3 of 5'
@@ -22315,7 +22289,7 @@ msgstr "Уелс"
 #. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Walk me through the steps"
-msgstr ""
+msgstr "Преведи ме през стъпките"
 
 # smartling.placeholder_format=C
 #. Label for walking directions on a map.
@@ -22433,8 +22407,8 @@ msgstr "Ние анонимизираме"
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
 msgstr ""
-"Можем да анонимизираме%1$s вашето местоположение%2$s, за да ви показваме по-"
-"точни резултати."
+"Можем да анонимизираме%1$s вашето местоположение%2$s, за да ви показваме "
+"по-точни резултати."
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
@@ -22446,6 +22420,9 @@ msgid ""
 "please share this conversation with DuckDuckGo so we can investigate and "
 "address the issue."
 msgstr ""
+"Можем да коригираме само това, което виждаме. За да докладвате за опасен или "
+"незаконен отговор, споделете този разговор с DuckDuckGo, за да можем да "
+"разследваме и да разрешим проблема."
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -22543,8 +22520,7 @@ msgstr "Ние не ви проследяваме. Никога."
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with a Continue button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don't track you. That's our Privacy Policy in a nutshell."
-msgstr ""
-"Ние не Ви проследяваме. Това е нашата Политика за поверителност накратко."
+msgstr "Ние не Ви проследяваме. Това е нашата Политика за поверителност накратко."
 
 # smartling.placeholder_format=C
 #. Description for the audio identification highlight in the dictation consent modal.
@@ -22585,8 +22561,7 @@ msgstr "Не ви следим нито във, нито извън режима
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with an Agree button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don’t track you. That’s our Privacy Policy in a nutshell…"
-msgstr ""
-"Ние не Ви проследяваме. Това е нашата Политика за поверителност накратко…"
+msgstr "Ние не Ви проследяваме. Това е нашата Политика за поверителност накратко…"
 
 # smartling.placeholder_format=C
 #. Displayed when the user's voice chat session is ended because of being inactive for too long.
@@ -22713,8 +22688,7 @@ msgctxt "duckai_migration"
 msgid ""
 "We're sorry for this inconvenience. We’re working hard to make your "
 "experience better."
-msgstr ""
-"Съжаляваме за това неудобство. Работим усилено, за да подобрим изживяването."
+msgstr "Съжаляваме за това неудобство. Работим усилено, за да подобрим изживяването."
 
 # smartling.placeholder_format=C
 #. Body text explaining the service update requires a page reload.
@@ -22873,8 +22847,7 @@ msgstr ""
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai! You can now import your downloaded chats."
-msgstr ""
-"Добре дошли в новия Duck.ai! Вече можете да импортирате изтеглените чатове."
+msgstr "Добре дошли в новия Duck.ai! Вече можете да импортирате изтеглените чатове."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -22965,15 +22938,13 @@ msgstr ""
 #. Text for a prompt suggestion for considering factors when purchasing a computer monitor.
 msgctxt "Full sentence for preparing for a purchase"
 msgid "What are some factors to consider when purchasing a computer monitor?"
-msgstr ""
-"Какви фактори трябва да се имам предвид, когато купувам монитор за компютър?"
+msgstr "Какви фактори трябва да се имам предвид, когато купувам монитор за компютър?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for asking about must-see attractions in Paris for a first-time visitor.
 msgctxt "Full sentence for planning a trip"
 msgid "What are some must-see attractions in Paris for a first-time visitor?"
-msgstr ""
-"Кои атракции трябва да види един турист, който посещава Париж за първи път?"
+msgstr "Кои атракции трябва да види един турист, който посещава Париж за първи път?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for finding options for the word 'better' in a specific context.
@@ -23013,98 +22984,98 @@ msgstr ""
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the counterarguments?"
-msgstr ""
+msgstr "Какви са контрааргументите?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the hours & location?"
-msgstr ""
+msgstr "Какво е работното време и местоположението?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key contributions of this paper?"
-msgstr ""
+msgstr "Какви са основните приноси на тази статия?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key contributions?"
-msgstr ""
+msgstr "Кои са основните приноси?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key details?"
-msgstr ""
+msgstr "Кои са основните подробности?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key points covered in this video?"
-msgstr ""
+msgstr "Кои са основните моменти, разгледани в това видео?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key points?"
-msgstr ""
+msgstr "Кои са основните моменти?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key takeaways from this article?"
-msgstr ""
+msgstr "Какви са основните изводи от тази статия?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key takeaways?"
-msgstr ""
+msgstr "Какви са основните изводи?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key things I will learn from this course?"
-msgstr ""
+msgstr "Кои са основните неща, които ще науча от този курс?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the main counterarguments or criticisms of this?"
-msgstr ""
+msgstr "Кои са основните контрааргументи или критики към това?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the main questions this page answers?"
-msgstr ""
+msgstr "На какви основни въпроси отговаря тази страница?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the must-try dishes here?"
-msgstr ""
+msgstr "Кои са ястията, които задължително трябва да опитам тук?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid ""
 "What are the opening hours, location, and contact details for this place?"
-msgstr ""
+msgstr "Какво е работното време, местоположението и данните за контакт на това място?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the pros and cons of this product?"
-msgstr ""
+msgstr "Какви са плюсовете и минусите на този продукт?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the pros and cons?"
-msgstr ""
+msgstr "Какви са плюсовете и минусите?"
 
 # smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
@@ -23210,7 +23181,7 @@ msgstr "Какво означава предсърдие в контекста �
 #. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What does this answer?"
-msgstr ""
+msgstr "Отговор на какъв въпрос е това?"
 
 # smartling.placeholder_format=C
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
@@ -23228,7 +23199,7 @@ msgstr "Каква информация се съхранява?"
 #. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What interview questions might come up for this role?"
-msgstr ""
+msgstr "Какви въпроси могат да бъдат зададени за тази роля?"
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -23250,7 +23221,7 @@ msgstr "Коя е столицата на Албания?"
 #. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What is the overall verdict and rating for this?"
-msgstr ""
+msgstr "Какво е общото мнение и оценка за това?"
 
 # smartling.placeholder_format=C
 #. Link to a page with additional information.
@@ -23278,7 +23249,7 @@ msgstr "Какво казват хората:"
 #. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What should I order?"
-msgstr ""
+msgstr "Какво да поръчам?"
 
 # smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
@@ -23296,13 +23267,13 @@ msgstr "Какво не е наред с отговора? (По избор)"
 #. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What will I learn?"
-msgstr ""
+msgstr "Какво ще науча?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What will I need?"
-msgstr ""
+msgstr "Какво ще ми трябва?"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -23327,7 +23298,7 @@ msgstr "Новости"
 #. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What's the verdict?"
-msgstr ""
+msgstr "Каква е крайната оценка?"
 
 # smartling.placeholder_format=C
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -23385,7 +23356,7 @@ msgstr "Кои функции липсват? (По избор)"
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Which features are missing? (optional)"
-msgstr ""
+msgstr "Кои функции липсват? (По избор)"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
@@ -23407,13 +23378,13 @@ msgstr "Кои сме ние"
 #. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Who are the main cast and crew, and what else are they known for?"
-msgstr ""
+msgstr "Кои са основните актьори и екипът и с какво друго са известни?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Who is this person?"
-msgstr ""
+msgstr "Кой е този човек?"
 
 # smartling.placeholder_format=C
 #. Header above a collection of privacy-related links.
@@ -23910,8 +23881,7 @@ msgstr "Можете да скриете това напомняне в %1$sНа
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
-msgstr ""
-"Вече можете да запазите до 100 чата на това устройство. Разговаряйте на воля!"
+msgstr "Вече можете да запазите до 100 чата на това устройство. Разговаряйте на воля!"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -23981,8 +23951,7 @@ msgstr "Можете да възстановите настройките си, 
 #. Text explaining the benefits of the cloud save feature.
 msgctxt "cloudsave"
 msgid "You can share your settings among computers and browsers."
-msgstr ""
-"Можете да споделяте и използвате настройките си с други компютри и браузъри."
+msgstr "Можете да споделяте и използвате настройките си с други компютри и браузъри."
 
 # smartling.placeholder_format=C
 #. Alternative option description on export screen.
@@ -24160,15 +24129,14 @@ msgid ""
 "You've reached the maximum number of messages for the moment. Please try "
 "again later."
 msgstr ""
-"Достигнахте максималния брой съобщения за момента. Моля, опитайте отново по-"
-"късно."
+"Достигнахте максималния брой съобщения за момента. Моля, опитайте отново "
+"по-късно."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
 msgctxt "voice chat duration limit modal"
 msgid "You've reached the maximum voice chat duration for a single session."
-msgstr ""
-"Достигнали сте максималната продължителност на гласовия чат за една сесия."
+msgstr "Достигнали сте максималната продължителност на гласовия чат за една сесия."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the daily voice chat limit.
@@ -24180,8 +24148,7 @@ msgstr "Достигнали сте лимита за гласов чат за �
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
 msgid "You've reached your dictation usage limit. Try again later."
-msgstr ""
-"Достигнали сте лимита за използване на диктовка. Опитайте отново по-късно."
+msgstr "Достигнали сте лимита за използване на диктовка. Опитайте отново по-късно."
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -24190,8 +24157,8 @@ msgid ""
 "You've run out of Sync & Backup storage for Duck.ai chats with attachments. "
 "Delete the %s oldest chats to resume Sync. Pinned chats will not be deleted."
 msgstr ""
-"Мястото за съхранение на Sync & Backup за чатове с прикачени файлове в Duck."
-"ai е недостатъчно. Изтрийте %1$s най-стари чатове, за да възобновите "
+"Мястото за съхранение на Sync & Backup за чатове с прикачени файлове в "
+"Duck.ai е недостатъчно. Изтрийте %1$s най-стари чатове, за да възобновите "
 "синхронизирането. Закачените чатове няма да бъдат изтрити."
 
 # smartling.placeholder_format=C
@@ -24219,8 +24186,8 @@ msgid ""
 "such, watching YouTube videos here will be tracked by YouTube/Google."
 msgstr ""
 "YouTube (притежаван от Google) не позволява да гледате видео анонимно. "
-"Следователно гледането на YouTube видео тук ще бъде следено от YouTube/"
-"Google."
+"Следователно гледането на YouTube видео тук ще бъде следено от "
+"YouTube/Google."
 
 # smartling.placeholder_format=C
 #. Label for a privacy disclaimer related to YouTube videos
@@ -24343,8 +24310,7 @@ msgstr ""
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never used to train AI models"
-msgstr ""
-"Чатовете са поверителни и никога не се използват за обучение на AI модели"
+msgstr "Чатовете са поверителни и никога не се използват за обучение на AI модели"
 
 # smartling.placeholder_format=C
 #. Text for a description of the active privacy protection for DuckDuckGo's AI Chat feature.
@@ -24405,8 +24371,7 @@ msgctxt "duckai_migration"
 msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
-msgstr ""
-"Чатовете са импортирани. Продължете оттам, откъдето сте спрели в Duck.ai."
+msgstr "Чатовете са импортирани. Продължете оттам, откъдето сте спрели в Duck.ai."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.
@@ -24613,8 +24578,7 @@ msgstr ""
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
 msgctxt "voice chat limit modal"
 msgid "You’ve reached the voice chat limit for now. Please try again later."
-msgstr ""
-"Достигнахте лимита за гласов чат засега. Моля, опитайте отново по-късно."
+msgstr "Достигнахте лимита за гласов чат засега. Моля, опитайте отново по-късно."
 
 # smartling.placeholder_format=C
 #. The name of the Yucatec Maya language
@@ -24697,8 +24661,7 @@ msgstr "от %1$s"
 #. Trust line shown at the bottom of the explainer panel, summarizing DuckDuckGo's reputation for online protection.
 msgctxt "Footer banner text in the How Duck.ai Works panel"
 msgid "by DuckDuckGo — online protection trusted by millions every day."
-msgstr ""
-"от DuckDuckGo — онлайн защита, на която милиони се доверяват всеки ден."
+msgstr "от DuckDuckGo — онлайн защита, на която милиони се доверяват всеки ден."
 
 # smartling.placeholder_format=C
 #. An abreviated unit of time indicating an age, e.g. "2d"

--- a/locales/bg_BG/LC_MESSAGES/duckduckgo.po
+++ b/locales/bg_BG/LC_MESSAGES/duckduckgo.po
@@ -2666,7 +2666,7 @@ msgstr "Баркод"
 #. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Based on this page, is this course worth taking?"
-msgstr "Въз основа на тази страница, струва ли си да курсът да бъде завършен?"
+msgstr "Въз основа на тази страница, струва ли си този курс?"
 
 # smartling.placeholder_format=C
 msgctxt "settings"

--- a/locales/bg_BG/LC_MESSAGES/duckduckgo.po
+++ b/locales/bg_BG/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: bg_BG\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -468,7 +468,8 @@ msgstr "%1$sНаучи повече%2$s."
 #. Link to a page with more information about how anonymous location works.
 msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
-msgstr "%1$sНаучете как запазваме поверителността на вашето местоположение%2$s."
+msgstr ""
+"%1$sНаучете как запазваме поверителността на вашето местоположение%2$s."
 
 # smartling.placeholder_format=C
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
@@ -943,8 +944,8 @@ msgstr ""
 "AI Chat ви позволява да провеждате анонимни разговори с модели за чат с "
 "изкуствен интелект на трети страни. Изключването на това ще скрие функцията "
 "AI Chat в DuckDuckGo Search. Все още можете да получите достъп до AI Chat, "
-"когато тази настройка е изключена, като посетите "
-"%1$sduckduckgo.com/aichat%2$s."
+"когато тази настройка е изключена, като посетите %1$sduckduckgo.com/"
+"aichat%2$s."
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -1448,6 +1449,12 @@ msgid "Address is incorrect"
 msgstr "Грешен адрес"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Adjust the servings"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. as in multiple advertisements
 msgid "Ads"
 msgstr "Реклами"
@@ -1659,6 +1666,14 @@ msgstr "Всички чатове са %1$s. AI може да прави гре�
 msgctxt "Empty state heading in Duck.ai chat mode"
 msgid "All chats are %sprivate%s"
 msgstr "Всички чатове са %1$sповерителни%2$s"
+
+# smartling.placeholder_format=C
+#. Paragraph in the Privacy & Terms section of the About & Legal page in Duck.ai settings, summarizing how chats are anonymized and are not stored or used to train chat models.
+msgctxt "Privacy & Terms section description on the Duck.ai settings page"
+msgid ""
+"All chats are anonymized by DuckDuckGo, and your conversations are not used "
+"to train chat models by DuckDuckGo or the model providers"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1931,6 +1946,13 @@ msgid "Anonymous location enabled"
 msgstr "Активирано анонимно местоположение"
 
 # smartling.placeholder_format=C
+msgctxt "settings"
+msgid ""
+"Anonymously generates answers for search queries based on web content. "
+"Choose how often you want it to appear, or disable it completely."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Instant Answer tab name
 msgid "Answer"
 msgstr "Отговор"
@@ -2083,7 +2105,8 @@ msgstr ""
 #. Body text of the modal that asks the user if they want to clear the conversation.
 msgctxt "Modal body for clearing conversation"
 msgid "Are you sure you want to clear this conversation and start a new one?"
-msgstr "Сигурни ли сте, че искате да изчистите този разговор и да започнете нов?"
+msgstr ""
+"Сигурни ли сте, че искате да изчистите този разговор и да започнете нов?"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to delete their current chat, explaining that this action cannot be undone.
@@ -2212,6 +2235,12 @@ msgstr "Задаване на последващ въпрос"
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse
 msgid "Ask a follow-up with Duck.ai"
 msgstr "Задайте последващи въпроси на Duck.ai"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
+msgctxt "Page suggestion chip label"
+msgid "Ask about this page"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2391,7 +2420,8 @@ msgstr "След приключване на чата аудиото не се �
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat is transcribed."
-msgstr "След транскрибиране на чата аудиото не се съхранява от нас или от OpenAI."
+msgstr ""
+"След транскрибиране на чата аудиото не се съхранява от нас или от OpenAI."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when MediaRecorder API is unavailable.
@@ -2630,6 +2660,12 @@ msgid "Barcode"
 msgstr "Баркод"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Based on this page, is this course worth taking?"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Basic"
 msgstr "Основно"
@@ -2668,6 +2704,14 @@ msgstr "Батсман"
 msgctxt "Assistant response placeholder"
 msgid "Before continuing..."
 msgstr "Преди да продължите..."
+
+# smartling.placeholder_format=C
+#. Explains that before storing the report, DuckDuckGo will anonymize the conversation by removing PII like names, email addresses, and identifying metadata.
+msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
+msgid ""
+"Before storing this report, DuckDuckGo will anonymize your conversation by "
+"removing PII like names, email addresses, and identifying metadata."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -2984,6 +3028,12 @@ msgstr "Бразилия"
 msgctxt "Sports module"
 msgid "Break Points Won"
 msgstr "Брейк точки"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Break this down into clear, numbered steps."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -3441,6 +3491,12 @@ msgid "Cast"
 msgstr "Актьорски състав"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Cast & Crew"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
 msgctxt "Tone option label for Casual"
 msgid "Casual"
@@ -3560,7 +3616,8 @@ msgstr "Променя фоновия цвят, когато курсорът б
 #. Description of a setting managing the color of search result snippet text.
 msgctxt "settings"
 msgid "Changes the color of descriptive content shown for results"
-msgstr "Променя цвета на описателното съдържание, което се показва с резултатите"
+msgstr ""
+"Променя цвета на описателното съдържание, което се показва с резултатите"
 
 # smartling.placeholder_format=C
 #. This is the description of a user setting
@@ -3906,7 +3963,8 @@ msgstr "Проверете правописа"
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
 msgctxt "noresults"
 msgid "Check the DuckDuckGo subreddit for updates on this outage."
-msgstr "Проверка на subreddit в DuckDuckGo за актуализации относно това прекъсване."
+msgstr ""
+"Проверка на subreddit в DuckDuckGo за актуализации относно това прекъсване."
 
 # smartling.placeholder_format=C
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
@@ -4293,7 +4351,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click %sPrivacy and Services%s in the left sidebar."
-msgstr "Щракнете върху %1$sПоверителност и услуги%2$s в лявата странична лента."
+msgstr ""
+"Щракнете върху %1$sПоверителност и услуги%2$s в лявата странична лента."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -4360,7 +4419,8 @@ msgstr "Щракнете върху %1$sБраузър%2$s в странично
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click on %sChange Search Settings%s in the dropdown menu"
-msgstr "Щракнете върху %1$sПромяна на настройките за търсене%2$s в падащото меню"
+msgstr ""
+"Щракнете върху %1$sПромяна на настройките за търсене%2$s в падащото меню"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -4378,7 +4438,8 @@ msgstr "Щракнете върху %1$sТърсачки%2$s под Видове
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click on the %sTools icon%s in the top-right of the browser"
-msgstr "Щракнете върху %1$sиконата Настройки%2$s в горния десен ъгъл на браузъра"
+msgstr ""
+"Щракнете върху %1$sиконата Настройки%2$s в горния десен ъгъл на браузъра"
 
 #  Firefox default search engine instruction
 # smartling.placeholder_format=C
@@ -4453,7 +4514,8 @@ msgstr "Щракнете върху %1$sиконата за разрешения
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to search using DuckDuckGo.
 msgid "Click the Duck icon at the top of your browser to search!"
-msgstr "Щракнете върху иконата с пате в горната част на браузъра си, за да търсите!"
+msgstr ""
+"Щракнете върху иконата с пате в горната част на браузъра си, за да търсите!"
 
 #  UC Browser on Android
 # smartling.placeholder_format=C
@@ -5041,7 +5103,8 @@ msgstr "Копиране"
 # smartling.placeholder_format=C
 #. Instructions on how to change the default search engine
 msgid "Copy &amp; paste %sabout:preferences#search%s into the address bar"
-msgstr "Копирайте и поставете %1$sabout:preferences#search%2$s в адресната лента"
+msgstr ""
+"Копирайте и поставете %1$sabout:preferences#search%2$s в адресната лента"
 
 # smartling.placeholder_format=C
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
@@ -5111,7 +5174,8 @@ msgstr "Коста Рика"
 #. Inline error shown on the recovery code screen when exportSyncSettings rejects.
 msgctxt "Error message when the recovery code fails to generate"
 msgid "Couldn't load your recovery code. Please close this and try again."
-msgstr "Неуспешно зареждане на кода. Затворете този прозорец и опитайте отново."
+msgstr ""
+"Неуспешно зареждане на кода. Затворете този прозорец и опитайте отново."
 
 # smartling.placeholder_format=C
 #. Pairs with a Retry button. Shown after two consecutive failed attempts to load the device list.
@@ -5155,6 +5219,12 @@ msgstr "Създаване на изображение"
 msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr "Създаване на изображение"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Create a shopping list with quantities from this recipe."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed in the input field when starting a new image generation session.
@@ -5801,6 +5871,11 @@ msgid "Dictation limit reached"
 msgstr "Достигнат лимит за диктовка"
 
 # smartling.placeholder_format=C
+#. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
+msgid "Dictation temporarily unavailable"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
@@ -5887,7 +5962,8 @@ msgstr "Деактивиране и изключване"
 #. Title of a modal that asks the user if they want to turn off chat history and disconnect from Sync & Backup.
 msgctxt "Modal header for disabling chat history and disconnecting sync"
 msgid "Disable chat history and disconnect from Sync & Backup?"
-msgstr "Деактивиране на историята на чата и прекъсване на връзката със Sync & Backup?"
+msgstr ""
+"Деактивиране на историята на чата и прекъсване на връзката със Sync & Backup?"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to turn off the chat history feature.
@@ -6075,7 +6151,8 @@ msgstr "Не виждате DuckDuckGo в списъка?"
 #. Link to download a file again if the user can't find it on their computer.
 msgctxt "install-extension"
 msgid "Don't see it? %s%s%sClick here to re-download%s"
-msgstr "Не го виждате? %1$s%2$s%3$sНатиснете тук, за да го изтеглите отново%4$s"
+msgstr ""
+"Не го виждате? %1$s%2$s%3$sНатиснете тук, за да го изтеглите отново%4$s"
 
 #  IE < 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -6099,6 +6176,22 @@ msgstr "Готово"
 msgctxt "precise_user_location"
 msgid "Done"
 msgstr "Готово"
+
+# smartling.placeholder_format=C
+#. Message shown in a modal after DuckDuckGo browser users disable AI features in Settings. The first two placeholders bold noai.duckduckgo.com. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
+"filtered out. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
+"and AI images filtered out. %sLearn more%s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6213,6 +6306,18 @@ msgid ""
 msgstr ""
 "Изготви стегнат и подробен имейл до доставчик на услуги с искане за оферта "
 "за ремонт на домашен хладилник."
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Draft a cover letter"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Draft a cover letter for this job."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -6348,7 +6453,8 @@ msgstr "Условия за ползване на Duck.ai"
 #. The HTML <title> for Duck.ai.
 msgctxt "duckai_seo"
 msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
-msgstr "Duck.ai от DuckDuckGo. Поверителен чат с изкуствен интелект. Безплатен."
+msgstr ""
+"Duck.ai от DuckDuckGo. Поверителен чат с изкуствен интелект. Безплатен."
 
 # smartling.placeholder_format=C
 #. Description explaining how the page context feature works in Duck.ai sidebar.
@@ -6388,7 +6494,17 @@ msgstr ""
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
-msgstr "Duck.ai е най-добър в нашия поверителен и безплатен браузър DuckDuckGo!"
+msgstr ""
+"Duck.ai е най-добър в нашия поверителен и безплатен браузър DuckDuckGo!"
+
+# smartling.placeholder_format=C
+#. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
+msgctxt "About section description on the Duck.ai settings page"
+msgid ""
+"Duck.ai is created by DuckDuckGo. We're an independent online protection "
+"company for anyone who wants to take back control of their personal "
+"information."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
@@ -6427,13 +6543,21 @@ msgstr ""
 msgctxt "Error message for VQD error"
 msgid ""
 "Duck.ai is temporarily unavailable. Please refresh the page and try again."
-msgstr "Duck.ai е временно недостъпен. Моля, опреснете страницата и опитайте отново."
+msgstr ""
+"Duck.ai е временно недостъпен. Моля, опреснете страницата и опитайте отново."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
 msgstr "Duck.ai е временно недостъпен. Моля, опитайте отново по-късно."
+
+# smartling.placeholder_format=C
+msgctxt "settings"
+msgid ""
+"Duck.ai lets you chat privately with popular AI models. Disabling it hides "
+"Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6448,8 +6572,8 @@ msgstr ""
 "интелект на трети страни, включително модели от OpenAI, Anthropic и други. "
 "Ако изключите тази настройка, бутоните и връзките на Duck.ai в DuckDuckGo "
 "Search ще се скрият. Въпреки това можете да получите достъп до Duck.ai, "
-"когато тази настройка е изключена, като посетите директно "
-"%1$shttps://duck.ai%2$s ."
+"когато тази настройка е изключена, като посетите директно %1$shttps://duck."
+"ai%2$s ."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
@@ -6683,8 +6807,8 @@ msgstr ""
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
 msgstr ""
-"Функцията DuckDuckGo AI Chat е временно недостъпна. Моля, опитайте отново "
-"по-късно."
+"Функцията DuckDuckGo AI Chat е временно недостъпна. Моля, опитайте отново по-"
+"късно."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -7293,13 +7417,15 @@ msgstr ""
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location Services' is %senabled%s."
-msgstr "Уверете се, че функцията \"Услуги за местоположение\" е %1$sактивирана%2$s."
+msgstr ""
+"Уверете се, че функцията \"Услуги за местоположение\" е %1$sактивирана%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location' is set to %sallow%s"
-msgstr "Уверете се, че функцията „Местоположение“ е зададена на %1$s„разрешаване“%2$s"
+msgstr ""
+"Уверете се, че функцията „Местоположение“ е зададена на %1$s„разрешаване“%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service.
@@ -7329,13 +7455,15 @@ msgstr "Уверете се, че достъпът до местоположен
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed %slocation access%s"
-msgstr "Уверете се, че на браузъра е разрешен %1$sдостъпът до местоположението%2$s"
+msgstr ""
+"Уверете се, че на браузъра е разрешен %1$sдостъпът до местоположението%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed %slocation access%s."
-msgstr "Уверете се, че браузърът има разрешен %1$sдостъп до местоположение%2$s."
+msgstr ""
+"Уверете се, че браузърът има разрешен %1$sдостъп до местоположение%2$s."
 
 # smartling.placeholder_format=C
 #. Tells how to enable location service. Part of a list of instructions on how to enable location service.
@@ -7435,11 +7563,24 @@ msgstr "Екваториална Гвинея"
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Erase your browsing data in a flash with our %sFire Button%s"
-msgstr "Изтрийте светкавично данните за сърфирането с нашия %1$sбутон Fire Button%2$s"
+msgstr ""
+"Изтрийте светкавично данните за сърфирането с нашия %1$sбутон Fire Button%2$s"
 
 # smartling.placeholder_format=C
 msgid "Eritrea"
 msgstr "Еритрея"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Estimate the nutrition"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Estimate the nutritional information for this recipe."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Estonia"
@@ -7498,11 +7639,60 @@ msgid "Expires in 1 day"
 msgstr "Изтича след 1 ден"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain the accepted answer in simple terms."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
-msgstr "Обясни ми основните принципи на черните дупки на ниво гимназиален етап."
+msgstr ""
+"Обясни ми основните принципи на черните дупки на ниво гимназиален етап."
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain the top answer"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this in simple, plain language."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this paper"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this repo"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this research paper in plain language."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this simply"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain what this repository does and how to use it."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label to show if song lyrics contain explicit content
@@ -7526,7 +7716,8 @@ msgstr "Нецензуриран текст на песен"
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
-msgstr "Разгледайте най-новите актуализации на продукти и функции на DuckDuckGo."
+msgstr ""
+"Разгледайте най-новите актуализации на продукти и функции на DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Links to a page that provides a list of DuckDuckGo product updates
@@ -7791,6 +7982,12 @@ msgstr ""
 "интелект. %1$sНаучете повече%2$s"
 
 # smartling.placeholder_format=C
+msgctxt "settings"
+msgid ""
+"Filters out known AI spam sites from image search results. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the final score of a sporting event.
 msgid "Final"
 msgstr "Краен резултат"
@@ -7817,7 +8014,8 @@ msgstr "Финансов консултант"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Find %sDuckDuckGo%s and click%sMake default%s"
-msgstr "Намерете %1$sDuckDuckGo%2$s и щракнете върху%3$sНаправи по подразбиране%4$s"
+msgstr ""
+"Намерете %1$sDuckDuckGo%2$s и щракнете върху%3$sНаправи по подразбиране%4$s"
 
 # smartling.placeholder_format=C
 #. Sentence shown after export, includes a placeholder for one or more filenames with bold formatting for the filename(s).
@@ -7844,6 +8042,12 @@ msgstr "Намери по-подходяща дума"
 msgctxt "Subtitle for the Web Search tool entry in the Tools dropdown menu"
 msgid "Find current information"
 msgstr "Намиране на актуална информация"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Find me alternatives"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button that searches for results closer to the user's current location.
@@ -8040,7 +8244,8 @@ msgstr "Безплатни и поверителни чатове, аноним�
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr "Безплатни и поверителни чатове, анонимизирани от нас. Не е необходим акаунт."
+msgstr ""
+"Безплатни и поверителни чатове, анонимизирани от нас. Не е необходим акаунт."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -8286,13 +8491,15 @@ msgstr "Общо предназначение"
 #. Text with short description for an AI (Artificial Intelligence) Model that has a high moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "General purpose AI with high built-in moderation"
-msgstr "Изкуствен интелект с общо предназначение с високо ниво на вградена модерация"
+msgstr ""
+"Изкуствен интелект с общо предназначение с високо ниво на вградена модерация"
 
 # smartling.placeholder_format=C
 #. Text with short description for an AI (Artificial Intelligence) Model that has a low moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "General purpose AI with low built-in moderation"
-msgstr "Изкуствен интелект с общо предназначение с ниско ниво на вградена модерация"
+msgstr ""
+"Изкуствен интелект с общо предназначение с ниско ниво на вградена модерация"
 
 # smartling.placeholder_format=C
 #. Text with short description for an AI (Artificial Intelligence) Model that has a medium moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
@@ -8323,6 +8530,12 @@ msgstr "Генериране на изображение"
 #. Text for the button that generates more of an answer from duckassist when the answer has come from a collapsed state
 msgid "Generate More"
 msgstr "Генерирай повече"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Generate a shopping list"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
@@ -8618,10 +8831,17 @@ msgid "Give it a Try"
 msgstr "Изпробвайте"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Give me a quick background on this person."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
-msgstr "Отидете на %1$s„Поверителност и сигурност > Услуги за местоположение“%2$s"
+msgstr ""
+"Отидете на %1$s„Поверителност и сигурност > Услуги за местоположение“%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9065,6 +9285,18 @@ msgid "Help Spread Privacy"
 msgstr "Помогнете да разпространим поверителността"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Help me prep for the interview"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Help me tailor my resume for this job."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title of a SERP popup that invites users to take a survey (desktop only)
 msgctxt "User survey popup"
 msgid "Help us improve DuckDuckGo"
@@ -9263,7 +9495,8 @@ msgstr "Скриване на Вашия имейл адрес"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Hides search term from being shown in browser tab/history"
-msgstr "Скрива търсената дума, за да не се показва в раздела/историята на браузъра"
+msgstr ""
+"Скрива търсената дума, за да не се показва в раздела/историята на браузъра"
 
 # smartling.placeholder_format=C
 #. The highest stock price in a day
@@ -9525,7 +9758,8 @@ msgstr "Колко често искате да виждате отговори�
 #. A header for the feedback form in the assist negative feedback flow. The user is being asked to update how often they want AI-assisted answers to appear.
 msgctxt "duckassist"
 msgid "How often do you want to see AI-assisted answers?"
-msgstr "Колко често искаш да виждаш отговори, подпомогнати от изкуствен интелект?"
+msgstr ""
+"Колко често искаш да виждаш отговори, подпомогнати от изкуствен интелект?"
 
 # smartling.placeholder_format=C
 #. Section title above the frequency radio options in the Search Assist settings modal.
@@ -9580,6 +9814,14 @@ msgstr "Ураган"
 msgctxt "Onboarding terms screen button text"
 msgid "I Agree"
 msgstr "Приемам"
+
+# smartling.placeholder_format=C
+#. Text for the button that takes the user to the external DuckDuckGo login subscription page.
+msgctxt ""
+"Text for the I already have a subscription button in the Duck.ai settings "
+"page"
+msgid "I Already Have a Subscription"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the button that takes the user to the login subscription page.
@@ -9655,8 +9897,8 @@ msgid ""
 "I like the book Name of the Wind. What are some other good books/series most "
 "like it and why?"
 msgstr ""
-"Харесва ми книгата „Името на вятъра“. Кажи ми какви други добри "
-"книги/поредици има, които приличат най-много на нея, и защо?"
+"Харесва ми книгата „Името на вятъра“. Кажи ми какви други добри книги/"
+"поредици има, които приличат най-много на нея, и защо?"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the user needs more help or information on how to use the chat.
@@ -10162,6 +10404,12 @@ msgid "Install Mac Browser"
 msgstr "Инсталиране на браузъра на Mac"
 
 # smartling.placeholder_format=C
+#. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
+msgctxt "settings"
+msgid "Install Now"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of a button to install the DuckDuckGo app
 msgctxt "Serp footer content"
 msgid "Install Our App"
@@ -10259,10 +10507,42 @@ msgid "Is deleted data really deleted?"
 msgstr "Изтритите данни наистина ли са изтрити?"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is it worth taking?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this place any good?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"Is this place any good? Summarize its reputation based on reviews and "
+"ratings."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "Is this video helpful?"
 msgstr "Полезно ли е това видео?"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this worth watching?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Is this worth watching? Give me a spoiler-free take."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -10294,7 +10574,8 @@ msgstr "Той е бърз, безплатен и осигурява още по
 msgctxt "settings"
 msgid ""
 "It's okay to (very infrequently) ask me about my experience using DuckDuckGo"
-msgstr "Няма проблем (много рядко) да ме питате за мнението ми относно DuckDuckGo"
+msgstr ""
+"Няма проблем (много рядко) да ме питате за мнението ми относно DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. The name of the Italian language
@@ -10850,7 +11131,8 @@ msgstr "Ограничено съхранение на данни за този 
 #. Description of a setting managing the length of search result snippet text.
 msgctxt "settings"
 msgid "Limits the amount of descriptive content shown for results"
-msgstr "Ограничава количеството описателно съдържание, което се показва с резултатите"
+msgstr ""
+"Ограничава количеството описателно съдържание, което се показва с резултатите"
 
 # smartling.placeholder_format=C
 #. i.e. a type of image comprised of lines without gradiations in shade or hue
@@ -10873,6 +11155,12 @@ msgstr "Шрифт на линковете:"
 #. https://duckduckgo.com/params under "Color Settings"
 msgid "Links:"
 msgstr "Линкове:"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "List the tools, materials, or prerequisites I need for this."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -10983,7 +11271,8 @@ msgstr "Зареждане на още резултати с изображен�
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Loads more results in Images, Videos, and Shopping when scrolling"
-msgstr "При превъртане зарежда повече резултати в изображения, видео и пазаруване"
+msgstr ""
+"При превъртане зарежда повече резултати в изображения, видео и пазаруване"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/WTkvs9I.png
@@ -11012,7 +11301,8 @@ msgstr "Местоположение"
 #. Message informing users that location-based search is private.
 msgctxt "precise_user_location"
 msgid "Location information is stored only on your device."
-msgstr "Информацията за местоположението се съхранява само на вашето устройство."
+msgstr ""
+"Информацията за местоположението се съхранява само на вашето устройство."
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -11281,6 +11571,12 @@ msgstr "Управление на абонамента"
 msgctxt "Exclusion message manage sites button"
 msgid "Manage blocked sites"
 msgstr "Управление на блокирани сайтове"
+
+# smartling.placeholder_format=C
+#. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
+msgctxt "setting"
+msgid "Manage in Browser Settings"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to the site exclusion settings page
@@ -13365,7 +13661,8 @@ msgstr "Отваряне на панела Как работи Duck.ai"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open the Safari menu and select %sSettings for DuckDuckGo...%s"
-msgstr "Отворете менюто на Safari и изберете %1$s„Настройки за DuckDuckGo“...%2$s"
+msgstr ""
+"Отворете менюто на Safari и изберете %1$s„Настройки за DuckDuckGo“...%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the time a business opens. For example: 'Opens at 10am'
@@ -13951,9 +14248,9 @@ msgid ""
 "DuckAssist more likely to appear and often yields better answers. To adjust "
 "how this feature works, or to turn it off, visit %sDuckAssist Settings%s."
 msgstr ""
-"Ако формулирате своето търсене като въпрос и в пълно изречение, е "
-"по-вероятно DuckAssist да се появи и често допринася за по-добри отговори. "
-"За да настроите как да работи тази функция или да я изключите, отидете на "
+"Ако формулирате своето търсене като въпрос и в пълно изречение, е по-"
+"вероятно DuckAssist да се появи и често допринася за по-добри отговори. За "
+"да настроите как да работи тази функция или да я изключите, отидете на "
 "%1$sНастройки на DuckAssist%2$s."
 
 # smartling.placeholder_format=C
@@ -14122,6 +14419,12 @@ msgstr ""
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
+msgid "Please describe why the chat response is harmful or illegal. (optional)"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
+msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
 msgstr "Опишете защо отговорът в чата е незаконен или опасен. (По избор)"
 
@@ -14146,6 +14449,14 @@ msgid ""
 msgstr ""
 "Имайте предвид, че при стартиране на нов чат с този или друг модел текущата "
 "чат сесия ще бъде изтрита."
+
+# smartling.placeholder_format=C
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
+msgctxt "Feedback prompt"
+msgid ""
+"Please paste your prompt and the problematic output (with any personal "
+"information removed) and describe why the content is harmful or illegal."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -14615,6 +14926,12 @@ msgid "Privacy"
 msgstr "Поверителност"
 
 # smartling.placeholder_format=C
+#. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
+msgctxt "Section heading on the Duck.ai settings page"
+msgid "Privacy & Terms"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Privacy Blog"
 msgstr "Блог за поверителност"
 
@@ -14683,6 +15000,12 @@ msgstr "Политика за поверителност и Условия за 
 msgctxt "Copy used to compose link in sentences"
 msgid "Privacy Policy and Terms of Service"
 msgstr "Политика за поверителност и Условия на услугата"
+
+# smartling.placeholder_format=C
+#. Text for a button that links to the terms of use and privacy policy page.
+msgctxt "Secondary button text in active privacy modal"
+msgid "Privacy Policy and Terms of Service"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title displayed on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
@@ -15187,6 +15510,30 @@ msgid "Recommend a book"
 msgstr "Препоръчай книга"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar books"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar books."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar movies or shows."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar titles"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
 msgid "Recording failed. Please try again."
 msgstr "Неуспешен запис. Моля, опитайте отново."
@@ -15410,7 +15757,8 @@ msgstr "Запомни моя избор"
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings
 msgid "Remember my choice (this can be changed in %s%s%sSettings%s)"
-msgstr "Запомни моя избор (това може да бъде променено в %1$s%2$s%3$sНастройки%4$s)"
+msgstr ""
+"Запомни моя избор (това може да бъде променено в %1$s%2$s%3$sНастройки%4$s)"
 
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
@@ -15587,6 +15935,15 @@ msgstr ""
 # smartling.placeholder_format=C
 msgid "Republic of Moldova"
 msgstr "Република Молдова"
+
+# smartling.placeholder_format=C
+#. Note indicating that sharing the conversation is mandatory when reporting harmful or illegal content. Rendered alongside the standard share label (DUCKCHAT_RESPONSE_FEEDBACK_SHARE_PROMPT_RESPONSE_LABEL), not replacing it.
+msgctxt ""
+"Note shown under the share-content switch label on the Duck.ai response "
+"feedback form when the user has selected Harmful or Illegal as the feedback "
+"reason"
+msgid "Required for harmful or illegal reports"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
@@ -15824,6 +16181,12 @@ msgstr "Рецензии"
 msgctxt "maps_places"
 msgid "Reviews"
 msgstr "Рецензии"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Rewrite this recipe scaled for a different number of servings."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Romania"
@@ -16227,13 +16590,15 @@ msgstr "Шотландия"
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Scroll down and click %sView advanced settings%s"
-msgstr "Превъртете надолу и щракнете върху %1$sПреглед на разширените настройки%2$s"
+msgstr ""
+"Превъртете надолу и щракнете върху %1$sПреглед на разширените настройки%2$s"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down and click %sView advanced settings%s."
-msgstr "Превъртете надолу и щракнете върху %1$sПреглед на разширените настройки%2$s."
+msgstr ""
+"Превъртете надолу и щракнете върху %1$sПреглед на разширените настройки%2$s."
 
 #  Edge Legacy default search engine instruction, obsolete?
 # smartling.placeholder_format=C
@@ -16660,7 +17025,8 @@ msgstr ""
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
 msgctxt "Sync feature benefit description"
 msgid "Securely stored on DuckDuckGo's server with end-to-end encryption."
-msgstr "Съхранява се сигурно на сървъра на DuckDuckGo с криптиране от край до край."
+msgstr ""
+"Съхранява се сигурно на сървъра на DuckDuckGo с криптиране от край до край."
 
 # smartling.placeholder_format=C
 #. List item explaining that synced chats are stored with end-to-end encryption on DuckDuckGo's server and only the user can access them.
@@ -16781,7 +17147,8 @@ msgstr "Вижте някои от най-новите ни актуализац
 #. Link to a page with more information about how user settings are stored in a URL.
 msgctxt "settings"
 msgid "See the %sURL Parameter Reference page%s for more details."
-msgstr "За повече подробности вижте %1$sстраницата за справка за URL параметър%2$s."
+msgstr ""
+"За повече подробности вижте %1$sстраницата за справка за URL параметър%2$s."
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the context menu of a chat in chat history, that allows the user to select the chat and begin batch selection mode.
@@ -16821,7 +17188,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
-msgstr "Изберете %1$sDuckDuckGo%2$s и натиснете %3$sДобавяне по подразбиране%4$s!"
+msgstr ""
+"Изберете %1$sDuckDuckGo%2$s и натиснете %3$sДобавяне по подразбиране%4$s!"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
@@ -16842,7 +17210,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Select %sDuckDuckGo%s in the Default Search Engine drop down"
-msgstr "Изберете %1$sDuckDuckGo%2$s в падащия списък като търсачка по подразбиране"
+msgstr ""
+"Изберете %1$sDuckDuckGo%2$s в падащия списък като търсачка по подразбиране"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
@@ -17166,6 +17535,12 @@ msgid "Set Up Now"
 msgstr "Настройване сега"
 
 # smartling.placeholder_format=C
+#. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
+msgctxt "Encrypted storage setup button shown in native browsers"
+msgid "Set Up Sync & Backup"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
 msgctxt "Title for the Sync & Backup intro screen"
 msgid "Set Up Sync & Backup"
@@ -17286,8 +17661,8 @@ msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
 msgstr ""
-"Споделете местоположение на ниво град с AI моделите, за да получавате "
-"по-подходящи отговори. Duck.ai никога не разкрива точното Ви местоположение "
+"Споделете местоположение на ниво град с AI моделите, за да получавате по-"
+"подходящи отговори. Duck.ai никога не разкрива точното Ви местоположение "
 "нито на нас, нито на AI моделите."
 
 # smartling.placeholder_format=C
@@ -17347,6 +17722,13 @@ msgstr "Споделяне на URL адрес на страницата"
 msgctxt "feedback form"
 msgid "Share positive feedback"
 msgstr "Споделяне на положителен отзив"
+
+# smartling.placeholder_format=C
+#. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
+msgctxt ""
+"Label beside the share-content switch on the Duck.ai response feedback form"
+msgid "Share this conversation with DuckDuckGo"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -17756,7 +18138,8 @@ msgstr "Показва периодично напомняне за добавя
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr "Показва периодично напомняне за добавяне на DuckDuckGo към устройствата ви"
+msgstr ""
+"Показва периодично напомняне за добавяне на DuckDuckGo към устройствата ви"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -17774,7 +18157,8 @@ msgstr "Показва номерата на страниците в края н
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows sign-up form for the DuckDuckGo privacy newsletters"
-msgstr "Показва формуляр за регистриране за бюлетините за поверителност на DuckDuckGo"
+msgstr ""
+"Показва формуляр за регистриране за бюлетините за поверителност на DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/94erFcS.png
@@ -17797,12 +18181,14 @@ msgstr "Показва фона на бутона за търсене"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message on top of the search results page"
-msgstr "Показва приветствие в горната част на страницата с резултати от търсенето"
+msgstr ""
+"Показва приветствие в горната част на страницата с резултати от търсенето"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message to EU Android preference menu users"
-msgstr "Показва приветствие за потребителите с меню за предпочитания за Android в ЕС"
+msgstr ""
+"Показва приветствие за потребителите с меню за предпочитания за Android в ЕС"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers sometimes.
@@ -17874,12 +18260,14 @@ msgstr "Имена на сайтове"
 #. A message saying that site filters are not currently working
 msgctxt "Site filter message"
 msgid "Site search is temporarily unavailable. We are working on a fix."
-msgstr "Търсенето в сайта е временно недостъпно. Работим за разрешаване на проблема."
+msgstr ""
+"Търсенето в сайта е временно недостъпно. Работим за разрешаване на проблема."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Sites you block will be hidden from all your search results"
-msgstr "Сайтовете, които блокирате, ще бъдат скрити от всички резултати от търсенето."
+msgstr ""
+"Сайтовете, които блокирате, ще бъдат скрити от всички резултати от търсенето."
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes full name (tooltip)
@@ -18024,7 +18412,8 @@ msgstr "Нещо се обърка при запазването на сървъ
 #. Body copy displayed under the Set Up Now button when the sync setup call fails.
 msgctxt "Generic error shown when sync setup fails"
 msgid "Something went wrong while enabling Sync & Backup. Please try again."
-msgstr "Нещо се обърка при активирането на Sync & Backup. Моля, опитайте отново."
+msgstr ""
+"Нещо се обърка при активирането на Sync & Backup. Моля, опитайте отново."
 
 # smartling.placeholder_format=C
 #. Displayed when the voice chat session ends with an unknown error.
@@ -18048,7 +18437,8 @@ msgstr "Понякога"
 #. Generic error message shown when the image generation model cannot process the user's request.
 msgctxt "Error message from the image generation model"
 msgid "Sorry I can't help, please describe your image in a different way."
-msgstr "Съжалявам, не мога да помогна, моля, опишете изображението по друг начин."
+msgstr ""
+"Съжалявам, не мога да помогна, моля, опишете изображението по друг начин."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -18123,8 +18513,8 @@ msgstr ""
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
 msgstr ""
-"За съжаление, не успяхме да подадем вашия отзив. Моля, опитайте отново "
-"по-късно."
+"За съжаление, не успяхме да подадем вашия отзив. Моля, опитайте отново по-"
+"късно."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -18434,7 +18824,8 @@ msgstr "Спрете скритите тракери, които се спота
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop most hidden trackers lurking on other websites."
-msgstr "Спрете повечето от скритите тракери, които се спотайват в други уебсайтове."
+msgstr ""
+"Спрете повечето от скритите тракери, които се спотайват в други уебсайтове."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18604,6 +18995,24 @@ msgid "Suggest a title for a blog post"
 msgstr "Предложи заглавие на публикация в блог"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest related articles or topics worth exploring next."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Suggest related articles to explore"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest some alternatives to this product."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
 msgctxt "directions"
 msgid "Suggestions:"
@@ -18615,10 +19024,100 @@ msgid "Suggestions:"
 msgstr "Предложения:"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Sum up the reviews"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A short title for the a message asking the AI to summarize a text.
 msgctxt "Title for the summarize message"
 msgid "Summarize"
 msgstr "Направи обобщение"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize the Q&As"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the background and notable work of this person."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the key details of this event."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the questions and answers on this page."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize their background"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this book"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this book."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this discussion"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this discussion thread."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this page"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this page."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this video"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this video."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize what the reviews say."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -18949,6 +19448,12 @@ msgid "Syria"
 msgstr "Сирия"
 
 # smartling.placeholder_format=C
+#. Text for a button that enables the theme to follow the operating system's color scheme preference.
+msgctxt "System theme button for theme selector"
+msgid "System"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Abbreviation indicating this is the total score for a game
 msgctxt "Sports module"
 msgid "T"
@@ -18975,6 +19480,12 @@ msgstr "Телевизия"
 msgctxt "language_name"
 msgid "Tahitian"
 msgstr "Таитянски"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Tailor my resume"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Taiwan"
@@ -19004,6 +19515,13 @@ msgstr "Поемете контрола върху личните си данн�
 msgctxt "homepage ATB modal"
 msgid "Take control of your personal data!"
 msgstr "Поемете контрола върху личните си данни!"
+
+# smartling.placeholder_format=C
+#. Description for the Feedback section of the Duck.ai settings page, asking the user to take an anonymous survey to let us know how we can make Duck.ai better.
+msgctxt "Feedback section description on the Duck.ai settings page"
+msgid ""
+"Take this anonymous survey to let us know how we can make Duck.ai better."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -19311,6 +19829,12 @@ msgid "Theme"
 msgstr "Тема"
 
 # smartling.placeholder_format=C
+#. Text for the theme selector label that allows users to switch between Light and dark theme.
+msgctxt "Label for the theme selector feature"
+msgid "Theme"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. http://i.imgur.com/LpFhb1e.png
 msgctxt "settings"
 msgid "Theme"
@@ -19361,7 +19885,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Error message for explore more questions when a retryable error occurs (timeout, network)
 msgid "There's been an issue loading this answer. Please try again."
-msgstr "Възникна проблем при зареждането на този отговор. Моля, опитайте отново."
+msgstr ""
+"Възникна проблем при зареждането на този отговор. Моля, опитайте отново."
 
 # smartling.placeholder_format=C
 #. Instant Answer Tab Name
@@ -19415,7 +19940,8 @@ msgctxt "AI Chat: Error message for when a model is removed"
 msgid ""
 "This AI model is no longer available. Try starting a new chat with a "
 "different model."
-msgstr "Този AI модел вече не е наличен. Опитайте да започнете нов чат с друг модел."
+msgstr ""
+"Този AI модел вече не е наличен. Опитайте да започнете нов чат с друг модел."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is no longer supported because it has been upgraded to a newest version.
@@ -19431,7 +19957,8 @@ msgstr ""
 #. Appears below a type of search results called 'Instant Answers'
 msgctxt "attribution"
 msgid "This Instant Answer was made by the %sDuckDuckHack%s Community."
-msgstr "Този незабавен отговор бе създаден от общността на %1$sDuckDuckHack%2$s."
+msgstr ""
+"Този незабавен отговор бе създаден от общността на %1$sDuckDuckHack%2$s."
 
 # smartling.placeholder_format=C
 #. Label for the monthly usage row in the Usage section of Duck.ai settings.
@@ -19692,7 +20219,8 @@ msgstr "Този превод е грешен"
 # smartling.placeholder_format=C
 #. Label indicating that the video can't be played on the current page, and only on the website that owns the vide. The placeholder is the name of the website that owns the video.
 msgid "This video is not yet able to be watched here. You can watch it on %s."
-msgstr "Все още не можете да гледате това видео тук. Можете да го гледате в %1$s."
+msgstr ""
+"Все още не можете да гледате това видео тук. Можете да го гледате в %1$s."
 
 # smartling.placeholder_format=C
 #. Message indicating that a website is not using an encrypted connection and is not secure.
@@ -20138,8 +20666,8 @@ msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
 msgstr ""
-"Преведи това изречение от английски на френски: „Как да стигна до "
-"най-близкото кино?“"
+"Преведи това изречение от английски на френски: „Как да стигна до най-"
+"близкото кино?“"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for translating a sentence into another language. Translate the whole sentence and please use target language instead of 'English' and modify the sentence to translate into 'English' instead of 'French'. Example: 'Translate this {target language} sentence into English: “How do I get to the nearest movie theatre?”'
@@ -20148,8 +20676,20 @@ msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
 msgstr ""
-"Преведи това изречение от български на английски: „Как да стигна до "
-"най-близкото кино?“"
+"Преведи това изречение от български на английски: „Как да стигна до най-"
+"близкото кино?“"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Translate this page"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
+msgctxt "Page suggestion prompt"
+msgid "Translate this page into %s."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder text for a region that will display translated text.
@@ -20255,7 +20795,8 @@ msgstr "Изпробвайте %1$s — първият ни модел с нул
 
 # smartling.placeholder_format=C
 msgid "Try %sDuck.ai%s, our private AI chat service:"
-msgstr "Опитайте %1$sDuck.ai%2$s, нашата частна услуга за чат с изкуствен интелект:"
+msgstr ""
+"Опитайте %1$sDuck.ai%2$s, нашата частна услуга за чат с изкуствен интелект:"
 
 # smartling.placeholder_format=C
 #. Button text to retry loading an explore more question that failed
@@ -20291,6 +20832,12 @@ msgstr "Нов опит"
 msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
 msgstr "Пробвайте безплатно"
+
+# smartling.placeholder_format=C
+#. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
+msgctxt "settings"
+msgid "Try It Now"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -20424,7 +20971,8 @@ msgstr "Изпробвайте нашия браузър"
 # smartling.placeholder_format=C
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
-msgstr "Опитайте нашата начална страница, която никога не показва тези съобщения:"
+msgstr ""
+"Опитайте нашата начална страница, която никога не показва тези съобщения:"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with different words to get more results.
@@ -20533,6 +21081,22 @@ msgstr "Опитайте: %1$s"
 msgctxt "new user poll"
 msgid "Trying DuckDuckGo again"
 msgstr "Повторно изпробване на DuckDuckGo"
+
+# smartling.placeholder_format=C
+#. Message shown in a modal after supported third-party browser users disable AI features in Settings. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -20857,7 +21421,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
-msgstr "Под %1$sСТАРТИРАНЕ > Начална страница%2$s въведете: https://duckduckgo.com"
+msgstr ""
+"Под %1$sСТАРТИРАНЕ > Начална страница%2$s въведете: https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -20875,7 +21440,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
-msgstr "В раздела %1$sТърсене%2$s щракнете върху %3$sУправляване на търсачките...%4$s"
+msgstr ""
+"В раздела %1$sТърсене%2$s щракнете върху %3$sУправляване на търсачките...%4$s"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -21288,6 +21854,12 @@ msgid "Uruguay"
 msgstr "Уругвай"
 
 # smartling.placeholder_format=C
+#. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
+msgctxt "Navigation label on the Duck.ai settings page"
+msgid "Usage"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A feedback suggestion
 msgctxt "Feedback prompt"
 msgid "Usage limit"
@@ -21382,7 +21954,8 @@ msgstr ""
 #. Prompt to ask the user if they want to use their approximate location for more accurate results
 msgctxt "DuckChat location prompt"
 msgid "Use your approximate location for more accurate results?"
-msgstr "Да се използва приблизителното Ви местоположение за по-точни резултати?"
+msgstr ""
+"Да се използва приблизителното Ви местоположение за по-точни резултати?"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes before every user message in the downloaded file, indicating which message it is out of the total number of messages. Example: 'User prompt 3 of 5'
@@ -21739,6 +22312,12 @@ msgid "Wales"
 msgstr "Уелс"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Walk me through the steps"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for walking directions on a map.
 msgctxt "directions"
 msgid "Walking"
@@ -21854,8 +22433,19 @@ msgstr "Ние анонимизираме"
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
 msgstr ""
-"Можем да анонимизираме%1$s вашето местоположение%2$s, за да ви показваме "
-"по-точни резултати."
+"Можем да анонимизираме%1$s вашето местоположение%2$s, за да ви показваме по-"
+"точни резултати."
+
+# smartling.placeholder_format=C
+#. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
+msgctxt ""
+"Inline warning shown below the share-content toggle when the user selects "
+"Harmful or Illegal but has not enabled sharing"
+msgid ""
+"We can only fix what we can see. To report a harmful or illegal response, "
+"please share this conversation with DuckDuckGo so we can investigate and "
+"address the issue."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -21953,7 +22543,8 @@ msgstr "Ние не ви проследяваме. Никога."
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with a Continue button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don't track you. That's our Privacy Policy in a nutshell."
-msgstr "Ние не Ви проследяваме. Това е нашата Политика за поверителност накратко."
+msgstr ""
+"Ние не Ви проследяваме. Това е нашата Политика за поверителност накратко."
 
 # smartling.placeholder_format=C
 #. Description for the audio identification highlight in the dictation consent modal.
@@ -21994,7 +22585,8 @@ msgstr "Не ви следим нито във, нито извън режима
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with an Agree button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don’t track you. That’s our Privacy Policy in a nutshell…"
-msgstr "Ние не Ви проследяваме. Това е нашата Политика за поверителност накратко…"
+msgstr ""
+"Ние не Ви проследяваме. Това е нашата Политика за поверителност накратко…"
 
 # smartling.placeholder_format=C
 #. Displayed when the user's voice chat session is ended because of being inactive for too long.
@@ -22121,7 +22713,8 @@ msgctxt "duckai_migration"
 msgid ""
 "We're sorry for this inconvenience. We’re working hard to make your "
 "experience better."
-msgstr "Съжаляваме за това неудобство. Работим усилено, за да подобрим изживяването."
+msgstr ""
+"Съжаляваме за това неудобство. Работим усилено, за да подобрим изживяването."
 
 # smartling.placeholder_format=C
 #. Body text explaining the service update requires a page reload.
@@ -22280,7 +22873,8 @@ msgstr ""
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai! You can now import your downloaded chats."
-msgstr "Добре дошли в новия Duck.ai! Вече можете да импортирате изтеглените чатове."
+msgstr ""
+"Добре дошли в новия Duck.ai! Вече можете да импортирате изтеглените чатове."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -22371,13 +22965,15 @@ msgstr ""
 #. Text for a prompt suggestion for considering factors when purchasing a computer monitor.
 msgctxt "Full sentence for preparing for a purchase"
 msgid "What are some factors to consider when purchasing a computer monitor?"
-msgstr "Какви фактори трябва да се имам предвид, когато купувам монитор за компютър?"
+msgstr ""
+"Какви фактори трябва да се имам предвид, когато купувам монитор за компютър?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for asking about must-see attractions in Paris for a first-time visitor.
 msgctxt "Full sentence for planning a trip"
 msgid "What are some must-see attractions in Paris for a first-time visitor?"
-msgstr "Кои атракции трябва да види един турист, който посещава Париж за първи път?"
+msgstr ""
+"Кои атракции трябва да види един турист, който посещава Париж за първи път?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for finding options for the word 'better' in a specific context.
@@ -22412,6 +23008,103 @@ msgstr ""
 "върху интеграциите с Duck.ai и защитата на поверителността. Дай кратък и "
 "ясен отговор, който да е разбираем за хора с или без много опит в "
 "изкуствения интелект или технически познания."
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the counterarguments?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the hours & location?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key contributions of this paper?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key contributions?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key details?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key points covered in this video?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key points?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key takeaways from this article?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key takeaways?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key things I will learn from this course?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main counterarguments or criticisms of this?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main questions this page answers?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the must-try dishes here?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"What are the opening hours, location, and contact details for this place?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the pros and cons of this product?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the pros and cons?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
@@ -22514,6 +23207,12 @@ msgid "What does atria mean in the context of a medical article?"
 msgstr "Какво означава предсърдие в контекста на медицинска статия?"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What does this answer?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
@@ -22524,6 +23223,12 @@ msgstr "Каква функция бихте искали да добавим? (
 msgctxt "cloudsave"
 msgid "What information gets saved?"
 msgstr "Каква информация се съхранява?"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What interview questions might come up for this role?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -22540,6 +23245,12 @@ msgstr ""
 msgctxt "Full sentence for looking up basic facts"
 msgid "What is the capital city of Albania?"
 msgstr "Коя е столицата на Албания?"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What is the overall verdict and rating for this?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to a page with additional information.
@@ -22564,6 +23275,12 @@ msgid "What people say:"
 msgstr "Какво казват хората:"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What should I order?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
 msgctxt "feedback form"
 msgid "What stood out?"
@@ -22574,6 +23291,18 @@ msgstr "Какво се открои в отговора?"
 msgctxt "feedback form"
 msgid "What was wrong with the response? (optional)"
 msgstr "Какво не е наред с отговора? (По избор)"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I learn?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I need?"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -22593,6 +23322,12 @@ msgstr ""
 msgctxt "SERP footer content"
 msgid "What's New"
 msgstr "Новости"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What's the verdict?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -22647,6 +23382,12 @@ msgid "Which features are missing? (Optional)"
 msgstr "Кои функции липсват? (По избор)"
 
 # smartling.placeholder_format=C
+#. An invitation for users to leave feedback
+msgctxt "Feedback prompt"
+msgid "Which features are missing? (optional)"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
 msgid "White"
 msgstr "Бяло"
@@ -22661,6 +23402,18 @@ msgstr "Бяло"
 #. Link to an about us page.
 msgid "Who We Are"
 msgstr "Кои сме ние"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Who are the main cast and crew, and what else are they known for?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Who is this person?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Header above a collection of privacy-related links.
@@ -23157,7 +23910,8 @@ msgstr "Можете да скриете това напомняне в %1$sНа
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
-msgstr "Вече можете да запазите до 100 чата на това устройство. Разговаряйте на воля!"
+msgstr ""
+"Вече можете да запазите до 100 чата на това устройство. Разговаряйте на воля!"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -23227,7 +23981,8 @@ msgstr "Можете да възстановите настройките си, 
 #. Text explaining the benefits of the cloud save feature.
 msgctxt "cloudsave"
 msgid "You can share your settings among computers and browsers."
-msgstr "Можете да споделяте и използвате настройките си с други компютри и браузъри."
+msgstr ""
+"Можете да споделяте и използвате настройките си с други компютри и браузъри."
 
 # smartling.placeholder_format=C
 #. Alternative option description on export screen.
@@ -23405,14 +24160,15 @@ msgid ""
 "You've reached the maximum number of messages for the moment. Please try "
 "again later."
 msgstr ""
-"Достигнахте максималния брой съобщения за момента. Моля, опитайте отново "
-"по-късно."
+"Достигнахте максималния брой съобщения за момента. Моля, опитайте отново по-"
+"късно."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
 msgctxt "voice chat duration limit modal"
 msgid "You've reached the maximum voice chat duration for a single session."
-msgstr "Достигнали сте максималната продължителност на гласовия чат за една сесия."
+msgstr ""
+"Достигнали сте максималната продължителност на гласовия чат за една сесия."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the daily voice chat limit.
@@ -23424,7 +24180,8 @@ msgstr "Достигнали сте лимита за гласов чат за �
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
 msgid "You've reached your dictation usage limit. Try again later."
-msgstr "Достигнали сте лимита за използване на диктовка. Опитайте отново по-късно."
+msgstr ""
+"Достигнали сте лимита за използване на диктовка. Опитайте отново по-късно."
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -23433,8 +24190,8 @@ msgid ""
 "You've run out of Sync & Backup storage for Duck.ai chats with attachments. "
 "Delete the %s oldest chats to resume Sync. Pinned chats will not be deleted."
 msgstr ""
-"Мястото за съхранение на Sync & Backup за чатове с прикачени файлове в "
-"Duck.ai е недостатъчно. Изтрийте %1$s най-стари чатове, за да възобновите "
+"Мястото за съхранение на Sync & Backup за чатове с прикачени файлове в Duck."
+"ai е недостатъчно. Изтрийте %1$s най-стари чатове, за да възобновите "
 "синхронизирането. Закачените чатове няма да бъдат изтрити."
 
 # smartling.placeholder_format=C
@@ -23462,8 +24219,8 @@ msgid ""
 "such, watching YouTube videos here will be tracked by YouTube/Google."
 msgstr ""
 "YouTube (притежаван от Google) не позволява да гледате видео анонимно. "
-"Следователно гледането на YouTube видео тук ще бъде следено от "
-"YouTube/Google."
+"Следователно гледането на YouTube видео тук ще бъде следено от YouTube/"
+"Google."
 
 # smartling.placeholder_format=C
 #. Label for a privacy disclaimer related to YouTube videos
@@ -23586,7 +24343,8 @@ msgstr ""
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never used to train AI models"
-msgstr "Чатовете са поверителни и никога не се използват за обучение на AI модели"
+msgstr ""
+"Чатовете са поверителни и никога не се използват за обучение на AI модели"
 
 # smartling.placeholder_format=C
 #. Text for a description of the active privacy protection for DuckDuckGo's AI Chat feature.
@@ -23647,7 +24405,8 @@ msgctxt "duckai_migration"
 msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
-msgstr "Чатовете са импортирани. Продължете оттам, откъдето сте спрели в Duck.ai."
+msgstr ""
+"Чатовете са импортирани. Продължете оттам, откъдето сте спрели в Duck.ai."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.
@@ -23854,7 +24613,8 @@ msgstr ""
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
 msgctxt "voice chat limit modal"
 msgid "You’ve reached the voice chat limit for now. Please try again later."
-msgstr "Достигнахте лимита за гласов чат засега. Моля, опитайте отново по-късно."
+msgstr ""
+"Достигнахте лимита за гласов чат засега. Моля, опитайте отново по-късно."
 
 # smartling.placeholder_format=C
 #. The name of the Yucatec Maya language
@@ -23937,7 +24697,8 @@ msgstr "от %1$s"
 #. Trust line shown at the bottom of the explainer panel, summarizing DuckDuckGo's reputation for online protection.
 msgctxt "Footer banner text in the How Duck.ai Works panel"
 msgid "by DuckDuckGo — online protection trusted by millions every day."
-msgstr "от DuckDuckGo — онлайн защита, на която милиони се доверяват всеки ден."
+msgstr ""
+"от DuckDuckGo — онлайн защита, на която милиони се доверяват всеки ден."
 
 # smartling.placeholder_format=C
 #. An abreviated unit of time indicating an age, e.g. "2d"

--- a/locales/bn_BD/LC_MESSAGES/duckduckgo.po
+++ b/locales/bn_BD/LC_MESSAGES/duckduckgo.po
@@ -1159,6 +1159,11 @@ msgctxt "feedback form"
 msgid "Address is incorrect"
 msgstr ""
 
+#. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Adjust the servings"
+msgstr ""
+
 #. as in multiple advertisements
 msgid "Ads"
 msgstr "বিজ্ঞাপন"
@@ -1330,6 +1335,13 @@ msgstr ""
 #. Heading shown on the empty chat screen. The text between the two %s markers is displayed inside a clickable privacy button. First %s renders a shield icon, second %s is an invisible end marker. Keep the word 'private' between both %s markers.
 msgctxt "Empty state heading in Duck.ai chat mode"
 msgid "All chats are %sprivate%s"
+msgstr ""
+
+#. Paragraph in the Privacy & Terms section of the About & Legal page in Duck.ai settings, summarizing how chats are anonymized and are not stored or used to train chat models.
+msgctxt "Privacy & Terms section description on the Duck.ai settings page"
+msgid ""
+"All chats are anonymized by DuckDuckGo, and your conversations are not used "
+"to train chat models by DuckDuckGo or the model providers"
 msgstr ""
 
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1542,6 +1554,12 @@ msgstr ""
 #. Confirmation message after location service is enabled.
 msgctxt "precise_user_location"
 msgid "Anonymous location enabled"
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Anonymously generates answers for search queries based on web content. "
+"Choose how often you want it to appear, or disable it completely."
 msgstr ""
 
 #. Instant Answer tab name
@@ -1764,6 +1782,11 @@ msgstr ""
 
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse
 msgid "Ask a follow-up with Duck.ai"
+msgstr ""
+
+#. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
+msgctxt "Page suggestion chip label"
+msgid "Ask about this page"
 msgstr ""
 
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2088,6 +2111,11 @@ msgstr ""
 msgid "Barcode"
 msgstr "বারকোড"
 
+#. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Based on this page, is this course worth taking?"
+msgstr ""
+
 msgctxt "settings"
 msgid "Basic"
 msgstr ""
@@ -2119,6 +2147,13 @@ msgstr ""
 #. Placeholder text displayed while the assistant waits for the user to choose an action.
 msgctxt "Assistant response placeholder"
 msgid "Before continuing..."
+msgstr ""
+
+#. Explains that before storing the report, DuckDuckGo will anonymize the conversation by removing PII like names, email addresses, and identifying metadata.
+msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
+msgid ""
+"Before storing this report, DuckDuckGo will anonymize your conversation by "
+"removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
 #. Label that's displayed next to a past start date below a web search result.
@@ -2377,6 +2412,11 @@ msgstr "ব্রাজিল"
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Break Points Won"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Break this down into clear, numbered steps."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -2736,6 +2776,11 @@ msgstr ""
 #. Text of a button that performs a search for the cast of a particular movie or tv show
 msgctxt "Movie/TV Show Title instant answer"
 msgid "Cast"
+msgstr ""
+
+#. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Cast & Crew"
 msgstr ""
 
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -4091,6 +4136,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Create a shopping list with quantities from this recipe."
+msgstr ""
+
 #. Placeholder text displayed in the input field when starting a new image generation session.
 msgctxt "Placeholder text for the image generation input field"
 msgid "Create an image of a cute duck..."
@@ -4617,6 +4667,10 @@ msgstr ""
 msgid "Dictation limit reached"
 msgstr ""
 
+#. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
+msgid "Dictation temporarily unavailable"
+msgstr ""
+
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
@@ -4861,6 +4915,20 @@ msgctxt "precise_user_location"
 msgid "Done"
 msgstr ""
 
+#. Message shown in a modal after DuckDuckGo browser users disable AI features in Settings. The first two placeholders bold noai.duckduckgo.com. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
+"filtered out. %sLearn More%s"
+msgstr ""
+
+#. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
+"and AI images filtered out. %sLearn more%s"
+msgstr ""
+
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Double Faults"
@@ -4951,6 +5019,16 @@ msgctxt "Full sentence for writing an email"
 msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
+msgstr ""
+
+#. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Draft a cover letter"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Draft a cover letter for this job."
 msgstr ""
 
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -5090,6 +5168,14 @@ msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
 msgstr ""
 
+#. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
+msgctxt "About section description on the Duck.ai settings page"
+msgid ""
+"Duck.ai is created by DuckDuckGo. We're an independent online protection "
+"company for anyone who wants to take back control of their personal "
+"information."
+msgstr ""
+
 #. Title shown when an update is required before proceeding.
 msgctxt "duckai_migration"
 msgid "Duck.ai is moving domains"
@@ -5123,6 +5209,12 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Duck.ai lets you chat privately with popular AI models. Disabling it hides "
+"Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
 
 msgctxt "settings"
@@ -5901,6 +5993,16 @@ msgstr ""
 msgid "Eritrea"
 msgstr ""
 
+#. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Estimate the nutrition"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Estimate the nutritional information for this recipe."
+msgstr ""
+
 msgid "Estonia"
 msgstr ""
 
@@ -5945,10 +6047,50 @@ msgctxt "merchant promotion product ad extension"
 msgid "Expires in 1 day"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain the accepted answer in simple terms."
+msgstr ""
+
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
+msgstr ""
+
+#. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain the top answer"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this in simple, plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this paper"
+msgstr ""
+
+#. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this repo"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this research paper in plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this simply"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain what this repository does and how to use it."
 msgstr ""
 
 #. Label to show if song lyrics contain explicit content
@@ -6179,6 +6321,11 @@ msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
 msgstr ""
 
+msgctxt "settings"
+msgid ""
+"Filters out known AI spam sites from image search results. %sLearn More%s"
+msgstr ""
+
 #. Label for the final score of a sporting event.
 msgid "Final"
 msgstr ""
@@ -6218,6 +6365,11 @@ msgstr ""
 #. Short description shown below the 'Web Search' label in the Tools dropdown.
 msgctxt "Subtitle for the Web Search tool entry in the Tools dropdown menu"
 msgid "Find current information"
+msgstr ""
+
+#. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Find me alternatives"
 msgstr ""
 
 #. Button that searches for results closer to the user's current location.
@@ -6608,6 +6760,11 @@ msgstr ""
 msgid "Generate More"
 msgstr ""
 
+#. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Generate a shopping list"
+msgstr ""
+
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
 msgid "Generate a short answer from the web"
 msgstr ""
@@ -6842,6 +6999,11 @@ msgstr ""
 #. Text for a button inviting users to give it a try for the Duck.ai product. On click, they're taken to the Duck.ai page.
 msgctxt "Onboarding welcome screen button text"
 msgid "Give it a Try"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Give me a quick background on this person."
 msgstr ""
 
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -7204,6 +7366,16 @@ msgstr ""
 
 #. Link to a page with information about sharing DuckDuckGo with friends.
 msgid "Help Spread Privacy"
+msgstr ""
+
+#. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Help me prep for the interview"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Help me tailor my resume for this job."
 msgstr ""
 
 #. Title of a SERP popup that invites users to take a survey (desktop only)
@@ -7623,6 +7795,13 @@ msgstr ""
 #. Text displayed on the button on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
 msgctxt "Onboarding terms screen button text"
 msgid "I Agree"
+msgstr ""
+
+#. Text for the button that takes the user to the external DuckDuckGo login subscription page.
+msgctxt ""
+"Text for the I already have a subscription button in the Duck.ai settings "
+"page"
+msgid "I Already Have a Subscription"
 msgstr ""
 
 #. Text for the button that takes the user to the login subscription page.
@@ -8079,6 +8258,11 @@ msgctxt "Sidemenu browser promo"
 msgid "Install Mac Browser"
 msgstr ""
 
+#. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
+msgctxt "settings"
+msgid "Install Now"
+msgstr ""
+
 #. Text of a button to install the DuckDuckGo app
 msgctxt "Serp footer content"
 msgid "Install Our App"
@@ -8158,9 +8342,36 @@ msgctxt "cloudsave"
 msgid "Is deleted data really deleted?"
 msgstr "আমার মুছে ফেলা তথ্য কি সত্যিই মুছা হয়?"
 
+#. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is it worth taking?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this place any good?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"Is this place any good? Summarize its reputation based on reviews and "
+"ratings."
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "Is this video helpful?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this worth watching?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Is this worth watching? Give me a spoiler-free take."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -8657,6 +8868,11 @@ msgstr "সংযোগ ফন্ট"
 msgid "Links:"
 msgstr "লিঙ্ক:"
 
+#. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "List the tools, materials, or prerequisites I need for this."
+msgstr ""
+
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
 msgid "Listen"
 msgstr "শুনুন"
@@ -8990,6 +9206,11 @@ msgstr ""
 #. Label for linke navigating to site exclusion feature on Settings page
 msgctxt "Exclusion message manage sites button"
 msgid "Manage blocked sites"
+msgstr ""
+
+#. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
+msgctxt "setting"
+msgid "Manage in Browser Settings"
 msgstr ""
 
 #. Link to the site exclusion settings page
@@ -11291,6 +11512,11 @@ msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
+msgid "Please describe why the chat response is harmful or illegal. (optional)"
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
+msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
 msgstr ""
 
@@ -11309,6 +11535,13 @@ msgctxt "Modal disclaimer text"
 msgid ""
 "Please note: starting a new chat with any model will delete your current "
 "chat session."
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
+msgctxt "Feedback prompt"
+msgid ""
+"Please paste your prompt and the problematic output (with any personal "
+"information removed) and describe why the content is harmful or illegal."
 msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -11693,6 +11926,11 @@ msgctxt "settings"
 msgid "Privacy"
 msgstr "গোপনীয়তা"
 
+#. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
+msgctxt "Section heading on the Duck.ai settings page"
+msgid "Privacy & Terms"
+msgstr ""
+
 msgid "Privacy Blog"
 msgstr ""
 
@@ -11746,6 +11984,11 @@ msgstr ""
 
 #. Text used in other strings to link to the Privacy Policy and Terms of Service content.
 msgctxt "Copy used to compose link in sentences"
+msgid "Privacy Policy and Terms of Service"
+msgstr ""
+
+#. Text for a button that links to the terms of use and privacy policy page.
+msgctxt "Secondary button text in active privacy modal"
 msgid "Privacy Policy and Terms of Service"
 msgstr ""
 
@@ -12154,6 +12397,26 @@ msgctxt "Brief for recommending a book"
 msgid "Recommend a book"
 msgstr ""
 
+#. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar books"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar books."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar movies or shows."
+msgstr ""
+
+#. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar titles"
+msgstr ""
+
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
 msgid "Recording failed. Please try again."
 msgstr ""
@@ -12473,6 +12736,14 @@ msgstr ""
 msgid "Republic of Moldova"
 msgstr ""
 
+#. Note indicating that sharing the conversation is mandatory when reporting harmful or illegal content. Rendered alongside the standard share label (DUCKCHAT_RESPONSE_FEEDBACK_SHARE_PROMPT_RESPONSE_LABEL), not replacing it.
+msgctxt ""
+"Note shown under the share-content switch label on the Duck.ai response "
+"feedback form when the user has selected Harmful or Illegal as the feedback "
+"reason"
+msgid "Required for harmful or illegal reports"
+msgstr ""
+
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
 msgctxt "Description for extended reasoning mode in Duck.ai"
 msgid "Researches before responding"
@@ -12658,6 +12929,11 @@ msgstr "নিরীক্ষা"
 #. Label above a list of customer reviews of a business.
 msgctxt "maps_places"
 msgid "Reviews"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Rewrite this recipe scaled for a different number of servings."
 msgstr ""
 
 msgid "Romania"
@@ -13699,6 +13975,11 @@ msgctxt "Setup button for native sync flow"
 msgid "Set Up Now"
 msgstr ""
 
+#. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
+msgctxt "Encrypted storage setup button shown in native browsers"
+msgid "Set Up Sync & Backup"
+msgstr ""
+
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
 msgctxt "Title for the Sync & Backup intro screen"
 msgid "Set Up Sync & Backup"
@@ -13841,6 +14122,12 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
+msgctxt ""
+"Label beside the share-content switch on the Duck.ai response feedback form"
+msgid "Share this conversation with DuckDuckGo"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -14856,6 +15143,21 @@ msgctxt "Brief for suggesting a blog post title"
 msgid "Suggest a title for a blog post"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest related articles or topics worth exploring next."
+msgstr ""
+
+#. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Suggest related articles to explore"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest some alternatives to this product."
+msgstr ""
+
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
 msgctxt "directions"
 msgid "Suggestions:"
@@ -14865,9 +15167,84 @@ msgctxt "noresults"
 msgid "Suggestions:"
 msgstr ""
 
+#. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Sum up the reviews"
+msgstr ""
+
 #. A short title for the a message asking the AI to summarize a text.
 msgctxt "Title for the summarize message"
 msgid "Summarize"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize the Q&As"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the background and notable work of this person."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the key details of this event."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the questions and answers on this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize their background"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this book"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this book."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this discussion"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this discussion thread."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this video"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this video."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize what the reviews say."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -15122,6 +15499,11 @@ msgstr ""
 msgid "Syria"
 msgstr ""
 
+#. Text for a button that enables the theme to follow the operating system's color scheme preference.
+msgctxt "System theme button for theme selector"
+msgid "System"
+msgstr ""
+
 #. Abbreviation indicating this is the total score for a game
 msgctxt "Sports module"
 msgid "T"
@@ -15145,6 +15527,11 @@ msgctxt "language_name"
 msgid "Tahitian"
 msgstr ""
 
+#. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Tailor my resume"
+msgstr ""
+
 msgid "Taiwan"
 msgstr ""
 
@@ -15166,6 +15553,12 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "Take control of your personal data!"
+msgstr ""
+
+#. Description for the Feedback section of the Duck.ai settings page, asking the user to take an anonymous survey to let us know how we can make Duck.ai better.
+msgctxt "Feedback section description on the Duck.ai settings page"
+msgid ""
+"Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
 
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -15410,6 +15803,11 @@ msgstr ""
 #. https://duck.co/media/files/theme.png
 msgid "Theme"
 msgstr "বিষয়বস্তু"
+
+#. Text for the theme selector label that allows users to switch between Light and dark theme.
+msgctxt "Label for the theme selector feature"
+msgid "Theme"
+msgstr ""
 
 #. http://i.imgur.com/LpFhb1e.png
 msgctxt "settings"
@@ -16062,6 +16460,16 @@ msgid ""
 "movie theatre?”"
 msgstr ""
 
+#. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Translate this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
+msgctxt "Page suggestion prompt"
+msgid "Translate this page into %s."
+msgstr ""
+
 #. Placeholder text for a region that will display translated text.
 msgctxt "translations_module"
 msgid "Translation"
@@ -16176,6 +16584,11 @@ msgstr ""
 #. Call-to-action button for the subscription promo in the SERP sidemenu.
 msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
+msgstr ""
+
+#. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
+msgctxt "settings"
+msgid "Try It Now"
 msgstr ""
 
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -16369,6 +16782,20 @@ msgstr "%s এর মাধ্যমে চেস্টা করুন"
 #. Response a user can select in a feedback form, indicating that they're trying DuckDuckGo again.
 msgctxt "new user poll"
 msgid "Trying DuckDuckGo again"
+msgstr ""
+
+#. Message shown in a modal after supported third-party browser users disable AI features in Settings. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+#. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
 msgstr ""
 
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -16971,6 +17398,11 @@ msgstr ""
 msgid "Uruguay"
 msgstr ""
 
+#. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
+msgctxt "Navigation label on the Duck.ai settings page"
+msgid "Usage"
+msgstr ""
+
 #. A feedback suggestion
 msgctxt "Feedback prompt"
 msgid "Usage limit"
@@ -17319,6 +17751,11 @@ msgstr ""
 msgid "Wales"
 msgstr ""
 
+#. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Walk me through the steps"
+msgstr ""
+
 #. Label for walking directions on a map.
 msgctxt "directions"
 msgid "Walking"
@@ -17409,6 +17846,16 @@ msgstr ""
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
+msgstr ""
+
+#. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
+msgctxt ""
+"Inline warning shown below the share-content toggle when the user selects "
+"Harmful or Illegal but has not enabled sharing"
+msgid ""
+"We can only fix what we can see. To report a harmful or illegal response, "
+"please share this conversation with DuckDuckGo so we can investigate and "
+"address the issue."
 msgstr ""
 
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -17828,6 +18275,87 @@ msgid ""
 "experience."
 msgstr ""
 
+#. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the counterarguments?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the hours & location?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key contributions of this paper?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key contributions?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key details?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key points covered in this video?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key points?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key takeaways from this article?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key takeaways?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key things I will learn from this course?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main counterarguments or criticisms of this?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main questions this page answers?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the must-try dishes here?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"What are the opening hours, location, and contact details for this place?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the pros and cons of this product?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the pros and cons?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
 msgctxt "feedback form"
 msgid "What bothered you most?"
@@ -17911,6 +18439,11 @@ msgctxt "Full sentence for defining a term"
 msgid "What does atria mean in the context of a medical article?"
 msgstr ""
 
+#. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What does this answer?"
+msgstr ""
+
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
@@ -17920,6 +18453,11 @@ msgstr ""
 msgctxt "cloudsave"
 msgid "What information gets saved?"
 msgstr "কোন তথ্যসমূহ সংরক্ষিত হয়?"
+
+#. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What interview questions might come up for this role?"
+msgstr ""
 
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
@@ -17931,6 +18469,11 @@ msgstr ""
 #. Text for a prompt suggestion for looking up the capital city of Albania.
 msgctxt "Full sentence for looking up basic facts"
 msgid "What is the capital city of Albania?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What is the overall verdict and rating for this?"
 msgstr ""
 
 #. Link to a page with additional information.
@@ -17951,6 +18494,11 @@ msgctxt "maps_places"
 msgid "What people say:"
 msgstr ""
 
+#. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What should I order?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
 msgctxt "feedback form"
 msgid "What stood out?"
@@ -17959,6 +18507,16 @@ msgstr ""
 #. Question on a feedback form for a negative feedback response.
 msgctxt "feedback form"
 msgid "What was wrong with the response? (optional)"
+msgstr ""
+
+#. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I learn?"
+msgstr ""
+
+#. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I need?"
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -17973,6 +18531,11 @@ msgstr ""
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
 msgctxt "SERP footer content"
 msgid "What's New"
+msgstr ""
+
+#. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What's the verdict?"
 msgstr ""
 
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -18014,6 +18577,11 @@ msgctxt "Feedback prompt"
 msgid "Which features are missing? (Optional)"
 msgstr ""
 
+#. An invitation for users to leave feedback
+msgctxt "Feedback prompt"
+msgid "Which features are missing? (optional)"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
 msgid "White"
 msgstr "সাদা "
@@ -18025,6 +18593,16 @@ msgstr ""
 
 #. Link to an about us page.
 msgid "Who We Are"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Who are the main cast and crew, and what else are they known for?"
+msgstr ""
+
+#. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Who is this person?"
 msgstr ""
 
 #. Header above a collection of privacy-related links.

--- a/locales/bn_IN/LC_MESSAGES/duckduckgo.po
+++ b/locales/bn_IN/LC_MESSAGES/duckduckgo.po
@@ -1161,6 +1161,11 @@ msgctxt "feedback form"
 msgid "Address is incorrect"
 msgstr ""
 
+#. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Adjust the servings"
+msgstr ""
+
 #. as in multiple advertisements
 msgid "Ads"
 msgstr ""
@@ -1332,6 +1337,13 @@ msgstr ""
 #. Heading shown on the empty chat screen. The text between the two %s markers is displayed inside a clickable privacy button. First %s renders a shield icon, second %s is an invisible end marker. Keep the word 'private' between both %s markers.
 msgctxt "Empty state heading in Duck.ai chat mode"
 msgid "All chats are %sprivate%s"
+msgstr ""
+
+#. Paragraph in the Privacy & Terms section of the About & Legal page in Duck.ai settings, summarizing how chats are anonymized and are not stored or used to train chat models.
+msgctxt "Privacy & Terms section description on the Duck.ai settings page"
+msgid ""
+"All chats are anonymized by DuckDuckGo, and your conversations are not used "
+"to train chat models by DuckDuckGo or the model providers"
 msgstr ""
 
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1544,6 +1556,12 @@ msgstr ""
 #. Confirmation message after location service is enabled.
 msgctxt "precise_user_location"
 msgid "Anonymous location enabled"
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Anonymously generates answers for search queries based on web content. "
+"Choose how often you want it to appear, or disable it completely."
 msgstr ""
 
 #. Instant Answer tab name
@@ -1766,6 +1784,11 @@ msgstr ""
 
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse
 msgid "Ask a follow-up with Duck.ai"
+msgstr ""
+
+#. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
+msgctxt "Page suggestion chip label"
+msgid "Ask about this page"
 msgstr ""
 
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2090,6 +2113,11 @@ msgstr ""
 msgid "Barcode"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Based on this page, is this course worth taking?"
+msgstr ""
+
 msgctxt "settings"
 msgid "Basic"
 msgstr ""
@@ -2121,6 +2149,13 @@ msgstr ""
 #. Placeholder text displayed while the assistant waits for the user to choose an action.
 msgctxt "Assistant response placeholder"
 msgid "Before continuing..."
+msgstr ""
+
+#. Explains that before storing the report, DuckDuckGo will anonymize the conversation by removing PII like names, email addresses, and identifying metadata.
+msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
+msgid ""
+"Before storing this report, DuckDuckGo will anonymize your conversation by "
+"removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
 #. Label that's displayed next to a past start date below a web search result.
@@ -2379,6 +2414,11 @@ msgstr ""
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Break Points Won"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Break this down into clear, numbered steps."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -2738,6 +2778,11 @@ msgstr ""
 #. Text of a button that performs a search for the cast of a particular movie or tv show
 msgctxt "Movie/TV Show Title instant answer"
 msgid "Cast"
+msgstr ""
+
+#. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Cast & Crew"
 msgstr ""
 
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -4089,6 +4134,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Create a shopping list with quantities from this recipe."
+msgstr ""
+
 #. Placeholder text displayed in the input field when starting a new image generation session.
 msgctxt "Placeholder text for the image generation input field"
 msgid "Create an image of a cute duck..."
@@ -4615,6 +4665,10 @@ msgstr ""
 msgid "Dictation limit reached"
 msgstr ""
 
+#. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
+msgid "Dictation temporarily unavailable"
+msgstr ""
+
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
@@ -4859,6 +4913,20 @@ msgctxt "precise_user_location"
 msgid "Done"
 msgstr ""
 
+#. Message shown in a modal after DuckDuckGo browser users disable AI features in Settings. The first two placeholders bold noai.duckduckgo.com. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
+"filtered out. %sLearn More%s"
+msgstr ""
+
+#. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
+"and AI images filtered out. %sLearn more%s"
+msgstr ""
+
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Double Faults"
@@ -4949,6 +5017,16 @@ msgctxt "Full sentence for writing an email"
 msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
+msgstr ""
+
+#. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Draft a cover letter"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Draft a cover letter for this job."
 msgstr ""
 
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -5088,6 +5166,14 @@ msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
 msgstr ""
 
+#. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
+msgctxt "About section description on the Duck.ai settings page"
+msgid ""
+"Duck.ai is created by DuckDuckGo. We're an independent online protection "
+"company for anyone who wants to take back control of their personal "
+"information."
+msgstr ""
+
 #. Title shown when an update is required before proceeding.
 msgctxt "duckai_migration"
 msgid "Duck.ai is moving domains"
@@ -5121,6 +5207,12 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Duck.ai lets you chat privately with popular AI models. Disabling it hides "
+"Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
 
 msgctxt "settings"
@@ -5898,6 +5990,16 @@ msgstr ""
 msgid "Eritrea"
 msgstr ""
 
+#. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Estimate the nutrition"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Estimate the nutritional information for this recipe."
+msgstr ""
+
 msgid "Estonia"
 msgstr ""
 
@@ -5942,10 +6044,50 @@ msgctxt "merchant promotion product ad extension"
 msgid "Expires in 1 day"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain the accepted answer in simple terms."
+msgstr ""
+
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
+msgstr ""
+
+#. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain the top answer"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this in simple, plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this paper"
+msgstr ""
+
+#. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this repo"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this research paper in plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this simply"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain what this repository does and how to use it."
 msgstr ""
 
 #. Label to show if song lyrics contain explicit content
@@ -6174,6 +6316,11 @@ msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
 msgstr ""
 
+msgctxt "settings"
+msgid ""
+"Filters out known AI spam sites from image search results. %sLearn More%s"
+msgstr ""
+
 #. Label for the final score of a sporting event.
 msgid "Final"
 msgstr ""
@@ -6213,6 +6360,11 @@ msgstr ""
 #. Short description shown below the 'Web Search' label in the Tools dropdown.
 msgctxt "Subtitle for the Web Search tool entry in the Tools dropdown menu"
 msgid "Find current information"
+msgstr ""
+
+#. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Find me alternatives"
 msgstr ""
 
 #. Button that searches for results closer to the user's current location.
@@ -6603,6 +6755,11 @@ msgstr ""
 msgid "Generate More"
 msgstr ""
 
+#. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Generate a shopping list"
+msgstr ""
+
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
 msgid "Generate a short answer from the web"
 msgstr ""
@@ -6837,6 +6994,11 @@ msgstr ""
 #. Text for a button inviting users to give it a try for the Duck.ai product. On click, they're taken to the Duck.ai page.
 msgctxt "Onboarding welcome screen button text"
 msgid "Give it a Try"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Give me a quick background on this person."
 msgstr ""
 
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -7199,6 +7361,16 @@ msgstr ""
 
 #. Link to a page with information about sharing DuckDuckGo with friends.
 msgid "Help Spread Privacy"
+msgstr ""
+
+#. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Help me prep for the interview"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Help me tailor my resume for this job."
 msgstr ""
 
 #. Title of a SERP popup that invites users to take a survey (desktop only)
@@ -7618,6 +7790,13 @@ msgstr ""
 #. Text displayed on the button on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
 msgctxt "Onboarding terms screen button text"
 msgid "I Agree"
+msgstr ""
+
+#. Text for the button that takes the user to the external DuckDuckGo login subscription page.
+msgctxt ""
+"Text for the I already have a subscription button in the Duck.ai settings "
+"page"
+msgid "I Already Have a Subscription"
 msgstr ""
 
 #. Text for the button that takes the user to the login subscription page.
@@ -8070,6 +8249,11 @@ msgctxt "Sidemenu browser promo"
 msgid "Install Mac Browser"
 msgstr ""
 
+#. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
+msgctxt "settings"
+msgid "Install Now"
+msgstr ""
+
 #. Text of a button to install the DuckDuckGo app
 msgctxt "Serp footer content"
 msgid "Install Our App"
@@ -8149,9 +8333,36 @@ msgctxt "cloudsave"
 msgid "Is deleted data really deleted?"
 msgstr "মুছে ফেলা তথ্য কি সত্যিই মুছে ফেলা হয়?"
 
+#. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is it worth taking?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this place any good?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"Is this place any good? Summarize its reputation based on reviews and "
+"ratings."
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "Is this video helpful?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this worth watching?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Is this worth watching? Give me a spoiler-free take."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -8648,6 +8859,11 @@ msgstr "লিংক ফন্ট:"
 msgid "Links:"
 msgstr "লিংকগুলি:"
 
+#. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "List the tools, materials, or prerequisites I need for this."
+msgstr ""
+
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
 msgid "Listen"
 msgstr "শোনা যাক"
@@ -8980,6 +9196,11 @@ msgstr ""
 #. Label for linke navigating to site exclusion feature on Settings page
 msgctxt "Exclusion message manage sites button"
 msgid "Manage blocked sites"
+msgstr ""
+
+#. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
+msgctxt "setting"
+msgid "Manage in Browser Settings"
 msgstr ""
 
 #. Link to the site exclusion settings page
@@ -11277,6 +11498,11 @@ msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
+msgid "Please describe why the chat response is harmful or illegal. (optional)"
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
+msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
 msgstr ""
 
@@ -11295,6 +11521,13 @@ msgctxt "Modal disclaimer text"
 msgid ""
 "Please note: starting a new chat with any model will delete your current "
 "chat session."
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
+msgctxt "Feedback prompt"
+msgid ""
+"Please paste your prompt and the problematic output (with any personal "
+"information removed) and describe why the content is harmful or illegal."
 msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -11679,6 +11912,11 @@ msgctxt "settings"
 msgid "Privacy"
 msgstr ""
 
+#. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
+msgctxt "Section heading on the Duck.ai settings page"
+msgid "Privacy & Terms"
+msgstr ""
+
 msgid "Privacy Blog"
 msgstr ""
 
@@ -11732,6 +11970,11 @@ msgstr ""
 
 #. Text used in other strings to link to the Privacy Policy and Terms of Service content.
 msgctxt "Copy used to compose link in sentences"
+msgid "Privacy Policy and Terms of Service"
+msgstr ""
+
+#. Text for a button that links to the terms of use and privacy policy page.
+msgctxt "Secondary button text in active privacy modal"
 msgid "Privacy Policy and Terms of Service"
 msgstr ""
 
@@ -12140,6 +12383,26 @@ msgctxt "Brief for recommending a book"
 msgid "Recommend a book"
 msgstr ""
 
+#. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar books"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar books."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar movies or shows."
+msgstr ""
+
+#. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar titles"
+msgstr ""
+
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
 msgid "Recording failed. Please try again."
 msgstr ""
@@ -12459,6 +12722,14 @@ msgstr ""
 msgid "Republic of Moldova"
 msgstr ""
 
+#. Note indicating that sharing the conversation is mandatory when reporting harmful or illegal content. Rendered alongside the standard share label (DUCKCHAT_RESPONSE_FEEDBACK_SHARE_PROMPT_RESPONSE_LABEL), not replacing it.
+msgctxt ""
+"Note shown under the share-content switch label on the Duck.ai response "
+"feedback form when the user has selected Harmful or Illegal as the feedback "
+"reason"
+msgid "Required for harmful or illegal reports"
+msgstr ""
+
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
 msgctxt "Description for extended reasoning mode in Duck.ai"
 msgid "Researches before responding"
@@ -12644,6 +12915,11 @@ msgstr "সমালোচনাসমূহ "
 #. Label above a list of customer reviews of a business.
 msgctxt "maps_places"
 msgid "Reviews"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Rewrite this recipe scaled for a different number of servings."
 msgstr ""
 
 msgid "Romania"
@@ -13681,6 +13957,11 @@ msgctxt "Setup button for native sync flow"
 msgid "Set Up Now"
 msgstr ""
 
+#. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
+msgctxt "Encrypted storage setup button shown in native browsers"
+msgid "Set Up Sync & Backup"
+msgstr ""
+
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
 msgctxt "Title for the Sync & Backup intro screen"
 msgid "Set Up Sync & Backup"
@@ -13823,6 +14104,12 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
+msgctxt ""
+"Label beside the share-content switch on the Duck.ai response feedback form"
+msgid "Share this conversation with DuckDuckGo"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -14837,6 +15124,21 @@ msgctxt "Brief for suggesting a blog post title"
 msgid "Suggest a title for a blog post"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest related articles or topics worth exploring next."
+msgstr ""
+
+#. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Suggest related articles to explore"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest some alternatives to this product."
+msgstr ""
+
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
 msgctxt "directions"
 msgid "Suggestions:"
@@ -14846,9 +15148,84 @@ msgctxt "noresults"
 msgid "Suggestions:"
 msgstr ""
 
+#. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Sum up the reviews"
+msgstr ""
+
 #. A short title for the a message asking the AI to summarize a text.
 msgctxt "Title for the summarize message"
 msgid "Summarize"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize the Q&As"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the background and notable work of this person."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the key details of this event."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the questions and answers on this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize their background"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this book"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this book."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this discussion"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this discussion thread."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this video"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this video."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize what the reviews say."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -15103,6 +15480,11 @@ msgstr ""
 msgid "Syria"
 msgstr ""
 
+#. Text for a button that enables the theme to follow the operating system's color scheme preference.
+msgctxt "System theme button for theme selector"
+msgid "System"
+msgstr ""
+
 #. Abbreviation indicating this is the total score for a game
 msgctxt "Sports module"
 msgid "T"
@@ -15126,6 +15508,11 @@ msgctxt "language_name"
 msgid "Tahitian"
 msgstr ""
 
+#. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Tailor my resume"
+msgstr ""
+
 msgid "Taiwan"
 msgstr ""
 
@@ -15147,6 +15534,12 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "Take control of your personal data!"
+msgstr ""
+
+#. Description for the Feedback section of the Duck.ai settings page, asking the user to take an anonymous survey to let us know how we can make Duck.ai better.
+msgctxt "Feedback section description on the Duck.ai settings page"
+msgid ""
+"Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
 
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -15389,6 +15782,11 @@ msgstr ""
 
 #. Title for the theme menu:
 #. https://duck.co/media/files/theme.png
+msgid "Theme"
+msgstr ""
+
+#. Text for the theme selector label that allows users to switch between Light and dark theme.
+msgctxt "Label for the theme selector feature"
 msgid "Theme"
 msgstr ""
 
@@ -16042,6 +16440,16 @@ msgid ""
 "movie theatre?”"
 msgstr ""
 
+#. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Translate this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
+msgctxt "Page suggestion prompt"
+msgid "Translate this page into %s."
+msgstr ""
+
 #. Placeholder text for a region that will display translated text.
 msgctxt "translations_module"
 msgid "Translation"
@@ -16156,6 +16564,11 @@ msgstr ""
 #. Call-to-action button for the subscription promo in the SERP sidemenu.
 msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
+msgstr ""
+
+#. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
+msgctxt "settings"
+msgid "Try It Now"
 msgstr ""
 
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -16349,6 +16762,20 @@ msgstr "এটি চেষ্টা করুন: %s"
 #. Response a user can select in a feedback form, indicating that they're trying DuckDuckGo again.
 msgctxt "new user poll"
 msgid "Trying DuckDuckGo again"
+msgstr ""
+
+#. Message shown in a modal after supported third-party browser users disable AI features in Settings. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+#. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
 msgstr ""
 
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -16949,6 +17376,11 @@ msgstr ""
 msgid "Uruguay"
 msgstr ""
 
+#. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
+msgctxt "Navigation label on the Duck.ai settings page"
+msgid "Usage"
+msgstr ""
+
 #. A feedback suggestion
 msgctxt "Feedback prompt"
 msgid "Usage limit"
@@ -17297,6 +17729,11 @@ msgstr ""
 msgid "Wales"
 msgstr ""
 
+#. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Walk me through the steps"
+msgstr ""
+
 #. Label for walking directions on a map.
 msgctxt "directions"
 msgid "Walking"
@@ -17387,6 +17824,16 @@ msgstr ""
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
+msgstr ""
+
+#. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
+msgctxt ""
+"Inline warning shown below the share-content toggle when the user selects "
+"Harmful or Illegal but has not enabled sharing"
+msgid ""
+"We can only fix what we can see. To report a harmful or illegal response, "
+"please share this conversation with DuckDuckGo so we can investigate and "
+"address the issue."
 msgstr ""
 
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -17806,6 +18253,87 @@ msgid ""
 "experience."
 msgstr ""
 
+#. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the counterarguments?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the hours & location?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key contributions of this paper?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key contributions?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key details?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key points covered in this video?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key points?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key takeaways from this article?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key takeaways?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key things I will learn from this course?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main counterarguments or criticisms of this?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main questions this page answers?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the must-try dishes here?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"What are the opening hours, location, and contact details for this place?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the pros and cons of this product?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the pros and cons?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
 msgctxt "feedback form"
 msgid "What bothered you most?"
@@ -17889,6 +18417,11 @@ msgctxt "Full sentence for defining a term"
 msgid "What does atria mean in the context of a medical article?"
 msgstr ""
 
+#. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What does this answer?"
+msgstr ""
+
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
@@ -17898,6 +18431,11 @@ msgstr ""
 msgctxt "cloudsave"
 msgid "What information gets saved?"
 msgstr "কোন কোন তথ্য সংরক্ষিত করা হয়?"
+
+#. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What interview questions might come up for this role?"
+msgstr ""
 
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
@@ -17909,6 +18447,11 @@ msgstr ""
 #. Text for a prompt suggestion for looking up the capital city of Albania.
 msgctxt "Full sentence for looking up basic facts"
 msgid "What is the capital city of Albania?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What is the overall verdict and rating for this?"
 msgstr ""
 
 #. Link to a page with additional information.
@@ -17929,6 +18472,11 @@ msgctxt "maps_places"
 msgid "What people say:"
 msgstr ""
 
+#. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What should I order?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
 msgctxt "feedback form"
 msgid "What stood out?"
@@ -17937,6 +18485,16 @@ msgstr ""
 #. Question on a feedback form for a negative feedback response.
 msgctxt "feedback form"
 msgid "What was wrong with the response? (optional)"
+msgstr ""
+
+#. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I learn?"
+msgstr ""
+
+#. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I need?"
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -17951,6 +18509,11 @@ msgstr ""
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
 msgctxt "SERP footer content"
 msgid "What's New"
+msgstr ""
+
+#. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What's the verdict?"
 msgstr ""
 
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -17992,6 +18555,11 @@ msgctxt "Feedback prompt"
 msgid "Which features are missing? (Optional)"
 msgstr ""
 
+#. An invitation for users to leave feedback
+msgctxt "Feedback prompt"
+msgid "Which features are missing? (optional)"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
 msgid "White"
 msgstr "সাদা"
@@ -18003,6 +18571,16 @@ msgstr ""
 
 #. Link to an about us page.
 msgid "Who We Are"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Who are the main cast and crew, and what else are they known for?"
+msgstr ""
+
+#. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Who is this person?"
 msgstr ""
 
 #. Header above a collection of privacy-related links.

--- a/locales/bo_CN/LC_MESSAGES/duckduckgo.po
+++ b/locales/bo_CN/LC_MESSAGES/duckduckgo.po
@@ -1159,6 +1159,11 @@ msgctxt "feedback form"
 msgid "Address is incorrect"
 msgstr ""
 
+#. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Adjust the servings"
+msgstr ""
+
 #. as in multiple advertisements
 msgid "Ads"
 msgstr ""
@@ -1330,6 +1335,13 @@ msgstr ""
 #. Heading shown on the empty chat screen. The text between the two %s markers is displayed inside a clickable privacy button. First %s renders a shield icon, second %s is an invisible end marker. Keep the word 'private' between both %s markers.
 msgctxt "Empty state heading in Duck.ai chat mode"
 msgid "All chats are %sprivate%s"
+msgstr ""
+
+#. Paragraph in the Privacy & Terms section of the About & Legal page in Duck.ai settings, summarizing how chats are anonymized and are not stored or used to train chat models.
+msgctxt "Privacy & Terms section description on the Duck.ai settings page"
+msgid ""
+"All chats are anonymized by DuckDuckGo, and your conversations are not used "
+"to train chat models by DuckDuckGo or the model providers"
 msgstr ""
 
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1542,6 +1554,12 @@ msgstr ""
 #. Confirmation message after location service is enabled.
 msgctxt "precise_user_location"
 msgid "Anonymous location enabled"
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Anonymously generates answers for search queries based on web content. "
+"Choose how often you want it to appear, or disable it completely."
 msgstr ""
 
 #. Instant Answer tab name
@@ -1764,6 +1782,11 @@ msgstr ""
 
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse
 msgid "Ask a follow-up with Duck.ai"
+msgstr ""
+
+#. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
+msgctxt "Page suggestion chip label"
+msgid "Ask about this page"
 msgstr ""
 
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2088,6 +2111,11 @@ msgstr ""
 msgid "Barcode"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Based on this page, is this course worth taking?"
+msgstr ""
+
 msgctxt "settings"
 msgid "Basic"
 msgstr ""
@@ -2119,6 +2147,13 @@ msgstr ""
 #. Placeholder text displayed while the assistant waits for the user to choose an action.
 msgctxt "Assistant response placeholder"
 msgid "Before continuing..."
+msgstr ""
+
+#. Explains that before storing the report, DuckDuckGo will anonymize the conversation by removing PII like names, email addresses, and identifying metadata.
+msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
+msgid ""
+"Before storing this report, DuckDuckGo will anonymize your conversation by "
+"removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
 #. Label that's displayed next to a past start date below a web search result.
@@ -2377,6 +2412,11 @@ msgstr ""
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Break Points Won"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Break this down into clear, numbered steps."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -2736,6 +2776,11 @@ msgstr ""
 #. Text of a button that performs a search for the cast of a particular movie or tv show
 msgctxt "Movie/TV Show Title instant answer"
 msgid "Cast"
+msgstr ""
+
+#. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Cast & Crew"
 msgstr ""
 
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -4085,6 +4130,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Create a shopping list with quantities from this recipe."
+msgstr ""
+
 #. Placeholder text displayed in the input field when starting a new image generation session.
 msgctxt "Placeholder text for the image generation input field"
 msgid "Create an image of a cute duck..."
@@ -4611,6 +4661,10 @@ msgstr ""
 msgid "Dictation limit reached"
 msgstr ""
 
+#. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
+msgid "Dictation temporarily unavailable"
+msgstr ""
+
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
@@ -4855,6 +4909,20 @@ msgctxt "precise_user_location"
 msgid "Done"
 msgstr ""
 
+#. Message shown in a modal after DuckDuckGo browser users disable AI features in Settings. The first two placeholders bold noai.duckduckgo.com. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
+"filtered out. %sLearn More%s"
+msgstr ""
+
+#. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
+"and AI images filtered out. %sLearn more%s"
+msgstr ""
+
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Double Faults"
@@ -4945,6 +5013,16 @@ msgctxt "Full sentence for writing an email"
 msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
+msgstr ""
+
+#. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Draft a cover letter"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Draft a cover letter for this job."
 msgstr ""
 
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -5084,6 +5162,14 @@ msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
 msgstr ""
 
+#. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
+msgctxt "About section description on the Duck.ai settings page"
+msgid ""
+"Duck.ai is created by DuckDuckGo. We're an independent online protection "
+"company for anyone who wants to take back control of their personal "
+"information."
+msgstr ""
+
 #. Title shown when an update is required before proceeding.
 msgctxt "duckai_migration"
 msgid "Duck.ai is moving domains"
@@ -5117,6 +5203,12 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Duck.ai lets you chat privately with popular AI models. Disabling it hides "
+"Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
 
 msgctxt "settings"
@@ -5882,6 +5974,16 @@ msgstr ""
 msgid "Eritrea"
 msgstr ""
 
+#. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Estimate the nutrition"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Estimate the nutritional information for this recipe."
+msgstr ""
+
 msgid "Estonia"
 msgstr ""
 
@@ -5926,10 +6028,50 @@ msgctxt "merchant promotion product ad extension"
 msgid "Expires in 1 day"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain the accepted answer in simple terms."
+msgstr ""
+
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
+msgstr ""
+
+#. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain the top answer"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this in simple, plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this paper"
+msgstr ""
+
+#. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this repo"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this research paper in plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this simply"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain what this repository does and how to use it."
 msgstr ""
 
 #. Label to show if song lyrics contain explicit content
@@ -6158,6 +6300,11 @@ msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
 msgstr ""
 
+msgctxt "settings"
+msgid ""
+"Filters out known AI spam sites from image search results. %sLearn More%s"
+msgstr ""
+
 #. Label for the final score of a sporting event.
 msgid "Final"
 msgstr ""
@@ -6197,6 +6344,11 @@ msgstr ""
 #. Short description shown below the 'Web Search' label in the Tools dropdown.
 msgctxt "Subtitle for the Web Search tool entry in the Tools dropdown menu"
 msgid "Find current information"
+msgstr ""
+
+#. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Find me alternatives"
 msgstr ""
 
 #. Button that searches for results closer to the user's current location.
@@ -6587,6 +6739,11 @@ msgstr ""
 msgid "Generate More"
 msgstr ""
 
+#. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Generate a shopping list"
+msgstr ""
+
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
 msgid "Generate a short answer from the web"
 msgstr ""
@@ -6821,6 +6978,11 @@ msgstr ""
 #. Text for a button inviting users to give it a try for the Duck.ai product. On click, they're taken to the Duck.ai page.
 msgctxt "Onboarding welcome screen button text"
 msgid "Give it a Try"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Give me a quick background on this person."
 msgstr ""
 
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -7183,6 +7345,16 @@ msgstr ""
 
 #. Link to a page with information about sharing DuckDuckGo with friends.
 msgid "Help Spread Privacy"
+msgstr ""
+
+#. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Help me prep for the interview"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Help me tailor my resume for this job."
 msgstr ""
 
 #. Title of a SERP popup that invites users to take a survey (desktop only)
@@ -7602,6 +7774,13 @@ msgstr ""
 #. Text displayed on the button on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
 msgctxt "Onboarding terms screen button text"
 msgid "I Agree"
+msgstr ""
+
+#. Text for the button that takes the user to the external DuckDuckGo login subscription page.
+msgctxt ""
+"Text for the I already have a subscription button in the Duck.ai settings "
+"page"
+msgid "I Already Have a Subscription"
 msgstr ""
 
 #. Text for the button that takes the user to the login subscription page.
@@ -8052,6 +8231,11 @@ msgctxt "Sidemenu browser promo"
 msgid "Install Mac Browser"
 msgstr ""
 
+#. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
+msgctxt "settings"
+msgid "Install Now"
+msgstr ""
+
 #. Text of a button to install the DuckDuckGo app
 msgctxt "Serp footer content"
 msgid "Install Our App"
@@ -8131,9 +8315,36 @@ msgctxt "cloudsave"
 msgid "Is deleted data really deleted?"
 msgstr ""
 
+#. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is it worth taking?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this place any good?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"Is this place any good? Summarize its reputation based on reviews and "
+"ratings."
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "Is this video helpful?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this worth watching?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Is this worth watching? Give me a spoiler-free take."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -8630,6 +8841,11 @@ msgstr ""
 msgid "Links:"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "List the tools, materials, or prerequisites I need for this."
+msgstr ""
+
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
 msgid "Listen"
 msgstr ""
@@ -8962,6 +9178,11 @@ msgstr ""
 #. Label for linke navigating to site exclusion feature on Settings page
 msgctxt "Exclusion message manage sites button"
 msgid "Manage blocked sites"
+msgstr ""
+
+#. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
+msgctxt "setting"
+msgid "Manage in Browser Settings"
 msgstr ""
 
 #. Link to the site exclusion settings page
@@ -11259,6 +11480,11 @@ msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
+msgid "Please describe why the chat response is harmful or illegal. (optional)"
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
+msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
 msgstr ""
 
@@ -11277,6 +11503,13 @@ msgctxt "Modal disclaimer text"
 msgid ""
 "Please note: starting a new chat with any model will delete your current "
 "chat session."
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
+msgctxt "Feedback prompt"
+msgid ""
+"Please paste your prompt and the problematic output (with any personal "
+"information removed) and describe why the content is harmful or illegal."
 msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -11661,6 +11894,11 @@ msgctxt "settings"
 msgid "Privacy"
 msgstr ""
 
+#. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
+msgctxt "Section heading on the Duck.ai settings page"
+msgid "Privacy & Terms"
+msgstr ""
+
 msgid "Privacy Blog"
 msgstr ""
 
@@ -11714,6 +11952,11 @@ msgstr ""
 
 #. Text used in other strings to link to the Privacy Policy and Terms of Service content.
 msgctxt "Copy used to compose link in sentences"
+msgid "Privacy Policy and Terms of Service"
+msgstr ""
+
+#. Text for a button that links to the terms of use and privacy policy page.
+msgctxt "Secondary button text in active privacy modal"
 msgid "Privacy Policy and Terms of Service"
 msgstr ""
 
@@ -12122,6 +12365,26 @@ msgctxt "Brief for recommending a book"
 msgid "Recommend a book"
 msgstr ""
 
+#. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar books"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar books."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar movies or shows."
+msgstr ""
+
+#. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar titles"
+msgstr ""
+
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
 msgid "Recording failed. Please try again."
 msgstr ""
@@ -12441,6 +12704,14 @@ msgstr ""
 msgid "Republic of Moldova"
 msgstr ""
 
+#. Note indicating that sharing the conversation is mandatory when reporting harmful or illegal content. Rendered alongside the standard share label (DUCKCHAT_RESPONSE_FEEDBACK_SHARE_PROMPT_RESPONSE_LABEL), not replacing it.
+msgctxt ""
+"Note shown under the share-content switch label on the Duck.ai response "
+"feedback form when the user has selected Harmful or Illegal as the feedback "
+"reason"
+msgid "Required for harmful or illegal reports"
+msgstr ""
+
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
 msgctxt "Description for extended reasoning mode in Duck.ai"
 msgid "Researches before responding"
@@ -12626,6 +12897,11 @@ msgstr ""
 #. Label above a list of customer reviews of a business.
 msgctxt "maps_places"
 msgid "Reviews"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Rewrite this recipe scaled for a different number of servings."
 msgstr ""
 
 msgid "Romania"
@@ -13661,6 +13937,11 @@ msgctxt "Setup button for native sync flow"
 msgid "Set Up Now"
 msgstr ""
 
+#. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
+msgctxt "Encrypted storage setup button shown in native browsers"
+msgid "Set Up Sync & Backup"
+msgstr ""
+
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
 msgctxt "Title for the Sync & Backup intro screen"
 msgid "Set Up Sync & Backup"
@@ -13803,6 +14084,12 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
+msgctxt ""
+"Label beside the share-content switch on the Duck.ai response feedback form"
+msgid "Share this conversation with DuckDuckGo"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -14817,6 +15104,21 @@ msgctxt "Brief for suggesting a blog post title"
 msgid "Suggest a title for a blog post"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest related articles or topics worth exploring next."
+msgstr ""
+
+#. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Suggest related articles to explore"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest some alternatives to this product."
+msgstr ""
+
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
 msgctxt "directions"
 msgid "Suggestions:"
@@ -14826,9 +15128,84 @@ msgctxt "noresults"
 msgid "Suggestions:"
 msgstr ""
 
+#. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Sum up the reviews"
+msgstr ""
+
 #. A short title for the a message asking the AI to summarize a text.
 msgctxt "Title for the summarize message"
 msgid "Summarize"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize the Q&As"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the background and notable work of this person."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the key details of this event."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the questions and answers on this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize their background"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this book"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this book."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this discussion"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this discussion thread."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this video"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this video."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize what the reviews say."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -15083,6 +15460,11 @@ msgstr ""
 msgid "Syria"
 msgstr ""
 
+#. Text for a button that enables the theme to follow the operating system's color scheme preference.
+msgctxt "System theme button for theme selector"
+msgid "System"
+msgstr ""
+
 #. Abbreviation indicating this is the total score for a game
 msgctxt "Sports module"
 msgid "T"
@@ -15106,6 +15488,11 @@ msgctxt "language_name"
 msgid "Tahitian"
 msgstr ""
 
+#. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Tailor my resume"
+msgstr ""
+
 msgid "Taiwan"
 msgstr ""
 
@@ -15127,6 +15514,12 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "Take control of your personal data!"
+msgstr ""
+
+#. Description for the Feedback section of the Duck.ai settings page, asking the user to take an anonymous survey to let us know how we can make Duck.ai better.
+msgctxt "Feedback section description on the Duck.ai settings page"
+msgid ""
+"Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
 
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -15369,6 +15762,11 @@ msgstr ""
 
 #. Title for the theme menu:
 #. https://duck.co/media/files/theme.png
+msgid "Theme"
+msgstr ""
+
+#. Text for the theme selector label that allows users to switch between Light and dark theme.
+msgctxt "Label for the theme selector feature"
 msgid "Theme"
 msgstr ""
 
@@ -16022,6 +16420,16 @@ msgid ""
 "movie theatre?”"
 msgstr ""
 
+#. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Translate this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
+msgctxt "Page suggestion prompt"
+msgid "Translate this page into %s."
+msgstr ""
+
 #. Placeholder text for a region that will display translated text.
 msgctxt "translations_module"
 msgid "Translation"
@@ -16136,6 +16544,11 @@ msgstr ""
 #. Call-to-action button for the subscription promo in the SERP sidemenu.
 msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
+msgstr ""
+
+#. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
+msgctxt "settings"
+msgid "Try It Now"
 msgstr ""
 
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -16329,6 +16742,20 @@ msgstr ""
 #. Response a user can select in a feedback form, indicating that they're trying DuckDuckGo again.
 msgctxt "new user poll"
 msgid "Trying DuckDuckGo again"
+msgstr ""
+
+#. Message shown in a modal after supported third-party browser users disable AI features in Settings. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+#. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
 msgstr ""
 
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -16929,6 +17356,11 @@ msgstr ""
 msgid "Uruguay"
 msgstr ""
 
+#. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
+msgctxt "Navigation label on the Duck.ai settings page"
+msgid "Usage"
+msgstr ""
+
 #. A feedback suggestion
 msgctxt "Feedback prompt"
 msgid "Usage limit"
@@ -17277,6 +17709,11 @@ msgstr ""
 msgid "Wales"
 msgstr ""
 
+#. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Walk me through the steps"
+msgstr ""
+
 #. Label for walking directions on a map.
 msgctxt "directions"
 msgid "Walking"
@@ -17367,6 +17804,16 @@ msgstr ""
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
+msgstr ""
+
+#. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
+msgctxt ""
+"Inline warning shown below the share-content toggle when the user selects "
+"Harmful or Illegal but has not enabled sharing"
+msgid ""
+"We can only fix what we can see. To report a harmful or illegal response, "
+"please share this conversation with DuckDuckGo so we can investigate and "
+"address the issue."
 msgstr ""
 
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -17786,6 +18233,87 @@ msgid ""
 "experience."
 msgstr ""
 
+#. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the counterarguments?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the hours & location?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key contributions of this paper?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key contributions?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key details?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key points covered in this video?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key points?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key takeaways from this article?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key takeaways?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key things I will learn from this course?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main counterarguments or criticisms of this?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main questions this page answers?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the must-try dishes here?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"What are the opening hours, location, and contact details for this place?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the pros and cons of this product?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the pros and cons?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
 msgctxt "feedback form"
 msgid "What bothered you most?"
@@ -17869,6 +18397,11 @@ msgctxt "Full sentence for defining a term"
 msgid "What does atria mean in the context of a medical article?"
 msgstr ""
 
+#. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What does this answer?"
+msgstr ""
+
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
@@ -17877,6 +18410,11 @@ msgstr ""
 #. Header above a list of types of information that gets saved by the cloud save feature.
 msgctxt "cloudsave"
 msgid "What information gets saved?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What interview questions might come up for this role?"
 msgstr ""
 
 #. Text explaining how the cloud save feature works.
@@ -17889,6 +18427,11 @@ msgstr ""
 #. Text for a prompt suggestion for looking up the capital city of Albania.
 msgctxt "Full sentence for looking up basic facts"
 msgid "What is the capital city of Albania?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What is the overall verdict and rating for this?"
 msgstr ""
 
 #. Link to a page with additional information.
@@ -17909,6 +18452,11 @@ msgctxt "maps_places"
 msgid "What people say:"
 msgstr ""
 
+#. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What should I order?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
 msgctxt "feedback form"
 msgid "What stood out?"
@@ -17917,6 +18465,16 @@ msgstr ""
 #. Question on a feedback form for a negative feedback response.
 msgctxt "feedback form"
 msgid "What was wrong with the response? (optional)"
+msgstr ""
+
+#. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I learn?"
+msgstr ""
+
+#. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I need?"
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -17931,6 +18489,11 @@ msgstr ""
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
 msgctxt "SERP footer content"
 msgid "What's New"
+msgstr ""
+
+#. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What's the verdict?"
 msgstr ""
 
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -17972,6 +18535,11 @@ msgctxt "Feedback prompt"
 msgid "Which features are missing? (Optional)"
 msgstr ""
 
+#. An invitation for users to leave feedback
+msgctxt "Feedback prompt"
+msgid "Which features are missing? (optional)"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
 msgid "White"
 msgstr ""
@@ -17983,6 +18551,16 @@ msgstr ""
 
 #. Link to an about us page.
 msgid "Who We Are"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Who are the main cast and crew, and what else are they known for?"
+msgstr ""
+
+#. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Who is this person?"
 msgstr ""
 
 #. Header above a collection of privacy-related links.

--- a/locales/br_FR/LC_MESSAGES/duckduckgo.po
+++ b/locales/br_FR/LC_MESSAGES/duckduckgo.po
@@ -1159,6 +1159,11 @@ msgctxt "feedback form"
 msgid "Address is incorrect"
 msgstr ""
 
+#. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Adjust the servings"
+msgstr ""
+
 #. as in multiple advertisements
 msgid "Ads"
 msgstr ""
@@ -1332,6 +1337,13 @@ msgstr ""
 #. Heading shown on the empty chat screen. The text between the two %s markers is displayed inside a clickable privacy button. First %s renders a shield icon, second %s is an invisible end marker. Keep the word 'private' between both %s markers.
 msgctxt "Empty state heading in Duck.ai chat mode"
 msgid "All chats are %sprivate%s"
+msgstr ""
+
+#. Paragraph in the Privacy & Terms section of the About & Legal page in Duck.ai settings, summarizing how chats are anonymized and are not stored or used to train chat models.
+msgctxt "Privacy & Terms section description on the Duck.ai settings page"
+msgid ""
+"All chats are anonymized by DuckDuckGo, and your conversations are not used "
+"to train chat models by DuckDuckGo or the model providers"
 msgstr ""
 
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1544,6 +1556,12 @@ msgstr ""
 #. Confirmation message after location service is enabled.
 msgctxt "precise_user_location"
 msgid "Anonymous location enabled"
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Anonymously generates answers for search queries based on web content. "
+"Choose how often you want it to appear, or disable it completely."
 msgstr ""
 
 #. Instant Answer tab name
@@ -1766,6 +1784,11 @@ msgstr ""
 
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse
 msgid "Ask a follow-up with Duck.ai"
+msgstr ""
+
+#. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
+msgctxt "Page suggestion chip label"
+msgid "Ask about this page"
 msgstr ""
 
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2090,6 +2113,11 @@ msgstr ""
 msgid "Barcode"
 msgstr "Rineg dre varrennoù"
 
+#. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Based on this page, is this course worth taking?"
+msgstr ""
+
 msgctxt "settings"
 msgid "Basic"
 msgstr "Diazez"
@@ -2121,6 +2149,13 @@ msgstr ""
 #. Placeholder text displayed while the assistant waits for the user to choose an action.
 msgctxt "Assistant response placeholder"
 msgid "Before continuing..."
+msgstr ""
+
+#. Explains that before storing the report, DuckDuckGo will anonymize the conversation by removing PII like names, email addresses, and identifying metadata.
+msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
+msgid ""
+"Before storing this report, DuckDuckGo will anonymize your conversation by "
+"removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
 #. Label that's displayed next to a past start date below a web search result.
@@ -2379,6 +2414,11 @@ msgstr ""
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Break Points Won"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Break this down into clear, numbered steps."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -2738,6 +2778,11 @@ msgstr ""
 #. Text of a button that performs a search for the cast of a particular movie or tv show
 msgctxt "Movie/TV Show Title instant answer"
 msgid "Cast"
+msgstr ""
+
+#. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Cast & Crew"
 msgstr ""
 
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -4097,6 +4142,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Create a shopping list with quantities from this recipe."
+msgstr ""
+
 #. Placeholder text displayed in the input field when starting a new image generation session.
 msgctxt "Placeholder text for the image generation input field"
 msgid "Create an image of a cute duck..."
@@ -4623,6 +4673,10 @@ msgstr ""
 msgid "Dictation limit reached"
 msgstr ""
 
+#. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
+msgid "Dictation temporarily unavailable"
+msgstr ""
+
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
@@ -4867,6 +4921,20 @@ msgctxt "precise_user_location"
 msgid "Done"
 msgstr ""
 
+#. Message shown in a modal after DuckDuckGo browser users disable AI features in Settings. The first two placeholders bold noai.duckduckgo.com. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
+"filtered out. %sLearn More%s"
+msgstr ""
+
+#. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
+"and AI images filtered out. %sLearn more%s"
+msgstr ""
+
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Double Faults"
@@ -4957,6 +5025,16 @@ msgctxt "Full sentence for writing an email"
 msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
+msgstr ""
+
+#. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Draft a cover letter"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Draft a cover letter for this job."
 msgstr ""
 
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -5096,6 +5174,14 @@ msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
 msgstr ""
 
+#. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
+msgctxt "About section description on the Duck.ai settings page"
+msgid ""
+"Duck.ai is created by DuckDuckGo. We're an independent online protection "
+"company for anyone who wants to take back control of their personal "
+"information."
+msgstr ""
+
 #. Title shown when an update is required before proceeding.
 msgctxt "duckai_migration"
 msgid "Duck.ai is moving domains"
@@ -5129,6 +5215,12 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Duck.ai lets you chat privately with popular AI models. Disabling it hides "
+"Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
 
 msgctxt "settings"
@@ -5895,6 +5987,16 @@ msgstr ""
 msgid "Eritrea"
 msgstr ""
 
+#. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Estimate the nutrition"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Estimate the nutritional information for this recipe."
+msgstr ""
+
 msgid "Estonia"
 msgstr ""
 
@@ -5939,10 +6041,50 @@ msgctxt "merchant promotion product ad extension"
 msgid "Expires in 1 day"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain the accepted answer in simple terms."
+msgstr ""
+
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
+msgstr ""
+
+#. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain the top answer"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this in simple, plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this paper"
+msgstr ""
+
+#. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this repo"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this research paper in plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this simply"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain what this repository does and how to use it."
 msgstr ""
 
 #. Label to show if song lyrics contain explicit content
@@ -6173,6 +6315,11 @@ msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
 msgstr ""
 
+msgctxt "settings"
+msgid ""
+"Filters out known AI spam sites from image search results. %sLearn More%s"
+msgstr ""
+
 #. Label for the final score of a sporting event.
 msgid "Final"
 msgstr ""
@@ -6213,6 +6360,11 @@ msgstr ""
 #. Short description shown below the 'Web Search' label in the Tools dropdown.
 msgctxt "Subtitle for the Web Search tool entry in the Tools dropdown menu"
 msgid "Find current information"
+msgstr ""
+
+#. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Find me alternatives"
 msgstr ""
 
 #. Button that searches for results closer to the user's current location.
@@ -6603,6 +6755,11 @@ msgstr ""
 msgid "Generate More"
 msgstr ""
 
+#. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Generate a shopping list"
+msgstr ""
+
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
 msgid "Generate a short answer from the web"
 msgstr ""
@@ -6837,6 +6994,11 @@ msgstr ""
 #. Text for a button inviting users to give it a try for the Duck.ai product. On click, they're taken to the Duck.ai page.
 msgctxt "Onboarding welcome screen button text"
 msgid "Give it a Try"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Give me a quick background on this person."
 msgstr ""
 
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -7199,6 +7361,16 @@ msgstr ""
 
 #. Link to a page with information about sharing DuckDuckGo with friends.
 msgid "Help Spread Privacy"
+msgstr ""
+
+#. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Help me prep for the interview"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Help me tailor my resume for this job."
 msgstr ""
 
 #. Title of a SERP popup that invites users to take a survey (desktop only)
@@ -7618,6 +7790,13 @@ msgstr ""
 #. Text displayed on the button on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
 msgctxt "Onboarding terms screen button text"
 msgid "I Agree"
+msgstr ""
+
+#. Text for the button that takes the user to the external DuckDuckGo login subscription page.
+msgctxt ""
+"Text for the I already have a subscription button in the Duck.ai settings "
+"page"
+msgid "I Already Have a Subscription"
 msgstr ""
 
 #. Text for the button that takes the user to the login subscription page.
@@ -8072,6 +8251,11 @@ msgctxt "Sidemenu browser promo"
 msgid "Install Mac Browser"
 msgstr ""
 
+#. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
+msgctxt "settings"
+msgid "Install Now"
+msgstr ""
+
 #. Text of a button to install the DuckDuckGo app
 msgctxt "Serp footer content"
 msgid "Install Our App"
@@ -8151,9 +8335,36 @@ msgctxt "cloudsave"
 msgid "Is deleted data really deleted?"
 msgstr "Diverket da vat eo ar roadennoù diverket ?"
 
+#. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is it worth taking?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this place any good?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"Is this place any good? Summarize its reputation based on reviews and "
+"ratings."
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "Is this video helpful?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this worth watching?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Is this worth watching? Give me a spoiler-free take."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -8650,6 +8861,11 @@ msgstr "Nodrezh an ere :"
 msgid "Links:"
 msgstr "Ereoù :"
 
+#. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "List the tools, materials, or prerequisites I need for this."
+msgstr ""
+
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
 msgid "Listen"
 msgstr "Selaou"
@@ -8984,6 +9200,11 @@ msgstr ""
 #. Label for linke navigating to site exclusion feature on Settings page
 msgctxt "Exclusion message manage sites button"
 msgid "Manage blocked sites"
+msgstr ""
+
+#. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
+msgctxt "setting"
+msgid "Manage in Browser Settings"
 msgstr ""
 
 #. Link to the site exclusion settings page
@@ -11286,6 +11507,11 @@ msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
+msgid "Please describe why the chat response is harmful or illegal. (optional)"
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
+msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
 msgstr ""
 
@@ -11304,6 +11530,13 @@ msgctxt "Modal disclaimer text"
 msgid ""
 "Please note: starting a new chat with any model will delete your current "
 "chat session."
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
+msgctxt "Feedback prompt"
+msgid ""
+"Please paste your prompt and the problematic output (with any personal "
+"information removed) and describe why the content is harmful or illegal."
 msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -11688,6 +11921,11 @@ msgctxt "settings"
 msgid "Privacy"
 msgstr "Buhez prevez"
 
+#. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
+msgctxt "Section heading on the Duck.ai settings page"
+msgid "Privacy & Terms"
+msgstr ""
+
 msgid "Privacy Blog"
 msgstr ""
 
@@ -11741,6 +11979,11 @@ msgstr ""
 
 #. Text used in other strings to link to the Privacy Policy and Terms of Service content.
 msgctxt "Copy used to compose link in sentences"
+msgid "Privacy Policy and Terms of Service"
+msgstr ""
+
+#. Text for a button that links to the terms of use and privacy policy page.
+msgctxt "Secondary button text in active privacy modal"
 msgid "Privacy Policy and Terms of Service"
 msgstr ""
 
@@ -12149,6 +12392,26 @@ msgctxt "Brief for recommending a book"
 msgid "Recommend a book"
 msgstr ""
 
+#. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar books"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar books."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar movies or shows."
+msgstr ""
+
+#. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar titles"
+msgstr ""
+
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
 msgid "Recording failed. Please try again."
 msgstr ""
@@ -12468,6 +12731,14 @@ msgstr ""
 msgid "Republic of Moldova"
 msgstr ""
 
+#. Note indicating that sharing the conversation is mandatory when reporting harmful or illegal content. Rendered alongside the standard share label (DUCKCHAT_RESPONSE_FEEDBACK_SHARE_PROMPT_RESPONSE_LABEL), not replacing it.
+msgctxt ""
+"Note shown under the share-content switch label on the Duck.ai response "
+"feedback form when the user has selected Harmful or Illegal as the feedback "
+"reason"
+msgid "Required for harmful or illegal reports"
+msgstr ""
+
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
 msgctxt "Description for extended reasoning mode in Duck.ai"
 msgid "Researches before responding"
@@ -12653,6 +12924,11 @@ msgstr "Priziadurioù"
 #. Label above a list of customer reviews of a business.
 msgctxt "maps_places"
 msgid "Reviews"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Rewrite this recipe scaled for a different number of servings."
 msgstr ""
 
 msgid "Romania"
@@ -13695,6 +13971,11 @@ msgctxt "Setup button for native sync flow"
 msgid "Set Up Now"
 msgstr ""
 
+#. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
+msgctxt "Encrypted storage setup button shown in native browsers"
+msgid "Set Up Sync & Backup"
+msgstr ""
+
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
 msgctxt "Title for the Sync & Backup intro screen"
 msgid "Set Up Sync & Backup"
@@ -13837,6 +14118,12 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
+msgctxt ""
+"Label beside the share-content switch on the Duck.ai response feedback form"
+msgid "Share this conversation with DuckDuckGo"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -14853,6 +15140,21 @@ msgctxt "Brief for suggesting a blog post title"
 msgid "Suggest a title for a blog post"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest related articles or topics worth exploring next."
+msgstr ""
+
+#. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Suggest related articles to explore"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest some alternatives to this product."
+msgstr ""
+
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
 msgctxt "directions"
 msgid "Suggestions:"
@@ -14862,9 +15164,84 @@ msgctxt "noresults"
 msgid "Suggestions:"
 msgstr ""
 
+#. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Sum up the reviews"
+msgstr ""
+
 #. A short title for the a message asking the AI to summarize a text.
 msgctxt "Title for the summarize message"
 msgid "Summarize"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize the Q&As"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the background and notable work of this person."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the key details of this event."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the questions and answers on this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize their background"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this book"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this book."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this discussion"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this discussion thread."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this video"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this video."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize what the reviews say."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -15119,6 +15496,11 @@ msgstr ""
 msgid "Syria"
 msgstr ""
 
+#. Text for a button that enables the theme to follow the operating system's color scheme preference.
+msgctxt "System theme button for theme selector"
+msgid "System"
+msgstr ""
+
 #. Abbreviation indicating this is the total score for a game
 msgctxt "Sports module"
 msgid "T"
@@ -15142,6 +15524,11 @@ msgctxt "language_name"
 msgid "Tahitian"
 msgstr ""
 
+#. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Tailor my resume"
+msgstr ""
+
 msgid "Taiwan"
 msgstr ""
 
@@ -15163,6 +15550,12 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "Take control of your personal data!"
+msgstr ""
+
+#. Description for the Feedback section of the Duck.ai settings page, asking the user to take an anonymous survey to let us know how we can make Duck.ai better.
+msgctxt "Feedback section description on the Duck.ai settings page"
+msgid ""
+"Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
 
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -15407,6 +15800,11 @@ msgstr ""
 #. https://duck.co/media/files/theme.png
 msgid "Theme"
 msgstr "Neuz"
+
+#. Text for the theme selector label that allows users to switch between Light and dark theme.
+msgctxt "Label for the theme selector feature"
+msgid "Theme"
+msgstr ""
 
 #. http://i.imgur.com/LpFhb1e.png
 msgctxt "settings"
@@ -16060,6 +16458,16 @@ msgid ""
 "movie theatre?”"
 msgstr ""
 
+#. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Translate this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
+msgctxt "Page suggestion prompt"
+msgid "Translate this page into %s."
+msgstr ""
+
 #. Placeholder text for a region that will display translated text.
 msgctxt "translations_module"
 msgid "Translation"
@@ -16174,6 +16582,11 @@ msgstr ""
 #. Call-to-action button for the subscription promo in the SERP sidemenu.
 msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
+msgstr ""
+
+#. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
+msgctxt "settings"
+msgid "Try It Now"
 msgstr ""
 
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -16367,6 +16780,20 @@ msgstr "Klask : %s"
 #. Response a user can select in a feedback form, indicating that they're trying DuckDuckGo again.
 msgctxt "new user poll"
 msgid "Trying DuckDuckGo again"
+msgstr ""
+
+#. Message shown in a modal after supported third-party browser users disable AI features in Settings. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+#. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
 msgstr ""
 
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -16974,6 +17401,11 @@ msgstr ""
 msgid "Uruguay"
 msgstr ""
 
+#. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
+msgctxt "Navigation label on the Duck.ai settings page"
+msgid "Usage"
+msgstr ""
+
 #. A feedback suggestion
 msgctxt "Feedback prompt"
 msgid "Usage limit"
@@ -17322,6 +17754,11 @@ msgstr ""
 msgid "Wales"
 msgstr ""
 
+#. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Walk me through the steps"
+msgstr ""
+
 #. Label for walking directions on a map.
 msgctxt "directions"
 msgid "Walking"
@@ -17412,6 +17849,16 @@ msgstr ""
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
+msgstr ""
+
+#. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
+msgctxt ""
+"Inline warning shown below the share-content toggle when the user selects "
+"Harmful or Illegal but has not enabled sharing"
+msgid ""
+"We can only fix what we can see. To report a harmful or illegal response, "
+"please share this conversation with DuckDuckGo so we can investigate and "
+"address the issue."
 msgstr ""
 
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -17831,6 +18278,87 @@ msgid ""
 "experience."
 msgstr ""
 
+#. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the counterarguments?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the hours & location?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key contributions of this paper?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key contributions?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key details?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key points covered in this video?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key points?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key takeaways from this article?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key takeaways?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key things I will learn from this course?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main counterarguments or criticisms of this?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main questions this page answers?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the must-try dishes here?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"What are the opening hours, location, and contact details for this place?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the pros and cons of this product?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the pros and cons?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
 msgctxt "feedback form"
 msgid "What bothered you most?"
@@ -17914,6 +18442,11 @@ msgctxt "Full sentence for defining a term"
 msgid "What does atria mean in the context of a medical article?"
 msgstr ""
 
+#. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What does this answer?"
+msgstr ""
+
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
@@ -17923,6 +18456,11 @@ msgstr ""
 msgctxt "cloudsave"
 msgid "What information gets saved?"
 msgstr "Peseurt stlennoù a vez enrollet ?"
+
+#. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What interview questions might come up for this role?"
+msgstr ""
 
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
@@ -17934,6 +18472,11 @@ msgstr ""
 #. Text for a prompt suggestion for looking up the capital city of Albania.
 msgctxt "Full sentence for looking up basic facts"
 msgid "What is the capital city of Albania?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What is the overall verdict and rating for this?"
 msgstr ""
 
 #. Link to a page with additional information.
@@ -17954,6 +18497,11 @@ msgctxt "maps_places"
 msgid "What people say:"
 msgstr ""
 
+#. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What should I order?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
 msgctxt "feedback form"
 msgid "What stood out?"
@@ -17962,6 +18510,16 @@ msgstr ""
 #. Question on a feedback form for a negative feedback response.
 msgctxt "feedback form"
 msgid "What was wrong with the response? (optional)"
+msgstr ""
+
+#. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I learn?"
+msgstr ""
+
+#. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I need?"
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -17976,6 +18534,11 @@ msgstr ""
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
 msgctxt "SERP footer content"
 msgid "What's New"
+msgstr ""
+
+#. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What's the verdict?"
 msgstr ""
 
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -18019,6 +18582,11 @@ msgctxt "Feedback prompt"
 msgid "Which features are missing? (Optional)"
 msgstr ""
 
+#. An invitation for users to leave feedback
+msgctxt "Feedback prompt"
+msgid "Which features are missing? (optional)"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
 msgid "White"
 msgstr "Gwenn"
@@ -18030,6 +18598,16 @@ msgstr ""
 
 #. Link to an about us page.
 msgid "Who We Are"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Who are the main cast and crew, and what else are they known for?"
+msgstr ""
+
+#. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Who is this person?"
 msgstr ""
 
 #. Header above a collection of privacy-related links.

--- a/locales/bs_BA/LC_MESSAGES/duckduckgo.po
+++ b/locales/bs_BA/LC_MESSAGES/duckduckgo.po
@@ -1170,6 +1170,11 @@ msgctxt "feedback form"
 msgid "Address is incorrect"
 msgstr "Adresa nije tačna"
 
+#. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Adjust the servings"
+msgstr ""
+
 #. as in multiple advertisements
 msgid "Ads"
 msgstr "Reklame"
@@ -1342,6 +1347,13 @@ msgstr ""
 #. Heading shown on the empty chat screen. The text between the two %s markers is displayed inside a clickable privacy button. First %s renders a shield icon, second %s is an invisible end marker. Keep the word 'private' between both %s markers.
 msgctxt "Empty state heading in Duck.ai chat mode"
 msgid "All chats are %sprivate%s"
+msgstr ""
+
+#. Paragraph in the Privacy & Terms section of the About & Legal page in Duck.ai settings, summarizing how chats are anonymized and are not stored or used to train chat models.
+msgctxt "Privacy & Terms section description on the Duck.ai settings page"
+msgid ""
+"All chats are anonymized by DuckDuckGo, and your conversations are not used "
+"to train chat models by DuckDuckGo or the model providers"
 msgstr ""
 
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1557,6 +1569,12 @@ msgstr ""
 msgctxt "precise_user_location"
 msgid "Anonymous location enabled"
 msgstr "Omogućena anonimna lokacija"
+
+msgctxt "settings"
+msgid ""
+"Anonymously generates answers for search queries based on web content. "
+"Choose how often you want it to appear, or disable it completely."
+msgstr ""
 
 #. Instant Answer tab name
 msgid "Answer"
@@ -1780,6 +1798,11 @@ msgstr ""
 
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse
 msgid "Ask a follow-up with Duck.ai"
+msgstr ""
+
+#. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
+msgctxt "Page suggestion chip label"
+msgid "Ask about this page"
 msgstr ""
 
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2107,6 +2130,11 @@ msgstr ""
 msgid "Barcode"
 msgstr "Barkod"
 
+#. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Based on this page, is this course worth taking?"
+msgstr ""
+
 msgctxt "settings"
 msgid "Basic"
 msgstr "Osnovno"
@@ -2138,6 +2166,13 @@ msgstr ""
 #. Placeholder text displayed while the assistant waits for the user to choose an action.
 msgctxt "Assistant response placeholder"
 msgid "Before continuing..."
+msgstr ""
+
+#. Explains that before storing the report, DuckDuckGo will anonymize the conversation by removing PII like names, email addresses, and identifying metadata.
+msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
+msgid ""
+"Before storing this report, DuckDuckGo will anonymize your conversation by "
+"removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
 #. Label that's displayed next to a past start date below a web search result.
@@ -2397,6 +2432,11 @@ msgstr "Brazil"
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Break Points Won"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Break this down into clear, numbered steps."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -2769,6 +2809,11 @@ msgstr "Poslovi"
 #. Text of a button that performs a search for the cast of a particular movie or tv show
 msgctxt "Movie/TV Show Title instant answer"
 msgid "Cast"
+msgstr ""
+
+#. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Cast & Crew"
 msgstr ""
 
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -4137,6 +4182,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Create a shopping list with quantities from this recipe."
+msgstr ""
+
 #. Placeholder text displayed in the input field when starting a new image generation session.
 msgctxt "Placeholder text for the image generation input field"
 msgid "Create an image of a cute duck..."
@@ -4663,6 +4713,10 @@ msgstr ""
 msgid "Dictation limit reached"
 msgstr ""
 
+#. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
+msgid "Dictation temporarily unavailable"
+msgstr ""
+
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
@@ -4907,6 +4961,20 @@ msgctxt "precise_user_location"
 msgid "Done"
 msgstr "Gotovo"
 
+#. Message shown in a modal after DuckDuckGo browser users disable AI features in Settings. The first two placeholders bold noai.duckduckgo.com. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
+"filtered out. %sLearn More%s"
+msgstr ""
+
+#. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
+"and AI images filtered out. %sLearn more%s"
+msgstr ""
+
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Double Faults"
@@ -4997,6 +5065,16 @@ msgctxt "Full sentence for writing an email"
 msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
+msgstr ""
+
+#. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Draft a cover letter"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Draft a cover letter for this job."
 msgstr ""
 
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -5136,6 +5214,14 @@ msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
 msgstr ""
 
+#. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
+msgctxt "About section description on the Duck.ai settings page"
+msgid ""
+"Duck.ai is created by DuckDuckGo. We're an independent online protection "
+"company for anyone who wants to take back control of their personal "
+"information."
+msgstr ""
+
 #. Title shown when an update is required before proceeding.
 msgctxt "duckai_migration"
 msgid "Duck.ai is moving domains"
@@ -5169,6 +5255,12 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Duck.ai lets you chat privately with popular AI models. Disabling it hides "
+"Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
 
 msgctxt "settings"
@@ -5954,6 +6046,16 @@ msgstr ""
 msgid "Eritrea"
 msgstr ""
 
+#. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Estimate the nutrition"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Estimate the nutritional information for this recipe."
+msgstr ""
+
 msgid "Estonia"
 msgstr "Estonija"
 
@@ -5998,10 +6100,50 @@ msgctxt "merchant promotion product ad extension"
 msgid "Expires in 1 day"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain the accepted answer in simple terms."
+msgstr ""
+
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
+msgstr ""
+
+#. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain the top answer"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this in simple, plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this paper"
+msgstr ""
+
+#. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this repo"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this research paper in plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this simply"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain what this repository does and how to use it."
 msgstr ""
 
 #. Label to show if song lyrics contain explicit content
@@ -6232,6 +6374,11 @@ msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
 msgstr ""
 
+msgctxt "settings"
+msgid ""
+"Filters out known AI spam sites from image search results. %sLearn More%s"
+msgstr ""
+
 #. Label for the final score of a sporting event.
 msgid "Final"
 msgstr "Konačno"
@@ -6273,6 +6420,11 @@ msgstr ""
 #. Short description shown below the 'Web Search' label in the Tools dropdown.
 msgctxt "Subtitle for the Web Search tool entry in the Tools dropdown menu"
 msgid "Find current information"
+msgstr ""
+
+#. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Find me alternatives"
 msgstr ""
 
 #. Button that searches for results closer to the user's current location.
@@ -6663,6 +6815,11 @@ msgstr ""
 msgid "Generate More"
 msgstr ""
 
+#. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Generate a shopping list"
+msgstr ""
+
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
 msgid "Generate a short answer from the web"
 msgstr ""
@@ -6899,6 +7056,11 @@ msgstr ""
 #. Text for a button inviting users to give it a try for the Duck.ai product. On click, they're taken to the Duck.ai page.
 msgctxt "Onboarding welcome screen button text"
 msgid "Give it a Try"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Give me a quick background on this person."
 msgstr ""
 
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -7262,6 +7424,16 @@ msgstr "Pomozite popularizirati DuckDuckGo!"
 #. Link to a page with information about sharing DuckDuckGo with friends.
 msgid "Help Spread Privacy"
 msgstr "Pomozite širiti privatnost"
+
+#. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Help me prep for the interview"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Help me tailor my resume for this job."
+msgstr ""
 
 #. Title of a SERP popup that invites users to take a survey (desktop only)
 msgctxt "User survey popup"
@@ -7684,6 +7856,13 @@ msgstr "Uragan"
 #. Text displayed on the button on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
 msgctxt "Onboarding terms screen button text"
 msgid "I Agree"
+msgstr ""
+
+#. Text for the button that takes the user to the external DuckDuckGo login subscription page.
+msgctxt ""
+"Text for the I already have a subscription button in the Duck.ai settings "
+"page"
+msgid "I Already Have a Subscription"
 msgstr ""
 
 #. Text for the button that takes the user to the login subscription page.
@@ -8153,6 +8332,11 @@ msgctxt "Sidemenu browser promo"
 msgid "Install Mac Browser"
 msgstr ""
 
+#. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
+msgctxt "settings"
+msgid "Install Now"
+msgstr ""
+
 #. Text of a button to install the DuckDuckGo app
 msgctxt "Serp footer content"
 msgid "Install Our App"
@@ -8232,10 +8416,37 @@ msgctxt "cloudsave"
 msgid "Is deleted data really deleted?"
 msgstr "Brišu li se zaista podaci?"
 
+#. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is it worth taking?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this place any good?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"Is this place any good? Summarize its reputation based on reviews and "
+"ratings."
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "Is this video helpful?"
 msgstr "Je li ovaj video koristan?"
+
+#. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this worth watching?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Is this worth watching? Give me a spoiler-free take."
+msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
 msgctxt "Weather IA"
@@ -8739,6 +8950,11 @@ msgstr "Font linka:"
 msgid "Links:"
 msgstr "Linkovi:"
 
+#. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "List the tools, materials, or prerequisites I need for this."
+msgstr ""
+
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
 msgid "Listen"
 msgstr "Slušaj"
@@ -9072,6 +9288,11 @@ msgstr ""
 #. Label for linke navigating to site exclusion feature on Settings page
 msgctxt "Exclusion message manage sites button"
 msgid "Manage blocked sites"
+msgstr ""
+
+#. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
+msgctxt "setting"
+msgid "Manage in Browser Settings"
 msgstr ""
 
 #. Link to the site exclusion settings page
@@ -11385,6 +11606,11 @@ msgstr "Ispunite sljedeći upit da potvrdimo da ste čovjek."
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
+msgid "Please describe why the chat response is harmful or illegal. (optional)"
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
+msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
 msgstr ""
 
@@ -11403,6 +11629,13 @@ msgctxt "Modal disclaimer text"
 msgid ""
 "Please note: starting a new chat with any model will delete your current "
 "chat session."
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
+msgctxt "Feedback prompt"
+msgid ""
+"Please paste your prompt and the problematic output (with any personal "
+"information removed) and describe why the content is harmful or illegal."
 msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -11787,6 +12020,11 @@ msgctxt "settings"
 msgid "Privacy"
 msgstr "Privatnost"
 
+#. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
+msgctxt "Section heading on the Duck.ai settings page"
+msgid "Privacy & Terms"
+msgstr ""
+
 msgid "Privacy Blog"
 msgstr "Blog o privatnosti"
 
@@ -11840,6 +12078,11 @@ msgstr ""
 
 #. Text used in other strings to link to the Privacy Policy and Terms of Service content.
 msgctxt "Copy used to compose link in sentences"
+msgid "Privacy Policy and Terms of Service"
+msgstr ""
+
+#. Text for a button that links to the terms of use and privacy policy page.
+msgctxt "Secondary button text in active privacy modal"
 msgid "Privacy Policy and Terms of Service"
 msgstr ""
 
@@ -12250,6 +12493,26 @@ msgctxt "Brief for recommending a book"
 msgid "Recommend a book"
 msgstr ""
 
+#. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar books"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar books."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar movies or shows."
+msgstr ""
+
+#. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar titles"
+msgstr ""
+
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
 msgid "Recording failed. Please try again."
 msgstr ""
@@ -12574,6 +12837,14 @@ msgstr ""
 msgid "Republic of Moldova"
 msgstr ""
 
+#. Note indicating that sharing the conversation is mandatory when reporting harmful or illegal content. Rendered alongside the standard share label (DUCKCHAT_RESPONSE_FEEDBACK_SHARE_PROMPT_RESPONSE_LABEL), not replacing it.
+msgctxt ""
+"Note shown under the share-content switch label on the Duck.ai response "
+"feedback form when the user has selected Harmful or Illegal as the feedback "
+"reason"
+msgid "Required for harmful or illegal reports"
+msgstr ""
+
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
 msgctxt "Description for extended reasoning mode in Duck.ai"
 msgid "Researches before responding"
@@ -12760,6 +13031,11 @@ msgstr "Pregledi"
 msgctxt "maps_places"
 msgid "Reviews"
 msgstr "Recenzije"
+
+#. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Rewrite this recipe scaled for a different number of servings."
+msgstr ""
 
 msgid "Romania"
 msgstr "Rumunija"
@@ -13810,6 +14086,11 @@ msgctxt "Setup button for native sync flow"
 msgid "Set Up Now"
 msgstr ""
 
+#. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
+msgctxt "Encrypted storage setup button shown in native browsers"
+msgid "Set Up Sync & Backup"
+msgstr ""
+
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
 msgctxt "Title for the Sync & Backup intro screen"
 msgid "Set Up Sync & Backup"
@@ -13954,6 +14235,12 @@ msgstr ""
 msgctxt "feedback form"
 msgid "Share positive feedback"
 msgstr "Podijeli pozitivne povratne informacije"
+
+#. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
+msgctxt ""
+"Label beside the share-content switch on the Duck.ai response feedback form"
+msgid "Share this conversation with DuckDuckGo"
+msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
 msgctxt ""
@@ -14979,6 +15266,21 @@ msgctxt "Brief for suggesting a blog post title"
 msgid "Suggest a title for a blog post"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest related articles or topics worth exploring next."
+msgstr ""
+
+#. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Suggest related articles to explore"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest some alternatives to this product."
+msgstr ""
+
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
 msgctxt "directions"
 msgid "Suggestions:"
@@ -14988,9 +15290,84 @@ msgctxt "noresults"
 msgid "Suggestions:"
 msgstr "Prijedlozi:"
 
+#. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Sum up the reviews"
+msgstr ""
+
 #. A short title for the a message asking the AI to summarize a text.
 msgctxt "Title for the summarize message"
 msgid "Summarize"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize the Q&As"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the background and notable work of this person."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the key details of this event."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the questions and answers on this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize their background"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this book"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this book."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this discussion"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this discussion thread."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this video"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this video."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize what the reviews say."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -15245,6 +15622,11 @@ msgstr ""
 msgid "Syria"
 msgstr ""
 
+#. Text for a button that enables the theme to follow the operating system's color scheme preference.
+msgctxt "System theme button for theme selector"
+msgid "System"
+msgstr ""
+
 #. Abbreviation indicating this is the total score for a game
 msgctxt "Sports module"
 msgid "T"
@@ -15268,6 +15650,11 @@ msgctxt "language_name"
 msgid "Tahitian"
 msgstr "Tahitijski"
 
+#. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Tailor my resume"
+msgstr ""
+
 msgid "Taiwan"
 msgstr "Tajvan"
 
@@ -15290,6 +15677,12 @@ msgstr "Preuzmite kontrolu nad svojim ličnim podacima"
 msgctxt "homepage ATB modal"
 msgid "Take control of your personal data!"
 msgstr "Preuzmite kontrolu nad svojim ličnim podacima!"
+
+#. Description for the Feedback section of the Duck.ai settings page, asking the user to take an anonymous survey to let us know how we can make Duck.ai better.
+msgctxt "Feedback section description on the Duck.ai settings page"
+msgid ""
+"Take this anonymous survey to let us know how we can make Duck.ai better."
+msgstr ""
 
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
 msgctxt "Description for reasoning mode in Duck.ai"
@@ -15538,6 +15931,11 @@ msgstr ""
 #. https://duck.co/media/files/theme.png
 msgid "Theme"
 msgstr "Tema"
+
+#. Text for the theme selector label that allows users to switch between Light and dark theme.
+msgctxt "Label for the theme selector feature"
+msgid "Theme"
+msgstr ""
 
 #. http://i.imgur.com/LpFhb1e.png
 msgctxt "settings"
@@ -16197,6 +16595,16 @@ msgid ""
 "movie theatre?”"
 msgstr ""
 
+#. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Translate this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
+msgctxt "Page suggestion prompt"
+msgid "Translate this page into %s."
+msgstr ""
+
 #. Placeholder text for a region that will display translated text.
 msgctxt "translations_module"
 msgid "Translation"
@@ -16311,6 +16719,11 @@ msgstr ""
 #. Call-to-action button for the subscription promo in the SERP sidemenu.
 msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
+msgstr ""
+
+#. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
+msgctxt "settings"
+msgid "Try It Now"
 msgstr ""
 
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -16505,6 +16918,20 @@ msgstr "Probajte: %s"
 msgctxt "new user poll"
 msgid "Trying DuckDuckGo again"
 msgstr "Ponovo isprobavam DuckDuckGo"
+
+#. Message shown in a modal after supported third-party browser users disable AI features in Settings. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+#. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
 
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
 msgctxt "Assistant response placeholder"
@@ -17112,6 +17539,11 @@ msgstr "Urdu"
 msgid "Uruguay"
 msgstr "Urugvaj"
 
+#. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
+msgctxt "Navigation label on the Duck.ai settings page"
+msgid "Usage"
+msgstr ""
+
 #. A feedback suggestion
 msgctxt "Feedback prompt"
 msgid "Usage limit"
@@ -17463,6 +17895,11 @@ msgstr "Čekam lokaciju…"
 msgid "Wales"
 msgstr "Vels"
 
+#. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Walk me through the steps"
+msgstr ""
+
 #. Label for walking directions on a map.
 msgctxt "directions"
 msgid "Walking"
@@ -17555,6 +17992,16 @@ msgstr ""
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
+msgstr ""
+
+#. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
+msgctxt ""
+"Inline warning shown below the share-content toggle when the user selects "
+"Harmful or Illegal but has not enabled sharing"
+msgid ""
+"We can only fix what we can see. To report a harmful or illegal response, "
+"please share this conversation with DuckDuckGo so we can investigate and "
+"address the issue."
 msgstr ""
 
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -17993,6 +18440,87 @@ msgid ""
 "experience."
 msgstr ""
 
+#. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the counterarguments?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the hours & location?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key contributions of this paper?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key contributions?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key details?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key points covered in this video?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key points?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key takeaways from this article?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key takeaways?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key things I will learn from this course?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main counterarguments or criticisms of this?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main questions this page answers?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the must-try dishes here?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"What are the opening hours, location, and contact details for this place?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the pros and cons of this product?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the pros and cons?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
 msgctxt "feedback form"
 msgid "What bothered you most?"
@@ -18076,6 +18604,11 @@ msgctxt "Full sentence for defining a term"
 msgid "What does atria mean in the context of a medical article?"
 msgstr ""
 
+#. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What does this answer?"
+msgstr ""
+
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
@@ -18085,6 +18618,11 @@ msgstr ""
 msgctxt "cloudsave"
 msgid "What information gets saved?"
 msgstr "Koje se informacije čuvaju?"
+
+#. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What interview questions might come up for this role?"
+msgstr ""
 
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
@@ -18098,6 +18636,11 @@ msgstr ""
 #. Text for a prompt suggestion for looking up the capital city of Albania.
 msgctxt "Full sentence for looking up basic facts"
 msgid "What is the capital city of Albania?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What is the overall verdict and rating for this?"
 msgstr ""
 
 #. Link to a page with additional information.
@@ -18118,6 +18661,11 @@ msgctxt "maps_places"
 msgid "What people say:"
 msgstr "Šta kažu ljudi:"
 
+#. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What should I order?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
 msgctxt "feedback form"
 msgid "What stood out?"
@@ -18126,6 +18674,16 @@ msgstr ""
 #. Question on a feedback form for a negative feedback response.
 msgctxt "feedback form"
 msgid "What was wrong with the response? (optional)"
+msgstr ""
+
+#. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I learn?"
+msgstr ""
+
+#. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I need?"
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -18140,6 +18698,11 @@ msgstr ""
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
 msgctxt "SERP footer content"
 msgid "What's New"
+msgstr ""
+
+#. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What's the verdict?"
 msgstr ""
 
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -18183,6 +18746,11 @@ msgctxt "Feedback prompt"
 msgid "Which features are missing? (Optional)"
 msgstr ""
 
+#. An invitation for users to leave feedback
+msgctxt "Feedback prompt"
+msgid "Which features are missing? (optional)"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
 msgid "White"
 msgstr "Bijela"
@@ -18195,6 +18763,16 @@ msgstr "Bijela"
 #. Link to an about us page.
 msgid "Who We Are"
 msgstr "Ko smo"
+
+#. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Who are the main cast and crew, and what else are they known for?"
+msgstr ""
+
+#. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Who is this person?"
+msgstr ""
 
 #. Header above a collection of privacy-related links.
 msgid "Why Privacy"

--- a/locales/ca_ES/LC_MESSAGES/duckduckgo.po
+++ b/locales/ca_ES/LC_MESSAGES/duckduckgo.po
@@ -1170,6 +1170,11 @@ msgctxt "feedback form"
 msgid "Address is incorrect"
 msgstr "L'adreça és incorrecta"
 
+#. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Adjust the servings"
+msgstr ""
+
 #. as in multiple advertisements
 msgid "Ads"
 msgstr "Anuncis"
@@ -1343,6 +1348,13 @@ msgstr ""
 #. Heading shown on the empty chat screen. The text between the two %s markers is displayed inside a clickable privacy button. First %s renders a shield icon, second %s is an invisible end marker. Keep the word 'private' between both %s markers.
 msgctxt "Empty state heading in Duck.ai chat mode"
 msgid "All chats are %sprivate%s"
+msgstr ""
+
+#. Paragraph in the Privacy & Terms section of the About & Legal page in Duck.ai settings, summarizing how chats are anonymized and are not stored or used to train chat models.
+msgctxt "Privacy & Terms section description on the Duck.ai settings page"
+msgid ""
+"All chats are anonymized by DuckDuckGo, and your conversations are not used "
+"to train chat models by DuckDuckGo or the model providers"
 msgstr ""
 
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1558,6 +1570,12 @@ msgstr ""
 msgctxt "precise_user_location"
 msgid "Anonymous location enabled"
 msgstr "S'ha activat la ubicació anònima"
+
+msgctxt "settings"
+msgid ""
+"Anonymously generates answers for search queries based on web content. "
+"Choose how often you want it to appear, or disable it completely."
+msgstr ""
 
 #. Instant Answer tab name
 msgid "Answer"
@@ -1782,6 +1800,11 @@ msgstr ""
 
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse
 msgid "Ask a follow-up with Duck.ai"
+msgstr ""
+
+#. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
+msgctxt "Page suggestion chip label"
+msgid "Ask about this page"
 msgstr ""
 
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2106,6 +2129,11 @@ msgstr ""
 msgid "Barcode"
 msgstr "Codi de barres"
 
+#. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Based on this page, is this course worth taking?"
+msgstr ""
+
 msgctxt "settings"
 msgid "Basic"
 msgstr "Bàsic"
@@ -2137,6 +2165,13 @@ msgstr ""
 #. Placeholder text displayed while the assistant waits for the user to choose an action.
 msgctxt "Assistant response placeholder"
 msgid "Before continuing..."
+msgstr ""
+
+#. Explains that before storing the report, DuckDuckGo will anonymize the conversation by removing PII like names, email addresses, and identifying metadata.
+msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
+msgid ""
+"Before storing this report, DuckDuckGo will anonymize your conversation by "
+"removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
 #. Label that's displayed next to a past start date below a web search result.
@@ -2395,6 +2430,11 @@ msgstr "Brasil"
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Break Points Won"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Break this down into clear, numbered steps."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -2768,6 +2808,11 @@ msgstr "Treballa amb nosaltres"
 #. Text of a button that performs a search for the cast of a particular movie or tv show
 msgctxt "Movie/TV Show Title instant answer"
 msgid "Cast"
+msgstr ""
+
+#. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Cast & Crew"
 msgstr ""
 
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -4138,6 +4183,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Create a shopping list with quantities from this recipe."
+msgstr ""
+
 #. Placeholder text displayed in the input field when starting a new image generation session.
 msgctxt "Placeholder text for the image generation input field"
 msgid "Create an image of a cute duck..."
@@ -4664,6 +4714,10 @@ msgstr ""
 msgid "Dictation limit reached"
 msgstr ""
 
+#. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
+msgid "Dictation temporarily unavailable"
+msgstr ""
+
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
@@ -4909,6 +4963,20 @@ msgctxt "precise_user_location"
 msgid "Done"
 msgstr "Fet"
 
+#. Message shown in a modal after DuckDuckGo browser users disable AI features in Settings. The first two placeholders bold noai.duckduckgo.com. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
+"filtered out. %sLearn More%s"
+msgstr ""
+
+#. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
+"and AI images filtered out. %sLearn more%s"
+msgstr ""
+
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Double Faults"
@@ -4999,6 +5067,16 @@ msgctxt "Full sentence for writing an email"
 msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
+msgstr ""
+
+#. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Draft a cover letter"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Draft a cover letter for this job."
 msgstr ""
 
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -5138,6 +5216,14 @@ msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
 msgstr ""
 
+#. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
+msgctxt "About section description on the Duck.ai settings page"
+msgid ""
+"Duck.ai is created by DuckDuckGo. We're an independent online protection "
+"company for anyone who wants to take back control of their personal "
+"information."
+msgstr ""
+
 #. Title shown when an update is required before proceeding.
 msgctxt "duckai_migration"
 msgid "Duck.ai is moving domains"
@@ -5171,6 +5257,12 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Duck.ai lets you chat privately with popular AI models. Disabling it hides "
+"Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
 
 msgctxt "settings"
@@ -5962,6 +6054,16 @@ msgstr ""
 msgid "Eritrea"
 msgstr ""
 
+#. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Estimate the nutrition"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Estimate the nutritional information for this recipe."
+msgstr ""
+
 msgid "Estonia"
 msgstr "Estònia"
 
@@ -6006,10 +6108,50 @@ msgctxt "merchant promotion product ad extension"
 msgid "Expires in 1 day"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain the accepted answer in simple terms."
+msgstr ""
+
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
+msgstr ""
+
+#. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain the top answer"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this in simple, plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this paper"
+msgstr ""
+
+#. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this repo"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this research paper in plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this simply"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain what this repository does and how to use it."
 msgstr ""
 
 #. Label to show if song lyrics contain explicit content
@@ -6240,6 +6382,11 @@ msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
 msgstr ""
 
+msgctxt "settings"
+msgid ""
+"Filters out known AI spam sites from image search results. %sLearn More%s"
+msgstr ""
+
 #. Label for the final score of a sporting event.
 msgid "Final"
 msgstr "Final"
@@ -6279,6 +6426,11 @@ msgstr ""
 #. Short description shown below the 'Web Search' label in the Tools dropdown.
 msgctxt "Subtitle for the Web Search tool entry in the Tools dropdown menu"
 msgid "Find current information"
+msgstr ""
+
+#. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Find me alternatives"
 msgstr ""
 
 #. Button that searches for results closer to the user's current location.
@@ -6669,6 +6821,11 @@ msgstr ""
 msgid "Generate More"
 msgstr ""
 
+#. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Generate a shopping list"
+msgstr ""
+
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
 msgid "Generate a short answer from the web"
 msgstr ""
@@ -6905,6 +7062,11 @@ msgstr ""
 #. Text for a button inviting users to give it a try for the Duck.ai product. On click, they're taken to the Duck.ai page.
 msgctxt "Onboarding welcome screen button text"
 msgid "Give it a Try"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Give me a quick background on this person."
 msgstr ""
 
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -7268,6 +7430,16 @@ msgstr "Ajudeu a difondre el DuckDuckGo!"
 #. Link to a page with information about sharing DuckDuckGo with friends.
 msgid "Help Spread Privacy"
 msgstr "Ajudeu a difondre la privadesa"
+
+#. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Help me prep for the interview"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Help me tailor my resume for this job."
+msgstr ""
 
 #. Title of a SERP popup that invites users to take a survey (desktop only)
 msgctxt "User survey popup"
@@ -7693,6 +7865,13 @@ msgstr ""
 #. Text displayed on the button on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
 msgctxt "Onboarding terms screen button text"
 msgid "I Agree"
+msgstr ""
+
+#. Text for the button that takes the user to the external DuckDuckGo login subscription page.
+msgctxt ""
+"Text for the I already have a subscription button in the Duck.ai settings "
+"page"
+msgid "I Already Have a Subscription"
 msgstr ""
 
 #. Text for the button that takes the user to the login subscription page.
@@ -8163,6 +8342,11 @@ msgctxt "Sidemenu browser promo"
 msgid "Install Mac Browser"
 msgstr ""
 
+#. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
+msgctxt "settings"
+msgid "Install Now"
+msgstr ""
+
 #. Text of a button to install the DuckDuckGo app
 msgctxt "Serp footer content"
 msgid "Install Our App"
@@ -8242,10 +8426,37 @@ msgctxt "cloudsave"
 msgid "Is deleted data really deleted?"
 msgstr "S'eliminen realment les dades eliminades?"
 
+#. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is it worth taking?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this place any good?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"Is this place any good? Summarize its reputation based on reviews and "
+"ratings."
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "Is this video helpful?"
 msgstr "Us és útil aquest vídeo?"
+
+#. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this worth watching?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Is this worth watching? Give me a spoiler-free take."
+msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
 msgctxt "Weather IA"
@@ -8752,6 +8963,11 @@ msgstr "Font de l'enllaç:"
 msgid "Links:"
 msgstr "Enllaços:"
 
+#. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "List the tools, materials, or prerequisites I need for this."
+msgstr ""
+
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
 msgid "Listen"
 msgstr "Escolta"
@@ -9085,6 +9301,11 @@ msgstr ""
 #. Label for linke navigating to site exclusion feature on Settings page
 msgctxt "Exclusion message manage sites button"
 msgid "Manage blocked sites"
+msgstr ""
+
+#. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
+msgctxt "setting"
+msgid "Manage in Browser Settings"
 msgstr ""
 
 #. Link to the site exclusion settings page
@@ -11399,6 +11620,11 @@ msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
+msgid "Please describe why the chat response is harmful or illegal. (optional)"
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
+msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
 msgstr ""
 
@@ -11417,6 +11643,13 @@ msgctxt "Modal disclaimer text"
 msgid ""
 "Please note: starting a new chat with any model will delete your current "
 "chat session."
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
+msgctxt "Feedback prompt"
+msgid ""
+"Please paste your prompt and the problematic output (with any personal "
+"information removed) and describe why the content is harmful or illegal."
 msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -11801,6 +12034,11 @@ msgctxt "settings"
 msgid "Privacy"
 msgstr "Privadesa"
 
+#. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
+msgctxt "Section heading on the Duck.ai settings page"
+msgid "Privacy & Terms"
+msgstr ""
+
 msgid "Privacy Blog"
 msgstr "Blog de privadesa"
 
@@ -11854,6 +12092,11 @@ msgstr ""
 
 #. Text used in other strings to link to the Privacy Policy and Terms of Service content.
 msgctxt "Copy used to compose link in sentences"
+msgid "Privacy Policy and Terms of Service"
+msgstr ""
+
+#. Text for a button that links to the terms of use and privacy policy page.
+msgctxt "Secondary button text in active privacy modal"
 msgid "Privacy Policy and Terms of Service"
 msgstr ""
 
@@ -12264,6 +12507,26 @@ msgctxt "Brief for recommending a book"
 msgid "Recommend a book"
 msgstr ""
 
+#. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar books"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar books."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar movies or shows."
+msgstr ""
+
+#. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar titles"
+msgstr ""
+
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
 msgid "Recording failed. Please try again."
 msgstr ""
@@ -12587,6 +12850,14 @@ msgstr ""
 msgid "Republic of Moldova"
 msgstr ""
 
+#. Note indicating that sharing the conversation is mandatory when reporting harmful or illegal content. Rendered alongside the standard share label (DUCKCHAT_RESPONSE_FEEDBACK_SHARE_PROMPT_RESPONSE_LABEL), not replacing it.
+msgctxt ""
+"Note shown under the share-content switch label on the Duck.ai response "
+"feedback form when the user has selected Harmful or Illegal as the feedback "
+"reason"
+msgid "Required for harmful or illegal reports"
+msgstr ""
+
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
 msgctxt "Description for extended reasoning mode in Duck.ai"
 msgid "Researches before responding"
@@ -12773,6 +13044,11 @@ msgstr "Valoracions"
 msgctxt "maps_places"
 msgid "Reviews"
 msgstr "Valoracions"
+
+#. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Rewrite this recipe scaled for a different number of servings."
+msgstr ""
 
 msgid "Romania"
 msgstr "Romania"
@@ -13833,6 +14109,11 @@ msgctxt "Setup button for native sync flow"
 msgid "Set Up Now"
 msgstr ""
 
+#. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
+msgctxt "Encrypted storage setup button shown in native browsers"
+msgid "Set Up Sync & Backup"
+msgstr ""
+
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
 msgctxt "Title for the Sync & Backup intro screen"
 msgid "Set Up Sync & Backup"
@@ -13978,6 +14259,12 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
+msgctxt ""
+"Label beside the share-content switch on the Duck.ai response feedback form"
+msgid "Share this conversation with DuckDuckGo"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -15007,6 +15294,21 @@ msgctxt "Brief for suggesting a blog post title"
 msgid "Suggest a title for a blog post"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest related articles or topics worth exploring next."
+msgstr ""
+
+#. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Suggest related articles to explore"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest some alternatives to this product."
+msgstr ""
+
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
 msgctxt "directions"
 msgid "Suggestions:"
@@ -15016,9 +15318,84 @@ msgctxt "noresults"
 msgid "Suggestions:"
 msgstr "Suggeriments:"
 
+#. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Sum up the reviews"
+msgstr ""
+
 #. A short title for the a message asking the AI to summarize a text.
 msgctxt "Title for the summarize message"
 msgid "Summarize"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize the Q&As"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the background and notable work of this person."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the key details of this event."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the questions and answers on this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize their background"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this book"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this book."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this discussion"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this discussion thread."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this video"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this video."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize what the reviews say."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -15273,6 +15650,11 @@ msgstr ""
 msgid "Syria"
 msgstr ""
 
+#. Text for a button that enables the theme to follow the operating system's color scheme preference.
+msgctxt "System theme button for theme selector"
+msgid "System"
+msgstr ""
+
 #. Abbreviation indicating this is the total score for a game
 msgctxt "Sports module"
 msgid "T"
@@ -15296,6 +15678,11 @@ msgctxt "language_name"
 msgid "Tahitian"
 msgstr "Tahitià"
 
+#. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Tailor my resume"
+msgstr ""
+
 msgid "Taiwan"
 msgstr "Taiwan"
 
@@ -15318,6 +15705,12 @@ msgstr "Preneu el control de les vostres dades personals"
 msgctxt "homepage ATB modal"
 msgid "Take control of your personal data!"
 msgstr "Preneu el control de les vostres dades personals!"
+
+#. Description for the Feedback section of the Duck.ai settings page, asking the user to take an anonymous survey to let us know how we can make Duck.ai better.
+msgctxt "Feedback section description on the Duck.ai settings page"
+msgid ""
+"Take this anonymous survey to let us know how we can make Duck.ai better."
+msgstr ""
 
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
 msgctxt "Description for reasoning mode in Duck.ai"
@@ -15566,6 +15959,11 @@ msgstr ""
 #. https://duck.co/media/files/theme.png
 msgid "Theme"
 msgstr "Tema"
+
+#. Text for the theme selector label that allows users to switch between Light and dark theme.
+msgctxt "Label for the theme selector feature"
+msgid "Theme"
+msgstr ""
 
 #. http://i.imgur.com/LpFhb1e.png
 msgctxt "settings"
@@ -16226,6 +16624,16 @@ msgid ""
 "movie theatre?”"
 msgstr ""
 
+#. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Translate this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
+msgctxt "Page suggestion prompt"
+msgid "Translate this page into %s."
+msgstr ""
+
 #. Placeholder text for a region that will display translated text.
 msgctxt "translations_module"
 msgid "Translation"
@@ -16340,6 +16748,11 @@ msgstr ""
 #. Call-to-action button for the subscription promo in the SERP sidemenu.
 msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
+msgstr ""
+
+#. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
+msgctxt "settings"
+msgid "Try It Now"
 msgstr ""
 
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -16535,6 +16948,20 @@ msgstr "Proveu amb: %s"
 msgctxt "new user poll"
 msgid "Trying DuckDuckGo again"
 msgstr "Al DuckDuckGo de nou"
+
+#. Message shown in a modal after supported third-party browser users disable AI features in Settings. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+#. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
 
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
 msgctxt "Assistant response placeholder"
@@ -17141,6 +17568,11 @@ msgstr "Urdú"
 msgid "Uruguay"
 msgstr "Uruguai"
 
+#. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
+msgctxt "Navigation label on the Duck.ai settings page"
+msgid "Usage"
+msgstr ""
+
 #. A feedback suggestion
 msgctxt "Feedback prompt"
 msgid "Usage limit"
@@ -17492,6 +17924,11 @@ msgstr "S'està esperant la ubicació..."
 msgid "Wales"
 msgstr "Gal·les"
 
+#. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Walk me through the steps"
+msgstr ""
+
 #. Label for walking directions on a map.
 msgctxt "directions"
 msgid "Walking"
@@ -17582,6 +18019,16 @@ msgstr ""
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
+msgstr ""
+
+#. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
+msgctxt ""
+"Inline warning shown below the share-content toggle when the user selects "
+"Harmful or Illegal but has not enabled sharing"
+msgid ""
+"We can only fix what we can see. To report a harmful or illegal response, "
+"please share this conversation with DuckDuckGo so we can investigate and "
+"address the issue."
 msgstr ""
 
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -18021,6 +18468,87 @@ msgid ""
 "experience."
 msgstr ""
 
+#. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the counterarguments?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the hours & location?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key contributions of this paper?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key contributions?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key details?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key points covered in this video?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key points?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key takeaways from this article?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key takeaways?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key things I will learn from this course?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main counterarguments or criticisms of this?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main questions this page answers?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the must-try dishes here?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"What are the opening hours, location, and contact details for this place?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the pros and cons of this product?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the pros and cons?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
 msgctxt "feedback form"
 msgid "What bothered you most?"
@@ -18104,6 +18632,11 @@ msgctxt "Full sentence for defining a term"
 msgid "What does atria mean in the context of a medical article?"
 msgstr ""
 
+#. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What does this answer?"
+msgstr ""
+
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
@@ -18113,6 +18646,11 @@ msgstr ""
 msgctxt "cloudsave"
 msgid "What information gets saved?"
 msgstr "Quina informació es desa?"
+
+#. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What interview questions might come up for this role?"
+msgstr ""
 
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
@@ -18126,6 +18664,11 @@ msgstr ""
 #. Text for a prompt suggestion for looking up the capital city of Albania.
 msgctxt "Full sentence for looking up basic facts"
 msgid "What is the capital city of Albania?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What is the overall verdict and rating for this?"
 msgstr ""
 
 #. Link to a page with additional information.
@@ -18146,6 +18689,11 @@ msgctxt "maps_places"
 msgid "What people say:"
 msgstr "El que diu la gent:"
 
+#. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What should I order?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
 msgctxt "feedback form"
 msgid "What stood out?"
@@ -18154,6 +18702,16 @@ msgstr ""
 #. Question on a feedback form for a negative feedback response.
 msgctxt "feedback form"
 msgid "What was wrong with the response? (optional)"
+msgstr ""
+
+#. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I learn?"
+msgstr ""
+
+#. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I need?"
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -18168,6 +18726,11 @@ msgstr ""
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
 msgctxt "SERP footer content"
 msgid "What's New"
+msgstr ""
+
+#. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What's the verdict?"
 msgstr ""
 
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -18209,6 +18772,11 @@ msgctxt "Feedback prompt"
 msgid "Which features are missing? (Optional)"
 msgstr ""
 
+#. An invitation for users to leave feedback
+msgctxt "Feedback prompt"
+msgid "Which features are missing? (optional)"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
 msgid "White"
 msgstr "Blanc"
@@ -18221,6 +18789,16 @@ msgstr "Blanc"
 #. Link to an about us page.
 msgid "Who We Are"
 msgstr "Qui som"
+
+#. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Who are the main cast and crew, and what else are they known for?"
+msgstr ""
+
+#. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Who is this person?"
+msgstr ""
 
 #. Header above a collection of privacy-related links.
 msgid "Why Privacy"

--- a/locales/cs_CZ/LC_MESSAGES/duckduckgo.po
+++ b/locales/cs_CZ/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: cs_CZ\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -98,7 +98,8 @@ msgstr "Počet pokusů: %1$s"
 # smartling.placeholder_format=C
 #. A summary description of how many tracking attempts where blocked, when there was more than 1. Eg: '1,028 attempts blocked by DuckDuckGo in the last 24 hours'
 msgid "%s attempts blocked by DuckDuckGo in the last 24 hours"
-msgstr "Počet pokusů zablokovaných službou DuckDuckGo za posledních 24 hodin: %1$s"
+msgstr ""
+"Počet pokusů zablokovaných službou DuckDuckGo za posledních 24 hodin: %1$s"
 
 # smartling.placeholder_format=C
 #. A label that indicates a specific search result has been blocked by the safe search filter. The placeholder value is the name of the search result that was blocked.
@@ -481,7 +482,8 @@ msgstr ""
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "%sLearn more%s about how chats are stored privately on your device."
-msgstr "%1$sPřečti si víc%2$s o tom, jak se chaty soukromě ukládají na tvé zařízení."
+msgstr ""
+"%1$sPřečti si víc%2$s o tom, jak se chaty soukromě ukládají na tvé zařízení."
 
 # smartling.placeholder_format=C
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
@@ -493,7 +495,8 @@ msgstr "%1$sPodrž%2$s ikonu aplikace DuckDuckGo na domovské obrazovce"
 #. A message displayed when there is an error loading content or no results on requery
 msgctxt "Error or no results message"
 msgid "%sOops!%s%sSomething went wrong. Please %srefresh%s and try again."
-msgstr "%1$sJejda!%2$s%3$sNěco se pokazilo. %4$sObnov stránku%5$s a zkus to znovu."
+msgstr ""
+"%1$sJejda!%2$s%3$sNěco se pokazilo. %4$sObnov stránku%5$s a zkus to znovu."
 
 # smartling.placeholder_format=C
 #. Tagline in a popover encouraging the user to download the DuckDuckGo browser
@@ -810,7 +813,8 @@ msgstr "Byl vyčerpán 6hodinový limit využití."
 #. Displayed when the user has reached a fixed 6-hour Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "6-hour usage limit reached. You can continue this chat after %s."
-msgstr "Byl vyčerpán 6hodinový limit využití. V tomto chatu můžeš pokračovat za %1$s."
+msgstr ""
+"Byl vyčerpán 6hodinový limit využití. V tomto chatu můžeš pokračovat za %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable 6-hour Duck.ai usage limit and can opt in to continue using the daily limit.
@@ -881,7 +885,8 @@ msgstr ""
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of AI Chat is available! Please refresh this page to continue."
-msgstr "Je dostupná nová verze AI Chatu! Pokud chceš pokračovat, obnov stránku."
+msgstr ""
+"Je dostupná nová verze AI Chatu! Pokud chceš pokračovat, obnov stránku."
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of Duck.ai is available and they need to refresh the page.
@@ -1432,6 +1437,12 @@ msgid "Address is incorrect"
 msgstr "Adresa je nesprávná"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Adjust the servings"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. as in multiple advertisements
 msgid "Ads"
 msgstr "Reklamy"
@@ -1643,6 +1654,14 @@ msgid "All chats are %sprivate%s"
 msgstr "Všechny chaty jsou %1$ssoukromé%2$s"
 
 # smartling.placeholder_format=C
+#. Paragraph in the Privacy & Terms section of the About & Legal page in Duck.ai settings, summarizing how chats are anonymized and are not stored or used to train chat models.
+msgctxt "Privacy & Terms section description on the Duck.ai settings page"
+msgid ""
+"All chats are anonymized by DuckDuckGo, and your conversations are not used "
+"to train chat models by DuckDuckGo or the model providers"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
 msgctxt "Privacy modal header in Duck.ai chat"
 msgid "All chats are private"
@@ -1733,7 +1752,8 @@ msgstr "Povolit reklamy, které respektují soukromí"
 # smartling.placeholder_format=C
 #. Title in a dialog informing the user how to disable their ad blocker for DuckDuckGo
 msgid "Allow privacy-respecting ads on DuckDuckGo Private Search"
-msgstr "Povolit na DuckDuckGo Private Search reklamy, které respektují soukromí"
+msgstr ""
+"Povolit na DuckDuckGo Private Search reklamy, které respektují soukromí"
 
 # smartling.placeholder_format=C
 #. Description explaining privacy implications of enabling web search on encrypted models. The first two placeholders are the full model name (e.g. 'gpt-oss 120B'). The third and fourth placeholders wrap a clickable link reading 'zero provider visibility' that opens the privacy modal, please keep those around the link text in your translation. An example full sentence would be: Allows gpt-oss 120B to search the web to improve responses to relevant prompts. Only sends AI-generated queries to a search engine with limited data retention. Prompts and responses with gpt-oss 120B still have zero provider visibility.
@@ -1913,6 +1933,13 @@ msgid "Anonymous location enabled"
 msgstr "Povolena anonymní poloha"
 
 # smartling.placeholder_format=C
+msgctxt "settings"
+msgid ""
+"Anonymously generates answers for search queries based on web content. "
+"Choose how often you want it to appear, or disable it completely."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Instant Answer tab name
 msgid "Answer"
 msgstr "Odpověď"
@@ -2057,7 +2084,8 @@ msgstr "Jsi tam ještě?"
 msgctxt "Body text for clear all chats confirmation modal"
 msgid ""
 "Are you sure you want to clear all of your chats? This cannot be undone."
-msgstr "Opravdu chceš vymazat všechny své chaty? Tenhle krok se nedá vrátit zpět."
+msgstr ""
+"Opravdu chceš vymazat všechny své chaty? Tenhle krok se nedá vrátit zpět."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that asks the user if they want to clear the conversation.
@@ -2189,6 +2217,12 @@ msgstr "Zeptej se na navazující otázku"
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse
 msgid "Ask a follow-up with Duck.ai"
 msgstr "Zeptej se Duck.ai na něco dalšího"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
+msgctxt "Page suggestion chip label"
+msgid "Ask about this page"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2609,6 +2643,12 @@ msgid "Barcode"
 msgstr "Čárový kód"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Based on this page, is this course worth taking?"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Basic"
 msgstr "Základní"
@@ -2647,6 +2687,14 @@ msgstr "Pálkař"
 msgctxt "Assistant response placeholder"
 msgid "Before continuing..."
 msgstr "Než budeš pokračovat..."
+
+# smartling.placeholder_format=C
+#. Explains that before storing the report, DuckDuckGo will anonymize the conversation by removing PII like names, email addresses, and identifying metadata.
+msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
+msgid ""
+"Before storing this report, DuckDuckGo will anonymize your conversation by "
+"removing PII like names, email addresses, and identifying metadata."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -2965,6 +3013,12 @@ msgid "Break Points Won"
 msgstr "Vyhrané breakbally"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Break this down into clear, numbered steps."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
 msgctxt "Weather IA"
 msgid "Breezy"
@@ -3128,7 +3182,8 @@ msgstr "Kliknutím na „%1$s“ odsouhlasíš naše %2$s."
 msgctxt ""
 "Copy stating agreement to Duck.ai Privacy Policy and Terms of Service."
 msgid "By clicking “%s,” you accept Duck.ai’s %s and %s."
-msgstr "Kliknutím na „%1$s“ vyjadřuješ souhlas s podmínkami Duck.ai, viz %2$s a %3$s."
+msgstr ""
+"Kliknutím na „%1$s“ vyjadřuješ souhlas s podmínkami Duck.ai, viz %2$s a %3$s."
 
 # smartling.placeholder_format=C
 #. Text stating agreement to Duck.ai Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'By clicking “Agree and Continue,” you accept Duck.ai’s Privacy Policy and Terms of Service.'
@@ -3207,7 +3262,8 @@ msgstr "Kamerun"
 #. Text for a prompt suggestion for creating a few simple recipes using chicken, broccoli, and rice.
 msgctxt "Full sentence for crafting a recipe"
 msgid "Can you create a few simple recipes using chicken, broccoli, and rice?"
-msgstr "Můžeš vytvořit několik jednoduchých receptů z kuřete, brokolice a rýže?"
+msgstr ""
+"Můžeš vytvořit několik jednoduchých receptů z kuřete, brokolice a rýže?"
 
 # smartling.placeholder_format=C
 msgid "Canada"
@@ -3416,6 +3472,12 @@ msgstr "Pracovní příležitosti"
 msgctxt "Movie/TV Show Title instant answer"
 msgid "Cast"
 msgstr "Obsazení"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Cast & Crew"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -4257,13 +4319,15 @@ msgstr "Klikni %1$ssem%2$s a stáhni si rozšíření DuckDuckGo"
 # smartling.placeholder_format=C
 #. Link to download the DuckDuckGo browser extension.
 msgid "Click %sOpen%s to download and open the DuckDuckGo Safari extension"
-msgstr "Klikni na %1$sOtevřít%2$s a stáhni si a otevři rozšíření DuckDuckGo Safari"
+msgstr ""
+"Klikni na %1$sOtevřít%2$s a stáhni si a otevři rozšíření DuckDuckGo Safari"
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click %sPrivacy and Services%s in the left sidebar."
-msgstr "V levém postranním panelu klepni na tlačítko %1$sSoukromí a služby%2$s."
+msgstr ""
+"V levém postranním panelu klepni na tlačítko %1$sSoukromí a služby%2$s."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -5131,6 +5195,12 @@ msgid "Create Image"
 msgstr "Vytvoř obrázek"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Create a shopping list with quantities from this recipe."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text displayed in the input field when starting a new image generation session.
 msgctxt "Placeholder text for the image generation input field"
 msgid "Create an image of a cute duck..."
@@ -5385,7 +5455,8 @@ msgstr "Byl vyčerpán denní limit"
 #. Displayed when the user has reached a fixed daily Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Daily usage limit reached. You can continue this chat after %s."
-msgstr "Byl vyčerpán denní limit využití. V tomto chatu můžeš pokračovat za %1$s."
+msgstr ""
+"Byl vyčerpán denní limit využití. V tomto chatu můžeš pokračovat za %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable daily Duck.ai usage limit and can opt in to continue using the weekly limit.
@@ -5771,6 +5842,11 @@ msgid "Dictation limit reached"
 msgstr "Byl dosažen limit pro diktát"
 
 # smartling.placeholder_format=C
+#. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
+msgid "Dictation temporarily unavailable"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
@@ -6045,7 +6121,8 @@ msgstr "Nevidíš v seznamu DuckDuckGo?"
 #. Link to download a file again if the user can't find it on their computer.
 msgctxt "install-extension"
 msgid "Don't see it? %s%s%sClick here to re-download%s"
-msgstr "Nedaří se ti soubor najít? %1$s%2$s%3$sKliknutím sem zopakuj stahování%4$s"
+msgstr ""
+"Nedaří se ti soubor najít? %1$s%2$s%3$sKliknutím sem zopakuj stahování%4$s"
 
 #  IE < 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -6069,6 +6146,22 @@ msgstr "Hotovo"
 msgctxt "precise_user_location"
 msgid "Done"
 msgstr "Hotovo"
+
+# smartling.placeholder_format=C
+#. Message shown in a modal after DuckDuckGo browser users disable AI features in Settings. The first two placeholders bold noai.duckduckgo.com. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
+"filtered out. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
+"and AI images filtered out. %sLearn more%s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6183,6 +6276,18 @@ msgid ""
 msgstr ""
 "Navrhni stručný e-mail opraváři lednic, který bude obsahovat poptávku opravy "
 "a všechny nezbytné informace."
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Draft a cover letter"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Draft a cover letter for this job."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -6357,7 +6462,17 @@ msgstr ""
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
-msgstr "Duck.ai je nejlepší v našem soukromém a bezplatném prohlížeči DuckDuckGo!"
+msgstr ""
+"Duck.ai je nejlepší v našem soukromém a bezplatném prohlížeči DuckDuckGo!"
+
+# smartling.placeholder_format=C
+#. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
+msgctxt "About section description on the Duck.ai settings page"
+msgid ""
+"Duck.ai is created by DuckDuckGo. We're an independent online protection "
+"company for anyone who wants to take back control of their personal "
+"information."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
@@ -6407,6 +6522,13 @@ msgstr "Funkce Duck.ai je dočasně nedostupná. Zkus to znovu později."
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
+"Duck.ai lets you chat privately with popular AI models. Disabling it hides "
+"Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
+msgstr ""
+
+# smartling.placeholder_format=C
+msgctxt "settings"
+msgid ""
 "Duck.ai lets you have anonymous conversations with 3rd-party AI chat models, "
 "including models from OpenAI, Anthropic, and others. Turning this setting "
 "off will hide Duck.ai buttons and links on DuckDuckGo Search. However, you "
@@ -6423,7 +6545,8 @@ msgstr ""
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
 msgctxt "Disclaimer text at the bottom of the feedback form."
 msgid "Duck.ai may display inaccurate or offensive information."
-msgstr "Duck.ai může zobrazovat může zobrazovat nepřesné nebo pohoršující informace."
+msgstr ""
+"Duck.ai může zobrazovat může zobrazovat nepřesné nebo pohoršující informace."
 
 # smartling.placeholder_format=C
 #. Error modal body line 2.
@@ -6466,7 +6589,8 @@ msgstr "Upgrade Duck.ai je hotový!"
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
-msgstr "Duck.ai funguje nejlíp v naší soukromé a bezplatné aplikaci DuckDuckGo!"
+msgstr ""
+"Duck.ai funguje nejlíp v naší soukromé a bezplatné aplikaci DuckDuckGo!"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -6643,7 +6767,8 @@ msgctxt "Error message for VQD error"
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. Please refresh the page and "
 "try again."
-msgstr "DuckDuckGo AI Chat je dočasně nedostupný. Obnov stránku a zkus to znovu."
+msgstr ""
+"DuckDuckGo AI Chat je dočasně nedostupný. Obnov stránku a zkus to znovu."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -7391,11 +7516,24 @@ msgstr "Rovníková Guinea"
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Erase your browsing data in a flash with our %sFire Button%s"
-msgstr "Pomocí tlačítka %1$sFire Button%2$s můžeš bleskově vymazat data o prohlížení."
+msgstr ""
+"Pomocí tlačítka %1$sFire Button%2$s můžeš bleskově vymazat data o prohlížení."
 
 # smartling.placeholder_format=C
 msgid "Eritrea"
 msgstr "Eritrea"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Estimate the nutrition"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Estimate the nutritional information for this recipe."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Estonia"
@@ -7452,6 +7590,12 @@ msgid "Expires in 1 day"
 msgstr "Platnost skončí za 1 den"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain the accepted answer in simple terms."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
@@ -7459,6 +7603,48 @@ msgid ""
 msgstr ""
 "Vysvětli mi základní pojmy ohledně černých děr, jako bys to vysvětloval "
 "středoškolákovi."
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain the top answer"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this in simple, plain language."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this paper"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this repo"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this research paper in plain language."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this simply"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain what this repository does and how to use it."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label to show if song lyrics contain explicit content
@@ -7654,7 +7840,8 @@ msgstr ""
 msgid ""
 "Feel free to adjust the settings below. Then, just copy and paste the code "
 "into your website."
-msgstr "Nastavení můžeš změnit níže. Pak jednoduše zkopíruj kód do svojí stránky."
+msgstr ""
+"Nastavení můžeš změnit níže. Pak jednoduše zkopíruj kód do svojí stránky."
 
 # smartling.placeholder_format=C
 msgid "Fiji"
@@ -7731,7 +7918,8 @@ msgstr "Filtry nefungují"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Filters out AI-generated images from image search results"
-msgstr "Odstraní obrázky vytvořené umělou inteligencí z výsledků vyhledávání obrázků"
+msgstr ""
+"Odstraní obrázky vytvořené umělou inteligencí z výsledků vyhledávání obrázků"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -7740,6 +7928,12 @@ msgid ""
 msgstr ""
 "Odstraní obrázky vygenerované umělou inteligencí z výsledků vyhledávání "
 "obrázků. %1$sDalší informace%2$s"
+
+# smartling.placeholder_format=C
+msgctxt "settings"
+msgid ""
+"Filters out known AI spam sites from image search results. %sLearn More%s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the final score of a sporting event.
@@ -7795,6 +7989,12 @@ msgstr "Najdi lepší slovo"
 msgctxt "Subtitle for the Web Search tool entry in the Tools dropdown menu"
 msgid "Find current information"
 msgstr "Hledání aktuálních informací"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Find me alternatives"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button that searches for results closer to the user's current location.
@@ -7886,7 +8086,8 @@ msgstr ""
 #. Privacy reassurance and instructions intro.
 msgctxt "duckai_migration"
 msgid "Follow these steps to move your chats to the new Duck.ai"
-msgstr "Postupuj podle těchto kroků a přesuň své chaty na novou doménu Duck.ai."
+msgstr ""
+"Postupuj podle těchto kroků a přesuň své chaty na novou doménu Duck.ai."
 
 # smartling.placeholder_format=C
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse on mobile
@@ -7991,7 +8192,8 @@ msgstr "Bezplatné a soukromé chaty, které anonymizujeme"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr "Bezplatné a soukromé chaty, které anonymizujeme. Není potřeba žádný účet."
+msgstr ""
+"Bezplatné a soukromé chaty, které anonymizujeme. Není potřeba žádný účet."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -8270,6 +8472,12 @@ msgstr "Vygenerovat obrázek"
 #. Text for the button that generates more of an answer from duckassist when the answer has come from a collapsed state
 msgid "Generate More"
 msgstr "Vygenerovat víc"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Generate a shopping list"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
@@ -8561,6 +8769,12 @@ msgstr "Vyzkoušet"
 msgctxt "Onboarding welcome screen button text"
 msgid "Give it a Try"
 msgstr "Vyzkoušet"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Give me a quick background on this person."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9011,6 +9225,18 @@ msgid "Help Spread Privacy"
 msgstr "Pomoz šířit ochranu soukromí"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Help me prep for the interview"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Help me tailor my resume for this job."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title of a SERP popup that invites users to take a survey (desktop only)
 msgctxt "User survey popup"
 msgid "Help us improve DuckDuckGo"
@@ -9451,7 +9677,8 @@ msgstr "Jak to funguje"
 #. Header for the assist settings modal where the user can choose how often they want AI-assisted answers to appear.
 msgctxt "duckassist"
 msgid "How much do you want AI-assisted answers to appear?"
-msgstr "Jak často chceš, aby se objevovaly odpovědi s podporou umělé inteligence?"
+msgstr ""
+"Jak často chceš, aby se objevovaly odpovědi s podporou umělé inteligence?"
 
 # smartling.placeholder_format=C
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
@@ -9524,6 +9751,14 @@ msgstr "Hurikán"
 msgctxt "Onboarding terms screen button text"
 msgid "I Agree"
 msgstr "Souhlasím"
+
+# smartling.placeholder_format=C
+#. Text for the button that takes the user to the external DuckDuckGo login subscription page.
+msgctxt ""
+"Text for the I already have a subscription button in the Duck.ai settings "
+"page"
+msgid "I Already Have a Subscription"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the button that takes the user to the login subscription page.
@@ -9691,7 +9926,8 @@ msgstr ""
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
-msgstr "Pokud nás stále chceš podpořit, %1$spoděl se o DuckDuckGo s ostatními%2$s"
+msgstr ""
+"Pokud nás stále chceš podpořit, %1$spoděl se o DuckDuckGo s ostatními%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -9700,7 +9936,8 @@ msgstr "Pokud nás stále chceš podpořit, %1$spoděl se o DuckDuckGo s ostatn�
 msgid ""
 "If you want to use DuckDuckGo without JavaScript, please use our %s or %s "
 "versions."
-msgstr "Pokud chceš používat DuckDuckGo bez JavaScriptu, použij verzi %1$s nebo %2$s."
+msgstr ""
+"Pokud chceš používat DuckDuckGo bez JavaScriptu, použij verzi %1$s nebo %2$s."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -10099,6 +10336,12 @@ msgid "Install Mac Browser"
 msgstr "Instalace prohlížeče Mac Browser"
 
 # smartling.placeholder_format=C
+#. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
+msgctxt "settings"
+msgid "Install Now"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of a button to install the DuckDuckGo app
 msgctxt "Serp footer content"
 msgid "Install Our App"
@@ -10196,10 +10439,42 @@ msgid "Is deleted data really deleted?"
 msgstr "Dochází smazáním dat k jejich skutečnému odstranění?"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is it worth taking?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this place any good?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"Is this place any good? Summarize its reputation based on reviews and "
+"ratings."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "Is this video helpful?"
 msgstr "Je toto video užitečné?"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this worth watching?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Is this worth watching? Give me a spoiler-free take."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -10812,6 +11087,12 @@ msgid "Links:"
 msgstr "Odkazy"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "List the tools, materials, or prerequisites I need for this."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
 msgid "Listen"
 msgstr "Poslechnout"
@@ -11100,7 +11381,8 @@ msgstr "Ujisti se, že jsou všechna slova napsaná správně."
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Make sure to check %s\"Make this my default search provider\"%s"
-msgstr "Zaškrtni možnost %1$sNastavit jako výchozího poskytovatele vyhledávání%2$s"
+msgstr ""
+"Zaškrtni možnost %1$sNastavit jako výchozího poskytovatele vyhledávání%2$s"
 
 # smartling.placeholder_format=C
 #. Message prompting users to check the spelling of their search term.
@@ -11216,6 +11498,12 @@ msgstr "Spravovat předplatné"
 msgctxt "Exclusion message manage sites button"
 msgid "Manage blocked sites"
 msgstr "Správa zablokovaných webů"
+
+# smartling.placeholder_format=C
+#. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
+msgctxt "setting"
+msgid "Manage in Browser Settings"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to the site exclusion settings page
@@ -11667,7 +11955,8 @@ msgstr "Byl vyčerpán měsíční limit"
 #. Displayed when the user has reached a fixed monthly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Monthly usage limit reached. You can continue this chat after %s."
-msgstr "Byl vyčerpán měsíční limit využití. V tomto chatu můžeš pokračovat za %1$s."
+msgstr ""
+"Byl vyčerpán měsíční limit využití. V tomto chatu můžeš pokračovat za %1$s."
 
 # smartling.placeholder_format=C
 #. Used to point to additional social networking profiles (in results).
@@ -12502,7 +12791,8 @@ msgstr "Nebyly nalezeny žádné výsledky."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the recording contains no audible speech.
 msgid "No speech detected. Please try again and speak into your microphone."
-msgstr "Nebyla zaznamenána žádná řeč. Zkus to prosím znovu a mluv do mikrofonu."
+msgstr ""
+"Nebyla zaznamenána žádná řeč. Zkus to prosím znovu a mluv do mikrofonu."
 
 # smartling.placeholder_format=C
 #. Button that dismisses a feedback form.
@@ -13075,7 +13365,8 @@ msgctxt "translations_module"
 msgid ""
 "Oops! An unexpected error occurred while translating this text. Please try "
 "again later."
-msgstr "Jejda! Při překládání tohoto textu došlo k neočekávané chybě. Zkus to znovu."
+msgstr ""
+"Jejda! Při překládání tohoto textu došlo k neočekávané chybě. Zkus to znovu."
 
 # smartling.placeholder_format=C
 #. Title shown in a fatal error modal when Duck.ai fails to load.
@@ -13150,7 +13441,8 @@ msgstr "Otevřít %1$sNastavení%2$s"
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open 'Location', and ensure location is %senabled%s."
-msgstr "Otevři možnost Poloha a ujisti se, že je přístup k poloze %1$spovolený%2$s."
+msgstr ""
+"Otevři možnost Poloha a ujisti se, že je přístup k poloze %1$spovolený%2$s."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -14044,6 +14336,12 @@ msgstr "Dokončením následující výzvy potvrdíš, že toto hledání proved
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
+msgid "Please describe why the chat response is harmful or illegal. (optional)"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
+msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
 msgstr "Popiš, proč je odpověď v chatu nelegální nebo škodlivá. (nepovinné)"
 
@@ -14068,6 +14366,14 @@ msgid ""
 msgstr ""
 "Nezapomeň: Když zahájíš nový chat (bez ohledu na model), smaže se tvoje "
 "aktuální chatová relace."
+
+# smartling.placeholder_format=C
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
+msgctxt "Feedback prompt"
+msgid ""
+"Please paste your prompt and the problematic output (with any personal "
+"information removed) and describe why the content is harmful or illegal."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -14537,6 +14843,12 @@ msgid "Privacy"
 msgstr "Soukromí"
 
 # smartling.placeholder_format=C
+#. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
+msgctxt "Section heading on the Duck.ai settings page"
+msgid "Privacy & Terms"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Privacy Blog"
 msgstr "Blog o ochraně osobních údajů"
 
@@ -14605,6 +14917,12 @@ msgstr "Zásady ochrany osobních údajů a podmínky služby"
 msgctxt "Copy used to compose link in sentences"
 msgid "Privacy Policy and Terms of Service"
 msgstr "Zásady ochrany osobních údajů a podmínky služby"
+
+# smartling.placeholder_format=C
+#. Text for a button that links to the terms of use and privacy policy page.
+msgctxt "Secondary button text in active privacy modal"
+msgid "Privacy Policy and Terms of Service"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title displayed on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
@@ -14778,7 +15096,8 @@ msgstr "Upozornit"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Prompt me to use my approximate location to get nearby results."
-msgstr "Vyzvat mě, abych použil/a svou přibližnou polohu a získal/a výsledky v okolí."
+msgstr ""
+"Vyzvat mě, abych použil/a svou přibližnou polohu a získal/a výsledky v okolí."
 
 # smartling.placeholder_format=C
 #. DuckDuckGo Email Protection removes trackers from emails
@@ -14820,7 +15139,8 @@ msgctxt "Full sentence for critiquing writing"
 msgid ""
 "Provide a few suggestions to make the following text more concise. [Insert "
 "your own text here.]"
-msgstr "Dej mi několik návrhů, jak následující text zestručnit. [Sem vlož svůj text.]"
+msgstr ""
+"Dej mi několik návrhů, jak následující text zestručnit. [Sem vlož svůj text.]"
 
 # smartling.placeholder_format=C
 #. In the context of a standings table for NHL (hockey), column title that abbreviates 'Total Points' (the total points of this team)
@@ -15102,6 +15422,30 @@ msgstr "Recepty pro dotaz %1$s%2$s%3$s"
 msgctxt "Brief for recommending a book"
 msgid "Recommend a book"
 msgstr "Doporuč mi knihu"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar books"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar books."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar movies or shows."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar titles"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
@@ -15508,6 +15852,15 @@ msgid "Republic of Moldova"
 msgstr "Moldavsko"
 
 # smartling.placeholder_format=C
+#. Note indicating that sharing the conversation is mandatory when reporting harmful or illegal content. Rendered alongside the standard share label (DUCKCHAT_RESPONSE_FEEDBACK_SHARE_PROMPT_RESPONSE_LABEL), not replacing it.
+msgctxt ""
+"Note shown under the share-content switch label on the Duck.ai response "
+"feedback form when the user has selected Harmful or Illegal as the feedback "
+"reason"
+msgid "Required for harmful or illegal reports"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
 msgctxt "Description for extended reasoning mode in Duck.ai"
 msgid "Researches before responding"
@@ -15742,6 +16095,12 @@ msgid "Reviews"
 msgstr "Recenze"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Rewrite this recipe scaled for a different number of servings."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Romania"
 msgstr "Rumunsko"
 
@@ -15816,7 +16175,8 @@ msgstr "SV"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "SERP promotion for desktop browsers has been dismissed"
-msgstr "Propagace na stránce s výsledky vyhledávání pro desktopový prohlížeč zavřena"
+msgstr ""
+"Propagace na stránce s výsledky vyhledávání pro desktopový prohlížeč zavřena"
 
 # smartling.placeholder_format=C
 #. Abbreviation indicating that a game is in shootouts, e.g. in NHL (hockey)
@@ -15883,7 +16243,8 @@ msgstr "Bezpečné vyhledávání zablokovalo výsledky pro %1$s."
 # smartling.placeholder_format=C
 #. A label above search results that lets the user know the safe search filter blocked some of the results from showing. The placeholder value is the user's search term.
 msgid "Safe search blocked some results for %s."
-msgstr "Bezpečné vyhledávání zablokovalo některé výsledky hledání pro dotaz %1$s."
+msgstr ""
+"Bezpečné vyhledávání zablokovalo některé výsledky hledání pro dotaz %1$s."
 
 # smartling.placeholder_format=C
 #. Safe search lets you remove adult content from results on DuckDuckGo. This string is used to invite users to select the desired level of protection (e.g., strict, moderate, off)
@@ -16025,7 +16386,8 @@ msgstr "Ukládej až 30 svých nejnovějších chatů lokálně na své zaříze
 msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
-msgstr "Ulož si chaty Duck.ai mezi svými zařízeními pomocí end-to-end šifrování."
+msgstr ""
+"Ulož si chaty Duck.ai mezi svými zařízeními pomocí end-to-end šifrování."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -16184,7 +16546,8 @@ msgstr "Přejdi dolů a vyhledej %1$ssvůj prohlížeč%2$s v seznamu."
 #. Tells users which setting to change to enable location service.
 msgctxt "precise_user_location"
 msgid "Scroll down to %sDuckDuckGo%s and allow it to use your location."
-msgstr "Přejdi dolů na položku %1$sDuckDuckGo%2$s a umožni jí používat tvou polohu."
+msgstr ""
+"Přejdi dolů na položku %1$sDuckDuckGo%2$s a umožni jí používat tvou polohu."
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -16722,13 +17085,14 @@ msgstr "V Safari zvol %1$sNastavení pro tuto webovou stránku...%2$s."
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
 msgstr ""
-"Vyber možnost %1$sPřizpůsobit%2$s a do vyhledávacího pole zadej "
-"%3$shttps://duckduckgo.com%4$s"
+"Vyber možnost %1$sPřizpůsobit%2$s a do vyhledávacího pole zadej %3$shttps://"
+"duckduckgo.com%4$s"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
-msgstr "Vyber %1$sDuckDuckGo%2$s a klikni na %3$sNastavit jako výchozí prohlížeč%4$s!"
+msgstr ""
+"Vyber %1$sDuckDuckGo%2$s a klikni na %3$sNastavit jako výchozí prohlížeč%4$s!"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
@@ -16870,7 +17234,8 @@ msgstr ""
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %syour browser%s in the list and %sallow%s location access"
-msgstr "V seznamu vyber %1$ssvůj prohlížeč%2$s a %3$spovol přístup k poloze%4$s"
+msgstr ""
+"V seznamu vyber %1$ssvůj prohlížeč%2$s a %3$spovol přístup k poloze%4$s"
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the modal for deleting all recent chats, that allows the user to select the chats to delete.
@@ -17063,6 +17428,12 @@ msgid "Set Up Now"
 msgstr "Nastavit"
 
 # smartling.placeholder_format=C
+#. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
+msgctxt "Encrypted storage setup button shown in native browsers"
+msgid "Set Up Sync & Backup"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
 msgctxt "Title for the Sync & Backup intro screen"
 msgid "Set Up Sync & Backup"
@@ -17098,7 +17469,8 @@ msgstr ""
 #. Prompt for the user to indicate their location on a map, to enable more relevant search results.
 msgctxt "precise_user_location"
 msgid "Set your location manually, or ensure Location Services is enabled."
-msgstr "Nastav polohu ručně nebo zkontroluj, jestli jsou povolené polohové služby."
+msgstr ""
+"Nastav polohu ručně nebo zkontroluj, jestli jsou povolené polohové služby."
 
 # smartling.placeholder_format=C
 #. In the top dropdown menu  ("More" > "Settings")
@@ -17179,8 +17551,8 @@ msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
 msgstr ""
-"Sdílej polohu na úrovni města s modely AI, aby se zlepšila relevance. "
-"Duck.ai nikdy neodhalí tvoji přesnou polohu nám ani modelům AI."
+"Sdílej polohu na úrovni města s modely AI, aby se zlepšila relevance. Duck."
+"ai nikdy neodhalí tvoji přesnou polohu nám ani modelům AI."
 
 # smartling.placeholder_format=C
 #. Menu option to share feedback about a result
@@ -17239,6 +17611,13 @@ msgstr "Sdílet adresu URL stránky"
 msgctxt "feedback form"
 msgid "Share positive feedback"
 msgstr "Sdílet pozitivní zpětnou vazbu"
+
+# smartling.placeholder_format=C
+#. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
+msgctxt ""
+"Label beside the share-content switch on the Duck.ai response feedback form"
+msgid "Share this conversation with DuckDuckGo"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -18070,7 +18449,8 @@ msgstr "Vymazaný zdrojový text"
 msgctxt "Error message for summary selection input limit"
 msgid ""
 "Source text is too long to summarize. Try again with a shorter selection."
-msgstr "Zdrojový text je na shrnutí příliš dlouhý. Zkus to znovu s kratším výběrem."
+msgstr ""
+"Zdrojový text je na shrnutí příliš dlouhý. Zkus to znovu s kratším výběrem."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under Interface Settings.in the end. It is a header
@@ -18494,6 +18874,24 @@ msgid "Suggest a title for a blog post"
 msgstr "Navrhni mi název příspěvku na blog"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest related articles or topics worth exploring next."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Suggest related articles to explore"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest some alternatives to this product."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
 msgctxt "directions"
 msgid "Suggestions:"
@@ -18505,10 +18903,100 @@ msgid "Suggestions:"
 msgstr "Návrhy:"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Sum up the reviews"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A short title for the a message asking the AI to summarize a text.
 msgctxt "Title for the summarize message"
 msgid "Summarize"
 msgstr "Shrň mi to"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize the Q&As"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the background and notable work of this person."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the key details of this event."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the questions and answers on this page."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize their background"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this book"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this book."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this discussion"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this discussion thread."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this page"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this page."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this video"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this video."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize what the reviews say."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -18832,6 +19320,12 @@ msgid "Syria"
 msgstr "Sýrie"
 
 # smartling.placeholder_format=C
+#. Text for a button that enables the theme to follow the operating system's color scheme preference.
+msgctxt "System theme button for theme selector"
+msgid "System"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Abbreviation indicating this is the total score for a game
 msgctxt "Sports module"
 msgid "T"
@@ -18858,6 +19352,12 @@ msgstr "TV"
 msgctxt "language_name"
 msgid "Tahitian"
 msgstr "Tahitština"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Tailor my resume"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Taiwan"
@@ -18887,6 +19387,13 @@ msgstr "Měj osobní údaje ve svých rukou"
 msgctxt "homepage ATB modal"
 msgid "Take control of your personal data!"
 msgstr "Měj osobní údaje ve svých rukou!"
+
+# smartling.placeholder_format=C
+#. Description for the Feedback section of the Duck.ai settings page, asking the user to take an anonymous survey to let us know how we can make Duck.ai better.
+msgctxt "Feedback section description on the Duck.ai settings page"
+msgid ""
+"Take this anonymous survey to let us know how we can make Duck.ai better."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -19085,13 +19592,15 @@ msgstr "Děkujeme za zpětnou vazbu!"
 #. Inform the users that "something" went wrong and we are unable to show any results.
 msgctxt "noresults"
 msgid "Thanks for your patience while we get our ducks in a row!"
-msgstr "Děkujeme ti za trpělivost. Snažíme se všechny kachny dostat zase do řady."
+msgstr ""
+"Děkujeme ti za trpělivost. Snažíme se všechny kachny dostat zase do řady."
 
 # smartling.placeholder_format=C
 #. Inform the users that "something" went wrong and we are unable to show any results.
 msgctxt "noresults"
 msgid "Thanks for your patience while we get our ducks in a row."
-msgstr "Děkujeme ti za trpělivost. Snažíme se všechny kachny dostat zase do řady."
+msgstr ""
+"Děkujeme ti za trpělivost. Snažíme se všechny kachny dostat zase do řady."
 
 # smartling.placeholder_format=C
 #. Message indicating that the open lock icon in the address bar means that a website is not secure.
@@ -19151,7 +19660,8 @@ msgstr ""
 msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider deletes any data associated with this chat within 30 days."
-msgstr "Poskytovatel modelu smaže veškerá data související s tímto chatem do 30 dnů."
+msgstr ""
+"Poskytovatel modelu smaže veškerá data související s tímto chatem do 30 dnů."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers.
@@ -19190,6 +19700,12 @@ msgstr "Server narazil na chybu a nemohl tvůj požadavek dokončit."
 #. https://duck.co/media/files/theme.png
 msgid "Theme"
 msgstr "Motiv"
+
+# smartling.placeholder_format=C
+#. Text for the theme selector label that allows users to switch between Light and dark theme.
+msgctxt "Label for the theme selector feature"
+msgid "Theme"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/LpFhb1e.png
@@ -19296,7 +19812,8 @@ msgctxt "AI Chat: Error message for when a model is removed"
 msgid ""
 "This AI model is no longer available. Try starting a new chat with a "
 "different model."
-msgstr "Tenhle model AI už není dostupný. Zkus začít nový chat s jiným modelem."
+msgstr ""
+"Tenhle model AI už není dostupný. Zkus začít nový chat s jiným modelem."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is no longer supported because it has been upgraded to a newest version.
@@ -19574,13 +20091,15 @@ msgstr "Tento překlad je špatný"
 # smartling.placeholder_format=C
 #. Label indicating that the video can't be played on the current page, and only on the website that owns the vide. The placeholder is the name of the website that owns the video.
 msgid "This video is not yet able to be watched here. You can watch it on %s."
-msgstr "Toto video zde ještě není možné sledovat. Můžete se na něho podívat na %1$s."
+msgstr ""
+"Toto video zde ještě není možné sledovat. Můžete se na něho podívat na %1$s."
 
 # smartling.placeholder_format=C
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr "Tahle webová stránka nepoužívá zabezpečené, šifrované připojení (HTTPS)."
+msgstr ""
+"Tahle webová stránka nepoužívá zabezpečené, šifrované připojení (HTTPS)."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -20027,6 +20546,18 @@ msgstr ""
 "zastávku hromadné dopravy?“"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Translate this page"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
+msgctxt "Page suggestion prompt"
+msgid "Translate this page into %s."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text for a region that will display translated text.
 msgctxt "translations_module"
 msgid "Translation"
@@ -20126,7 +20657,8 @@ msgstr "Zkus přejít na %1$s a podobné zprávy už ti nebudeme ukazovat."
 #. Text for a promotional card that encourages users to try the encrypted AI model whose inference runs in a confidential environment so the model provider cannot access user data. %s is replaced with the model's full display name (e.g. 'GPT-OSS 120B').
 msgctxt "Promotional text for encrypted AI model"
 msgid "Try %s, our first model with zero provider visibility."
-msgstr "Zkus %1$s, náš první model, ve kterém má poskytovatel nulovou viditelnost."
+msgstr ""
+"Zkus %1$s, náš první model, ve kterém má poskytovatel nulovou viditelnost."
 
 # smartling.placeholder_format=C
 msgid "Try %sDuck.ai%s, our private AI chat service:"
@@ -20166,6 +20698,12 @@ msgstr "Zkus to znovu"
 msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
 msgstr "Vyzkoušet zdarma"
+
+# smartling.placeholder_format=C
+#. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
+msgctxt "settings"
+msgid "Try It Now"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -20400,6 +20938,22 @@ msgstr "Zkus: %1$s"
 msgctxt "new user poll"
 msgid "Trying DuckDuckGo again"
 msgstr "Zkouším DuckDuckGo znovu"
+
+# smartling.placeholder_format=C
+#. Message shown in a modal after supported third-party browser users disable AI features in Settings. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -20724,8 +21278,8 @@ msgstr ""
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
 msgstr ""
-"Pod možností %1$sSpuštění > Domovská stránka%2$s zadej: "
-"https://duckduckgo.com"
+"Pod možností %1$sSpuštění > Domovská stránka%2$s zadej: https://duckduckgo."
+"com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -20735,7 +21289,8 @@ msgstr "V nabídce %1$sNastavení vyhledávání%2$s zvol %3$sDuckDuckGo%4$s"
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch in the address bar with%s select %sAdd New%s"
-msgstr "Pod %1$shledáním v adresním řádku pomocí %2$s vyber %3$sPřidat nový%4$s"
+msgstr ""
+"Pod %1$shledáním v adresním řádku pomocí %2$s vyber %3$sPřidat nový%4$s"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -21103,7 +21658,8 @@ msgstr ""
 #. Upsell message shown in the voice chat limit and duration limit modals for Plus subscribers, encouraging them to upgrade to Pro.
 msgctxt "voice chat limit modal"
 msgid "Upgrade to Pro to unlock 2x higher usage limits than Plus"
-msgstr "Upgraduj na tarif Pro a aktivuj si dvojnásobné limity, než má tarif Plus"
+msgstr ""
+"Upgraduj na tarif Pro a aktivuj si dvojnásobné limity, než má tarif Plus"
 
 # smartling.placeholder_format=C
 #. Heading in a promotion for a desktop web browser
@@ -21150,6 +21706,12 @@ msgstr "Urdština"
 # smartling.placeholder_format=C
 msgid "Uruguay"
 msgstr "Uruguay"
+
+# smartling.placeholder_format=C
+#. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
+msgctxt "Navigation label on the Duck.ai settings page"
+msgid "Usage"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -21207,7 +21769,8 @@ msgstr "Použít vyhledávač Private Search od DuckDuckGo"
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Use DuckDuckGo private search on your iPad, iPhone, or Android!"
-msgstr "Používej soukromé vyhledávání DuckDuckGo na iPadu, iPhonu nebo Androidu"
+msgstr ""
+"Používej soukromé vyhledávání DuckDuckGo na iPadu, iPhonu nebo Androidu"
 
 # smartling.placeholder_format=C
 #. User clicks this button to share their device's location
@@ -21601,6 +22164,12 @@ msgid "Wales"
 msgstr "Wales"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Walk me through the steps"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for walking directions on a map.
 msgctxt "directions"
 msgid "Walking"
@@ -21719,6 +22288,17 @@ msgstr ""
 "výsledky."
 
 # smartling.placeholder_format=C
+#. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
+msgctxt ""
+"Inline warning shown below the share-content toggle when the user selects "
+"Harmful or Illegal but has not enabled sharing"
+msgid ""
+"We can only fix what we can see. To report a harmful or illegal response, "
+"please share this conversation with DuckDuckGo so we can investigate and "
+"address the issue."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
 msgctxt ""
 "Inline warning shown below the share-content toggle when the user selects "
@@ -21789,7 +22369,8 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what brought you "
 "back today:"
-msgstr "Nesledujeme tě, takže by nám pomohlo, když nám řekneš, co tě přivádí zpátky:"
+msgstr ""
+"Nesledujeme tě, takže by nám pomohlo, když nám řekneš, co tě přivádí zpátky:"
 
 # smartling.placeholder_format=C
 #. Message prompting users to fill out a feedback form.
@@ -21810,7 +22391,8 @@ msgstr "Nesledujeme tě. Nikdy."
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with a Continue button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don't track you. That's our Privacy Policy in a nutshell."
-msgstr "My tě nesledujeme. To jsou naše Zásady ochrany osobních údajů v kostce."
+msgstr ""
+"My tě nesledujeme. To jsou naše Zásady ochrany osobních údajů v kostce."
 
 # smartling.placeholder_format=C
 #. Description for the audio identification highlight in the dictation consent modal.
@@ -21851,7 +22433,8 @@ msgstr "Nesledujeme tě. Ani v anonymním režimu ani mimo něj."
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with an Agree button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don’t track you. That’s our Privacy Policy in a nutshell…"
-msgstr "My vás nesledujeme. To jsou naše Zásady ochrany osobních údajů v kostce…"
+msgstr ""
+"My vás nesledujeme. To jsou naše Zásady ochrany osobních údajů v kostce…"
 
 # smartling.placeholder_format=C
 #. Displayed when the user's voice chat session is ended because of being inactive for too long.
@@ -22080,7 +22663,8 @@ msgstr "Byl vyčerpán týdenní limit"
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Weekly usage limit reached. You can continue this chat after %s."
-msgstr "Byl vyčerpán týdenní limit využití. V tomto chatu můžeš pokračovat za %1$s."
+msgstr ""
+"Byl vyčerpán týdenní limit využití. V tomto chatu můžeš pokračovat za %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable weekly Duck.ai usage limit and can opt in to continue using the monthly limit.
@@ -22267,6 +22851,103 @@ msgstr ""
 "zkušeností."
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the counterarguments?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the hours & location?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key contributions of this paper?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key contributions?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key details?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key points covered in this video?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key points?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key takeaways from this article?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key takeaways?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key things I will learn from this course?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main counterarguments or criticisms of this?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main questions this page answers?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the must-try dishes here?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"What are the opening hours, location, and contact details for this place?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the pros and cons of this product?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the pros and cons?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
 msgctxt "feedback form"
 msgid "What bothered you most?"
@@ -22367,6 +23048,12 @@ msgid "What does atria mean in the context of a medical article?"
 msgstr "Co je to atrium v kontextu lékařského článku?"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What does this answer?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
@@ -22377,6 +23064,12 @@ msgstr "Jakou funkci bychom podle tebe měli přidat? (nepovinné)"
 msgctxt "cloudsave"
 msgid "What information gets saved?"
 msgstr "Jaké informace se ukládají?"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What interview questions might come up for this role?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -22393,6 +23086,12 @@ msgstr ""
 msgctxt "Full sentence for looking up basic facts"
 msgid "What is the capital city of Albania?"
 msgstr "Jaké je hlavní město Albánie?"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What is the overall verdict and rating for this?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to a page with additional information.
@@ -22417,6 +23116,12 @@ msgid "What people say:"
 msgstr "Co říkají ostatní:"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What should I order?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
 msgctxt "feedback form"
 msgid "What stood out?"
@@ -22427,6 +23132,18 @@ msgstr "Co bylo dobré?"
 msgctxt "feedback form"
 msgid "What was wrong with the response? (optional)"
 msgstr "Co bylo na odpovědi špatně? (nepovinné)"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I learn?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I need?"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -22446,6 +23163,12 @@ msgid "What's New"
 msgstr "Co je nového"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What's the verdict?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to a page featuring the most recent updates from DuckDuckGo.
 msgid "What’s New"
 msgstr "Co je nového"
@@ -22463,7 +23186,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "When enabled, Duck.ai will show instant answers in the chat."
-msgstr "Když je možnost zapnutá, Duck.ai bude v chatu zobrazovat okamžité odpovědi."
+msgstr ""
+"Když je možnost zapnutá, Duck.ai bude v chatu zobrazovat okamžité odpovědi."
 
 # smartling.placeholder_format=C
 #. Text of a button that performs a search for the available streaming services that show a particular movie or tv show
@@ -22496,6 +23220,12 @@ msgid "Which features are missing? (Optional)"
 msgstr "Které funkce chybí? (nepovinné)"
 
 # smartling.placeholder_format=C
+#. An invitation for users to leave feedback
+msgctxt "Feedback prompt"
+msgid "Which features are missing? (optional)"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
 msgid "White"
 msgstr "Bílé"
@@ -22510,6 +23240,18 @@ msgstr "Bílá"
 #. Link to an about us page.
 msgid "Who We Are"
 msgstr "Kdo jsme"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Who are the main cast and crew, and what else are they known for?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Who is this person?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Header above a collection of privacy-related links.
@@ -23489,7 +24231,8 @@ msgctxt "duckai_migration"
 msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
-msgstr "Import tvých chatů je hotový. Na Duck.ai můžeš pokračovat v rozdělané práci."
+msgstr ""
+"Import tvých chatů je hotový. Na Duck.ai můžeš pokračovat v rozdělané práci."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.
@@ -23600,7 +24343,8 @@ msgctxt "Popover text for recent chats onboarding"
 msgid ""
 "Your recent chats live here! You can refer to your chats or clear them "
 "anytime."
-msgstr "Tady najdeš svoje nedávné chaty. Můžeš je kdykoli otevřít nebo vymazat."
+msgstr ""
+"Tady najdeš svoje nedávné chaty. Můžeš je kdykoli otevřít nebo vymazat."
 
 # smartling.placeholder_format=C
 #. Message on a feedback form.
@@ -23686,7 +24430,8 @@ msgctxt "Error message for user limit"
 msgid ""
 "You’ve reached the maximum number of messages for one day. Please continue "
 "this chat tomorrow."
-msgstr "Bylo dosaženo maximálního počtu zpráv za jeden den. V chatu pokračuj zítra."
+msgstr ""
+"Bylo dosaženo maximálního počtu zpráv za jeden den. V chatu pokračuj zítra."
 
 # smartling.placeholder_format=C
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
@@ -23988,7 +24733,8 @@ msgstr "oficiálních webových stránkách"
 #. <em>%s</em> is for a hexadecimal color code as <em>#395323</em>, but it has to be safe encoded, and as <em>#</em> seems not safe, <em>%23</em> must be used in place of the sharp symbol, but they are the same for your browser.
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
-msgstr "nebo napište kód libovolné barvy, např. %1$s (%2$s je kód pro znak %3$s)."
+msgstr ""
+"nebo napište kód libovolné barvy, např. %1$s (%2$s je kód pro znak %3$s)."
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "

--- a/locales/cs_CZ/LC_MESSAGES/duckduckgo.po
+++ b/locales/cs_CZ/LC_MESSAGES/duckduckgo.po
@@ -1435,7 +1435,7 @@ msgstr "Adresa je nesprávná"
 #. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Adjust the servings"
-msgstr "Upravte porce"
+msgstr "Uprav porce"
 
 # smartling.placeholder_format=C
 #. as in multiple advertisements

--- a/locales/cs_CZ/LC_MESSAGES/duckduckgo.po
+++ b/locales/cs_CZ/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: cs_CZ\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -98,8 +98,7 @@ msgstr "Počet pokusů: %1$s"
 # smartling.placeholder_format=C
 #. A summary description of how many tracking attempts where blocked, when there was more than 1. Eg: '1,028 attempts blocked by DuckDuckGo in the last 24 hours'
 msgid "%s attempts blocked by DuckDuckGo in the last 24 hours"
-msgstr ""
-"Počet pokusů zablokovaných službou DuckDuckGo za posledních 24 hodin: %1$s"
+msgstr "Počet pokusů zablokovaných službou DuckDuckGo za posledních 24 hodin: %1$s"
 
 # smartling.placeholder_format=C
 #. A label that indicates a specific search result has been blocked by the safe search filter. The placeholder value is the name of the search result that was blocked.
@@ -482,8 +481,7 @@ msgstr ""
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "%sLearn more%s about how chats are stored privately on your device."
-msgstr ""
-"%1$sPřečti si víc%2$s o tom, jak se chaty soukromě ukládají na tvé zařízení."
+msgstr "%1$sPřečti si víc%2$s o tom, jak se chaty soukromě ukládají na tvé zařízení."
 
 # smartling.placeholder_format=C
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
@@ -495,8 +493,7 @@ msgstr "%1$sPodrž%2$s ikonu aplikace DuckDuckGo na domovské obrazovce"
 #. A message displayed when there is an error loading content or no results on requery
 msgctxt "Error or no results message"
 msgid "%sOops!%s%sSomething went wrong. Please %srefresh%s and try again."
-msgstr ""
-"%1$sJejda!%2$s%3$sNěco se pokazilo. %4$sObnov stránku%5$s a zkus to znovu."
+msgstr "%1$sJejda!%2$s%3$sNěco se pokazilo. %4$sObnov stránku%5$s a zkus to znovu."
 
 # smartling.placeholder_format=C
 #. Tagline in a popover encouraging the user to download the DuckDuckGo browser
@@ -813,8 +810,7 @@ msgstr "Byl vyčerpán 6hodinový limit využití."
 #. Displayed when the user has reached a fixed 6-hour Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "6-hour usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Byl vyčerpán 6hodinový limit využití. V tomto chatu můžeš pokračovat za %1$s."
+msgstr "Byl vyčerpán 6hodinový limit využití. V tomto chatu můžeš pokračovat za %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable 6-hour Duck.ai usage limit and can opt in to continue using the daily limit.
@@ -885,8 +881,7 @@ msgstr ""
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of AI Chat is available! Please refresh this page to continue."
-msgstr ""
-"Je dostupná nová verze AI Chatu! Pokud chceš pokračovat, obnov stránku."
+msgstr "Je dostupná nová verze AI Chatu! Pokud chceš pokračovat, obnov stránku."
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of Duck.ai is available and they need to refresh the page.
@@ -1440,7 +1435,7 @@ msgstr "Adresa je nesprávná"
 #. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Adjust the servings"
-msgstr ""
+msgstr "Upravte porce"
 
 # smartling.placeholder_format=C
 #. as in multiple advertisements
@@ -1660,6 +1655,8 @@ msgid ""
 "All chats are anonymized by DuckDuckGo, and your conversations are not used "
 "to train chat models by DuckDuckGo or the model providers"
 msgstr ""
+"DuckDuckGo anonymizuje všechny chaty a DuckDuckGo ani poskytovatelů modelů "
+"nevyužívají tvoje konverzace k trénování chatovacích modelů"
 
 # smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1752,8 +1749,7 @@ msgstr "Povolit reklamy, které respektují soukromí"
 # smartling.placeholder_format=C
 #. Title in a dialog informing the user how to disable their ad blocker for DuckDuckGo
 msgid "Allow privacy-respecting ads on DuckDuckGo Private Search"
-msgstr ""
-"Povolit na DuckDuckGo Private Search reklamy, které respektují soukromí"
+msgstr "Povolit na DuckDuckGo Private Search reklamy, které respektují soukromí"
 
 # smartling.placeholder_format=C
 #. Description explaining privacy implications of enabling web search on encrypted models. The first two placeholders are the full model name (e.g. 'gpt-oss 120B'). The third and fourth placeholders wrap a clickable link reading 'zero provider visibility' that opens the privacy modal, please keep those around the link text in your translation. An example full sentence would be: Allows gpt-oss 120B to search the web to improve responses to relevant prompts. Only sends AI-generated queries to a search engine with limited data retention. Prompts and responses with gpt-oss 120B still have zero provider visibility.
@@ -1938,6 +1934,8 @@ msgid ""
 "Anonymously generates answers for search queries based on web content. "
 "Choose how often you want it to appear, or disable it completely."
 msgstr ""
+"Anonymně generuje odpovědi na vyhledávací dotazy na základě webového obsahu. "
+"Vyber, jak často se má zobrazovat, nebo funkci vypni úplně."
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -2084,8 +2082,7 @@ msgstr "Jsi tam ještě?"
 msgctxt "Body text for clear all chats confirmation modal"
 msgid ""
 "Are you sure you want to clear all of your chats? This cannot be undone."
-msgstr ""
-"Opravdu chceš vymazat všechny své chaty? Tenhle krok se nedá vrátit zpět."
+msgstr "Opravdu chceš vymazat všechny své chaty? Tenhle krok se nedá vrátit zpět."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that asks the user if they want to clear the conversation.
@@ -2222,7 +2219,7 @@ msgstr "Zeptej se Duck.ai na něco dalšího"
 #. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
 msgctxt "Page suggestion chip label"
 msgid "Ask about this page"
-msgstr ""
+msgstr "Zeptej se na tuhle stránku"
 
 # smartling.placeholder_format=C
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2646,7 +2643,7 @@ msgstr "Čárový kód"
 #. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Based on this page, is this course worth taking?"
-msgstr ""
+msgstr "Stojí tento kurz podle této stránky za to?"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2695,6 +2692,9 @@ msgid ""
 "Before storing this report, DuckDuckGo will anonymize your conversation by "
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
+"Před uložením tohoto reportu DuckDuckGo anonymizuje tvoji konverzaci "
+"odstraněním osobních údajů, jako jsou jména, e-mailové adresy a "
+"identifikační metadata."
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -3016,7 +3016,7 @@ msgstr "Vyhrané breakbally"
 #. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Break this down into clear, numbered steps."
-msgstr ""
+msgstr "Rozděl to na jasné, očíslované kroky."
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -3182,8 +3182,7 @@ msgstr "Kliknutím na „%1$s“ odsouhlasíš naše %2$s."
 msgctxt ""
 "Copy stating agreement to Duck.ai Privacy Policy and Terms of Service."
 msgid "By clicking “%s,” you accept Duck.ai’s %s and %s."
-msgstr ""
-"Kliknutím na „%1$s“ vyjadřuješ souhlas s podmínkami Duck.ai, viz %2$s a %3$s."
+msgstr "Kliknutím na „%1$s“ vyjadřuješ souhlas s podmínkami Duck.ai, viz %2$s a %3$s."
 
 # smartling.placeholder_format=C
 #. Text stating agreement to Duck.ai Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'By clicking “Agree and Continue,” you accept Duck.ai’s Privacy Policy and Terms of Service.'
@@ -3262,8 +3261,7 @@ msgstr "Kamerun"
 #. Text for a prompt suggestion for creating a few simple recipes using chicken, broccoli, and rice.
 msgctxt "Full sentence for crafting a recipe"
 msgid "Can you create a few simple recipes using chicken, broccoli, and rice?"
-msgstr ""
-"Můžeš vytvořit několik jednoduchých receptů z kuřete, brokolice a rýže?"
+msgstr "Můžeš vytvořit několik jednoduchých receptů z kuřete, brokolice a rýže?"
 
 # smartling.placeholder_format=C
 msgid "Canada"
@@ -3477,7 +3475,7 @@ msgstr "Obsazení"
 #. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Cast & Crew"
-msgstr ""
+msgstr "Obsazení a štáb"
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -4319,15 +4317,13 @@ msgstr "Klikni %1$ssem%2$s a stáhni si rozšíření DuckDuckGo"
 # smartling.placeholder_format=C
 #. Link to download the DuckDuckGo browser extension.
 msgid "Click %sOpen%s to download and open the DuckDuckGo Safari extension"
-msgstr ""
-"Klikni na %1$sOtevřít%2$s a stáhni si a otevři rozšíření DuckDuckGo Safari"
+msgstr "Klikni na %1$sOtevřít%2$s a stáhni si a otevři rozšíření DuckDuckGo Safari"
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click %sPrivacy and Services%s in the left sidebar."
-msgstr ""
-"V levém postranním panelu klepni na tlačítko %1$sSoukromí a služby%2$s."
+msgstr "V levém postranním panelu klepni na tlačítko %1$sSoukromí a služby%2$s."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -5198,7 +5194,7 @@ msgstr "Vytvoř obrázek"
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
-msgstr ""
+msgstr "Vytvoř nákupní seznam s množstvími z tohoto receptu."
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed in the input field when starting a new image generation session.
@@ -5455,8 +5451,7 @@ msgstr "Byl vyčerpán denní limit"
 #. Displayed when the user has reached a fixed daily Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Daily usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Byl vyčerpán denní limit využití. V tomto chatu můžeš pokračovat za %1$s."
+msgstr "Byl vyčerpán denní limit využití. V tomto chatu můžeš pokračovat za %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable daily Duck.ai usage limit and can opt in to continue using the weekly limit.
@@ -5844,7 +5839,7 @@ msgstr "Byl dosažen limit pro diktát"
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
 msgid "Dictation temporarily unavailable"
-msgstr ""
+msgstr "Diktování je dočasně nedostupné"
 
 # smartling.placeholder_format=C
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
@@ -6121,8 +6116,7 @@ msgstr "Nevidíš v seznamu DuckDuckGo?"
 #. Link to download a file again if the user can't find it on their computer.
 msgctxt "install-extension"
 msgid "Don't see it? %s%s%sClick here to re-download%s"
-msgstr ""
-"Nedaří se ti soubor najít? %1$s%2$s%3$sKliknutím sem zopakuj stahování%4$s"
+msgstr "Nedaří se ti soubor najít? %1$s%2$s%3$sKliknutím sem zopakuj stahování%4$s"
 
 #  IE < 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -6154,6 +6148,8 @@ msgid ""
 "Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
 "filtered out. %sLearn More%s"
 msgstr ""
+"Nechceš AI? %1$snoai.duckduckgo.com%2$s nenabízí žádné funkce AI a obrázky "
+"generované AI jsou odfiltrovány. %3$sDalší informace%4$s"
 
 # smartling.placeholder_format=C
 #. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
@@ -6162,6 +6158,8 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
+"Nechceš AI? Navštiv %1$snoai.duckduckgo.com%2$s pro vyhledávání bez funkcí "
+"AI a s odfiltrovanými AI obrázky. %3$sDalší informace%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6281,13 +6279,13 @@ msgstr ""
 #. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Draft a cover letter"
-msgstr ""
+msgstr "Napiš motivační dopis"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Draft a cover letter for this job."
-msgstr ""
+msgstr "Napiš motivační dopis pro tuto pracovní pozici."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -6462,8 +6460,7 @@ msgstr ""
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
-msgstr ""
-"Duck.ai je nejlepší v našem soukromém a bezplatném prohlížeči DuckDuckGo!"
+msgstr "Duck.ai je nejlepší v našem soukromém a bezplatném prohlížeči DuckDuckGo!"
 
 # smartling.placeholder_format=C
 #. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
@@ -6473,6 +6470,9 @@ msgid ""
 "company for anyone who wants to take back control of their personal "
 "information."
 msgstr ""
+"Duck.ai vytvořila společnost DuckDuckGo. Jsme nezávislá firma zaměřená na "
+"ochranu soukromí na internetu pro každého, kdo chce mít své osobní údaje "
+"zase pod kontrolou."
 
 # smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
@@ -6525,6 +6525,9 @@ msgid ""
 "Duck.ai lets you chat privately with popular AI models. Disabling it hides "
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
+"Duck.ai ti umožňuje soukromě chatovat s oblíbenými AI modely. Vypnutím "
+"skryješ tlačítka a odkazy Duck.ai, ale pořád můžeš navštívit %1$sduck.ai%2$s "
+"přímo."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6545,8 +6548,7 @@ msgstr ""
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
 msgctxt "Disclaimer text at the bottom of the feedback form."
 msgid "Duck.ai may display inaccurate or offensive information."
-msgstr ""
-"Duck.ai může zobrazovat může zobrazovat nepřesné nebo pohoršující informace."
+msgstr "Duck.ai může zobrazovat může zobrazovat nepřesné nebo pohoršující informace."
 
 # smartling.placeholder_format=C
 #. Error modal body line 2.
@@ -6589,8 +6591,7 @@ msgstr "Upgrade Duck.ai je hotový!"
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
-msgstr ""
-"Duck.ai funguje nejlíp v naší soukromé a bezplatné aplikaci DuckDuckGo!"
+msgstr "Duck.ai funguje nejlíp v naší soukromé a bezplatné aplikaci DuckDuckGo!"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -6767,8 +6768,7 @@ msgctxt "Error message for VQD error"
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. Please refresh the page and "
 "try again."
-msgstr ""
-"DuckDuckGo AI Chat je dočasně nedostupný. Obnov stránku a zkus to znovu."
+msgstr "DuckDuckGo AI Chat je dočasně nedostupný. Obnov stránku a zkus to znovu."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -7516,8 +7516,7 @@ msgstr "Rovníková Guinea"
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Erase your browsing data in a flash with our %sFire Button%s"
-msgstr ""
-"Pomocí tlačítka %1$sFire Button%2$s můžeš bleskově vymazat data o prohlížení."
+msgstr "Pomocí tlačítka %1$sFire Button%2$s můžeš bleskově vymazat data o prohlížení."
 
 # smartling.placeholder_format=C
 msgid "Eritrea"
@@ -7527,13 +7526,13 @@ msgstr "Eritrea"
 #. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Estimate the nutrition"
-msgstr ""
+msgstr "Odhadni nutriční hodnoty"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Estimate the nutritional information for this recipe."
-msgstr ""
+msgstr "Odhadni nutriční informace pro tento recept."
 
 # smartling.placeholder_format=C
 msgid "Estonia"
@@ -7593,7 +7592,7 @@ msgstr "Platnost skončí za 1 den"
 #. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain the accepted answer in simple terms."
-msgstr ""
+msgstr "Vysvětli přijatou odpověď jednoduchými slovy."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
@@ -7608,43 +7607,43 @@ msgstr ""
 #. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain the top answer"
-msgstr ""
+msgstr "Vysvětlit nejlepší odpověď"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain this in simple, plain language."
-msgstr ""
+msgstr "Vysvětli to jednoduše a srozumitelně."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain this paper"
-msgstr ""
+msgstr "Vysvětli tento článek"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain this repo"
-msgstr ""
+msgstr "Vysvětli tento repozitář"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain this research paper in plain language."
-msgstr ""
+msgstr "Vysvětli tento vědecký článek jednoduše."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain this simply"
-msgstr ""
+msgstr "Vysvětli to jednoduše"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain what this repository does and how to use it."
-msgstr ""
+msgstr "Vysvětli, co tento repozitář dělá a jak ho používat."
 
 # smartling.placeholder_format=C
 #. Label to show if song lyrics contain explicit content
@@ -7840,8 +7839,7 @@ msgstr ""
 msgid ""
 "Feel free to adjust the settings below. Then, just copy and paste the code "
 "into your website."
-msgstr ""
-"Nastavení můžeš změnit níže. Pak jednoduše zkopíruj kód do svojí stránky."
+msgstr "Nastavení můžeš změnit níže. Pak jednoduše zkopíruj kód do svojí stránky."
 
 # smartling.placeholder_format=C
 msgid "Fiji"
@@ -7918,8 +7916,7 @@ msgstr "Filtry nefungují"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Filters out AI-generated images from image search results"
-msgstr ""
-"Odstraní obrázky vytvořené umělou inteligencí z výsledků vyhledávání obrázků"
+msgstr "Odstraní obrázky vytvořené umělou inteligencí z výsledků vyhledávání obrázků"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -7934,6 +7931,8 @@ msgctxt "settings"
 msgid ""
 "Filters out known AI spam sites from image search results. %sLearn More%s"
 msgstr ""
+"Vyfiltruje známé weby s AI spamem z výsledků vyhledávání obrázků. %1$sDalší "
+"informace%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the final score of a sporting event.
@@ -7994,7 +7993,7 @@ msgstr "Hledání aktuálních informací"
 #. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Find me alternatives"
-msgstr ""
+msgstr "Najdi mi alternativy"
 
 # smartling.placeholder_format=C
 #. Button that searches for results closer to the user's current location.
@@ -8086,8 +8085,7 @@ msgstr ""
 #. Privacy reassurance and instructions intro.
 msgctxt "duckai_migration"
 msgid "Follow these steps to move your chats to the new Duck.ai"
-msgstr ""
-"Postupuj podle těchto kroků a přesuň své chaty na novou doménu Duck.ai."
+msgstr "Postupuj podle těchto kroků a přesuň své chaty na novou doménu Duck.ai."
 
 # smartling.placeholder_format=C
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse on mobile
@@ -8192,8 +8190,7 @@ msgstr "Bezplatné a soukromé chaty, které anonymizujeme"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr ""
-"Bezplatné a soukromé chaty, které anonymizujeme. Není potřeba žádný účet."
+msgstr "Bezplatné a soukromé chaty, které anonymizujeme. Není potřeba žádný účet."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -8477,7 +8474,7 @@ msgstr "Vygenerovat víc"
 #. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Generate a shopping list"
-msgstr ""
+msgstr "Vytvoř nákupní seznam"
 
 # smartling.placeholder_format=C
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
@@ -8774,7 +8771,7 @@ msgstr "Vyzkoušet"
 #. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Give me a quick background on this person."
-msgstr ""
+msgstr "Řekni mi stručně něco o této osobě."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9228,13 +9225,13 @@ msgstr "Pomoz šířit ochranu soukromí"
 #. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Help me prep for the interview"
-msgstr ""
+msgstr "Pomoz mi s přípravou na pohovor"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Help me tailor my resume for this job."
-msgstr ""
+msgstr "Pomoz mi upravit můj životopis pro tuto pracovní pozici."
 
 # smartling.placeholder_format=C
 #. Title of a SERP popup that invites users to take a survey (desktop only)
@@ -9677,8 +9674,7 @@ msgstr "Jak to funguje"
 #. Header for the assist settings modal where the user can choose how often they want AI-assisted answers to appear.
 msgctxt "duckassist"
 msgid "How much do you want AI-assisted answers to appear?"
-msgstr ""
-"Jak často chceš, aby se objevovaly odpovědi s podporou umělé inteligence?"
+msgstr "Jak často chceš, aby se objevovaly odpovědi s podporou umělé inteligence?"
 
 # smartling.placeholder_format=C
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
@@ -9758,7 +9754,7 @@ msgctxt ""
 "Text for the I already have a subscription button in the Duck.ai settings "
 "page"
 msgid "I Already Have a Subscription"
-msgstr ""
+msgstr "Předplatné už mám"
 
 # smartling.placeholder_format=C
 #. Text for the button that takes the user to the login subscription page.
@@ -9926,8 +9922,7 @@ msgstr ""
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
-msgstr ""
-"Pokud nás stále chceš podpořit, %1$spoděl se o DuckDuckGo s ostatními%2$s"
+msgstr "Pokud nás stále chceš podpořit, %1$spoděl se o DuckDuckGo s ostatními%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -9936,8 +9931,7 @@ msgstr ""
 msgid ""
 "If you want to use DuckDuckGo without JavaScript, please use our %s or %s "
 "versions."
-msgstr ""
-"Pokud chceš používat DuckDuckGo bez JavaScriptu, použij verzi %1$s nebo %2$s."
+msgstr "Pokud chceš používat DuckDuckGo bez JavaScriptu, použij verzi %1$s nebo %2$s."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -10339,7 +10333,7 @@ msgstr "Instalace prohlížeče Mac Browser"
 #. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
 msgctxt "settings"
 msgid "Install Now"
-msgstr ""
+msgstr "Chci ho nainstalovat"
 
 # smartling.placeholder_format=C
 #. Text of a button to install the DuckDuckGo app
@@ -10442,13 +10436,13 @@ msgstr "Dochází smazáním dat k jejich skutečnému odstranění?"
 #. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Is it worth taking?"
-msgstr ""
+msgstr "Stojí to za to?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Is this place any good?"
-msgstr ""
+msgstr "Stojí to tady za něco?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
@@ -10456,7 +10450,7 @@ msgctxt "Page suggestion prompt"
 msgid ""
 "Is this place any good? Summarize its reputation based on reviews and "
 "ratings."
-msgstr ""
+msgstr "Stojí to tady za něco? Shrň pověst podniku na základě recenzí a hodnocení."
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -10468,13 +10462,13 @@ msgstr "Je toto video užitečné?"
 #. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Is this worth watching?"
-msgstr ""
+msgstr "Stojí to za zhlédnutí?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Is this worth watching? Give me a spoiler-free take."
-msgstr ""
+msgstr "Stojí to za zhlédnutí? Dej mi názor bez spoilerů."
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -11090,7 +11084,7 @@ msgstr "Odkazy"
 #. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
-msgstr ""
+msgstr "Vypiš nástroje, materiály nebo předpoklady, které k tomu potřebuješ."
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -11381,8 +11375,7 @@ msgstr "Ujisti se, že jsou všechna slova napsaná správně."
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Make sure to check %s\"Make this my default search provider\"%s"
-msgstr ""
-"Zaškrtni možnost %1$sNastavit jako výchozího poskytovatele vyhledávání%2$s"
+msgstr "Zaškrtni možnost %1$sNastavit jako výchozího poskytovatele vyhledávání%2$s"
 
 # smartling.placeholder_format=C
 #. Message prompting users to check the spelling of their search term.
@@ -11503,7 +11496,7 @@ msgstr "Správa zablokovaných webů"
 #. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
 msgctxt "setting"
 msgid "Manage in Browser Settings"
-msgstr ""
+msgstr "Spravovat v nastavení prohlížeče"
 
 # smartling.placeholder_format=C
 #. Link to the site exclusion settings page
@@ -11955,8 +11948,7 @@ msgstr "Byl vyčerpán měsíční limit"
 #. Displayed when the user has reached a fixed monthly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Monthly usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Byl vyčerpán měsíční limit využití. V tomto chatu můžeš pokračovat za %1$s."
+msgstr "Byl vyčerpán měsíční limit využití. V tomto chatu můžeš pokračovat za %1$s."
 
 # smartling.placeholder_format=C
 #. Used to point to additional social networking profiles (in results).
@@ -12791,8 +12783,7 @@ msgstr "Nebyly nalezeny žádné výsledky."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the recording contains no audible speech.
 msgid "No speech detected. Please try again and speak into your microphone."
-msgstr ""
-"Nebyla zaznamenána žádná řeč. Zkus to prosím znovu a mluv do mikrofonu."
+msgstr "Nebyla zaznamenána žádná řeč. Zkus to prosím znovu a mluv do mikrofonu."
 
 # smartling.placeholder_format=C
 #. Button that dismisses a feedback form.
@@ -13365,8 +13356,7 @@ msgctxt "translations_module"
 msgid ""
 "Oops! An unexpected error occurred while translating this text. Please try "
 "again later."
-msgstr ""
-"Jejda! Při překládání tohoto textu došlo k neočekávané chybě. Zkus to znovu."
+msgstr "Jejda! Při překládání tohoto textu došlo k neočekávané chybě. Zkus to znovu."
 
 # smartling.placeholder_format=C
 #. Title shown in a fatal error modal when Duck.ai fails to load.
@@ -13441,8 +13431,7 @@ msgstr "Otevřít %1$sNastavení%2$s"
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open 'Location', and ensure location is %senabled%s."
-msgstr ""
-"Otevři možnost Poloha a ujisti se, že je přístup k poloze %1$spovolený%2$s."
+msgstr "Otevři možnost Poloha a ujisti se, že je přístup k poloze %1$spovolený%2$s."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -14337,7 +14326,7 @@ msgstr "Dokončením následující výzvy potvrdíš, že toto hledání proved
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is harmful or illegal. (optional)"
-msgstr ""
+msgstr "Popiš, proč je odpověď v chatu škodlivá nebo nelegální. (nepovinné)"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
@@ -14374,6 +14363,8 @@ msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is harmful or illegal."
 msgstr ""
+"Zadej prompt a problematický výstup (bez jakýchkoliv osobních údajů) a "
+"popiš, proč je obsah škodlivý nebo nelegální."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -14846,7 +14837,7 @@ msgstr "Soukromí"
 #. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
 msgctxt "Section heading on the Duck.ai settings page"
 msgid "Privacy & Terms"
-msgstr ""
+msgstr "Soukromí a podmínky"
 
 # smartling.placeholder_format=C
 msgid "Privacy Blog"
@@ -14922,7 +14913,7 @@ msgstr "Zásady ochrany osobních údajů a podmínky služby"
 #. Text for a button that links to the terms of use and privacy policy page.
 msgctxt "Secondary button text in active privacy modal"
 msgid "Privacy Policy and Terms of Service"
-msgstr ""
+msgstr "Zásady ochrany osobních údajů a podmínky služby"
 
 # smartling.placeholder_format=C
 #. Title displayed on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
@@ -15096,8 +15087,7 @@ msgstr "Upozornit"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Prompt me to use my approximate location to get nearby results."
-msgstr ""
-"Vyzvat mě, abych použil/a svou přibližnou polohu a získal/a výsledky v okolí."
+msgstr "Vyzvat mě, abych použil/a svou přibližnou polohu a získal/a výsledky v okolí."
 
 # smartling.placeholder_format=C
 #. DuckDuckGo Email Protection removes trackers from emails
@@ -15139,8 +15129,7 @@ msgctxt "Full sentence for critiquing writing"
 msgid ""
 "Provide a few suggestions to make the following text more concise. [Insert "
 "your own text here.]"
-msgstr ""
-"Dej mi několik návrhů, jak následující text zestručnit. [Sem vlož svůj text.]"
+msgstr "Dej mi několik návrhů, jak následující text zestručnit. [Sem vlož svůj text.]"
 
 # smartling.placeholder_format=C
 #. In the context of a standings table for NHL (hockey), column title that abbreviates 'Total Points' (the total points of this team)
@@ -15427,25 +15416,25 @@ msgstr "Doporuč mi knihu"
 #. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Recommend similar books"
-msgstr ""
+msgstr "Doporuč mi podobné knihy"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Recommend similar books."
-msgstr ""
+msgstr "Doporuč mi podobné knihy."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Recommend similar movies or shows."
-msgstr ""
+msgstr "Doporuč mi podobné filmy nebo pořady."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Recommend similar titles"
-msgstr ""
+msgstr "Doporuč mi podobné tituly"
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
@@ -15858,7 +15847,7 @@ msgctxt ""
 "feedback form when the user has selected Harmful or Illegal as the feedback "
 "reason"
 msgid "Required for harmful or illegal reports"
-msgstr ""
+msgstr "Povinné pro hlášení škodlivého nebo nezákonného obsahu"
 
 # smartling.placeholder_format=C
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
@@ -16098,7 +16087,7 @@ msgstr "Recenze"
 #. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Rewrite this recipe scaled for a different number of servings."
-msgstr ""
+msgstr "Přepiš tento recept pro jiný počet porcí."
 
 # smartling.placeholder_format=C
 msgid "Romania"
@@ -16175,8 +16164,7 @@ msgstr "SV"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "SERP promotion for desktop browsers has been dismissed"
-msgstr ""
-"Propagace na stránce s výsledky vyhledávání pro desktopový prohlížeč zavřena"
+msgstr "Propagace na stránce s výsledky vyhledávání pro desktopový prohlížeč zavřena"
 
 # smartling.placeholder_format=C
 #. Abbreviation indicating that a game is in shootouts, e.g. in NHL (hockey)
@@ -16243,8 +16231,7 @@ msgstr "Bezpečné vyhledávání zablokovalo výsledky pro %1$s."
 # smartling.placeholder_format=C
 #. A label above search results that lets the user know the safe search filter blocked some of the results from showing. The placeholder value is the user's search term.
 msgid "Safe search blocked some results for %s."
-msgstr ""
-"Bezpečné vyhledávání zablokovalo některé výsledky hledání pro dotaz %1$s."
+msgstr "Bezpečné vyhledávání zablokovalo některé výsledky hledání pro dotaz %1$s."
 
 # smartling.placeholder_format=C
 #. Safe search lets you remove adult content from results on DuckDuckGo. This string is used to invite users to select the desired level of protection (e.g., strict, moderate, off)
@@ -16386,8 +16373,7 @@ msgstr "Ukládej až 30 svých nejnovějších chatů lokálně na své zaříze
 msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
-msgstr ""
-"Ulož si chaty Duck.ai mezi svými zařízeními pomocí end-to-end šifrování."
+msgstr "Ulož si chaty Duck.ai mezi svými zařízeními pomocí end-to-end šifrování."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -16546,8 +16532,7 @@ msgstr "Přejdi dolů a vyhledej %1$ssvůj prohlížeč%2$s v seznamu."
 #. Tells users which setting to change to enable location service.
 msgctxt "precise_user_location"
 msgid "Scroll down to %sDuckDuckGo%s and allow it to use your location."
-msgstr ""
-"Přejdi dolů na položku %1$sDuckDuckGo%2$s a umožni jí používat tvou polohu."
+msgstr "Přejdi dolů na položku %1$sDuckDuckGo%2$s a umožni jí používat tvou polohu."
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -17085,14 +17070,13 @@ msgstr "V Safari zvol %1$sNastavení pro tuto webovou stránku...%2$s."
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
 msgstr ""
-"Vyber možnost %1$sPřizpůsobit%2$s a do vyhledávacího pole zadej %3$shttps://"
-"duckduckgo.com%4$s"
+"Vyber možnost %1$sPřizpůsobit%2$s a do vyhledávacího pole zadej "
+"%3$shttps://duckduckgo.com%4$s"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
-msgstr ""
-"Vyber %1$sDuckDuckGo%2$s a klikni na %3$sNastavit jako výchozí prohlížeč%4$s!"
+msgstr "Vyber %1$sDuckDuckGo%2$s a klikni na %3$sNastavit jako výchozí prohlížeč%4$s!"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
@@ -17234,8 +17218,7 @@ msgstr ""
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %syour browser%s in the list and %sallow%s location access"
-msgstr ""
-"V seznamu vyber %1$ssvůj prohlížeč%2$s a %3$spovol přístup k poloze%4$s"
+msgstr "V seznamu vyber %1$ssvůj prohlížeč%2$s a %3$spovol přístup k poloze%4$s"
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the modal for deleting all recent chats, that allows the user to select the chats to delete.
@@ -17431,7 +17414,7 @@ msgstr "Nastavit"
 #. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
 msgctxt "Encrypted storage setup button shown in native browsers"
 msgid "Set Up Sync & Backup"
-msgstr ""
+msgstr "Nastavení Sync & Backup"
 
 # smartling.placeholder_format=C
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
@@ -17469,8 +17452,7 @@ msgstr ""
 #. Prompt for the user to indicate their location on a map, to enable more relevant search results.
 msgctxt "precise_user_location"
 msgid "Set your location manually, or ensure Location Services is enabled."
-msgstr ""
-"Nastav polohu ručně nebo zkontroluj, jestli jsou povolené polohové služby."
+msgstr "Nastav polohu ručně nebo zkontroluj, jestli jsou povolené polohové služby."
 
 # smartling.placeholder_format=C
 #. In the top dropdown menu  ("More" > "Settings")
@@ -17551,8 +17533,8 @@ msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
 msgstr ""
-"Sdílej polohu na úrovni města s modely AI, aby se zlepšila relevance. Duck."
-"ai nikdy neodhalí tvoji přesnou polohu nám ani modelům AI."
+"Sdílej polohu na úrovni města s modely AI, aby se zlepšila relevance. "
+"Duck.ai nikdy neodhalí tvoji přesnou polohu nám ani modelům AI."
 
 # smartling.placeholder_format=C
 #. Menu option to share feedback about a result
@@ -17617,7 +17599,7 @@ msgstr "Sdílet pozitivní zpětnou vazbu"
 msgctxt ""
 "Label beside the share-content switch on the Duck.ai response feedback form"
 msgid "Share this conversation with DuckDuckGo"
-msgstr ""
+msgstr "Sdílet tuto konverzaci s DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -18449,8 +18431,7 @@ msgstr "Vymazaný zdrojový text"
 msgctxt "Error message for summary selection input limit"
 msgid ""
 "Source text is too long to summarize. Try again with a shorter selection."
-msgstr ""
-"Zdrojový text je na shrnutí příliš dlouhý. Zkus to znovu s kratším výběrem."
+msgstr "Zdrojový text je na shrnutí příliš dlouhý. Zkus to znovu s kratším výběrem."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under Interface Settings.in the end. It is a header
@@ -18877,19 +18858,19 @@ msgstr "Navrhni mi název příspěvku na blog"
 #. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Suggest related articles or topics worth exploring next."
-msgstr ""
+msgstr "Navrhni související články nebo témata, která stojí za to prozkoumat."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Suggest related articles to explore"
-msgstr ""
+msgstr "Navrhni související články k prozkoumání"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Suggest some alternatives to this product."
-msgstr ""
+msgstr "Navrhni nějaké alternativy k tomuto produktu."
 
 # smartling.placeholder_format=C
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
@@ -18906,7 +18887,7 @@ msgstr "Návrhy:"
 #. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Sum up the reviews"
-msgstr ""
+msgstr "Shrň mi recenze"
 
 # smartling.placeholder_format=C
 #. A short title for the a message asking the AI to summarize a text.
@@ -18918,85 +18899,85 @@ msgstr "Shrň mi to"
 #. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize the Q&As"
-msgstr ""
+msgstr "Shrň mi otázky a odpovědi"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the background and notable work of this person."
-msgstr ""
+msgstr "Shrň mi základní informace a významná díla této osoby."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the key details of this event."
-msgstr ""
+msgstr "Shrň mi hlavní fakta o téhle události."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the questions and answers on this page."
-msgstr ""
+msgstr "Shrň mi otázky a odpovědi na této stránce."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize their background"
-msgstr ""
+msgstr "Shrň mi základní informace"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this book"
-msgstr ""
+msgstr "Shrň mi tuhle knihu"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this book."
-msgstr ""
+msgstr "Shrň mi tuhle knihu."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this discussion"
-msgstr ""
+msgstr "Shrň mi tuhle diskuzi"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this discussion thread."
-msgstr ""
+msgstr "Shrň mi tohle diskuzní vlákno."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this page"
-msgstr ""
+msgstr "Shrň mi tuhle stránku"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this page."
-msgstr ""
+msgstr "Shrň mi tuhle stránku."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this video"
-msgstr ""
+msgstr "Shrň mi tohle video"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this video."
-msgstr ""
+msgstr "Shrň mi tohle video."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize what the reviews say."
-msgstr ""
+msgstr "Shrň mi, co říkají recenze."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -19323,7 +19304,7 @@ msgstr "Sýrie"
 #. Text for a button that enables the theme to follow the operating system's color scheme preference.
 msgctxt "System theme button for theme selector"
 msgid "System"
-msgstr ""
+msgstr "Systém"
 
 # smartling.placeholder_format=C
 #. Abbreviation indicating this is the total score for a game
@@ -19357,7 +19338,7 @@ msgstr "Tahitština"
 #. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Tailor my resume"
-msgstr ""
+msgstr "Uprav můj životopis"
 
 # smartling.placeholder_format=C
 msgid "Taiwan"
@@ -19393,7 +19374,7 @@ msgstr "Měj osobní údaje ve svých rukou!"
 msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
-msgstr ""
+msgstr "Vyplň tento anonymní dotazník a dej nám vědět, jak můžeme Duck.ai vylepšit."
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -19592,15 +19573,13 @@ msgstr "Děkujeme za zpětnou vazbu!"
 #. Inform the users that "something" went wrong and we are unable to show any results.
 msgctxt "noresults"
 msgid "Thanks for your patience while we get our ducks in a row!"
-msgstr ""
-"Děkujeme ti za trpělivost. Snažíme se všechny kachny dostat zase do řady."
+msgstr "Děkujeme ti za trpělivost. Snažíme se všechny kachny dostat zase do řady."
 
 # smartling.placeholder_format=C
 #. Inform the users that "something" went wrong and we are unable to show any results.
 msgctxt "noresults"
 msgid "Thanks for your patience while we get our ducks in a row."
-msgstr ""
-"Děkujeme ti za trpělivost. Snažíme se všechny kachny dostat zase do řady."
+msgstr "Děkujeme ti za trpělivost. Snažíme se všechny kachny dostat zase do řady."
 
 # smartling.placeholder_format=C
 #. Message indicating that the open lock icon in the address bar means that a website is not secure.
@@ -19660,8 +19639,7 @@ msgstr ""
 msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider deletes any data associated with this chat within 30 days."
-msgstr ""
-"Poskytovatel modelu smaže veškerá data související s tímto chatem do 30 dnů."
+msgstr "Poskytovatel modelu smaže veškerá data související s tímto chatem do 30 dnů."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers.
@@ -19705,7 +19683,7 @@ msgstr "Motiv"
 #. Text for the theme selector label that allows users to switch between Light and dark theme.
 msgctxt "Label for the theme selector feature"
 msgid "Theme"
-msgstr ""
+msgstr "Motiv"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/LpFhb1e.png
@@ -19812,8 +19790,7 @@ msgctxt "AI Chat: Error message for when a model is removed"
 msgid ""
 "This AI model is no longer available. Try starting a new chat with a "
 "different model."
-msgstr ""
-"Tenhle model AI už není dostupný. Zkus začít nový chat s jiným modelem."
+msgstr "Tenhle model AI už není dostupný. Zkus začít nový chat s jiným modelem."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is no longer supported because it has been upgraded to a newest version.
@@ -20091,15 +20068,13 @@ msgstr "Tento překlad je špatný"
 # smartling.placeholder_format=C
 #. Label indicating that the video can't be played on the current page, and only on the website that owns the vide. The placeholder is the name of the website that owns the video.
 msgid "This video is not yet able to be watched here. You can watch it on %s."
-msgstr ""
-"Toto video zde ještě není možné sledovat. Můžete se na něho podívat na %1$s."
+msgstr "Toto video zde ještě není možné sledovat. Můžete se na něho podívat na %1$s."
 
 # smartling.placeholder_format=C
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr ""
-"Tahle webová stránka nepoužívá zabezpečené, šifrované připojení (HTTPS)."
+msgstr "Tahle webová stránka nepoužívá zabezpečené, šifrované připojení (HTTPS)."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -20549,13 +20524,13 @@ msgstr ""
 #. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Translate this page"
-msgstr ""
+msgstr "Přeložit tuto stránku"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
 msgctxt "Page suggestion prompt"
 msgid "Translate this page into %s."
-msgstr ""
+msgstr "Přelož tuto stránku do jazyka %1$s."
 
 # smartling.placeholder_format=C
 #. Placeholder text for a region that will display translated text.
@@ -20657,8 +20632,7 @@ msgstr "Zkus přejít na %1$s a podobné zprávy už ti nebudeme ukazovat."
 #. Text for a promotional card that encourages users to try the encrypted AI model whose inference runs in a confidential environment so the model provider cannot access user data. %s is replaced with the model's full display name (e.g. 'GPT-OSS 120B').
 msgctxt "Promotional text for encrypted AI model"
 msgid "Try %s, our first model with zero provider visibility."
-msgstr ""
-"Zkus %1$s, náš první model, ve kterém má poskytovatel nulovou viditelnost."
+msgstr "Zkus %1$s, náš první model, ve kterém má poskytovatel nulovou viditelnost."
 
 # smartling.placeholder_format=C
 msgid "Try %sDuck.ai%s, our private AI chat service:"
@@ -20703,7 +20677,7 @@ msgstr "Vyzkoušet zdarma"
 #. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
 msgctxt "settings"
 msgid "Try It Now"
-msgstr ""
+msgstr "Vyzkoušet"
 
 # smartling.placeholder_format=C
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -20946,6 +20920,9 @@ msgid ""
 "Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
+"Pokoušíš se vypnout funkce AI? Nainstaluj si vyhledávací rozšíření "
+"%1$sDuckDuckGo No AI%2$s, aby si pamatovalo tvoje nastavení. %3$sDalší "
+"informace%4$s"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -20954,6 +20931,9 @@ msgid ""
 "Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
+"Pokoušíš se vypnout funkce AI? Přepni na vyhledávací rozšíření "
+"%1$sDuckDuckGo No AI%2$s, které si bude pamatovat tvá nastavení. %3$sDalší "
+"informace%4$s"
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -21278,8 +21258,8 @@ msgstr ""
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
 msgstr ""
-"Pod možností %1$sSpuštění > Domovská stránka%2$s zadej: https://duckduckgo."
-"com"
+"Pod možností %1$sSpuštění > Domovská stránka%2$s zadej: "
+"https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -21289,8 +21269,7 @@ msgstr "V nabídce %1$sNastavení vyhledávání%2$s zvol %3$sDuckDuckGo%4$s"
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch in the address bar with%s select %sAdd New%s"
-msgstr ""
-"Pod %1$shledáním v adresním řádku pomocí %2$s vyber %3$sPřidat nový%4$s"
+msgstr "Pod %1$shledáním v adresním řádku pomocí %2$s vyber %3$sPřidat nový%4$s"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -21658,8 +21637,7 @@ msgstr ""
 #. Upsell message shown in the voice chat limit and duration limit modals for Plus subscribers, encouraging them to upgrade to Pro.
 msgctxt "voice chat limit modal"
 msgid "Upgrade to Pro to unlock 2x higher usage limits than Plus"
-msgstr ""
-"Upgraduj na tarif Pro a aktivuj si dvojnásobné limity, než má tarif Plus"
+msgstr "Upgraduj na tarif Pro a aktivuj si dvojnásobné limity, než má tarif Plus"
 
 # smartling.placeholder_format=C
 #. Heading in a promotion for a desktop web browser
@@ -21711,7 +21689,7 @@ msgstr "Uruguay"
 #. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
 msgctxt "Navigation label on the Duck.ai settings page"
 msgid "Usage"
-msgstr ""
+msgstr "Využití"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -21769,8 +21747,7 @@ msgstr "Použít vyhledávač Private Search od DuckDuckGo"
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Use DuckDuckGo private search on your iPad, iPhone, or Android!"
-msgstr ""
-"Používej soukromé vyhledávání DuckDuckGo na iPadu, iPhonu nebo Androidu"
+msgstr "Používej soukromé vyhledávání DuckDuckGo na iPadu, iPhonu nebo Androidu"
 
 # smartling.placeholder_format=C
 #. User clicks this button to share their device's location
@@ -22167,7 +22144,7 @@ msgstr "Wales"
 #. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Walk me through the steps"
-msgstr ""
+msgstr "Proveď mě jednotlivými kroky"
 
 # smartling.placeholder_format=C
 #. Label for walking directions on a map.
@@ -22297,6 +22274,9 @@ msgid ""
 "please share this conversation with DuckDuckGo so we can investigate and "
 "address the issue."
 msgstr ""
+"Můžeme napravit jen to, co vidíme. Pokud chceš nahlásit škodlivou nebo "
+"nezákonnou reakci, sdílej prosím tuto konverzaci s DuckDuckGo, abychom mohli "
+"problém vyšetřit a vyřešit."
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -22369,8 +22349,7 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what brought you "
 "back today:"
-msgstr ""
-"Nesledujeme tě, takže by nám pomohlo, když nám řekneš, co tě přivádí zpátky:"
+msgstr "Nesledujeme tě, takže by nám pomohlo, když nám řekneš, co tě přivádí zpátky:"
 
 # smartling.placeholder_format=C
 #. Message prompting users to fill out a feedback form.
@@ -22391,8 +22370,7 @@ msgstr "Nesledujeme tě. Nikdy."
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with a Continue button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don't track you. That's our Privacy Policy in a nutshell."
-msgstr ""
-"My tě nesledujeme. To jsou naše Zásady ochrany osobních údajů v kostce."
+msgstr "My tě nesledujeme. To jsou naše Zásady ochrany osobních údajů v kostce."
 
 # smartling.placeholder_format=C
 #. Description for the audio identification highlight in the dictation consent modal.
@@ -22433,8 +22411,7 @@ msgstr "Nesledujeme tě. Ani v anonymním režimu ani mimo něj."
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with an Agree button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don’t track you. That’s our Privacy Policy in a nutshell…"
-msgstr ""
-"My vás nesledujeme. To jsou naše Zásady ochrany osobních údajů v kostce…"
+msgstr "My vás nesledujeme. To jsou naše Zásady ochrany osobních údajů v kostce…"
 
 # smartling.placeholder_format=C
 #. Displayed when the user's voice chat session is ended because of being inactive for too long.
@@ -22663,8 +22640,7 @@ msgstr "Byl vyčerpán týdenní limit"
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Weekly usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Byl vyčerpán týdenní limit využití. V tomto chatu můžeš pokračovat za %1$s."
+msgstr "Byl vyčerpán týdenní limit využití. V tomto chatu můžeš pokračovat za %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable weekly Duck.ai usage limit and can opt in to continue using the monthly limit.
@@ -22854,98 +22830,98 @@ msgstr ""
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the counterarguments?"
-msgstr ""
+msgstr "Jaké jsou protiargumenty?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the hours & location?"
-msgstr ""
+msgstr "Jaká je otevírací doba a poloha?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key contributions of this paper?"
-msgstr ""
+msgstr "Jaké jsou hlavní přínosy tohoto článku?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key contributions?"
-msgstr ""
+msgstr "Jaké jsou hlavní přínosy?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key details?"
-msgstr ""
+msgstr "Jaké jsou klíčové podrobnosti?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key points covered in this video?"
-msgstr ""
+msgstr "Jaké jsou hlavní body tohoto videa?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key points?"
-msgstr ""
+msgstr "Jaké jsou hlavní body?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key takeaways from this article?"
-msgstr ""
+msgstr "Jaké jsou hlavní body tohoto článku?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key takeaways?"
-msgstr ""
+msgstr "Jaké jsou hlavní poznatky?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key things I will learn from this course?"
-msgstr ""
+msgstr "Co jsou ty hlavní věci, které se v tomto kurzu dozvím?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the main counterarguments or criticisms of this?"
-msgstr ""
+msgstr "Jaké jsou proti tomu hlavní protiargumenty nebo kritika?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the main questions this page answers?"
-msgstr ""
+msgstr "Na jaké hlavní otázky tato stránka odpovídá?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the must-try dishes here?"
-msgstr ""
+msgstr "Jaká jídla tady musím ochutnat?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid ""
 "What are the opening hours, location, and contact details for this place?"
-msgstr ""
+msgstr "Jaká je otevírací doba, poloha a kontaktní údaje tohoto místa?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the pros and cons of this product?"
-msgstr ""
+msgstr "Jaké jsou výhody a nevýhody tohoto produktu?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the pros and cons?"
-msgstr ""
+msgstr "Jaké jsou výhody a nevýhody?"
 
 # smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
@@ -23051,7 +23027,7 @@ msgstr "Co je to atrium v kontextu lékařského článku?"
 #. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What does this answer?"
-msgstr ""
+msgstr "Na co to odpovídá?"
 
 # smartling.placeholder_format=C
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
@@ -23069,7 +23045,7 @@ msgstr "Jaké informace se ukládají?"
 #. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What interview questions might come up for this role?"
-msgstr ""
+msgstr "Jaké otázky mohou být pro tuto roli položeny u pohovoru?"
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -23091,7 +23067,7 @@ msgstr "Jaké je hlavní město Albánie?"
 #. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What is the overall verdict and rating for this?"
-msgstr ""
+msgstr "Jaké je pro to celkové hodnocení a známka?"
 
 # smartling.placeholder_format=C
 #. Link to a page with additional information.
@@ -23119,7 +23095,7 @@ msgstr "Co říkají ostatní:"
 #. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What should I order?"
-msgstr ""
+msgstr "Co si mám objednat?"
 
 # smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
@@ -23137,13 +23113,13 @@ msgstr "Co bylo na odpovědi špatně? (nepovinné)"
 #. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What will I learn?"
-msgstr ""
+msgstr "Co se dozvím?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What will I need?"
-msgstr ""
+msgstr "Co budu potřebovat?"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -23166,7 +23142,7 @@ msgstr "Co je nového"
 #. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What's the verdict?"
-msgstr ""
+msgstr "Jaký je verdikt?"
 
 # smartling.placeholder_format=C
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -23186,8 +23162,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "When enabled, Duck.ai will show instant answers in the chat."
-msgstr ""
-"Když je možnost zapnutá, Duck.ai bude v chatu zobrazovat okamžité odpovědi."
+msgstr "Když je možnost zapnutá, Duck.ai bude v chatu zobrazovat okamžité odpovědi."
 
 # smartling.placeholder_format=C
 #. Text of a button that performs a search for the available streaming services that show a particular movie or tv show
@@ -23223,7 +23198,7 @@ msgstr "Které funkce chybí? (nepovinné)"
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Which features are missing? (optional)"
-msgstr ""
+msgstr "Které funkce chybí? (nepovinné)"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
@@ -23245,13 +23220,13 @@ msgstr "Kdo jsme"
 #. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Who are the main cast and crew, and what else are they known for?"
-msgstr ""
+msgstr "Kdo tvoří hlavní obsazení a štáb a čím dalším jsou známí?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Who is this person?"
-msgstr ""
+msgstr "Kdo je tato osoba?"
 
 # smartling.placeholder_format=C
 #. Header above a collection of privacy-related links.
@@ -24231,8 +24206,7 @@ msgctxt "duckai_migration"
 msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
-msgstr ""
-"Import tvých chatů je hotový. Na Duck.ai můžeš pokračovat v rozdělané práci."
+msgstr "Import tvých chatů je hotový. Na Duck.ai můžeš pokračovat v rozdělané práci."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.
@@ -24343,8 +24317,7 @@ msgctxt "Popover text for recent chats onboarding"
 msgid ""
 "Your recent chats live here! You can refer to your chats or clear them "
 "anytime."
-msgstr ""
-"Tady najdeš svoje nedávné chaty. Můžeš je kdykoli otevřít nebo vymazat."
+msgstr "Tady najdeš svoje nedávné chaty. Můžeš je kdykoli otevřít nebo vymazat."
 
 # smartling.placeholder_format=C
 #. Message on a feedback form.
@@ -24430,8 +24403,7 @@ msgctxt "Error message for user limit"
 msgid ""
 "You’ve reached the maximum number of messages for one day. Please continue "
 "this chat tomorrow."
-msgstr ""
-"Bylo dosaženo maximálního počtu zpráv za jeden den. V chatu pokračuj zítra."
+msgstr "Bylo dosaženo maximálního počtu zpráv za jeden den. V chatu pokračuj zítra."
 
 # smartling.placeholder_format=C
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
@@ -24733,8 +24705,7 @@ msgstr "oficiálních webových stránkách"
 #. <em>%s</em> is for a hexadecimal color code as <em>#395323</em>, but it has to be safe encoded, and as <em>#</em> seems not safe, <em>%23</em> must be used in place of the sharp symbol, but they are the same for your browser.
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
-msgstr ""
-"nebo napište kód libovolné barvy, např. %1$s (%2$s je kód pro znak %3$s)."
+msgstr "nebo napište kód libovolné barvy, např. %1$s (%2$s je kód pro znak %3$s)."
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "

--- a/locales/cs_CZ/LC_MESSAGES/duckduckgo.po
+++ b/locales/cs_CZ/LC_MESSAGES/duckduckgo.po
@@ -10333,7 +10333,7 @@ msgstr "Instalace prohlížeče Mac Browser"
 #. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
 msgctxt "settings"
 msgid "Install Now"
-msgstr "Chci ho nainstalovat"
+msgstr "Nainstalovat"
 
 # smartling.placeholder_format=C
 #. Text of a button to install the DuckDuckGo app

--- a/locales/cy_GB/LC_MESSAGES/duckduckgo.po
+++ b/locales/cy_GB/LC_MESSAGES/duckduckgo.po
@@ -1168,6 +1168,11 @@ msgctxt "feedback form"
 msgid "Address is incorrect"
 msgstr ""
 
+#. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Adjust the servings"
+msgstr ""
+
 #. as in multiple advertisements
 msgid "Ads"
 msgstr "Hysbysebion"
@@ -1340,6 +1345,13 @@ msgstr ""
 #. Heading shown on the empty chat screen. The text between the two %s markers is displayed inside a clickable privacy button. First %s renders a shield icon, second %s is an invisible end marker. Keep the word 'private' between both %s markers.
 msgctxt "Empty state heading in Duck.ai chat mode"
 msgid "All chats are %sprivate%s"
+msgstr ""
+
+#. Paragraph in the Privacy & Terms section of the About & Legal page in Duck.ai settings, summarizing how chats are anonymized and are not stored or used to train chat models.
+msgctxt "Privacy & Terms section description on the Duck.ai settings page"
+msgid ""
+"All chats are anonymized by DuckDuckGo, and your conversations are not used "
+"to train chat models by DuckDuckGo or the model providers"
 msgstr ""
 
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1552,6 +1564,12 @@ msgstr ""
 #. Confirmation message after location service is enabled.
 msgctxt "precise_user_location"
 msgid "Anonymous location enabled"
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Anonymously generates answers for search queries based on web content. "
+"Choose how often you want it to appear, or disable it completely."
 msgstr ""
 
 #. Instant Answer tab name
@@ -1774,6 +1792,11 @@ msgstr ""
 
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse
 msgid "Ask a follow-up with Duck.ai"
+msgstr ""
+
+#. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
+msgctxt "Page suggestion chip label"
+msgid "Ask about this page"
 msgstr ""
 
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2098,6 +2121,11 @@ msgstr ""
 msgid "Barcode"
 msgstr "Côd Sganio"
 
+#. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Based on this page, is this course worth taking?"
+msgstr ""
+
 msgctxt "settings"
 msgid "Basic"
 msgstr "Syml"
@@ -2129,6 +2157,13 @@ msgstr ""
 #. Placeholder text displayed while the assistant waits for the user to choose an action.
 msgctxt "Assistant response placeholder"
 msgid "Before continuing..."
+msgstr ""
+
+#. Explains that before storing the report, DuckDuckGo will anonymize the conversation by removing PII like names, email addresses, and identifying metadata.
+msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
+msgid ""
+"Before storing this report, DuckDuckGo will anonymize your conversation by "
+"removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
 #. Label that's displayed next to a past start date below a web search result.
@@ -2389,6 +2424,11 @@ msgstr "Brasil"
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Break Points Won"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Break this down into clear, numbered steps."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -2755,6 +2795,11 @@ msgstr "Swyddi"
 #. Text of a button that performs a search for the cast of a particular movie or tv show
 msgctxt "Movie/TV Show Title instant answer"
 msgid "Cast"
+msgstr ""
+
+#. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Cast & Crew"
 msgstr ""
 
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -4112,6 +4157,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Create a shopping list with quantities from this recipe."
+msgstr ""
+
 #. Placeholder text displayed in the input field when starting a new image generation session.
 msgctxt "Placeholder text for the image generation input field"
 msgid "Create an image of a cute duck..."
@@ -4639,6 +4689,10 @@ msgstr ""
 msgid "Dictation limit reached"
 msgstr ""
 
+#. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
+msgid "Dictation temporarily unavailable"
+msgstr ""
+
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
@@ -4884,6 +4938,20 @@ msgctxt "precise_user_location"
 msgid "Done"
 msgstr "Wedi Gorffen"
 
+#. Message shown in a modal after DuckDuckGo browser users disable AI features in Settings. The first two placeholders bold noai.duckduckgo.com. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
+"filtered out. %sLearn More%s"
+msgstr ""
+
+#. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
+"and AI images filtered out. %sLearn more%s"
+msgstr ""
+
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Double Faults"
@@ -4974,6 +5042,16 @@ msgctxt "Full sentence for writing an email"
 msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
+msgstr ""
+
+#. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Draft a cover letter"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Draft a cover letter for this job."
 msgstr ""
 
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -5113,6 +5191,14 @@ msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
 msgstr ""
 
+#. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
+msgctxt "About section description on the Duck.ai settings page"
+msgid ""
+"Duck.ai is created by DuckDuckGo. We're an independent online protection "
+"company for anyone who wants to take back control of their personal "
+"information."
+msgstr ""
+
 #. Title shown when an update is required before proceeding.
 msgctxt "duckai_migration"
 msgid "Duck.ai is moving domains"
@@ -5146,6 +5232,12 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Duck.ai lets you chat privately with popular AI models. Disabling it hides "
+"Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
 
 msgctxt "settings"
@@ -5911,6 +6003,16 @@ msgstr ""
 msgid "Eritrea"
 msgstr ""
 
+#. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Estimate the nutrition"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Estimate the nutritional information for this recipe."
+msgstr ""
+
 msgid "Estonia"
 msgstr "Estonia"
 
@@ -5955,10 +6057,50 @@ msgctxt "merchant promotion product ad extension"
 msgid "Expires in 1 day"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain the accepted answer in simple terms."
+msgstr ""
+
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
+msgstr ""
+
+#. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain the top answer"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this in simple, plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this paper"
+msgstr ""
+
+#. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this repo"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this research paper in plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this simply"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain what this repository does and how to use it."
 msgstr ""
 
 #. Label to show if song lyrics contain explicit content
@@ -6192,6 +6334,11 @@ msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
 msgstr ""
 
+msgctxt "settings"
+msgid ""
+"Filters out known AI spam sites from image search results. %sLearn More%s"
+msgstr ""
+
 #. Label for the final score of a sporting event.
 msgid "Final"
 msgstr "Terfynol"
@@ -6234,6 +6381,11 @@ msgstr ""
 #. Short description shown below the 'Web Search' label in the Tools dropdown.
 msgctxt "Subtitle for the Web Search tool entry in the Tools dropdown menu"
 msgid "Find current information"
+msgstr ""
+
+#. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Find me alternatives"
 msgstr ""
 
 #. Button that searches for results closer to the user's current location.
@@ -6624,6 +6776,11 @@ msgstr ""
 msgid "Generate More"
 msgstr ""
 
+#. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Generate a shopping list"
+msgstr ""
+
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
 msgid "Generate a short answer from the web"
 msgstr ""
@@ -6858,6 +7015,11 @@ msgstr ""
 #. Text for a button inviting users to give it a try for the Duck.ai product. On click, they're taken to the Duck.ai page.
 msgctxt "Onboarding welcome screen button text"
 msgid "Give it a Try"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Give me a quick background on this person."
 msgstr ""
 
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -7221,6 +7383,16 @@ msgstr ""
 #. Link to a page with information about sharing DuckDuckGo with friends.
 msgid "Help Spread Privacy"
 msgstr "Helpu Lledaenu Preifatrwydd"
+
+#. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Help me prep for the interview"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Help me tailor my resume for this job."
+msgstr ""
 
 #. Title of a SERP popup that invites users to take a survey (desktop only)
 msgctxt "User survey popup"
@@ -7641,6 +7813,13 @@ msgstr ""
 #. Text displayed on the button on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
 msgctxt "Onboarding terms screen button text"
 msgid "I Agree"
+msgstr ""
+
+#. Text for the button that takes the user to the external DuckDuckGo login subscription page.
+msgctxt ""
+"Text for the I already have a subscription button in the Duck.ai settings "
+"page"
+msgid "I Already Have a Subscription"
 msgstr ""
 
 #. Text for the button that takes the user to the login subscription page.
@@ -8096,6 +8275,11 @@ msgctxt "Sidemenu browser promo"
 msgid "Install Mac Browser"
 msgstr ""
 
+#. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
+msgctxt "settings"
+msgid "Install Now"
+msgstr ""
+
 #. Text of a button to install the DuckDuckGo app
 msgctxt "Serp footer content"
 msgid "Install Our App"
@@ -8176,9 +8360,36 @@ msgctxt "cloudsave"
 msgid "Is deleted data really deleted?"
 msgstr "A yw data wedi ei ddileu, wedi ei ddileu go iawn?"
 
+#. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is it worth taking?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this place any good?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"Is this place any good? Summarize its reputation based on reviews and "
+"ratings."
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "Is this video helpful?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this worth watching?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Is this worth watching? Give me a spoiler-free take."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -8679,6 +8890,11 @@ msgstr "Ffont dolen:"
 msgid "Links:"
 msgstr "Dolenni:"
 
+#. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "List the tools, materials, or prerequisites I need for this."
+msgstr ""
+
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
 msgid "Listen"
 msgstr "Gwrando"
@@ -9013,6 +9229,11 @@ msgstr ""
 #. Label for linke navigating to site exclusion feature on Settings page
 msgctxt "Exclusion message manage sites button"
 msgid "Manage blocked sites"
+msgstr ""
+
+#. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
+msgctxt "setting"
+msgid "Manage in Browser Settings"
 msgstr ""
 
 #. Link to the site exclusion settings page
@@ -11331,6 +11552,11 @@ msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
+msgid "Please describe why the chat response is harmful or illegal. (optional)"
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
+msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
 msgstr ""
 
@@ -11349,6 +11575,13 @@ msgctxt "Modal disclaimer text"
 msgid ""
 "Please note: starting a new chat with any model will delete your current "
 "chat session."
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
+msgctxt "Feedback prompt"
+msgid ""
+"Please paste your prompt and the problematic output (with any personal "
+"information removed) and describe why the content is harmful or illegal."
 msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -11733,6 +11966,11 @@ msgctxt "settings"
 msgid "Privacy"
 msgstr "Preifatrwydd"
 
+#. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
+msgctxt "Section heading on the Duck.ai settings page"
+msgid "Privacy & Terms"
+msgstr ""
+
 msgid "Privacy Blog"
 msgstr "Blog Preifatrwydd"
 
@@ -11788,6 +12026,11 @@ msgstr ""
 
 #. Text used in other strings to link to the Privacy Policy and Terms of Service content.
 msgctxt "Copy used to compose link in sentences"
+msgid "Privacy Policy and Terms of Service"
+msgstr ""
+
+#. Text for a button that links to the terms of use and privacy policy page.
+msgctxt "Secondary button text in active privacy modal"
 msgid "Privacy Policy and Terms of Service"
 msgstr ""
 
@@ -12197,6 +12440,26 @@ msgctxt "Brief for recommending a book"
 msgid "Recommend a book"
 msgstr ""
 
+#. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar books"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar books."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar movies or shows."
+msgstr ""
+
+#. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar titles"
+msgstr ""
+
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
 msgid "Recording failed. Please try again."
 msgstr ""
@@ -12517,6 +12780,14 @@ msgstr ""
 msgid "Republic of Moldova"
 msgstr ""
 
+#. Note indicating that sharing the conversation is mandatory when reporting harmful or illegal content. Rendered alongside the standard share label (DUCKCHAT_RESPONSE_FEEDBACK_SHARE_PROMPT_RESPONSE_LABEL), not replacing it.
+msgctxt ""
+"Note shown under the share-content switch label on the Duck.ai response "
+"feedback form when the user has selected Harmful or Illegal as the feedback "
+"reason"
+msgid "Required for harmful or illegal reports"
+msgstr ""
+
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
 msgctxt "Description for extended reasoning mode in Duck.ai"
 msgid "Researches before responding"
@@ -12703,6 +12974,11 @@ msgstr "Adolygiadau"
 msgctxt "maps_places"
 msgid "Reviews"
 msgstr "Adolygiadau"
+
+#. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Rewrite this recipe scaled for a different number of servings."
+msgstr ""
 
 msgid "Romania"
 msgstr "Rwmania"
@@ -13741,6 +14017,11 @@ msgctxt "Setup button for native sync flow"
 msgid "Set Up Now"
 msgstr ""
 
+#. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
+msgctxt "Encrypted storage setup button shown in native browsers"
+msgid "Set Up Sync & Backup"
+msgstr ""
+
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
 msgctxt "Title for the Sync & Backup intro screen"
 msgid "Set Up Sync & Backup"
@@ -13886,6 +14167,12 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
+msgctxt ""
+"Label beside the share-content switch on the Duck.ai response feedback form"
+msgid "Share this conversation with DuckDuckGo"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -14904,6 +15191,21 @@ msgctxt "Brief for suggesting a blog post title"
 msgid "Suggest a title for a blog post"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest related articles or topics worth exploring next."
+msgstr ""
+
+#. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Suggest related articles to explore"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest some alternatives to this product."
+msgstr ""
+
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
 msgctxt "directions"
 msgid "Suggestions:"
@@ -14913,9 +15215,84 @@ msgctxt "noresults"
 msgid "Suggestions:"
 msgstr "Awgrymiadau:"
 
+#. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Sum up the reviews"
+msgstr ""
+
 #. A short title for the a message asking the AI to summarize a text.
 msgctxt "Title for the summarize message"
 msgid "Summarize"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize the Q&As"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the background and notable work of this person."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the key details of this event."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the questions and answers on this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize their background"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this book"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this book."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this discussion"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this discussion thread."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this video"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this video."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize what the reviews say."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -15170,6 +15547,11 @@ msgstr ""
 msgid "Syria"
 msgstr ""
 
+#. Text for a button that enables the theme to follow the operating system's color scheme preference.
+msgctxt "System theme button for theme selector"
+msgid "System"
+msgstr ""
+
 #. Abbreviation indicating this is the total score for a game
 msgctxt "Sports module"
 msgid "T"
@@ -15193,6 +15575,11 @@ msgctxt "language_name"
 msgid "Tahitian"
 msgstr ""
 
+#. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Tailor my resume"
+msgstr ""
+
 msgid "Taiwan"
 msgstr "Taiwan"
 
@@ -15214,6 +15601,12 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "Take control of your personal data!"
+msgstr ""
+
+#. Description for the Feedback section of the Duck.ai settings page, asking the user to take an anonymous survey to let us know how we can make Duck.ai better.
+msgctxt "Feedback section description on the Duck.ai settings page"
+msgid ""
+"Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
 
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -15458,6 +15851,11 @@ msgstr ""
 #. https://duck.co/media/files/theme.png
 msgid "Theme"
 msgstr "Thema"
+
+#. Text for the theme selector label that allows users to switch between Light and dark theme.
+msgctxt "Label for the theme selector feature"
+msgid "Theme"
+msgstr ""
 
 #. http://i.imgur.com/LpFhb1e.png
 msgctxt "settings"
@@ -16109,6 +16507,16 @@ msgid ""
 "movie theatre?”"
 msgstr ""
 
+#. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Translate this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
+msgctxt "Page suggestion prompt"
+msgid "Translate this page into %s."
+msgstr ""
+
 #. Placeholder text for a region that will display translated text.
 msgctxt "translations_module"
 msgid "Translation"
@@ -16223,6 +16631,11 @@ msgstr ""
 #. Call-to-action button for the subscription promo in the SERP sidemenu.
 msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
+msgstr ""
+
+#. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
+msgctxt "settings"
+msgid "Try It Now"
 msgstr ""
 
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -16417,6 +16830,20 @@ msgstr "Ceisiwch: %s"
 msgctxt "new user poll"
 msgid "Trying DuckDuckGo again"
 msgstr "Ceisio DuckDuckGo eto"
+
+#. Message shown in a modal after supported third-party browser users disable AI features in Settings. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+#. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
 
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
 msgctxt "Assistant response placeholder"
@@ -17020,6 +17447,11 @@ msgstr ""
 msgid "Uruguay"
 msgstr ""
 
+#. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
+msgctxt "Navigation label on the Duck.ai settings page"
+msgid "Usage"
+msgstr ""
+
 #. A feedback suggestion
 msgctxt "Feedback prompt"
 msgid "Usage limit"
@@ -17371,6 +17803,11 @@ msgstr "Aros am Lleoliad..."
 msgid "Wales"
 msgstr ""
 
+#. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Walk me through the steps"
+msgstr ""
+
 #. Label for walking directions on a map.
 msgctxt "directions"
 msgid "Walking"
@@ -17461,6 +17898,16 @@ msgstr ""
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
+msgstr ""
+
+#. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
+msgctxt ""
+"Inline warning shown below the share-content toggle when the user selects "
+"Harmful or Illegal but has not enabled sharing"
+msgid ""
+"We can only fix what we can see. To report a harmful or illegal response, "
+"please share this conversation with DuckDuckGo so we can investigate and "
+"address the issue."
 msgstr ""
 
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -17890,6 +18337,87 @@ msgid ""
 "experience."
 msgstr ""
 
+#. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the counterarguments?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the hours & location?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key contributions of this paper?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key contributions?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key details?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key points covered in this video?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key points?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key takeaways from this article?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key takeaways?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key things I will learn from this course?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main counterarguments or criticisms of this?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main questions this page answers?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the must-try dishes here?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"What are the opening hours, location, and contact details for this place?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the pros and cons of this product?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the pros and cons?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
 msgctxt "feedback form"
 msgid "What bothered you most?"
@@ -17974,6 +18502,11 @@ msgctxt "Full sentence for defining a term"
 msgid "What does atria mean in the context of a medical article?"
 msgstr ""
 
+#. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What does this answer?"
+msgstr ""
+
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
@@ -17983,6 +18516,11 @@ msgstr ""
 msgctxt "cloudsave"
 msgid "What information gets saved?"
 msgstr "Pa wybodaeth sy'n cael ei arbed?"
+
+#. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What interview questions might come up for this role?"
+msgstr ""
 
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
@@ -17994,6 +18532,11 @@ msgstr ""
 #. Text for a prompt suggestion for looking up the capital city of Albania.
 msgctxt "Full sentence for looking up basic facts"
 msgid "What is the capital city of Albania?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What is the overall verdict and rating for this?"
 msgstr ""
 
 #. Link to a page with additional information.
@@ -18014,6 +18557,11 @@ msgctxt "maps_places"
 msgid "What people say:"
 msgstr ""
 
+#. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What should I order?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
 msgctxt "feedback form"
 msgid "What stood out?"
@@ -18022,6 +18570,16 @@ msgstr ""
 #. Question on a feedback form for a negative feedback response.
 msgctxt "feedback form"
 msgid "What was wrong with the response? (optional)"
+msgstr ""
+
+#. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I learn?"
+msgstr ""
+
+#. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I need?"
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -18036,6 +18594,11 @@ msgstr ""
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
 msgctxt "SERP footer content"
 msgid "What's New"
+msgstr ""
+
+#. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What's the verdict?"
 msgstr ""
 
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -18078,6 +18641,11 @@ msgctxt "Feedback prompt"
 msgid "Which features are missing? (Optional)"
 msgstr ""
 
+#. An invitation for users to leave feedback
+msgctxt "Feedback prompt"
+msgid "Which features are missing? (optional)"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
 msgid "White"
 msgstr "Gwyn"
@@ -18090,6 +18658,16 @@ msgstr "Gwyn"
 #. Link to an about us page.
 msgid "Who We Are"
 msgstr "Pwy Ydym Ni"
+
+#. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Who are the main cast and crew, and what else are they known for?"
+msgstr ""
+
+#. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Who is this person?"
+msgstr ""
 
 #. Header above a collection of privacy-related links.
 msgid "Why Privacy"

--- a/locales/da_DK/LC_MESSAGES/duckduckgo.po
+++ b/locales/da_DK/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: da_DK\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -416,8 +416,7 @@ msgstr "%1$s ord"
 #. Instructions on which buttons and options the user has to click in order to add the DuckDuckGo extension to their browser.
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
-msgstr ""
-"%1$sKlik %2$sTilføj%3$sTjek %4$sTillad%5$s, og klik derefter på %6$sOkay%7$s"
+msgstr "%1$sKlik %2$sTilføj%3$sTjek %4$sTillad%5$s, og klik derefter på %6$sOkay%7$s"
 
 # Firefox, obsolete
 # smartling.placeholder_format=C
@@ -472,8 +471,7 @@ msgstr "%1$sSe, hvordan vi holder din placering hemmelig%2$s."
 msgctxt "Footer text for About Sync modal"
 msgid ""
 "%sLearn more%s about how chats are stored privately on DuckDuckGo's server."
-msgstr ""
-"%1$sLæs mere%2$s om, hvordan chats gemmes privat på DuckDuckGos server."
+msgstr "%1$sLæs mere%2$s om, hvordan chats gemmes privat på DuckDuckGos server."
 
 # smartling.placeholder_format=C
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
@@ -808,8 +806,7 @@ msgstr "Grænsen på 6 timers brug er nået."
 #. Displayed when the user has reached a fixed 6-hour Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "6-hour usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Grænsen på 6 timers brug er nået. Du kan fortsætte denne chat efter %1$s."
+msgstr "Grænsen på 6 timers brug er nået. Du kan fortsætte denne chat efter %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable 6-hour Duck.ai usage limit and can opt in to continue using the daily limit.
@@ -880,16 +877,14 @@ msgstr ""
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of AI Chat is available! Please refresh this page to continue."
-msgstr ""
-"En ny version af AI Chat er tilgængelig! Opdater denne side for at fortsætte."
+msgstr "En ny version af AI Chat er tilgængelig! Opdater denne side for at fortsætte."
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of Duck.ai is available and they need to refresh the page.
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of Duck.ai is available! Please refresh this page to continue."
-msgstr ""
-"En ny version af Duck.ai er tilgængelig! Opdater denne side for at fortsætte."
+msgstr "En ny version af Duck.ai er tilgængelig! Opdater denne side for at fortsætte."
 
 # smartling.placeholder_format=C
 #. Shown when the Duck.ai desktop app has been open a long time and a newer version exists.
@@ -1436,7 +1431,7 @@ msgstr "Adressen er forkert"
 #. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Adjust the servings"
-msgstr ""
+msgstr "Tilpas portionerne"
 
 # smartling.placeholder_format=C
 #. as in multiple advertisements
@@ -1658,6 +1653,8 @@ msgid ""
 "All chats are anonymized by DuckDuckGo, and your conversations are not used "
 "to train chat models by DuckDuckGo or the model providers"
 msgstr ""
+"Alle chats anonymiseres af DuckDuckGo, og dine samtaler bruges ikke til at "
+"træne chatmodeller af DuckDuckGo eller modeludbyderne"
 
 # smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1689,8 +1686,7 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "All model providers are prevented from training their AI on your "
 "conversations."
-msgstr ""
-"Alle modeludbydere er forhindret i at træne deres AI på jeres samtaler."
+msgstr "Alle modeludbydere er forhindret i at træne deres AI på jeres samtaler."
 
 # smartling.placeholder_format=C
 #. Text displayed in the subheader of the modal that allows the user to pick an AI chat model.
@@ -1936,6 +1932,8 @@ msgid ""
 "Anonymously generates answers for search queries based on web content. "
 "Choose how often you want it to appear, or disable it completely."
 msgstr ""
+"Genererer anonymt svar på søgeforespørgsler baseret på webindhold. Vælg, "
+"hvor ofte det skal vises, eller deaktiver det helt."
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -1982,8 +1980,8 @@ msgid ""
 "Any additional instructions you want Duck.ai to follow. e.g. Always tell me "
 "facts about ducks"
 msgstr ""
-"Eventuelle yderligere instruktioner, du vil have Duck.ai til at følge. f."
-"eks. Fortæl mig altid fakta om ænder"
+"Eventuelle yderligere instruktioner, du vil have Duck.ai til at følge. "
+"f.eks. Fortæl mig altid fakta om ænder"
 
 # smartling.placeholder_format=C
 #. Shown in video filtering. https://duckduckgo.com/?q=videos+of+cats&iax=videos&ia=videos
@@ -2082,8 +2080,7 @@ msgstr "Er du der stadig?"
 msgctxt "Body text for clear all chats confirmation modal"
 msgid ""
 "Are you sure you want to clear all of your chats? This cannot be undone."
-msgstr ""
-"Er du sikker på, at du vil slette alle dine chats? Dette kan ikke fortrydes."
+msgstr "Er du sikker på, at du vil slette alle dine chats? Dette kan ikke fortrydes."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that asks the user if they want to clear the conversation.
@@ -2095,8 +2092,7 @@ msgstr "Er du sikker på, at du vil rydde denne samtale og starte en ny?"
 #. Text asking the user to confirm if they want to delete their current chat, explaining that this action cannot be undone.
 msgctxt "Body text for delete chat confirmation modal"
 msgid "Are you sure you want to delete this chat? This cannot be undone."
-msgstr ""
-"Er du sikker på, at du vil slette denne chat? Dette kan ikke fortrydes."
+msgstr "Er du sikker på, at du vil slette denne chat? Dette kan ikke fortrydes."
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to disable chat history, with a warning that it will also delete currently saved chats including pinned chats.
@@ -2222,7 +2218,7 @@ msgstr "Stil et opfølgende spørgsmål med Duck.ai"
 #. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
 msgctxt "Page suggestion chip label"
 msgid "Ask about this page"
-msgstr ""
+msgstr "Spørg om denne side"
 
 # smartling.placeholder_format=C
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2291,8 +2287,8 @@ msgstr ""
 "skal vises: Aldrig (fjerner Assist UI fra søgeresultaterne), On-demand "
 "(viser kun AI-assisterede svar, hvis du klikker på knappen Assist), Nogle "
 "gange (viser kun AI-assisterede svar, når det er yderst relevant) eller Ofte "
-"(vises oftere på en bredere række af søgninger). Indtil videre er AI-"
-"assisterede svar kun tilgængelige i USA (engelsk)."
+"(vises oftere på en bredere række af søgninger). Indtil videre er "
+"AI-assisterede svar kun tilgængelige i USA (engelsk)."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2640,7 +2636,7 @@ msgstr "Stregkode"
 #. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Based on this page, is this course worth taking?"
-msgstr ""
+msgstr "Er dette kursus værd at tage på baggrund af denne side?"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2689,6 +2685,8 @@ msgid ""
 "Before storing this report, DuckDuckGo will anonymize your conversation by "
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
+"Før denne rapport gemmes, anonymiserer DuckDuckGo din samtale ved at fjerne "
+"PII som navne, e-mailadresser og identificerende metadata."
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -3010,7 +3008,7 @@ msgstr "Vundne break-point"
 #. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Break this down into clear, numbered steps."
-msgstr ""
+msgstr "Opdel dette i klare, nummererede trin."
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -3470,7 +3468,7 @@ msgstr "Rollebesætning"
 #. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Cast & Crew"
-msgstr ""
+msgstr "Rollebesætning og filmhold"
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -3557,8 +3555,7 @@ msgstr "Ændrer den måde, URL-resultaterne vises på"
 #. This is the description of a user setting
 msgctxt "settings"
 msgid "Changes how the header is displayed and its behavior as you scroll"
-msgstr ""
-"Ændrer den måde overskriften vises på, samt dens opførsel, når du scroller"
+msgstr "Ændrer den måde overskriften vises på, samt dens opførsel, når du scroller"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/mcZdcaF.png
@@ -4000,8 +3997,7 @@ msgstr "Vælg mellem flere AI-modeller, herunder %1$s og %2$s"
 # smartling.placeholder_format=C
 #. As in 'Choose to keep DuckDuckGo as your default search engine'. Placeholders are for markup, you can ignore them.
 msgid "Choose %skeep it%s to continue protecting your privacy."
-msgstr ""
-"Vælg %1$sbehold den%2$s for at fortsætte med at beskytte dit privatliv."
+msgstr "Vælg %1$sbehold den%2$s for at fortsætte med at beskytte dit privatliv."
 
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
@@ -4435,8 +4431,8 @@ msgid ""
 "it remains in your browser until you click/tap %sReset All Settings%s."
 msgstr ""
 "Klik eller tryk på %1$sSlet mine oplysninger%2$s. Dette fjerner "
-"oplysningerne fra skyen, men de forbliver i din browser, indtil du klikker/"
-"trykker på %3$sNulstil alle indstillinger%4$s."
+"oplysningerne fra skyen, men de forbliver i din browser, indtil du "
+"klikker/trykker på %3$sNulstil alle indstillinger%4$s."
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -5183,7 +5179,7 @@ msgstr "Opret billede"
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
-msgstr ""
+msgstr "Opret en indkøbsliste med mængder fra denne opskrift."
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed in the input field when starting a new image generation session.
@@ -5707,8 +5703,7 @@ msgstr "Vil du slette de ældste chats for at frigøre lagerplads?"
 #. Title shown when user has reached the file storage sync quota (5GB).
 msgctxt "Sync file storage limit modal title"
 msgid "Delete oldest chats with attachments to free up storage?"
-msgstr ""
-"Vil du slette de ældste chats med vedhæftede filer for at frigøre lagerplads?"
+msgstr "Vil du slette de ældste chats med vedhæftede filer for at frigøre lagerplads?"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to delete all recent chats.
@@ -5817,8 +5812,7 @@ msgstr "Diktering i Duck.ai"
 # smartling.placeholder_format=C
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
-msgstr ""
-"Diktering er anonymiseret af os og bruges aldrig til at træne AI-modeller."
+msgstr "Diktering er anonymiseret af os og bruges aldrig til at træne AI-modeller."
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
@@ -5828,7 +5822,7 @@ msgstr "Grænse for diktering er nået"
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
 msgid "Dictation temporarily unavailable"
-msgstr ""
+msgstr "Diktering er midlertidigt utilgængelig"
 
 # smartling.placeholder_format=C
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
@@ -6137,6 +6131,8 @@ msgid ""
 "Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
 "filtered out. %sLearn More%s"
 msgstr ""
+"Vil du ikke have AI? %1$snoai.duckduckgo.com%2$s tilbyder ingen "
+"AI-funktioner, og AI-billeder filtreres fra. %3$sLæs mere%4$s"
 
 # smartling.placeholder_format=C
 #. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
@@ -6145,6 +6141,8 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
+"Vil du ikke have AI? Besøg %1$snoai.duckduckgo.com%2$s for at søge uden "
+"AI-funktioner og med AI-billeder filtreret fra. %3$sLæs mere%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6264,13 +6262,13 @@ msgstr ""
 #. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Draft a cover letter"
-msgstr ""
+msgstr "Skriv en ansøgning"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Draft a cover letter for this job."
-msgstr ""
+msgstr "Lav et udkast til en ansøgning til dette job."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -6456,6 +6454,9 @@ msgid ""
 "company for anyone who wants to take back control of their personal "
 "information."
 msgstr ""
+"Duck.ai er skabt af DuckDuckGo. Vi er en uafhængig "
+"onlinebeskyttelsesvirksomhed for alle, der vil tage kontrollen over deres "
+"personlige oplysninger tilbage."
 
 # smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
@@ -6508,6 +6509,9 @@ msgid ""
 "Duck.ai lets you chat privately with popular AI models. Disabling it hides "
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
+"Duck.ai lader dig chatte privat med populære AI-modeller. Hvis du "
+"deaktiverer den, skjules Duck.ai-knapper og -links, men du kan stadig besøge "
+"%1$sduck.ai%2$s direkte."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6518,11 +6522,12 @@ msgid ""
 "can still access Duck.ai when this setting is off by visiting %shttps://duck."
 "ai%s directly."
 msgstr ""
-"Duck.ai giver dig mulighed for at have anonyme samtaler med tredjeparts-AI-"
-"chatmodeller, herunder modeller fra OpenAI, Anthropic og andre. Hvis du "
-"deaktiverer denne indstilling, vil Duck.ai-knapper og -links blive skjult på "
-"DuckDuckGo Search. Du kan dog stadig få adgang til Duck.ai, når denne "
-"indstilling er slået fra, ved at besøge %1$shttps://duck.ai%2$s direkte."
+"Duck.ai giver dig mulighed for at have anonyme samtaler med "
+"tredjeparts-AI-chatmodeller, herunder modeller fra OpenAI, Anthropic og "
+"andre. Hvis du deaktiverer denne indstilling, vil Duck.ai-knapper og -links "
+"blive skjult på DuckDuckGo Search. Du kan dog stadig få adgang til Duck.ai, "
+"når denne indstilling er slået fra, ved at besøge %1$shttps://duck.ai%2$s "
+"direkte."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
@@ -6582,8 +6587,8 @@ msgid ""
 "models, privacy focused AI, no account AI chat"
 msgstr ""
 "Duck.ai, DuckDuckGo AI, privat AI-chatbot, gratis AI-chat, anonym AI-chat, "
-"AI-chat uden tilmelding, OpenAI, Anthropic, Llama, Mistral, open-source AI-"
-"modeller, fortrolighedsfokuseret AI, privatlivsfokuseret AI, AI-chat uden "
+"AI-chat uden tilmelding, OpenAI, Anthropic, Llama, Mistral, open-source "
+"AI-modeller, fortrolighedsfokuseret AI, privatlivsfokuseret AI, AI-chat uden "
 "konto"
 
 # smartling.placeholder_format=C
@@ -6746,8 +6751,7 @@ msgctxt "Error message for VQD error"
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. Please refresh the page and "
 "try again."
-msgstr ""
-"DuckDuckGo AI Chat er midlertidigt utilgængelig. Opdater siden og prøv igen."
+msgstr "DuckDuckGo AI Chat er midlertidigt utilgængelig. Opdater siden og prøv igen."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -7240,8 +7244,7 @@ msgstr "Aktivér diktering i Duck.ai"
 #. Prompt to enable location service so that search results can be displayed near the user's current location.
 msgctxt "precise_user_location"
 msgid "Enable location settings on your device to use anonymous location"
-msgstr ""
-"Aktivér placeringsindstillinger på din enhed for at bruge anonym placering"
+msgstr "Aktivér placeringsindstillinger på din enhed for at bruge anonym placering"
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -7351,8 +7354,7 @@ msgstr "Kan du lide Duck.ai?"
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure %s'Allow'%s is selected for the 'Location' setting."
-msgstr ""
-"Sørg for, at %1$s\"Tillad\"%2$s er valgt til indstillingen \"Placering\"."
+msgstr "Sørg for, at %1$s\"Tillad\"%2$s er valgt til indstillingen \"Placering\"."
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
@@ -7510,13 +7512,13 @@ msgstr "Eritrea"
 #. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Estimate the nutrition"
-msgstr ""
+msgstr "Vurder ernæringen"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Estimate the nutritional information for this recipe."
-msgstr ""
+msgstr "Vurder næringsindholdet for denne opskrift."
 
 # smartling.placeholder_format=C
 msgid "Estonia"
@@ -7576,57 +7578,56 @@ msgstr "Udløber om 1 dag"
 #. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain the accepted answer in simple terms."
-msgstr ""
+msgstr "Forklar det accepterede svar i simple termer."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
-msgstr ""
-"Forklar de grundlæggende begreber om sorte huller for mig på gymnasieniveau."
+msgstr "Forklar de grundlæggende begreber om sorte huller for mig på gymnasieniveau."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain the top answer"
-msgstr ""
+msgstr "Forklar det øverste svar"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain this in simple, plain language."
-msgstr ""
+msgstr "Forklar dette i et enkelt og letforståeligt sprog."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain this paper"
-msgstr ""
+msgstr "Forklar denne artikel"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain this repo"
-msgstr ""
+msgstr "Forklar dette repo"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain this research paper in plain language."
-msgstr ""
+msgstr "Forklar denne forskningsartikel i et letforståeligt sprog."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain this simply"
-msgstr ""
+msgstr "Forklar dette enkelt"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain what this repository does and how to use it."
-msgstr ""
+msgstr "Forklar, hvad dette kodelager gør, og hvordan du bruger det."
 
 # smartling.placeholder_format=C
 #. Label to show if song lyrics contain explicit content
@@ -7804,8 +7805,8 @@ msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and improvements."
 msgstr ""
-"Feedback som din har direkte indflydelse på vores produktopdateringer og -"
-"forbedringer."
+"Feedback som din har direkte indflydelse på vores produktopdateringer og "
+"-forbedringer."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -7814,8 +7815,8 @@ msgid ""
 "Feedback like yours directly influences our product updates and "
 "improvements. Hopefully we can address the issue you shared too."
 msgstr ""
-"Feedback som din har direkte indflydelse på vores produktopdateringer og -"
-"forbedringer. Forhåbentlig kan vi også løse det problem, du delte."
+"Feedback som din har direkte indflydelse på vores produktopdateringer og "
+"-forbedringer. Forhåbentlig kan vi også løse det problem, du delte."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box
@@ -7907,14 +7908,15 @@ msgstr "Filtrerer AI-genererede billeder fra billedsøgeresultater"
 msgctxt "settings"
 msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
-msgstr ""
-"Filtrerer AI-genererede billeder fra billedsøgeresultater. %1$sLæs mere%2$s"
+msgstr "Filtrerer AI-genererede billeder fra billedsøgeresultater. %1$sLæs mere%2$s"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Filters out known AI spam sites from image search results. %sLearn More%s"
 msgstr ""
+"Filtrerer kendte AI-spamsider fra billedsøgeresultater. %1$sFå mere at "
+"vide%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the final score of a sporting event.
@@ -7973,7 +7975,7 @@ msgstr "Find aktuelle oplysninger"
 #. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Find me alternatives"
-msgstr ""
+msgstr "Find alternativer til mig"
 
 # smartling.placeholder_format=C
 #. Button that searches for results closer to the user's current location.
@@ -8200,8 +8202,7 @@ msgstr "Gratis at dele og bruge kommercielt"
 #. Description text explaining how to free up sync storage. Pinned chats are chats the user has explicitly marked to keep.
 msgctxt "Sync limit modal description"
 msgid "Free up space by deleting your chats. Pinned chats will not be deleted."
-msgstr ""
-"Frigør plads ved at slette dine chats. Fastgjorte chats bliver ikke slettet."
+msgstr "Frigør plads ved at slette dine chats. Fastgjorte chats bliver ikke slettet."
 
 # smartling.placeholder_format=C
 #. Indicates that this streaming service is free to watch but shows ads
@@ -8455,7 +8456,7 @@ msgstr "Generer mere"
 #. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Generate a shopping list"
-msgstr ""
+msgstr "Generér en indkøbsliste"
 
 # smartling.placeholder_format=C
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
@@ -8753,7 +8754,7 @@ msgstr "Prøv det"
 #. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Give me a quick background on this person."
-msgstr ""
+msgstr "Giv mig en hurtig oversigt om denne persons baggrund."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9205,13 +9206,13 @@ msgstr "Hjælp med at udbrede privatlivets fred"
 #. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Help me prep for the interview"
-msgstr ""
+msgstr "Hjælp mig med at forberede mig til jobsamtalen"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Help me tailor my resume for this job."
-msgstr ""
+msgstr "Hjælp mig med at tilpasse mit CV til dette job."
 
 # smartling.placeholder_format=C
 #. Title of a SERP popup that invites users to take a survey (desktop only)
@@ -9660,8 +9661,7 @@ msgstr "Hvor tit vil du have, at AI-assisterede svar skal dukke op?"
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
 msgctxt "Duck.ai settings usage section"
 msgid "How much of your daily and weekly limits you've used so far."
-msgstr ""
-"Hvor meget af dine daglige og ugentlige grænser du har brugt indtil videre."
+msgstr "Hvor meget af dine daglige og ugentlige grænser du har brugt indtil videre."
 
 # smartling.placeholder_format=C
 #. A header for the feedback form in the assist negative feedback flow. The user is being asked to update how often they want AI-assisted answers to appear.
@@ -9735,7 +9735,7 @@ msgctxt ""
 "Text for the I already have a subscription button in the Duck.ai settings "
 "page"
 msgid "I Already Have a Subscription"
-msgstr ""
+msgstr "Jeg har allerede et abonnement"
 
 # smartling.placeholder_format=C
 #. Text for the button that takes the user to the login subscription page.
@@ -10102,8 +10102,7 @@ msgstr ""
 
 # smartling.placeholder_format=C
 msgid "In the menu at the top select %sTools%s > %sSettings%s"
-msgstr ""
-"Vælg %1$sVærktøjer%2$s i menuen i toppen af siden > %3$sIndstillinger%4$s"
+msgstr "Vælg %1$sVærktøjer%2$s i menuen i toppen af siden > %3$sIndstillinger%4$s"
 
 #  IE < 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -10318,7 +10317,7 @@ msgstr "Installer Mac browser"
 #. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
 msgctxt "settings"
 msgid "Install Now"
-msgstr ""
+msgstr "Installér nu"
 
 # smartling.placeholder_format=C
 #. Text of a button to install the DuckDuckGo app
@@ -10421,13 +10420,13 @@ msgstr "Er slettede data virkelig slettet?"
 #. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Is it worth taking?"
-msgstr ""
+msgstr "Er det værd at tage?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Is this place any good?"
-msgstr ""
+msgstr "Er det her sted godt?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
@@ -10436,6 +10435,8 @@ msgid ""
 "Is this place any good? Summarize its reputation based on reviews and "
 "ratings."
 msgstr ""
+"Er det her sted godt? Sammenfat dets omdømme baseret på anmeldelser og "
+"vurderinger."
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -10447,13 +10448,13 @@ msgstr "Er denne video nyttig?"
 #. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Is this worth watching?"
-msgstr ""
+msgstr "Er dette værd at se?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Is this worth watching? Give me a spoiler-free take."
-msgstr ""
+msgstr "Er dette værd at se? Giv mig en vurdering uden spoilere."
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -11070,6 +11071,8 @@ msgstr "Links:"
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
 msgstr ""
+"Angiv de værktøjer, materialer eller forudsætninger, jeg har brug for til "
+"dette."
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -11180,8 +11183,7 @@ msgstr "Indlæser flere billedresultater, mens du scroller"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Loads more results in Images, Videos, and Shopping when scrolling"
-msgstr ""
-"Indlæser flere resultater i billeder, videoer og shopping, når du scroller"
+msgstr "Indlæser flere resultater i billeder, videoer og shopping, når du scroller"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/WTkvs9I.png
@@ -11482,7 +11484,7 @@ msgstr "Administrer blokerede websteder"
 #. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
 msgctxt "setting"
 msgid "Manage in Browser Settings"
-msgstr ""
+msgstr "Administrer i browserindstillinger"
 
 # smartling.placeholder_format=C
 #. Link to the site exclusion settings page
@@ -12455,10 +12457,11 @@ msgid ""
 "internet connection. Disabling chat history will delete pinned chats, and "
 "disable the temporary storage of new prompts and responses."
 msgstr ""
-"Nye prompter og svar krypteres og gemmes midlertidigt på en DuckDuckGo-"
-"server efter afsendelse for at hjælpe med at gendanne en chat, hvis du "
-"mister din internetforbindelse. Deaktivering af chathistorikken sletter "
-"fastgjorte chats og deaktiverer midlertidig lagring af nye prompter og svar."
+"Nye prompter og svar krypteres og gemmes midlertidigt på en "
+"DuckDuckGo-server efter afsendelse for at hjælpe med at gendanne en chat, "
+"hvis du mister din internetforbindelse. Deaktivering af chathistorikken "
+"sletter fastgjorte chats og deaktiverer midlertidig lagring af nye prompter "
+"og svar."
 
 # smartling.placeholder_format=C
 #. Question in a feedback form.
@@ -13659,8 +13662,8 @@ msgid ""
 "Other search engines track your searches even when you’re in private "
 "browsing mode. We don’t track you &mdash; period."
 msgstr ""
-"Andre søgemaskiner sporer dine søgninger, selv når du er i privat browsing-"
-"tilstand. Vi sporer dig ikke – punktum."
+"Andre søgemaskiner sporer dine søgninger, selv når du er i privat "
+"browsing-tilstand. Vi sporer dig ikke – punktum."
 
 # smartling.placeholder_format=C
 msgctxt "SERP footer content"
@@ -14316,7 +14319,7 @@ msgstr ""
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is harmful or illegal. (optional)"
-msgstr ""
+msgstr "Beskriv, hvorfor chat-svaret er skadeligt eller ulovligt. (valgfrit)"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
@@ -14353,6 +14356,8 @@ msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is harmful or illegal."
 msgstr ""
+"Indsæt din prompt og det problematiske output (uden personlige oplysninger), "
+"og beskriv hvorfor indholdet er skadeligt eller ulovligt."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -14825,7 +14830,7 @@ msgstr "Fortrolighed"
 #. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
 msgctxt "Section heading on the Duck.ai settings page"
 msgid "Privacy & Terms"
-msgstr ""
+msgstr "Privatliv og vilkår"
 
 # smartling.placeholder_format=C
 msgid "Privacy Blog"
@@ -14901,7 +14906,7 @@ msgstr "Fortrolighedspolitik og servicevilkår"
 #. Text for a button that links to the terms of use and privacy policy page.
 msgctxt "Secondary button text in active privacy modal"
 msgid "Privacy Policy and Terms of Service"
-msgstr ""
+msgstr "Fortrolighedspolitik og servicevilkår"
 
 # smartling.placeholder_format=C
 #. Title displayed on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
@@ -15408,25 +15413,25 @@ msgstr "Anbefal en bog"
 #. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Recommend similar books"
-msgstr ""
+msgstr "Anbefal lignende bøger"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Recommend similar books."
-msgstr ""
+msgstr "Anbefal lignende bøger."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Recommend similar movies or shows."
-msgstr ""
+msgstr "Anbefal lignende film eller serier."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Recommend similar titles"
-msgstr ""
+msgstr "Anbefal lignende titler"
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
@@ -15835,7 +15840,7 @@ msgctxt ""
 "feedback form when the user has selected Harmful or Illegal as the feedback "
 "reason"
 msgid "Required for harmful or illegal reports"
-msgstr ""
+msgstr "Påkrævet for rapportering om skadeligt eller ulovligt indhold"
 
 # smartling.placeholder_format=C
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
@@ -16077,7 +16082,7 @@ msgstr "Bedømmelser"
 #. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Rewrite this recipe scaled for a different number of servings."
-msgstr ""
+msgstr "Omskriv denne opskrift, så den passer til et andet antal portioner."
 
 # smartling.placeholder_format=C
 msgid "Romania"
@@ -16528,8 +16533,7 @@ msgstr "Rul ned til %1$sDuckDuckGo%2$s, og lad den bruge din placering."
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down to the %sServices%s section and click %sAddress bar%s."
-msgstr ""
-"Scroll ned til sektionen %1$sTjenester%2$s, og klik på %3$sAdresselinje%4$s."
+msgstr "Scroll ned til sektionen %1$sTjenester%2$s, og klik på %3$sAdresselinje%4$s."
 
 # smartling.placeholder_format=C
 #. Rugby match stats
@@ -16753,8 +16757,8 @@ msgctxt "settings"
 msgid ""
 "Search queries are included in URL (if off, searches will use POST requests)"
 msgstr ""
-"Søgeforespørgsler indgår i URL (hvis slået fra, vil søgninger bruge POST-"
-"anmodninger)"
+"Søgeforespørgsler indgår i URL (hvis slået fra, vil søgninger bruge "
+"POST-anmodninger)"
 
 # smartling.placeholder_format=C
 #. Describes how cookies are used to store user settings privately and securely.
@@ -17207,8 +17211,7 @@ msgstr ""
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %syour browser%s in the list and %sallow%s location access"
-msgstr ""
-"Vælg %1$sdin browser%2$s på listen, og %3$stillad%4$s placeringssadgang"
+msgstr "Vælg %1$sdin browser%2$s på listen, og %3$stillad%4$s placeringssadgang"
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the modal for deleting all recent chats, that allows the user to select the chats to delete.
@@ -17405,7 +17408,7 @@ msgstr "Sæt det op nu"
 #. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
 msgctxt "Encrypted storage setup button shown in native browsers"
 msgid "Set Up Sync & Backup"
-msgstr ""
+msgstr "Opsætning af Sync & Backup"
 
 # smartling.placeholder_format=C
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
@@ -17499,8 +17502,7 @@ msgstr "Del"
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "Share DuckDuckGo and help friends take their privacy back!"
-msgstr ""
-"Del DuckDuckGo, og hjælp dine venner med at få deres privatliv tilbage!"
+msgstr "Del DuckDuckGo, og hjælp dine venner med at få deres privatliv tilbage!"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button that opens a feedback modal when clicked.
@@ -17593,7 +17595,7 @@ msgstr "Del positiv feedback"
 msgctxt ""
 "Label beside the share-content switch on the Duck.ai response feedback form"
 msgid "Share this conversation with DuckDuckGo"
-msgstr ""
+msgstr "Del denne samtale med DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -17980,8 +17982,7 @@ msgstr "Viser vandrette linjer ved resultat-sideskift"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows links to instructions for how to add DuckDuckGo to your browser"
-msgstr ""
-"Viser links til vejledning i, hvordan du føjer DuckDuckGo til din browser"
+msgstr "Viser links til vejledning i, hvordan du føjer DuckDuckGo til din browser"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers more frequently.
@@ -18002,8 +18003,7 @@ msgstr "Viser lejlighedsvise påmindelser om at føje DuckDuckGo til din browser
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr ""
-"Viser lejlighedsvise påmindelser om at tilføje DuckDuckGo til dine enheder"
+msgstr "Viser lejlighedsvise påmindelser om at tilføje DuckDuckGo til dine enheder"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18021,8 +18021,7 @@ msgstr "Vis sidenumre ved resultat-sideskift"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows sign-up form for the DuckDuckGo privacy newsletters"
-msgstr ""
-"Vis tilmeldingsformular til DuckDuckGos nyhedsbreve om privatlivets fred"
+msgstr "Vis tilmeldingsformular til DuckDuckGos nyhedsbreve om privatlivets fred"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/94erFcS.png
@@ -18120,8 +18119,7 @@ msgstr "Navne på websteder"
 #. A message saying that site filters are not currently working
 msgctxt "Site filter message"
 msgid "Site search is temporarily unavailable. We are working on a fix."
-msgstr ""
-"Webstedssøgning er midlertidigt utilgængelig. Vi arbejder på en løsning."
+msgstr "Webstedssøgning er midlertidigt utilgængelig. Vi arbejder på en løsning."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18423,8 +18421,7 @@ msgstr "Kildetekst ryddet"
 msgctxt "Error message for summary selection input limit"
 msgid ""
 "Source text is too long to summarize. Try again with a shorter selection."
-msgstr ""
-"Kildeteksten er for lang til at opsummere. Prøv igen med et kortere valg."
+msgstr "Kildeteksten er for lang til at opsummere. Prøv igen med et kortere valg."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under Interface Settings.in the end. It is a header
@@ -18587,8 +18584,7 @@ msgstr "Start med et billede"
 #. Warning that starting fresh deletes conversations.
 msgctxt "duckai_migration"
 msgid "Starting fresh will delete all your past conversations."
-msgstr ""
-"Hvis du starter forfra, vil alle dine tidligere samtaler blive slettet."
+msgstr "Hvis du starter forfra, vil alle dine tidligere samtaler blive slettet."
 
 # smartling.placeholder_format=C
 #. Footnote warning that starting fresh deletes conversations.
@@ -18624,8 +18620,7 @@ msgstr "Bliv på DuckDuckGo"
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletter."
-msgstr ""
-"Beskyt dig, og hold dig informeret med vores nyhedsbrev om privatlivets fred."
+msgstr "Beskyt dig, og hold dig informeret med vores nyhedsbrev om privatlivets fred."
 
 # smartling.placeholder_format=C
 #. Prompt to subscribe to a newsletter.
@@ -18858,18 +18853,20 @@ msgstr "Forslag til en overskrift til et blogindlæg"
 msgctxt "Page suggestion prompt"
 msgid "Suggest related articles or topics worth exploring next."
 msgstr ""
+"Foreslå relaterede artikler eller emner, der er værd at udforske som det "
+"næste."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Suggest related articles to explore"
-msgstr ""
+msgstr "Foreslå relaterede artikler at udforske"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Suggest some alternatives to this product."
-msgstr ""
+msgstr "Foreslå nogle alternativer til dette produkt."
 
 # smartling.placeholder_format=C
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
@@ -18886,7 +18883,7 @@ msgstr "Anbefalinger:"
 #. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Sum up the reviews"
-msgstr ""
+msgstr "Sammenfat anmeldelserne"
 
 # smartling.placeholder_format=C
 #. A short title for the a message asking the AI to summarize a text.
@@ -18898,85 +18895,85 @@ msgstr "Opsummér"
 #. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize the Q&As"
-msgstr ""
+msgstr "Sammenfat spørgsmål og svar"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the background and notable work of this person."
-msgstr ""
+msgstr "Sammenfat denne persons baggrund og bemærkelsesværdige arbejde."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the key details of this event."
-msgstr ""
+msgstr "Sammenfat de vigtigste detaljer om denne begivenhed."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the questions and answers on this page."
-msgstr ""
+msgstr "Sammenfat spørgsmålene og svarene på denne side."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize their background"
-msgstr ""
+msgstr "Sammenfat personens baggrund"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this book"
-msgstr ""
+msgstr "Sammenfat denne bog"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this book."
-msgstr ""
+msgstr "Sammenfat denne bog."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this discussion"
-msgstr ""
+msgstr "Sammenfat denne diskussion"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this discussion thread."
-msgstr ""
+msgstr "Sammenfat denne diskussionstråd."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this page"
-msgstr ""
+msgstr "Sammenfat denne side"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this page."
-msgstr ""
+msgstr "Sammenfat denne side."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this video"
-msgstr ""
+msgstr "Sammenfat denne video"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this video."
-msgstr ""
+msgstr "Sammenfat denne video."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize what the reviews say."
-msgstr ""
+msgstr "Sammenfat hvad anmeldelserne siger."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -19306,7 +19303,7 @@ msgstr "Syrien"
 #. Text for a button that enables the theme to follow the operating system's color scheme preference.
 msgctxt "System theme button for theme selector"
 msgid "System"
-msgstr ""
+msgstr "System"
 
 # smartling.placeholder_format=C
 #. Abbreviation indicating this is the total score for a game
@@ -19340,7 +19337,7 @@ msgstr "Tahitiansk"
 #. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Tailor my resume"
-msgstr ""
+msgstr "Tilpas mit CV"
 
 # smartling.placeholder_format=C
 msgid "Taiwan"
@@ -19377,6 +19374,8 @@ msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
+"Deltag i denne anonyme undersøgelse for at fortælle os, hvordan vi kan gøre "
+"Duck.ai bedre."
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -19613,15 +19612,13 @@ msgstr "Gambia"
 #. Error message displayed when the total size of all attached files in a conversation exceeds the allowed limit. Placeholder is the combined size limit in megabytes. E.g. The attached files exceed the total size limit of 5 MB
 msgctxt "Error message when combined file size exceeds the limit"
 msgid "The attached files exceed the total size limit of %s MB"
-msgstr ""
-"De vedhæftede filer overstiger grænsen for den samlede størrelse på %1$s MB"
+msgstr "De vedhæftede filer overstiger grænsen for den samlede størrelse på %1$s MB"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the total size of all attached files in a conversation exceeds the allowed limit. Placeholder is the combined size limit in megabytes. E.g. The attached files exceed the total size limit of 5 MB
 msgctxt "Error message when combined file size exceeds the limit"
 msgid "The attached files exceed the total size limit of %s MB."
-msgstr ""
-"De vedhæftede filer overstiger grænsen for den samlede størrelse på %1$s MB."
+msgstr "De vedhæftede filer overstiger grænsen for den samlede størrelse på %1$s MB."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the server rejects corrupt or unrecognized audio.
@@ -19659,8 +19656,7 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider does not save this chat or any associated data on their "
 "servers."
-msgstr ""
-"Modeludbyderen gemmer ikke denne chat eller tilknyttede data på sine servere."
+msgstr "Modeludbyderen gemmer ikke denne chat eller tilknyttede data på sine servere."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19688,7 +19684,7 @@ msgstr "Tema"
 #. Text for the theme selector label that allows users to switch between Light and dark theme.
 msgctxt "Label for the theme selector feature"
 msgid "Theme"
-msgstr ""
+msgstr "Tema"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/LpFhb1e.png
@@ -19812,8 +19808,7 @@ msgstr ""
 #. Appears below a type of search results called 'Instant Answers'
 msgctxt "attribution"
 msgid "This Instant Answer was made by the %sDuckDuckHack%s Community."
-msgstr ""
-"Dette Øjeblikkeligt svar er leveret af fællesskabet %1$sDuckDuckHack%2$s."
+msgstr "Dette Øjeblikkeligt svar er leveret af fællesskabet %1$sDuckDuckHack%2$s."
 
 # smartling.placeholder_format=C
 #. Label for the monthly usage row in the Usage section of Duck.ai settings.
@@ -19941,16 +19936,14 @@ msgstr "Dette billede kunne ikke oprettes."
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF"
-msgstr ""
-"Denne billedtype understøttes ikke. Vedhæft en JPG, PNG, WebP eller GIF"
+msgstr "Denne billedtype understøttes ikke. Vedhæft en JPG, PNG, WebP eller GIF"
 
 # smartling.placeholder_format=C
 #. Error message displayed when a file that the user tried to upload is not of a supported format
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF."
-msgstr ""
-"Denne billedtype understøttes ikke. Vedhæft en JPG, PNG, WebP eller GIF."
+msgstr "Denne billedtype understøttes ikke. Vedhæft en JPG, PNG, WebP eller GIF."
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
@@ -20003,8 +19996,7 @@ msgstr "Denne side kræver JavaScript for at kunne fungere."
 #. Information tooltip text explaining that the current page's content will be included with the chat message.
 msgctxt "Tooltip explaining that page content will be sent to Duck.ai"
 msgid "This page's content will be sent with your message to Duck.ai"
-msgstr ""
-"Indholdet af denne side vil blive sendt sammen med din besked til Duck.ai"
+msgstr "Indholdet af denne side vil blive sendt sammen med din besked til Duck.ai"
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -20071,8 +20063,7 @@ msgstr "Denne oversættelse er forkert"
 # smartling.placeholder_format=C
 #. Label indicating that the video can't be played on the current page, and only on the website that owns the vide. The placeholder is the name of the website that owns the video.
 msgid "This video is not yet able to be watched here. You can watch it on %s."
-msgstr ""
-"Videoen er endnu ikke tilgængelig til visning her. Du kan se den på %1$s."
+msgstr "Videoen er endnu ikke tilgængelig til visning her. Du kan se den på %1$s."
 
 # smartling.placeholder_format=C
 #. Message indicating that a website is not using an encrypted connection and is not secure.
@@ -20529,13 +20520,13 @@ msgstr ""
 #. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Translate this page"
-msgstr ""
+msgstr "Oversæt denne side"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
 msgctxt "Page suggestion prompt"
 msgid "Translate this page into %s."
-msgstr ""
+msgstr "Oversæt denne side til %1$s."
 
 # smartling.placeholder_format=C
 #. Placeholder text for a region that will display translated text.
@@ -20682,7 +20673,7 @@ msgstr "Prøv gratis"
 #. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
 msgctxt "settings"
 msgid "Try It Now"
-msgstr ""
+msgstr "Prøv det nu"
 
 # smartling.placeholder_format=C
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -20740,8 +20731,7 @@ msgstr "Prøv andre nøgleord."
 # smartling.placeholder_format=C
 #. Prompt encouraging the user to turn off their ad blocker to see more results for their query.
 msgid "Try disabling your ad blocker on DuckDuckGo to see more results."
-msgstr ""
-"Prøv at deaktivere din adblocker på DuckDuckGo for at se flere resultater."
+msgstr "Prøv at deaktivere din adblocker på DuckDuckGo for at se flere resultater."
 
 # smartling.placeholder_format=C
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
@@ -20926,6 +20916,8 @@ msgid ""
 "Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
+"Prøver du at deaktivere AI-funktioner? Installer søgeudvidelsen "
+"%1$sDuckDuckGo No AI%2$s for at huske dine indstillinger. %3$sLæs mere%4$s"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -20934,6 +20926,8 @@ msgid ""
 "Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
+"Prøver du at deaktivere AI-funktioner? Skift til søgeudvidelsen "
+"%1$sDuckDuckGo No AI%2$s for at huske dine indstillinger. %3$sLæs mere%4$s"
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -21245,8 +21239,8 @@ msgstr ""
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
 msgstr ""
-"Under %1$sVed opstart%2$s, vælg %3$sStartside%4$s og indtast: https://"
-"duckduckgo.com"
+"Under %1$sVed opstart%2$s, vælg %3$sStartside%4$s og indtast: "
+"https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -21273,15 +21267,14 @@ msgstr "Under %1$sSøg i adressefeltet med%2$s vælger du %3$sTilføj ny%4$s"
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
 msgstr ""
-"Under %1$sSøge%2$s-sektionen klikker du på %3$sAdministrer søgemaskiner ..."
-"%4$s"
+"Under %1$sSøge%2$s-sektionen klikker du på %3$sAdministrer søgemaskiner "
+"...%4$s"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under On startup select %sOpen a specific page or set of pages%s"
-msgstr ""
-"Under \"Ved opstart\" vælger du %1$sÅbn en bestemt side eller sider%2$s"
+msgstr "Under \"Ved opstart\" vælger du %1$sÅbn en bestemt side eller sider%2$s"
 
 #  Opera default search engine instruction
 # smartling.placeholder_format=C
@@ -21388,8 +21381,8 @@ msgctxt "voice chat limit modal"
 msgid ""
 "Unlock advanced AI models and higher limits with a DuckDuckGo Subscription"
 msgstr ""
-"Lås op for avancerede AI-modeller og højere grænser med et DuckDuckGo-"
-"abonnement"
+"Lås op for avancerede AI-modeller og højere grænser med et "
+"DuckDuckGo-abonnement"
 
 # smartling.placeholder_format=C
 #. Text informing the user that advanced AI models can be unlocked with a subscription. The variable is used to insert a link that opens the subscription modal. Example: Unlock advanced AI models with a DuckDuckGo subscription.
@@ -21422,8 +21415,7 @@ msgctxt ""
 "Text shown in the subscription promo card, with a trailing call-to-action "
 "link."
 msgid "Unlock more capable AI models with a DuckDuckGo subscription. %s"
-msgstr ""
-"Få adgang til mere avancerede AI-modeller med et DuckDuckGo-abonnement. %1$s"
+msgstr "Få adgang til mere avancerede AI-modeller med et DuckDuckGo-abonnement. %1$s"
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to unmute the microphone.
@@ -21636,8 +21628,7 @@ msgstr ""
 #. Upsell message shown in the voice chat limit and duration limit modals for Plus subscribers, encouraging them to upgrade to Pro.
 msgctxt "voice chat limit modal"
 msgid "Upgrade to Pro to unlock 2x higher usage limits than Plus"
-msgstr ""
-"Opgrader til Pro for at låse op for dobbelt så høje forbrugsgrænser som Plus"
+msgstr "Opgrader til Pro for at låse op for dobbelt så høje forbrugsgrænser som Plus"
 
 # smartling.placeholder_format=C
 #. Heading in a promotion for a desktop web browser
@@ -21689,7 +21680,7 @@ msgstr "Uruguay"
 #. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
 msgctxt "Navigation label on the Duck.ai settings page"
 msgid "Usage"
-msgstr ""
+msgstr "Anvendelse"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -21747,8 +21738,7 @@ msgstr "Brug DuckDuckGo Private Search"
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Use DuckDuckGo private search on your iPad, iPhone, or Android!"
-msgstr ""
-"Brug DuckDuckGo Private Search på din iPad, iPhone eller Android-enhed!"
+msgstr "Brug DuckDuckGo Private Search på din iPad, iPhone eller Android-enhed!"
 
 # smartling.placeholder_format=C
 #. User clicks this button to share their device's location
@@ -22024,9 +22014,10 @@ msgid ""
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
 msgstr ""
-"Besøg Duck.ai i din anden browser eller DuckDuckGo-appen, og åbn Duck.ai-"
-"indstillinger. Vælg \"Slå til\" under Sync & Backup, og vælg \"Synkroniser "
-"med en anden enhed\". Eller scan QR-koden på din gendannelses-PDF."
+"Besøg Duck.ai i din anden browser eller DuckDuckGo-appen, og åbn "
+"Duck.ai-indstillinger. Vælg \"Slå til\" under Sync & Backup, og vælg "
+"\"Synkroniser med en anden enhed\". Eller scan QR-koden på din "
+"gendannelses-PDF."
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -22078,8 +22069,7 @@ msgstr "Stemmesamtale afsluttet"
 #. Description in consent disclaimer informing that voice chats with the AI (Artificial Intelligence) are anonymized by us, and are never used to train AI models.
 msgctxt "voice chat"
 msgid "Voice chat is anonymized by us, and never used to train AI models."
-msgstr ""
-"Stemmechat er anonymiseret af os og bruges aldrig til at træne AI-modeller."
+msgstr "Stemmechat er anonymiseret af os og bruges aldrig til at træne AI-modeller."
 
 # smartling.placeholder_format=C
 #. Title of the modal shown when the user has reached their daily voice chat limit.
@@ -22143,7 +22133,7 @@ msgstr "Wales"
 #. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Walk me through the steps"
-msgstr ""
+msgstr "Gennemgå trinnene med mig"
 
 # smartling.placeholder_format=C
 #. Label for walking directions on a map.
@@ -22273,6 +22263,9 @@ msgid ""
 "please share this conversation with DuckDuckGo so we can investigate and "
 "address the issue."
 msgstr ""
+"Vi kan kun rette det, vi kan se. For at rapportere et skadeligt eller "
+"ulovligt svar, bedes du dele denne samtale med DuckDuckGo, så vi kan "
+"undersøge det og tage hånd om problemet."
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -22301,8 +22294,7 @@ msgstr ""
 msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
-msgstr ""
-"Vi kan ikke læse de vedhæftede filer, fordi mindst én af dem er krypteret."
+msgstr "Vi kan ikke læse de vedhæftede filer, fordi mindst én af dem er krypteret."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -22498,8 +22490,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
-msgstr ""
-"Vi blokerer trackere, der forsøger at indsamle dine data, mens du browser."
+msgstr "Vi blokerer trackere, der forsøger at indsamle dine data, mens du browser."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -22533,8 +22524,7 @@ msgctxt "duckai_migration"
 msgid ""
 "We're sorry for this inconvenience. We’re working hard to make your "
 "experience better."
-msgstr ""
-"Vi beklager ulejligheden. Vi arbejder hårdt på at gøre din oplevelse bedre."
+msgstr "Vi beklager ulejligheden. Vi arbejder hårdt på at gøre din oplevelse bedre."
 
 # smartling.placeholder_format=C
 #. Body text explaining the service update requires a page reload.
@@ -22691,8 +22681,7 @@ msgstr ""
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai! You can now import your downloaded chats."
-msgstr ""
-"Velkommen til det nye Duck.ai! Du kan nu importere dine downloadede chats."
+msgstr "Velkommen til det nye Duck.ai! Du kan nu importere dine downloadede chats."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -22783,15 +22772,13 @@ msgstr ""
 #. Text for a prompt suggestion for considering factors when purchasing a computer monitor.
 msgctxt "Full sentence for preparing for a purchase"
 msgid "What are some factors to consider when purchasing a computer monitor?"
-msgstr ""
-"Hvad er nogle faktorer, der skal overvejes, når man køber en computerskærm?"
+msgstr "Hvad er nogle faktorer, der skal overvejes, når man køber en computerskærm?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for asking about must-see attractions in Paris for a first-time visitor.
 msgctxt "Full sentence for planning a trip"
 msgid "What are some must-see attractions in Paris for a first-time visitor?"
-msgstr ""
-"Hvad er nogle must-see attraktioner i Paris for en førstegangsbesøgende?"
+msgstr "Hvad er nogle must-see attraktioner i Paris for en førstegangsbesøgende?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for finding options for the word 'better' in a specific context.
@@ -22822,106 +22809,107 @@ msgid ""
 msgstr ""
 "Hvad er fordelene ved at downloade DuckDuckGo-browseren, hvis du er "
 "interesseret i at bruge Duck.ai? Referer kun officielle DuckDuckGo-kilder. "
-"Opdel svaret i klare sektioner med titler, med fokus på Duck.ai-"
-"integrationer og beskyttelse af privatlivet. Hold det kort, enkelt og "
-"letforståeligt for folk med eller uden betydelig AI- eller teknisk erfaring."
+"Opdel svaret i klare sektioner med titler, med fokus på "
+"Duck.ai-integrationer og beskyttelse af privatlivet. Hold det kort, enkelt "
+"og letforståeligt for folk med eller uden betydelig AI- eller teknisk "
+"erfaring."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the counterarguments?"
-msgstr ""
+msgstr "Hvad er modargumenterne?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the hours & location?"
-msgstr ""
+msgstr "Hvad er åbningstiderne og placeringen?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key contributions of this paper?"
-msgstr ""
+msgstr "Hvad er de vigtigste bidrag fra denne artikel?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key contributions?"
-msgstr ""
+msgstr "Hvad er de vigtigste bidrag?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key details?"
-msgstr ""
+msgstr "Hvad er de vigtigste detaljer?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key points covered in this video?"
-msgstr ""
+msgstr "Hvad er hovedpunkterne i denne video?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key points?"
-msgstr ""
+msgstr "Hvad er de vigtigste pointer?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key takeaways from this article?"
-msgstr ""
+msgstr "Hvad er de vigtigste pointer fra denne artikel?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key takeaways?"
-msgstr ""
+msgstr "Hvad er de vigtigste pointer?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key things I will learn from this course?"
-msgstr ""
+msgstr "Hvad er de vigtigste ting, jeg vil lære på dette kursus?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the main counterarguments or criticisms of this?"
-msgstr ""
+msgstr "Hvad er de vigtigste modargumenter eller kritikpunkter af dette?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the main questions this page answers?"
-msgstr ""
+msgstr "Hvad er de vigtigste spørgsmål, denne side besvarer?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the must-try dishes here?"
-msgstr ""
+msgstr "Hvilke retter bør man prøve her?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid ""
 "What are the opening hours, location, and contact details for this place?"
-msgstr ""
+msgstr "Hvad er åbningstiderne, placeringen og kontaktoplysningerne for dette sted?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the pros and cons of this product?"
-msgstr ""
+msgstr "Hvad er fordelene og ulemperne ved dette produkt?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the pros and cons?"
-msgstr ""
+msgstr "Hvad er fordelene og ulemperne?"
 
 # smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
@@ -23027,7 +23015,7 @@ msgstr "Hvad betyder atria i forbindelse med en medicinsk artikel?"
 #. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What does this answer?"
-msgstr ""
+msgstr "Hvad svarer dette på?"
 
 # smartling.placeholder_format=C
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
@@ -23045,7 +23033,7 @@ msgstr "Hvilke informationer bliver gemt?"
 #. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What interview questions might come up for this role?"
-msgstr ""
+msgstr "Hvilke spørgsmål kan blive stillet under jobsamtalen til denne stilling?"
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -23067,7 +23055,7 @@ msgstr "Hvad hedder hovedstaden i Albanien?"
 #. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What is the overall verdict and rating for this?"
-msgstr ""
+msgstr "Hvad er den samlede vurdering og bedømmelse af dette?"
 
 # smartling.placeholder_format=C
 #. Link to a page with additional information.
@@ -23095,7 +23083,7 @@ msgstr "Hvad folk siger:"
 #. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What should I order?"
-msgstr ""
+msgstr "Hvad skal jeg bestille?"
 
 # smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
@@ -23113,13 +23101,13 @@ msgstr "Hvad var der galt med svaret? (valgfrit)"
 #. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What will I learn?"
-msgstr ""
+msgstr "Hvad vil jeg lære?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What will I need?"
-msgstr ""
+msgstr "Hvad skal jeg bruge?"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -23142,7 +23130,7 @@ msgstr "Nyheder"
 #. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What's the verdict?"
-msgstr ""
+msgstr "Hvad er dommen?"
 
 # smartling.placeholder_format=C
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -23162,8 +23150,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "When enabled, Duck.ai will show instant answers in the chat."
-msgstr ""
-"Når funktionen er aktiveret, vil Duck.ai vise Øjeblikkeligt svar i chatten."
+msgstr "Når funktionen er aktiveret, vil Duck.ai vise Øjeblikkeligt svar i chatten."
 
 # smartling.placeholder_format=C
 #. Text of a button that performs a search for the available streaming services that show a particular movie or tv show
@@ -23201,7 +23188,7 @@ msgstr "Hvilke funktioner mangler? (valgfrit)"
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Which features are missing? (optional)"
-msgstr ""
+msgstr "Hvilke funktioner mangler? (valgfrit)"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
@@ -23224,12 +23211,14 @@ msgstr "Hvem vi er"
 msgctxt "Page suggestion prompt"
 msgid "Who are the main cast and crew, and what else are they known for?"
 msgstr ""
+"Hvem er de vigtigste skuespillere og filmfolk, og hvad er de ellers kendt "
+"for?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Who is this person?"
-msgstr ""
+msgstr "Hvem er denne person?"
 
 # smartling.placeholder_format=C
 #. Header above a collection of privacy-related links.
@@ -23621,8 +23610,7 @@ msgctxt "Disclaimer bellow chat input - desktop"
 msgid ""
 "You are chatting with %s. AI chats may display inaccurate or offensive "
 "information."
-msgstr ""
-"Du chatter med %1$s. AI-chats kan vise unøjagtige eller stødende oplysninger."
+msgstr "Du chatter med %1$s. AI-chats kan vise unøjagtige eller stødende oplysninger."
 
 # smartling.placeholder_format=C
 #. Provide users with the ability to retry their search on a different search engine. First placeholder will be a link with the text "try your search again" OR "try your search later". Second is a URL to the !bangs page: https://duckduckgo.com/bangs.
@@ -23892,8 +23880,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
 msgid "You won't see this message again unless you clear your browser data."
-msgstr ""
-"Du vil ikke se denne meddelelse igen, medmindre du rydder dine browserdata."
+msgstr "Du vil ikke se denne meddelelse igen, medmindre du rydder dine browserdata."
 
 # smartling.placeholder_format=C
 #. The second paragraph of a pop up where we explain how to update the browser manually.
@@ -23976,16 +23963,14 @@ msgstr "Du har nået det maksimale antal beskeder for nu. Prøv igen senere."
 #. Description shown when the user has reached the maximum voice chat duration.
 msgctxt "voice chat duration limit modal"
 msgid "You've reached the maximum voice chat duration for a single session."
-msgstr ""
-"Du har nået den maksimale varighed af stemmechat for en enkelt session."
+msgstr "Du har nået den maksimale varighed af stemmechat for en enkelt session."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the daily voice chat limit.
 msgctxt "voice chat limit modal"
 msgid ""
 "You've reached the voice chat limit for today. Please try again tomorrow."
-msgstr ""
-"Du har nået grænsen for stemmechat for i dag. Prøv venligst igen i morgen."
+msgstr "Du har nået grænsen for stemmechat for i dag. Prøv venligst igen i morgen."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
@@ -24143,8 +24128,7 @@ msgstr "Dine chats bliver nu gemt."
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never saved or used to train AI models"
-msgstr ""
-"Dine chats er private og hverken gemmes eller bruges til at træne AI-modeller"
+msgstr "Dine chats er private og hverken gemmes eller bruges til at træne AI-modeller"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
@@ -24158,8 +24142,8 @@ msgctxt "Active Privacy protection description"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
 msgstr ""
-"Dine chats er private, anonymiseret af os, og bruges ikke til at træne AI-"
-"modeller."
+"Dine chats er private, anonymiseret af os, og bruges ikke til at træne "
+"AI-modeller."
 
 # smartling.placeholder_format=C
 #. Text explaining that user chats are private and not used for AI (Artificial Intelligence) training.
@@ -24167,8 +24151,8 @@ msgctxt "Body text for privacy protection modal"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
 msgstr ""
-"Dine chats er private, anonymiseret af os, og bruges ikke til at træne AI-"
-"modeller."
+"Dine chats er private, anonymiseret af os, og bruges ikke til at træne "
+"AI-modeller."
 
 # smartling.placeholder_format=C
 #. Text for a menu item that describes the privacy protection feature.
@@ -24286,8 +24270,8 @@ msgid ""
 "browser. We save the settings file using the key as the name. DuckDuckGo "
 "never knows your passphrase."
 msgstr ""
-"Dit adgangsudtryk genererer en 512-bit-nøgle ved hjælp af Secure Hash-"
-"algoritmen kendt som %1$sSHA-2%2$s. Kun nøglen og den tilhørende "
+"Dit adgangsudtryk genererer en 512-bit-nøgle ved hjælp af Secure "
+"Hash-algoritmen kendt som %1$sSHA-2%2$s. Kun nøglen og den tilhørende "
 "indstillingsfil forlader din browser. Vi gemmer indstillingsfilen ved at "
 "bruge nøglen som navnet. DuckDuckGo får aldrig dit adgangsudtryk at vide."
 

--- a/locales/da_DK/LC_MESSAGES/duckduckgo.po
+++ b/locales/da_DK/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: da_DK\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -416,7 +416,8 @@ msgstr "%1$s ord"
 #. Instructions on which buttons and options the user has to click in order to add the DuckDuckGo extension to their browser.
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
-msgstr "%1$sKlik %2$sTilføj%3$sTjek %4$sTillad%5$s, og klik derefter på %6$sOkay%7$s"
+msgstr ""
+"%1$sKlik %2$sTilføj%3$sTjek %4$sTillad%5$s, og klik derefter på %6$sOkay%7$s"
 
 # Firefox, obsolete
 # smartling.placeholder_format=C
@@ -471,7 +472,8 @@ msgstr "%1$sSe, hvordan vi holder din placering hemmelig%2$s."
 msgctxt "Footer text for About Sync modal"
 msgid ""
 "%sLearn more%s about how chats are stored privately on DuckDuckGo's server."
-msgstr "%1$sLæs mere%2$s om, hvordan chats gemmes privat på DuckDuckGos server."
+msgstr ""
+"%1$sLæs mere%2$s om, hvordan chats gemmes privat på DuckDuckGos server."
 
 # smartling.placeholder_format=C
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
@@ -806,7 +808,8 @@ msgstr "Grænsen på 6 timers brug er nået."
 #. Displayed when the user has reached a fixed 6-hour Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "6-hour usage limit reached. You can continue this chat after %s."
-msgstr "Grænsen på 6 timers brug er nået. Du kan fortsætte denne chat efter %1$s."
+msgstr ""
+"Grænsen på 6 timers brug er nået. Du kan fortsætte denne chat efter %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable 6-hour Duck.ai usage limit and can opt in to continue using the daily limit.
@@ -877,14 +880,16 @@ msgstr ""
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of AI Chat is available! Please refresh this page to continue."
-msgstr "En ny version af AI Chat er tilgængelig! Opdater denne side for at fortsætte."
+msgstr ""
+"En ny version af AI Chat er tilgængelig! Opdater denne side for at fortsætte."
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of Duck.ai is available and they need to refresh the page.
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of Duck.ai is available! Please refresh this page to continue."
-msgstr "En ny version af Duck.ai er tilgængelig! Opdater denne side for at fortsætte."
+msgstr ""
+"En ny version af Duck.ai er tilgængelig! Opdater denne side for at fortsætte."
 
 # smartling.placeholder_format=C
 #. Shown when the Duck.ai desktop app has been open a long time and a newer version exists.
@@ -1428,6 +1433,12 @@ msgid "Address is incorrect"
 msgstr "Adressen er forkert"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Adjust the servings"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. as in multiple advertisements
 msgid "Ads"
 msgstr "Annoncer"
@@ -1641,6 +1652,14 @@ msgid "All chats are %sprivate%s"
 msgstr "Alle chats er %1$sprivate%2$s"
 
 # smartling.placeholder_format=C
+#. Paragraph in the Privacy & Terms section of the About & Legal page in Duck.ai settings, summarizing how chats are anonymized and are not stored or used to train chat models.
+msgctxt "Privacy & Terms section description on the Duck.ai settings page"
+msgid ""
+"All chats are anonymized by DuckDuckGo, and your conversations are not used "
+"to train chat models by DuckDuckGo or the model providers"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
 msgctxt "Privacy modal header in Duck.ai chat"
 msgid "All chats are private"
@@ -1670,7 +1689,8 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "All model providers are prevented from training their AI on your "
 "conversations."
-msgstr "Alle modeludbydere er forhindret i at træne deres AI på jeres samtaler."
+msgstr ""
+"Alle modeludbydere er forhindret i at træne deres AI på jeres samtaler."
 
 # smartling.placeholder_format=C
 #. Text displayed in the subheader of the modal that allows the user to pick an AI chat model.
@@ -1911,6 +1931,13 @@ msgid "Anonymous location enabled"
 msgstr "Anonym placering aktiveret"
 
 # smartling.placeholder_format=C
+msgctxt "settings"
+msgid ""
+"Anonymously generates answers for search queries based on web content. "
+"Choose how often you want it to appear, or disable it completely."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Instant Answer tab name
 msgid "Answer"
 msgstr "Svar"
@@ -1955,8 +1982,8 @@ msgid ""
 "Any additional instructions you want Duck.ai to follow. e.g. Always tell me "
 "facts about ducks"
 msgstr ""
-"Eventuelle yderligere instruktioner, du vil have Duck.ai til at følge. "
-"f.eks. Fortæl mig altid fakta om ænder"
+"Eventuelle yderligere instruktioner, du vil have Duck.ai til at følge. f."
+"eks. Fortæl mig altid fakta om ænder"
 
 # smartling.placeholder_format=C
 #. Shown in video filtering. https://duckduckgo.com/?q=videos+of+cats&iax=videos&ia=videos
@@ -2055,7 +2082,8 @@ msgstr "Er du der stadig?"
 msgctxt "Body text for clear all chats confirmation modal"
 msgid ""
 "Are you sure you want to clear all of your chats? This cannot be undone."
-msgstr "Er du sikker på, at du vil slette alle dine chats? Dette kan ikke fortrydes."
+msgstr ""
+"Er du sikker på, at du vil slette alle dine chats? Dette kan ikke fortrydes."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that asks the user if they want to clear the conversation.
@@ -2067,7 +2095,8 @@ msgstr "Er du sikker på, at du vil rydde denne samtale og starte en ny?"
 #. Text asking the user to confirm if they want to delete their current chat, explaining that this action cannot be undone.
 msgctxt "Body text for delete chat confirmation modal"
 msgid "Are you sure you want to delete this chat? This cannot be undone."
-msgstr "Er du sikker på, at du vil slette denne chat? Dette kan ikke fortrydes."
+msgstr ""
+"Er du sikker på, at du vil slette denne chat? Dette kan ikke fortrydes."
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to disable chat history, with a warning that it will also delete currently saved chats including pinned chats.
@@ -2190,6 +2219,12 @@ msgid "Ask a follow-up with Duck.ai"
 msgstr "Stil et opfølgende spørgsmål med Duck.ai"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
+msgctxt "Page suggestion chip label"
+msgid "Ask about this page"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
 msgctxt "Title for the page context onboarding modal"
 msgid "Ask about this page"
@@ -2256,8 +2291,8 @@ msgstr ""
 "skal vises: Aldrig (fjerner Assist UI fra søgeresultaterne), On-demand "
 "(viser kun AI-assisterede svar, hvis du klikker på knappen Assist), Nogle "
 "gange (viser kun AI-assisterede svar, når det er yderst relevant) eller Ofte "
-"(vises oftere på en bredere række af søgninger). Indtil videre er "
-"AI-assisterede svar kun tilgængelige i USA (engelsk)."
+"(vises oftere på en bredere række af søgninger). Indtil videre er AI-"
+"assisterede svar kun tilgængelige i USA (engelsk)."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2602,6 +2637,12 @@ msgid "Barcode"
 msgstr "Stregkode"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Based on this page, is this course worth taking?"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Basic"
 msgstr "Grundlæggende"
@@ -2640,6 +2681,14 @@ msgstr "Batter"
 msgctxt "Assistant response placeholder"
 msgid "Before continuing..."
 msgstr "Før du fortsætter ..."
+
+# smartling.placeholder_format=C
+#. Explains that before storing the report, DuckDuckGo will anonymize the conversation by removing PII like names, email addresses, and identifying metadata.
+msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
+msgid ""
+"Before storing this report, DuckDuckGo will anonymize your conversation by "
+"removing PII like names, email addresses, and identifying metadata."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -2956,6 +3005,12 @@ msgstr "Brasilien"
 msgctxt "Sports module"
 msgid "Break Points Won"
 msgstr "Vundne break-point"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Break this down into clear, numbered steps."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -3412,6 +3467,12 @@ msgid "Cast"
 msgstr "Rollebesætning"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Cast & Crew"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
 msgctxt "Tone option label for Casual"
 msgid "Casual"
@@ -3496,7 +3557,8 @@ msgstr "Ændrer den måde, URL-resultaterne vises på"
 #. This is the description of a user setting
 msgctxt "settings"
 msgid "Changes how the header is displayed and its behavior as you scroll"
-msgstr "Ændrer den måde overskriften vises på, samt dens opførsel, når du scroller"
+msgstr ""
+"Ændrer den måde overskriften vises på, samt dens opførsel, når du scroller"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/mcZdcaF.png
@@ -3938,7 +4000,8 @@ msgstr "Vælg mellem flere AI-modeller, herunder %1$s og %2$s"
 # smartling.placeholder_format=C
 #. As in 'Choose to keep DuckDuckGo as your default search engine'. Placeholders are for markup, you can ignore them.
 msgid "Choose %skeep it%s to continue protecting your privacy."
-msgstr "Vælg %1$sbehold den%2$s for at fortsætte med at beskytte dit privatliv."
+msgstr ""
+"Vælg %1$sbehold den%2$s for at fortsætte med at beskytte dit privatliv."
 
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
@@ -4372,8 +4435,8 @@ msgid ""
 "it remains in your browser until you click/tap %sReset All Settings%s."
 msgstr ""
 "Klik eller tryk på %1$sSlet mine oplysninger%2$s. Dette fjerner "
-"oplysningerne fra skyen, men de forbliver i din browser, indtil du "
-"klikker/trykker på %3$sNulstil alle indstillinger%4$s."
+"oplysningerne fra skyen, men de forbliver i din browser, indtil du klikker/"
+"trykker på %3$sNulstil alle indstillinger%4$s."
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -5117,6 +5180,12 @@ msgid "Create Image"
 msgstr "Opret billede"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Create a shopping list with quantities from this recipe."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text displayed in the input field when starting a new image generation session.
 msgctxt "Placeholder text for the image generation input field"
 msgid "Create an image of a cute duck..."
@@ -5638,7 +5707,8 @@ msgstr "Vil du slette de ældste chats for at frigøre lagerplads?"
 #. Title shown when user has reached the file storage sync quota (5GB).
 msgctxt "Sync file storage limit modal title"
 msgid "Delete oldest chats with attachments to free up storage?"
-msgstr "Vil du slette de ældste chats med vedhæftede filer for at frigøre lagerplads?"
+msgstr ""
+"Vil du slette de ældste chats med vedhæftede filer for at frigøre lagerplads?"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to delete all recent chats.
@@ -5747,12 +5817,18 @@ msgstr "Diktering i Duck.ai"
 # smartling.placeholder_format=C
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
-msgstr "Diktering er anonymiseret af os og bruges aldrig til at træne AI-modeller."
+msgstr ""
+"Diktering er anonymiseret af os og bruges aldrig til at træne AI-modeller."
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
 msgid "Dictation limit reached"
 msgstr "Grænse for diktering er nået"
+
+# smartling.placeholder_format=C
+#. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
+msgid "Dictation temporarily unavailable"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
@@ -6055,6 +6131,22 @@ msgid "Done"
 msgstr "Færdig"
 
 # smartling.placeholder_format=C
+#. Message shown in a modal after DuckDuckGo browser users disable AI features in Settings. The first two placeholders bold noai.duckduckgo.com. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
+"filtered out. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
+"and AI images filtered out. %sLearn more%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Double Faults"
@@ -6167,6 +6259,18 @@ msgid ""
 msgstr ""
 "Skriv en kortfattet og detaljeret e-mail til en leverandør, hvor du beder om "
 "et tilbud på reparation af et køleskab."
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Draft a cover letter"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Draft a cover letter for this job."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -6345,6 +6449,15 @@ msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
 msgstr "Duck.ai er bedst i vores private og gratis DuckDuckGo-browser!"
 
 # smartling.placeholder_format=C
+#. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
+msgctxt "About section description on the Duck.ai settings page"
+msgid ""
+"Duck.ai is created by DuckDuckGo. We're an independent online protection "
+"company for anyone who wants to take back control of their personal "
+"information."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
 msgctxt "duckai_migration"
 msgid "Duck.ai is moving domains"
@@ -6392,18 +6505,24 @@ msgstr "Duck.ai er midlertidigt utilgængelig. Prøv igen senere."
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
+"Duck.ai lets you chat privately with popular AI models. Disabling it hides "
+"Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
+msgstr ""
+
+# smartling.placeholder_format=C
+msgctxt "settings"
+msgid ""
 "Duck.ai lets you have anonymous conversations with 3rd-party AI chat models, "
 "including models from OpenAI, Anthropic, and others. Turning this setting "
 "off will hide Duck.ai buttons and links on DuckDuckGo Search. However, you "
 "can still access Duck.ai when this setting is off by visiting %shttps://duck."
 "ai%s directly."
 msgstr ""
-"Duck.ai giver dig mulighed for at have anonyme samtaler med "
-"tredjeparts-AI-chatmodeller, herunder modeller fra OpenAI, Anthropic og "
-"andre. Hvis du deaktiverer denne indstilling, vil Duck.ai-knapper og -links "
-"blive skjult på DuckDuckGo Search. Du kan dog stadig få adgang til Duck.ai, "
-"når denne indstilling er slået fra, ved at besøge %1$shttps://duck.ai%2$s "
-"direkte."
+"Duck.ai giver dig mulighed for at have anonyme samtaler med tredjeparts-AI-"
+"chatmodeller, herunder modeller fra OpenAI, Anthropic og andre. Hvis du "
+"deaktiverer denne indstilling, vil Duck.ai-knapper og -links blive skjult på "
+"DuckDuckGo Search. Du kan dog stadig få adgang til Duck.ai, når denne "
+"indstilling er slået fra, ved at besøge %1$shttps://duck.ai%2$s direkte."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
@@ -6463,8 +6582,8 @@ msgid ""
 "models, privacy focused AI, no account AI chat"
 msgstr ""
 "Duck.ai, DuckDuckGo AI, privat AI-chatbot, gratis AI-chat, anonym AI-chat, "
-"AI-chat uden tilmelding, OpenAI, Anthropic, Llama, Mistral, open-source "
-"AI-modeller, fortrolighedsfokuseret AI, privatlivsfokuseret AI, AI-chat uden "
+"AI-chat uden tilmelding, OpenAI, Anthropic, Llama, Mistral, open-source AI-"
+"modeller, fortrolighedsfokuseret AI, privatlivsfokuseret AI, AI-chat uden "
 "konto"
 
 # smartling.placeholder_format=C
@@ -6627,7 +6746,8 @@ msgctxt "Error message for VQD error"
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. Please refresh the page and "
 "try again."
-msgstr "DuckDuckGo AI Chat er midlertidigt utilgængelig. Opdater siden og prøv igen."
+msgstr ""
+"DuckDuckGo AI Chat er midlertidigt utilgængelig. Opdater siden og prøv igen."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -7120,7 +7240,8 @@ msgstr "Aktivér diktering i Duck.ai"
 #. Prompt to enable location service so that search results can be displayed near the user's current location.
 msgctxt "precise_user_location"
 msgid "Enable location settings on your device to use anonymous location"
-msgstr "Aktivér placeringsindstillinger på din enhed for at bruge anonym placering"
+msgstr ""
+"Aktivér placeringsindstillinger på din enhed for at bruge anonym placering"
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -7230,7 +7351,8 @@ msgstr "Kan du lide Duck.ai?"
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure %s'Allow'%s is selected for the 'Location' setting."
-msgstr "Sørg for, at %1$s\"Tillad\"%2$s er valgt til indstillingen \"Placering\"."
+msgstr ""
+"Sørg for, at %1$s\"Tillad\"%2$s er valgt til indstillingen \"Placering\"."
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
@@ -7385,6 +7507,18 @@ msgid "Eritrea"
 msgstr "Eritrea"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Estimate the nutrition"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Estimate the nutritional information for this recipe."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Estonia"
 msgstr "Estland"
 
@@ -7439,11 +7573,60 @@ msgid "Expires in 1 day"
 msgstr "Udløber om 1 dag"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain the accepted answer in simple terms."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
-msgstr "Forklar de grundlæggende begreber om sorte huller for mig på gymnasieniveau."
+msgstr ""
+"Forklar de grundlæggende begreber om sorte huller for mig på gymnasieniveau."
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain the top answer"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this in simple, plain language."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this paper"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this repo"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this research paper in plain language."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this simply"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain what this repository does and how to use it."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label to show if song lyrics contain explicit content
@@ -7621,8 +7804,8 @@ msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and improvements."
 msgstr ""
-"Feedback som din har direkte indflydelse på vores produktopdateringer og "
-"-forbedringer."
+"Feedback som din har direkte indflydelse på vores produktopdateringer og -"
+"forbedringer."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -7631,8 +7814,8 @@ msgid ""
 "Feedback like yours directly influences our product updates and "
 "improvements. Hopefully we can address the issue you shared too."
 msgstr ""
-"Feedback som din har direkte indflydelse på vores produktopdateringer og "
-"-forbedringer. Forhåbentlig kan vi også løse det problem, du delte."
+"Feedback som din har direkte indflydelse på vores produktopdateringer og -"
+"forbedringer. Forhåbentlig kan vi også løse det problem, du delte."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box
@@ -7724,7 +7907,14 @@ msgstr "Filtrerer AI-genererede billeder fra billedsøgeresultater"
 msgctxt "settings"
 msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
-msgstr "Filtrerer AI-genererede billeder fra billedsøgeresultater. %1$sLæs mere%2$s"
+msgstr ""
+"Filtrerer AI-genererede billeder fra billedsøgeresultater. %1$sLæs mere%2$s"
+
+# smartling.placeholder_format=C
+msgctxt "settings"
+msgid ""
+"Filters out known AI spam sites from image search results. %sLearn More%s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the final score of a sporting event.
@@ -7778,6 +7968,12 @@ msgstr "Find et bedre ord"
 msgctxt "Subtitle for the Web Search tool entry in the Tools dropdown menu"
 msgid "Find current information"
 msgstr "Find aktuelle oplysninger"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Find me alternatives"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button that searches for results closer to the user's current location.
@@ -8004,7 +8200,8 @@ msgstr "Gratis at dele og bruge kommercielt"
 #. Description text explaining how to free up sync storage. Pinned chats are chats the user has explicitly marked to keep.
 msgctxt "Sync limit modal description"
 msgid "Free up space by deleting your chats. Pinned chats will not be deleted."
-msgstr "Frigør plads ved at slette dine chats. Fastgjorte chats bliver ikke slettet."
+msgstr ""
+"Frigør plads ved at slette dine chats. Fastgjorte chats bliver ikke slettet."
 
 # smartling.placeholder_format=C
 #. Indicates that this streaming service is free to watch but shows ads
@@ -8253,6 +8450,12 @@ msgstr "Generer billede"
 #. Text for the button that generates more of an answer from duckassist when the answer has come from a collapsed state
 msgid "Generate More"
 msgstr "Generer mere"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Generate a shopping list"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
@@ -8545,6 +8748,12 @@ msgstr "Prøv det"
 msgctxt "Onboarding welcome screen button text"
 msgid "Give it a Try"
 msgstr "Prøv det"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Give me a quick background on this person."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -8993,6 +9202,18 @@ msgid "Help Spread Privacy"
 msgstr "Hjælp med at udbrede privatlivets fred"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Help me prep for the interview"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Help me tailor my resume for this job."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title of a SERP popup that invites users to take a survey (desktop only)
 msgctxt "User survey popup"
 msgid "Help us improve DuckDuckGo"
@@ -9439,7 +9660,8 @@ msgstr "Hvor tit vil du have, at AI-assisterede svar skal dukke op?"
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
 msgctxt "Duck.ai settings usage section"
 msgid "How much of your daily and weekly limits you've used so far."
-msgstr "Hvor meget af dine daglige og ugentlige grænser du har brugt indtil videre."
+msgstr ""
+"Hvor meget af dine daglige og ugentlige grænser du har brugt indtil videre."
 
 # smartling.placeholder_format=C
 #. A header for the feedback form in the assist negative feedback flow. The user is being asked to update how often they want AI-assisted answers to appear.
@@ -9506,6 +9728,14 @@ msgstr "Orkan"
 msgctxt "Onboarding terms screen button text"
 msgid "I Agree"
 msgstr "Jeg accepterer"
+
+# smartling.placeholder_format=C
+#. Text for the button that takes the user to the external DuckDuckGo login subscription page.
+msgctxt ""
+"Text for the I already have a subscription button in the Duck.ai settings "
+"page"
+msgid "I Already Have a Subscription"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the button that takes the user to the login subscription page.
@@ -9872,7 +10102,8 @@ msgstr ""
 
 # smartling.placeholder_format=C
 msgid "In the menu at the top select %sTools%s > %sSettings%s"
-msgstr "Vælg %1$sVærktøjer%2$s i menuen i toppen af siden > %3$sIndstillinger%4$s"
+msgstr ""
+"Vælg %1$sVærktøjer%2$s i menuen i toppen af siden > %3$sIndstillinger%4$s"
 
 #  IE < 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -10084,6 +10315,12 @@ msgid "Install Mac Browser"
 msgstr "Installer Mac browser"
 
 # smartling.placeholder_format=C
+#. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
+msgctxt "settings"
+msgid "Install Now"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of a button to install the DuckDuckGo app
 msgctxt "Serp footer content"
 msgid "Install Our App"
@@ -10181,10 +10418,42 @@ msgid "Is deleted data really deleted?"
 msgstr "Er slettede data virkelig slettet?"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is it worth taking?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this place any good?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"Is this place any good? Summarize its reputation based on reviews and "
+"ratings."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "Is this video helpful?"
 msgstr "Er denne video nyttig?"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this worth watching?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Is this worth watching? Give me a spoiler-free take."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -10797,6 +11066,12 @@ msgid "Links:"
 msgstr "Links:"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "List the tools, materials, or prerequisites I need for this."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
 msgid "Listen"
 msgstr "Lyt"
@@ -10905,7 +11180,8 @@ msgstr "Indlæser flere billedresultater, mens du scroller"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Loads more results in Images, Videos, and Shopping when scrolling"
-msgstr "Indlæser flere resultater i billeder, videoer og shopping, når du scroller"
+msgstr ""
+"Indlæser flere resultater i billeder, videoer og shopping, når du scroller"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/WTkvs9I.png
@@ -11201,6 +11477,12 @@ msgstr "Administrer dit abonnement"
 msgctxt "Exclusion message manage sites button"
 msgid "Manage blocked sites"
 msgstr "Administrer blokerede websteder"
+
+# smartling.placeholder_format=C
+#. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
+msgctxt "setting"
+msgid "Manage in Browser Settings"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to the site exclusion settings page
@@ -12173,11 +12455,10 @@ msgid ""
 "internet connection. Disabling chat history will delete pinned chats, and "
 "disable the temporary storage of new prompts and responses."
 msgstr ""
-"Nye prompter og svar krypteres og gemmes midlertidigt på en "
-"DuckDuckGo-server efter afsendelse for at hjælpe med at gendanne en chat, "
-"hvis du mister din internetforbindelse. Deaktivering af chathistorikken "
-"sletter fastgjorte chats og deaktiverer midlertidig lagring af nye prompter "
-"og svar."
+"Nye prompter og svar krypteres og gemmes midlertidigt på en DuckDuckGo-"
+"server efter afsendelse for at hjælpe med at gendanne en chat, hvis du "
+"mister din internetforbindelse. Deaktivering af chathistorikken sletter "
+"fastgjorte chats og deaktiverer midlertidig lagring af nye prompter og svar."
 
 # smartling.placeholder_format=C
 #. Question in a feedback form.
@@ -13378,8 +13659,8 @@ msgid ""
 "Other search engines track your searches even when you’re in private "
 "browsing mode. We don’t track you &mdash; period."
 msgstr ""
-"Andre søgemaskiner sporer dine søgninger, selv når du er i privat "
-"browsing-tilstand. Vi sporer dig ikke – punktum."
+"Andre søgemaskiner sporer dine søgninger, selv når du er i privat browsing-"
+"tilstand. Vi sporer dig ikke – punktum."
 
 # smartling.placeholder_format=C
 msgctxt "SERP footer content"
@@ -14034,6 +14315,12 @@ msgstr ""
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
+msgid "Please describe why the chat response is harmful or illegal. (optional)"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
+msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
 msgstr "Beskriv, hvorfor chatsvaret er ulovligt eller skadeligt. (valgfrit)"
 
@@ -14058,6 +14345,14 @@ msgid ""
 msgstr ""
 "Bemærk: Hvis du starter en ny chat med en chatmodel, slettes din aktuelle "
 "chatsession."
+
+# smartling.placeholder_format=C
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
+msgctxt "Feedback prompt"
+msgid ""
+"Please paste your prompt and the problematic output (with any personal "
+"information removed) and describe why the content is harmful or illegal."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -14527,6 +14822,12 @@ msgid "Privacy"
 msgstr "Fortrolighed"
 
 # smartling.placeholder_format=C
+#. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
+msgctxt "Section heading on the Duck.ai settings page"
+msgid "Privacy & Terms"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Privacy Blog"
 msgstr "Privatlivsblog"
 
@@ -14595,6 +14896,12 @@ msgstr "Fortrolighedspolitik og vilkår for brug"
 msgctxt "Copy used to compose link in sentences"
 msgid "Privacy Policy and Terms of Service"
 msgstr "Fortrolighedspolitik og servicevilkår"
+
+# smartling.placeholder_format=C
+#. Text for a button that links to the terms of use and privacy policy page.
+msgctxt "Secondary button text in active privacy modal"
+msgid "Privacy Policy and Terms of Service"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title displayed on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
@@ -15098,6 +15405,30 @@ msgid "Recommend a book"
 msgstr "Anbefal en bog"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar books"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar books."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar movies or shows."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar titles"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
 msgid "Recording failed. Please try again."
 msgstr "Optagelsen mislykkedes. Prøv igen."
@@ -15498,6 +15829,15 @@ msgid "Republic of Moldova"
 msgstr "Republikken Moldova"
 
 # smartling.placeholder_format=C
+#. Note indicating that sharing the conversation is mandatory when reporting harmful or illegal content. Rendered alongside the standard share label (DUCKCHAT_RESPONSE_FEEDBACK_SHARE_PROMPT_RESPONSE_LABEL), not replacing it.
+msgctxt ""
+"Note shown under the share-content switch label on the Duck.ai response "
+"feedback form when the user has selected Harmful or Illegal as the feedback "
+"reason"
+msgid "Required for harmful or illegal reports"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
 msgctxt "Description for extended reasoning mode in Duck.ai"
 msgid "Researches before responding"
@@ -15732,6 +16072,12 @@ msgstr "Bedømmelser"
 msgctxt "maps_places"
 msgid "Reviews"
 msgstr "Bedømmelser"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Rewrite this recipe scaled for a different number of servings."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Romania"
@@ -16182,7 +16528,8 @@ msgstr "Rul ned til %1$sDuckDuckGo%2$s, og lad den bruge din placering."
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down to the %sServices%s section and click %sAddress bar%s."
-msgstr "Scroll ned til sektionen %1$sTjenester%2$s, og klik på %3$sAdresselinje%4$s."
+msgstr ""
+"Scroll ned til sektionen %1$sTjenester%2$s, og klik på %3$sAdresselinje%4$s."
 
 # smartling.placeholder_format=C
 #. Rugby match stats
@@ -16406,8 +16753,8 @@ msgctxt "settings"
 msgid ""
 "Search queries are included in URL (if off, searches will use POST requests)"
 msgstr ""
-"Søgeforespørgsler indgår i URL (hvis slået fra, vil søgninger bruge "
-"POST-anmodninger)"
+"Søgeforespørgsler indgår i URL (hvis slået fra, vil søgninger bruge POST-"
+"anmodninger)"
 
 # smartling.placeholder_format=C
 #. Describes how cookies are used to store user settings privately and securely.
@@ -16860,7 +17207,8 @@ msgstr ""
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %syour browser%s in the list and %sallow%s location access"
-msgstr "Vælg %1$sdin browser%2$s på listen, og %3$stillad%4$s placeringssadgang"
+msgstr ""
+"Vælg %1$sdin browser%2$s på listen, og %3$stillad%4$s placeringssadgang"
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the modal for deleting all recent chats, that allows the user to select the chats to delete.
@@ -17054,6 +17402,12 @@ msgid "Set Up Now"
 msgstr "Sæt det op nu"
 
 # smartling.placeholder_format=C
+#. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
+msgctxt "Encrypted storage setup button shown in native browsers"
+msgid "Set Up Sync & Backup"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
 msgctxt "Title for the Sync & Backup intro screen"
 msgid "Set Up Sync & Backup"
@@ -17145,7 +17499,8 @@ msgstr "Del"
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "Share DuckDuckGo and help friends take their privacy back!"
-msgstr "Del DuckDuckGo, og hjælp dine venner med at få deres privatliv tilbage!"
+msgstr ""
+"Del DuckDuckGo, og hjælp dine venner med at få deres privatliv tilbage!"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button that opens a feedback modal when clicked.
@@ -17232,6 +17587,13 @@ msgstr "Del webadresse på siden"
 msgctxt "feedback form"
 msgid "Share positive feedback"
 msgstr "Del positiv feedback"
+
+# smartling.placeholder_format=C
+#. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
+msgctxt ""
+"Label beside the share-content switch on the Duck.ai response feedback form"
+msgid "Share this conversation with DuckDuckGo"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -17618,7 +17980,8 @@ msgstr "Viser vandrette linjer ved resultat-sideskift"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows links to instructions for how to add DuckDuckGo to your browser"
-msgstr "Viser links til vejledning i, hvordan du føjer DuckDuckGo til din browser"
+msgstr ""
+"Viser links til vejledning i, hvordan du føjer DuckDuckGo til din browser"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers more frequently.
@@ -17639,7 +18002,8 @@ msgstr "Viser lejlighedsvise påmindelser om at føje DuckDuckGo til din browser
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr "Viser lejlighedsvise påmindelser om at tilføje DuckDuckGo til dine enheder"
+msgstr ""
+"Viser lejlighedsvise påmindelser om at tilføje DuckDuckGo til dine enheder"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -17657,7 +18021,8 @@ msgstr "Vis sidenumre ved resultat-sideskift"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows sign-up form for the DuckDuckGo privacy newsletters"
-msgstr "Vis tilmeldingsformular til DuckDuckGos nyhedsbreve om privatlivets fred"
+msgstr ""
+"Vis tilmeldingsformular til DuckDuckGos nyhedsbreve om privatlivets fred"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/94erFcS.png
@@ -17755,7 +18120,8 @@ msgstr "Navne på websteder"
 #. A message saying that site filters are not currently working
 msgctxt "Site filter message"
 msgid "Site search is temporarily unavailable. We are working on a fix."
-msgstr "Webstedssøgning er midlertidigt utilgængelig. Vi arbejder på en løsning."
+msgstr ""
+"Webstedssøgning er midlertidigt utilgængelig. Vi arbejder på en løsning."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18057,7 +18423,8 @@ msgstr "Kildetekst ryddet"
 msgctxt "Error message for summary selection input limit"
 msgid ""
 "Source text is too long to summarize. Try again with a shorter selection."
-msgstr "Kildeteksten er for lang til at opsummere. Prøv igen med et kortere valg."
+msgstr ""
+"Kildeteksten er for lang til at opsummere. Prøv igen med et kortere valg."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under Interface Settings.in the end. It is a header
@@ -18220,7 +18587,8 @@ msgstr "Start med et billede"
 #. Warning that starting fresh deletes conversations.
 msgctxt "duckai_migration"
 msgid "Starting fresh will delete all your past conversations."
-msgstr "Hvis du starter forfra, vil alle dine tidligere samtaler blive slettet."
+msgstr ""
+"Hvis du starter forfra, vil alle dine tidligere samtaler blive slettet."
 
 # smartling.placeholder_format=C
 #. Footnote warning that starting fresh deletes conversations.
@@ -18256,7 +18624,8 @@ msgstr "Bliv på DuckDuckGo"
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletter."
-msgstr "Beskyt dig, og hold dig informeret med vores nyhedsbrev om privatlivets fred."
+msgstr ""
+"Beskyt dig, og hold dig informeret med vores nyhedsbrev om privatlivets fred."
 
 # smartling.placeholder_format=C
 #. Prompt to subscribe to a newsletter.
@@ -18485,6 +18854,24 @@ msgid "Suggest a title for a blog post"
 msgstr "Forslag til en overskrift til et blogindlæg"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest related articles or topics worth exploring next."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Suggest related articles to explore"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest some alternatives to this product."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
 msgctxt "directions"
 msgid "Suggestions:"
@@ -18496,10 +18883,100 @@ msgid "Suggestions:"
 msgstr "Anbefalinger:"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Sum up the reviews"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A short title for the a message asking the AI to summarize a text.
 msgctxt "Title for the summarize message"
 msgid "Summarize"
 msgstr "Opsummér"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize the Q&As"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the background and notable work of this person."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the key details of this event."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the questions and answers on this page."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize their background"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this book"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this book."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this discussion"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this discussion thread."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this page"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this page."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this video"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this video."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize what the reviews say."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -18826,6 +19303,12 @@ msgid "Syria"
 msgstr "Syrien"
 
 # smartling.placeholder_format=C
+#. Text for a button that enables the theme to follow the operating system's color scheme preference.
+msgctxt "System theme button for theme selector"
+msgid "System"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Abbreviation indicating this is the total score for a game
 msgctxt "Sports module"
 msgid "T"
@@ -18852,6 +19335,12 @@ msgstr "TV"
 msgctxt "language_name"
 msgid "Tahitian"
 msgstr "Tahitiansk"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Tailor my resume"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Taiwan"
@@ -18881,6 +19370,13 @@ msgstr "Tag kontrol over dine persondata"
 msgctxt "homepage ATB modal"
 msgid "Take control of your personal data!"
 msgstr "Tag kontrol over dine persondata!"
+
+# smartling.placeholder_format=C
+#. Description for the Feedback section of the Duck.ai settings page, asking the user to take an anonymous survey to let us know how we can make Duck.ai better.
+msgctxt "Feedback section description on the Duck.ai settings page"
+msgid ""
+"Take this anonymous survey to let us know how we can make Duck.ai better."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -19117,13 +19613,15 @@ msgstr "Gambia"
 #. Error message displayed when the total size of all attached files in a conversation exceeds the allowed limit. Placeholder is the combined size limit in megabytes. E.g. The attached files exceed the total size limit of 5 MB
 msgctxt "Error message when combined file size exceeds the limit"
 msgid "The attached files exceed the total size limit of %s MB"
-msgstr "De vedhæftede filer overstiger grænsen for den samlede størrelse på %1$s MB"
+msgstr ""
+"De vedhæftede filer overstiger grænsen for den samlede størrelse på %1$s MB"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the total size of all attached files in a conversation exceeds the allowed limit. Placeholder is the combined size limit in megabytes. E.g. The attached files exceed the total size limit of 5 MB
 msgctxt "Error message when combined file size exceeds the limit"
 msgid "The attached files exceed the total size limit of %s MB."
-msgstr "De vedhæftede filer overstiger grænsen for den samlede størrelse på %1$s MB."
+msgstr ""
+"De vedhæftede filer overstiger grænsen for den samlede størrelse på %1$s MB."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the server rejects corrupt or unrecognized audio.
@@ -19161,7 +19659,8 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider does not save this chat or any associated data on their "
 "servers."
-msgstr "Modeludbyderen gemmer ikke denne chat eller tilknyttede data på sine servere."
+msgstr ""
+"Modeludbyderen gemmer ikke denne chat eller tilknyttede data på sine servere."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19184,6 +19683,12 @@ msgstr "Serveren stødte på en fejl og kunne ikke fuldføre din forespørgsel."
 #. https://duck.co/media/files/theme.png
 msgid "Theme"
 msgstr "Tema"
+
+# smartling.placeholder_format=C
+#. Text for the theme selector label that allows users to switch between Light and dark theme.
+msgctxt "Label for the theme selector feature"
+msgid "Theme"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/LpFhb1e.png
@@ -19307,7 +19812,8 @@ msgstr ""
 #. Appears below a type of search results called 'Instant Answers'
 msgctxt "attribution"
 msgid "This Instant Answer was made by the %sDuckDuckHack%s Community."
-msgstr "Dette Øjeblikkeligt svar er leveret af fællesskabet %1$sDuckDuckHack%2$s."
+msgstr ""
+"Dette Øjeblikkeligt svar er leveret af fællesskabet %1$sDuckDuckHack%2$s."
 
 # smartling.placeholder_format=C
 #. Label for the monthly usage row in the Usage section of Duck.ai settings.
@@ -19435,14 +19941,16 @@ msgstr "Dette billede kunne ikke oprettes."
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF"
-msgstr "Denne billedtype understøttes ikke. Vedhæft en JPG, PNG, WebP eller GIF"
+msgstr ""
+"Denne billedtype understøttes ikke. Vedhæft en JPG, PNG, WebP eller GIF"
 
 # smartling.placeholder_format=C
 #. Error message displayed when a file that the user tried to upload is not of a supported format
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF."
-msgstr "Denne billedtype understøttes ikke. Vedhæft en JPG, PNG, WebP eller GIF."
+msgstr ""
+"Denne billedtype understøttes ikke. Vedhæft en JPG, PNG, WebP eller GIF."
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
@@ -19495,7 +20003,8 @@ msgstr "Denne side kræver JavaScript for at kunne fungere."
 #. Information tooltip text explaining that the current page's content will be included with the chat message.
 msgctxt "Tooltip explaining that page content will be sent to Duck.ai"
 msgid "This page's content will be sent with your message to Duck.ai"
-msgstr "Indholdet af denne side vil blive sendt sammen med din besked til Duck.ai"
+msgstr ""
+"Indholdet af denne side vil blive sendt sammen med din besked til Duck.ai"
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -19562,7 +20071,8 @@ msgstr "Denne oversættelse er forkert"
 # smartling.placeholder_format=C
 #. Label indicating that the video can't be played on the current page, and only on the website that owns the vide. The placeholder is the name of the website that owns the video.
 msgid "This video is not yet able to be watched here. You can watch it on %s."
-msgstr "Videoen er endnu ikke tilgængelig til visning her. Du kan se den på %1$s."
+msgstr ""
+"Videoen er endnu ikke tilgængelig til visning her. Du kan se den på %1$s."
 
 # smartling.placeholder_format=C
 #. Message indicating that a website is not using an encrypted connection and is not secure.
@@ -20016,6 +20526,18 @@ msgstr ""
 "biograf?\""
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Translate this page"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
+msgctxt "Page suggestion prompt"
+msgid "Translate this page into %s."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text for a region that will display translated text.
 msgctxt "translations_module"
 msgid "Translation"
@@ -20157,6 +20679,12 @@ msgid "Try Free"
 msgstr "Prøv gratis"
 
 # smartling.placeholder_format=C
+#. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
+msgctxt "settings"
+msgid "Try It Now"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
 msgctxt "Promotional CTA for new AI models"
 msgid "Try Now"
@@ -20212,7 +20740,8 @@ msgstr "Prøv andre nøgleord."
 # smartling.placeholder_format=C
 #. Prompt encouraging the user to turn off their ad blocker to see more results for their query.
 msgid "Try disabling your ad blocker on DuckDuckGo to see more results."
-msgstr "Prøv at deaktivere din adblocker på DuckDuckGo for at se flere resultater."
+msgstr ""
+"Prøv at deaktivere din adblocker på DuckDuckGo for at se flere resultater."
 
 # smartling.placeholder_format=C
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
@@ -20389,6 +20918,22 @@ msgstr "Prøv: %1$s"
 msgctxt "new user poll"
 msgid "Trying DuckDuckGo again"
 msgstr "Prøver DuckDuckGo igen"
+
+# smartling.placeholder_format=C
+#. Message shown in a modal after supported third-party browser users disable AI features in Settings. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -20700,8 +21245,8 @@ msgstr ""
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
 msgstr ""
-"Under %1$sVed opstart%2$s, vælg %3$sStartside%4$s og indtast: "
-"https://duckduckgo.com"
+"Under %1$sVed opstart%2$s, vælg %3$sStartside%4$s og indtast: https://"
+"duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -20728,14 +21273,15 @@ msgstr "Under %1$sSøg i adressefeltet med%2$s vælger du %3$sTilføj ny%4$s"
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
 msgstr ""
-"Under %1$sSøge%2$s-sektionen klikker du på %3$sAdministrer søgemaskiner "
-"...%4$s"
+"Under %1$sSøge%2$s-sektionen klikker du på %3$sAdministrer søgemaskiner ..."
+"%4$s"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under On startup select %sOpen a specific page or set of pages%s"
-msgstr "Under \"Ved opstart\" vælger du %1$sÅbn en bestemt side eller sider%2$s"
+msgstr ""
+"Under \"Ved opstart\" vælger du %1$sÅbn en bestemt side eller sider%2$s"
 
 #  Opera default search engine instruction
 # smartling.placeholder_format=C
@@ -20842,8 +21388,8 @@ msgctxt "voice chat limit modal"
 msgid ""
 "Unlock advanced AI models and higher limits with a DuckDuckGo Subscription"
 msgstr ""
-"Lås op for avancerede AI-modeller og højere grænser med et "
-"DuckDuckGo-abonnement"
+"Lås op for avancerede AI-modeller og højere grænser med et DuckDuckGo-"
+"abonnement"
 
 # smartling.placeholder_format=C
 #. Text informing the user that advanced AI models can be unlocked with a subscription. The variable is used to insert a link that opens the subscription modal. Example: Unlock advanced AI models with a DuckDuckGo subscription.
@@ -20876,7 +21422,8 @@ msgctxt ""
 "Text shown in the subscription promo card, with a trailing call-to-action "
 "link."
 msgid "Unlock more capable AI models with a DuckDuckGo subscription. %s"
-msgstr "Få adgang til mere avancerede AI-modeller med et DuckDuckGo-abonnement. %1$s"
+msgstr ""
+"Få adgang til mere avancerede AI-modeller med et DuckDuckGo-abonnement. %1$s"
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to unmute the microphone.
@@ -21089,7 +21636,8 @@ msgstr ""
 #. Upsell message shown in the voice chat limit and duration limit modals for Plus subscribers, encouraging them to upgrade to Pro.
 msgctxt "voice chat limit modal"
 msgid "Upgrade to Pro to unlock 2x higher usage limits than Plus"
-msgstr "Opgrader til Pro for at låse op for dobbelt så høje forbrugsgrænser som Plus"
+msgstr ""
+"Opgrader til Pro for at låse op for dobbelt så høje forbrugsgrænser som Plus"
 
 # smartling.placeholder_format=C
 #. Heading in a promotion for a desktop web browser
@@ -21136,6 +21684,12 @@ msgstr "Urdu"
 # smartling.placeholder_format=C
 msgid "Uruguay"
 msgstr "Uruguay"
+
+# smartling.placeholder_format=C
+#. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
+msgctxt "Navigation label on the Duck.ai settings page"
+msgid "Usage"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -21193,7 +21747,8 @@ msgstr "Brug DuckDuckGo Private Search"
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Use DuckDuckGo private search on your iPad, iPhone, or Android!"
-msgstr "Brug DuckDuckGo Private Search på din iPad, iPhone eller Android-enhed!"
+msgstr ""
+"Brug DuckDuckGo Private Search på din iPad, iPhone eller Android-enhed!"
 
 # smartling.placeholder_format=C
 #. User clicks this button to share their device's location
@@ -21469,10 +22024,9 @@ msgid ""
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
 msgstr ""
-"Besøg Duck.ai i din anden browser eller DuckDuckGo-appen, og åbn "
-"Duck.ai-indstillinger. Vælg \"Slå til\" under Sync & Backup, og vælg "
-"\"Synkroniser med en anden enhed\". Eller scan QR-koden på din "
-"gendannelses-PDF."
+"Besøg Duck.ai i din anden browser eller DuckDuckGo-appen, og åbn Duck.ai-"
+"indstillinger. Vælg \"Slå til\" under Sync & Backup, og vælg \"Synkroniser "
+"med en anden enhed\". Eller scan QR-koden på din gendannelses-PDF."
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -21524,7 +22078,8 @@ msgstr "Stemmesamtale afsluttet"
 #. Description in consent disclaimer informing that voice chats with the AI (Artificial Intelligence) are anonymized by us, and are never used to train AI models.
 msgctxt "voice chat"
 msgid "Voice chat is anonymized by us, and never used to train AI models."
-msgstr "Stemmechat er anonymiseret af os og bruges aldrig til at træne AI-modeller."
+msgstr ""
+"Stemmechat er anonymiseret af os og bruges aldrig til at træne AI-modeller."
 
 # smartling.placeholder_format=C
 #. Title of the modal shown when the user has reached their daily voice chat limit.
@@ -21583,6 +22138,12 @@ msgstr "Venter på placering ..."
 # smartling.placeholder_format=C
 msgid "Wales"
 msgstr "Wales"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Walk me through the steps"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for walking directions on a map.
@@ -21703,6 +22264,17 @@ msgstr ""
 "resultater."
 
 # smartling.placeholder_format=C
+#. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
+msgctxt ""
+"Inline warning shown below the share-content toggle when the user selects "
+"Harmful or Illegal but has not enabled sharing"
+msgid ""
+"We can only fix what we can see. To report a harmful or illegal response, "
+"please share this conversation with DuckDuckGo so we can investigate and "
+"address the issue."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
 msgctxt ""
 "Inline warning shown below the share-content toggle when the user selects "
@@ -21729,7 +22301,8 @@ msgstr ""
 msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
-msgstr "Vi kan ikke læse de vedhæftede filer, fordi mindst én af dem er krypteret."
+msgstr ""
+"Vi kan ikke læse de vedhæftede filer, fordi mindst én af dem er krypteret."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -21925,7 +22498,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
-msgstr "Vi blokerer trackere, der forsøger at indsamle dine data, mens du browser."
+msgstr ""
+"Vi blokerer trackere, der forsøger at indsamle dine data, mens du browser."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -21959,7 +22533,8 @@ msgctxt "duckai_migration"
 msgid ""
 "We're sorry for this inconvenience. We’re working hard to make your "
 "experience better."
-msgstr "Vi beklager ulejligheden. Vi arbejder hårdt på at gøre din oplevelse bedre."
+msgstr ""
+"Vi beklager ulejligheden. Vi arbejder hårdt på at gøre din oplevelse bedre."
 
 # smartling.placeholder_format=C
 #. Body text explaining the service update requires a page reload.
@@ -22116,7 +22691,8 @@ msgstr ""
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai! You can now import your downloaded chats."
-msgstr "Velkommen til det nye Duck.ai! Du kan nu importere dine downloadede chats."
+msgstr ""
+"Velkommen til det nye Duck.ai! Du kan nu importere dine downloadede chats."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -22207,13 +22783,15 @@ msgstr ""
 #. Text for a prompt suggestion for considering factors when purchasing a computer monitor.
 msgctxt "Full sentence for preparing for a purchase"
 msgid "What are some factors to consider when purchasing a computer monitor?"
-msgstr "Hvad er nogle faktorer, der skal overvejes, når man køber en computerskærm?"
+msgstr ""
+"Hvad er nogle faktorer, der skal overvejes, når man køber en computerskærm?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for asking about must-see attractions in Paris for a first-time visitor.
 msgctxt "Full sentence for planning a trip"
 msgid "What are some must-see attractions in Paris for a first-time visitor?"
-msgstr "Hvad er nogle must-see attraktioner i Paris for en førstegangsbesøgende?"
+msgstr ""
+"Hvad er nogle must-see attraktioner i Paris for en førstegangsbesøgende?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for finding options for the word 'better' in a specific context.
@@ -22244,10 +22822,106 @@ msgid ""
 msgstr ""
 "Hvad er fordelene ved at downloade DuckDuckGo-browseren, hvis du er "
 "interesseret i at bruge Duck.ai? Referer kun officielle DuckDuckGo-kilder. "
-"Opdel svaret i klare sektioner med titler, med fokus på "
-"Duck.ai-integrationer og beskyttelse af privatlivet. Hold det kort, enkelt "
-"og letforståeligt for folk med eller uden betydelig AI- eller teknisk "
-"erfaring."
+"Opdel svaret i klare sektioner med titler, med fokus på Duck.ai-"
+"integrationer og beskyttelse af privatlivet. Hold det kort, enkelt og "
+"letforståeligt for folk med eller uden betydelig AI- eller teknisk erfaring."
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the counterarguments?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the hours & location?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key contributions of this paper?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key contributions?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key details?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key points covered in this video?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key points?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key takeaways from this article?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key takeaways?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key things I will learn from this course?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main counterarguments or criticisms of this?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main questions this page answers?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the must-try dishes here?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"What are the opening hours, location, and contact details for this place?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the pros and cons of this product?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the pros and cons?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
@@ -22350,6 +23024,12 @@ msgid "What does atria mean in the context of a medical article?"
 msgstr "Hvad betyder atria i forbindelse med en medicinsk artikel?"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What does this answer?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
@@ -22360,6 +23040,12 @@ msgstr "Hvilken funktion vil du gerne have, at vi tilføjer? (valgfri)"
 msgctxt "cloudsave"
 msgid "What information gets saved?"
 msgstr "Hvilke informationer bliver gemt?"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What interview questions might come up for this role?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -22376,6 +23062,12 @@ msgstr ""
 msgctxt "Full sentence for looking up basic facts"
 msgid "What is the capital city of Albania?"
 msgstr "Hvad hedder hovedstaden i Albanien?"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What is the overall verdict and rating for this?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to a page with additional information.
@@ -22400,6 +23092,12 @@ msgid "What people say:"
 msgstr "Hvad folk siger:"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What should I order?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
 msgctxt "feedback form"
 msgid "What stood out?"
@@ -22410,6 +23108,18 @@ msgstr "Hvad skilte sig ud?"
 msgctxt "feedback form"
 msgid "What was wrong with the response? (optional)"
 msgstr "Hvad var der galt med svaret? (valgfrit)"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I learn?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I need?"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -22429,6 +23139,12 @@ msgid "What's New"
 msgstr "Nyheder"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What's the verdict?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to a page featuring the most recent updates from DuckDuckGo.
 msgid "What’s New"
 msgstr "Nyheder"
@@ -22446,7 +23162,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "When enabled, Duck.ai will show instant answers in the chat."
-msgstr "Når funktionen er aktiveret, vil Duck.ai vise Øjeblikkeligt svar i chatten."
+msgstr ""
+"Når funktionen er aktiveret, vil Duck.ai vise Øjeblikkeligt svar i chatten."
 
 # smartling.placeholder_format=C
 #. Text of a button that performs a search for the available streaming services that show a particular movie or tv show
@@ -22481,6 +23198,12 @@ msgid "Which features are missing? (Optional)"
 msgstr "Hvilke funktioner mangler? (valgfrit)"
 
 # smartling.placeholder_format=C
+#. An invitation for users to leave feedback
+msgctxt "Feedback prompt"
+msgid "Which features are missing? (optional)"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
 msgid "White"
 msgstr "Hvid"
@@ -22495,6 +23218,18 @@ msgstr "Hvid"
 #. Link to an about us page.
 msgid "Who We Are"
 msgstr "Hvem vi er"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Who are the main cast and crew, and what else are they known for?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Who is this person?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Header above a collection of privacy-related links.
@@ -22886,7 +23621,8 @@ msgctxt "Disclaimer bellow chat input - desktop"
 msgid ""
 "You are chatting with %s. AI chats may display inaccurate or offensive "
 "information."
-msgstr "Du chatter med %1$s. AI-chats kan vise unøjagtige eller stødende oplysninger."
+msgstr ""
+"Du chatter med %1$s. AI-chats kan vise unøjagtige eller stødende oplysninger."
 
 # smartling.placeholder_format=C
 #. Provide users with the ability to retry their search on a different search engine. First placeholder will be a link with the text "try your search again" OR "try your search later". Second is a URL to the !bangs page: https://duckduckgo.com/bangs.
@@ -23156,7 +23892,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
 msgid "You won't see this message again unless you clear your browser data."
-msgstr "Du vil ikke se denne meddelelse igen, medmindre du rydder dine browserdata."
+msgstr ""
+"Du vil ikke se denne meddelelse igen, medmindre du rydder dine browserdata."
 
 # smartling.placeholder_format=C
 #. The second paragraph of a pop up where we explain how to update the browser manually.
@@ -23239,14 +23976,16 @@ msgstr "Du har nået det maksimale antal beskeder for nu. Prøv igen senere."
 #. Description shown when the user has reached the maximum voice chat duration.
 msgctxt "voice chat duration limit modal"
 msgid "You've reached the maximum voice chat duration for a single session."
-msgstr "Du har nået den maksimale varighed af stemmechat for en enkelt session."
+msgstr ""
+"Du har nået den maksimale varighed af stemmechat for en enkelt session."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the daily voice chat limit.
 msgctxt "voice chat limit modal"
 msgid ""
 "You've reached the voice chat limit for today. Please try again tomorrow."
-msgstr "Du har nået grænsen for stemmechat for i dag. Prøv venligst igen i morgen."
+msgstr ""
+"Du har nået grænsen for stemmechat for i dag. Prøv venligst igen i morgen."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
@@ -23404,7 +24143,8 @@ msgstr "Dine chats bliver nu gemt."
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never saved or used to train AI models"
-msgstr "Dine chats er private og hverken gemmes eller bruges til at træne AI-modeller"
+msgstr ""
+"Dine chats er private og hverken gemmes eller bruges til at træne AI-modeller"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
@@ -23418,8 +24158,8 @@ msgctxt "Active Privacy protection description"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
 msgstr ""
-"Dine chats er private, anonymiseret af os, og bruges ikke til at træne "
-"AI-modeller."
+"Dine chats er private, anonymiseret af os, og bruges ikke til at træne AI-"
+"modeller."
 
 # smartling.placeholder_format=C
 #. Text explaining that user chats are private and not used for AI (Artificial Intelligence) training.
@@ -23427,8 +24167,8 @@ msgctxt "Body text for privacy protection modal"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
 msgstr ""
-"Dine chats er private, anonymiseret af os, og bruges ikke til at træne "
-"AI-modeller."
+"Dine chats er private, anonymiseret af os, og bruges ikke til at træne AI-"
+"modeller."
 
 # smartling.placeholder_format=C
 #. Text for a menu item that describes the privacy protection feature.
@@ -23546,8 +24286,8 @@ msgid ""
 "browser. We save the settings file using the key as the name. DuckDuckGo "
 "never knows your passphrase."
 msgstr ""
-"Dit adgangsudtryk genererer en 512-bit-nøgle ved hjælp af Secure "
-"Hash-algoritmen kendt som %1$sSHA-2%2$s. Kun nøglen og den tilhørende "
+"Dit adgangsudtryk genererer en 512-bit-nøgle ved hjælp af Secure Hash-"
+"algoritmen kendt som %1$sSHA-2%2$s. Kun nøglen og den tilhørende "
 "indstillingsfil forlader din browser. Vi gemmer indstillingsfilen ved at "
 "bruge nøglen som navnet. DuckDuckGo får aldrig dit adgangsudtryk at vide."
 

--- a/locales/da_DK/LC_MESSAGES/duckduckgo.po
+++ b/locales/da_DK/LC_MESSAGES/duckduckgo.po
@@ -21680,7 +21680,7 @@ msgstr "Uruguay"
 #. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
 msgctxt "Navigation label on the Duck.ai settings page"
 msgid "Usage"
-msgstr "Anvendelse"
+msgstr "Forbrug"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion

--- a/locales/da_DK/LC_MESSAGES/duckduckgo.po
+++ b/locales/da_DK/LC_MESSAGES/duckduckgo.po
@@ -17408,7 +17408,7 @@ msgstr "Sæt det op nu"
 #. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
 msgctxt "Encrypted storage setup button shown in native browsers"
 msgid "Set Up Sync & Backup"
-msgstr "Opsætning af Sync & Backup"
+msgstr "Opsæt Sync & Backup"
 
 # smartling.placeholder_format=C
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.

--- a/locales/de_CH/LC_MESSAGES/duckduckgo.po
+++ b/locales/de_CH/LC_MESSAGES/duckduckgo.po
@@ -1165,6 +1165,11 @@ msgctxt "feedback form"
 msgid "Address is incorrect"
 msgstr ""
 
+#. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Adjust the servings"
+msgstr ""
+
 #. as in multiple advertisements
 msgid "Ads"
 msgstr "Werbungen"
@@ -1338,6 +1343,13 @@ msgstr ""
 #. Heading shown on the empty chat screen. The text between the two %s markers is displayed inside a clickable privacy button. First %s renders a shield icon, second %s is an invisible end marker. Keep the word 'private' between both %s markers.
 msgctxt "Empty state heading in Duck.ai chat mode"
 msgid "All chats are %sprivate%s"
+msgstr ""
+
+#. Paragraph in the Privacy & Terms section of the About & Legal page in Duck.ai settings, summarizing how chats are anonymized and are not stored or used to train chat models.
+msgctxt "Privacy & Terms section description on the Duck.ai settings page"
+msgid ""
+"All chats are anonymized by DuckDuckGo, and your conversations are not used "
+"to train chat models by DuckDuckGo or the model providers"
 msgstr ""
 
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1550,6 +1562,12 @@ msgstr ""
 #. Confirmation message after location service is enabled.
 msgctxt "precise_user_location"
 msgid "Anonymous location enabled"
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Anonymously generates answers for search queries based on web content. "
+"Choose how often you want it to appear, or disable it completely."
 msgstr ""
 
 #. Instant Answer tab name
@@ -1774,6 +1792,11 @@ msgstr ""
 
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse
 msgid "Ask a follow-up with Duck.ai"
+msgstr ""
+
+#. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
+msgctxt "Page suggestion chip label"
+msgid "Ask about this page"
 msgstr ""
 
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2098,6 +2121,11 @@ msgstr ""
 msgid "Barcode"
 msgstr "Strichcode"
 
+#. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Based on this page, is this course worth taking?"
+msgstr ""
+
 msgctxt "settings"
 msgid "Basic"
 msgstr "einfach"
@@ -2129,6 +2157,13 @@ msgstr ""
 #. Placeholder text displayed while the assistant waits for the user to choose an action.
 msgctxt "Assistant response placeholder"
 msgid "Before continuing..."
+msgstr ""
+
+#. Explains that before storing the report, DuckDuckGo will anonymize the conversation by removing PII like names, email addresses, and identifying metadata.
+msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
+msgid ""
+"Before storing this report, DuckDuckGo will anonymize your conversation by "
+"removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
 #. Label that's displayed next to a past start date below a web search result.
@@ -2387,6 +2422,11 @@ msgstr "Brasilien"
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Break Points Won"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Break this down into clear, numbered steps."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -2755,6 +2795,11 @@ msgstr "Stellenangebote"
 #. Text of a button that performs a search for the cast of a particular movie or tv show
 msgctxt "Movie/TV Show Title instant answer"
 msgid "Cast"
+msgstr ""
+
+#. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Cast & Crew"
 msgstr ""
 
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -4119,6 +4164,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Create a shopping list with quantities from this recipe."
+msgstr ""
+
 #. Placeholder text displayed in the input field when starting a new image generation session.
 msgctxt "Placeholder text for the image generation input field"
 msgid "Create an image of a cute duck..."
@@ -4645,6 +4695,10 @@ msgstr ""
 msgid "Dictation limit reached"
 msgstr ""
 
+#. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
+msgid "Dictation temporarily unavailable"
+msgstr ""
+
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
@@ -4889,6 +4943,20 @@ msgctxt "precise_user_location"
 msgid "Done"
 msgstr "Fertig"
 
+#. Message shown in a modal after DuckDuckGo browser users disable AI features in Settings. The first two placeholders bold noai.duckduckgo.com. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
+"filtered out. %sLearn More%s"
+msgstr ""
+
+#. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
+"and AI images filtered out. %sLearn more%s"
+msgstr ""
+
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Double Faults"
@@ -4979,6 +5047,16 @@ msgctxt "Full sentence for writing an email"
 msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
+msgstr ""
+
+#. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Draft a cover letter"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Draft a cover letter for this job."
 msgstr ""
 
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -5118,6 +5196,14 @@ msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
 msgstr ""
 
+#. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
+msgctxt "About section description on the Duck.ai settings page"
+msgid ""
+"Duck.ai is created by DuckDuckGo. We're an independent online protection "
+"company for anyone who wants to take back control of their personal "
+"information."
+msgstr ""
+
 #. Title shown when an update is required before proceeding.
 msgctxt "duckai_migration"
 msgid "Duck.ai is moving domains"
@@ -5151,6 +5237,12 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Duck.ai lets you chat privately with popular AI models. Disabling it hides "
+"Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
 
 msgctxt "settings"
@@ -5917,6 +6009,16 @@ msgstr ""
 msgid "Eritrea"
 msgstr ""
 
+#. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Estimate the nutrition"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Estimate the nutritional information for this recipe."
+msgstr ""
+
 msgid "Estonia"
 msgstr "Estland"
 
@@ -5961,10 +6063,50 @@ msgctxt "merchant promotion product ad extension"
 msgid "Expires in 1 day"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain the accepted answer in simple terms."
+msgstr ""
+
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
+msgstr ""
+
+#. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain the top answer"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this in simple, plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this paper"
+msgstr ""
+
+#. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this repo"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this research paper in plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this simply"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain what this repository does and how to use it."
 msgstr ""
 
 #. Label to show if song lyrics contain explicit content
@@ -6195,6 +6337,11 @@ msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
 msgstr ""
 
+msgctxt "settings"
+msgid ""
+"Filters out known AI spam sites from image search results. %sLearn More%s"
+msgstr ""
+
 #. Label for the final score of a sporting event.
 msgid "Final"
 msgstr "Final"
@@ -6235,6 +6382,11 @@ msgstr ""
 #. Short description shown below the 'Web Search' label in the Tools dropdown.
 msgctxt "Subtitle for the Web Search tool entry in the Tools dropdown menu"
 msgid "Find current information"
+msgstr ""
+
+#. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Find me alternatives"
 msgstr ""
 
 #. Button that searches for results closer to the user's current location.
@@ -6625,6 +6777,11 @@ msgstr ""
 msgid "Generate More"
 msgstr ""
 
+#. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Generate a shopping list"
+msgstr ""
+
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
 msgid "Generate a short answer from the web"
 msgstr ""
@@ -6861,6 +7018,11 @@ msgstr ""
 #. Text for a button inviting users to give it a try for the Duck.ai product. On click, they're taken to the Duck.ai page.
 msgctxt "Onboarding welcome screen button text"
 msgid "Give it a Try"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Give me a quick background on this person."
 msgstr ""
 
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -7224,6 +7386,16 @@ msgstr ""
 #. Link to a page with information about sharing DuckDuckGo with friends.
 msgid "Help Spread Privacy"
 msgstr "Hilf Privatsphäre zu verbreiten."
+
+#. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Help me prep for the interview"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Help me tailor my resume for this job."
+msgstr ""
 
 #. Title of a SERP popup that invites users to take a survey (desktop only)
 msgctxt "User survey popup"
@@ -7645,6 +7817,13 @@ msgstr ""
 #. Text displayed on the button on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
 msgctxt "Onboarding terms screen button text"
 msgid "I Agree"
+msgstr ""
+
+#. Text for the button that takes the user to the external DuckDuckGo login subscription page.
+msgctxt ""
+"Text for the I already have a subscription button in the Duck.ai settings "
+"page"
+msgid "I Already Have a Subscription"
 msgstr ""
 
 #. Text for the button that takes the user to the login subscription page.
@@ -8103,6 +8282,11 @@ msgctxt "Sidemenu browser promo"
 msgid "Install Mac Browser"
 msgstr ""
 
+#. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
+msgctxt "settings"
+msgid "Install Now"
+msgstr ""
+
 #. Text of a button to install the DuckDuckGo app
 msgctxt "Serp footer content"
 msgid "Install Our App"
@@ -8182,9 +8366,36 @@ msgctxt "cloudsave"
 msgid "Is deleted data really deleted?"
 msgstr "Sind gelöschte Daten wirklich gelöscht?"
 
+#. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is it worth taking?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this place any good?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"Is this place any good? Summarize its reputation based on reviews and "
+"ratings."
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "Is this video helpful?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this worth watching?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Is this worth watching? Give me a spoiler-free take."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -8683,6 +8894,11 @@ msgstr "Link-Schriftart"
 msgid "Links:"
 msgstr "Links"
 
+#. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "List the tools, materials, or prerequisites I need for this."
+msgstr ""
+
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
 msgid "Listen"
 msgstr "zuhören"
@@ -9017,6 +9233,11 @@ msgstr ""
 #. Label for linke navigating to site exclusion feature on Settings page
 msgctxt "Exclusion message manage sites button"
 msgid "Manage blocked sites"
+msgstr ""
+
+#. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
+msgctxt "setting"
+msgid "Manage in Browser Settings"
 msgstr ""
 
 #. Link to the site exclusion settings page
@@ -11325,6 +11546,11 @@ msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
+msgid "Please describe why the chat response is harmful or illegal. (optional)"
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
+msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
 msgstr ""
 
@@ -11343,6 +11569,13 @@ msgctxt "Modal disclaimer text"
 msgid ""
 "Please note: starting a new chat with any model will delete your current "
 "chat session."
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
+msgctxt "Feedback prompt"
+msgid ""
+"Please paste your prompt and the problematic output (with any personal "
+"information removed) and describe why the content is harmful or illegal."
 msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -11727,6 +11960,11 @@ msgctxt "settings"
 msgid "Privacy"
 msgstr "Privatsphäre "
 
+#. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
+msgctxt "Section heading on the Duck.ai settings page"
+msgid "Privacy & Terms"
+msgstr ""
+
 msgid "Privacy Blog"
 msgstr "Datenschutzblog"
 
@@ -11780,6 +12018,11 @@ msgstr ""
 
 #. Text used in other strings to link to the Privacy Policy and Terms of Service content.
 msgctxt "Copy used to compose link in sentences"
+msgid "Privacy Policy and Terms of Service"
+msgstr ""
+
+#. Text for a button that links to the terms of use and privacy policy page.
+msgctxt "Secondary button text in active privacy modal"
 msgid "Privacy Policy and Terms of Service"
 msgstr ""
 
@@ -12188,6 +12431,26 @@ msgctxt "Brief for recommending a book"
 msgid "Recommend a book"
 msgstr ""
 
+#. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar books"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar books."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar movies or shows."
+msgstr ""
+
+#. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar titles"
+msgstr ""
+
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
 msgid "Recording failed. Please try again."
 msgstr ""
@@ -12507,6 +12770,14 @@ msgstr ""
 msgid "Republic of Moldova"
 msgstr ""
 
+#. Note indicating that sharing the conversation is mandatory when reporting harmful or illegal content. Rendered alongside the standard share label (DUCKCHAT_RESPONSE_FEEDBACK_SHARE_PROMPT_RESPONSE_LABEL), not replacing it.
+msgctxt ""
+"Note shown under the share-content switch label on the Duck.ai response "
+"feedback form when the user has selected Harmful or Illegal as the feedback "
+"reason"
+msgid "Required for harmful or illegal reports"
+msgstr ""
+
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
 msgctxt "Description for extended reasoning mode in Duck.ai"
 msgid "Researches before responding"
@@ -12693,6 +12964,11 @@ msgstr "Bewertungen"
 msgctxt "maps_places"
 msgid "Reviews"
 msgstr "Reviews"
+
+#. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Rewrite this recipe scaled for a different number of servings."
+msgstr ""
 
 msgid "Romania"
 msgstr "Rumänien"
@@ -13742,6 +14018,11 @@ msgctxt "Setup button for native sync flow"
 msgid "Set Up Now"
 msgstr ""
 
+#. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
+msgctxt "Encrypted storage setup button shown in native browsers"
+msgid "Set Up Sync & Backup"
+msgstr ""
+
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
 msgctxt "Title for the Sync & Backup intro screen"
 msgid "Set Up Sync & Backup"
@@ -13888,6 +14169,12 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
+msgctxt ""
+"Label beside the share-content switch on the Duck.ai response feedback form"
+msgid "Share this conversation with DuckDuckGo"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -14904,6 +15191,21 @@ msgctxt "Brief for suggesting a blog post title"
 msgid "Suggest a title for a blog post"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest related articles or topics worth exploring next."
+msgstr ""
+
+#. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Suggest related articles to explore"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest some alternatives to this product."
+msgstr ""
+
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
 msgctxt "directions"
 msgid "Suggestions:"
@@ -14913,9 +15215,84 @@ msgctxt "noresults"
 msgid "Suggestions:"
 msgstr "Vorschläge:"
 
+#. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Sum up the reviews"
+msgstr ""
+
 #. A short title for the a message asking the AI to summarize a text.
 msgctxt "Title for the summarize message"
 msgid "Summarize"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize the Q&As"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the background and notable work of this person."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the key details of this event."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the questions and answers on this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize their background"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this book"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this book."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this discussion"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this discussion thread."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this video"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this video."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize what the reviews say."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -15170,6 +15547,11 @@ msgstr ""
 msgid "Syria"
 msgstr ""
 
+#. Text for a button that enables the theme to follow the operating system's color scheme preference.
+msgctxt "System theme button for theme selector"
+msgid "System"
+msgstr ""
+
 #. Abbreviation indicating this is the total score for a game
 msgctxt "Sports module"
 msgid "T"
@@ -15193,6 +15575,11 @@ msgctxt "language_name"
 msgid "Tahitian"
 msgstr ""
 
+#. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Tailor my resume"
+msgstr ""
+
 msgid "Taiwan"
 msgstr "Taiwan"
 
@@ -15214,6 +15601,12 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "Take control of your personal data!"
+msgstr ""
+
+#. Description for the Feedback section of the Duck.ai settings page, asking the user to take an anonymous survey to let us know how we can make Duck.ai better.
+msgctxt "Feedback section description on the Duck.ai settings page"
+msgid ""
+"Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
 
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -15462,6 +15855,11 @@ msgstr ""
 #. https://duck.co/media/files/theme.png
 msgid "Theme"
 msgstr "Design"
+
+#. Text for the theme selector label that allows users to switch between Light and dark theme.
+msgctxt "Label for the theme selector feature"
+msgid "Theme"
+msgstr ""
 
 #. http://i.imgur.com/LpFhb1e.png
 msgctxt "settings"
@@ -16121,6 +16519,16 @@ msgid ""
 "movie theatre?”"
 msgstr ""
 
+#. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Translate this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
+msgctxt "Page suggestion prompt"
+msgid "Translate this page into %s."
+msgstr ""
+
 #. Placeholder text for a region that will display translated text.
 msgctxt "translations_module"
 msgid "Translation"
@@ -16235,6 +16643,11 @@ msgstr ""
 #. Call-to-action button for the subscription promo in the SERP sidemenu.
 msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
+msgstr ""
+
+#. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
+msgctxt "settings"
+msgid "Try It Now"
 msgstr ""
 
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -16429,6 +16842,20 @@ msgstr "Versuche: %s"
 msgctxt "new user poll"
 msgid "Trying DuckDuckGo again"
 msgstr "Ich probiere DuckDuckGo erneut aus"
+
+#. Message shown in a modal after supported third-party browser users disable AI features in Settings. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+#. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
 
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
 msgctxt "Assistant response placeholder"
@@ -17037,6 +17464,11 @@ msgstr ""
 msgid "Uruguay"
 msgstr ""
 
+#. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
+msgctxt "Navigation label on the Duck.ai settings page"
+msgid "Usage"
+msgstr ""
+
 #. A feedback suggestion
 msgctxt "Feedback prompt"
 msgid "Usage limit"
@@ -17387,6 +17819,11 @@ msgstr ""
 msgid "Wales"
 msgstr ""
 
+#. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Walk me through the steps"
+msgstr ""
+
 #. Label for walking directions on a map.
 msgctxt "directions"
 msgid "Walking"
@@ -17477,6 +17914,16 @@ msgstr ""
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
+msgstr ""
+
+#. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
+msgctxt ""
+"Inline warning shown below the share-content toggle when the user selects "
+"Harmful or Illegal but has not enabled sharing"
+msgid ""
+"We can only fix what we can see. To report a harmful or illegal response, "
+"please share this conversation with DuckDuckGo so we can investigate and "
+"address the issue."
 msgstr ""
 
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -17908,6 +18355,87 @@ msgid ""
 "experience."
 msgstr ""
 
+#. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the counterarguments?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the hours & location?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key contributions of this paper?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key contributions?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key details?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key points covered in this video?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key points?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key takeaways from this article?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key takeaways?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key things I will learn from this course?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main counterarguments or criticisms of this?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main questions this page answers?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the must-try dishes here?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"What are the opening hours, location, and contact details for this place?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the pros and cons of this product?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the pros and cons?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
 msgctxt "feedback form"
 msgid "What bothered you most?"
@@ -17991,6 +18519,11 @@ msgctxt "Full sentence for defining a term"
 msgid "What does atria mean in the context of a medical article?"
 msgstr ""
 
+#. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What does this answer?"
+msgstr ""
+
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
@@ -18000,6 +18533,11 @@ msgstr ""
 msgctxt "cloudsave"
 msgid "What information gets saved?"
 msgstr "Welche Informationen werden gespeichert?"
+
+#. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What interview questions might come up for this role?"
+msgstr ""
 
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
@@ -18011,6 +18549,11 @@ msgstr ""
 #. Text for a prompt suggestion for looking up the capital city of Albania.
 msgctxt "Full sentence for looking up basic facts"
 msgid "What is the capital city of Albania?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What is the overall verdict and rating for this?"
 msgstr ""
 
 #. Link to a page with additional information.
@@ -18031,6 +18574,11 @@ msgctxt "maps_places"
 msgid "What people say:"
 msgstr ""
 
+#. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What should I order?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
 msgctxt "feedback form"
 msgid "What stood out?"
@@ -18039,6 +18587,16 @@ msgstr ""
 #. Question on a feedback form for a negative feedback response.
 msgctxt "feedback form"
 msgid "What was wrong with the response? (optional)"
+msgstr ""
+
+#. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I learn?"
+msgstr ""
+
+#. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I need?"
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -18053,6 +18611,11 @@ msgstr ""
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
 msgctxt "SERP footer content"
 msgid "What's New"
+msgstr ""
+
+#. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What's the verdict?"
 msgstr ""
 
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -18094,6 +18657,11 @@ msgctxt "Feedback prompt"
 msgid "Which features are missing? (Optional)"
 msgstr ""
 
+#. An invitation for users to leave feedback
+msgctxt "Feedback prompt"
+msgid "Which features are missing? (optional)"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
 msgid "White"
 msgstr "Weiss"
@@ -18106,6 +18674,16 @@ msgstr "Weiss"
 #. Link to an about us page.
 msgid "Who We Are"
 msgstr "Wer wir sind"
+
+#. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Who are the main cast and crew, and what else are they known for?"
+msgstr ""
+
+#. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Who is this person?"
+msgstr ""
 
 #. Header above a collection of privacy-related links.
 msgid "Why Privacy"

--- a/locales/de_DE/LC_MESSAGES/duckduckgo.po
+++ b/locales/de_DE/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: de_DE\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1244,8 +1244,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. An item in the ads tooltip that explains that ad clicks aren’t used to profile you.
 msgid "Ad clicks aren’t used to profile you"
-msgstr ""
-"Werbungsklicks werden nicht verwendet, um ein Profil von dir zu erstellen"
+msgstr "Werbungsklicks werden nicht verwendet, um ein Profil von dir zu erstellen"
 
 # smartling.placeholder_format=C
 #. Category of problem a user can select on a feedback form.
@@ -1450,7 +1449,7 @@ msgstr "Adresse ist falsch"
 #. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Adjust the servings"
-msgstr ""
+msgstr "Portionen anpassen"
 
 # smartling.placeholder_format=C
 #. as in multiple advertisements
@@ -1672,6 +1671,9 @@ msgid ""
 "All chats are anonymized by DuckDuckGo, and your conversations are not used "
 "to train chat models by DuckDuckGo or the model providers"
 msgstr ""
+"Alle Chats werden von DuckDuckGo anonymisiert, und deine Unterhaltungen "
+"werden von DuckDuckGo oder den Modellanbietern nicht zum Trainieren von "
+"Chatmodellen verwendet"
 
 # smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1764,8 +1766,7 @@ msgstr "Privatsphäre-respektierende Werbung zulassen"
 # smartling.placeholder_format=C
 #. Title in a dialog informing the user how to disable their ad blocker for DuckDuckGo
 msgid "Allow privacy-respecting ads on DuckDuckGo Private Search"
-msgstr ""
-"Lass datenschutzfreundliche Werbung in der Private Search von DuckDuckGo zu"
+msgstr "Lass datenschutzfreundliche Werbung in der Private Search von DuckDuckGo zu"
 
 # smartling.placeholder_format=C
 #. Description explaining privacy implications of enabling web search on encrypted models. The first two placeholders are the full model name (e.g. 'gpt-oss 120B'). The third and fourth placeholders wrap a clickable link reading 'zero provider visibility' that opens the privacy modal, please keep those around the link text in your translation. An example full sentence would be: Allows gpt-oss 120B to search the web to improve responses to relevant prompts. Only sends AI-generated queries to a search engine with limited data retention. Prompts and responses with gpt-oss 120B still have zero provider visibility.
@@ -1950,6 +1951,9 @@ msgid ""
 "Anonymously generates answers for search queries based on web content. "
 "Choose how often you want it to appear, or disable it completely."
 msgstr ""
+"Generiert anonym Antworten für Suchanfragen auf der Grundlage von "
+"Webinhalten. Du kannst auswählen, wie oft es angezeigt werden soll, oder es "
+"vollständig deaktivieren."
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -2104,8 +2108,7 @@ msgstr ""
 #. Body text of the modal that asks the user if they want to clear the conversation.
 msgctxt "Modal body for clearing conversation"
 msgid "Are you sure you want to clear this conversation and start a new one?"
-msgstr ""
-"Möchtest du diese Konversation wirklich löschen und eine neue beginnen?"
+msgstr "Möchtest du diese Konversation wirklich löschen und eine neue beginnen?"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to delete their current chat, explaining that this action cannot be undone.
@@ -2239,7 +2242,7 @@ msgstr "Stelle eine Folgefrage mit Duck.ai"
 #. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
 msgctxt "Page suggestion chip label"
 msgid "Ask about this page"
-msgstr ""
+msgstr "Fragen zu dieser Seite"
 
 # smartling.placeholder_format=C
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2305,13 +2308,13 @@ msgid ""
 msgstr ""
 "Assist kann anonym KI-gestützte Antworten auf einige Suchanfragen "
 "generieren, die auf der Zusammenfassung relevanter Webinhalte basieren. Du "
-"kannst auswählen, wie oft Assist angezeigt werden soll: Nie (die Assist-"
-"Benutzeroberfläche wird vollständig aus den Suchergebnissen entfernt), Bei "
-"Bedarf (KI-gestützte Antworten werden nur angezeigt, wenn du auf die Assist-"
-"Schaltfläche klickst), Manchmal (KI-gestützte Antworten werden nur bei hoher "
-"Relevanz angezeigt) oder Oft (werden häufiger bei einer größeren Anzahl von "
-"Suchanfragen angezeigt). Derzeit sind KI-gestützte Antworten nur in den USA "
-"(Englisch) verfügbar."
+"kannst auswählen, wie oft Assist angezeigt werden soll: Nie (die "
+"Assist-Benutzeroberfläche wird vollständig aus den Suchergebnissen "
+"entfernt), Bei Bedarf (KI-gestützte Antworten werden nur angezeigt, wenn du "
+"auf die Assist-Schaltfläche klickst), Manchmal (KI-gestützte Antworten "
+"werden nur bei hoher Relevanz angezeigt) oder Oft (werden häufiger bei einer "
+"größeren Anzahl von Suchanfragen angezeigt). Derzeit sind KI-gestützte "
+"Antworten nur in den USA (Englisch) verfügbar."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2323,8 +2326,8 @@ msgid ""
 "to remember that responses are auto-generated from cited sources and based "
 "on %scrawling the web%s."
 msgstr ""
-"Assist ist eine optionale Funktion in unseren Suchergebnissen, die anonym KI-"
-"gestützte Antworten auf Suchanfragen generieren kann. Dazu durchsucht sie "
+"Assist ist eine optionale Funktion in unseren Suchergebnissen, die anonym "
+"KI-gestützte Antworten auf Suchanfragen generieren kann. Dazu durchsucht sie "
 "das Internet nach relevanten Inhalten und verwendet dann KI-gestützte "
 "natürliche Sprachtechnologie, um eine kurze Antwort auf der Grundlage der "
 "gefundenen relevanten Informationen zu generieren. Es ist wichtig, zu "
@@ -2482,8 +2485,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI) on mobile
 msgid "Auto-generated from sources. May be inaccurate."
-msgstr ""
-"Automatisch generiert basierend auf Quellen. Kann Ungenauigkeiten enthalten."
+msgstr "Automatisch generiert basierend auf Quellen. Kann Ungenauigkeiten enthalten."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2551,8 +2553,7 @@ msgstr "Durchschn. Vol."
 #. Warning text shown below the chat input when the user has attached files, advising them not to upload files from untrusted sources.
 msgctxt "Disclaimer below chat input in Duck.ai when files are attached"
 msgid "Avoid uploading files from sources you don't trust."
-msgstr ""
-"Vermeide das Hochladen von Dateien aus Quellen, denen du nicht vertraust."
+msgstr "Vermeide das Hochladen von Dateien aus Quellen, denen du nicht vertraust."
 
 # smartling.placeholder_format=C
 #. Indicates the Win-Loss record of a team when playing away
@@ -2671,7 +2672,7 @@ msgstr "Strichcode"
 #. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Based on this page, is this course worth taking?"
-msgstr ""
+msgstr "Lohnt es sich, basierend auf dieser Seite, diesen Kurs zu belegen?"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2720,6 +2721,9 @@ msgid ""
 "Before storing this report, DuckDuckGo will anonymize your conversation by "
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
+"Bevor dieser Bericht gespeichert wird, anonymisiert DuckDuckGo deinen Chat, "
+"indem personenbezogene Daten wie Namen, E-Mail-Adressen und identifizierende "
+"Metadaten entfernt werden."
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -2845,8 +2849,7 @@ msgstr "E-Mail-Tracker blockieren und deine Adresse verbergen."
 # smartling.placeholder_format=C
 #. A disclaimer about AI-generated images in search results
 msgid "Block list is not exhaustive and may contain inaccuracies."
-msgstr ""
-"Die Blockliste ist nicht vollständig und kann Ungenauigkeiten enthalten."
+msgstr "Die Blockliste ist nicht vollständig und kann Ungenauigkeiten enthalten."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -2862,8 +2865,7 @@ msgstr "Diese Seite in allen Ergebnissen blockieren"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Block trackers and take control of your personal data"
-msgstr ""
-"Blockiere Tracker und übernimm die Kontrolle über deine persönlichen Daten"
+msgstr "Blockiere Tracker und übernimm die Kontrolle über deine persönlichen Daten"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -3043,7 +3045,7 @@ msgstr "Gewonnene Breakpunkte"
 #. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Break this down into clear, numbered steps."
-msgstr ""
+msgstr "Unterteile dies in klare, nummerierte Schritte."
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -3121,9 +3123,9 @@ msgid ""
 "search, tracker blocking, and site encryption, all in one download, for "
 "%smajor browsers%s."
 msgstr ""
-"Surfe wie immer und wir kümmern uns um den Rest: Private Suche, Tracker-"
-"Blockade, und Website-Verschlüsselung – alles in einem Download, für %1$sdie "
-"wichtigsten Browser%2$s."
+"Surfe wie immer und wir kümmern uns um den Rest: Private Suche, "
+"Tracker-Blockade, und Website-Verschlüsselung – alles in einem Download, für "
+"%1$sdie wichtigsten Browser%2$s."
 
 # smartling.placeholder_format=C
 #. Header for a call to action to browse with the DuckDuckGo browser
@@ -3209,8 +3211,7 @@ msgstr "Indem du auf „%1$s“ klickst, akzeptierst du unsere %2$s."
 msgctxt ""
 "Copy stating agreement to Duck.ai Privacy Policy and Terms of Service."
 msgid "By clicking “%s,” you accept Duck.ai’s %s and %s."
-msgstr ""
-"Indem du auf „%1$s“ klickst, akzeptierst du die %2$s und %3$s von Duck.ai."
+msgstr "Indem du auf „%1$s“ klickst, akzeptierst du die %2$s und %3$s von Duck.ai."
 
 # smartling.placeholder_format=C
 #. Text stating agreement to Duck.ai Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'By clicking “Agree and Continue,” you accept Duck.ai’s Privacy Policy and Terms of Service.'
@@ -3231,11 +3232,11 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"Normalerweise werden die Einstellungen in nicht personenbezogenen Browser-"
-"Cookies gespeichert (im eigenen Browser). Im anonymen Cloud Save lassen sich "
-"Einstellungen dauerhafter sichern (auf einem Remote-Server in der Cloud). Es "
-"werden dabei keine personenbezogenen Daten in der Cloud gespeichert und die "
-"Passphrase verlässt nie den eigenen Browser."
+"Normalerweise werden die Einstellungen in nicht personenbezogenen "
+"Browser-Cookies gespeichert (im eigenen Browser). Im anonymen Cloud Save "
+"lassen sich Einstellungen dauerhafter sichern (auf einem Remote-Server in "
+"der Cloud). Es werden dabei keine personenbezogenen Daten in der Cloud "
+"gespeichert und die Passphrase verlässt nie den eigenen Browser."
 
 # smartling.placeholder_format=C
 #. Description for the consent highlight in the dictation consent modal. %s is replaced with a link to the help page.
@@ -3291,8 +3292,7 @@ msgstr "Kamerun"
 #. Text for a prompt suggestion for creating a few simple recipes using chicken, broccoli, and rice.
 msgctxt "Full sentence for crafting a recipe"
 msgid "Can you create a few simple recipes using chicken, broccoli, and rice?"
-msgstr ""
-"Kannst du ein paar einfache Rezepte mit Hühnchen, Brokkoli und Reis kreieren?"
+msgstr "Kannst du ein paar einfache Rezepte mit Hühnchen, Brokkoli und Reis kreieren?"
 
 # smartling.placeholder_format=C
 msgid "Canada"
@@ -3506,7 +3506,7 @@ msgstr "Besetzung"
 #. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Cast & Crew"
-msgstr ""
+msgstr "Besetzung & Crew"
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -3620,8 +3620,7 @@ msgstr ""
 #. http://i.imgur.com/NdpkbY0.png
 msgctxt "settings"
 msgid "Changes the background color when hovering over a result"
-msgstr ""
-"Ändert die Hintergrundfarbe, wenn du den Mauszeiger über ein Ergebnis bewegst"
+msgstr "Ändert die Hintergrundfarbe, wenn du den Mauszeiger über ein Ergebnis bewegst"
 
 # smartling.placeholder_format=C
 #. Description of a setting managing the color of search result snippet text.
@@ -3752,8 +3751,8 @@ msgstr ""
 "KI-Chatmodellen von Drittanbietern zu führen, etwa OpenAI oder Anthropic. "
 "Wenn du diese Einstellung deaktivierst, werden Chat-Schaltflächen und -Links "
 "in DuckDuckGo Search ausgeblendet. Du kannst jedoch auch dann auf den Chat "
-"zugreifen, wenn diese Einstellung deaktiviert ist, indem du %1$shttps://duck."
-"ai%2$s direkt besuchst."
+"zugreifen, wenn diese Einstellung deaktiviert ist, indem du "
+"%1$shttps://duck.ai%2$s direkt besuchst."
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -3882,9 +3881,9 @@ msgid ""
 "Chats are stored locally on your device instead of on DuckDuckGo servers or "
 "remote servers. Disabling chat history will delete pinned chats."
 msgstr ""
-"Chats werden lokal auf deinem Gerät gespeichert, anstatt auf DuckDuckGo-"
-"Servern oder Remote-Servern. Wenn du den Chatverlauf deaktivierst, werden "
-"angeheftete Chats gelöscht."
+"Chats werden lokal auf deinem Gerät gespeichert, anstatt auf "
+"DuckDuckGo-Servern oder Remote-Servern. Wenn du den Chatverlauf "
+"deaktivierst, werden angeheftete Chats gelöscht."
 
 # smartling.placeholder_format=C
 #. Text explaining how the Chat History feature stores the user's chats locally to their device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection. Also explains that disabling chat history will delete pinned chats.
@@ -3897,11 +3896,11 @@ msgid ""
 "prompts and responses."
 msgstr ""
 "Chats werden lokal auf deinem Gerät gespeichert. Neue Prompts und Antworten "
-"werden verschlüsselt und nach dem Senden vorübergehend auf einem DuckDuckGo-"
-"Server gespeichert, damit du einen Chat wiederherstellen kannst, falls deine "
-"Internetverbindung unterbrochen wird. Wenn du den Chatverlauf deaktivierst, "
-"werden angeheftete Chats gelöscht und die vorübergehende Speicherung neuer "
-"Aufforderungen und Antworten deaktiviert."
+"werden verschlüsselt und nach dem Senden vorübergehend auf einem "
+"DuckDuckGo-Server gespeichert, damit du einen Chat wiederherstellen kannst, "
+"falls deine Internetverbindung unterbrochen wird. Wenn du den Chatverlauf "
+"deaktivierst, werden angeheftete Chats gelöscht und die vorübergehende "
+"Speicherung neuer Aufforderungen und Antworten deaktiviert."
 
 # smartling.placeholder_format=C
 #. Title shown above the body copy in the Duck.ai recent chats IndexedDB unavailable notice.
@@ -4042,8 +4041,7 @@ msgstr "Auswahl von KI-Modellen, darunter %1$s und %2$s"
 # smartling.placeholder_format=C
 #. As in 'Choose to keep DuckDuckGo as your default search engine'. Placeholders are for markup, you can ignore them.
 msgid "Choose %skeep it%s to continue protecting your privacy."
-msgstr ""
-"Wähle %1$sBeibehalten%2$s aus, um weiterhin deine Privatsphäre zu schützen."
+msgstr "Wähle %1$sBeibehalten%2$s aus, um weiterhin deine Privatsphäre zu schützen."
 
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
@@ -5235,7 +5233,7 @@ msgstr "Bild erstellen"
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
-msgstr ""
+msgstr "Erstelle eine Einkaufsliste mit Mengen aus diesem Rezept."
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed in the input field when starting a new image generation session.
@@ -5492,8 +5490,7 @@ msgstr "Tageslimit erreicht"
 #. Displayed when the user has reached a fixed daily Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Daily usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Tägliches Nutzungslimit erreicht. Du kannst diesen Chat nach %1$s fortsetzen."
+msgstr "Tägliches Nutzungslimit erreicht. Du kannst diesen Chat nach %1$s fortsetzen."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable daily Duck.ai usage limit and can opt in to continue using the weekly limit.
@@ -5784,8 +5781,7 @@ msgstr "Gelöschte Chats"
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
 msgctxt "settings"
 msgid "Deleting cookies will reset these settings."
-msgstr ""
-"Durch das Löschen der Cookies werden diese Einstellungen zurückgesetzt."
+msgstr "Durch das Löschen der Cookies werden diese Einstellungen zurückgesetzt."
 
 # smartling.placeholder_format=C
 msgid "Democratic People's Republic of Korea"
@@ -5807,8 +5803,7 @@ msgstr "Beschreibe die Änderungen basierend auf dem Bild"
 #. Placeholder text displayed in the input field when the user can make follow-up edits to a generated image.
 msgctxt "Placeholder text for the image generation input field for follow-ups"
 msgid "Describe changes to continue editing this image"
-msgstr ""
-"Beschreibe die Änderungen, um mit der Bearbeitung dieses Bildes fortzufahren."
+msgstr "Beschreibe die Änderungen, um mit der Bearbeitung dieses Bildes fortzufahren."
 
 # smartling.placeholder_format=C
 #. Title shown when the user first enters Image Generation mode, prompting them to describe the image they want to create.
@@ -5872,8 +5867,8 @@ msgstr "Diktierfunktion in Duck.ai"
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
 msgstr ""
-"Die Diktate werden von uns anonymisiert und niemals zum Trainieren von KI-"
-"Modellen verwendet."
+"Die Diktate werden von uns anonymisiert und niemals zum Trainieren von "
+"KI-Modellen verwendet."
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
@@ -5883,7 +5878,7 @@ msgstr "Diktatlimit erreicht"
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
 msgid "Dictation temporarily unavailable"
-msgstr ""
+msgstr "Diktierfunktion vorübergehend nicht verfügbar"
 
 # smartling.placeholder_format=C
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
@@ -6194,6 +6189,8 @@ msgid ""
 "Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
 "filtered out. %sLearn More%s"
 msgstr ""
+"Du möchtest keine KI? %1$snoai.duckduckgo.com%2$s bietet keine KI-Funktionen "
+"und KI-generierte Bilder sind herausgefiltert. %3$sMehr erfahren%4$s"
 
 # smartling.placeholder_format=C
 #. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
@@ -6202,6 +6199,9 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
+"Du möchtest keine KI? Besuche %1$snoai.duckduckgo.com%2$s um ohne "
+"KI-Funktionen und mit herausgefilterten KI-Bildern zu suchen. %3$sMehr "
+"erfahren%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6321,13 +6321,13 @@ msgstr ""
 #. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Draft a cover letter"
-msgstr ""
+msgstr "Schreibe ein Anschreiben"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Draft a cover letter for this job."
-msgstr ""
+msgstr "Schreibe ein Anschreiben für diesen Job."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -6515,6 +6515,9 @@ msgid ""
 "company for anyone who wants to take back control of their personal "
 "information."
 msgstr ""
+"Duck.ai wurde von DuckDuckGo entwickelt. Wir sind ein unabhängiges "
+"Unternehmen im Bereich Online-Schutz für alle, die die Kontrolle über ihre "
+"persönlichen Informationen zurückerlangen möchten."
 
 # smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
@@ -6571,6 +6574,9 @@ msgid ""
 "Duck.ai lets you chat privately with popular AI models. Disabling it hides "
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
+"Duck.ai ermöglicht es dir, privat mit beliebten KI-Modellen zu chatten. Wenn "
+"du es deaktivierst, werden Duck.ai-Schaltflächen und -Links ausgeblendet, "
+"aber du kannst weiterhin %1$sduck.ai%2$s direkt besuchen."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6583,10 +6589,10 @@ msgid ""
 msgstr ""
 "Mit Duck.ai kannst du anonyme Unterhaltungen mit KI-Chatmodellen von "
 "Drittanbietern führen, darunter Modelle von OpenAI, Anthropic und anderen. "
-"Wenn du diese Einstellung deaktivierst, werden Duck.ai-Schaltflächen und -"
-"Links in DuckDuckGo Search ausgeblendet. Du kannst jedoch weiterhin auf Duck."
-"ai zugreifen, wenn diese Einstellung deaktiviert ist, indem du %1$shttps://"
-"duck.ai%2$s direkt besuchst."
+"Wenn du diese Einstellung deaktivierst, werden Duck.ai-Schaltflächen und "
+"-Links in DuckDuckGo Search ausgeblendet. Du kannst jedoch weiterhin auf "
+"Duck.ai zugreifen, wenn diese Einstellung deaktiviert ist, indem du "
+"%1$shttps://duck.ai%2$s direkt besuchst."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
@@ -6774,8 +6780,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"DuckDuckGo AI Chat ist ein privater KI-gestützter Chat-Dienst, der die Chat-"
-"Modelle %2$s von %1$s und %4$s von %3$s nutzt."
+"DuckDuckGo AI Chat ist ein privater KI-gestützter Chat-Dienst, der die "
+"Chat-Modelle %2$s von %1$s und %4$s von %3$s nutzt."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the welcome screen of the onboarding. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -6784,8 +6790,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"DuckDuckGo AI Chat ist ein privater, KI-gestützter Chat-Dienst, der die Chat-"
-"Modelle %2$s von %1$s und %4$s von %3$s nutzt."
+"DuckDuckGo AI Chat ist ein privater, KI-gestützter Chat-Dienst, der die "
+"Chat-Modelle %2$s von %1$s und %4$s von %3$s nutzt."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding DuckDuckGo AI Chat.
@@ -7462,8 +7468,7 @@ msgstr "Stelle sicher, dass der Zugriff auf den Standort %1$saktiviert%2$s ist"
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure location access is %sallowed%s."
-msgstr ""
-"Stelle sicher, dass der Zugriff auf den Standort %1$saktiviert%2$s ist."
+msgstr "Stelle sicher, dass der Zugriff auf den Standort %1$saktiviert%2$s ist."
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
@@ -7583,8 +7588,7 @@ msgstr "Äquatorialguinea"
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Erase your browsing data in a flash with our %sFire Button%s"
-msgstr ""
-"Lösche deine Browserdaten im Handumdrehen mit unserem %1$sFire Button%2$s"
+msgstr "Lösche deine Browserdaten im Handumdrehen mit unserem %1$sFire Button%2$s"
 
 # smartling.placeholder_format=C
 msgid "Eritrea"
@@ -7594,13 +7598,13 @@ msgstr "Eritrea"
 #. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Estimate the nutrition"
-msgstr ""
+msgstr "Ernährung schätzen"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Estimate the nutritional information for this recipe."
-msgstr ""
+msgstr "Schätze die Nährwertinformationen für dieses Rezept."
 
 # smartling.placeholder_format=C
 msgid "Estonia"
@@ -7662,57 +7666,56 @@ msgstr "Läuft in 1 Tag ab"
 #. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain the accepted answer in simple terms."
-msgstr ""
+msgstr "Erkläre die akzeptierte Antwort in einfachen Worten."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
-msgstr ""
-"Erkläre mir die grundlegenden Konzepte von Schwarzen Löchern auf Schulniveau."
+msgstr "Erkläre mir die grundlegenden Konzepte von Schwarzen Löchern auf Schulniveau."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain the top answer"
-msgstr ""
+msgstr "Erkläre die oberste Antwort"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain this in simple, plain language."
-msgstr ""
+msgstr "Erkläre das in einfachen, klaren Worten."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain this paper"
-msgstr ""
+msgstr "Erkläre diese Arbeit"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain this repo"
-msgstr ""
+msgstr "Erkläre dieses Repo"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain this research paper in plain language."
-msgstr ""
+msgstr "Erkläre dieses Forschungspapier in einfachen Worten."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain this simply"
-msgstr ""
+msgstr "Erkläre das einfach"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain what this repository does and how to use it."
-msgstr ""
+msgstr "Erkläre, was dieses Repository tut und wie man es verwendet."
 
 # smartling.placeholder_format=C
 #. Label to show if song lyrics contain explicit content
@@ -8003,6 +8006,8 @@ msgctxt "settings"
 msgid ""
 "Filters out known AI spam sites from image search results. %sLearn More%s"
 msgstr ""
+"Filtert bekannte KI-Spam-Websites aus den Bildersuchergebnissen heraus. "
+"%1$sMehr erfahren%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the final score of a sporting event.
@@ -8065,7 +8070,7 @@ msgstr "Aktuelle Informationen finden"
 #. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Find me alternatives"
-msgstr ""
+msgstr "Finde mir Alternativen"
 
 # smartling.placeholder_format=C
 #. Button that searches for results closer to the user's current location.
@@ -8158,8 +8163,7 @@ msgstr ""
 #. Privacy reassurance and instructions intro.
 msgctxt "duckai_migration"
 msgid "Follow these steps to move your chats to the new Duck.ai"
-msgstr ""
-"Folge diesen Schritten, um deine Chats auf das neue Duck.ai zu übertragen."
+msgstr "Folge diesen Schritten, um deine Chats auf das neue Duck.ai zu übertragen."
 
 # smartling.placeholder_format=C
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse on mobile
@@ -8264,8 +8268,7 @@ msgstr "Kostenlose und private Chats, von uns anonymisiert"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr ""
-"Kostenlose und private Chats, von uns anonymisiert. Kein Konto erforderlich."
+msgstr "Kostenlose und private Chats, von uns anonymisiert. Kein Konto erforderlich."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -8378,9 +8381,9 @@ msgid ""
 "<strong>Check for Updates...</strong>, then select <strong>Install Update</"
 "strong>."
 msgstr ""
-"Wähle in der Menüleiste der Anwendung auf dem Mac <strong>DuckDuckGo</"
-"strong> &gt; <strong>Nach Updates suchen ...</strong> und dann "
-"<strong>Update installieren</strong>."
+"Wähle in der Menüleiste der Anwendung auf dem Mac "
+"<strong>DuckDuckGo</strong> &gt; <strong>Nach Updates suchen ...</strong> "
+"und dann <strong>Update installieren</strong>."
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -8551,7 +8554,7 @@ msgstr "Mehr erzeugen"
 #. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Generate a shopping list"
-msgstr ""
+msgstr "Erstelle eine Einkaufsliste"
 
 # smartling.placeholder_format=C
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
@@ -8724,8 +8727,7 @@ msgstr ""
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Get a VPN + two more protections. Try it for free!"
-msgstr ""
-"Hol dir ein VPN + zwei weitere Schutzmaßnahmen. Probiere es kostenlos aus!"
+msgstr "Hol dir ein VPN + zwei weitere Schutzmaßnahmen. Probiere es kostenlos aus!"
 
 # smartling.placeholder_format=C
 #. Description for the subscription modal where users can update their subscription to DuckDuckGo.
@@ -8735,8 +8737,8 @@ msgid ""
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
 "Erhalte Zugang zu den fortschrittlichen KI-Modellen in Duck.ai, indem du "
-"DuckDuckGo abonnierst, was auch unser VPN und andere Premium-"
-"Datenschutzmaßnahmen beinhaltet."
+"DuckDuckGo abonnierst, was auch unser VPN und andere "
+"Premium-Datenschutzmaßnahmen beinhaltet."
 
 # smartling.placeholder_format=C
 #. Description for the subscription setting where users can subscribe to DuckDuckGo.
@@ -8747,9 +8749,9 @@ msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"Mit einem DuckDuckGo-Abo erhältst du Zugang zu den fortschrittlichen KI-"
-"Modellen in Duck.ai, das auch unser VPN und andere Premium-"
-"Datenschutzmaßnahmen beinhaltet."
+"Mit einem DuckDuckGo-Abo erhältst du Zugang zu den fortschrittlichen "
+"KI-Modellen in Duck.ai, das auch unser VPN und andere "
+"Premium-Datenschutzmaßnahmen beinhaltet."
 
 # smartling.placeholder_format=C
 #. A button for users to generate an AI generated answer from their query on the duckassist module
@@ -8853,7 +8855,7 @@ msgstr "Ausprobieren"
 #. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Give me a quick background on this person."
-msgstr ""
+msgstr "Gib mir einen kurzen Hintergrund zu dieser Person."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9307,13 +9309,13 @@ msgstr "Hilf mit, unser aller Privatsphäre zu stärken"
 #. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Help me prep for the interview"
-msgstr ""
+msgstr "Hilf mir, mich auf das Vorstellungsgespräch vorzubereiten"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Help me tailor my resume for this job."
-msgstr ""
+msgstr "Hilf mir, meinen Lebenslauf für diesen Job anzupassen."
 
 # smartling.placeholder_format=C
 #. Title of a SERP popup that invites users to take a survey (desktop only)
@@ -9377,15 +9379,13 @@ msgstr "Hilf uns zu verstehen, was wir falsch gemacht haben"
 #. A subtitle of a page that encourages users to share DuckDuckGo with their friends.
 msgctxt "showcase_spread"
 msgid "Help your friends and family join the Duck Side!"
-msgstr ""
-"Hilf deinen Freunden und Verwandten, sich unserer Entenfamilie anzuschließen!"
+msgstr "Hilf deinen Freunden und Verwandten, sich unserer Entenfamilie anzuschließen!"
 
 # smartling.placeholder_format=C
 #. Text description for the Spread card in the SERP footer
 msgctxt "footer_card"
 msgid "Help your friends and family take back their privacy!"
-msgstr ""
-"Hilf deinen Freunden und Verwandten, ihre Privatsphäre zurückzugewinnen!"
+msgstr "Hilf deinen Freunden und Verwandten, ihre Privatsphäre zurückzugewinnen!"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -9397,8 +9397,7 @@ msgstr "Hilfreich"
 #. The title of a menu that shows other applications DuckDuckGo has made.
 msgctxt "showcase_aria_dropdown"
 msgid "Here are some things that we made that you might like."
-msgstr ""
-"Hier sind einige Dinge, die wir gemacht haben, die dir gefallen könnten."
+msgstr "Hier sind einige Dinge, die wir gemacht haben, die dir gefallen könnten."
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -9598,8 +9597,8 @@ msgid ""
 "Hold on! Changing it back will disable the DuckDuckGo extension and you'll "
 "lose our privacy protection."
 msgstr ""
-"Achtung! Wenn du die Einstellung zurücksetzt, wird die DuckDuckGo-"
-"Erweiterung deaktiviert und du verlierst unseren Datenschutz."
+"Achtung! Wenn du die Einstellung zurücksetzt, wird die "
+"DuckDuckGo-Erweiterung deaktiviert und du verlierst unseren Datenschutz."
 
 # smartling.placeholder_format=C
 #. Heading shown above warning messages in the AI chat, for non-critical issues like unsupported file formats or file size limits. Analogous to 'Oops...' for error messages.
@@ -9841,7 +9840,7 @@ msgctxt ""
 "Text for the I already have a subscription button in the Duck.ai settings "
 "page"
 msgid "I Already Have a Subscription"
-msgstr ""
+msgstr "Ich habe bereits ein Abonnement"
 
 # smartling.placeholder_format=C
 #. Text for the button that takes the user to the login subscription page.
@@ -9919,8 +9918,8 @@ msgid ""
 "I like the book Name of the Wind. What are some other good books/series most "
 "like it and why?"
 msgstr ""
-"Ich mag das Buch „Der Name des Windes“. Welche anderen guten Bücher/"
-"Buchreihen ähneln diesem am meisten und warum?"
+"Ich mag das Buch „Der Name des Windes“. Welche anderen guten "
+"Bücher/Buchreihen ähneln diesem am meisten und warum?"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the user needs more help or information on how to use the chat.
@@ -9995,9 +9994,9 @@ msgid ""
 "If you have concerns about our chat providers or any particular chat "
 "response, you can also reach out directly to %s and %s support pages."
 msgstr ""
-"Wenn du Bedenken bezüglich unserer Chat-Anbieter oder einer bestimmten Chat-"
-"Antwort hast, kannst du dich auch direkt über ihre Support-Seiten an %1$s "
-"und %2$s wenden."
+"Wenn du Bedenken bezüglich unserer Chat-Anbieter oder einer bestimmten "
+"Chat-Antwort hast, kannst du dich auch direkt über ihre Support-Seiten an "
+"%1$s und %2$s wenden."
 
 # smartling.placeholder_format=C
 #. Body copy explaining what the recovery code is for and how it can be saved.
@@ -10035,8 +10034,8 @@ msgstr ""
 msgid ""
 "If you want, select Home Page next to New windows and New tabs (open with)."
 msgstr ""
-"Wenn du willst, wähle »Startseite« neben »Neues Fenster« und »Neue "
-"Tabs« (öffnen mit) aus."
+"Wenn du willst, wähle »Startseite« neben »Neues Fenster« und »Neue Tabs« "
+"(öffnen mit) aus."
 
 # smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that adds an image to the AI chat message being composed.
@@ -10428,7 +10427,7 @@ msgstr "Mac-Browser installieren"
 #. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
 msgctxt "settings"
 msgid "Install Now"
-msgstr ""
+msgstr "Jetzt installieren"
 
 # smartling.placeholder_format=C
 #. Text of a button to install the DuckDuckGo app
@@ -10531,13 +10530,13 @@ msgstr "Sind gelöschte Daten wirklich gelöscht?"
 #. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Is it worth taking?"
-msgstr ""
+msgstr "Lohnt es sich, daran teilzunehmen?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Is this place any good?"
-msgstr ""
+msgstr "Ist dieser Ort gut?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
@@ -10546,6 +10545,8 @@ msgid ""
 "Is this place any good? Summarize its reputation based on reviews and "
 "ratings."
 msgstr ""
+"Ist dieser Ort gut? Fasse den Ruf basierend auf Bewertungen und Rezensionen "
+"zusammen."
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -10557,13 +10558,13 @@ msgstr "Ist dieses Video hilfreich?"
 #. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Is this worth watching?"
-msgstr ""
+msgstr "Lohnt es sich, das anzuschauen?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Is this worth watching? Give me a spoiler-free take."
-msgstr ""
+msgstr "Lohnt es sich, das anzuschauen? Gib mir eine spoilerfreie Einschätzung."
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -11182,6 +11183,8 @@ msgstr "Links:"
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
 msgstr ""
+"Ich benötige eine Liste der Werkzeuge, Materialien oder Voraussetzungen, die "
+"ich dafür brauche."
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -11595,7 +11598,7 @@ msgstr "Blockierte Websites verwalten"
 #. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
 msgctxt "setting"
 msgid "Manage in Browser Settings"
-msgstr ""
+msgstr "In den Browser-Einstellungen verwalten"
 
 # smartling.placeholder_format=C
 #. Link to the site exclusion settings page
@@ -12492,8 +12495,7 @@ msgstr "Niederlande"
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when a network error occurs during dictation upload.
 msgid "Network error. Please check your connection and try again."
-msgstr ""
-"Netzwerkfehler. Bitte überprüfe deine Verbindung und versuche es erneut."
+msgstr "Netzwerkfehler. Bitte überprüfe deine Verbindung und versuche es erneut."
 
 # smartling.placeholder_format=C
 #. The title of the 'Never' option in the assist settings modal.
@@ -12887,8 +12889,7 @@ msgstr "Keine Ergebnisse gefunden."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the recording contains no audible speech.
 msgid "No speech detected. Please try again and speak into your microphone."
-msgstr ""
-"Keine Sprache erkannt. Bitte versuche es erneut und sprich in dein Mikrofon."
+msgstr "Keine Sprache erkannt. Bitte versuche es erneut und sprich in dein Mikrofon."
 
 # smartling.placeholder_format=C
 #. Button that dismisses a feedback form.
@@ -13538,8 +13539,7 @@ msgstr "%1$sEinstellungen%2$s öffnen"
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open 'Location', and ensure location is %senabled%s."
-msgstr ""
-"Öffne „Standort“ und stelle sicher, dass der Standort %1$saktiviert%2$s ist."
+msgstr "Öffne „Standort“ und stelle sicher, dass der Standort %1$saktiviert%2$s ist."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -13682,8 +13682,7 @@ msgstr "Öffne das Bedienfeld „So funktioniert Duck.ai“"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open the Safari menu and select %sSettings for DuckDuckGo...%s"
-msgstr ""
-"Öffne das Safari-Menü und wähle %1$sEinstellungen für DuckDuckGo ...%2$s"
+msgstr "Öffne das Safari-Menü und wähle %1$sEinstellungen für DuckDuckGo ...%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the time a business opens. For example: 'Opens at 10am'
@@ -14259,8 +14258,8 @@ msgid ""
 msgstr ""
 "Wenn du deine Suche als vollständigen Fragesatz formulierst, ist es "
 "wahrscheinlicher, dass KI-gestützte Antworten automatisch erscheinen, und du "
-"erhältst oft bessere Antworten. Um sie auszuschalten und die Assist-"
-"Schaltfläche auszublenden, besuche die %1$s-Sucheinstellungen%2$s."
+"erhältst oft bessere Antworten. Um sie auszuschalten und die "
+"Assist-Schaltfläche auszublenden, besuche die %1$s-Sucheinstellungen%2$s."
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -14284,8 +14283,8 @@ msgid ""
 msgstr ""
 "Wenn du deine Suche als Frage und in einem vollständigen Satz formulierst, "
 "ist es wahrscheinlicher, dass DuckAssist automatisch erscheint, und du "
-"erhältst oft bessere Antworten. Um die Funktion auszuschalten und die Assist-"
-"Taste auszublenden, besuche die %1$sDuckAssist-Einstellungen%2$s."
+"erhältst oft bessere Antworten. Um die Funktion auszuschalten und die "
+"Assist-Taste auszublenden, besuche die %1$sDuckAssist-Einstellungen%2$s."
 
 # smartling.placeholder_format=C
 #. Button that allows users to manually select a location on a map.
@@ -14442,6 +14441,8 @@ msgstr ""
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is harmful or illegal. (optional)"
 msgstr ""
+"Beschreibe bitte, warum die Antwort im Chat schädlich oder rechtswidrig ist. "
+"(optional)"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
@@ -14482,6 +14483,9 @@ msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is harmful or illegal."
 msgstr ""
+"Bitte füge deinen Prompt und die problematische Ausgabe ein (ohne "
+"persönliche Informationen) und beschreibe, warum der Inhalt schädlich oder "
+"illegal ist."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -14955,7 +14959,7 @@ msgstr "Datenschutz"
 #. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
 msgctxt "Section heading on the Duck.ai settings page"
 msgid "Privacy & Terms"
-msgstr ""
+msgstr "Privatsphäre & Bedingungen"
 
 # smartling.placeholder_format=C
 msgid "Privacy Blog"
@@ -15031,7 +15035,7 @@ msgstr "Datenschutzerklärung und Nutzungsbedingungen"
 #. Text for a button that links to the terms of use and privacy policy page.
 msgctxt "Secondary button text in active privacy modal"
 msgid "Privacy Policy and Terms of Service"
-msgstr ""
+msgstr "Datenschutzerklärung und Nutzungsbedingungen"
 
 # smartling.placeholder_format=C
 #. Title displayed on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
@@ -15539,25 +15543,25 @@ msgstr "Empfehle ein Buch"
 #. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Recommend similar books"
-msgstr ""
+msgstr "Ähnliche Bücher empfehlen"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Recommend similar books."
-msgstr ""
+msgstr "Empfiehl ähnliche Bücher."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Recommend similar movies or shows."
-msgstr ""
+msgstr "Ähnliche Filme oder Serien empfehlen."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Recommend similar titles"
-msgstr ""
+msgstr "Ähnliche Titel empfehlen"
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
@@ -15783,8 +15787,7 @@ msgstr "Meine Auswahl merken"
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings
 msgid "Remember my choice (this can be changed in %s%s%sSettings%s)"
-msgstr ""
-"Auswahl merken (kann in den %1$s%2$s%3$sEinstellungen%4$s geändert werden)"
+msgstr "Auswahl merken (kann in den %1$s%2$s%3$sEinstellungen%4$s geändert werden)"
 
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
@@ -15969,7 +15972,7 @@ msgctxt ""
 "feedback form when the user has selected Harmful or Illegal as the feedback "
 "reason"
 msgid "Required for harmful or illegal reports"
-msgstr ""
+msgstr "Erforderlich bei Meldungen über schädliche oder illegale Inhalte"
 
 # smartling.placeholder_format=C
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
@@ -16214,7 +16217,7 @@ msgstr "Rezensionen"
 #. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Rewrite this recipe scaled for a different number of servings."
-msgstr ""
+msgstr "Schreibe dieses Rezept für eine andere Anzahl an Portionen um."
 
 # smartling.placeholder_format=C
 msgid "Romania"
@@ -16503,8 +16506,8 @@ msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
 msgstr ""
-"Speichere deine Duck.ai-Chats zwischen deinen Geräten mit Ende-zu-Ende-"
-"Verschlüsselung."
+"Speichere deine Duck.ai-Chats zwischen deinen Geräten mit "
+"Ende-zu-Ende-Verschlüsselung."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -16626,8 +16629,7 @@ msgstr "Scrolle herunter und wähle %1$sErweiterte Einstellungen%2$s aus"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down and click %sView advanced settings%s."
-msgstr ""
-"Scrolle herunter und klicke auf %1$sErweiterte Einstellungen anzeigen%2$s."
+msgstr "Scrolle herunter und klicke auf %1$sErweiterte Einstellungen anzeigen%2$s."
 
 #  Edge Legacy default search engine instruction, obsolete?
 # smartling.placeholder_format=C
@@ -16898,8 +16900,8 @@ msgctxt "settings"
 msgid ""
 "Search queries are included in URL (if off, searches will use POST requests)"
 msgstr ""
-"Suchanfragen sind Teil der Adresse (wenn ausgeschaltet, wird die POST-"
-"Methode verwendet)"
+"Suchanfragen sind Teil der Adresse (wenn ausgeschaltet, wird die "
+"POST-Methode verwendet)"
 
 # smartling.placeholder_format=C
 #. Describes how cookies are used to store user settings privately and securely.
@@ -17003,8 +17005,7 @@ msgstr "Saisonwochen"
 #. Description shown in the Sync & Backup settings section when sync is not yet enabled, explaining the feature.
 msgctxt "Description for sync and backup feature"
 msgid "Securely save and sync your chats across all your devices."
-msgstr ""
-"Speichere und synchronisiere deine Chats sicher auf all deinen Geräten."
+msgstr "Speichere und synchronisiere deine Chats sicher auf all deinen Geräten."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17013,8 +17014,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
 msgstr ""
-"Speichere nahezu unbegrenzt viele Chats sicher auf unserem Server mit Ende-"
-"zu-Ende-Verschlüsselung und greife von all deinen Geräten darauf zu."
+"Speichere nahezu unbegrenzt viele Chats sicher auf unserem Server mit "
+"Ende-zu-Ende-Verschlüsselung und greife von all deinen Geräten darauf zu."
 
 # smartling.placeholder_format=C
 #. Text explaining that the Encrypted Storage feature stores the user's chats encrypted on their device.
@@ -17023,8 +17024,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
 msgstr ""
-"Speichere nahezu unbegrenzt viele Chats sicher auf unserem Server mit Ende-"
-"zu-Ende-Verschlüsselung und greife von all deinen Geräten darauf zu."
+"Speichere nahezu unbegrenzt viele Chats sicher auf unserem Server mit "
+"Ende-zu-Ende-Verschlüsselung und greife von all deinen Geräten darauf zu."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17033,9 +17034,9 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your synced devices."
 msgstr ""
-"Speichere nahezu unbegrenzt viele Chats sicher auf unserem Server mit Ende-"
-"zu-Ende-Verschlüsselung und greife von all deinen synchronisierten Geräten "
-"darauf zu."
+"Speichere nahezu unbegrenzt viele Chats sicher auf unserem Server mit "
+"Ende-zu-Ende-Verschlüsselung und greife von all deinen synchronisierten "
+"Geräten darauf zu."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17044,16 +17045,16 @@ msgid ""
 "Securely store your chats on our server using end-to-end encryption, and "
 "access them from all your devices."
 msgstr ""
-"Speichere deine Chats sicher auf unserem Server mit Ende-zu-Ende-"
-"Verschlüsselung und greife von all deinen Geräten darauf zu."
+"Speichere deine Chats sicher auf unserem Server mit "
+"Ende-zu-Ende-Verschlüsselung und greife von all deinen Geräten darauf zu."
 
 # smartling.placeholder_format=C
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
 msgctxt "Sync feature benefit description"
 msgid "Securely stored on DuckDuckGo's server with end-to-end encryption."
 msgstr ""
-"Sicher gespeichert auf dem Server von DuckDuckGo mit End-to-End-"
-"Verschlüsselung."
+"Sicher gespeichert auf dem Server von DuckDuckGo mit "
+"End-to-End-Verschlüsselung."
 
 # smartling.placeholder_format=C
 #. List item explaining that synced chats are stored with end-to-end encryption on DuckDuckGo's server and only the user can access them.
@@ -17062,8 +17063,9 @@ msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
 msgstr ""
-"Sicher gespeichert auf dem Server von DuckDuckGo mit End-to-End-"
-"Verschlüsselung. Niemand außer dir kann deine Daten sehen, nicht einmal wir."
+"Sicher gespeichert auf dem Server von DuckDuckGo mit "
+"End-to-End-Verschlüsselung. Niemand außer dir kann deine Daten sehen, nicht "
+"einmal wir."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -17174,8 +17176,7 @@ msgstr "Entdecke einige unserer neuesten Updates"
 #. Link to a page with more information about how user settings are stored in a URL.
 msgctxt "settings"
 msgid "See the %sURL Parameter Reference page%s for more details."
-msgstr ""
-"Mehr Informationen findest du in der %1$sÜbersicht über URL-Parameter%2$s."
+msgstr "Mehr Informationen findest du in der %1$sÜbersicht über URL-Parameter%2$s."
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the context menu of a chat in chat history, that allows the user to select the chat and begin batch selection mode.
@@ -17202,8 +17203,7 @@ msgstr "%1$s%2$s%3$s auswählen, dann %4$sSuchmaschine%5$s"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %s'Setting for this Website...'%s from the Safari menu."
-msgstr ""
-"Wähle %1$s„Einstellung für diese Website …“%2$s aus dem Safari-Menü aus."
+msgstr "Wähle %1$s„Einstellung für diese Website …“%2$s aus dem Safari-Menü aus."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -17229,15 +17229,13 @@ msgstr "Wähle %1$sDuckDuckGo%2$s und klicke auf %3$sAls Standard festlegen%4$s"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s."
-msgstr ""
-"Wähle %1$sDuckDuckGo%2$s und klicke auf %3$sAls Standard festlegen%4$s."
+msgstr "Wähle %1$sDuckDuckGo%2$s und klicke auf %3$sAls Standard festlegen%4$s."
 
 #  Firefox 33
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Select %sDuckDuckGo%s in the Default Search Engine drop down"
-msgstr ""
-"Im Dropdown-Menü für die Standardsuchmaschine %1$sDuckDuckGo%2$s auswählen"
+msgstr "Im Dropdown-Menü für die Standardsuchmaschine %1$sDuckDuckGo%2$s auswählen"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
@@ -17565,7 +17563,7 @@ msgstr "Jetzt einrichten"
 #. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
 msgctxt "Encrypted storage setup button shown in native browsers"
 msgid "Set Up Sync & Backup"
-msgstr ""
+msgstr "Sync & Backup einrichten"
 
 # smartling.placeholder_format=C
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
@@ -17659,8 +17657,7 @@ msgstr "Teilen"
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "Share DuckDuckGo and help friends take their privacy back!"
-msgstr ""
-"Teile DuckDuckGo und hilf deinen Freunden, ihre Privatsphäre zurück zu holen!"
+msgstr "Teile DuckDuckGo und hilf deinen Freunden, ihre Privatsphäre zurück zu holen!"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button that opens a feedback modal when clicked.
@@ -17688,8 +17685,8 @@ msgid ""
 "never reveals your precise location to us or AI models."
 msgstr ""
 "Teile den Standort in Form der Stadt mit KI-Modellen, um die Relevanz zu "
-"verbessern. Duck.ai gibt niemals deinen genauen Standort an uns oder KI-"
-"Modelle weiter."
+"verbessern. Duck.ai gibt niemals deinen genauen Standort an uns oder "
+"KI-Modelle weiter."
 
 # smartling.placeholder_format=C
 #. Menu option to share feedback about a result
@@ -17754,7 +17751,7 @@ msgstr "Positives Feedback teilen"
 msgctxt ""
 "Label beside the share-content switch on the Duck.ai response feedback form"
 msgid "Share this conversation with DuckDuckGo"
-msgstr ""
+msgstr "Teile diese Unterhaltung mit DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -17893,8 +17890,7 @@ msgstr "DuckAssist <sup>BETA</sup>"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show DuckAssist more often. (You can also completely %sturn it off%s.)"
-msgstr ""
-"DuckAssist öfter anzeigen. (Du kannst es auch %1$skomplett ausschalten%2$s.)"
+msgstr "DuckAssist öfter anzeigen. (Du kannst es auch %1$skomplett ausschalten%2$s.)"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
@@ -18215,8 +18211,7 @@ msgstr "Begrüßung oben auf der Suchergebnisseite anzeigen"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message to EU Android preference menu users"
-msgstr ""
-"Begrüßung für Benutzer des Android-Einstellungsmenüs in der EU wird angezeigt"
+msgstr "Begrüßung für Benutzer des Android-Einstellungsmenüs in der EU wird angezeigt"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers sometimes.
@@ -18295,8 +18290,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Sites you block will be hidden from all your search results"
-msgstr ""
-"Von dir blockierte Websites werden in all deinen Suchergebnissen ausgeblendet"
+msgstr "Von dir blockierte Websites werden in all deinen Suchergebnissen ausgeblendet"
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes full name (tooltip)
@@ -18496,8 +18490,7 @@ msgstr "Entschuldigung, ein unerwarteter Fehler ist aufgetreten."
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
 msgid "Sorry, no relevant information was found in our search."
-msgstr ""
-"Leider wurden bei unserer Suche keine relevanten Informationen gefunden."
+msgstr "Leider wurden bei unserer Suche keine relevanten Informationen gefunden."
 
 # smartling.placeholder_format=C
 #. Indicates that there were no search results for a user's search.
@@ -18767,8 +18760,7 @@ msgstr "Beginne mit einem Bild"
 #. Warning that starting fresh deletes conversations.
 msgctxt "duckai_migration"
 msgid "Starting fresh will delete all your past conversations."
-msgstr ""
-"Wenn du neu anfängst, werden alle deine bisherigen Unterhaltungen gelöscht."
+msgstr "Wenn du neu anfängst, werden alle deine bisherigen Unterhaltungen gelöscht."
 
 # smartling.placeholder_format=C
 #. Footnote warning that starting fresh deletes conversations.
@@ -18805,8 +18797,8 @@ msgstr "Bleib auf DuckDuckGo"
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletter."
 msgstr ""
-"Bleibe gut geschützt und gut informiert – mit unseren Privatsphäre-"
-"Newslettern."
+"Bleibe gut geschützt und gut informiert – mit unseren "
+"Privatsphäre-Newslettern."
 
 # smartling.placeholder_format=C
 #. Prompt to subscribe to a newsletter.
@@ -18861,8 +18853,7 @@ msgstr "Versteckte Tracker stoppen, die auf anderen Websites lauern."
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop most hidden trackers lurking on other websites."
-msgstr ""
-"Stoppe die meisten versteckten Tracker, die auf anderen Websites lauern."
+msgstr "Stoppe die meisten versteckten Tracker, die auf anderen Websites lauern."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19036,18 +19027,20 @@ msgstr "Schlage Titel für einen Blog-Artikel vor"
 msgctxt "Page suggestion prompt"
 msgid "Suggest related articles or topics worth exploring next."
 msgstr ""
+"Schlage verwandte Artikel oder Themen vor, die als Nächstes interessant sein "
+"könnten."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Suggest related articles to explore"
-msgstr ""
+msgstr "Schlage verwandte Artikel zum Erkunden vor"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Suggest some alternatives to this product."
-msgstr ""
+msgstr "Schlage einige Alternativen zu diesem Produkt vor."
 
 # smartling.placeholder_format=C
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
@@ -19064,7 +19057,7 @@ msgstr "Vorschläge:"
 #. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Sum up the reviews"
-msgstr ""
+msgstr "Fasse die Rezensionen zusammen"
 
 # smartling.placeholder_format=C
 #. A short title for the a message asking the AI to summarize a text.
@@ -19076,85 +19069,85 @@ msgstr "Zusammenfassen"
 #. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize the Q&As"
-msgstr ""
+msgstr "Q&As zusammenfassen"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the background and notable work of this person."
-msgstr ""
+msgstr "Fasse den Hintergrund und die bemerkenswerte Arbeit dieser Person zusammen."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the key details of this event."
-msgstr ""
+msgstr "Fasse die wichtigsten Details dieses Ereignisses zusammen."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the questions and answers on this page."
-msgstr ""
+msgstr "Die Fragen und Antworten auf dieser Seite zusammenfassen."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize their background"
-msgstr ""
+msgstr "Hintergrund zusammenfassen"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this book"
-msgstr ""
+msgstr "Dieses Buch zusammenfassen"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this book."
-msgstr ""
+msgstr "Fasse dieses Buch zusammen."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this discussion"
-msgstr ""
+msgstr "Diese Diskussion zusammenfassen"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this discussion thread."
-msgstr ""
+msgstr "Fasse diesen Diskussionsfaden zusammen."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this page"
-msgstr ""
+msgstr "Diese Seite zusammenfassen"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this page."
-msgstr ""
+msgstr "Diese Seite zusammenfassen."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this video"
-msgstr ""
+msgstr "Dieses Video zusammenfassen"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this video."
-msgstr ""
+msgstr "Dieses Video zusammenfassen."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize what the reviews say."
-msgstr ""
+msgstr "Fasse zusammen, was in den Bewertungen steht."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -19488,7 +19481,7 @@ msgstr "Syrien"
 #. Text for a button that enables the theme to follow the operating system's color scheme preference.
 msgctxt "System theme button for theme selector"
 msgid "System"
-msgstr ""
+msgstr "Standard"
 
 # smartling.placeholder_format=C
 #. Abbreviation indicating this is the total score for a game
@@ -19522,7 +19515,7 @@ msgstr "Tahitianisch"
 #. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Tailor my resume"
-msgstr ""
+msgstr "Passe meinen Lebenslauf an"
 
 # smartling.placeholder_format=C
 msgid "Taiwan"
@@ -19559,6 +19552,8 @@ msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
+"Nimm an dieser anonymen Umfrage teil und lass uns wissen, wie wir Duck.ai "
+"verbessern können."
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -19802,8 +19797,7 @@ msgstr "Die angehängten Dateien überschreiten die Größenbegrenzung von %1$s 
 #. Error message displayed when the total size of all attached files in a conversation exceeds the allowed limit. Placeholder is the combined size limit in megabytes. E.g. The attached files exceed the total size limit of 5 MB
 msgctxt "Error message when combined file size exceeds the limit"
 msgid "The attached files exceed the total size limit of %s MB."
-msgstr ""
-"Die angehängten Dateien überschreiten die Größenbegrenzung von %1$s MB."
+msgstr "Die angehängten Dateien überschreiten die Größenbegrenzung von %1$s MB."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the server rejects corrupt or unrecognized audio.
@@ -19835,8 +19829,7 @@ msgstr ""
 #. Description explaining that the AI model provider does not store any chat data on their servers.
 msgctxt "Privacy claim description in Duck.ai chat"
 msgid "The model provider does not save this chat on their servers."
-msgstr ""
-"Der Anbieter des Modells speichert diesen Chat nicht auf seinen Servern."
+msgstr "Der Anbieter des Modells speichert diesen Chat nicht auf seinen Servern."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers.
@@ -19876,7 +19869,7 @@ msgstr "Theme"
 #. Text for the theme selector label that allows users to switch between Light and dark theme.
 msgctxt "Label for the theme selector feature"
 msgid "Theme"
-msgstr ""
+msgstr "Theme"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/LpFhb1e.png
@@ -20003,8 +19996,7 @@ msgstr ""
 #. Appears below a type of search results called 'Instant Answers'
 msgctxt "attribution"
 msgid "This Instant Answer was made by the %sDuckDuckHack%s Community."
-msgstr ""
-"Diese Sofort-Antwort wurde von der %1$sDuckDuckHack%2$s-Community erstellt."
+msgstr "Diese Sofort-Antwort wurde von der %1$sDuckDuckHack%2$s-Community erstellt."
 
 # smartling.placeholder_format=C
 #. Label for the monthly usage row in the Usage section of Duck.ai settings.
@@ -20025,8 +20017,8 @@ msgid ""
 "This conversation was generated with Duck.ai (%s) using %s's %s Model. AI "
 "chats may display inaccurate or offensive information (see %s for more info)."
 msgstr ""
-"Diese Konversation wurde mit Duck.ai (%1$s) unter Verwendung des %3$s-"
-"Modells von %2$s generiert. KI-Chats zeigen möglicherweise falsche oder "
+"Diese Konversation wurde mit Duck.ai (%1$s) unter Verwendung des "
+"%3$s-Modells von %2$s generiert. KI-Chats zeigen möglicherweise falsche oder "
 "anstößige Informationen an (weitere Informationen siehe %4$s)."
 
 # smartling.placeholder_format=C
@@ -20230,8 +20222,8 @@ msgid ""
 "com browser data, then you may see AI-assisted answers again."
 msgstr ""
 "Diese Einstellung wird in deinem Browser gespeichert. Das heißt, wenn du die "
-"Browserdaten von duckduckgo.com löschst, siehst du möglicherweise wieder KI-"
-"gestützte Antworten."
+"Browserdaten von duckduckgo.com löschst, siehst du möglicherweise wieder "
+"KI-gestützte Antworten."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -20242,9 +20234,9 @@ msgid ""
 "also have a start page that never shows AI-assisted answers at %s."
 msgstr ""
 "Diese Einstellung wird in deinem Browser gespeichert. Das heißt, wenn du die "
-"Browserdaten von duckduckgo.com löschst, siehst du möglicherweise wieder KI-"
-"gestützte Antworten. Allerdings haben wir auch eine Startseite unter %1$s, "
-"auf der niemals KI-gestützte Antworten angezeigt werden."
+"Browserdaten von duckduckgo.com löschst, siehst du möglicherweise wieder "
+"KI-gestützte Antworten. Allerdings haben wir auch eine Startseite unter "
+"%1$s, auf der niemals KI-gestützte Antworten angezeigt werden."
 
 # smartling.placeholder_format=C
 #. User feedback indicating that a translation is helpful
@@ -20275,8 +20267,7 @@ msgstr ""
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr ""
-"Diese Webseite verwendet keine sichere, verschlüsselte Verbindung (HTTPS)."
+msgstr "Diese Webseite verwendet keine sichere, verschlüsselte Verbindung (HTTPS)."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -20394,8 +20385,7 @@ msgstr "Tipps"
 
 # smartling.placeholder_format=C
 msgid "Tired of being tracked online? %sWe can help.%s"
-msgstr ""
-"Du bist es leid, online getrackt zu werden? %1$sWir schaffen Abhilfe.%2$s"
+msgstr "Du bist es leid, online getrackt zu werden? %1$sWir schaffen Abhilfe.%2$s"
 
 # smartling.placeholder_format=C
 #. This is the name of a user setting
@@ -20735,13 +20725,13 @@ msgstr ""
 #. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Translate this page"
-msgstr ""
+msgstr "Diese Seite übersetzen"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
 msgctxt "Page suggestion prompt"
 msgid "Translate this page into %s."
-msgstr ""
+msgstr "Diese Seite in %1$s übersetzen."
 
 # smartling.placeholder_format=C
 #. Placeholder text for a region that will display translated text.
@@ -20843,8 +20833,7 @@ msgstr "Versuche, %1$s, um solche Nachrichten nicht mehr zu sehen."
 #. Text for a promotional card that encourages users to try the encrypted AI model whose inference runs in a confidential environment so the model provider cannot access user data. %s is replaced with the model's full display name (e.g. 'GPT-OSS 120B').
 msgctxt "Promotional text for encrypted AI model"
 msgid "Try %s, our first model with zero provider visibility."
-msgstr ""
-"Probiere %1$s, unser erstes Modell ohne Sichtbarkeit auf Anbieterseite."
+msgstr "Probiere %1$s, unser erstes Modell ohne Sichtbarkeit auf Anbieterseite."
 
 # smartling.placeholder_format=C
 msgid "Try %sDuck.ai%s, our private AI chat service:"
@@ -20889,7 +20878,7 @@ msgstr "Kostenlos testen"
 #. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
 msgctxt "settings"
 msgid "Try It Now"
-msgstr ""
+msgstr "Jetzt ausprobieren"
 
 # smartling.placeholder_format=C
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -20992,8 +20981,7 @@ msgstr "Gratis testen"
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
-msgstr ""
-"Kostenlos testen! Ein sicheres VPN, fortschrittliche und private KI und mehr."
+msgstr "Kostenlos testen! Ein sicheres VPN, fortschrittliche und private KI und mehr."
 
 # smartling.placeholder_format=C
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -21043,8 +21031,7 @@ msgstr "Versuche deinen Standort manuell einzustellen."
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Try the %sDuckDuckGo Browser.%s Fast. Free. Private."
-msgstr ""
-"Probiere den %1$sDuckDuckGo-Browser aus.%2$s Schnell. Kostenlos. Privat."
+msgstr "Probiere den %1$sDuckDuckGo-Browser aus.%2$s Schnell. Kostenlos. Privat."
 
 # smartling.placeholder_format=C
 #. Link to a page where users can download the DuckDuckGo Browser for iOS or Android.
@@ -21090,8 +21077,7 @@ msgstr "Probiere den neuen privaten Echtzeit-Sprachchat aus!"
 #. Text for a promotional card that encourages users to try the recently added open-source AI models. The placeholders are the names of AI models like 'Try the recently added open-source Llama 3.1 and Mistral.'
 msgctxt "Promotional text for new AI models"
 msgid "Try the recently added open-source %s and %s"
-msgstr ""
-"Probier die kürzlich hinzugefügten Open-Source-Versionen %1$s und %2$s aus"
+msgstr "Probier die kürzlich hinzugefügten Open-Source-Versionen %1$s und %2$s aus"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that encourages users to try the recently added open-source AI models Llama 3.1 and Mixtral.
@@ -21115,8 +21101,7 @@ msgctxt ""
 "Description shown when a chat search in Duck.ai returns no matching chats, "
 "suggesting the user rephrase their query"
 msgid "Try using a different search term or phrase."
-msgstr ""
-"Versuche, einen anderen Suchbegriff oder eine andere Suchphrase zu verwenden."
+msgstr "Versuche, einen anderen Suchbegriff oder eine andere Suchphrase zu verwenden."
 
 # smartling.placeholder_format=C
 #. In the context of an AI Chat, text prompting the user to try their prompt with a different AI model.
@@ -21142,6 +21127,9 @@ msgid ""
 "Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
+"Versuchst du, KI-Funktionen zu deaktivieren? Installiere die %1$sDuckDuckGo "
+"No AI%2$s-Sucherweiterung, um deine Einstellungen zu speichern. %3$sMehr "
+"erfahren%4$s"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -21150,6 +21138,9 @@ msgid ""
 "Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
+"Möchtest du KI-Funktionen deaktivieren? Wechsle zur %1$sDuckDuckGo No "
+"AI%2$s-Sucherweiterung, damit deine Einstellungen gespeichert bleiben. "
+"%3$sMehr erfahren%4$s"
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -21251,8 +21242,7 @@ msgstr "Abschalten:"
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on %sPrecise Location%s for more accurate results"
-msgstr ""
-"Aktiviere %1$sPräziser Standort%2$s, um genauere Ergebnisse zu erhalten"
+msgstr "Aktiviere %1$sPräziser Standort%2$s, um genauere Ergebnisse zu erhalten"
 
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
@@ -21269,8 +21259,7 @@ msgstr "Aktiviere „Präziser Standort“, um genauere Ergebnisse zu erhalten."
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on “Use precise location” for more accurate results."
-msgstr ""
-"Aktiviere „Präzisen Standort verwenden“, um genauere Ergebnisse zu erhalten."
+msgstr "Aktiviere „Präzisen Standort verwenden“, um genauere Ergebnisse zu erhalten."
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Create Image' label in the Tools dropdown.
@@ -21467,8 +21456,8 @@ msgstr ""
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
 msgstr ""
-"Unter %1$sEinstellungen%2$s > Allgemein > %3$sStartseite%4$s https://"
-"duckduckgo.com eingeben"
+"Unter %1$sEinstellungen%2$s > Allgemein > %3$sStartseite%4$s "
+"https://duckduckgo.com eingeben"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -21500,8 +21489,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
-msgstr ""
-"Im Bereich %1$sSuchen%2$s bitte %3$sSuchmaschinen verwalten …%4$s anklicken"
+msgstr "Im Bereich %1$sSuchen%2$s bitte %3$sSuchmaschinen verwalten …%4$s anklicken"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -21618,8 +21606,8 @@ msgctxt "voice chat limit modal"
 msgid ""
 "Unlock advanced AI models and higher limits with a DuckDuckGo Subscription"
 msgstr ""
-"Schalte fortschrittliche KI-Modelle und höhere Limits mit einem DuckDuckGo-"
-"Abo frei"
+"Schalte fortschrittliche KI-Modelle und höhere Limits mit einem "
+"DuckDuckGo-Abo frei"
 
 # smartling.placeholder_format=C
 #. Text informing the user that advanced AI models can be unlocked with a subscription. The variable is used to insert a link that opens the subscription modal. Example: Unlock advanced AI models with a DuckDuckGo subscription.
@@ -21652,8 +21640,7 @@ msgctxt ""
 "Text shown in the subscription promo card, with a trailing call-to-action "
 "link."
 msgid "Unlock more capable AI models with a DuckDuckGo subscription. %s"
-msgstr ""
-"Schalte leistungsfähigere KI-Modelle mit einem DuckDuckGo-Abo frei. %1$s"
+msgstr "Schalte leistungsfähigere KI-Modelle mit einem DuckDuckGo-Abo frei. %1$s"
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to unmute the microphone.
@@ -21922,7 +21909,7 @@ msgstr "Uruguay"
 #. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
 msgctxt "Navigation label on the Duck.ai settings page"
 msgid "Usage"
-msgstr ""
+msgstr "Verwendung"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -22019,8 +22006,7 @@ msgstr ""
 #. Prompt to ask the user if they want to use their approximate location for more accurate results
 msgctxt "DuckChat location prompt"
 msgid "Use your approximate location for more accurate results?"
-msgstr ""
-"Verwende deinen ungefähren Standort, um genauere Ergebnisse zu erhalten?"
+msgstr "Verwende deinen ungefähren Standort, um genauere Ergebnisse zu erhalten?"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes before every user message in the downloaded file, indicating which message it is out of the total number of messages. Example: 'User prompt 3 of 5'
@@ -22321,8 +22307,8 @@ msgstr "Sprachchat beendet"
 msgctxt "voice chat"
 msgid "Voice chat is anonymized by us, and never used to train AI models."
 msgstr ""
-"Der Sprachchat wird von uns anonymisiert und niemals zum Trainieren von KI-"
-"Modellen verwendet."
+"Der Sprachchat wird von uns anonymisiert und niemals zum Trainieren von "
+"KI-Modellen verwendet."
 
 # smartling.placeholder_format=C
 #. Title of the modal shown when the user has reached their daily voice chat limit.
@@ -22386,7 +22372,7 @@ msgstr "Wales"
 #. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Walk me through the steps"
-msgstr ""
+msgstr "Führe mich durch die Schritte"
 
 # smartling.placeholder_format=C
 #. Label for walking directions on a map.
@@ -22467,8 +22453,8 @@ msgid ""
 "viewing activity from influencing YouTube recommendations."
 msgstr ""
 "Benutze den Duck Player, um personalisierte Werbung auf YouTube zu "
-"blockieren und zu verhindern, dass deine Aktivitäten die YouTube-"
-"Empfehlungen beeinflussen."
+"blockieren und zu verhindern, dass deine Aktivitäten die "
+"YouTube-Empfehlungen beeinflussen."
 
 # smartling.placeholder_format=C
 #. A button that takes a user to another site in order to watch a video. The placeholder is the name of the video site. For example: 'Watch on Vimeo'
@@ -22517,6 +22503,9 @@ msgid ""
 "please share this conversation with DuckDuckGo so we can investigate and "
 "address the issue."
 msgstr ""
+"Wir können nur das reparieren, was wir sehen können. Um eine schädliche oder "
+"illegale Antwort zu melden, teile diese Unterhaltung bitte mit DuckDuckGo, "
+"damit wir dem nachgehen und das Problem beheben können."
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -22612,8 +22601,7 @@ msgstr "Wir tracken dich nicht. Niemals."
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with a Continue button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don't track you. That's our Privacy Policy in a nutshell."
-msgstr ""
-"Wir tracken dich nicht. Das ist unsere Datenschutzerklärung in Kurzform."
+msgstr "Wir tracken dich nicht. Das ist unsere Datenschutzerklärung in Kurzform."
 
 # smartling.placeholder_format=C
 #. Description for the audio identification highlight in the dictation consent modal.
@@ -22654,8 +22642,7 @@ msgstr "Wir tracken dich nicht, ob im privaten oder normalen Modus."
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with an Agree button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don’t track you. That’s our Privacy Policy in a nutshell…"
-msgstr ""
-"Wir tracken dich nicht. Das ist unsere Datenschutzerklärung in Kurzform …"
+msgstr "Wir tracken dich nicht. Das ist unsere Datenschutzerklärung in Kurzform …"
 
 # smartling.placeholder_format=C
 #. Displayed when the user's voice chat session is ended because of being inactive for too long.
@@ -22685,8 +22672,7 @@ msgstr "Wir halten deinen Suchverlauf privat"
 #. Displayed when the voice chat connection is lost and the session ends.
 msgctxt "voice chat error"
 msgid "We lost the connection, please try again later."
-msgstr ""
-"Die Verbindung wurde unterbrochen. Bitte versuche es später noch einmal."
+msgstr "Die Verbindung wurde unterbrochen. Bitte versuche es später noch einmal."
 
 # smartling.placeholder_format=C
 #. We store chats for 15 minutes in the BE. If the user tries to fetch it after the 15 minutes elapsed or if we had an issue saving it we show them this error message so they can re-submit their prompt.
@@ -22727,8 +22713,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We stop anyone from getting your search history, including us."
-msgstr ""
-"Wir verhindern, dass jemand deinen Suchverlauf erhält, einschließlich uns."
+msgstr "Wir verhindern, dass jemand deinen Suchverlauf erhält, einschließlich uns."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -23077,108 +23062,108 @@ msgid ""
 "experience."
 msgstr ""
 "Welche Vorteile bietet das Herunterladen des DuckDuckGo-Browsers für "
-"jemanden, der Duck.ai nutzen möchte? Beziehe nur offizielle DuckDuckGo-"
-"Quellen ein. Teile die Antwort in übersichtliche Abschnitte mit Titeln auf, "
-"wobei der Schwerpunkt auf den Integrationen von Duck.ai und dem Datenschutz "
-"liegt. Halte es sehr kurz, einfach und leicht verständlich für Menschen mit "
-"oder ohne viel KI- oder technische Erfahrung."
+"jemanden, der Duck.ai nutzen möchte? Beziehe nur offizielle "
+"DuckDuckGo-Quellen ein. Teile die Antwort in übersichtliche Abschnitte mit "
+"Titeln auf, wobei der Schwerpunkt auf den Integrationen von Duck.ai und dem "
+"Datenschutz liegt. Halte es sehr kurz, einfach und leicht verständlich für "
+"Menschen mit oder ohne viel KI- oder technische Erfahrung."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the counterarguments?"
-msgstr ""
+msgstr "Was sind die Gegenargumente?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the hours & location?"
-msgstr ""
+msgstr "Wie sind die Öffnungszeiten & der Standort?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key contributions of this paper?"
-msgstr ""
+msgstr "Was sind die wichtigsten Beiträge dieses Artikels?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key contributions?"
-msgstr ""
+msgstr "Was sind die wichtigsten Beiträge?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key details?"
-msgstr ""
+msgstr "Was sind die wichtigsten Details?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key points covered in this video?"
-msgstr ""
+msgstr "Was sind die wichtigsten Punkte, die in diesem Video behandelt werden?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key points?"
-msgstr ""
+msgstr "Was sind die wichtigsten Punkte?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key takeaways from this article?"
-msgstr ""
+msgstr "Was sind die wichtigsten Erkenntnisse aus diesem Artikel?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key takeaways?"
-msgstr ""
+msgstr "Was sind die wichtigsten Erkenntnisse?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key things I will learn from this course?"
-msgstr ""
+msgstr "Was sind die wichtigsten Dinge, die ich in diesem Kurs lernen werde?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the main counterarguments or criticisms of this?"
-msgstr ""
+msgstr "Was sind die wichtigsten Gegenargumente oder Kritikpunkte dazu?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the main questions this page answers?"
-msgstr ""
+msgstr "Welche Hauptfragen beantwortet diese Seite?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the must-try dishes here?"
-msgstr ""
+msgstr "Was muss man hier unbedingt probieren?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid ""
 "What are the opening hours, location, and contact details for this place?"
-msgstr ""
+msgstr "Wie sind die Öffnungszeiten, der Standort und die Kontaktdaten dieses Ortes?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the pros and cons of this product?"
-msgstr ""
+msgstr "Was sind die Vor- und Nachteile dieses Produkts?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the pros and cons?"
-msgstr ""
+msgstr "Was sind die Vor- und Nachteile?"
 
 # smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
@@ -23284,7 +23269,7 @@ msgstr "Was bedeutet Atrien im Kontext eines medizinischen Artikels?"
 #. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What does this answer?"
-msgstr ""
+msgstr "Was beantwortet das?"
 
 # smartling.placeholder_format=C
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
@@ -23303,6 +23288,8 @@ msgstr "Welche Daten werden gespeichert?"
 msgctxt "Page suggestion prompt"
 msgid "What interview questions might come up for this role?"
 msgstr ""
+"Welche Fragen könnten bei diesem Vorstellungsgespräch für diese Rolle "
+"aufkommen?"
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -23324,7 +23311,7 @@ msgstr "Was ist die Hauptstadt von Albanien?"
 #. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What is the overall verdict and rating for this?"
-msgstr ""
+msgstr "Wie lauten das Gesamturteil und die Bewertung hierfür?"
 
 # smartling.placeholder_format=C
 #. Link to a page with additional information.
@@ -23352,7 +23339,7 @@ msgstr "Was andere darüber sagen:"
 #. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What should I order?"
-msgstr ""
+msgstr "Was soll ich bestellen?"
 
 # smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
@@ -23370,13 +23357,13 @@ msgstr "Was war falsch an der Antwort? (optional)"
 #. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What will I learn?"
-msgstr ""
+msgstr "Was werde ich lernen?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What will I need?"
-msgstr ""
+msgstr "Was brauche ich?"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -23401,7 +23388,7 @@ msgstr "Was gibt's Neues?"
 #. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What's the verdict?"
-msgstr ""
+msgstr "Wie lautet das Fazit?"
 
 # smartling.placeholder_format=C
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -23459,7 +23446,7 @@ msgstr "Welche Funktionen fehlen dir? Optional"
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Which features are missing? (optional)"
-msgstr ""
+msgstr "Welche Funktionen fehlen dir? (optional)"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
@@ -23482,12 +23469,14 @@ msgstr "Wer wir sind"
 msgctxt "Page suggestion prompt"
 msgid "Who are the main cast and crew, and what else are they known for?"
 msgstr ""
+"Wer gehört zur Hauptbesetzung und zum Stab, und wofür sind sie sonst noch "
+"bekannt?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Who is this person?"
-msgstr ""
+msgstr "Wer ist diese Person?"
 
 # smartling.placeholder_format=C
 #. Header above a collection of privacy-related links.
@@ -24230,8 +24219,7 @@ msgstr "Du hast das Limit für die Erstellung von Bildern erreicht."
 #. Title shown when a user has reached their image generation edit limit.
 msgctxt "Title for image generation edit limit reached message"
 msgid "You've reached the maximum number of edits for this image"
-msgstr ""
-"Du hast die maximale Anzahl von Bearbeitungen für dieses Bild erreicht."
+msgstr "Du hast die maximale Anzahl von Bearbeitungen für dieses Bild erreicht."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum number of messages for a given moment, and should try again later when they might be able to send more messages again.
@@ -24538,8 +24526,7 @@ msgctxt ""
 "Subtitle of the one-time popover shown above the thumbs up/down buttons on "
 "an AI response"
 msgid "Your feedback is anonymized and not used to train AI."
-msgstr ""
-"Dein Feedback wird anonymisiert und nicht zum Training der KI verwendet."
+msgstr "Dein Feedback wird anonymisiert und nicht zum Training der KI verwendet."
 
 # smartling.placeholder_format=C
 #. Explains that the User's Location is always private to DuckDuckGo.
@@ -24633,8 +24620,7 @@ msgstr "Deine Suchanfragen können nicht auf dich zurückgeführt werden"
 #. Confirms the recovery succeeded. The Next CTA closes the sheet.
 msgctxt "Body copy on the recover-data success sheet"
 msgid "Your synced chats are being restored to this device."
-msgstr ""
-"Deine synchronisierten Chats werden auf diesem Gerät wiederhergestellt."
+msgstr "Deine synchronisierten Chats werden auf diesem Gerät wiederhergestellt."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"

--- a/locales/de_DE/LC_MESSAGES/duckduckgo.po
+++ b/locales/de_DE/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: de_DE\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1244,7 +1244,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. An item in the ads tooltip that explains that ad clicks aren’t used to profile you.
 msgid "Ad clicks aren’t used to profile you"
-msgstr "Werbungsklicks werden nicht verwendet, um ein Profil von dir zu erstellen"
+msgstr ""
+"Werbungsklicks werden nicht verwendet, um ein Profil von dir zu erstellen"
 
 # smartling.placeholder_format=C
 #. Category of problem a user can select on a feedback form.
@@ -1444,6 +1445,12 @@ msgstr "Adressleiste:"
 msgctxt "feedback form"
 msgid "Address is incorrect"
 msgstr "Adresse ist falsch"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Adjust the servings"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. as in multiple advertisements
@@ -1659,6 +1666,14 @@ msgid "All chats are %sprivate%s"
 msgstr "Alle Chats sind %1$sprivat%2$s"
 
 # smartling.placeholder_format=C
+#. Paragraph in the Privacy & Terms section of the About & Legal page in Duck.ai settings, summarizing how chats are anonymized and are not stored or used to train chat models.
+msgctxt "Privacy & Terms section description on the Duck.ai settings page"
+msgid ""
+"All chats are anonymized by DuckDuckGo, and your conversations are not used "
+"to train chat models by DuckDuckGo or the model providers"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
 msgctxt "Privacy modal header in Duck.ai chat"
 msgid "All chats are private"
@@ -1749,7 +1764,8 @@ msgstr "Privatsphäre-respektierende Werbung zulassen"
 # smartling.placeholder_format=C
 #. Title in a dialog informing the user how to disable their ad blocker for DuckDuckGo
 msgid "Allow privacy-respecting ads on DuckDuckGo Private Search"
-msgstr "Lass datenschutzfreundliche Werbung in der Private Search von DuckDuckGo zu"
+msgstr ""
+"Lass datenschutzfreundliche Werbung in der Private Search von DuckDuckGo zu"
 
 # smartling.placeholder_format=C
 #. Description explaining privacy implications of enabling web search on encrypted models. The first two placeholders are the full model name (e.g. 'gpt-oss 120B'). The third and fourth placeholders wrap a clickable link reading 'zero provider visibility' that opens the privacy modal, please keep those around the link text in your translation. An example full sentence would be: Allows gpt-oss 120B to search the web to improve responses to relevant prompts. Only sends AI-generated queries to a search engine with limited data retention. Prompts and responses with gpt-oss 120B still have zero provider visibility.
@@ -1929,6 +1945,13 @@ msgid "Anonymous location enabled"
 msgstr "Anonymer Standort aktiviert"
 
 # smartling.placeholder_format=C
+msgctxt "settings"
+msgid ""
+"Anonymously generates answers for search queries based on web content. "
+"Choose how often you want it to appear, or disable it completely."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Instant Answer tab name
 msgid "Answer"
 msgstr "Antwort"
@@ -2081,7 +2104,8 @@ msgstr ""
 #. Body text of the modal that asks the user if they want to clear the conversation.
 msgctxt "Modal body for clearing conversation"
 msgid "Are you sure you want to clear this conversation and start a new one?"
-msgstr "Möchtest du diese Konversation wirklich löschen und eine neue beginnen?"
+msgstr ""
+"Möchtest du diese Konversation wirklich löschen und eine neue beginnen?"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to delete their current chat, explaining that this action cannot be undone.
@@ -2212,6 +2236,12 @@ msgid "Ask a follow-up with Duck.ai"
 msgstr "Stelle eine Folgefrage mit Duck.ai"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
+msgctxt "Page suggestion chip label"
+msgid "Ask about this page"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
 msgctxt "Title for the page context onboarding modal"
 msgid "Ask about this page"
@@ -2275,13 +2305,13 @@ msgid ""
 msgstr ""
 "Assist kann anonym KI-gestützte Antworten auf einige Suchanfragen "
 "generieren, die auf der Zusammenfassung relevanter Webinhalte basieren. Du "
-"kannst auswählen, wie oft Assist angezeigt werden soll: Nie (die "
-"Assist-Benutzeroberfläche wird vollständig aus den Suchergebnissen "
-"entfernt), Bei Bedarf (KI-gestützte Antworten werden nur angezeigt, wenn du "
-"auf die Assist-Schaltfläche klickst), Manchmal (KI-gestützte Antworten "
-"werden nur bei hoher Relevanz angezeigt) oder Oft (werden häufiger bei einer "
-"größeren Anzahl von Suchanfragen angezeigt). Derzeit sind KI-gestützte "
-"Antworten nur in den USA (Englisch) verfügbar."
+"kannst auswählen, wie oft Assist angezeigt werden soll: Nie (die Assist-"
+"Benutzeroberfläche wird vollständig aus den Suchergebnissen entfernt), Bei "
+"Bedarf (KI-gestützte Antworten werden nur angezeigt, wenn du auf die Assist-"
+"Schaltfläche klickst), Manchmal (KI-gestützte Antworten werden nur bei hoher "
+"Relevanz angezeigt) oder Oft (werden häufiger bei einer größeren Anzahl von "
+"Suchanfragen angezeigt). Derzeit sind KI-gestützte Antworten nur in den USA "
+"(Englisch) verfügbar."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2293,8 +2323,8 @@ msgid ""
 "to remember that responses are auto-generated from cited sources and based "
 "on %scrawling the web%s."
 msgstr ""
-"Assist ist eine optionale Funktion in unseren Suchergebnissen, die anonym "
-"KI-gestützte Antworten auf Suchanfragen generieren kann. Dazu durchsucht sie "
+"Assist ist eine optionale Funktion in unseren Suchergebnissen, die anonym KI-"
+"gestützte Antworten auf Suchanfragen generieren kann. Dazu durchsucht sie "
 "das Internet nach relevanten Inhalten und verwendet dann KI-gestützte "
 "natürliche Sprachtechnologie, um eine kurze Antwort auf der Grundlage der "
 "gefundenen relevanten Informationen zu generieren. Es ist wichtig, zu "
@@ -2452,7 +2482,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI) on mobile
 msgid "Auto-generated from sources. May be inaccurate."
-msgstr "Automatisch generiert basierend auf Quellen. Kann Ungenauigkeiten enthalten."
+msgstr ""
+"Automatisch generiert basierend auf Quellen. Kann Ungenauigkeiten enthalten."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2520,7 +2551,8 @@ msgstr "Durchschn. Vol."
 #. Warning text shown below the chat input when the user has attached files, advising them not to upload files from untrusted sources.
 msgctxt "Disclaimer below chat input in Duck.ai when files are attached"
 msgid "Avoid uploading files from sources you don't trust."
-msgstr "Vermeide das Hochladen von Dateien aus Quellen, denen du nicht vertraust."
+msgstr ""
+"Vermeide das Hochladen von Dateien aus Quellen, denen du nicht vertraust."
 
 # smartling.placeholder_format=C
 #. Indicates the Win-Loss record of a team when playing away
@@ -2636,6 +2668,12 @@ msgid "Barcode"
 msgstr "Strichcode"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Based on this page, is this course worth taking?"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Basic"
 msgstr "Basis"
@@ -2674,6 +2712,14 @@ msgstr "Batter"
 msgctxt "Assistant response placeholder"
 msgid "Before continuing..."
 msgstr "Bevor wir fortfahren ..."
+
+# smartling.placeholder_format=C
+#. Explains that before storing the report, DuckDuckGo will anonymize the conversation by removing PII like names, email addresses, and identifying metadata.
+msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
+msgid ""
+"Before storing this report, DuckDuckGo will anonymize your conversation by "
+"removing PII like names, email addresses, and identifying metadata."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -2799,7 +2845,8 @@ msgstr "E-Mail-Tracker blockieren und deine Adresse verbergen."
 # smartling.placeholder_format=C
 #. A disclaimer about AI-generated images in search results
 msgid "Block list is not exhaustive and may contain inaccuracies."
-msgstr "Die Blockliste ist nicht vollständig und kann Ungenauigkeiten enthalten."
+msgstr ""
+"Die Blockliste ist nicht vollständig und kann Ungenauigkeiten enthalten."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -2815,7 +2862,8 @@ msgstr "Diese Seite in allen Ergebnissen blockieren"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Block trackers and take control of your personal data"
-msgstr "Blockiere Tracker und übernimm die Kontrolle über deine persönlichen Daten"
+msgstr ""
+"Blockiere Tracker und übernimm die Kontrolle über deine persönlichen Daten"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -2992,6 +3040,12 @@ msgid "Break Points Won"
 msgstr "Gewonnene Breakpunkte"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Break this down into clear, numbered steps."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
 msgctxt "Weather IA"
 msgid "Breezy"
@@ -3067,9 +3121,9 @@ msgid ""
 "search, tracker blocking, and site encryption, all in one download, for "
 "%smajor browsers%s."
 msgstr ""
-"Surfe wie immer und wir kümmern uns um den Rest: Private Suche, "
-"Tracker-Blockade, und Website-Verschlüsselung – alles in einem Download, für "
-"%1$sdie wichtigsten Browser%2$s."
+"Surfe wie immer und wir kümmern uns um den Rest: Private Suche, Tracker-"
+"Blockade, und Website-Verschlüsselung – alles in einem Download, für %1$sdie "
+"wichtigsten Browser%2$s."
 
 # smartling.placeholder_format=C
 #. Header for a call to action to browse with the DuckDuckGo browser
@@ -3155,7 +3209,8 @@ msgstr "Indem du auf „%1$s“ klickst, akzeptierst du unsere %2$s."
 msgctxt ""
 "Copy stating agreement to Duck.ai Privacy Policy and Terms of Service."
 msgid "By clicking “%s,” you accept Duck.ai’s %s and %s."
-msgstr "Indem du auf „%1$s“ klickst, akzeptierst du die %2$s und %3$s von Duck.ai."
+msgstr ""
+"Indem du auf „%1$s“ klickst, akzeptierst du die %2$s und %3$s von Duck.ai."
 
 # smartling.placeholder_format=C
 #. Text stating agreement to Duck.ai Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'By clicking “Agree and Continue,” you accept Duck.ai’s Privacy Policy and Terms of Service.'
@@ -3176,11 +3231,11 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"Normalerweise werden die Einstellungen in nicht personenbezogenen "
-"Browser-Cookies gespeichert (im eigenen Browser). Im anonymen Cloud Save "
-"lassen sich Einstellungen dauerhafter sichern (auf einem Remote-Server in "
-"der Cloud). Es werden dabei keine personenbezogenen Daten in der Cloud "
-"gespeichert und die Passphrase verlässt nie den eigenen Browser."
+"Normalerweise werden die Einstellungen in nicht personenbezogenen Browser-"
+"Cookies gespeichert (im eigenen Browser). Im anonymen Cloud Save lassen sich "
+"Einstellungen dauerhafter sichern (auf einem Remote-Server in der Cloud). Es "
+"werden dabei keine personenbezogenen Daten in der Cloud gespeichert und die "
+"Passphrase verlässt nie den eigenen Browser."
 
 # smartling.placeholder_format=C
 #. Description for the consent highlight in the dictation consent modal. %s is replaced with a link to the help page.
@@ -3236,7 +3291,8 @@ msgstr "Kamerun"
 #. Text for a prompt suggestion for creating a few simple recipes using chicken, broccoli, and rice.
 msgctxt "Full sentence for crafting a recipe"
 msgid "Can you create a few simple recipes using chicken, broccoli, and rice?"
-msgstr "Kannst du ein paar einfache Rezepte mit Hühnchen, Brokkoli und Reis kreieren?"
+msgstr ""
+"Kannst du ein paar einfache Rezepte mit Hühnchen, Brokkoli und Reis kreieren?"
 
 # smartling.placeholder_format=C
 msgid "Canada"
@@ -3447,6 +3503,12 @@ msgid "Cast"
 msgstr "Besetzung"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Cast & Crew"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
 msgctxt "Tone option label for Casual"
 msgid "Casual"
@@ -3558,7 +3620,8 @@ msgstr ""
 #. http://i.imgur.com/NdpkbY0.png
 msgctxt "settings"
 msgid "Changes the background color when hovering over a result"
-msgstr "Ändert die Hintergrundfarbe, wenn du den Mauszeiger über ein Ergebnis bewegst"
+msgstr ""
+"Ändert die Hintergrundfarbe, wenn du den Mauszeiger über ein Ergebnis bewegst"
 
 # smartling.placeholder_format=C
 #. Description of a setting managing the color of search result snippet text.
@@ -3689,8 +3752,8 @@ msgstr ""
 "KI-Chatmodellen von Drittanbietern zu führen, etwa OpenAI oder Anthropic. "
 "Wenn du diese Einstellung deaktivierst, werden Chat-Schaltflächen und -Links "
 "in DuckDuckGo Search ausgeblendet. Du kannst jedoch auch dann auf den Chat "
-"zugreifen, wenn diese Einstellung deaktiviert ist, indem du "
-"%1$shttps://duck.ai%2$s direkt besuchst."
+"zugreifen, wenn diese Einstellung deaktiviert ist, indem du %1$shttps://duck."
+"ai%2$s direkt besuchst."
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -3819,9 +3882,9 @@ msgid ""
 "Chats are stored locally on your device instead of on DuckDuckGo servers or "
 "remote servers. Disabling chat history will delete pinned chats."
 msgstr ""
-"Chats werden lokal auf deinem Gerät gespeichert, anstatt auf "
-"DuckDuckGo-Servern oder Remote-Servern. Wenn du den Chatverlauf "
-"deaktivierst, werden angeheftete Chats gelöscht."
+"Chats werden lokal auf deinem Gerät gespeichert, anstatt auf DuckDuckGo-"
+"Servern oder Remote-Servern. Wenn du den Chatverlauf deaktivierst, werden "
+"angeheftete Chats gelöscht."
 
 # smartling.placeholder_format=C
 #. Text explaining how the Chat History feature stores the user's chats locally to their device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection. Also explains that disabling chat history will delete pinned chats.
@@ -3834,11 +3897,11 @@ msgid ""
 "prompts and responses."
 msgstr ""
 "Chats werden lokal auf deinem Gerät gespeichert. Neue Prompts und Antworten "
-"werden verschlüsselt und nach dem Senden vorübergehend auf einem "
-"DuckDuckGo-Server gespeichert, damit du einen Chat wiederherstellen kannst, "
-"falls deine Internetverbindung unterbrochen wird. Wenn du den Chatverlauf "
-"deaktivierst, werden angeheftete Chats gelöscht und die vorübergehende "
-"Speicherung neuer Aufforderungen und Antworten deaktiviert."
+"werden verschlüsselt und nach dem Senden vorübergehend auf einem DuckDuckGo-"
+"Server gespeichert, damit du einen Chat wiederherstellen kannst, falls deine "
+"Internetverbindung unterbrochen wird. Wenn du den Chatverlauf deaktivierst, "
+"werden angeheftete Chats gelöscht und die vorübergehende Speicherung neuer "
+"Aufforderungen und Antworten deaktiviert."
 
 # smartling.placeholder_format=C
 #. Title shown above the body copy in the Duck.ai recent chats IndexedDB unavailable notice.
@@ -3979,7 +4042,8 @@ msgstr "Auswahl von KI-Modellen, darunter %1$s und %2$s"
 # smartling.placeholder_format=C
 #. As in 'Choose to keep DuckDuckGo as your default search engine'. Placeholders are for markup, you can ignore them.
 msgid "Choose %skeep it%s to continue protecting your privacy."
-msgstr "Wähle %1$sBeibehalten%2$s aus, um weiterhin deine Privatsphäre zu schützen."
+msgstr ""
+"Wähle %1$sBeibehalten%2$s aus, um weiterhin deine Privatsphäre zu schützen."
 
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
@@ -5168,6 +5232,12 @@ msgid "Create Image"
 msgstr "Bild erstellen"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Create a shopping list with quantities from this recipe."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text displayed in the input field when starting a new image generation session.
 msgctxt "Placeholder text for the image generation input field"
 msgid "Create an image of a cute duck..."
@@ -5422,7 +5492,8 @@ msgstr "Tageslimit erreicht"
 #. Displayed when the user has reached a fixed daily Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Daily usage limit reached. You can continue this chat after %s."
-msgstr "Tägliches Nutzungslimit erreicht. Du kannst diesen Chat nach %1$s fortsetzen."
+msgstr ""
+"Tägliches Nutzungslimit erreicht. Du kannst diesen Chat nach %1$s fortsetzen."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable daily Duck.ai usage limit and can opt in to continue using the weekly limit.
@@ -5713,7 +5784,8 @@ msgstr "Gelöschte Chats"
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
 msgctxt "settings"
 msgid "Deleting cookies will reset these settings."
-msgstr "Durch das Löschen der Cookies werden diese Einstellungen zurückgesetzt."
+msgstr ""
+"Durch das Löschen der Cookies werden diese Einstellungen zurückgesetzt."
 
 # smartling.placeholder_format=C
 msgid "Democratic People's Republic of Korea"
@@ -5735,7 +5807,8 @@ msgstr "Beschreibe die Änderungen basierend auf dem Bild"
 #. Placeholder text displayed in the input field when the user can make follow-up edits to a generated image.
 msgctxt "Placeholder text for the image generation input field for follow-ups"
 msgid "Describe changes to continue editing this image"
-msgstr "Beschreibe die Änderungen, um mit der Bearbeitung dieses Bildes fortzufahren."
+msgstr ""
+"Beschreibe die Änderungen, um mit der Bearbeitung dieses Bildes fortzufahren."
 
 # smartling.placeholder_format=C
 #. Title shown when the user first enters Image Generation mode, prompting them to describe the image they want to create.
@@ -5799,13 +5872,18 @@ msgstr "Diktierfunktion in Duck.ai"
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
 msgstr ""
-"Die Diktate werden von uns anonymisiert und niemals zum Trainieren von "
-"KI-Modellen verwendet."
+"Die Diktate werden von uns anonymisiert und niemals zum Trainieren von KI-"
+"Modellen verwendet."
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
 msgid "Dictation limit reached"
 msgstr "Diktatlimit erreicht"
+
+# smartling.placeholder_format=C
+#. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
+msgid "Dictation temporarily unavailable"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
@@ -6110,6 +6188,22 @@ msgid "Done"
 msgstr "Fertig"
 
 # smartling.placeholder_format=C
+#. Message shown in a modal after DuckDuckGo browser users disable AI features in Settings. The first two placeholders bold noai.duckduckgo.com. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
+"filtered out. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
+"and AI images filtered out. %sLearn more%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Double Faults"
@@ -6222,6 +6316,18 @@ msgid ""
 msgstr ""
 "Verfasse eine kurze und detaillierte E-Mail an einen Anbieter, in der du ein "
 "Angebot für die Reparatur eines Kühlschranks anforderst."
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Draft a cover letter"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Draft a cover letter for this job."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -6402,6 +6508,15 @@ msgstr ""
 "DuckDuckGo-Browser!"
 
 # smartling.placeholder_format=C
+#. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
+msgctxt "About section description on the Duck.ai settings page"
+msgid ""
+"Duck.ai is created by DuckDuckGo. We're an independent online protection "
+"company for anyone who wants to take back control of their personal "
+"information."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
 msgctxt "duckai_migration"
 msgid "Duck.ai is moving domains"
@@ -6453,6 +6568,13 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
+"Duck.ai lets you chat privately with popular AI models. Disabling it hides "
+"Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
+msgstr ""
+
+# smartling.placeholder_format=C
+msgctxt "settings"
+msgid ""
 "Duck.ai lets you have anonymous conversations with 3rd-party AI chat models, "
 "including models from OpenAI, Anthropic, and others. Turning this setting "
 "off will hide Duck.ai buttons and links on DuckDuckGo Search. However, you "
@@ -6461,10 +6583,10 @@ msgid ""
 msgstr ""
 "Mit Duck.ai kannst du anonyme Unterhaltungen mit KI-Chatmodellen von "
 "Drittanbietern führen, darunter Modelle von OpenAI, Anthropic und anderen. "
-"Wenn du diese Einstellung deaktivierst, werden Duck.ai-Schaltflächen und "
-"-Links in DuckDuckGo Search ausgeblendet. Du kannst jedoch weiterhin auf "
-"Duck.ai zugreifen, wenn diese Einstellung deaktiviert ist, indem du "
-"%1$shttps://duck.ai%2$s direkt besuchst."
+"Wenn du diese Einstellung deaktivierst, werden Duck.ai-Schaltflächen und -"
+"Links in DuckDuckGo Search ausgeblendet. Du kannst jedoch weiterhin auf Duck."
+"ai zugreifen, wenn diese Einstellung deaktiviert ist, indem du %1$shttps://"
+"duck.ai%2$s direkt besuchst."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
@@ -6652,8 +6774,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"DuckDuckGo AI Chat ist ein privater KI-gestützter Chat-Dienst, der die "
-"Chat-Modelle %2$s von %1$s und %4$s von %3$s nutzt."
+"DuckDuckGo AI Chat ist ein privater KI-gestützter Chat-Dienst, der die Chat-"
+"Modelle %2$s von %1$s und %4$s von %3$s nutzt."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the welcome screen of the onboarding. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -6662,8 +6784,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"DuckDuckGo AI Chat ist ein privater, KI-gestützter Chat-Dienst, der die "
-"Chat-Modelle %2$s von %1$s und %4$s von %3$s nutzt."
+"DuckDuckGo AI Chat ist ein privater, KI-gestützter Chat-Dienst, der die Chat-"
+"Modelle %2$s von %1$s und %4$s von %3$s nutzt."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding DuckDuckGo AI Chat.
@@ -7340,7 +7462,8 @@ msgstr "Stelle sicher, dass der Zugriff auf den Standort %1$saktiviert%2$s ist"
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure location access is %sallowed%s."
-msgstr "Stelle sicher, dass der Zugriff auf den Standort %1$saktiviert%2$s ist."
+msgstr ""
+"Stelle sicher, dass der Zugriff auf den Standort %1$saktiviert%2$s ist."
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
@@ -7460,11 +7583,24 @@ msgstr "Äquatorialguinea"
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Erase your browsing data in a flash with our %sFire Button%s"
-msgstr "Lösche deine Browserdaten im Handumdrehen mit unserem %1$sFire Button%2$s"
+msgstr ""
+"Lösche deine Browserdaten im Handumdrehen mit unserem %1$sFire Button%2$s"
 
 # smartling.placeholder_format=C
 msgid "Eritrea"
 msgstr "Eritrea"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Estimate the nutrition"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Estimate the nutritional information for this recipe."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Estonia"
@@ -7523,11 +7659,60 @@ msgid "Expires in 1 day"
 msgstr "Läuft in 1 Tag ab"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain the accepted answer in simple terms."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
-msgstr "Erkläre mir die grundlegenden Konzepte von Schwarzen Löchern auf Schulniveau."
+msgstr ""
+"Erkläre mir die grundlegenden Konzepte von Schwarzen Löchern auf Schulniveau."
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain the top answer"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this in simple, plain language."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this paper"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this repo"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this research paper in plain language."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this simply"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain what this repository does and how to use it."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label to show if song lyrics contain explicit content
@@ -7814,6 +7999,12 @@ msgstr ""
 "erfahren%2$s"
 
 # smartling.placeholder_format=C
+msgctxt "settings"
+msgid ""
+"Filters out known AI spam sites from image search results. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the final score of a sporting event.
 msgid "Final"
 msgstr "Endergebnis"
@@ -7869,6 +8060,12 @@ msgstr "Finde ein besseres Wort"
 msgctxt "Subtitle for the Web Search tool entry in the Tools dropdown menu"
 msgid "Find current information"
 msgstr "Aktuelle Informationen finden"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Find me alternatives"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button that searches for results closer to the user's current location.
@@ -7961,7 +8158,8 @@ msgstr ""
 #. Privacy reassurance and instructions intro.
 msgctxt "duckai_migration"
 msgid "Follow these steps to move your chats to the new Duck.ai"
-msgstr "Folge diesen Schritten, um deine Chats auf das neue Duck.ai zu übertragen."
+msgstr ""
+"Folge diesen Schritten, um deine Chats auf das neue Duck.ai zu übertragen."
 
 # smartling.placeholder_format=C
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse on mobile
@@ -8066,7 +8264,8 @@ msgstr "Kostenlose und private Chats, von uns anonymisiert"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr "Kostenlose und private Chats, von uns anonymisiert. Kein Konto erforderlich."
+msgstr ""
+"Kostenlose und private Chats, von uns anonymisiert. Kein Konto erforderlich."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -8179,9 +8378,9 @@ msgid ""
 "<strong>Check for Updates...</strong>, then select <strong>Install Update</"
 "strong>."
 msgstr ""
-"Wähle in der Menüleiste der Anwendung auf dem Mac "
-"<strong>DuckDuckGo</strong> &gt; <strong>Nach Updates suchen ...</strong> "
-"und dann <strong>Update installieren</strong>."
+"Wähle in der Menüleiste der Anwendung auf dem Mac <strong>DuckDuckGo</"
+"strong> &gt; <strong>Nach Updates suchen ...</strong> und dann "
+"<strong>Update installieren</strong>."
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -8347,6 +8546,12 @@ msgstr "Bild generieren"
 #. Text for the button that generates more of an answer from duckassist when the answer has come from a collapsed state
 msgid "Generate More"
 msgstr "Mehr erzeugen"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Generate a shopping list"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
@@ -8519,7 +8724,8 @@ msgstr ""
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Get a VPN + two more protections. Try it for free!"
-msgstr "Hol dir ein VPN + zwei weitere Schutzmaßnahmen. Probiere es kostenlos aus!"
+msgstr ""
+"Hol dir ein VPN + zwei weitere Schutzmaßnahmen. Probiere es kostenlos aus!"
 
 # smartling.placeholder_format=C
 #. Description for the subscription modal where users can update their subscription to DuckDuckGo.
@@ -8529,8 +8735,8 @@ msgid ""
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
 "Erhalte Zugang zu den fortschrittlichen KI-Modellen in Duck.ai, indem du "
-"DuckDuckGo abonnierst, was auch unser VPN und andere "
-"Premium-Datenschutzmaßnahmen beinhaltet."
+"DuckDuckGo abonnierst, was auch unser VPN und andere Premium-"
+"Datenschutzmaßnahmen beinhaltet."
 
 # smartling.placeholder_format=C
 #. Description for the subscription setting where users can subscribe to DuckDuckGo.
@@ -8541,9 +8747,9 @@ msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"Mit einem DuckDuckGo-Abo erhältst du Zugang zu den fortschrittlichen "
-"KI-Modellen in Duck.ai, das auch unser VPN und andere "
-"Premium-Datenschutzmaßnahmen beinhaltet."
+"Mit einem DuckDuckGo-Abo erhältst du Zugang zu den fortschrittlichen KI-"
+"Modellen in Duck.ai, das auch unser VPN und andere Premium-"
+"Datenschutzmaßnahmen beinhaltet."
 
 # smartling.placeholder_format=C
 #. A button for users to generate an AI generated answer from their query on the duckassist module
@@ -8642,6 +8848,12 @@ msgstr "Ausprobieren"
 msgctxt "Onboarding welcome screen button text"
 msgid "Give it a Try"
 msgstr "Ausprobieren"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Give me a quick background on this person."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9092,6 +9304,18 @@ msgid "Help Spread Privacy"
 msgstr "Hilf mit, unser aller Privatsphäre zu stärken"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Help me prep for the interview"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Help me tailor my resume for this job."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title of a SERP popup that invites users to take a survey (desktop only)
 msgctxt "User survey popup"
 msgid "Help us improve DuckDuckGo"
@@ -9153,13 +9377,15 @@ msgstr "Hilf uns zu verstehen, was wir falsch gemacht haben"
 #. A subtitle of a page that encourages users to share DuckDuckGo with their friends.
 msgctxt "showcase_spread"
 msgid "Help your friends and family join the Duck Side!"
-msgstr "Hilf deinen Freunden und Verwandten, sich unserer Entenfamilie anzuschließen!"
+msgstr ""
+"Hilf deinen Freunden und Verwandten, sich unserer Entenfamilie anzuschließen!"
 
 # smartling.placeholder_format=C
 #. Text description for the Spread card in the SERP footer
 msgctxt "footer_card"
 msgid "Help your friends and family take back their privacy!"
-msgstr "Hilf deinen Freunden und Verwandten, ihre Privatsphäre zurückzugewinnen!"
+msgstr ""
+"Hilf deinen Freunden und Verwandten, ihre Privatsphäre zurückzugewinnen!"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -9171,7 +9397,8 @@ msgstr "Hilfreich"
 #. The title of a menu that shows other applications DuckDuckGo has made.
 msgctxt "showcase_aria_dropdown"
 msgid "Here are some things that we made that you might like."
-msgstr "Hier sind einige Dinge, die wir gemacht haben, die dir gefallen könnten."
+msgstr ""
+"Hier sind einige Dinge, die wir gemacht haben, die dir gefallen könnten."
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -9371,8 +9598,8 @@ msgid ""
 "Hold on! Changing it back will disable the DuckDuckGo extension and you'll "
 "lose our privacy protection."
 msgstr ""
-"Achtung! Wenn du die Einstellung zurücksetzt, wird die "
-"DuckDuckGo-Erweiterung deaktiviert und du verlierst unseren Datenschutz."
+"Achtung! Wenn du die Einstellung zurücksetzt, wird die DuckDuckGo-"
+"Erweiterung deaktiviert und du verlierst unseren Datenschutz."
 
 # smartling.placeholder_format=C
 #. Heading shown above warning messages in the AI chat, for non-critical issues like unsupported file formats or file size limits. Analogous to 'Oops...' for error messages.
@@ -9609,6 +9836,14 @@ msgid "I Agree"
 msgstr "Ich stimme zu"
 
 # smartling.placeholder_format=C
+#. Text for the button that takes the user to the external DuckDuckGo login subscription page.
+msgctxt ""
+"Text for the I already have a subscription button in the Duck.ai settings "
+"page"
+msgid "I Already Have a Subscription"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for the button that takes the user to the login subscription page.
 msgctxt "Text for the I have a subscription button"
 msgid "I Have a Subscription"
@@ -9684,8 +9919,8 @@ msgid ""
 "I like the book Name of the Wind. What are some other good books/series most "
 "like it and why?"
 msgstr ""
-"Ich mag das Buch „Der Name des Windes“. Welche anderen guten "
-"Bücher/Buchreihen ähneln diesem am meisten und warum?"
+"Ich mag das Buch „Der Name des Windes“. Welche anderen guten Bücher/"
+"Buchreihen ähneln diesem am meisten und warum?"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the user needs more help or information on how to use the chat.
@@ -9760,9 +9995,9 @@ msgid ""
 "If you have concerns about our chat providers or any particular chat "
 "response, you can also reach out directly to %s and %s support pages."
 msgstr ""
-"Wenn du Bedenken bezüglich unserer Chat-Anbieter oder einer bestimmten "
-"Chat-Antwort hast, kannst du dich auch direkt über ihre Support-Seiten an "
-"%1$s und %2$s wenden."
+"Wenn du Bedenken bezüglich unserer Chat-Anbieter oder einer bestimmten Chat-"
+"Antwort hast, kannst du dich auch direkt über ihre Support-Seiten an %1$s "
+"und %2$s wenden."
 
 # smartling.placeholder_format=C
 #. Body copy explaining what the recovery code is for and how it can be saved.
@@ -9800,8 +10035,8 @@ msgstr ""
 msgid ""
 "If you want, select Home Page next to New windows and New tabs (open with)."
 msgstr ""
-"Wenn du willst, wähle »Startseite« neben »Neues Fenster« und »Neue Tabs« "
-"(öffnen mit) aus."
+"Wenn du willst, wähle »Startseite« neben »Neues Fenster« und »Neue "
+"Tabs« (öffnen mit) aus."
 
 # smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that adds an image to the AI chat message being composed.
@@ -10190,6 +10425,12 @@ msgid "Install Mac Browser"
 msgstr "Mac-Browser installieren"
 
 # smartling.placeholder_format=C
+#. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
+msgctxt "settings"
+msgid "Install Now"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of a button to install the DuckDuckGo app
 msgctxt "Serp footer content"
 msgid "Install Our App"
@@ -10287,10 +10528,42 @@ msgid "Is deleted data really deleted?"
 msgstr "Sind gelöschte Daten wirklich gelöscht?"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is it worth taking?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this place any good?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"Is this place any good? Summarize its reputation based on reviews and "
+"ratings."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "Is this video helpful?"
 msgstr "Ist dieses Video hilfreich?"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this worth watching?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Is this worth watching? Give me a spoiler-free take."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -10905,6 +11178,12 @@ msgid "Links:"
 msgstr "Links:"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "List the tools, materials, or prerequisites I need for this."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
 msgid "Listen"
 msgstr "Anhören"
@@ -11311,6 +11590,12 @@ msgstr "Verwalte dein Abonnement"
 msgctxt "Exclusion message manage sites button"
 msgid "Manage blocked sites"
 msgstr "Blockierte Websites verwalten"
+
+# smartling.placeholder_format=C
+#. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
+msgctxt "setting"
+msgid "Manage in Browser Settings"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to the site exclusion settings page
@@ -12207,7 +12492,8 @@ msgstr "Niederlande"
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when a network error occurs during dictation upload.
 msgid "Network error. Please check your connection and try again."
-msgstr "Netzwerkfehler. Bitte überprüfe deine Verbindung und versuche es erneut."
+msgstr ""
+"Netzwerkfehler. Bitte überprüfe deine Verbindung und versuche es erneut."
 
 # smartling.placeholder_format=C
 #. The title of the 'Never' option in the assist settings modal.
@@ -12601,7 +12887,8 @@ msgstr "Keine Ergebnisse gefunden."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the recording contains no audible speech.
 msgid "No speech detected. Please try again and speak into your microphone."
-msgstr "Keine Sprache erkannt. Bitte versuche es erneut und sprich in dein Mikrofon."
+msgstr ""
+"Keine Sprache erkannt. Bitte versuche es erneut und sprich in dein Mikrofon."
 
 # smartling.placeholder_format=C
 #. Button that dismisses a feedback form.
@@ -13251,7 +13538,8 @@ msgstr "%1$sEinstellungen%2$s öffnen"
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open 'Location', and ensure location is %senabled%s."
-msgstr "Öffne „Standort“ und stelle sicher, dass der Standort %1$saktiviert%2$s ist."
+msgstr ""
+"Öffne „Standort“ und stelle sicher, dass der Standort %1$saktiviert%2$s ist."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -13394,7 +13682,8 @@ msgstr "Öffne das Bedienfeld „So funktioniert Duck.ai“"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open the Safari menu and select %sSettings for DuckDuckGo...%s"
-msgstr "Öffne das Safari-Menü und wähle %1$sEinstellungen für DuckDuckGo ...%2$s"
+msgstr ""
+"Öffne das Safari-Menü und wähle %1$sEinstellungen für DuckDuckGo ...%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the time a business opens. For example: 'Opens at 10am'
@@ -13970,8 +14259,8 @@ msgid ""
 msgstr ""
 "Wenn du deine Suche als vollständigen Fragesatz formulierst, ist es "
 "wahrscheinlicher, dass KI-gestützte Antworten automatisch erscheinen, und du "
-"erhältst oft bessere Antworten. Um sie auszuschalten und die "
-"Assist-Schaltfläche auszublenden, besuche die %1$s-Sucheinstellungen%2$s."
+"erhältst oft bessere Antworten. Um sie auszuschalten und die Assist-"
+"Schaltfläche auszublenden, besuche die %1$s-Sucheinstellungen%2$s."
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -13995,8 +14284,8 @@ msgid ""
 msgstr ""
 "Wenn du deine Suche als Frage und in einem vollständigen Satz formulierst, "
 "ist es wahrscheinlicher, dass DuckAssist automatisch erscheint, und du "
-"erhältst oft bessere Antworten. Um die Funktion auszuschalten und die "
-"Assist-Taste auszublenden, besuche die %1$sDuckAssist-Einstellungen%2$s."
+"erhältst oft bessere Antworten. Um die Funktion auszuschalten und die Assist-"
+"Taste auszublenden, besuche die %1$sDuckAssist-Einstellungen%2$s."
 
 # smartling.placeholder_format=C
 #. Button that allows users to manually select a location on a map.
@@ -14151,6 +14440,12 @@ msgstr ""
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
+msgid "Please describe why the chat response is harmful or illegal. (optional)"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
+msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
 msgstr ""
 "Bitte beschreibe, warum die Chat-Antwort illegal oder schädlich ist. "
@@ -14179,6 +14474,14 @@ msgid ""
 msgstr ""
 "Bitte beachte: Wenn du einen neuen Chat mit einem beliebigen Modell "
 "beginnst, wird deine aktuelle Chatsitzung gelöscht."
+
+# smartling.placeholder_format=C
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
+msgctxt "Feedback prompt"
+msgid ""
+"Please paste your prompt and the problematic output (with any personal "
+"information removed) and describe why the content is harmful or illegal."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -14649,6 +14952,12 @@ msgid "Privacy"
 msgstr "Datenschutz"
 
 # smartling.placeholder_format=C
+#. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
+msgctxt "Section heading on the Duck.ai settings page"
+msgid "Privacy & Terms"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Privacy Blog"
 msgstr "Privatsphärenblog"
 
@@ -14717,6 +15026,12 @@ msgstr "Datenschutzerklärung & Nutzungsbedingungen"
 msgctxt "Copy used to compose link in sentences"
 msgid "Privacy Policy and Terms of Service"
 msgstr "Datenschutzerklärung und Nutzungsbedingungen"
+
+# smartling.placeholder_format=C
+#. Text for a button that links to the terms of use and privacy policy page.
+msgctxt "Secondary button text in active privacy modal"
+msgid "Privacy Policy and Terms of Service"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title displayed on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
@@ -15221,6 +15536,30 @@ msgid "Recommend a book"
 msgstr "Empfehle ein Buch"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar books"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar books."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar movies or shows."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar titles"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
 msgid "Recording failed. Please try again."
 msgstr "Aufnahme fehlgeschlagen. Bitte versuche es noch einmal."
@@ -15444,7 +15783,8 @@ msgstr "Meine Auswahl merken"
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings
 msgid "Remember my choice (this can be changed in %s%s%sSettings%s)"
-msgstr "Auswahl merken (kann in den %1$s%2$s%3$sEinstellungen%4$s geändert werden)"
+msgstr ""
+"Auswahl merken (kann in den %1$s%2$s%3$sEinstellungen%4$s geändert werden)"
 
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
@@ -15621,6 +15961,15 @@ msgstr ""
 # smartling.placeholder_format=C
 msgid "Republic of Moldova"
 msgstr "Republik Moldau"
+
+# smartling.placeholder_format=C
+#. Note indicating that sharing the conversation is mandatory when reporting harmful or illegal content. Rendered alongside the standard share label (DUCKCHAT_RESPONSE_FEEDBACK_SHARE_PROMPT_RESPONSE_LABEL), not replacing it.
+msgctxt ""
+"Note shown under the share-content switch label on the Duck.ai response "
+"feedback form when the user has selected Harmful or Illegal as the feedback "
+"reason"
+msgid "Required for harmful or illegal reports"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
@@ -15860,6 +16209,12 @@ msgstr "Rezensionen"
 msgctxt "maps_places"
 msgid "Reviews"
 msgstr "Rezensionen"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Rewrite this recipe scaled for a different number of servings."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Romania"
@@ -16148,8 +16503,8 @@ msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
 msgstr ""
-"Speichere deine Duck.ai-Chats zwischen deinen Geräten mit "
-"Ende-zu-Ende-Verschlüsselung."
+"Speichere deine Duck.ai-Chats zwischen deinen Geräten mit Ende-zu-Ende-"
+"Verschlüsselung."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -16271,7 +16626,8 @@ msgstr "Scrolle herunter und wähle %1$sErweiterte Einstellungen%2$s aus"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down and click %sView advanced settings%s."
-msgstr "Scrolle herunter und klicke auf %1$sErweiterte Einstellungen anzeigen%2$s."
+msgstr ""
+"Scrolle herunter und klicke auf %1$sErweiterte Einstellungen anzeigen%2$s."
 
 #  Edge Legacy default search engine instruction, obsolete?
 # smartling.placeholder_format=C
@@ -16542,8 +16898,8 @@ msgctxt "settings"
 msgid ""
 "Search queries are included in URL (if off, searches will use POST requests)"
 msgstr ""
-"Suchanfragen sind Teil der Adresse (wenn ausgeschaltet, wird die "
-"POST-Methode verwendet)"
+"Suchanfragen sind Teil der Adresse (wenn ausgeschaltet, wird die POST-"
+"Methode verwendet)"
 
 # smartling.placeholder_format=C
 #. Describes how cookies are used to store user settings privately and securely.
@@ -16647,7 +17003,8 @@ msgstr "Saisonwochen"
 #. Description shown in the Sync & Backup settings section when sync is not yet enabled, explaining the feature.
 msgctxt "Description for sync and backup feature"
 msgid "Securely save and sync your chats across all your devices."
-msgstr "Speichere und synchronisiere deine Chats sicher auf all deinen Geräten."
+msgstr ""
+"Speichere und synchronisiere deine Chats sicher auf all deinen Geräten."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -16656,8 +17013,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
 msgstr ""
-"Speichere nahezu unbegrenzt viele Chats sicher auf unserem Server mit "
-"Ende-zu-Ende-Verschlüsselung und greife von all deinen Geräten darauf zu."
+"Speichere nahezu unbegrenzt viele Chats sicher auf unserem Server mit Ende-"
+"zu-Ende-Verschlüsselung und greife von all deinen Geräten darauf zu."
 
 # smartling.placeholder_format=C
 #. Text explaining that the Encrypted Storage feature stores the user's chats encrypted on their device.
@@ -16666,8 +17023,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
 msgstr ""
-"Speichere nahezu unbegrenzt viele Chats sicher auf unserem Server mit "
-"Ende-zu-Ende-Verschlüsselung und greife von all deinen Geräten darauf zu."
+"Speichere nahezu unbegrenzt viele Chats sicher auf unserem Server mit Ende-"
+"zu-Ende-Verschlüsselung und greife von all deinen Geräten darauf zu."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -16676,9 +17033,9 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your synced devices."
 msgstr ""
-"Speichere nahezu unbegrenzt viele Chats sicher auf unserem Server mit "
-"Ende-zu-Ende-Verschlüsselung und greife von all deinen synchronisierten "
-"Geräten darauf zu."
+"Speichere nahezu unbegrenzt viele Chats sicher auf unserem Server mit Ende-"
+"zu-Ende-Verschlüsselung und greife von all deinen synchronisierten Geräten "
+"darauf zu."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -16687,16 +17044,16 @@ msgid ""
 "Securely store your chats on our server using end-to-end encryption, and "
 "access them from all your devices."
 msgstr ""
-"Speichere deine Chats sicher auf unserem Server mit "
-"Ende-zu-Ende-Verschlüsselung und greife von all deinen Geräten darauf zu."
+"Speichere deine Chats sicher auf unserem Server mit Ende-zu-Ende-"
+"Verschlüsselung und greife von all deinen Geräten darauf zu."
 
 # smartling.placeholder_format=C
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
 msgctxt "Sync feature benefit description"
 msgid "Securely stored on DuckDuckGo's server with end-to-end encryption."
 msgstr ""
-"Sicher gespeichert auf dem Server von DuckDuckGo mit "
-"End-to-End-Verschlüsselung."
+"Sicher gespeichert auf dem Server von DuckDuckGo mit End-to-End-"
+"Verschlüsselung."
 
 # smartling.placeholder_format=C
 #. List item explaining that synced chats are stored with end-to-end encryption on DuckDuckGo's server and only the user can access them.
@@ -16705,9 +17062,8 @@ msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
 msgstr ""
-"Sicher gespeichert auf dem Server von DuckDuckGo mit "
-"End-to-End-Verschlüsselung. Niemand außer dir kann deine Daten sehen, nicht "
-"einmal wir."
+"Sicher gespeichert auf dem Server von DuckDuckGo mit End-to-End-"
+"Verschlüsselung. Niemand außer dir kann deine Daten sehen, nicht einmal wir."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -16818,7 +17174,8 @@ msgstr "Entdecke einige unserer neuesten Updates"
 #. Link to a page with more information about how user settings are stored in a URL.
 msgctxt "settings"
 msgid "See the %sURL Parameter Reference page%s for more details."
-msgstr "Mehr Informationen findest du in der %1$sÜbersicht über URL-Parameter%2$s."
+msgstr ""
+"Mehr Informationen findest du in der %1$sÜbersicht über URL-Parameter%2$s."
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the context menu of a chat in chat history, that allows the user to select the chat and begin batch selection mode.
@@ -16845,7 +17202,8 @@ msgstr "%1$s%2$s%3$s auswählen, dann %4$sSuchmaschine%5$s"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %s'Setting for this Website...'%s from the Safari menu."
-msgstr "Wähle %1$s„Einstellung für diese Website …“%2$s aus dem Safari-Menü aus."
+msgstr ""
+"Wähle %1$s„Einstellung für diese Website …“%2$s aus dem Safari-Menü aus."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -16871,13 +17229,15 @@ msgstr "Wähle %1$sDuckDuckGo%2$s und klicke auf %3$sAls Standard festlegen%4$s"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s."
-msgstr "Wähle %1$sDuckDuckGo%2$s und klicke auf %3$sAls Standard festlegen%4$s."
+msgstr ""
+"Wähle %1$sDuckDuckGo%2$s und klicke auf %3$sAls Standard festlegen%4$s."
 
 #  Firefox 33
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Select %sDuckDuckGo%s in the Default Search Engine drop down"
-msgstr "Im Dropdown-Menü für die Standardsuchmaschine %1$sDuckDuckGo%2$s auswählen"
+msgstr ""
+"Im Dropdown-Menü für die Standardsuchmaschine %1$sDuckDuckGo%2$s auswählen"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
@@ -17202,6 +17562,12 @@ msgid "Set Up Now"
 msgstr "Jetzt einrichten"
 
 # smartling.placeholder_format=C
+#. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
+msgctxt "Encrypted storage setup button shown in native browsers"
+msgid "Set Up Sync & Backup"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
 msgctxt "Title for the Sync & Backup intro screen"
 msgid "Set Up Sync & Backup"
@@ -17293,7 +17659,8 @@ msgstr "Teilen"
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "Share DuckDuckGo and help friends take their privacy back!"
-msgstr "Teile DuckDuckGo und hilf deinen Freunden, ihre Privatsphäre zurück zu holen!"
+msgstr ""
+"Teile DuckDuckGo und hilf deinen Freunden, ihre Privatsphäre zurück zu holen!"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button that opens a feedback modal when clicked.
@@ -17321,8 +17688,8 @@ msgid ""
 "never reveals your precise location to us or AI models."
 msgstr ""
 "Teile den Standort in Form der Stadt mit KI-Modellen, um die Relevanz zu "
-"verbessern. Duck.ai gibt niemals deinen genauen Standort an uns oder "
-"KI-Modelle weiter."
+"verbessern. Duck.ai gibt niemals deinen genauen Standort an uns oder KI-"
+"Modelle weiter."
 
 # smartling.placeholder_format=C
 #. Menu option to share feedback about a result
@@ -17381,6 +17748,13 @@ msgstr "Seiten-URL teilen"
 msgctxt "feedback form"
 msgid "Share positive feedback"
 msgstr "Positives Feedback teilen"
+
+# smartling.placeholder_format=C
+#. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
+msgctxt ""
+"Label beside the share-content switch on the Duck.ai response feedback form"
+msgid "Share this conversation with DuckDuckGo"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -17519,7 +17893,8 @@ msgstr "DuckAssist <sup>BETA</sup>"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show DuckAssist more often. (You can also completely %sturn it off%s.)"
-msgstr "DuckAssist öfter anzeigen. (Du kannst es auch %1$skomplett ausschalten%2$s.)"
+msgstr ""
+"DuckAssist öfter anzeigen. (Du kannst es auch %1$skomplett ausschalten%2$s.)"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
@@ -17840,7 +18215,8 @@ msgstr "Begrüßung oben auf der Suchergebnisseite anzeigen"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message to EU Android preference menu users"
-msgstr "Begrüßung für Benutzer des Android-Einstellungsmenüs in der EU wird angezeigt"
+msgstr ""
+"Begrüßung für Benutzer des Android-Einstellungsmenüs in der EU wird angezeigt"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers sometimes.
@@ -17919,7 +18295,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Sites you block will be hidden from all your search results"
-msgstr "Von dir blockierte Websites werden in all deinen Suchergebnissen ausgeblendet"
+msgstr ""
+"Von dir blockierte Websites werden in all deinen Suchergebnissen ausgeblendet"
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes full name (tooltip)
@@ -18119,7 +18496,8 @@ msgstr "Entschuldigung, ein unerwarteter Fehler ist aufgetreten."
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
 msgid "Sorry, no relevant information was found in our search."
-msgstr "Leider wurden bei unserer Suche keine relevanten Informationen gefunden."
+msgstr ""
+"Leider wurden bei unserer Suche keine relevanten Informationen gefunden."
 
 # smartling.placeholder_format=C
 #. Indicates that there were no search results for a user's search.
@@ -18389,7 +18767,8 @@ msgstr "Beginne mit einem Bild"
 #. Warning that starting fresh deletes conversations.
 msgctxt "duckai_migration"
 msgid "Starting fresh will delete all your past conversations."
-msgstr "Wenn du neu anfängst, werden alle deine bisherigen Unterhaltungen gelöscht."
+msgstr ""
+"Wenn du neu anfängst, werden alle deine bisherigen Unterhaltungen gelöscht."
 
 # smartling.placeholder_format=C
 #. Footnote warning that starting fresh deletes conversations.
@@ -18426,8 +18805,8 @@ msgstr "Bleib auf DuckDuckGo"
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletter."
 msgstr ""
-"Bleibe gut geschützt und gut informiert – mit unseren "
-"Privatsphäre-Newslettern."
+"Bleibe gut geschützt und gut informiert – mit unseren Privatsphäre-"
+"Newslettern."
 
 # smartling.placeholder_format=C
 #. Prompt to subscribe to a newsletter.
@@ -18482,7 +18861,8 @@ msgstr "Versteckte Tracker stoppen, die auf anderen Websites lauern."
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop most hidden trackers lurking on other websites."
-msgstr "Stoppe die meisten versteckten Tracker, die auf anderen Websites lauern."
+msgstr ""
+"Stoppe die meisten versteckten Tracker, die auf anderen Websites lauern."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18652,6 +19032,24 @@ msgid "Suggest a title for a blog post"
 msgstr "Schlage Titel für einen Blog-Artikel vor"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest related articles or topics worth exploring next."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Suggest related articles to explore"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest some alternatives to this product."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
 msgctxt "directions"
 msgid "Suggestions:"
@@ -18663,10 +19061,100 @@ msgid "Suggestions:"
 msgstr "Vorschläge:"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Sum up the reviews"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A short title for the a message asking the AI to summarize a text.
 msgctxt "Title for the summarize message"
 msgid "Summarize"
 msgstr "Zusammenfassen"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize the Q&As"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the background and notable work of this person."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the key details of this event."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the questions and answers on this page."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize their background"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this book"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this book."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this discussion"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this discussion thread."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this page"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this page."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this video"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this video."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize what the reviews say."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -18997,6 +19485,12 @@ msgid "Syria"
 msgstr "Syrien"
 
 # smartling.placeholder_format=C
+#. Text for a button that enables the theme to follow the operating system's color scheme preference.
+msgctxt "System theme button for theme selector"
+msgid "System"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Abbreviation indicating this is the total score for a game
 msgctxt "Sports module"
 msgid "T"
@@ -19023,6 +19517,12 @@ msgstr "TV"
 msgctxt "language_name"
 msgid "Tahitian"
 msgstr "Tahitianisch"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Tailor my resume"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Taiwan"
@@ -19052,6 +19552,13 @@ msgstr "Übernimm die Kontrolle über deine personenbezogenen Daten"
 msgctxt "homepage ATB modal"
 msgid "Take control of your personal data!"
 msgstr "Übernimm die Kontrolle über deine personenbezogenen Daten!"
+
+# smartling.placeholder_format=C
+#. Description for the Feedback section of the Duck.ai settings page, asking the user to take an anonymous survey to let us know how we can make Duck.ai better.
+msgctxt "Feedback section description on the Duck.ai settings page"
+msgid ""
+"Take this anonymous survey to let us know how we can make Duck.ai better."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -19295,7 +19802,8 @@ msgstr "Die angehängten Dateien überschreiten die Größenbegrenzung von %1$s 
 #. Error message displayed when the total size of all attached files in a conversation exceeds the allowed limit. Placeholder is the combined size limit in megabytes. E.g. The attached files exceed the total size limit of 5 MB
 msgctxt "Error message when combined file size exceeds the limit"
 msgid "The attached files exceed the total size limit of %s MB."
-msgstr "Die angehängten Dateien überschreiten die Größenbegrenzung von %1$s MB."
+msgstr ""
+"Die angehängten Dateien überschreiten die Größenbegrenzung von %1$s MB."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the server rejects corrupt or unrecognized audio.
@@ -19327,7 +19835,8 @@ msgstr ""
 #. Description explaining that the AI model provider does not store any chat data on their servers.
 msgctxt "Privacy claim description in Duck.ai chat"
 msgid "The model provider does not save this chat on their servers."
-msgstr "Der Anbieter des Modells speichert diesen Chat nicht auf seinen Servern."
+msgstr ""
+"Der Anbieter des Modells speichert diesen Chat nicht auf seinen Servern."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers.
@@ -19362,6 +19871,12 @@ msgstr ""
 #. https://duck.co/media/files/theme.png
 msgid "Theme"
 msgstr "Theme"
+
+# smartling.placeholder_format=C
+#. Text for the theme selector label that allows users to switch between Light and dark theme.
+msgctxt "Label for the theme selector feature"
+msgid "Theme"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/LpFhb1e.png
@@ -19488,7 +20003,8 @@ msgstr ""
 #. Appears below a type of search results called 'Instant Answers'
 msgctxt "attribution"
 msgid "This Instant Answer was made by the %sDuckDuckHack%s Community."
-msgstr "Diese Sofort-Antwort wurde von der %1$sDuckDuckHack%2$s-Community erstellt."
+msgstr ""
+"Diese Sofort-Antwort wurde von der %1$sDuckDuckHack%2$s-Community erstellt."
 
 # smartling.placeholder_format=C
 #. Label for the monthly usage row in the Usage section of Duck.ai settings.
@@ -19509,8 +20025,8 @@ msgid ""
 "This conversation was generated with Duck.ai (%s) using %s's %s Model. AI "
 "chats may display inaccurate or offensive information (see %s for more info)."
 msgstr ""
-"Diese Konversation wurde mit Duck.ai (%1$s) unter Verwendung des "
-"%3$s-Modells von %2$s generiert. KI-Chats zeigen möglicherweise falsche oder "
+"Diese Konversation wurde mit Duck.ai (%1$s) unter Verwendung des %3$s-"
+"Modells von %2$s generiert. KI-Chats zeigen möglicherweise falsche oder "
 "anstößige Informationen an (weitere Informationen siehe %4$s)."
 
 # smartling.placeholder_format=C
@@ -19714,8 +20230,8 @@ msgid ""
 "com browser data, then you may see AI-assisted answers again."
 msgstr ""
 "Diese Einstellung wird in deinem Browser gespeichert. Das heißt, wenn du die "
-"Browserdaten von duckduckgo.com löschst, siehst du möglicherweise wieder "
-"KI-gestützte Antworten."
+"Browserdaten von duckduckgo.com löschst, siehst du möglicherweise wieder KI-"
+"gestützte Antworten."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -19726,9 +20242,9 @@ msgid ""
 "also have a start page that never shows AI-assisted answers at %s."
 msgstr ""
 "Diese Einstellung wird in deinem Browser gespeichert. Das heißt, wenn du die "
-"Browserdaten von duckduckgo.com löschst, siehst du möglicherweise wieder "
-"KI-gestützte Antworten. Allerdings haben wir auch eine Startseite unter "
-"%1$s, auf der niemals KI-gestützte Antworten angezeigt werden."
+"Browserdaten von duckduckgo.com löschst, siehst du möglicherweise wieder KI-"
+"gestützte Antworten. Allerdings haben wir auch eine Startseite unter %1$s, "
+"auf der niemals KI-gestützte Antworten angezeigt werden."
 
 # smartling.placeholder_format=C
 #. User feedback indicating that a translation is helpful
@@ -19759,7 +20275,8 @@ msgstr ""
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr "Diese Webseite verwendet keine sichere, verschlüsselte Verbindung (HTTPS)."
+msgstr ""
+"Diese Webseite verwendet keine sichere, verschlüsselte Verbindung (HTTPS)."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -19877,7 +20394,8 @@ msgstr "Tipps"
 
 # smartling.placeholder_format=C
 msgid "Tired of being tracked online? %sWe can help.%s"
-msgstr "Du bist es leid, online getrackt zu werden? %1$sWir schaffen Abhilfe.%2$s"
+msgstr ""
+"Du bist es leid, online getrackt zu werden? %1$sWir schaffen Abhilfe.%2$s"
 
 # smartling.placeholder_format=C
 #. This is the name of a user setting
@@ -20214,6 +20732,18 @@ msgstr ""
 "Kino?“"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Translate this page"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
+msgctxt "Page suggestion prompt"
+msgid "Translate this page into %s."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text for a region that will display translated text.
 msgctxt "translations_module"
 msgid "Translation"
@@ -20313,7 +20843,8 @@ msgstr "Versuche, %1$s, um solche Nachrichten nicht mehr zu sehen."
 #. Text for a promotional card that encourages users to try the encrypted AI model whose inference runs in a confidential environment so the model provider cannot access user data. %s is replaced with the model's full display name (e.g. 'GPT-OSS 120B').
 msgctxt "Promotional text for encrypted AI model"
 msgid "Try %s, our first model with zero provider visibility."
-msgstr "Probiere %1$s, unser erstes Modell ohne Sichtbarkeit auf Anbieterseite."
+msgstr ""
+"Probiere %1$s, unser erstes Modell ohne Sichtbarkeit auf Anbieterseite."
 
 # smartling.placeholder_format=C
 msgid "Try %sDuck.ai%s, our private AI chat service:"
@@ -20353,6 +20884,12 @@ msgstr "Erneut versuchen"
 msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
 msgstr "Kostenlos testen"
+
+# smartling.placeholder_format=C
+#. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
+msgctxt "settings"
+msgid "Try It Now"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -20455,7 +20992,8 @@ msgstr "Gratis testen"
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
-msgstr "Kostenlos testen! Ein sicheres VPN, fortschrittliche und private KI und mehr."
+msgstr ""
+"Kostenlos testen! Ein sicheres VPN, fortschrittliche und private KI und mehr."
 
 # smartling.placeholder_format=C
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -20505,7 +21043,8 @@ msgstr "Versuche deinen Standort manuell einzustellen."
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Try the %sDuckDuckGo Browser.%s Fast. Free. Private."
-msgstr "Probiere den %1$sDuckDuckGo-Browser aus.%2$s Schnell. Kostenlos. Privat."
+msgstr ""
+"Probiere den %1$sDuckDuckGo-Browser aus.%2$s Schnell. Kostenlos. Privat."
 
 # smartling.placeholder_format=C
 #. Link to a page where users can download the DuckDuckGo Browser for iOS or Android.
@@ -20551,7 +21090,8 @@ msgstr "Probiere den neuen privaten Echtzeit-Sprachchat aus!"
 #. Text for a promotional card that encourages users to try the recently added open-source AI models. The placeholders are the names of AI models like 'Try the recently added open-source Llama 3.1 and Mistral.'
 msgctxt "Promotional text for new AI models"
 msgid "Try the recently added open-source %s and %s"
-msgstr "Probier die kürzlich hinzugefügten Open-Source-Versionen %1$s und %2$s aus"
+msgstr ""
+"Probier die kürzlich hinzugefügten Open-Source-Versionen %1$s und %2$s aus"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that encourages users to try the recently added open-source AI models Llama 3.1 and Mixtral.
@@ -20575,7 +21115,8 @@ msgctxt ""
 "Description shown when a chat search in Duck.ai returns no matching chats, "
 "suggesting the user rephrase their query"
 msgid "Try using a different search term or phrase."
-msgstr "Versuche, einen anderen Suchbegriff oder eine andere Suchphrase zu verwenden."
+msgstr ""
+"Versuche, einen anderen Suchbegriff oder eine andere Suchphrase zu verwenden."
 
 # smartling.placeholder_format=C
 #. In the context of an AI Chat, text prompting the user to try their prompt with a different AI model.
@@ -20593,6 +21134,22 @@ msgstr "Versuche: %1$s"
 msgctxt "new user poll"
 msgid "Trying DuckDuckGo again"
 msgstr "DuckDuckGo nochmal ausprobieren"
+
+# smartling.placeholder_format=C
+#. Message shown in a modal after supported third-party browser users disable AI features in Settings. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -20694,7 +21251,8 @@ msgstr "Abschalten:"
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on %sPrecise Location%s for more accurate results"
-msgstr "Aktiviere %1$sPräziser Standort%2$s, um genauere Ergebnisse zu erhalten"
+msgstr ""
+"Aktiviere %1$sPräziser Standort%2$s, um genauere Ergebnisse zu erhalten"
 
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
@@ -20711,7 +21269,8 @@ msgstr "Aktiviere „Präziser Standort“, um genauere Ergebnisse zu erhalten."
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on “Use precise location” for more accurate results."
-msgstr "Aktiviere „Präzisen Standort verwenden“, um genauere Ergebnisse zu erhalten."
+msgstr ""
+"Aktiviere „Präzisen Standort verwenden“, um genauere Ergebnisse zu erhalten."
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Create Image' label in the Tools dropdown.
@@ -20908,8 +21467,8 @@ msgstr ""
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
 msgstr ""
-"Unter %1$sEinstellungen%2$s > Allgemein > %3$sStartseite%4$s "
-"https://duckduckgo.com eingeben"
+"Unter %1$sEinstellungen%2$s > Allgemein > %3$sStartseite%4$s https://"
+"duckduckgo.com eingeben"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -20941,7 +21500,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
-msgstr "Im Bereich %1$sSuchen%2$s bitte %3$sSuchmaschinen verwalten …%4$s anklicken"
+msgstr ""
+"Im Bereich %1$sSuchen%2$s bitte %3$sSuchmaschinen verwalten …%4$s anklicken"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -21058,8 +21618,8 @@ msgctxt "voice chat limit modal"
 msgid ""
 "Unlock advanced AI models and higher limits with a DuckDuckGo Subscription"
 msgstr ""
-"Schalte fortschrittliche KI-Modelle und höhere Limits mit einem "
-"DuckDuckGo-Abo frei"
+"Schalte fortschrittliche KI-Modelle und höhere Limits mit einem DuckDuckGo-"
+"Abo frei"
 
 # smartling.placeholder_format=C
 #. Text informing the user that advanced AI models can be unlocked with a subscription. The variable is used to insert a link that opens the subscription modal. Example: Unlock advanced AI models with a DuckDuckGo subscription.
@@ -21092,7 +21652,8 @@ msgctxt ""
 "Text shown in the subscription promo card, with a trailing call-to-action "
 "link."
 msgid "Unlock more capable AI models with a DuckDuckGo subscription. %s"
-msgstr "Schalte leistungsfähigere KI-Modelle mit einem DuckDuckGo-Abo frei. %1$s"
+msgstr ""
+"Schalte leistungsfähigere KI-Modelle mit einem DuckDuckGo-Abo frei. %1$s"
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to unmute the microphone.
@@ -21358,6 +21919,12 @@ msgid "Uruguay"
 msgstr "Uruguay"
 
 # smartling.placeholder_format=C
+#. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
+msgctxt "Navigation label on the Duck.ai settings page"
+msgid "Usage"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A feedback suggestion
 msgctxt "Feedback prompt"
 msgid "Usage limit"
@@ -21452,7 +22019,8 @@ msgstr ""
 #. Prompt to ask the user if they want to use their approximate location for more accurate results
 msgctxt "DuckChat location prompt"
 msgid "Use your approximate location for more accurate results?"
-msgstr "Verwende deinen ungefähren Standort, um genauere Ergebnisse zu erhalten?"
+msgstr ""
+"Verwende deinen ungefähren Standort, um genauere Ergebnisse zu erhalten?"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes before every user message in the downloaded file, indicating which message it is out of the total number of messages. Example: 'User prompt 3 of 5'
@@ -21753,8 +22321,8 @@ msgstr "Sprachchat beendet"
 msgctxt "voice chat"
 msgid "Voice chat is anonymized by us, and never used to train AI models."
 msgstr ""
-"Der Sprachchat wird von uns anonymisiert und niemals zum Trainieren von "
-"KI-Modellen verwendet."
+"Der Sprachchat wird von uns anonymisiert und niemals zum Trainieren von KI-"
+"Modellen verwendet."
 
 # smartling.placeholder_format=C
 #. Title of the modal shown when the user has reached their daily voice chat limit.
@@ -21813,6 +22381,12 @@ msgstr "Warten auf Standort ..."
 # smartling.placeholder_format=C
 msgid "Wales"
 msgstr "Wales"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Walk me through the steps"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for walking directions on a map.
@@ -21893,8 +22467,8 @@ msgid ""
 "viewing activity from influencing YouTube recommendations."
 msgstr ""
 "Benutze den Duck Player, um personalisierte Werbung auf YouTube zu "
-"blockieren und zu verhindern, dass deine Aktivitäten die "
-"YouTube-Empfehlungen beeinflussen."
+"blockieren und zu verhindern, dass deine Aktivitäten die YouTube-"
+"Empfehlungen beeinflussen."
 
 # smartling.placeholder_format=C
 #. A button that takes a user to another site in order to watch a video. The placeholder is the name of the video site. For example: 'Watch on Vimeo'
@@ -21932,6 +22506,17 @@ msgid "We can anonymize%s your location%s to show you more accurate results."
 msgstr ""
 "Wir können%1$s deinen Standort%2$s anonymisieren, um dir genauere Ergebnisse "
 "anzuzeigen."
+
+# smartling.placeholder_format=C
+#. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
+msgctxt ""
+"Inline warning shown below the share-content toggle when the user selects "
+"Harmful or Illegal but has not enabled sharing"
+msgid ""
+"We can only fix what we can see. To report a harmful or illegal response, "
+"please share this conversation with DuckDuckGo so we can investigate and "
+"address the issue."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -22027,7 +22612,8 @@ msgstr "Wir tracken dich nicht. Niemals."
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with a Continue button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don't track you. That's our Privacy Policy in a nutshell."
-msgstr "Wir tracken dich nicht. Das ist unsere Datenschutzerklärung in Kurzform."
+msgstr ""
+"Wir tracken dich nicht. Das ist unsere Datenschutzerklärung in Kurzform."
 
 # smartling.placeholder_format=C
 #. Description for the audio identification highlight in the dictation consent modal.
@@ -22068,7 +22654,8 @@ msgstr "Wir tracken dich nicht, ob im privaten oder normalen Modus."
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with an Agree button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don’t track you. That’s our Privacy Policy in a nutshell…"
-msgstr "Wir tracken dich nicht. Das ist unsere Datenschutzerklärung in Kurzform …"
+msgstr ""
+"Wir tracken dich nicht. Das ist unsere Datenschutzerklärung in Kurzform …"
 
 # smartling.placeholder_format=C
 #. Displayed when the user's voice chat session is ended because of being inactive for too long.
@@ -22098,7 +22685,8 @@ msgstr "Wir halten deinen Suchverlauf privat"
 #. Displayed when the voice chat connection is lost and the session ends.
 msgctxt "voice chat error"
 msgid "We lost the connection, please try again later."
-msgstr "Die Verbindung wurde unterbrochen. Bitte versuche es später noch einmal."
+msgstr ""
+"Die Verbindung wurde unterbrochen. Bitte versuche es später noch einmal."
 
 # smartling.placeholder_format=C
 #. We store chats for 15 minutes in the BE. If the user tries to fetch it after the 15 minutes elapsed or if we had an issue saving it we show them this error message so they can re-submit their prompt.
@@ -22139,7 +22727,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We stop anyone from getting your search history, including us."
-msgstr "Wir verhindern, dass jemand deinen Suchverlauf erhält, einschließlich uns."
+msgstr ""
+"Wir verhindern, dass jemand deinen Suchverlauf erhält, einschließlich uns."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -22488,11 +23077,108 @@ msgid ""
 "experience."
 msgstr ""
 "Welche Vorteile bietet das Herunterladen des DuckDuckGo-Browsers für "
-"jemanden, der Duck.ai nutzen möchte? Beziehe nur offizielle "
-"DuckDuckGo-Quellen ein. Teile die Antwort in übersichtliche Abschnitte mit "
-"Titeln auf, wobei der Schwerpunkt auf den Integrationen von Duck.ai und dem "
-"Datenschutz liegt. Halte es sehr kurz, einfach und leicht verständlich für "
-"Menschen mit oder ohne viel KI- oder technische Erfahrung."
+"jemanden, der Duck.ai nutzen möchte? Beziehe nur offizielle DuckDuckGo-"
+"Quellen ein. Teile die Antwort in übersichtliche Abschnitte mit Titeln auf, "
+"wobei der Schwerpunkt auf den Integrationen von Duck.ai und dem Datenschutz "
+"liegt. Halte es sehr kurz, einfach und leicht verständlich für Menschen mit "
+"oder ohne viel KI- oder technische Erfahrung."
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the counterarguments?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the hours & location?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key contributions of this paper?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key contributions?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key details?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key points covered in this video?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key points?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key takeaways from this article?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key takeaways?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key things I will learn from this course?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main counterarguments or criticisms of this?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main questions this page answers?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the must-try dishes here?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"What are the opening hours, location, and contact details for this place?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the pros and cons of this product?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the pros and cons?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
@@ -22595,6 +23281,12 @@ msgid "What does atria mean in the context of a medical article?"
 msgstr "Was bedeutet Atrien im Kontext eines medizinischen Artikels?"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What does this answer?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
@@ -22605,6 +23297,12 @@ msgstr "Welche Funktion möchtest du, dass wir hinzufügen? (optional)"
 msgctxt "cloudsave"
 msgid "What information gets saved?"
 msgstr "Welche Daten werden gespeichert?"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What interview questions might come up for this role?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -22621,6 +23319,12 @@ msgstr ""
 msgctxt "Full sentence for looking up basic facts"
 msgid "What is the capital city of Albania?"
 msgstr "Was ist die Hauptstadt von Albanien?"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What is the overall verdict and rating for this?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to a page with additional information.
@@ -22645,6 +23349,12 @@ msgid "What people say:"
 msgstr "Was andere darüber sagen:"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What should I order?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
 msgctxt "feedback form"
 msgid "What stood out?"
@@ -22655,6 +23365,18 @@ msgstr "Was fiel besonders auf?"
 msgctxt "feedback form"
 msgid "What was wrong with the response? (optional)"
 msgstr "Was war falsch an der Antwort? (optional)"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I learn?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I need?"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -22674,6 +23396,12 @@ msgstr ""
 msgctxt "SERP footer content"
 msgid "What's New"
 msgstr "Was gibt's Neues?"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What's the verdict?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -22728,6 +23456,12 @@ msgid "Which features are missing? (Optional)"
 msgstr "Welche Funktionen fehlen dir? Optional"
 
 # smartling.placeholder_format=C
+#. An invitation for users to leave feedback
+msgctxt "Feedback prompt"
+msgid "Which features are missing? (optional)"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
 msgid "White"
 msgstr "Weiß"
@@ -22742,6 +23476,18 @@ msgstr "Weiß"
 #. Link to an about us page.
 msgid "Who We Are"
 msgstr "Wer wir sind"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Who are the main cast and crew, and what else are they known for?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Who is this person?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Header above a collection of privacy-related links.
@@ -23484,7 +24230,8 @@ msgstr "Du hast das Limit für die Erstellung von Bildern erreicht."
 #. Title shown when a user has reached their image generation edit limit.
 msgctxt "Title for image generation edit limit reached message"
 msgid "You've reached the maximum number of edits for this image"
-msgstr "Du hast die maximale Anzahl von Bearbeitungen für dieses Bild erreicht."
+msgstr ""
+"Du hast die maximale Anzahl von Bearbeitungen für dieses Bild erreicht."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum number of messages for a given moment, and should try again later when they might be able to send more messages again.
@@ -23791,7 +24538,8 @@ msgctxt ""
 "Subtitle of the one-time popover shown above the thumbs up/down buttons on "
 "an AI response"
 msgid "Your feedback is anonymized and not used to train AI."
-msgstr "Dein Feedback wird anonymisiert und nicht zum Training der KI verwendet."
+msgstr ""
+"Dein Feedback wird anonymisiert und nicht zum Training der KI verwendet."
 
 # smartling.placeholder_format=C
 #. Explains that the User's Location is always private to DuckDuckGo.
@@ -23885,7 +24633,8 @@ msgstr "Deine Suchanfragen können nicht auf dich zurückgeführt werden"
 #. Confirms the recovery succeeded. The Next CTA closes the sheet.
 msgctxt "Body copy on the recover-data success sheet"
 msgid "Your synced chats are being restored to this device."
-msgstr "Deine synchronisierten Chats werden auf diesem Gerät wiederhergestellt."
+msgstr ""
+"Deine synchronisierten Chats werden auf diesem Gerät wiederhergestellt."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"

--- a/locales/de_DE/LC_MESSAGES/duckduckgo.po
+++ b/locales/de_DE/LC_MESSAGES/duckduckgo.po
@@ -19481,7 +19481,7 @@ msgstr "Syrien"
 #. Text for a button that enables the theme to follow the operating system's color scheme preference.
 msgctxt "System theme button for theme selector"
 msgid "System"
-msgstr "Standard"
+msgstr "System"
 
 # smartling.placeholder_format=C
 #. Abbreviation indicating this is the total score for a game

--- a/locales/el_GR/LC_MESSAGES/duckduckgo.po
+++ b/locales/el_GR/LC_MESSAGES/duckduckgo.po
@@ -1686,7 +1686,7 @@ msgid ""
 "to train chat models by DuckDuckGo or the model providers"
 msgstr ""
 "Όλες οι συνομιλίες σας ανωνυμοποιούνται από το DuckDuckGo και οι συζητήσεις "
-"σας δεν χρησιμοποιούνται την εκπαίδευση μοντέλων συνομιλίας από το "
+"σας δεν χρησιμοποιούνται για την εκπαίδευση μοντέλων συνομιλίας από το "
 "DuckDuckGo ή τους παρόχους μοντέλων"
 
 # smartling.placeholder_format=C
@@ -6576,8 +6576,7 @@ msgid ""
 msgstr ""
 "Το Duck.ai δημιουργήθηκε από το DuckDuckGo. Είμαστε μια ανεξάρτητη εταιρεία "
 "διαδικτυακής προστασίας για οποιονδήποτε επιθυμεί να ανακτήσει τον έλεγχο "
-"των προσωπικών πληροφοριών του.\n"
-"\n"
+"των προσωπικών πληροφοριών του."
 
 # smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.

--- a/locales/el_GR/LC_MESSAGES/duckduckgo.po
+++ b/locales/el_GR/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: el_GR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -102,8 +102,7 @@ msgstr "%1$s απόπειρες"
 # smartling.placeholder_format=C
 #. A summary description of how many tracking attempts where blocked, when there was more than 1. Eg: '1,028 attempts blocked by DuckDuckGo in the last 24 hours'
 msgid "%s attempts blocked by DuckDuckGo in the last 24 hours"
-msgstr ""
-"Αποκλείστηκαν %1$s προσπάθειες από το DuckDuckGo κατά τις τελευταίες 24 ώρες"
+msgstr "Αποκλείστηκαν %1$s προσπάθειες από το DuckDuckGo κατά τις τελευταίες 24 ώρες"
 
 # smartling.placeholder_format=C
 #. A label that indicates a specific search result has been blocked by the safe search filter. The placeholder value is the name of the search result that was blocked.
@@ -506,8 +505,7 @@ msgstr ""
 #. A message displayed when there is an error loading content or no results on requery
 msgctxt "Error or no results message"
 msgid "%sOops!%s%sSomething went wrong. Please %srefresh%s and try again."
-msgstr ""
-"%1$sΚρίμα!%2$s%3$sΚάτι πήγε λάθος. %4$sΑνανεώστε%5$s και προσπαθήστε ξανά."
+msgstr "%1$sΚρίμα!%2$s%3$sΚάτι πήγε λάθος. %4$sΑνανεώστε%5$s και προσπαθήστε ξανά."
 
 # smartling.placeholder_format=C
 #. Tagline in a popover encouraging the user to download the DuckDuckGo browser
@@ -597,8 +595,7 @@ msgstr "1 προσπάθεια"
 # smartling.placeholder_format=C
 #. A summary description of how many tracking attempts where blocked, when only one exists.
 msgid "1 attempt blocked by DuckDuckGo in the last 24 hours"
-msgstr ""
-"Αποκλείστηκε 1 προσπάθεια από το DuckDuckGo κατά τις τελευταίες 24 ώρες"
+msgstr "Αποκλείστηκε 1 προσπάθεια από το DuckDuckGo κατά τις τελευταίες 24 ώρες"
 
 # smartling.placeholder_format=C
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -986,8 +983,7 @@ msgstr ""
 #. Disclaimer text displayed at the bottom of the voice chat dialog informing the user that the AI (Artificial Intelligence) may provide inaccurate or offensive information.
 msgctxt "voice chat"
 msgid "AI may provide inaccurate or offensive information."
-msgstr ""
-"Η τεχνητή νοημοσύνη μπορεί να παρέχει ανακριβείς ή προσβλητικές πληροφορίες."
+msgstr "Η τεχνητή νοημοσύνη μπορεί να παρέχει ανακριβείς ή προσβλητικές πληροφορίες."
 
 # smartling.placeholder_format=C
 #. Label for the input field where user can specify how the AI assistant should refer to itself. Example: 'AI nickname (is): Fred'
@@ -1467,7 +1463,7 @@ msgstr "Η διεύθυνση είναι λάθος"
 #. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Adjust the servings"
-msgstr ""
+msgstr "Προσαρμόστε τις μερίδες"
 
 # smartling.placeholder_format=C
 #. as in multiple advertisements
@@ -1674,8 +1670,7 @@ msgstr "Όλες οι συνομιλίες είναι %1$s"
 #. Disclaimer text shown below chat input. %s is replaced with a clickable underlined 'private' link that opens the privacy protection modal.
 msgctxt "Disclaimer below chat input in Duck.ai"
 msgid "All chats are %s. AI can make mistakes."
-msgstr ""
-"Όλες οι συνομιλίες είναι %1$s. Η τεχνητή νοημοσύνη μπορεί να κάνει λάθη."
+msgstr "Όλες οι συνομιλίες είναι %1$s. Η τεχνητή νοημοσύνη μπορεί να κάνει λάθη."
 
 # smartling.placeholder_format=C
 #. Heading shown on the empty chat screen. The text between the two %s markers is displayed inside a clickable privacy button. First %s renders a shield icon, second %s is an invisible end marker. Keep the word 'private' between both %s markers.
@@ -1690,6 +1685,9 @@ msgid ""
 "All chats are anonymized by DuckDuckGo, and your conversations are not used "
 "to train chat models by DuckDuckGo or the model providers"
 msgstr ""
+"Όλες οι συνομιλίες σας ανωνυμοποιούνται από το DuckDuckGo και οι συζητήσεις "
+"σας δεν χρησιμοποιούνται την εκπαίδευση μοντέλων συνομιλίας από το "
+"DuckDuckGo ή τους παρόχους μοντέλων"
 
 # smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1970,6 +1968,9 @@ msgid ""
 "Anonymously generates answers for search queries based on web content. "
 "Choose how often you want it to appear, or disable it completely."
 msgstr ""
+"Δημιουργεί ανώνυμα απαντήσεις για ερωτήματα αναζήτησης με βάση το "
+"περιεχόμενο του διαδικτύου. Επιλέξτε πόσο συχνά θέλετε να εμφανίζεται ή "
+"απενεργοποιήστε το εντελώς."
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -2124,8 +2125,7 @@ msgstr ""
 #. Body text of the modal that asks the user if they want to clear the conversation.
 msgctxt "Modal body for clearing conversation"
 msgid "Are you sure you want to clear this conversation and start a new one?"
-msgstr ""
-"Θέλετε σίγουρα να διαγράψετε τη συνομιλία αυτή και να αρχίσετε μια νέα;"
+msgstr "Θέλετε σίγουρα να διαγράψετε τη συνομιλία αυτή και να αρχίσετε μια νέα;"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to delete their current chat, explaining that this action cannot be undone.
@@ -2260,7 +2260,7 @@ msgstr "Ζητήστε συμπληρωματική ερώτηση από το D
 #. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
 msgctxt "Page suggestion chip label"
 msgid "Ask about this page"
-msgstr ""
+msgstr "Ρωτήστε γι' αυτήν τη σελίδα"
 
 # smartling.placeholder_format=C
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2693,7 +2693,7 @@ msgstr "Γραμμοκώδικας"
 #. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Based on this page, is this course worth taking?"
-msgstr ""
+msgstr "Με βάση αυτήν τη σελίδα, αξίζει να παρακολουθήσω αυτήν τη σειρά μαθημάτων;"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2742,6 +2742,9 @@ msgid ""
 "Before storing this report, DuckDuckGo will anonymize your conversation by "
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
+"Πριν από την αποθήκευση αυτής της αναφοράς, το DuckDuckGo θα ανωνυμοποιήσει "
+"τη συνομιλία σου αφαιρώντας προσωπικά δεδομένα (PII), όπως ονόματα, "
+"διευθύνσεις email και μεταδεδομένα ταυτοποίησης."
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -2862,14 +2865,12 @@ msgstr "Αποκλεισμός ενοχλητικών αναδυόμενων π�
 #. DuckDuckGo Email Protection offers the ability to generate random email addresses to protect your personal email address
 msgctxt "SERP footer content"
 msgid "Block email trackers and hide your address."
-msgstr ""
-"Αποκλείστε εφαρμογές παρακολούθησης email και αποκρύψτε τη διεύθυνσή σας."
+msgstr "Αποκλείστε εφαρμογές παρακολούθησης email και αποκρύψτε τη διεύθυνσή σας."
 
 # smartling.placeholder_format=C
 #. A disclaimer about AI-generated images in search results
 msgid "Block list is not exhaustive and may contain inaccuracies."
-msgstr ""
-"Η λίστα αποκλεισμού δεν είναι πλήρης και ενδέχεται να περιέχει ανακρίβειες."
+msgstr "Η λίστα αποκλεισμού δεν είναι πλήρης και ενδέχεται να περιέχει ανακρίβειες."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -2952,8 +2953,7 @@ msgstr "Αποκλεισμένα:"
 #. shown after the DuckDuckGo extension is installed
 msgctxt "welcome message"
 msgid "Blocks trackers on websites you visit"
-msgstr ""
-"Μπλοκάρει τα προγράμματα παρακολούθησης στους ιστοτόπους που επισκέπτεστε"
+msgstr "Μπλοκάρει τα προγράμματα παρακολούθησης στους ιστοτόπους που επισκέπτεστε"
 
 # smartling.placeholder_format=C
 msgid "Blog"
@@ -3070,7 +3070,7 @@ msgstr "Κερδισμένα Μπρέικ πόιντ"
 #. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Break this down into clear, numbered steps."
-msgstr ""
+msgstr "Χωρίστε το σε σαφή, αριθμημένα βήματα."
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -3237,8 +3237,7 @@ msgstr "Κάνοντας κλικ στο «%1$s» συμφωνείτε με το
 msgctxt ""
 "Copy stating agreement to Duck.ai Privacy Policy and Terms of Service."
 msgid "By clicking “%s,” you accept Duck.ai’s %s and %s."
-msgstr ""
-"Κάνοντας κλικ στο «%1$s», αποδέχεστε την %2$s και τους %3$s του Duck.ai."
+msgstr "Κάνοντας κλικ στο «%1$s», αποδέχεστε την %2$s και τους %3$s του Duck.ai."
 
 # smartling.placeholder_format=C
 #. Text stating agreement to Duck.ai Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'By clicking “Agree and Continue,” you accept Duck.ai’s Privacy Policy and Terms of Service.'
@@ -3537,7 +3536,7 @@ msgstr "Ηθοποιοί"
 #. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Cast & Crew"
-msgstr ""
+msgstr "Ηθοποιοί και συντελεστές"
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -3624,8 +3623,7 @@ msgstr "Αλλάζει την εμφάνιση των διευθύνσεων URL
 #. This is the description of a user setting
 msgctxt "settings"
 msgid "Changes how the header is displayed and its behavior as you scroll"
-msgstr ""
-"Αλλάζει την εμφάνιση της κεφαλίδας και τη συμπεριφορά της κατά την κύλιση"
+msgstr "Αλλάζει την εμφάνιση της κεφαλίδας και τη συμπεριφορά της κατά την κύλιση"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/mcZdcaF.png
@@ -4312,8 +4310,8 @@ msgid ""
 msgstr ""
 "Η εκκαθάριση των δεδομένων του προγράμματος περιήγησης διαγράφει τις "
 "πρόσφατες συνομιλίες. Οι πρόσφατες συνομιλίες μπορεί να αποθηκευτούν επ' "
-"αόριστον ή να διαγραφούν αυτόματα μετά από 7 ημέρες χωρίς χρήση του Duck."
-"ai., ανάλογα με το πρόγραμμα περιήγησής σας."
+"αόριστον ή να διαγραφούν αυτόματα μετά από 7 ημέρες χωρίς χρήση του "
+"Duck.ai., ανάλογα με το πρόγραμμα περιήγησής σας."
 
 # smartling.placeholder_format=C
 #. Warning message shown on the Block domain success modal. Blocked sites are stored in localStorage which is cleared alongside cookies when users clear browser data. Followed by a linked 'our free browser' text.
@@ -4433,8 +4431,7 @@ msgstr "Κάνε κλικ στις %1$sΡυθμίσεις%2$s στο αναπτ�
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
-msgstr ""
-"Κάνε κλικ στο %1$sΧρήση τρεχουσών σελίδων%2$s και έπειτα στο %3$sΟΚ%4$s"
+msgstr "Κάνε κλικ στο %1$sΧρήση τρεχουσών σελίδων%2$s και έπειτα στο %3$sΟΚ%4$s"
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -4472,8 +4469,7 @@ msgstr "Κάνε κλικ στο %1$sΠρόγραμμα περιήγησης%2$s
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click on %sChange Search Settings%s in the dropdown menu"
-msgstr ""
-"Κάνε κλικ στο %1$sΑλλαγή ρυθμίσεων αναζήτησης%2$s στο αναπτυσσόμενο μενού"
+msgstr "Κάνε κλικ στο %1$sΑλλαγή ρυθμίσεων αναζήτησης%2$s στο αναπτυσσόμενο μενού"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -4553,15 +4549,13 @@ msgstr "Κάνε κλικ στην καρτέλα %1$sΓενικά%2$s."
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click the %sellipsis icon%s in the toolbar."
-msgstr ""
-"Κάνε κλικ στο %1$sεικονίδιο με τα αποσιωπητικά%2$s στη γραμμή εργαλείων."
+msgstr "Κάνε κλικ στο %1$sεικονίδιο με τα αποσιωπητικά%2$s στη γραμμή εργαλείων."
 
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Click the %slock icon%s on the address bar."
-msgstr ""
-"Κάνε κλικ στο %1$sεικονίδιο με την κλειδαριά%2$s στη γραμμή διευθύνσεων."
+msgstr "Κάνε κλικ στο %1$sεικονίδιο με την κλειδαριά%2$s στη γραμμή διευθύνσεων."
 
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to enable location service. Part of a list of instructions on how to enable location service.
@@ -5289,7 +5283,7 @@ msgstr "Δημιουργία εικόνας"
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
-msgstr ""
+msgstr "Δημιούργησε μια λίστα αγορών με τις ποσότητες από αυτήν τη συνταγή."
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed in the input field when starting a new image generation session.
@@ -5863,8 +5857,7 @@ msgstr "Περιγράψτε τις αλλαγές με βάση την εικό
 #. Placeholder text displayed in the input field when the user can make follow-up edits to a generated image.
 msgctxt "Placeholder text for the image generation input field for follow-ups"
 msgid "Describe changes to continue editing this image"
-msgstr ""
-"Περιγράψτε τις αλλαγές για να συνεχίσετε την επεξεργασία αυτής της εικόνας"
+msgstr "Περιγράψτε τις αλλαγές για να συνεχίσετε την επεξεργασία αυτής της εικόνας"
 
 # smartling.placeholder_format=C
 #. Title shown when the user first enters Image Generation mode, prompting them to describe the image they want to create.
@@ -5939,7 +5932,7 @@ msgstr "Συμπληρώθηκε το όριο υπαγόρευσης"
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
 msgid "Dictation temporarily unavailable"
-msgstr ""
+msgstr "Η υπαγόρευση δεν είναι διαθέσιμη προσωρινά"
 
 # smartling.placeholder_format=C
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
@@ -6029,8 +6022,7 @@ msgstr "Απενεργοποίηση και αποσύνδεση"
 #. Title of a modal that asks the user if they want to turn off chat history and disconnect from Sync & Backup.
 msgctxt "Modal header for disabling chat history and disconnecting sync"
 msgid "Disable chat history and disconnect from Sync & Backup?"
-msgstr ""
-"Απενεργοποίηση ιστορικού συνομιλιών και αποσύνδεση από το Sync & Backup;"
+msgstr "Απενεργοποίηση ιστορικού συνομιλιών και αποσύνδεση από το Sync & Backup;"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to turn off the chat history feature.
@@ -6135,8 +6127,7 @@ msgstr "Γλώσσα οθόνης"
 #. This is the description of a user setting
 msgctxt "settings"
 msgid "Displays a checkmark to the left of results you've visited"
-msgstr ""
-"Εμφανίζει ένα σημάδι στα αριστερά των αποτελεσμάτων που έχεις επισκεφθεί"
+msgstr "Εμφανίζει ένα σημάδι στα αριστερά των αποτελεσμάτων που έχεις επισκεφθεί"
 
 # smartling.placeholder_format=C
 #. This is the description of a user setting
@@ -6219,8 +6210,7 @@ msgstr "Δεν βλέπεις το DuckDuckGo στη λίστα;"
 #. Link to download a file again if the user can't find it on their computer.
 msgctxt "install-extension"
 msgid "Don't see it? %s%s%sClick here to re-download%s"
-msgstr ""
-"Δεν το βλέπεις; %1$s%2$s%3$sΚάνε κλικ εδώ για να το ξανακατεβάσεις.%4$s"
+msgstr "Δεν το βλέπεις; %1$s%2$s%3$sΚάνε κλικ εδώ για να το ξανακατεβάσεις.%4$s"
 
 #  IE < 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -6252,6 +6242,9 @@ msgid ""
 "Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
 "filtered out. %sLearn More%s"
 msgstr ""
+"Δεν επιθυμείτε τεχνητή νοημοσύνη; Το %1$snoai.duckduckgo.com%2$s δεν "
+"προσφέρει λειτουργίες τεχνητής νοημοσύνης και οι εικόνες τεχνητής νοημοσύνης "
+"φιλτράρονται. %3$sΜάθετε περισσότερα%4$s"
 
 # smartling.placeholder_format=C
 #. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
@@ -6260,6 +6253,10 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
+"Δεν επιθυμείτε τεχνητή νοημοσύνη; Επισκεφθείτε το "
+"%1$snoai.duckduckgo.com%2$s για αναζήτηση χωρίς λειτουργίες τεχνητής "
+"νοημοσύνης και με φιλτραρισμένες εικόνες τεχνητής νοημοσύνης. %3$sΜάθετε "
+"περισσότερα%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6379,13 +6376,13 @@ msgstr ""
 #. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Draft a cover letter"
-msgstr ""
+msgstr "Συντάξτε μια συνοδευτική επιστολή"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Draft a cover letter for this job."
-msgstr ""
+msgstr "Συντάξτε μια συνοδευτική επιστολή γι' αυτήν την εργασία."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -6523,8 +6520,7 @@ msgstr "Όρους χρήσης υπηρεσίας του Duck.ai"
 #. The HTML <title> for Duck.ai.
 msgctxt "duckai_seo"
 msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
-msgstr ""
-"Duck.ai από το DuckDuckGo. Ιδιωτική συνομιλία με τεχνητή νοημοσύνη. Δωρεάν."
+msgstr "Duck.ai από το DuckDuckGo. Ιδιωτική συνομιλία με τεχνητή νοημοσύνη. Δωρεάν."
 
 # smartling.placeholder_format=C
 #. Description explaining how the page context feature works in Duck.ai sidebar.
@@ -6578,6 +6574,10 @@ msgid ""
 "company for anyone who wants to take back control of their personal "
 "information."
 msgstr ""
+"Το Duck.ai δημιουργήθηκε από το DuckDuckGo. Είμαστε μια ανεξάρτητη εταιρεία "
+"διαδικτυακής προστασίας για οποιονδήποτε επιθυμεί να ανακτήσει τον έλεγχο "
+"των προσωπικών πληροφοριών του.\n"
+"\n"
 
 # smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
@@ -6593,8 +6593,8 @@ msgid ""
 "remember home on the web: https://duck.ai"
 msgstr ""
 "Το Duck.ai εξακολουθεί να αποτελεί προϊόν της DuckDuckGo, ωστόσο πλέον θα "
-"έχει μια πιο εύκολη στην απομνημόνευση διεύθυνση στο διαδίκτυο: https://duck."
-"ai"
+"έχει μια πιο εύκολη στην απομνημόνευση διεύθυνση στο διαδίκτυο: "
+"https://duck.ai"
 
 # smartling.placeholder_format=C
 #. Headline for domain change notice.
@@ -6633,6 +6633,10 @@ msgid ""
 "Duck.ai lets you chat privately with popular AI models. Disabling it hides "
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
+"Το Duck.ai σάς επιτρέπει να συνομιλείτε ιδιωτικά με δημοφιλή μοντέλα "
+"τεχνητής νοημοσύνης. Η απενεργοποίησή του αποκρύπτει τα κουμπιά και τους "
+"συνδέσμους του Duck.ai, ωστόσο μπορείτε ακόμα να επισκεφθείτε το "
+"%1$sduck.ai%2$s απευθείας."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6655,8 +6659,7 @@ msgstr ""
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
 msgctxt "Disclaimer text at the bottom of the feedback form."
 msgid "Duck.ai may display inaccurate or offensive information."
-msgstr ""
-"Το Duck.ai ενδέχεται να εμφανίζει ανακριβείς ή προσβλητικές πληροφορίες."
+msgstr "Το Duck.ai ενδέχεται να εμφανίζει ανακριβείς ή προσβλητικές πληροφορίες."
 
 # smartling.placeholder_format=C
 #. Error modal body line 2.
@@ -6672,8 +6675,7 @@ msgstr ""
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
 msgctxt "Promotional text for PDF upload feature"
 msgid "Duck.ai now can read and analyze PDFs. Give it a try!"
-msgstr ""
-"Το Duck.ai μπορεί πλέον να διαβάζει και να αναλύει αρχεία PDF. Δοκιμάστε το!"
+msgstr "Το Duck.ai μπορεί πλέον να διαβάζει και να αναλύει αρχεία PDF. Δοκιμάστε το!"
 
 # smartling.placeholder_format=C
 #. Disclaimer text shown above the chat input only when coming from a DuckAssist grounded response into ungrounded models.
@@ -6700,8 +6702,7 @@ msgstr "Το Duck.ai αναβαθμίστηκε!"
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
-msgstr ""
-"Το Duck.ai λειτουργεί καλύτερα στην ιδιωτική και δωρεάν εφαρμογή DuckDuckGo!"
+msgstr "Το Duck.ai λειτουργεί καλύτερα στην ιδιωτική και δωρεάν εφαρμογή DuckDuckGo!"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -6895,8 +6896,7 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr ""
-"Το DuckDuckGo AI Chat δεν είναι διαθέσιμο προσωρινά. Ξαναδοκιμάστε αργότερα."
+msgstr "Το DuckDuckGo AI Chat δεν είναι διαθέσιμο προσωρινά. Ξαναδοκιμάστε αργότερα."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -7121,8 +7121,7 @@ msgctxt ""
 "Description of the DuckDuckGo subscription setting when it is not available "
 "in the user region"
 msgid "DuckDuckGo subscriptions are not available to purchase in this region."
-msgstr ""
-"Οι συνδρομές DuckDuckGo δεν είναι διαθέσιμες για αγορά στην περιοχή αυτή."
+msgstr "Οι συνδρομές DuckDuckGo δεν είναι διαθέσιμες για αγορά στην περιοχή αυτή."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use 'ducky' tone in its responses. When this option is selected, the AI assistant speaks like a duck.
@@ -7294,8 +7293,7 @@ msgstr "Δώστε έμφαση σε σημαντικές πληροφορίες
 #. Tells users which setting to change to enable location service.
 msgctxt "precise_user_location"
 msgid "Enable 'Sites can ask for my location.'"
-msgstr ""
-"Ενεργοποίησε την επιλογή «Οι ιστότοποι μπορούν να ζητούν την τοποθεσία μου»."
+msgstr "Ενεργοποίησε την επιλογή «Οι ιστότοποι μπορούν να ζητούν την τοποθεσία μου»."
 
 # smartling.placeholder_format=C
 #. Button shown during outages to enable AI features
@@ -7307,8 +7305,7 @@ msgstr "Ενεργοποίηση λειτουργιών τεχνητής νοη�
 #. Text explaining how to enable the cloud save feature.
 msgctxt "cloudsave"
 msgid "Enable Cloud Save by entering your existing passphrase."
-msgstr ""
-"Ενεργοποίησε το Cloud Save, πληκτρολογώντας την υπάρχουσα φράση πρόσβασης."
+msgstr "Ενεργοποίησε το Cloud Save, πληκτρολογώντας την υπάρχουσα φράση πρόσβασης."
 
 # smartling.placeholder_format=C
 #. Primary button text in the dictation privacy consent modal to enable dictation.
@@ -7509,22 +7506,19 @@ msgstr "Βεβαιώσου ότι έχεις επιλέξει %1$sΑποδοχή
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location Services' is %senabled%s."
-msgstr ""
-"Βεβαιώσου ότι η επιλογή «Υπηρεσίες τοποθεσίας» είναι %1$sενεργοποιημένη%2$s."
+msgstr "Βεβαιώσου ότι η επιλογή «Υπηρεσίες τοποθεσίας» είναι %1$sενεργοποιημένη%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location' is set to %sallow%s"
-msgstr ""
-"Βεβαιωθείτε ότι η επιλογή «Τοποθεσία» έχει οριστεί σε %1$sΝα επιτρέπεται%2$s"
+msgstr "Βεβαιωθείτε ότι η επιλογή «Τοποθεσία» έχει οριστεί σε %1$sΝα επιτρέπεται%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location' is set to %sallow%s."
-msgstr ""
-"Βεβαιώσου ότι η επιλογή «Τοποθεσία» έχει οριστεί σε %1$sΝα επιτρέπεται%2$s."
+msgstr "Βεβαιώσου ότι η επιλογή «Τοποθεσία» έχει οριστεί σε %1$sΝα επιτρέπεται%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -7647,8 +7641,7 @@ msgstr "Καταχώρισε τη διεύθυνση email σου."
 #. A prompt asking users to enter their passphrase.
 msgctxt "cloudsave"
 msgid "Enter your passphrase to load your settings."
-msgstr ""
-"Πληκτρολόγησε τη φράση πρόσβασής σου για να φορτωθούν οι ρυθμίσεις σου."
+msgstr "Πληκτρολόγησε τη φράση πρόσβασής σου για να φορτωθούν οι ρυθμίσεις σου."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of an entertainment guide in its responses.
@@ -7676,13 +7669,13 @@ msgstr "Ερυθραία"
 #. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Estimate the nutrition"
-msgstr ""
+msgstr "Υπολογίστε τη διατροφή"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Estimate the nutritional information for this recipe."
-msgstr ""
+msgstr "Υπολόγισε τις διατροφικές πληροφορίες γι' αυτήν τη συνταγή."
 
 # smartling.placeholder_format=C
 msgid "Estonia"
@@ -7718,8 +7711,7 @@ msgstr "Ανάπτυξη χάρτη"
 #. Subtitle for the Collaborations promotional card at the bottom of search results. Describes the branded merchandise line. 'Give a duck' is a wordplay on the DuckDuckGo brand name.
 msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
-msgstr ""
-"Εξειδικευμένα προϊόντα για άτομα που ενδιαφέρονται για την ιδιωτικότητα."
+msgstr "Εξειδικευμένα προϊόντα για άτομα που ενδιαφέρονται για την ιδιωτικότητα."
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
@@ -7743,7 +7735,7 @@ msgstr "Λήγει σε 1 ημέρα"
 #. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain the accepted answer in simple terms."
-msgstr ""
+msgstr "Επεξηγήστε την αποδεκτή απάντηση με απλά λόγια."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
@@ -7758,43 +7750,43 @@ msgstr ""
 #. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain the top answer"
-msgstr ""
+msgstr "Επεξηγήστε την κορυφαία απάντηση"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain this in simple, plain language."
-msgstr ""
+msgstr "Επεξηγήστε το αυτό με απλά, κατανοητά λόγια."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain this paper"
-msgstr ""
+msgstr "Επεξηγήστε αυτό το άρθρο"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain this repo"
-msgstr ""
+msgstr "Επεξηγήστε αυτό το αποθετήριο"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain this research paper in plain language."
-msgstr ""
+msgstr "Επεξηγήστε αυτή την ερευνητική εργασία με απλά λόγια."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain this simply"
-msgstr ""
+msgstr "Επεξηγήστε το αυτό απλά"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain what this repository does and how to use it."
-msgstr ""
+msgstr "Επεξηγήστε τι κάνει αυτό το αποθετήριο και πώς χρησιμοποιείται."
 
 # smartling.placeholder_format=C
 #. Label to show if song lyrics contain explicit content
@@ -8089,6 +8081,8 @@ msgctxt "settings"
 msgid ""
 "Filters out known AI spam sites from image search results. %sLearn More%s"
 msgstr ""
+"Αποκλείει γνωστούς ιστότοπους με απατηλό περιεχόμενο τεχνητής νοημοσύνης από "
+"τα αποτελέσματα αναζήτησης εικόνων. %1$sΜάθετε περισσότερα%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the final score of a sporting event.
@@ -8117,8 +8111,7 @@ msgstr "Οικονομικός σύμβουλος"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Find %sDuckDuckGo%s and click%sMake default%s"
-msgstr ""
-"Βρες το %1$sDuckDuckGo%2$s και κάνε κλικ στο%3$sΟρισμός ως προεπιλογής%4$s"
+msgstr "Βρες το %1$sDuckDuckGo%2$s και κάνε κλικ στο%3$sΟρισμός ως προεπιλογής%4$s"
 
 # smartling.placeholder_format=C
 #. Sentence shown after export, includes a placeholder for one or more filenames with bold formatting for the filename(s).
@@ -8150,7 +8143,7 @@ msgstr "Βρείτε τρέχουσες πληροφορίες"
 #. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Find me alternatives"
-msgstr ""
+msgstr "Βρείτε μου εναλλακτικές λύσεις"
 
 # smartling.placeholder_format=C
 #. Button that searches for results closer to the user's current location.
@@ -8638,7 +8631,7 @@ msgstr "Δημιουργήστε περισσότερα"
 #. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Generate a shopping list"
-msgstr ""
+msgstr "Δημιουργήστε μια λίστα αγορών"
 
 # smartling.placeholder_format=C
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
@@ -8941,14 +8934,13 @@ msgstr "Δοκιμάστε το"
 #. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Give me a quick background on this person."
-msgstr ""
+msgstr "Δώστε μου μια γρήγορη πληροφορία γι' αυτό το άτομο."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
-msgstr ""
-"Μεταβείτε στις επιλογές %1$sΑπόρρητο και ασφάλεια > Υπηρεσίες τοποθεσίας%2$s"
+msgstr "Μεταβείτε στις επιλογές %1$sΑπόρρητο και ασφάλεια > Υπηρεσίες τοποθεσίας%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9395,13 +9387,13 @@ msgstr "Βοήθησέ μας να προστατεύσουμε το ιδιωτ�
 #. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Help me prep for the interview"
-msgstr ""
+msgstr "Βοηθήστε με να προετοιμαστώ για τη συνέντευξη"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Help me tailor my resume for this job."
-msgstr ""
+msgstr "Βοηθήστε με να προσαρμόσω το βιογραφικό μου γι' αυτήν τη θέση εργασίας."
 
 # smartling.placeholder_format=C
 #. Title of a SERP popup that invites users to take a survey (desktop only)
@@ -9413,8 +9405,7 @@ msgstr "Βοηθήστε μας να βελτιώσουμε το DuckDuckGo"
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Help us improve DuckDuckGo searches with your feedback"
-msgstr ""
-"Βοηθήστε μας να βελτιώσουμε τις αναζητήσεις DuckDuckGo με τα σχόλιά σας"
+msgstr "Βοηθήστε μας να βελτιώσουμε τις αναζητήσεις DuckDuckGo με τα σχόλιά σας"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -9466,8 +9457,7 @@ msgstr "Βοηθήστε μας να καταλάβουμε πώς δεν πετ
 #. A subtitle of a page that encourages users to share DuckDuckGo with their friends.
 msgctxt "showcase_spread"
 msgid "Help your friends and family join the Duck Side!"
-msgstr ""
-"Βοήθησε τους φίλους και την οικογένειά σου να μάθουν τον κόσμο του Παπιού!"
+msgstr "Βοήθησε τους φίλους και την οικογένειά σου να μάθουν τον κόσμο του Παπιού!"
 
 # smartling.placeholder_format=C
 #. Text description for the Spread card in the SERP footer
@@ -9766,8 +9756,7 @@ msgstr "Οι ώρες λείπουν"
 #. This is the name of a user setting
 msgctxt "settings"
 msgid "Hover, Module, and Dropdown Background Color"
-msgstr ""
-"Χρώμα δείκτη αποτελεσμάτων, λειτουργικής μονάδας και αναπτυσσόμενου μενού"
+msgstr "Χρώμα δείκτη αποτελεσμάτων, λειτουργικής μονάδας και αναπτυσσόμενου μενού"
 
 # smartling.placeholder_format=C
 #. Label for a pill-shaped tab below the empty-state Duck.ai chat input. Clicking it opens a panel that explains how Duck.ai protects user privacy.
@@ -9874,8 +9863,7 @@ msgstr "Πόσο συχνά θέλετε να βλέπετε τις απαντή
 #. A header for the feedback form in the assist negative feedback flow. The user is being asked to update how often they want AI-assisted answers to appear.
 msgctxt "duckassist"
 msgid "How often do you want to see AI-assisted answers?"
-msgstr ""
-"Πόσο συχνά θέλετε να βλέπετε απαντήσεις με τη βοήθεια τεχνητής νοημοσύνης;"
+msgstr "Πόσο συχνά θέλετε να βλέπετε απαντήσεις με τη βοήθεια τεχνητής νοημοσύνης;"
 
 # smartling.placeholder_format=C
 #. Section title above the frequency radio options in the Search Assist settings modal.
@@ -9937,7 +9925,7 @@ msgctxt ""
 "Text for the I already have a subscription button in the Duck.ai settings "
 "page"
 msgid "I Already Have a Subscription"
-msgstr ""
+msgstr "Έχω ήδη συνδρομή"
 
 # smartling.placeholder_format=C
 #. Text for the button that takes the user to the login subscription page.
@@ -10110,8 +10098,7 @@ msgstr ""
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
-msgstr ""
-"Αν θες παρ' όλα αυτά να μας υποστηρίξεις, %1$sδιάδωσε το DuckDuckGo%2$s"
+msgstr "Αν θες παρ' όλα αυτά να μας υποστηρίξεις, %1$sδιάδωσε το DuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -10525,7 +10512,7 @@ msgstr "Εγκαταστήστε το πρόγραμμα περιήγησης γ
 #. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
 msgctxt "settings"
 msgid "Install Now"
-msgstr ""
+msgstr "Εγκατάσταση τώρα"
 
 # smartling.placeholder_format=C
 #. Text of a button to install the DuckDuckGo app
@@ -10628,13 +10615,13 @@ msgstr "Τα διαγραμμένα δεδομένα διαγράφονται π
 #. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Is it worth taking?"
-msgstr ""
+msgstr "Αξίζει να το αποκτήσετε;"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Is this place any good?"
-msgstr ""
+msgstr "Είναι καλό αυτό το μέρος;"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
@@ -10643,6 +10630,8 @@ msgid ""
 "Is this place any good? Summarize its reputation based on reviews and "
 "ratings."
 msgstr ""
+"Είναι καλό αυτό το μέρος; Συνοψίστε τη φήμη του με βάση κριτικές και "
+"αξιολογήσεις."
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -10654,13 +10643,13 @@ msgstr "Είναι χρήσιμο αυτό το βίντεο;"
 #. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Is this worth watching?"
-msgstr ""
+msgstr "Αξίζει να το παρακολουθήσω;"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Is this worth watching? Give me a spoiler-free take."
-msgstr ""
+msgstr "Αξίζει να το παρακολουθήσω; Δώστε μου μια ιδέα χωρίς spoiler."
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -10694,8 +10683,7 @@ msgstr ""
 msgctxt "settings"
 msgid ""
 "It's okay to (very infrequently) ask me about my experience using DuckDuckGo"
-msgstr ""
-"Δέχομαι να με ρωτάτε (πολύ σποραδικά) για την εμπειρία μου με το DuckDuckGo"
+msgstr "Δέχομαι να με ρωτάτε (πολύ σποραδικά) για την εμπειρία μου με το DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. The name of the Italian language
@@ -11287,6 +11275,8 @@ msgstr "Σύνδεσμοι:"
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
 msgstr ""
+"Απαρίθμηση των εργαλείων, των υλικών ή των προϋποθέσεων που χρειάζομαι γι' "
+"αυτό."
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -11702,7 +11692,7 @@ msgstr "Διαχείριση αποκλεισμένων ιστότοπων"
 #. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
 msgctxt "setting"
 msgid "Manage in Browser Settings"
-msgstr ""
+msgstr "Διαχείριση στις ρυθμίσεις του προγράμματος περιήγησης"
 
 # smartling.placeholder_format=C
 #. Link to the site exclusion settings page
@@ -12993,8 +12983,7 @@ msgstr "Δεν βρέθηκαν αποτελέσματα."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the recording contains no audible speech.
 msgid "No speech detected. Please try again and speak into your microphone."
-msgstr ""
-"Δεν εντοπίστηκε ομιλία. Προσπαθήστε ξανά και μιλήστε στο μικρόφωνό σας."
+msgstr "Δεν εντοπίστηκε ομιλία. Προσπαθήστε ξανά και μιλήστε στο μικρόφωνό σας."
 
 # smartling.placeholder_format=C
 #. Button that dismisses a feedback form.
@@ -13018,15 +13007,13 @@ msgstr "Δεν αποκλείστηκαν εφαρμογές παρακολού�
 #. Refers to how web searches on DuckDuckGo aren't tracked.
 msgctxt "homepage onboarding"
 msgid "No tracking, no ad targeting, just searching!"
-msgstr ""
-"Χωρίς παρακολούθηση, χωρίς στοχευμένες διαφημίσεις, μόνο καθαρή αναζήτηση!"
+msgstr "Χωρίς παρακολούθηση, χωρίς στοχευμένες διαφημίσεις, μόνο καθαρή αναζήτηση!"
 
 # smartling.placeholder_format=C
 #. Refers to how web searches on DuckDuckGo aren't tracked.
 msgctxt "homepage onboarding"
 msgid "No tracking, no ad targeting, just searching."
-msgstr ""
-"Χωρίς παρακολούθηση, χωρίς στοχευμένες διαφημίσεις, μόνο καθαρή αναζήτηση."
+msgstr "Χωρίς παρακολούθηση, χωρίς στοχευμένες διαφημίσεις, μόνο καθαρή αναζήτηση."
 
 # smartling.placeholder_format=C
 #. Indicates that there were no search results for a user's search. The placeholder is the user's search term. For example: 'No videos found for 'bad dogs''
@@ -13792,8 +13779,8 @@ msgstr "Άνοιγμα του πίνακα «Πώς λειτουργεί το Du
 msgctxt "precise_user_location"
 msgid "Open the Safari menu and select %sSettings for DuckDuckGo...%s"
 msgstr ""
-"Ανοίξτε το μενού του Safari και επιλέξτε %1$sΡυθμίσεις για το DuckDuckGo..."
-"%2$s"
+"Ανοίξτε το μενού του Safari και επιλέξτε %1$sΡυθμίσεις για το "
+"DuckDuckGo...%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the time a business opens. For example: 'Opens at 10am'
@@ -14556,6 +14543,8 @@ msgstr ""
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is harmful or illegal. (optional)"
 msgstr ""
+"Περίγραψε γιατί η απάντηση στη συνομιλία είναι επιβλαβής ή παράνομη. "
+"(προαιρετικά)"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
@@ -14594,6 +14583,9 @@ msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is harmful or illegal."
 msgstr ""
+"Επικόλλησε την προτροπή σου και το προβληματικό αποτέλεσμα (αφού αφαιρέσεις "
+"τυχόν προσωπικές πληροφορίες) και περίγραψε γιατί το περιεχόμενο είναι "
+"επιβλαβές ή παράνομο."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -15067,7 +15059,7 @@ msgstr "Ιδιωτικό απόρρητο"
 #. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
 msgctxt "Section heading on the Duck.ai settings page"
 msgid "Privacy & Terms"
-msgstr ""
+msgstr "Απόρρητο και Όροι"
 
 # smartling.placeholder_format=C
 msgid "Privacy Blog"
@@ -15143,7 +15135,7 @@ msgstr "Πολιτική απορρήτου και Όροι χρήσης υπη�
 #. Text for a button that links to the terms of use and privacy policy page.
 msgctxt "Secondary button text in active privacy modal"
 msgid "Privacy Policy and Terms of Service"
-msgstr ""
+msgstr "Πολιτική απορρήτου και Όροι χρήσης υπηρεσιών"
 
 # smartling.placeholder_format=C
 #. Title displayed on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
@@ -15331,8 +15323,7 @@ msgstr "Προστατέψτε τα εισερχόμενά σας"
 #. DuckDuckGo's browser app has features to protect your data by keeping it private
 msgctxt "SERP footer content"
 msgid "Protect your data as you search and browse."
-msgstr ""
-"Προστατέψτε τα δεδομένα σας καθώς πραγματοποιείτε αναζήτηση και περιήγηση."
+msgstr "Προστατέψτε τα δεδομένα σας καθώς πραγματοποιείτε αναζήτηση και περιήγηση."
 
 # smartling.placeholder_format=C
 #. Shown on the Mac and Windows browser promo cards. DuckDuckGo's desktop browser protects your data across search, browsing, and AI chat.
@@ -15654,25 +15645,25 @@ msgstr "Προτείνετε ένα βιβλίο"
 #. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Recommend similar books"
-msgstr ""
+msgstr "Προτείνετε παρόμοια βιβλία"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Recommend similar books."
-msgstr ""
+msgstr "Προτείνετε παρόμοια βιβλία."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Recommend similar movies or shows."
-msgstr ""
+msgstr "Προτείνετε παρόμοιες ταινίες ή εκπομπές."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Recommend similar titles"
-msgstr ""
+msgstr "Προτείνετε παρόμοιους τίτλους"
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
@@ -15905,8 +15896,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
 msgid "Remember my choice (this can be changed in %sSettings%s)"
-msgstr ""
-"Να θυμάσαι την επιλογή μου (αυτό μπορεί να αλλαχθεί στις %1$sΡυθμίσεις%2$s)"
+msgstr "Να θυμάσαι την επιλογή μου (αυτό μπορεί να αλλαχθεί στις %1$sΡυθμίσεις%2$s)"
 
 # smartling.placeholder_format=C
 #. Button to be reminded later to update, shown in a banner that appears in Duck.ai when a subscribed user is using an old version of the DuckDuckGo browser.
@@ -16088,7 +16078,7 @@ msgctxt ""
 "feedback form when the user has selected Harmful or Illegal as the feedback "
 "reason"
 msgid "Required for harmful or illegal reports"
-msgstr ""
+msgstr "Απαιτείται για αναφορές επιβλαβούς ή παράνομου περιεχομένου"
 
 # smartling.placeholder_format=C
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
@@ -16333,7 +16323,7 @@ msgstr "Κριτικές"
 #. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Rewrite this recipe scaled for a different number of servings."
-msgstr ""
+msgstr "Ξαναγράψτε αυτή τη συνταγή προσαρμοσμένη για διαφορετικό αριθμό μερίδων."
 
 # smartling.placeholder_format=C
 msgid "Romania"
@@ -16410,8 +16400,7 @@ msgstr "ΝΑ"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "SERP promotion for desktop browsers has been dismissed"
-msgstr ""
-"Η προώθηση SERP για τα προγράμματα περιήγησης υπολογιστών έχει απορριφθεί"
+msgstr "Η προώθηση SERP για τα προγράμματα περιήγησης υπολογιστών έχει απορριφθεί"
 
 # smartling.placeholder_format=C
 #. Abbreviation indicating that a game is in shootouts, e.g. in NHL (hockey)
@@ -16743,15 +16732,13 @@ msgstr "Σκωτία"
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Scroll down and click %sView advanced settings%s"
-msgstr ""
-"Κάνε κύλιση προς τα κάτω και κλικ στην %1$sΠροβολή σύνθετων ρυθμίσεων%2$s"
+msgstr "Κάνε κύλιση προς τα κάτω και κλικ στην %1$sΠροβολή σύνθετων ρυθμίσεων%2$s"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down and click %sView advanced settings%s."
-msgstr ""
-"Κάνε κύλιση προς τα κάτω και κλικ στην %1$sΠροβολή σύνθετων ρυθμίσεων%2$s"
+msgstr "Κάνε κύλιση προς τα κάτω και κλικ στην %1$sΠροβολή σύνθετων ρυθμίσεων%2$s"
 
 #  Edge Legacy default search engine instruction, obsolete?
 # smartling.placeholder_format=C
@@ -16957,8 +16944,7 @@ msgstr "Ορατότητα αναζήτησης"
 # smartling.placeholder_format=C
 #. Message prompting users to download the DuckDuckGo app.
 msgid "Search and browse privately with the DuckDuckGo app."
-msgstr ""
-"Απόλαυσε ιδιωτική αναζήτηση και περιήγηση με την εφαρμογή του DuckDuckGo."
+msgstr "Απόλαυσε ιδιωτική αναζήτηση και περιήγηση με την εφαρμογή του DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Category a user can select on a feedback form.
@@ -17354,8 +17340,8 @@ msgstr "Επιλέξτε %1$sΡύθμιση για αυτόν τον ιστότ�
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
 msgstr ""
-"Διάλεξε %1$sΠροσαρμοσμένη%2$s και πληκτρολόγησε %3$shttps://duckduckgo."
-"com%4$s στο πεδίο εισαγωγής"
+"Διάλεξε %1$sΠροσαρμοσμένη%2$s και πληκτρολόγησε "
+"%3$shttps://duckduckgo.com%4$s στο πεδίο εισαγωγής"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
@@ -17367,15 +17353,13 @@ msgstr ""
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s"
-msgstr ""
-"Διάλεξε %1$sDuckDuckGo%2$s και κάνε κλικ στο %3$sΟρισμός ως προεπιλογής%4$s"
+msgstr "Διάλεξε %1$sDuckDuckGo%2$s και κάνε κλικ στο %3$sΟρισμός ως προεπιλογής%4$s"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s."
-msgstr ""
-"Διάλεξε %1$sDuckDuckGo%2$s και κάνε κλικ στο %3$sΟρισμός ως προεπιλογής%4$s."
+msgstr "Διάλεξε %1$sDuckDuckGo%2$s και κάνε κλικ στο %3$sΟρισμός ως προεπιλογής%4$s."
 
 #  Firefox 33
 # smartling.placeholder_format=C
@@ -17416,8 +17400,7 @@ msgstr "Διάλεξε %1$sDuckDuckGo%2$s!"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Select %sEdit Search Engines...%sin the dropdown"
-msgstr ""
-"Επιλέξτε %1$sΕπεξεργασία μηχανών αναζήτησης…%2$sστο αναπτυσσόμενη μενού"
+msgstr "Επιλέξτε %1$sΕπεξεργασία μηχανών αναζήτησης…%2$sστο αναπτυσσόμενη μενού"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -17491,8 +17474,7 @@ msgstr "Διάλεξε %1$sΡυθμίσεις%2$s και έπειτα %3$sΣύν
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sDefault search engine%s"
-msgstr ""
-"Επιλέξτε %1$sΡυθμίσεις%2$s και έπειτα %3$sΠροεπιλεγμένη μηχανή αναζήτησης%4$s"
+msgstr "Επιλέξτε %1$sΡυθμίσεις%2$s και έπειτα %3$sΠροεπιλεγμένη μηχανή αναζήτησης%4$s"
 
 #  Chrome/Firefox on Android
 # smartling.placeholder_format=C
@@ -17553,8 +17535,7 @@ msgstr "Διάλεξε όλα τα τετράγωνα που περιέχουν 
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select an option to %sallow%s location access"
-msgstr ""
-"Ορίστε μια επιλογή για να %1$sεπιτρέπεται%2$s η πρόσβαση στην τοποθεσία"
+msgstr "Ορίστε μια επιλογή για να %1$sεπιτρέπεται%2$s η πρόσβαση στην τοποθεσία"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -17716,7 +17697,7 @@ msgstr "Ρύθμιση τώρα"
 #. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
 msgctxt "Encrypted storage setup button shown in native browsers"
 msgid "Set Up Sync & Backup"
-msgstr ""
+msgstr "Ρύθμιση του Sync & Backup"
 
 # smartling.placeholder_format=C
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
@@ -17906,15 +17887,14 @@ msgstr "Κοινοποίηση θετικών σχολίων"
 msgctxt ""
 "Label beside the share-content switch on the Duck.ai response feedback form"
 msgid "Share this conversation with DuckDuckGo"
-msgstr ""
+msgstr "Κοινοποίησε αυτή τη συνομιλία στο DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
 msgctxt ""
 "Label beside the share-content switch on the Duck.ai response feedback form"
 msgid "Share your prompt and chat response with DuckDuckGo"
-msgstr ""
-"Μοιραστείτε την απάντηση στην προτροπή και στη συνομιλία σας με το DuckDuckGo"
+msgstr "Μοιραστείτε την απάντηση στην προτροπή και στη συνομιλία σας με το DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Variant of the share toggle label that makes sharing mandatory when reporting harmful or illegal content.
@@ -18605,8 +18585,7 @@ msgstr "Κάτι πήγε στραβά κατά την αποθήκευση στ
 #. Body copy displayed under the Set Up Now button when the sync setup call fails.
 msgctxt "Generic error shown when sync setup fails"
 msgid "Something went wrong while enabling Sync & Backup. Please try again."
-msgstr ""
-"Κάτι πήγε λάθος κατά την ενεργοποίηση του Sync & Backup. Προσπαθήστε ξανά."
+msgstr "Κάτι πήγε λάθος κατά την ενεργοποίηση του Sync & Backup. Προσπαθήστε ξανά."
 
 # smartling.placeholder_format=C
 #. Displayed when the voice chat session ends with an unknown error.
@@ -18927,8 +18906,7 @@ msgstr "Αρχίστε με μια εικόνα"
 #. Warning that starting fresh deletes conversations.
 msgctxt "duckai_migration"
 msgid "Starting fresh will delete all your past conversations."
-msgstr ""
-"Ξεκινώντας από την αρχή θα διαγραφούν όλες οι προηγούμενες συνομιλίες σας."
+msgstr "Ξεκινώντας από την αρχή θα διαγραφούν όλες οι προηγούμενες συνομιλίες σας."
 
 # smartling.placeholder_format=C
 #. Footnote warning that starting fresh deletes conversations.
@@ -19202,19 +19180,19 @@ msgstr "Πρότεινε έναν τίτλο για μια ανάρτηση σε
 #. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Suggest related articles or topics worth exploring next."
-msgstr ""
+msgstr "Προτείνετε σχετικά άρθρα ή θέματα που αξίζει να εξερευνήσετε στη συνέχεια."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Suggest related articles to explore"
-msgstr ""
+msgstr "Προτείνετε σχετικά άρθρα για εξερεύνηση"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Suggest some alternatives to this product."
-msgstr ""
+msgstr "Προτείνετε μερικές εναλλακτικές γι' αυτό το προϊόν."
 
 # smartling.placeholder_format=C
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
@@ -19231,7 +19209,7 @@ msgstr "Συστάσεις:"
 #. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Sum up the reviews"
-msgstr ""
+msgstr "Συνοψίστε τις κριτικές"
 
 # smartling.placeholder_format=C
 #. A short title for the a message asking the AI to summarize a text.
@@ -19243,85 +19221,85 @@ msgstr "Σύνοψη"
 #. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize the Q&As"
-msgstr ""
+msgstr "Συνοψίστε τις ερωταπαντήσεις"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the background and notable work of this person."
-msgstr ""
+msgstr "Συνοψίστε το υπόβαθρο και το σημαντικό έργο αυτού του ατόμου."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the key details of this event."
-msgstr ""
+msgstr "Συνοψίστε τις βασικές λεπτομέρειες αυτού του γεγονότος."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the questions and answers on this page."
-msgstr ""
+msgstr "Συνοψίστε τις ερωτήσεις και τις απαντήσεις σε αυτήν τη σελίδα."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize their background"
-msgstr ""
+msgstr "Συνοψίστε το ιστορικό τους"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this book"
-msgstr ""
+msgstr "Συνοψίστε αυτό το βιβλίο"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this book."
-msgstr ""
+msgstr "Συνοψίστε αυτό το βιβλίο."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this discussion"
-msgstr ""
+msgstr "Συνοψίστε αυτήν τη συζήτηση"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this discussion thread."
-msgstr ""
+msgstr "Συνοψίστε αυτό το νήμα συζήτησης."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this page"
-msgstr ""
+msgstr "Συνοψίστε αυτήν τη σελίδα"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this page."
-msgstr ""
+msgstr "Συνοψίστε αυτήν τη σελίδα."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this video"
-msgstr ""
+msgstr "Συνοψίστε αυτό το βίντεο"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this video."
-msgstr ""
+msgstr "Συνοψίστε αυτό το βίντεο."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize what the reviews say."
-msgstr ""
+msgstr "Συνοψίστε τι λένε οι κριτικές."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -19657,7 +19635,7 @@ msgstr "Συρία"
 #. Text for a button that enables the theme to follow the operating system's color scheme preference.
 msgctxt "System theme button for theme selector"
 msgid "System"
-msgstr ""
+msgstr "Σύστημα"
 
 # smartling.placeholder_format=C
 #. Abbreviation indicating this is the total score for a game
@@ -19691,7 +19669,7 @@ msgstr "Ταϊτιανά"
 #. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Tailor my resume"
-msgstr ""
+msgstr "Προσαρμόστε το βιογραφικό μου"
 
 # smartling.placeholder_format=C
 msgid "Taiwan"
@@ -19728,6 +19706,8 @@ msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
+"Συμπληρώστε αυτήν την ανώνυμη έρευνα για να μας πείτε πώς μπορούμε να "
+"βελτιώσουμε το Duck.ai."
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -19926,15 +19906,13 @@ msgstr "Ευχαριστούμε για τα σχόλιά σας!"
 #. Inform the users that "something" went wrong and we are unable to show any results.
 msgctxt "noresults"
 msgid "Thanks for your patience while we get our ducks in a row!"
-msgstr ""
-"Ευχαριστούμε για την υπομονή σας ενώ θα βάλουμε τα παπάκια μας στη σειρά!"
+msgstr "Ευχαριστούμε για την υπομονή σας ενώ θα βάλουμε τα παπάκια μας στη σειρά!"
 
 # smartling.placeholder_format=C
 #. Inform the users that "something" went wrong and we are unable to show any results.
 msgctxt "noresults"
 msgid "Thanks for your patience while we get our ducks in a row."
-msgstr ""
-"Ευχαριστούμε για την υπομονή σας ενώ θα βάλουμε τα παπάκια μας στη σειρά."
+msgstr "Ευχαριστούμε για την υπομονή σας ενώ θα βάλουμε τα παπάκια μας στη σειρά."
 
 # smartling.placeholder_format=C
 #. Message indicating that the open lock icon in the address bar means that a website is not secure.
@@ -20045,7 +20023,7 @@ msgstr "Θέμα"
 #. Text for the theme selector label that allows users to switch between Light and dark theme.
 msgctxt "Label for the theme selector feature"
 msgid "Theme"
-msgstr ""
+msgstr "Θέμα"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/LpFhb1e.png
@@ -20099,8 +20077,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Error message for explore more questions when a retryable error occurs (timeout, network)
 msgid "There's been an issue loading this answer. Please try again."
-msgstr ""
-"Παρουσιάστηκε πρόβλημα κατά τη φόρτωση αυτής της απάντησης. Δοκιμάστε ξανά."
+msgstr "Παρουσιάστηκε πρόβλημα κατά τη φόρτωση αυτής της απάντησης. Δοκιμάστε ξανά."
 
 # smartling.placeholder_format=C
 #. Instant Answer Tab Name
@@ -20174,8 +20151,7 @@ msgstr ""
 #. Appears below a type of search results called 'Instant Answers'
 msgctxt "attribution"
 msgid "This Instant Answer was made by the %sDuckDuckHack%s Community."
-msgstr ""
-"Αυτή η άμεση απάντηση δημιουργήθηκε από την κοινότητα %1$sDuckDuckHack%2$s."
+msgstr "Αυτή η άμεση απάντηση δημιουργήθηκε από την κοινότητα %1$sDuckDuckHack%2$s."
 
 # smartling.placeholder_format=C
 #. Label for the monthly usage row in the Usage section of Duck.ai settings.
@@ -20242,15 +20218,13 @@ msgstr ""
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
-msgstr ""
-"Αυτό το αρχείο είναι πολύ μεγάλο. Το μέγιστο μέγεθος αρχείου είναι %1$s MB"
+msgstr "Αυτό το αρχείο είναι πολύ μεγάλο. Το μέγιστο μέγεθος αρχείου είναι %1$s MB"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB."
-msgstr ""
-"Αυτό το αρχείο είναι πολύ μεγάλο. Το μέγιστο μέγεθος αρχείου είναι %1$s MB."
+msgstr "Αυτό το αρχείο είναι πολύ μεγάλο. Το μέγιστο μέγεθος αρχείου είναι %1$s MB."
 
 # smartling.placeholder_format=C
 #. Generic error message displayed when the user tries to upload an unsupported file type and we cannot determine the accepted types
@@ -20309,16 +20283,14 @@ msgstr "Δεν ήταν δυνατή η δημιουργία αυτής της �
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF"
-msgstr ""
-"Αυτός ο τύπος εικόνας δεν υποστηρίζεται. Επισύναψε JPG, PNG, WebP ή GIF"
+msgstr "Αυτός ο τύπος εικόνας δεν υποστηρίζεται. Επισύναψε JPG, PNG, WebP ή GIF"
 
 # smartling.placeholder_format=C
 #. Error message displayed when a file that the user tried to upload is not of a supported format
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF."
-msgstr ""
-"Αυτός ο τύπος εικόνας δεν υποστηρίζεται, επισύναψε JPG, PNG, WebP ή GIF."
+msgstr "Αυτός ο τύπος εικόνας δεν υποστηρίζεται, επισύναψε JPG, PNG, WebP ή GIF."
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
@@ -20373,8 +20345,7 @@ msgstr "Αυτή η σελίδα απαιτεί Javascript για να λειτ�
 #. Information tooltip text explaining that the current page's content will be included with the chat message.
 msgctxt "Tooltip explaining that page content will be sent to Duck.ai"
 msgid "This page's content will be sent with your message to Duck.ai"
-msgstr ""
-"Το περιεχόμενο της σελίδας αυτής θα σταλεί μαζί με το μήνυμά σας στο Duck.ai"
+msgstr "Το περιεχόμενο της σελίδας αυτής θα σταλεί μαζί με το μήνυμά σας στο Duck.ai"
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -20453,8 +20424,7 @@ msgstr ""
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr ""
-"Η ιστοσελίδα αυτή δεν χρησιμοποιεί ασφαλή, κρυπτογραφημένη σύνδεση (HTTPS)."
+msgstr "Η ιστοσελίδα αυτή δεν χρησιμοποιεί ασφαλή, κρυπτογραφημένη σύνδεση (HTTPS)."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -20483,8 +20453,7 @@ msgstr ""
 #. Message explaining what will happen when the user deletes an image.
 msgctxt "Confirmation message in delete image modal"
 msgid "This will delete your selected image. This cannot be undone."
-msgstr ""
-"Αυτό θα διαγράψει την επιλεγμένη εικόνα σας. Αυτό δεν μπορεί να αναιρεθεί."
+msgstr "Αυτό θα διαγράψει την επιλεγμένη εικόνα σας. Αυτό δεν μπορεί να αναιρεθεί."
 
 # smartling.placeholder_format=C
 #. Confirmation message asking if the user is sure they want to reset all of their settings.
@@ -20572,8 +20541,7 @@ msgstr "Συμβουλές"
 
 # smartling.placeholder_format=C
 msgid "Tired of being tracked online? %sWe can help.%s"
-msgstr ""
-"Έχεις βαρεθεί να σε παρακολουθούν στο διαδίκτυο; %1$sΆσ' το πάνω μας.%2$s"
+msgstr "Έχεις βαρεθεί να σε παρακολουθούν στο διαδίκτυο; %1$sΆσ' το πάνω μας.%2$s"
 
 # smartling.placeholder_format=C
 #. This is the name of a user setting
@@ -20606,8 +20574,8 @@ msgctxt ""
 "Copy stating agreement to Duck.ai Privacy Policy and Terms of Service."
 msgid "To continue, you must agree to Duck.ai’s %s and %s"
 msgstr ""
-"Για να συνεχίσετε, πρέπει να συμφωνήσετε με την %1$s και τους %2$s του Duck."
-"ai"
+"Για να συνεχίσετε, πρέπει να συμφωνήσετε με την %1$s και τους %2$s του "
+"Duck.ai"
 
 # smartling.placeholder_format=C
 #. Text stating agreement to AI Chat Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'To continue, you must agree to DuckDuckGo AI Chat’s Privacy Policy and Terms of Service'
@@ -20840,8 +20808,7 @@ msgstr "Εφαρμογές παρακολούθησης που αποκλείσ�
 #. Placeholder for when we cannot report any blocked trackers yet
 msgctxt "tracker_stats"
 msgid "Trackers that DuckDuckGo blocks will appear here"
-msgstr ""
-"Οι εφαρμογές παρακολούθησης που αποκλείει το DuckDuckGo θα εμφανίζονται εδώ"
+msgstr "Οι εφαρμογές παρακολούθησης που αποκλείει το DuckDuckGo θα εμφανίζονται εδώ"
 
 # smartling.placeholder_format=C
 #. Placeholder for when we cannot report any blocked trackers yet
@@ -20919,13 +20886,13 @@ msgstr ""
 #. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Translate this page"
-msgstr ""
+msgstr "Μεταφράστε αυτή τη σελίδα"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
 msgctxt "Page suggestion prompt"
 msgid "Translate this page into %s."
-msgstr ""
+msgstr "Μεταφράστε αυτή τη σελίδα στα %1$s."
 
 # smartling.placeholder_format=C
 #. Placeholder text for a region that will display translated text.
@@ -21027,8 +20994,7 @@ msgstr "Δοκιμάστε το %1$s για να σταματήσετε να β�
 #. Text for a promotional card that encourages users to try the encrypted AI model whose inference runs in a confidential environment so the model provider cannot access user data. %s is replaced with the model's full display name (e.g. 'GPT-OSS 120B').
 msgctxt "Promotional text for encrypted AI model"
 msgid "Try %s, our first model with zero provider visibility."
-msgstr ""
-"Δοκίμασε το %1$s, το πρώτο μας μοντέλο με μηδενική ορατότητα από τον πάροχο."
+msgstr "Δοκίμασε το %1$s, το πρώτο μας μοντέλο με μηδενική ορατότητα από τον πάροχο."
 
 # smartling.placeholder_format=C
 msgid "Try %sDuck.ai%s, our private AI chat service:"
@@ -21075,7 +21041,7 @@ msgstr "Δοκιμάστε το δωρεάν"
 #. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
 msgctxt "settings"
 msgid "Try It Now"
-msgstr ""
+msgstr "Δοκιμάστε το τώρα"
 
 # smartling.placeholder_format=C
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -21124,8 +21090,7 @@ msgstr ""
 #. A message suggesting that the user clears their filters and tries their search again when they get no results
 msgctxt "noresults"
 msgid "Try clearing your filters and searching again."
-msgstr ""
-"Δοκιμάστε να καθαρίσετε τα φίλτρα σας και να πραγματοποιήσετε αναζήτηση ξανά."
+msgstr "Δοκιμάστε να καθαρίσετε τα φίλτρα σας και να πραγματοποιήσετε αναζήτηση ξανά."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with different words.
@@ -21144,8 +21109,7 @@ msgstr ""
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
 msgctxt "precise_user_location"
 msgid "Try enabling anonymous location for more accurate results."
-msgstr ""
-"Δοκίμασε να ενεργοποιήσεις την ανώνυμη τοποθεσία για πιο ακριβή αποτελέσματα."
+msgstr "Δοκίμασε να ενεργοποιήσεις την ανώνυμη τοποθεσία για πιο ακριβή αποτελέσματα."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the screen of the onboarding where the user picks a chat model.
@@ -21189,8 +21153,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
 msgid "Try generating an AI-assisted answer"
-msgstr ""
-"Δοκιμάστε να δημιουργήσετε μια απάντηση με τη βοήθεια τεχνητής νοημοσύνης"
+msgstr "Δοκιμάστε να δημιουργήσετε μια απάντηση με τη βοήθεια τεχνητής νοημοσύνης"
 
 # smartling.placeholder_format=C
 #. Copy to invite the user to ask duckassist (an instant answer based on generative AI) for an answer
@@ -21212,8 +21175,7 @@ msgstr "Δοκιμάστε το πρόγραμμα περιήγησής μας"
 # smartling.placeholder_format=C
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
-msgstr ""
-"Δοκίμασε την αρχική μας σελίδα που ποτέ δεν εμφανίζει αυτά τα μηνύματα:"
+msgstr "Δοκίμασε την αρχική μας σελίδα που ποτέ δεν εμφανίζει αυτά τα μηνύματα:"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with different words to get more results.
@@ -21334,6 +21296,9 @@ msgid ""
 "Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
+"Προσπαθείτε να απενεργοποιήσετε τις λειτουργίες τεχνητής νοημοσύνης; "
+"Εγκαταστήστε την επέκταση αναζήτησης %1$sDuckDuckGo No AI%2$s για να θυμάστε "
+"τις ρυθμίσεις σας. %3$sΜάθετε περισσότερα%4$s"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -21342,6 +21307,9 @@ msgid ""
 "Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
+"Προσπαθείτε να απενεργοποιήσετε τις λειτουργίες τεχνητής νοημοσύνης; "
+"Μεταβείτε στην επέκταση αναζήτησης %1$sDuckDuckGo No AI%2$s για να θυμάστε "
+"τις ρυθμίσεις σας. %3$sΜάθετε περισσότερα%4$s"
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -21464,8 +21432,7 @@ msgstr "Ενεργοποιήστε την «Ακριβή τοποθεσία» γ
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on “Use precise location” for more accurate results."
-msgstr ""
-"Ενεργοποιήστε τη «Χρήση ακριβούς τοποθεσίας» για πιο ακριβή αποτελέσματα."
+msgstr "Ενεργοποιήστε τη «Χρήση ακριβούς τοποθεσίας» για πιο ακριβή αποτελέσματα."
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Create Image' label in the Tools dropdown.
@@ -21617,8 +21584,7 @@ msgstr "Δεν είναι δυνατή η αποστολή σχολίων"
 #. Message shown to the user when the voice chat failed to establish a connection, and they should try again later.
 msgctxt "voice chat"
 msgid "Unable to connect to voice chat, please try again later."
-msgstr ""
-"Δεν είναι δυνατή η σύνδεση στη φωνητική συνομιλία. Προσπαθήστε πάλι αργότερα."
+msgstr "Δεν είναι δυνατή η σύνδεση στη φωνητική συνομιλία. Προσπαθήστε πάλι αργότερα."
 
 # smartling.placeholder_format=C
 #. Message shown to the user when there was an issue connecting to their microphone.
@@ -21672,8 +21638,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
-msgstr ""
-"Στο %1$sΕΚΚΙΝΗΣΗ > Αρχική σελίδα%2$s, πληκτρολόγησε: https://duckduckgo.com"
+msgstr "Στο %1$sΕΚΚΙΝΗΣΗ > Αρχική σελίδα%2$s, πληκτρολόγησε: https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -21692,8 +21657,8 @@ msgstr ""
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
 msgstr ""
-"Στην ενότητα %1$sΑναζήτηση%2$s, διάλεξε %3$sΔιαχείριση μηχανών αναζήτησης…"
-"%4$s"
+"Στην ενότητα %1$sΑναζήτηση%2$s, διάλεξε %3$sΔιαχείριση μηχανών "
+"αναζήτησης…%4$s"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -21794,8 +21759,7 @@ msgstr ""
 #. Title for the subscription promo shown in the SERP sidemenu.
 msgctxt "Sidemenu subscription promo"
 msgid "Unlock VPN + Advanced AI"
-msgstr ""
-"Αποκτήστε πρόσβαση σε δίκτυο VPN + προηγμένες δυνατότητες τεχνητής νοημοσύνης"
+msgstr "Αποκτήστε πρόσβαση σε δίκτυο VPN + προηγμένες δυνατότητες τεχνητής νοημοσύνης"
 
 # smartling.placeholder_format=C
 #. Text for the button that allows the user to unlock an AI model with a DuckDuckGo subscription when clicked.
@@ -21825,8 +21789,7 @@ msgstr "Ξεκλειδώστε προηγμένα μοντέλα τεχνητή�
 #. Tooltip text shown when the user hovers over the free badge telling the user that they can unlock advanced AI (Artificial Intelligence) models with a DuckDuckGo subscription.
 msgctxt "Tooltip for the free badge"
 msgid "Unlock advanced AI models with a DuckDuckGo subscription"
-msgstr ""
-"Ξεκλείδωσε προηγμένα μοντέλα τεχνητής νοημοσύνης με συνδρομή στο DuckDuckGo"
+msgstr "Ξεκλείδωσε προηγμένα μοντέλα τεχνητής νοημοσύνης με συνδρομή στο DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. A link to a blog post explaining the new AI benefits to a subscription. Please keep translations to 50 characters or less.
@@ -22119,7 +22082,7 @@ msgstr "Ουρουγουάη"
 #. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
 msgctxt "Navigation label on the Duck.ai settings page"
 msgid "Usage"
-msgstr ""
+msgstr "Χρήση"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -22177,8 +22140,7 @@ msgstr "Χρήση της ιδιωτικής αναζήτησης του DuckDuc
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Use DuckDuckGo private search on your iPad, iPhone, or Android!"
-msgstr ""
-"Χρησιμοποίησε την ιδιωτική αναζήτηση DuckDuckGo σε iPad, iPhone ή Android!"
+msgstr "Χρησιμοποίησε την ιδιωτική αναζήτηση DuckDuckGo σε iPad, iPhone ή Android!"
 
 # smartling.placeholder_format=C
 #. User clicks this button to share their device's location
@@ -22353,8 +22315,7 @@ msgstr "Δείτε τιμές για τη διαμονή σας"
 # smartling.placeholder_format=C
 #. A description for the ads tooltip that explains that viewing ads is privacy protected by DuckDuckGo.
 msgid "Viewing ads is privacy protected by DuckDuckGo."
-msgstr ""
-"Στην προβολή διαφημίσεων υπάρχει προστασία απορρήτου από την DuckDuckGo."
+msgstr "Στην προβολή διαφημίσεων υπάρχει προστασία απορρήτου από την DuckDuckGo."
 
 # smartling.placeholder_format=C
 msgctxt "Ads GDPR, internal use only. Do not change"
@@ -22581,7 +22542,7 @@ msgstr "Ουαλία"
 #. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Walk me through the steps"
-msgstr ""
+msgstr "Καθοδηγήστε με στα βήματα"
 
 # smartling.placeholder_format=C
 #. Label for walking directions on a map.
@@ -22712,6 +22673,9 @@ msgid ""
 "please share this conversation with DuckDuckGo so we can investigate and "
 "address the issue."
 msgstr ""
+"Μπορούμε να διορθώσουμε μόνο ό,τι βλέπουμε. Για να αναφέρεις μια επιβλαβή ή "
+"παράνομη απάντηση, κοινοποίησε αυτή τη συνομιλία στο DuckDuckGo, ώστε να "
+"μπορέσουμε να ερευνήσουμε και να επιλύσουμε το ζήτημα."
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -22811,8 +22775,7 @@ msgstr "Δεν σε παρακολουθούμε, ποτέ μα ποτέ."
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with a Continue button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don't track you. That's our Privacy Policy in a nutshell."
-msgstr ""
-"Δεν σας παρακολουθούμε. Αυτή είναι η Πολιτική απορρήτου μας με λίγα λόγια."
+msgstr "Δεν σας παρακολουθούμε. Αυτή είναι η Πολιτική απορρήτου μας με λίγα λόγια."
 
 # smartling.placeholder_format=C
 #. Description for the audio identification highlight in the dictation consent modal.
@@ -22855,8 +22818,7 @@ msgstr ""
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with an Agree button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don’t track you. That’s our Privacy Policy in a nutshell…"
-msgstr ""
-"Δεν σας παρακολουθούμε. Αυτή είναι η Πολιτική απορρήτου μας με λίγα λόγια…"
+msgstr "Δεν σας παρακολουθούμε. Αυτή είναι η Πολιτική απορρήτου μας με λίγα λόγια…"
 
 # smartling.placeholder_format=C
 #. Displayed when the user's voice chat session is ended because of being inactive for too long.
@@ -23157,8 +23119,7 @@ msgstr ""
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai, it's time to import your chats"
-msgstr ""
-"Καλώς ορίσατε στο νέο Duck.ai, ήρθε η ώρα να εισαγάγετε τις συνομιλίες σας"
+msgstr "Καλώς ορίσατε στο νέο Duck.ai, ήρθε η ώρα να εισαγάγετε τις συνομιλίες σας"
 
 # smartling.placeholder_format=C
 #. Welcome message for new DuckDuckGo users.
@@ -23220,15 +23181,14 @@ msgid ""
 "We’re really sorry, but it seems there was a problem loading Duck.ai. Try "
 "reloading the page."
 msgstr ""
-"Λυπούμαστε πολύ, αλλά φαίνεται ότι υπήρξε πρόβλημα κατά τη φόρτωση του Duck."
-"ai. Προσπαθήστε να επαναλάβετε τη φόρτωση της σελίδας."
+"Λυπούμαστε πολύ, αλλά φαίνεται ότι υπήρξε πρόβλημα κατά τη φόρτωση του "
+"Duck.ai. Προσπαθήστε να επαναλάβετε τη φόρτωση της σελίδας."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to suggest an AI (Artificial Intelligence) model to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What AI model would you like us to add? (optional)"
-msgstr ""
-"Ποιο μοντέλο τεχνητής νοημοσύνης θα θέλατε να προσθέσουμε; (προαιρετικό)"
+msgstr "Ποιο μοντέλο τεχνητής νοημοσύνης θα θέλατε να προσθέσουμε; (προαιρετικό)"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for providing arguments, counter-arguments, and rebuttals to the concept of a plant-based diet.
@@ -23294,79 +23254,79 @@ msgstr ""
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the counterarguments?"
-msgstr ""
+msgstr "Ποια είναι τα αντεπιχειρήματα;"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the hours & location?"
-msgstr ""
+msgstr "Ποιες είναι οι ώρες και η τοποθεσία;"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key contributions of this paper?"
-msgstr ""
+msgstr "Ποιες είναι οι βασικές συνεισφορές αυτής της εργασίας;"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key contributions?"
-msgstr ""
+msgstr "Ποιες είναι οι βασικές συνεισφορές;"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key details?"
-msgstr ""
+msgstr "Ποιες είναι οι βασικές λεπτομέρειες;"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key points covered in this video?"
-msgstr ""
+msgstr "Ποια είναι τα βασικά σημεία που καλύπτονται σε αυτό το βίντεο;"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key points?"
-msgstr ""
+msgstr "Ποια είναι τα βασικά σημεία;"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key takeaways from this article?"
-msgstr ""
+msgstr "Ποια είναι τα βασικά σημεία αυτού του άρθρου;"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key takeaways?"
-msgstr ""
+msgstr "Ποια είναι τα βασικά σημεία;"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key things I will learn from this course?"
-msgstr ""
+msgstr "Ποια είναι τα βασικά πράγματα που θα μάθω από αυτή τη σειρά μαθημάτων;"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the main counterarguments or criticisms of this?"
-msgstr ""
+msgstr "Ποια είναι τα κύρια αντεπιχειρήματα ή οι επικρίσεις γι' αυτό;"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the main questions this page answers?"
-msgstr ""
+msgstr "Ποιες είναι οι κύριες ερωτήσεις που απαντά αυτή η σελίδα;"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the must-try dishes here?"
-msgstr ""
+msgstr "Ποια πιάτα πρέπει οπωσδήποτε να δοκιμάσω εδώ;"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
@@ -23374,18 +23334,20 @@ msgctxt "Page suggestion prompt"
 msgid ""
 "What are the opening hours, location, and contact details for this place?"
 msgstr ""
+"Ποιες είναι οι ώρες λειτουργίας, η τοποθεσία και τα στοιχεία επικοινωνίας "
+"γι' αυτό το μέρος;"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the pros and cons of this product?"
-msgstr ""
+msgstr "Ποια είναι τα πλεονεκτήματα και τα μειονεκτήματα αυτού του προϊόντος;"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the pros and cons?"
-msgstr ""
+msgstr "Ποια είναι τα πλεονεκτήματα και τα μειονεκτήματα;"
 
 # smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
@@ -23491,7 +23453,7 @@ msgstr "Τι σημαίνει atria στο πλαίσιο ενός ιατρικ�
 #. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What does this answer?"
-msgstr ""
+msgstr "Σε τι απαντά αυτό;"
 
 # smartling.placeholder_format=C
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
@@ -23509,7 +23471,7 @@ msgstr "Ποιες πληροφορίες αποθηκεύονται;"
 #. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What interview questions might come up for this role?"
-msgstr ""
+msgstr "Ποιες ερωτήσεις συνέντευξης μπορεί να προκύψουν για αυτόν τον ρόλο;"
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -23531,7 +23493,7 @@ msgstr "Ποια είναι η πρωτεύουσα της Αλβανίας;"
 #. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What is the overall verdict and rating for this?"
-msgstr ""
+msgstr "Ποια είναι η συνολική ετυμηγορία και η βαθμολογία γι' αυτό;"
 
 # smartling.placeholder_format=C
 #. Link to a page with additional information.
@@ -23559,7 +23521,7 @@ msgstr "Ποια είναι η άποψη του κόσμου:"
 #. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What should I order?"
-msgstr ""
+msgstr "Τι να παραγγείλω;"
 
 # smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
@@ -23577,13 +23539,13 @@ msgstr "Τι ήταν λάθος με την απάντηση; (προαιρετ
 #. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What will I learn?"
-msgstr ""
+msgstr "Τι θα μάθω;"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What will I need?"
-msgstr ""
+msgstr "Τι θα χρειαστώ;"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -23608,7 +23570,7 @@ msgstr "Τι νέο υπάρχει"
 #. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What's the verdict?"
-msgstr ""
+msgstr "Ποιο είναι το συμπέρασμα;"
 
 # smartling.placeholder_format=C
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -23668,7 +23630,7 @@ msgstr "Ποιες λειτουργίες λείπουν; (Προαιρετικ�
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Which features are missing? (optional)"
-msgstr ""
+msgstr "Ποιες λειτουργίες λείπουν; (προαιρετικά)"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
@@ -23691,12 +23653,14 @@ msgstr "Ποιοι είμαστε"
 msgctxt "Page suggestion prompt"
 msgid "Who are the main cast and crew, and what else are they known for?"
 msgstr ""
+"Ποιοι είναι οι βασικοί ηθοποιοί και οι συντελεστές, και για τι άλλο είναι "
+"γνωστοί;"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Who is this person?"
-msgstr ""
+msgstr "Ποιο είναι αυτό το άτομο;"
 
 # smartling.placeholder_format=C
 #. Header above a collection of privacy-related links.
@@ -24106,8 +24070,7 @@ msgstr ""
 #. Text informing the user that they can access DuckDuckGo AI Chat directly at a specific URL. The placeholder %s will be replaced with the link. Example: 'You can access DuckDuckGo AI Chat directly at duck.ai.'
 msgctxt "Information about direct access to DuckDuckGo AI Chat"
 msgid "You can access DuckDuckGo AI Chat directly at %s."
-msgstr ""
-"Μπορείτε να αποκτήσετε πρόσβαση στο DuckDuckGo AI Chat απευθείας από το %1$s."
+msgstr "Μπορείτε να αποκτήσετε πρόσβαση στο DuckDuckGo AI Chat απευθείας από το %1$s."
 
 # smartling.placeholder_format=C
 #. Search Assist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate Search Assist.
@@ -24298,8 +24261,7 @@ msgstr "Μπορείς να ξεκινήσεις από την αρχή σε α�
 #. Text explaining the benefits of the cloud save feature.
 msgctxt "cloudsave"
 msgid "You can store several sets of settings for different purposes."
-msgstr ""
-"Μπορείς να αποθηκεύσεις διάφορα σύνολα ρυθμίσεων για διαφορετικούς σκοπούς."
+msgstr "Μπορείς να αποθηκεύσεις διάφορα σύνολα ρυθμίσεων για διαφορετικούς σκοπούς."
 
 # smartling.placeholder_format=C
 #. Instructions for user once they've failed the bot challenge
@@ -24463,16 +24425,14 @@ msgstr ""
 #. Description shown when the user has reached the maximum voice chat duration.
 msgctxt "voice chat duration limit modal"
 msgid "You've reached the maximum voice chat duration for a single session."
-msgstr ""
-"Έχετε φτάσει τη μέγιστη διάρκεια φωνητικής συνομιλίας για μία συνεδρία."
+msgstr "Έχετε φτάσει τη μέγιστη διάρκεια φωνητικής συνομιλίας για μία συνεδρία."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the daily voice chat limit.
 msgctxt "voice chat limit modal"
 msgid ""
 "You've reached the voice chat limit for today. Please try again tomorrow."
-msgstr ""
-"Έχετε φτάσει το όριο φωνητικής συνομιλίας για σήμερα. Δοκιμάστε ξανά αύριο."
+msgstr "Έχετε φτάσει το όριο φωνητικής συνομιλίας για σήμερα. Δοκιμάστε ξανά αύριο."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
@@ -24498,9 +24458,9 @@ msgid ""
 "oldest chats with attachments to resume Sync. Pinned chats will not be "
 "deleted."
 msgstr ""
-"Έχει εξαντληθεί ο χώρος αποθήκευσης του Sync & Backup για συνομιλίες Duck."
-"ai. Διαγράψτε τις %1$s παλαιότερες συνομιλίες με συνημμένα για να συνεχίσετε "
-"τον συγχρονισμό. Οι καρφιτσωμένες συνομιλίες δεν θα διαγραφούν."
+"Έχει εξαντληθεί ο χώρος αποθήκευσης του Sync & Backup για συνομιλίες "
+"Duck.ai. Διαγράψτε τις %1$s παλαιότερες συνομιλίες με συνημμένα για να "
+"συνεχίσετε τον συγχρονισμό. Οι καρφιτσωμένες συνομιλίες δεν θα διαγραφούν."
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the sync storage limit.

--- a/locales/el_GR/LC_MESSAGES/duckduckgo.po
+++ b/locales/el_GR/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: el_GR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -102,7 +102,8 @@ msgstr "%1$s απόπειρες"
 # smartling.placeholder_format=C
 #. A summary description of how many tracking attempts where blocked, when there was more than 1. Eg: '1,028 attempts blocked by DuckDuckGo in the last 24 hours'
 msgid "%s attempts blocked by DuckDuckGo in the last 24 hours"
-msgstr "Αποκλείστηκαν %1$s προσπάθειες από το DuckDuckGo κατά τις τελευταίες 24 ώρες"
+msgstr ""
+"Αποκλείστηκαν %1$s προσπάθειες από το DuckDuckGo κατά τις τελευταίες 24 ώρες"
 
 # smartling.placeholder_format=C
 #. A label that indicates a specific search result has been blocked by the safe search filter. The placeholder value is the name of the search result that was blocked.
@@ -505,7 +506,8 @@ msgstr ""
 #. A message displayed when there is an error loading content or no results on requery
 msgctxt "Error or no results message"
 msgid "%sOops!%s%sSomething went wrong. Please %srefresh%s and try again."
-msgstr "%1$sΚρίμα!%2$s%3$sΚάτι πήγε λάθος. %4$sΑνανεώστε%5$s και προσπαθήστε ξανά."
+msgstr ""
+"%1$sΚρίμα!%2$s%3$sΚάτι πήγε λάθος. %4$sΑνανεώστε%5$s και προσπαθήστε ξανά."
 
 # smartling.placeholder_format=C
 #. Tagline in a popover encouraging the user to download the DuckDuckGo browser
@@ -595,7 +597,8 @@ msgstr "1 προσπάθεια"
 # smartling.placeholder_format=C
 #. A summary description of how many tracking attempts where blocked, when only one exists.
 msgid "1 attempt blocked by DuckDuckGo in the last 24 hours"
-msgstr "Αποκλείστηκε 1 προσπάθεια από το DuckDuckGo κατά τις τελευταίες 24 ώρες"
+msgstr ""
+"Αποκλείστηκε 1 προσπάθεια από το DuckDuckGo κατά τις τελευταίες 24 ώρες"
 
 # smartling.placeholder_format=C
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -983,7 +986,8 @@ msgstr ""
 #. Disclaimer text displayed at the bottom of the voice chat dialog informing the user that the AI (Artificial Intelligence) may provide inaccurate or offensive information.
 msgctxt "voice chat"
 msgid "AI may provide inaccurate or offensive information."
-msgstr "Η τεχνητή νοημοσύνη μπορεί να παρέχει ανακριβείς ή προσβλητικές πληροφορίες."
+msgstr ""
+"Η τεχνητή νοημοσύνη μπορεί να παρέχει ανακριβείς ή προσβλητικές πληροφορίες."
 
 # smartling.placeholder_format=C
 #. Label for the input field where user can specify how the AI assistant should refer to itself. Example: 'AI nickname (is): Fred'
@@ -1460,6 +1464,12 @@ msgid "Address is incorrect"
 msgstr "Η διεύθυνση είναι λάθος"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Adjust the servings"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. as in multiple advertisements
 msgid "Ads"
 msgstr "Διαφημίσεις"
@@ -1664,13 +1674,22 @@ msgstr "Όλες οι συνομιλίες είναι %1$s"
 #. Disclaimer text shown below chat input. %s is replaced with a clickable underlined 'private' link that opens the privacy protection modal.
 msgctxt "Disclaimer below chat input in Duck.ai"
 msgid "All chats are %s. AI can make mistakes."
-msgstr "Όλες οι συνομιλίες είναι %1$s. Η τεχνητή νοημοσύνη μπορεί να κάνει λάθη."
+msgstr ""
+"Όλες οι συνομιλίες είναι %1$s. Η τεχνητή νοημοσύνη μπορεί να κάνει λάθη."
 
 # smartling.placeholder_format=C
 #. Heading shown on the empty chat screen. The text between the two %s markers is displayed inside a clickable privacy button. First %s renders a shield icon, second %s is an invisible end marker. Keep the word 'private' between both %s markers.
 msgctxt "Empty state heading in Duck.ai chat mode"
 msgid "All chats are %sprivate%s"
 msgstr "Όλες οι συνομιλίες είναι %1$sιδιωτικές%2$s"
+
+# smartling.placeholder_format=C
+#. Paragraph in the Privacy & Terms section of the About & Legal page in Duck.ai settings, summarizing how chats are anonymized and are not stored or used to train chat models.
+msgctxt "Privacy & Terms section description on the Duck.ai settings page"
+msgid ""
+"All chats are anonymized by DuckDuckGo, and your conversations are not used "
+"to train chat models by DuckDuckGo or the model providers"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1946,6 +1965,13 @@ msgid "Anonymous location enabled"
 msgstr "Ενεργοποιήθηκε ανώνυμη χρήση τοποθεσίας"
 
 # smartling.placeholder_format=C
+msgctxt "settings"
+msgid ""
+"Anonymously generates answers for search queries based on web content. "
+"Choose how often you want it to appear, or disable it completely."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Instant Answer tab name
 msgid "Answer"
 msgstr "Απάντηση"
@@ -2098,7 +2124,8 @@ msgstr ""
 #. Body text of the modal that asks the user if they want to clear the conversation.
 msgctxt "Modal body for clearing conversation"
 msgid "Are you sure you want to clear this conversation and start a new one?"
-msgstr "Θέλετε σίγουρα να διαγράψετε τη συνομιλία αυτή και να αρχίσετε μια νέα;"
+msgstr ""
+"Θέλετε σίγουρα να διαγράψετε τη συνομιλία αυτή και να αρχίσετε μια νέα;"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to delete their current chat, explaining that this action cannot be undone.
@@ -2228,6 +2255,12 @@ msgstr "Κάντε μια συμπληρωματική ερώτηση"
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse
 msgid "Ask a follow-up with Duck.ai"
 msgstr "Ζητήστε συμπληρωματική ερώτηση από το Duck.ai"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
+msgctxt "Page suggestion chip label"
+msgid "Ask about this page"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2657,6 +2690,12 @@ msgid "Barcode"
 msgstr "Γραμμοκώδικας"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Based on this page, is this course worth taking?"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Basic"
 msgstr "Βασική"
@@ -2695,6 +2734,14 @@ msgstr "Μπάτερ"
 msgctxt "Assistant response placeholder"
 msgid "Before continuing..."
 msgstr "Προτού συνεχίσουμε..."
+
+# smartling.placeholder_format=C
+#. Explains that before storing the report, DuckDuckGo will anonymize the conversation by removing PII like names, email addresses, and identifying metadata.
+msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
+msgid ""
+"Before storing this report, DuckDuckGo will anonymize your conversation by "
+"removing PII like names, email addresses, and identifying metadata."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -2815,12 +2862,14 @@ msgstr "Αποκλεισμός ενοχλητικών αναδυόμενων π�
 #. DuckDuckGo Email Protection offers the ability to generate random email addresses to protect your personal email address
 msgctxt "SERP footer content"
 msgid "Block email trackers and hide your address."
-msgstr "Αποκλείστε εφαρμογές παρακολούθησης email και αποκρύψτε τη διεύθυνσή σας."
+msgstr ""
+"Αποκλείστε εφαρμογές παρακολούθησης email και αποκρύψτε τη διεύθυνσή σας."
 
 # smartling.placeholder_format=C
 #. A disclaimer about AI-generated images in search results
 msgid "Block list is not exhaustive and may contain inaccuracies."
-msgstr "Η λίστα αποκλεισμού δεν είναι πλήρης και ενδέχεται να περιέχει ανακρίβειες."
+msgstr ""
+"Η λίστα αποκλεισμού δεν είναι πλήρης και ενδέχεται να περιέχει ανακρίβειες."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -2903,7 +2952,8 @@ msgstr "Αποκλεισμένα:"
 #. shown after the DuckDuckGo extension is installed
 msgctxt "welcome message"
 msgid "Blocks trackers on websites you visit"
-msgstr "Μπλοκάρει τα προγράμματα παρακολούθησης στους ιστοτόπους που επισκέπτεστε"
+msgstr ""
+"Μπλοκάρει τα προγράμματα παρακολούθησης στους ιστοτόπους που επισκέπτεστε"
 
 # smartling.placeholder_format=C
 msgid "Blog"
@@ -3015,6 +3065,12 @@ msgstr "Βραζιλία"
 msgctxt "Sports module"
 msgid "Break Points Won"
 msgstr "Κερδισμένα Μπρέικ πόιντ"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Break this down into clear, numbered steps."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -3181,7 +3237,8 @@ msgstr "Κάνοντας κλικ στο «%1$s» συμφωνείτε με το
 msgctxt ""
 "Copy stating agreement to Duck.ai Privacy Policy and Terms of Service."
 msgid "By clicking “%s,” you accept Duck.ai’s %s and %s."
-msgstr "Κάνοντας κλικ στο «%1$s», αποδέχεστε την %2$s και τους %3$s του Duck.ai."
+msgstr ""
+"Κάνοντας κλικ στο «%1$s», αποδέχεστε την %2$s και τους %3$s του Duck.ai."
 
 # smartling.placeholder_format=C
 #. Text stating agreement to Duck.ai Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'By clicking “Agree and Continue,” you accept Duck.ai’s Privacy Policy and Terms of Service.'
@@ -3477,6 +3534,12 @@ msgid "Cast"
 msgstr "Ηθοποιοί"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Cast & Crew"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
 msgctxt "Tone option label for Casual"
 msgid "Casual"
@@ -3561,7 +3624,8 @@ msgstr "Αλλάζει την εμφάνιση των διευθύνσεων URL
 #. This is the description of a user setting
 msgctxt "settings"
 msgid "Changes how the header is displayed and its behavior as you scroll"
-msgstr "Αλλάζει την εμφάνιση της κεφαλίδας και τη συμπεριφορά της κατά την κύλιση"
+msgstr ""
+"Αλλάζει την εμφάνιση της κεφαλίδας και τη συμπεριφορά της κατά την κύλιση"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/mcZdcaF.png
@@ -4248,8 +4312,8 @@ msgid ""
 msgstr ""
 "Η εκκαθάριση των δεδομένων του προγράμματος περιήγησης διαγράφει τις "
 "πρόσφατες συνομιλίες. Οι πρόσφατες συνομιλίες μπορεί να αποθηκευτούν επ' "
-"αόριστον ή να διαγραφούν αυτόματα μετά από 7 ημέρες χωρίς χρήση του "
-"Duck.ai., ανάλογα με το πρόγραμμα περιήγησής σας."
+"αόριστον ή να διαγραφούν αυτόματα μετά από 7 ημέρες χωρίς χρήση του Duck."
+"ai., ανάλογα με το πρόγραμμα περιήγησής σας."
 
 # smartling.placeholder_format=C
 #. Warning message shown on the Block domain success modal. Blocked sites are stored in localStorage which is cleared alongside cookies when users clear browser data. Followed by a linked 'our free browser' text.
@@ -4369,7 +4433,8 @@ msgstr "Κάνε κλικ στις %1$sΡυθμίσεις%2$s στο αναπτ�
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
-msgstr "Κάνε κλικ στο %1$sΧρήση τρεχουσών σελίδων%2$s και έπειτα στο %3$sΟΚ%4$s"
+msgstr ""
+"Κάνε κλικ στο %1$sΧρήση τρεχουσών σελίδων%2$s και έπειτα στο %3$sΟΚ%4$s"
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -4407,7 +4472,8 @@ msgstr "Κάνε κλικ στο %1$sΠρόγραμμα περιήγησης%2$s
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click on %sChange Search Settings%s in the dropdown menu"
-msgstr "Κάνε κλικ στο %1$sΑλλαγή ρυθμίσεων αναζήτησης%2$s στο αναπτυσσόμενο μενού"
+msgstr ""
+"Κάνε κλικ στο %1$sΑλλαγή ρυθμίσεων αναζήτησης%2$s στο αναπτυσσόμενο μενού"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -4487,13 +4553,15 @@ msgstr "Κάνε κλικ στην καρτέλα %1$sΓενικά%2$s."
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click the %sellipsis icon%s in the toolbar."
-msgstr "Κάνε κλικ στο %1$sεικονίδιο με τα αποσιωπητικά%2$s στη γραμμή εργαλείων."
+msgstr ""
+"Κάνε κλικ στο %1$sεικονίδιο με τα αποσιωπητικά%2$s στη γραμμή εργαλείων."
 
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Click the %slock icon%s on the address bar."
-msgstr "Κάνε κλικ στο %1$sεικονίδιο με την κλειδαριά%2$s στη γραμμή διευθύνσεων."
+msgstr ""
+"Κάνε κλικ στο %1$sεικονίδιο με την κλειδαριά%2$s στη γραμμή διευθύνσεων."
 
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to enable location service. Part of a list of instructions on how to enable location service.
@@ -5218,6 +5286,12 @@ msgid "Create Image"
 msgstr "Δημιουργία εικόνας"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Create a shopping list with quantities from this recipe."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text displayed in the input field when starting a new image generation session.
 msgctxt "Placeholder text for the image generation input field"
 msgid "Create an image of a cute duck..."
@@ -5789,7 +5863,8 @@ msgstr "Περιγράψτε τις αλλαγές με βάση την εικό
 #. Placeholder text displayed in the input field when the user can make follow-up edits to a generated image.
 msgctxt "Placeholder text for the image generation input field for follow-ups"
 msgid "Describe changes to continue editing this image"
-msgstr "Περιγράψτε τις αλλαγές για να συνεχίσετε την επεξεργασία αυτής της εικόνας"
+msgstr ""
+"Περιγράψτε τις αλλαγές για να συνεχίσετε την επεξεργασία αυτής της εικόνας"
 
 # smartling.placeholder_format=C
 #. Title shown when the user first enters Image Generation mode, prompting them to describe the image they want to create.
@@ -5860,6 +5935,11 @@ msgstr ""
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
 msgid "Dictation limit reached"
 msgstr "Συμπληρώθηκε το όριο υπαγόρευσης"
+
+# smartling.placeholder_format=C
+#. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
+msgid "Dictation temporarily unavailable"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
@@ -5949,7 +6029,8 @@ msgstr "Απενεργοποίηση και αποσύνδεση"
 #. Title of a modal that asks the user if they want to turn off chat history and disconnect from Sync & Backup.
 msgctxt "Modal header for disabling chat history and disconnecting sync"
 msgid "Disable chat history and disconnect from Sync & Backup?"
-msgstr "Απενεργοποίηση ιστορικού συνομιλιών και αποσύνδεση από το Sync & Backup;"
+msgstr ""
+"Απενεργοποίηση ιστορικού συνομιλιών και αποσύνδεση από το Sync & Backup;"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to turn off the chat history feature.
@@ -6054,7 +6135,8 @@ msgstr "Γλώσσα οθόνης"
 #. This is the description of a user setting
 msgctxt "settings"
 msgid "Displays a checkmark to the left of results you've visited"
-msgstr "Εμφανίζει ένα σημάδι στα αριστερά των αποτελεσμάτων που έχεις επισκεφθεί"
+msgstr ""
+"Εμφανίζει ένα σημάδι στα αριστερά των αποτελεσμάτων που έχεις επισκεφθεί"
 
 # smartling.placeholder_format=C
 #. This is the description of a user setting
@@ -6137,7 +6219,8 @@ msgstr "Δεν βλέπεις το DuckDuckGo στη λίστα;"
 #. Link to download a file again if the user can't find it on their computer.
 msgctxt "install-extension"
 msgid "Don't see it? %s%s%sClick here to re-download%s"
-msgstr "Δεν το βλέπεις; %1$s%2$s%3$sΚάνε κλικ εδώ για να το ξανακατεβάσεις.%4$s"
+msgstr ""
+"Δεν το βλέπεις; %1$s%2$s%3$sΚάνε κλικ εδώ για να το ξανακατεβάσεις.%4$s"
 
 #  IE < 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -6161,6 +6244,22 @@ msgstr "Ολοκληρώθηκε"
 msgctxt "precise_user_location"
 msgid "Done"
 msgstr "Ολοκληρώθηκε"
+
+# smartling.placeholder_format=C
+#. Message shown in a modal after DuckDuckGo browser users disable AI features in Settings. The first two placeholders bold noai.duckduckgo.com. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
+"filtered out. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
+"and AI images filtered out. %sLearn more%s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6275,6 +6374,18 @@ msgid ""
 msgstr ""
 "Γράψε ένα συνοπτικό και λεπτομερές email προς έναν πωλητή ζητώντας προσφορά "
 "για υπηρεσίες επισκευής ενός οικιακού ψυγείου."
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Draft a cover letter"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Draft a cover letter for this job."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -6412,7 +6523,8 @@ msgstr "Όρους χρήσης υπηρεσίας του Duck.ai"
 #. The HTML <title> for Duck.ai.
 msgctxt "duckai_seo"
 msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
-msgstr "Duck.ai από το DuckDuckGo. Ιδιωτική συνομιλία με τεχνητή νοημοσύνη. Δωρεάν."
+msgstr ""
+"Duck.ai από το DuckDuckGo. Ιδιωτική συνομιλία με τεχνητή νοημοσύνη. Δωρεάν."
 
 # smartling.placeholder_format=C
 #. Description explaining how the page context feature works in Duck.ai sidebar.
@@ -6459,6 +6571,15 @@ msgstr ""
 "DuckDuckGo!"
 
 # smartling.placeholder_format=C
+#. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
+msgctxt "About section description on the Duck.ai settings page"
+msgid ""
+"Duck.ai is created by DuckDuckGo. We're an independent online protection "
+"company for anyone who wants to take back control of their personal "
+"information."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
 msgctxt "duckai_migration"
 msgid "Duck.ai is moving domains"
@@ -6472,8 +6593,8 @@ msgid ""
 "remember home on the web: https://duck.ai"
 msgstr ""
 "Το Duck.ai εξακολουθεί να αποτελεί προϊόν της DuckDuckGo, ωστόσο πλέον θα "
-"έχει μια πιο εύκολη στην απομνημόνευση διεύθυνση στο διαδίκτυο: "
-"https://duck.ai"
+"έχει μια πιο εύκολη στην απομνημόνευση διεύθυνση στο διαδίκτυο: https://duck."
+"ai"
 
 # smartling.placeholder_format=C
 #. Headline for domain change notice.
@@ -6509,6 +6630,13 @@ msgstr "Το Duck.ai δεν είναι διαθέσιμο προσωρινά. Ξ
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
+"Duck.ai lets you chat privately with popular AI models. Disabling it hides "
+"Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
+msgstr ""
+
+# smartling.placeholder_format=C
+msgctxt "settings"
+msgid ""
 "Duck.ai lets you have anonymous conversations with 3rd-party AI chat models, "
 "including models from OpenAI, Anthropic, and others. Turning this setting "
 "off will hide Duck.ai buttons and links on DuckDuckGo Search. However, you "
@@ -6527,7 +6655,8 @@ msgstr ""
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
 msgctxt "Disclaimer text at the bottom of the feedback form."
 msgid "Duck.ai may display inaccurate or offensive information."
-msgstr "Το Duck.ai ενδέχεται να εμφανίζει ανακριβείς ή προσβλητικές πληροφορίες."
+msgstr ""
+"Το Duck.ai ενδέχεται να εμφανίζει ανακριβείς ή προσβλητικές πληροφορίες."
 
 # smartling.placeholder_format=C
 #. Error modal body line 2.
@@ -6543,7 +6672,8 @@ msgstr ""
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
 msgctxt "Promotional text for PDF upload feature"
 msgid "Duck.ai now can read and analyze PDFs. Give it a try!"
-msgstr "Το Duck.ai μπορεί πλέον να διαβάζει και να αναλύει αρχεία PDF. Δοκιμάστε το!"
+msgstr ""
+"Το Duck.ai μπορεί πλέον να διαβάζει και να αναλύει αρχεία PDF. Δοκιμάστε το!"
 
 # smartling.placeholder_format=C
 #. Disclaimer text shown above the chat input only when coming from a DuckAssist grounded response into ungrounded models.
@@ -6570,7 +6700,8 @@ msgstr "Το Duck.ai αναβαθμίστηκε!"
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
-msgstr "Το Duck.ai λειτουργεί καλύτερα στην ιδιωτική και δωρεάν εφαρμογή DuckDuckGo!"
+msgstr ""
+"Το Duck.ai λειτουργεί καλύτερα στην ιδιωτική και δωρεάν εφαρμογή DuckDuckGo!"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -6764,7 +6895,8 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr "Το DuckDuckGo AI Chat δεν είναι διαθέσιμο προσωρινά. Ξαναδοκιμάστε αργότερα."
+msgstr ""
+"Το DuckDuckGo AI Chat δεν είναι διαθέσιμο προσωρινά. Ξαναδοκιμάστε αργότερα."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -6989,7 +7121,8 @@ msgctxt ""
 "Description of the DuckDuckGo subscription setting when it is not available "
 "in the user region"
 msgid "DuckDuckGo subscriptions are not available to purchase in this region."
-msgstr "Οι συνδρομές DuckDuckGo δεν είναι διαθέσιμες για αγορά στην περιοχή αυτή."
+msgstr ""
+"Οι συνδρομές DuckDuckGo δεν είναι διαθέσιμες για αγορά στην περιοχή αυτή."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use 'ducky' tone in its responses. When this option is selected, the AI assistant speaks like a duck.
@@ -7161,7 +7294,8 @@ msgstr "Δώστε έμφαση σε σημαντικές πληροφορίες
 #. Tells users which setting to change to enable location service.
 msgctxt "precise_user_location"
 msgid "Enable 'Sites can ask for my location.'"
-msgstr "Ενεργοποίησε την επιλογή «Οι ιστότοποι μπορούν να ζητούν την τοποθεσία μου»."
+msgstr ""
+"Ενεργοποίησε την επιλογή «Οι ιστότοποι μπορούν να ζητούν την τοποθεσία μου»."
 
 # smartling.placeholder_format=C
 #. Button shown during outages to enable AI features
@@ -7173,7 +7307,8 @@ msgstr "Ενεργοποίηση λειτουργιών τεχνητής νοη�
 #. Text explaining how to enable the cloud save feature.
 msgctxt "cloudsave"
 msgid "Enable Cloud Save by entering your existing passphrase."
-msgstr "Ενεργοποίησε το Cloud Save, πληκτρολογώντας την υπάρχουσα φράση πρόσβασης."
+msgstr ""
+"Ενεργοποίησε το Cloud Save, πληκτρολογώντας την υπάρχουσα φράση πρόσβασης."
 
 # smartling.placeholder_format=C
 #. Primary button text in the dictation privacy consent modal to enable dictation.
@@ -7374,19 +7509,22 @@ msgstr "Βεβαιώσου ότι έχεις επιλέξει %1$sΑποδοχή
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location Services' is %senabled%s."
-msgstr "Βεβαιώσου ότι η επιλογή «Υπηρεσίες τοποθεσίας» είναι %1$sενεργοποιημένη%2$s."
+msgstr ""
+"Βεβαιώσου ότι η επιλογή «Υπηρεσίες τοποθεσίας» είναι %1$sενεργοποιημένη%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location' is set to %sallow%s"
-msgstr "Βεβαιωθείτε ότι η επιλογή «Τοποθεσία» έχει οριστεί σε %1$sΝα επιτρέπεται%2$s"
+msgstr ""
+"Βεβαιωθείτε ότι η επιλογή «Τοποθεσία» έχει οριστεί σε %1$sΝα επιτρέπεται%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location' is set to %sallow%s."
-msgstr "Βεβαιώσου ότι η επιλογή «Τοποθεσία» έχει οριστεί σε %1$sΝα επιτρέπεται%2$s."
+msgstr ""
+"Βεβαιώσου ότι η επιλογή «Τοποθεσία» έχει οριστεί σε %1$sΝα επιτρέπεται%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -7509,7 +7647,8 @@ msgstr "Καταχώρισε τη διεύθυνση email σου."
 #. A prompt asking users to enter their passphrase.
 msgctxt "cloudsave"
 msgid "Enter your passphrase to load your settings."
-msgstr "Πληκτρολόγησε τη φράση πρόσβασής σου για να φορτωθούν οι ρυθμίσεις σου."
+msgstr ""
+"Πληκτρολόγησε τη φράση πρόσβασής σου για να φορτωθούν οι ρυθμίσεις σου."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of an entertainment guide in its responses.
@@ -7532,6 +7671,18 @@ msgstr ""
 # smartling.placeholder_format=C
 msgid "Eritrea"
 msgstr "Ερυθραία"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Estimate the nutrition"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Estimate the nutritional information for this recipe."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Estonia"
@@ -7567,7 +7718,8 @@ msgstr "Ανάπτυξη χάρτη"
 #. Subtitle for the Collaborations promotional card at the bottom of search results. Describes the branded merchandise line. 'Give a duck' is a wordplay on the DuckDuckGo brand name.
 msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
-msgstr "Εξειδικευμένα προϊόντα για άτομα που ενδιαφέρονται για την ιδιωτικότητα."
+msgstr ""
+"Εξειδικευμένα προϊόντα για άτομα που ενδιαφέρονται για την ιδιωτικότητα."
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
@@ -7588,6 +7740,12 @@ msgid "Expires in 1 day"
 msgstr "Λήγει σε 1 ημέρα"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain the accepted answer in simple terms."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
@@ -7595,6 +7753,48 @@ msgid ""
 msgstr ""
 "Εξήγησέ μου τις θεμελιώδεις έννοιες των μαύρων τρυπών σε επίπεδο γυμνασίου "
 "και λυκείου."
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain the top answer"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this in simple, plain language."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this paper"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this repo"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this research paper in plain language."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this simply"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain what this repository does and how to use it."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label to show if song lyrics contain explicit content
@@ -7885,6 +8085,12 @@ msgstr ""
 "αποτελέσματα αναζήτησης εικόνων. %1$sΜάθετε περισσότερα%2$s"
 
 # smartling.placeholder_format=C
+msgctxt "settings"
+msgid ""
+"Filters out known AI spam sites from image search results. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the final score of a sporting event.
 msgid "Final"
 msgstr "Τελικό"
@@ -7911,7 +8117,8 @@ msgstr "Οικονομικός σύμβουλος"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Find %sDuckDuckGo%s and click%sMake default%s"
-msgstr "Βρες το %1$sDuckDuckGo%2$s και κάνε κλικ στο%3$sΟρισμός ως προεπιλογής%4$s"
+msgstr ""
+"Βρες το %1$sDuckDuckGo%2$s και κάνε κλικ στο%3$sΟρισμός ως προεπιλογής%4$s"
 
 # smartling.placeholder_format=C
 #. Sentence shown after export, includes a placeholder for one or more filenames with bold formatting for the filename(s).
@@ -7938,6 +8145,12 @@ msgstr "Βρες μια καλύτερη λέξη"
 msgctxt "Subtitle for the Web Search tool entry in the Tools dropdown menu"
 msgid "Find current information"
 msgstr "Βρείτε τρέχουσες πληροφορίες"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Find me alternatives"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button that searches for results closer to the user's current location.
@@ -8422,6 +8635,12 @@ msgid "Generate More"
 msgstr "Δημιουργήστε περισσότερα"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Generate a shopping list"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
 msgid "Generate a short answer from the web"
 msgstr "Δημιουργήστε μια σύντομη απάντηση από το διαδίκτυο"
@@ -8719,10 +8938,17 @@ msgid "Give it a Try"
 msgstr "Δοκιμάστε το"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Give me a quick background on this person."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
-msgstr "Μεταβείτε στις επιλογές %1$sΑπόρρητο και ασφάλεια > Υπηρεσίες τοποθεσίας%2$s"
+msgstr ""
+"Μεταβείτε στις επιλογές %1$sΑπόρρητο και ασφάλεια > Υπηρεσίες τοποθεσίας%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9166,6 +9392,18 @@ msgid "Help Spread Privacy"
 msgstr "Βοήθησέ μας να προστατεύσουμε το ιδιωτικό απόρρητο"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Help me prep for the interview"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Help me tailor my resume for this job."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title of a SERP popup that invites users to take a survey (desktop only)
 msgctxt "User survey popup"
 msgid "Help us improve DuckDuckGo"
@@ -9175,7 +9413,8 @@ msgstr "Βοηθήστε μας να βελτιώσουμε το DuckDuckGo"
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Help us improve DuckDuckGo searches with your feedback"
-msgstr "Βοηθήστε μας να βελτιώσουμε τις αναζητήσεις DuckDuckGo με τα σχόλιά σας"
+msgstr ""
+"Βοηθήστε μας να βελτιώσουμε τις αναζητήσεις DuckDuckGo με τα σχόλιά σας"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -9227,7 +9466,8 @@ msgstr "Βοηθήστε μας να καταλάβουμε πώς δεν πετ
 #. A subtitle of a page that encourages users to share DuckDuckGo with their friends.
 msgctxt "showcase_spread"
 msgid "Help your friends and family join the Duck Side!"
-msgstr "Βοήθησε τους φίλους και την οικογένειά σου να μάθουν τον κόσμο του Παπιού!"
+msgstr ""
+"Βοήθησε τους φίλους και την οικογένειά σου να μάθουν τον κόσμο του Παπιού!"
 
 # smartling.placeholder_format=C
 #. Text description for the Spread card in the SERP footer
@@ -9526,7 +9766,8 @@ msgstr "Οι ώρες λείπουν"
 #. This is the name of a user setting
 msgctxt "settings"
 msgid "Hover, Module, and Dropdown Background Color"
-msgstr "Χρώμα δείκτη αποτελεσμάτων, λειτουργικής μονάδας και αναπτυσσόμενου μενού"
+msgstr ""
+"Χρώμα δείκτη αποτελεσμάτων, λειτουργικής μονάδας και αναπτυσσόμενου μενού"
 
 # smartling.placeholder_format=C
 #. Label for a pill-shaped tab below the empty-state Duck.ai chat input. Clicking it opens a panel that explains how Duck.ai protects user privacy.
@@ -9633,7 +9874,8 @@ msgstr "Πόσο συχνά θέλετε να βλέπετε τις απαντή
 #. A header for the feedback form in the assist negative feedback flow. The user is being asked to update how often they want AI-assisted answers to appear.
 msgctxt "duckassist"
 msgid "How often do you want to see AI-assisted answers?"
-msgstr "Πόσο συχνά θέλετε να βλέπετε απαντήσεις με τη βοήθεια τεχνητής νοημοσύνης;"
+msgstr ""
+"Πόσο συχνά θέλετε να βλέπετε απαντήσεις με τη βοήθεια τεχνητής νοημοσύνης;"
 
 # smartling.placeholder_format=C
 #. Section title above the frequency radio options in the Search Assist settings modal.
@@ -9688,6 +9930,14 @@ msgstr "Τυφώνας"
 msgctxt "Onboarding terms screen button text"
 msgid "I Agree"
 msgstr "Συμφωνώ"
+
+# smartling.placeholder_format=C
+#. Text for the button that takes the user to the external DuckDuckGo login subscription page.
+msgctxt ""
+"Text for the I already have a subscription button in the Duck.ai settings "
+"page"
+msgid "I Already Have a Subscription"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the button that takes the user to the login subscription page.
@@ -9860,7 +10110,8 @@ msgstr ""
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
-msgstr "Αν θες παρ' όλα αυτά να μας υποστηρίξεις, %1$sδιάδωσε το DuckDuckGo%2$s"
+msgstr ""
+"Αν θες παρ' όλα αυτά να μας υποστηρίξεις, %1$sδιάδωσε το DuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -10271,6 +10522,12 @@ msgid "Install Mac Browser"
 msgstr "Εγκαταστήστε το πρόγραμμα περιήγησης για Mac"
 
 # smartling.placeholder_format=C
+#. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
+msgctxt "settings"
+msgid "Install Now"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of a button to install the DuckDuckGo app
 msgctxt "Serp footer content"
 msgid "Install Our App"
@@ -10368,10 +10625,42 @@ msgid "Is deleted data really deleted?"
 msgstr "Τα διαγραμμένα δεδομένα διαγράφονται πραγματικά;"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is it worth taking?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this place any good?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"Is this place any good? Summarize its reputation based on reviews and "
+"ratings."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "Is this video helpful?"
 msgstr "Είναι χρήσιμο αυτό το βίντεο;"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this worth watching?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Is this worth watching? Give me a spoiler-free take."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -10405,7 +10694,8 @@ msgstr ""
 msgctxt "settings"
 msgid ""
 "It's okay to (very infrequently) ask me about my experience using DuckDuckGo"
-msgstr "Δέχομαι να με ρωτάτε (πολύ σποραδικά) για την εμπειρία μου με το DuckDuckGo"
+msgstr ""
+"Δέχομαι να με ρωτάτε (πολύ σποραδικά) για την εμπειρία μου με το DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. The name of the Italian language
@@ -10993,6 +11283,12 @@ msgid "Links:"
 msgstr "Σύνδεσμοι:"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "List the tools, materials, or prerequisites I need for this."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
 msgid "Listen"
 msgstr "Ακρόαση"
@@ -11401,6 +11697,12 @@ msgstr "Διαχειριστείτε τη συνδρομή σας"
 msgctxt "Exclusion message manage sites button"
 msgid "Manage blocked sites"
 msgstr "Διαχείριση αποκλεισμένων ιστότοπων"
+
+# smartling.placeholder_format=C
+#. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
+msgctxt "setting"
+msgid "Manage in Browser Settings"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to the site exclusion settings page
@@ -12691,7 +12993,8 @@ msgstr "Δεν βρέθηκαν αποτελέσματα."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the recording contains no audible speech.
 msgid "No speech detected. Please try again and speak into your microphone."
-msgstr "Δεν εντοπίστηκε ομιλία. Προσπαθήστε ξανά και μιλήστε στο μικρόφωνό σας."
+msgstr ""
+"Δεν εντοπίστηκε ομιλία. Προσπαθήστε ξανά και μιλήστε στο μικρόφωνό σας."
 
 # smartling.placeholder_format=C
 #. Button that dismisses a feedback form.
@@ -12715,13 +13018,15 @@ msgstr "Δεν αποκλείστηκαν εφαρμογές παρακολού�
 #. Refers to how web searches on DuckDuckGo aren't tracked.
 msgctxt "homepage onboarding"
 msgid "No tracking, no ad targeting, just searching!"
-msgstr "Χωρίς παρακολούθηση, χωρίς στοχευμένες διαφημίσεις, μόνο καθαρή αναζήτηση!"
+msgstr ""
+"Χωρίς παρακολούθηση, χωρίς στοχευμένες διαφημίσεις, μόνο καθαρή αναζήτηση!"
 
 # smartling.placeholder_format=C
 #. Refers to how web searches on DuckDuckGo aren't tracked.
 msgctxt "homepage onboarding"
 msgid "No tracking, no ad targeting, just searching."
-msgstr "Χωρίς παρακολούθηση, χωρίς στοχευμένες διαφημίσεις, μόνο καθαρή αναζήτηση."
+msgstr ""
+"Χωρίς παρακολούθηση, χωρίς στοχευμένες διαφημίσεις, μόνο καθαρή αναζήτηση."
 
 # smartling.placeholder_format=C
 #. Indicates that there were no search results for a user's search. The placeholder is the user's search term. For example: 'No videos found for 'bad dogs''
@@ -13487,8 +13792,8 @@ msgstr "Άνοιγμα του πίνακα «Πώς λειτουργεί το Du
 msgctxt "precise_user_location"
 msgid "Open the Safari menu and select %sSettings for DuckDuckGo...%s"
 msgstr ""
-"Ανοίξτε το μενού του Safari και επιλέξτε %1$sΡυθμίσεις για το "
-"DuckDuckGo...%2$s"
+"Ανοίξτε το μενού του Safari και επιλέξτε %1$sΡυθμίσεις για το DuckDuckGo..."
+"%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the time a business opens. For example: 'Opens at 10am'
@@ -14249,6 +14554,12 @@ msgstr ""
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
+msgid "Please describe why the chat response is harmful or illegal. (optional)"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
+msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
 msgstr ""
 "Περιγράψτε γιατί η απάντηση στη συνομιλία είναι παράνομη ή επιβλαβής. "
@@ -14275,6 +14586,14 @@ msgid ""
 msgstr ""
 "Σημείωση: αρχίζοντας μια νέα συνομιλία με οποιοδήποτε μοντέλο θα διαγράψει "
 "την τρέχουσα συνεδρία συνομιλίας σας."
+
+# smartling.placeholder_format=C
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
+msgctxt "Feedback prompt"
+msgid ""
+"Please paste your prompt and the problematic output (with any personal "
+"information removed) and describe why the content is harmful or illegal."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -14745,6 +15064,12 @@ msgid "Privacy"
 msgstr "Ιδιωτικό απόρρητο"
 
 # smartling.placeholder_format=C
+#. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
+msgctxt "Section heading on the Duck.ai settings page"
+msgid "Privacy & Terms"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Privacy Blog"
 msgstr "Ιστολόγιο για την ιδιωτικότητα"
 
@@ -14813,6 +15138,12 @@ msgstr "Πολιτική απορρήτου και Όροι χρήσης"
 msgctxt "Copy used to compose link in sentences"
 msgid "Privacy Policy and Terms of Service"
 msgstr "Πολιτική απορρήτου και Όροι χρήσης υπηρεσιών"
+
+# smartling.placeholder_format=C
+#. Text for a button that links to the terms of use and privacy policy page.
+msgctxt "Secondary button text in active privacy modal"
+msgid "Privacy Policy and Terms of Service"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title displayed on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
@@ -15000,7 +15331,8 @@ msgstr "Προστατέψτε τα εισερχόμενά σας"
 #. DuckDuckGo's browser app has features to protect your data by keeping it private
 msgctxt "SERP footer content"
 msgid "Protect your data as you search and browse."
-msgstr "Προστατέψτε τα δεδομένα σας καθώς πραγματοποιείτε αναζήτηση και περιήγηση."
+msgstr ""
+"Προστατέψτε τα δεδομένα σας καθώς πραγματοποιείτε αναζήτηση και περιήγηση."
 
 # smartling.placeholder_format=C
 #. Shown on the Mac and Windows browser promo cards. DuckDuckGo's desktop browser protects your data across search, browsing, and AI chat.
@@ -15319,6 +15651,30 @@ msgid "Recommend a book"
 msgstr "Προτείνετε ένα βιβλίο"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar books"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar books."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar movies or shows."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar titles"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
 msgid "Recording failed. Please try again."
 msgstr "Η ηχογράφηση απέτυχε. Δοκίμασε ξανά."
@@ -15549,7 +15905,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
 msgid "Remember my choice (this can be changed in %sSettings%s)"
-msgstr "Να θυμάσαι την επιλογή μου (αυτό μπορεί να αλλαχθεί στις %1$sΡυθμίσεις%2$s)"
+msgstr ""
+"Να θυμάσαι την επιλογή μου (αυτό μπορεί να αλλαχθεί στις %1$sΡυθμίσεις%2$s)"
 
 # smartling.placeholder_format=C
 #. Button to be reminded later to update, shown in a banner that appears in Duck.ai when a subscribed user is using an old version of the DuckDuckGo browser.
@@ -15723,6 +16080,15 @@ msgstr ""
 # smartling.placeholder_format=C
 msgid "Republic of Moldova"
 msgstr "Δημοκρατία της Μολδαβίας"
+
+# smartling.placeholder_format=C
+#. Note indicating that sharing the conversation is mandatory when reporting harmful or illegal content. Rendered alongside the standard share label (DUCKCHAT_RESPONSE_FEEDBACK_SHARE_PROMPT_RESPONSE_LABEL), not replacing it.
+msgctxt ""
+"Note shown under the share-content switch label on the Duck.ai response "
+"feedback form when the user has selected Harmful or Illegal as the feedback "
+"reason"
+msgid "Required for harmful or illegal reports"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
@@ -15964,6 +16330,12 @@ msgid "Reviews"
 msgstr "Κριτικές"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Rewrite this recipe scaled for a different number of servings."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Romania"
 msgstr "Ρουμανία"
 
@@ -16038,7 +16410,8 @@ msgstr "ΝΑ"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "SERP promotion for desktop browsers has been dismissed"
-msgstr "Η προώθηση SERP για τα προγράμματα περιήγησης υπολογιστών έχει απορριφθεί"
+msgstr ""
+"Η προώθηση SERP για τα προγράμματα περιήγησης υπολογιστών έχει απορριφθεί"
 
 # smartling.placeholder_format=C
 #. Abbreviation indicating that a game is in shootouts, e.g. in NHL (hockey)
@@ -16370,13 +16743,15 @@ msgstr "Σκωτία"
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Scroll down and click %sView advanced settings%s"
-msgstr "Κάνε κύλιση προς τα κάτω και κλικ στην %1$sΠροβολή σύνθετων ρυθμίσεων%2$s"
+msgstr ""
+"Κάνε κύλιση προς τα κάτω και κλικ στην %1$sΠροβολή σύνθετων ρυθμίσεων%2$s"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down and click %sView advanced settings%s."
-msgstr "Κάνε κύλιση προς τα κάτω και κλικ στην %1$sΠροβολή σύνθετων ρυθμίσεων%2$s"
+msgstr ""
+"Κάνε κύλιση προς τα κάτω και κλικ στην %1$sΠροβολή σύνθετων ρυθμίσεων%2$s"
 
 #  Edge Legacy default search engine instruction, obsolete?
 # smartling.placeholder_format=C
@@ -16582,7 +16957,8 @@ msgstr "Ορατότητα αναζήτησης"
 # smartling.placeholder_format=C
 #. Message prompting users to download the DuckDuckGo app.
 msgid "Search and browse privately with the DuckDuckGo app."
-msgstr "Απόλαυσε ιδιωτική αναζήτηση και περιήγηση με την εφαρμογή του DuckDuckGo."
+msgstr ""
+"Απόλαυσε ιδιωτική αναζήτηση και περιήγηση με την εφαρμογή του DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Category a user can select on a feedback form.
@@ -16978,8 +17354,8 @@ msgstr "Επιλέξτε %1$sΡύθμιση για αυτόν τον ιστότ�
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
 msgstr ""
-"Διάλεξε %1$sΠροσαρμοσμένη%2$s και πληκτρολόγησε "
-"%3$shttps://duckduckgo.com%4$s στο πεδίο εισαγωγής"
+"Διάλεξε %1$sΠροσαρμοσμένη%2$s και πληκτρολόγησε %3$shttps://duckduckgo."
+"com%4$s στο πεδίο εισαγωγής"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
@@ -16991,13 +17367,15 @@ msgstr ""
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s"
-msgstr "Διάλεξε %1$sDuckDuckGo%2$s και κάνε κλικ στο %3$sΟρισμός ως προεπιλογής%4$s"
+msgstr ""
+"Διάλεξε %1$sDuckDuckGo%2$s και κάνε κλικ στο %3$sΟρισμός ως προεπιλογής%4$s"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s."
-msgstr "Διάλεξε %1$sDuckDuckGo%2$s και κάνε κλικ στο %3$sΟρισμός ως προεπιλογής%4$s."
+msgstr ""
+"Διάλεξε %1$sDuckDuckGo%2$s και κάνε κλικ στο %3$sΟρισμός ως προεπιλογής%4$s."
 
 #  Firefox 33
 # smartling.placeholder_format=C
@@ -17038,7 +17416,8 @@ msgstr "Διάλεξε %1$sDuckDuckGo%2$s!"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Select %sEdit Search Engines...%sin the dropdown"
-msgstr "Επιλέξτε %1$sΕπεξεργασία μηχανών αναζήτησης…%2$sστο αναπτυσσόμενη μενού"
+msgstr ""
+"Επιλέξτε %1$sΕπεξεργασία μηχανών αναζήτησης…%2$sστο αναπτυσσόμενη μενού"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -17112,7 +17491,8 @@ msgstr "Διάλεξε %1$sΡυθμίσεις%2$s και έπειτα %3$sΣύν
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sDefault search engine%s"
-msgstr "Επιλέξτε %1$sΡυθμίσεις%2$s και έπειτα %3$sΠροεπιλεγμένη μηχανή αναζήτησης%4$s"
+msgstr ""
+"Επιλέξτε %1$sΡυθμίσεις%2$s και έπειτα %3$sΠροεπιλεγμένη μηχανή αναζήτησης%4$s"
 
 #  Chrome/Firefox on Android
 # smartling.placeholder_format=C
@@ -17173,7 +17553,8 @@ msgstr "Διάλεξε όλα τα τετράγωνα που περιέχουν 
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select an option to %sallow%s location access"
-msgstr "Ορίστε μια επιλογή για να %1$sεπιτρέπεται%2$s η πρόσβαση στην τοποθεσία"
+msgstr ""
+"Ορίστε μια επιλογή για να %1$sεπιτρέπεται%2$s η πρόσβαση στην τοποθεσία"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -17330,6 +17711,12 @@ msgstr "Ρύθμιση τώρα"
 msgctxt "Setup button for native sync flow"
 msgid "Set Up Now"
 msgstr "Ρύθμιση τώρα"
+
+# smartling.placeholder_format=C
+#. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
+msgctxt "Encrypted storage setup button shown in native browsers"
+msgid "Set Up Sync & Backup"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
@@ -17515,11 +17902,19 @@ msgid "Share positive feedback"
 msgstr "Κοινοποίηση θετικών σχολίων"
 
 # smartling.placeholder_format=C
+#. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
+msgctxt ""
+"Label beside the share-content switch on the Duck.ai response feedback form"
+msgid "Share this conversation with DuckDuckGo"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
 msgctxt ""
 "Label beside the share-content switch on the Duck.ai response feedback form"
 msgid "Share your prompt and chat response with DuckDuckGo"
-msgstr "Μοιραστείτε την απάντηση στην προτροπή και στη συνομιλία σας με το DuckDuckGo"
+msgstr ""
+"Μοιραστείτε την απάντηση στην προτροπή και στη συνομιλία σας με το DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Variant of the share toggle label that makes sharing mandatory when reporting harmful or illegal content.
@@ -18210,7 +18605,8 @@ msgstr "Κάτι πήγε στραβά κατά την αποθήκευση στ
 #. Body copy displayed under the Set Up Now button when the sync setup call fails.
 msgctxt "Generic error shown when sync setup fails"
 msgid "Something went wrong while enabling Sync & Backup. Please try again."
-msgstr "Κάτι πήγε λάθος κατά την ενεργοποίηση του Sync & Backup. Προσπαθήστε ξανά."
+msgstr ""
+"Κάτι πήγε λάθος κατά την ενεργοποίηση του Sync & Backup. Προσπαθήστε ξανά."
 
 # smartling.placeholder_format=C
 #. Displayed when the voice chat session ends with an unknown error.
@@ -18531,7 +18927,8 @@ msgstr "Αρχίστε με μια εικόνα"
 #. Warning that starting fresh deletes conversations.
 msgctxt "duckai_migration"
 msgid "Starting fresh will delete all your past conversations."
-msgstr "Ξεκινώντας από την αρχή θα διαγραφούν όλες οι προηγούμενες συνομιλίες σας."
+msgstr ""
+"Ξεκινώντας από την αρχή θα διαγραφούν όλες οι προηγούμενες συνομιλίες σας."
 
 # smartling.placeholder_format=C
 #. Footnote warning that starting fresh deletes conversations.
@@ -18802,6 +19199,24 @@ msgid "Suggest a title for a blog post"
 msgstr "Πρότεινε έναν τίτλο για μια ανάρτηση σε blog"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest related articles or topics worth exploring next."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Suggest related articles to explore"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest some alternatives to this product."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
 msgctxt "directions"
 msgid "Suggestions:"
@@ -18813,10 +19228,100 @@ msgid "Suggestions:"
 msgstr "Συστάσεις:"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Sum up the reviews"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A short title for the a message asking the AI to summarize a text.
 msgctxt "Title for the summarize message"
 msgid "Summarize"
 msgstr "Σύνοψη"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize the Q&As"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the background and notable work of this person."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the key details of this event."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the questions and answers on this page."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize their background"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this book"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this book."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this discussion"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this discussion thread."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this page"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this page."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this video"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this video."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize what the reviews say."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -19149,6 +19654,12 @@ msgid "Syria"
 msgstr "Συρία"
 
 # smartling.placeholder_format=C
+#. Text for a button that enables the theme to follow the operating system's color scheme preference.
+msgctxt "System theme button for theme selector"
+msgid "System"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Abbreviation indicating this is the total score for a game
 msgctxt "Sports module"
 msgid "T"
@@ -19175,6 +19686,12 @@ msgstr "Τηλεόραση"
 msgctxt "language_name"
 msgid "Tahitian"
 msgstr "Ταϊτιανά"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Tailor my resume"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Taiwan"
@@ -19204,6 +19721,13 @@ msgstr "Απόκτησε τον έλεγχο των προσωπικών σου 
 msgctxt "homepage ATB modal"
 msgid "Take control of your personal data!"
 msgstr "Απόκτησε τον έλεγχο των προσωπικών δεδομένων σου!"
+
+# smartling.placeholder_format=C
+#. Description for the Feedback section of the Duck.ai settings page, asking the user to take an anonymous survey to let us know how we can make Duck.ai better.
+msgctxt "Feedback section description on the Duck.ai settings page"
+msgid ""
+"Take this anonymous survey to let us know how we can make Duck.ai better."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -19402,13 +19926,15 @@ msgstr "Ευχαριστούμε για τα σχόλιά σας!"
 #. Inform the users that "something" went wrong and we are unable to show any results.
 msgctxt "noresults"
 msgid "Thanks for your patience while we get our ducks in a row!"
-msgstr "Ευχαριστούμε για την υπομονή σας ενώ θα βάλουμε τα παπάκια μας στη σειρά!"
+msgstr ""
+"Ευχαριστούμε για την υπομονή σας ενώ θα βάλουμε τα παπάκια μας στη σειρά!"
 
 # smartling.placeholder_format=C
 #. Inform the users that "something" went wrong and we are unable to show any results.
 msgctxt "noresults"
 msgid "Thanks for your patience while we get our ducks in a row."
-msgstr "Ευχαριστούμε για την υπομονή σας ενώ θα βάλουμε τα παπάκια μας στη σειρά."
+msgstr ""
+"Ευχαριστούμε για την υπομονή σας ενώ θα βάλουμε τα παπάκια μας στη σειρά."
 
 # smartling.placeholder_format=C
 #. Message indicating that the open lock icon in the address bar means that a website is not secure.
@@ -19516,6 +20042,12 @@ msgid "Theme"
 msgstr "Θέμα"
 
 # smartling.placeholder_format=C
+#. Text for the theme selector label that allows users to switch between Light and dark theme.
+msgctxt "Label for the theme selector feature"
+msgid "Theme"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. http://i.imgur.com/LpFhb1e.png
 msgctxt "settings"
 msgid "Theme"
@@ -19567,7 +20099,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Error message for explore more questions when a retryable error occurs (timeout, network)
 msgid "There's been an issue loading this answer. Please try again."
-msgstr "Παρουσιάστηκε πρόβλημα κατά τη φόρτωση αυτής της απάντησης. Δοκιμάστε ξανά."
+msgstr ""
+"Παρουσιάστηκε πρόβλημα κατά τη φόρτωση αυτής της απάντησης. Δοκιμάστε ξανά."
 
 # smartling.placeholder_format=C
 #. Instant Answer Tab Name
@@ -19641,7 +20174,8 @@ msgstr ""
 #. Appears below a type of search results called 'Instant Answers'
 msgctxt "attribution"
 msgid "This Instant Answer was made by the %sDuckDuckHack%s Community."
-msgstr "Αυτή η άμεση απάντηση δημιουργήθηκε από την κοινότητα %1$sDuckDuckHack%2$s."
+msgstr ""
+"Αυτή η άμεση απάντηση δημιουργήθηκε από την κοινότητα %1$sDuckDuckHack%2$s."
 
 # smartling.placeholder_format=C
 #. Label for the monthly usage row in the Usage section of Duck.ai settings.
@@ -19708,13 +20242,15 @@ msgstr ""
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
-msgstr "Αυτό το αρχείο είναι πολύ μεγάλο. Το μέγιστο μέγεθος αρχείου είναι %1$s MB"
+msgstr ""
+"Αυτό το αρχείο είναι πολύ μεγάλο. Το μέγιστο μέγεθος αρχείου είναι %1$s MB"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB."
-msgstr "Αυτό το αρχείο είναι πολύ μεγάλο. Το μέγιστο μέγεθος αρχείου είναι %1$s MB."
+msgstr ""
+"Αυτό το αρχείο είναι πολύ μεγάλο. Το μέγιστο μέγεθος αρχείου είναι %1$s MB."
 
 # smartling.placeholder_format=C
 #. Generic error message displayed when the user tries to upload an unsupported file type and we cannot determine the accepted types
@@ -19773,14 +20309,16 @@ msgstr "Δεν ήταν δυνατή η δημιουργία αυτής της �
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF"
-msgstr "Αυτός ο τύπος εικόνας δεν υποστηρίζεται. Επισύναψε JPG, PNG, WebP ή GIF"
+msgstr ""
+"Αυτός ο τύπος εικόνας δεν υποστηρίζεται. Επισύναψε JPG, PNG, WebP ή GIF"
 
 # smartling.placeholder_format=C
 #. Error message displayed when a file that the user tried to upload is not of a supported format
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF."
-msgstr "Αυτός ο τύπος εικόνας δεν υποστηρίζεται, επισύναψε JPG, PNG, WebP ή GIF."
+msgstr ""
+"Αυτός ο τύπος εικόνας δεν υποστηρίζεται, επισύναψε JPG, PNG, WebP ή GIF."
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
@@ -19835,7 +20373,8 @@ msgstr "Αυτή η σελίδα απαιτεί Javascript για να λειτ�
 #. Information tooltip text explaining that the current page's content will be included with the chat message.
 msgctxt "Tooltip explaining that page content will be sent to Duck.ai"
 msgid "This page's content will be sent with your message to Duck.ai"
-msgstr "Το περιεχόμενο της σελίδας αυτής θα σταλεί μαζί με το μήνυμά σας στο Duck.ai"
+msgstr ""
+"Το περιεχόμενο της σελίδας αυτής θα σταλεί μαζί με το μήνυμά σας στο Duck.ai"
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -19914,7 +20453,8 @@ msgstr ""
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr "Η ιστοσελίδα αυτή δεν χρησιμοποιεί ασφαλή, κρυπτογραφημένη σύνδεση (HTTPS)."
+msgstr ""
+"Η ιστοσελίδα αυτή δεν χρησιμοποιεί ασφαλή, κρυπτογραφημένη σύνδεση (HTTPS)."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -19943,7 +20483,8 @@ msgstr ""
 #. Message explaining what will happen when the user deletes an image.
 msgctxt "Confirmation message in delete image modal"
 msgid "This will delete your selected image. This cannot be undone."
-msgstr "Αυτό θα διαγράψει την επιλεγμένη εικόνα σας. Αυτό δεν μπορεί να αναιρεθεί."
+msgstr ""
+"Αυτό θα διαγράψει την επιλεγμένη εικόνα σας. Αυτό δεν μπορεί να αναιρεθεί."
 
 # smartling.placeholder_format=C
 #. Confirmation message asking if the user is sure they want to reset all of their settings.
@@ -20031,7 +20572,8 @@ msgstr "Συμβουλές"
 
 # smartling.placeholder_format=C
 msgid "Tired of being tracked online? %sWe can help.%s"
-msgstr "Έχεις βαρεθεί να σε παρακολουθούν στο διαδίκτυο; %1$sΆσ' το πάνω μας.%2$s"
+msgstr ""
+"Έχεις βαρεθεί να σε παρακολουθούν στο διαδίκτυο; %1$sΆσ' το πάνω μας.%2$s"
 
 # smartling.placeholder_format=C
 #. This is the name of a user setting
@@ -20064,8 +20606,8 @@ msgctxt ""
 "Copy stating agreement to Duck.ai Privacy Policy and Terms of Service."
 msgid "To continue, you must agree to Duck.ai’s %s and %s"
 msgstr ""
-"Για να συνεχίσετε, πρέπει να συμφωνήσετε με την %1$s και τους %2$s του "
-"Duck.ai"
+"Για να συνεχίσετε, πρέπει να συμφωνήσετε με την %1$s και τους %2$s του Duck."
+"ai"
 
 # smartling.placeholder_format=C
 #. Text stating agreement to AI Chat Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'To continue, you must agree to DuckDuckGo AI Chat’s Privacy Policy and Terms of Service'
@@ -20298,7 +20840,8 @@ msgstr "Εφαρμογές παρακολούθησης που αποκλείσ�
 #. Placeholder for when we cannot report any blocked trackers yet
 msgctxt "tracker_stats"
 msgid "Trackers that DuckDuckGo blocks will appear here"
-msgstr "Οι εφαρμογές παρακολούθησης που αποκλείει το DuckDuckGo θα εμφανίζονται εδώ"
+msgstr ""
+"Οι εφαρμογές παρακολούθησης που αποκλείει το DuckDuckGo θα εμφανίζονται εδώ"
 
 # smartling.placeholder_format=C
 #. Placeholder for when we cannot report any blocked trackers yet
@@ -20371,6 +20914,18 @@ msgid ""
 msgstr ""
 "Μετάφρασε αυτήν την ελληνική πρόταση στα αγγλικά: «Πώς μπορώ να πάω στον "
 "πλησιέστερο κινηματογράφο;»"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Translate this page"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
+msgctxt "Page suggestion prompt"
+msgid "Translate this page into %s."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder text for a region that will display translated text.
@@ -20472,7 +21027,8 @@ msgstr "Δοκιμάστε το %1$s για να σταματήσετε να β�
 #. Text for a promotional card that encourages users to try the encrypted AI model whose inference runs in a confidential environment so the model provider cannot access user data. %s is replaced with the model's full display name (e.g. 'GPT-OSS 120B').
 msgctxt "Promotional text for encrypted AI model"
 msgid "Try %s, our first model with zero provider visibility."
-msgstr "Δοκίμασε το %1$s, το πρώτο μας μοντέλο με μηδενική ορατότητα από τον πάροχο."
+msgstr ""
+"Δοκίμασε το %1$s, το πρώτο μας μοντέλο με μηδενική ορατότητα από τον πάροχο."
 
 # smartling.placeholder_format=C
 msgid "Try %sDuck.ai%s, our private AI chat service:"
@@ -20514,6 +21070,12 @@ msgstr "Προσπάθησε ξανά"
 msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
 msgstr "Δοκιμάστε το δωρεάν"
+
+# smartling.placeholder_format=C
+#. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
+msgctxt "settings"
+msgid "Try It Now"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -20562,7 +21124,8 @@ msgstr ""
 #. A message suggesting that the user clears their filters and tries their search again when they get no results
 msgctxt "noresults"
 msgid "Try clearing your filters and searching again."
-msgstr "Δοκιμάστε να καθαρίσετε τα φίλτρα σας και να πραγματοποιήσετε αναζήτηση ξανά."
+msgstr ""
+"Δοκιμάστε να καθαρίσετε τα φίλτρα σας και να πραγματοποιήσετε αναζήτηση ξανά."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with different words.
@@ -20581,7 +21144,8 @@ msgstr ""
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
 msgctxt "precise_user_location"
 msgid "Try enabling anonymous location for more accurate results."
-msgstr "Δοκίμασε να ενεργοποιήσεις την ανώνυμη τοποθεσία για πιο ακριβή αποτελέσματα."
+msgstr ""
+"Δοκίμασε να ενεργοποιήσεις την ανώνυμη τοποθεσία για πιο ακριβή αποτελέσματα."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the screen of the onboarding where the user picks a chat model.
@@ -20625,7 +21189,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
 msgid "Try generating an AI-assisted answer"
-msgstr "Δοκιμάστε να δημιουργήσετε μια απάντηση με τη βοήθεια τεχνητής νοημοσύνης"
+msgstr ""
+"Δοκιμάστε να δημιουργήσετε μια απάντηση με τη βοήθεια τεχνητής νοημοσύνης"
 
 # smartling.placeholder_format=C
 #. Copy to invite the user to ask duckassist (an instant answer based on generative AI) for an answer
@@ -20647,7 +21212,8 @@ msgstr "Δοκιμάστε το πρόγραμμα περιήγησής μας"
 # smartling.placeholder_format=C
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
-msgstr "Δοκίμασε την αρχική μας σελίδα που ποτέ δεν εμφανίζει αυτά τα μηνύματα:"
+msgstr ""
+"Δοκίμασε την αρχική μας σελίδα που ποτέ δεν εμφανίζει αυτά τα μηνύματα:"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with different words to get more results.
@@ -20760,6 +21326,22 @@ msgstr "Δοκίμασε : %1$s"
 msgctxt "new user poll"
 msgid "Trying DuckDuckGo again"
 msgstr "Δοκιμάζω ξανά το DuckDuckGo"
+
+# smartling.placeholder_format=C
+#. Message shown in a modal after supported third-party browser users disable AI features in Settings. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -20882,7 +21464,8 @@ msgstr "Ενεργοποιήστε την «Ακριβή τοποθεσία» γ
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on “Use precise location” for more accurate results."
-msgstr "Ενεργοποιήστε τη «Χρήση ακριβούς τοποθεσίας» για πιο ακριβή αποτελέσματα."
+msgstr ""
+"Ενεργοποιήστε τη «Χρήση ακριβούς τοποθεσίας» για πιο ακριβή αποτελέσματα."
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Create Image' label in the Tools dropdown.
@@ -21034,7 +21617,8 @@ msgstr "Δεν είναι δυνατή η αποστολή σχολίων"
 #. Message shown to the user when the voice chat failed to establish a connection, and they should try again later.
 msgctxt "voice chat"
 msgid "Unable to connect to voice chat, please try again later."
-msgstr "Δεν είναι δυνατή η σύνδεση στη φωνητική συνομιλία. Προσπαθήστε πάλι αργότερα."
+msgstr ""
+"Δεν είναι δυνατή η σύνδεση στη φωνητική συνομιλία. Προσπαθήστε πάλι αργότερα."
 
 # smartling.placeholder_format=C
 #. Message shown to the user when there was an issue connecting to their microphone.
@@ -21088,7 +21672,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
-msgstr "Στο %1$sΕΚΚΙΝΗΣΗ > Αρχική σελίδα%2$s, πληκτρολόγησε: https://duckduckgo.com"
+msgstr ""
+"Στο %1$sΕΚΚΙΝΗΣΗ > Αρχική σελίδα%2$s, πληκτρολόγησε: https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -21107,8 +21692,8 @@ msgstr ""
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
 msgstr ""
-"Στην ενότητα %1$sΑναζήτηση%2$s, διάλεξε %3$sΔιαχείριση μηχανών "
-"αναζήτησης…%4$s"
+"Στην ενότητα %1$sΑναζήτηση%2$s, διάλεξε %3$sΔιαχείριση μηχανών αναζήτησης…"
+"%4$s"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -21209,7 +21794,8 @@ msgstr ""
 #. Title for the subscription promo shown in the SERP sidemenu.
 msgctxt "Sidemenu subscription promo"
 msgid "Unlock VPN + Advanced AI"
-msgstr "Αποκτήστε πρόσβαση σε δίκτυο VPN + προηγμένες δυνατότητες τεχνητής νοημοσύνης"
+msgstr ""
+"Αποκτήστε πρόσβαση σε δίκτυο VPN + προηγμένες δυνατότητες τεχνητής νοημοσύνης"
 
 # smartling.placeholder_format=C
 #. Text for the button that allows the user to unlock an AI model with a DuckDuckGo subscription when clicked.
@@ -21239,7 +21825,8 @@ msgstr "Ξεκλειδώστε προηγμένα μοντέλα τεχνητή�
 #. Tooltip text shown when the user hovers over the free badge telling the user that they can unlock advanced AI (Artificial Intelligence) models with a DuckDuckGo subscription.
 msgctxt "Tooltip for the free badge"
 msgid "Unlock advanced AI models with a DuckDuckGo subscription"
-msgstr "Ξεκλείδωσε προηγμένα μοντέλα τεχνητής νοημοσύνης με συνδρομή στο DuckDuckGo"
+msgstr ""
+"Ξεκλείδωσε προηγμένα μοντέλα τεχνητής νοημοσύνης με συνδρομή στο DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. A link to a blog post explaining the new AI benefits to a subscription. Please keep translations to 50 characters or less.
@@ -21529,6 +22116,12 @@ msgid "Uruguay"
 msgstr "Ουρουγουάη"
 
 # smartling.placeholder_format=C
+#. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
+msgctxt "Navigation label on the Duck.ai settings page"
+msgid "Usage"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A feedback suggestion
 msgctxt "Feedback prompt"
 msgid "Usage limit"
@@ -21584,7 +22177,8 @@ msgstr "Χρήση της ιδιωτικής αναζήτησης του DuckDuc
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Use DuckDuckGo private search on your iPad, iPhone, or Android!"
-msgstr "Χρησιμοποίησε την ιδιωτική αναζήτηση DuckDuckGo σε iPad, iPhone ή Android!"
+msgstr ""
+"Χρησιμοποίησε την ιδιωτική αναζήτηση DuckDuckGo σε iPad, iPhone ή Android!"
 
 # smartling.placeholder_format=C
 #. User clicks this button to share their device's location
@@ -21759,7 +22353,8 @@ msgstr "Δείτε τιμές για τη διαμονή σας"
 # smartling.placeholder_format=C
 #. A description for the ads tooltip that explains that viewing ads is privacy protected by DuckDuckGo.
 msgid "Viewing ads is privacy protected by DuckDuckGo."
-msgstr "Στην προβολή διαφημίσεων υπάρχει προστασία απορρήτου από την DuckDuckGo."
+msgstr ""
+"Στην προβολή διαφημίσεων υπάρχει προστασία απορρήτου από την DuckDuckGo."
 
 # smartling.placeholder_format=C
 msgctxt "Ads GDPR, internal use only. Do not change"
@@ -21983,6 +22578,12 @@ msgid "Wales"
 msgstr "Ουαλία"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Walk me through the steps"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for walking directions on a map.
 msgctxt "directions"
 msgid "Walking"
@@ -22102,6 +22703,17 @@ msgstr ""
 "πιο ακριβή αποτελέσματα."
 
 # smartling.placeholder_format=C
+#. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
+msgctxt ""
+"Inline warning shown below the share-content toggle when the user selects "
+"Harmful or Illegal but has not enabled sharing"
+msgid ""
+"We can only fix what we can see. To report a harmful or illegal response, "
+"please share this conversation with DuckDuckGo so we can investigate and "
+"address the issue."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
 msgctxt ""
 "Inline warning shown below the share-content toggle when the user selects "
@@ -22199,7 +22811,8 @@ msgstr "Δεν σε παρακολουθούμε, ποτέ μα ποτέ."
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with a Continue button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don't track you. That's our Privacy Policy in a nutshell."
-msgstr "Δεν σας παρακολουθούμε. Αυτή είναι η Πολιτική απορρήτου μας με λίγα λόγια."
+msgstr ""
+"Δεν σας παρακολουθούμε. Αυτή είναι η Πολιτική απορρήτου μας με λίγα λόγια."
 
 # smartling.placeholder_format=C
 #. Description for the audio identification highlight in the dictation consent modal.
@@ -22242,7 +22855,8 @@ msgstr ""
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with an Agree button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don’t track you. That’s our Privacy Policy in a nutshell…"
-msgstr "Δεν σας παρακολουθούμε. Αυτή είναι η Πολιτική απορρήτου μας με λίγα λόγια…"
+msgstr ""
+"Δεν σας παρακολουθούμε. Αυτή είναι η Πολιτική απορρήτου μας με λίγα λόγια…"
 
 # smartling.placeholder_format=C
 #. Displayed when the user's voice chat session is ended because of being inactive for too long.
@@ -22543,7 +23157,8 @@ msgstr ""
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai, it's time to import your chats"
-msgstr "Καλώς ορίσατε στο νέο Duck.ai, ήρθε η ώρα να εισαγάγετε τις συνομιλίες σας"
+msgstr ""
+"Καλώς ορίσατε στο νέο Duck.ai, ήρθε η ώρα να εισαγάγετε τις συνομιλίες σας"
 
 # smartling.placeholder_format=C
 #. Welcome message for new DuckDuckGo users.
@@ -22605,14 +23220,15 @@ msgid ""
 "We’re really sorry, but it seems there was a problem loading Duck.ai. Try "
 "reloading the page."
 msgstr ""
-"Λυπούμαστε πολύ, αλλά φαίνεται ότι υπήρξε πρόβλημα κατά τη φόρτωση του "
-"Duck.ai. Προσπαθήστε να επαναλάβετε τη φόρτωση της σελίδας."
+"Λυπούμαστε πολύ, αλλά φαίνεται ότι υπήρξε πρόβλημα κατά τη φόρτωση του Duck."
+"ai. Προσπαθήστε να επαναλάβετε τη φόρτωση της σελίδας."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to suggest an AI (Artificial Intelligence) model to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What AI model would you like us to add? (optional)"
-msgstr "Ποιο μοντέλο τεχνητής νοημοσύνης θα θέλατε να προσθέσουμε; (προαιρετικό)"
+msgstr ""
+"Ποιο μοντέλο τεχνητής νοημοσύνης θα θέλατε να προσθέσουμε; (προαιρετικό)"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for providing arguments, counter-arguments, and rebuttals to the concept of a plant-based diet.
@@ -22673,6 +23289,103 @@ msgstr ""
 "έμφαση στις ενσωματώσεις του Duck.ai και στην προστασία του απορρήτου. Να "
 "είναι αρκετά σύντομη, απλή και εύληπτη από άτομα με ή χωρίς πολλή εμπειρία "
 "στην Τεχνητή Νοημοσύνη ή σε τεχνικές γνώσεις."
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the counterarguments?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the hours & location?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key contributions of this paper?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key contributions?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key details?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key points covered in this video?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key points?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key takeaways from this article?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key takeaways?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key things I will learn from this course?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main counterarguments or criticisms of this?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main questions this page answers?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the must-try dishes here?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"What are the opening hours, location, and contact details for this place?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the pros and cons of this product?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the pros and cons?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
@@ -22775,6 +23488,12 @@ msgid "What does atria mean in the context of a medical article?"
 msgstr "Τι σημαίνει atria στο πλαίσιο ενός ιατρικού άρθρου;"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What does this answer?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
@@ -22785,6 +23504,12 @@ msgstr "Ποια λειτουργία θα θέλατε να προσθέσου�
 msgctxt "cloudsave"
 msgid "What information gets saved?"
 msgstr "Ποιες πληροφορίες αποθηκεύονται;"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What interview questions might come up for this role?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -22801,6 +23526,12 @@ msgstr ""
 msgctxt "Full sentence for looking up basic facts"
 msgid "What is the capital city of Albania?"
 msgstr "Ποια είναι η πρωτεύουσα της Αλβανίας;"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What is the overall verdict and rating for this?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to a page with additional information.
@@ -22825,6 +23556,12 @@ msgid "What people say:"
 msgstr "Ποια είναι η άποψη του κόσμου:"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What should I order?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
 msgctxt "feedback form"
 msgid "What stood out?"
@@ -22835,6 +23572,18 @@ msgstr "Τι ξεχώρισε;"
 msgctxt "feedback form"
 msgid "What was wrong with the response? (optional)"
 msgstr "Τι ήταν λάθος με την απάντηση; (προαιρετικά)"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I learn?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I need?"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -22854,6 +23603,12 @@ msgstr ""
 msgctxt "SERP footer content"
 msgid "What's New"
 msgstr "Τι νέο υπάρχει"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What's the verdict?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -22910,6 +23665,12 @@ msgid "Which features are missing? (Optional)"
 msgstr "Ποιες λειτουργίες λείπουν; (Προαιρετικό)"
 
 # smartling.placeholder_format=C
+#. An invitation for users to leave feedback
+msgctxt "Feedback prompt"
+msgid "Which features are missing? (optional)"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
 msgid "White"
 msgstr "Άσπρο"
@@ -22924,6 +23685,18 @@ msgstr "Άσπρο"
 #. Link to an about us page.
 msgid "Who We Are"
 msgstr "Ποιοι είμαστε"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Who are the main cast and crew, and what else are they known for?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Who is this person?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Header above a collection of privacy-related links.
@@ -23333,7 +24106,8 @@ msgstr ""
 #. Text informing the user that they can access DuckDuckGo AI Chat directly at a specific URL. The placeholder %s will be replaced with the link. Example: 'You can access DuckDuckGo AI Chat directly at duck.ai.'
 msgctxt "Information about direct access to DuckDuckGo AI Chat"
 msgid "You can access DuckDuckGo AI Chat directly at %s."
-msgstr "Μπορείτε να αποκτήσετε πρόσβαση στο DuckDuckGo AI Chat απευθείας από το %1$s."
+msgstr ""
+"Μπορείτε να αποκτήσετε πρόσβαση στο DuckDuckGo AI Chat απευθείας από το %1$s."
 
 # smartling.placeholder_format=C
 #. Search Assist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate Search Assist.
@@ -23524,7 +24298,8 @@ msgstr "Μπορείς να ξεκινήσεις από την αρχή σε α�
 #. Text explaining the benefits of the cloud save feature.
 msgctxt "cloudsave"
 msgid "You can store several sets of settings for different purposes."
-msgstr "Μπορείς να αποθηκεύσεις διάφορα σύνολα ρυθμίσεων για διαφορετικούς σκοπούς."
+msgstr ""
+"Μπορείς να αποθηκεύσεις διάφορα σύνολα ρυθμίσεων για διαφορετικούς σκοπούς."
 
 # smartling.placeholder_format=C
 #. Instructions for user once they've failed the bot challenge
@@ -23688,14 +24463,16 @@ msgstr ""
 #. Description shown when the user has reached the maximum voice chat duration.
 msgctxt "voice chat duration limit modal"
 msgid "You've reached the maximum voice chat duration for a single session."
-msgstr "Έχετε φτάσει τη μέγιστη διάρκεια φωνητικής συνομιλίας για μία συνεδρία."
+msgstr ""
+"Έχετε φτάσει τη μέγιστη διάρκεια φωνητικής συνομιλίας για μία συνεδρία."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the daily voice chat limit.
 msgctxt "voice chat limit modal"
 msgid ""
 "You've reached the voice chat limit for today. Please try again tomorrow."
-msgstr "Έχετε φτάσει το όριο φωνητικής συνομιλίας για σήμερα. Δοκιμάστε ξανά αύριο."
+msgstr ""
+"Έχετε φτάσει το όριο φωνητικής συνομιλίας για σήμερα. Δοκιμάστε ξανά αύριο."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
@@ -23721,9 +24498,9 @@ msgid ""
 "oldest chats with attachments to resume Sync. Pinned chats will not be "
 "deleted."
 msgstr ""
-"Έχει εξαντληθεί ο χώρος αποθήκευσης του Sync & Backup για συνομιλίες "
-"Duck.ai. Διαγράψτε τις %1$s παλαιότερες συνομιλίες με συνημμένα για να "
-"συνεχίσετε τον συγχρονισμό. Οι καρφιτσωμένες συνομιλίες δεν θα διαγραφούν."
+"Έχει εξαντληθεί ο χώρος αποθήκευσης του Sync & Backup για συνομιλίες Duck."
+"ai. Διαγράψτε τις %1$s παλαιότερες συνομιλίες με συνημμένα για να συνεχίσετε "
+"τον συγχρονισμό. Οι καρφιτσωμένες συνομιλίες δεν θα διαγραφούν."
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the sync storage limit.

--- a/locales/en_AU/LC_MESSAGES/duckduckgo.po
+++ b/locales/en_AU/LC_MESSAGES/duckduckgo.po
@@ -1161,6 +1161,11 @@ msgctxt "feedback form"
 msgid "Address is incorrect"
 msgstr ""
 
+#. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Adjust the servings"
+msgstr ""
+
 #. as in multiple advertisements
 msgid "Ads"
 msgstr ""
@@ -1333,6 +1338,13 @@ msgstr ""
 #. Heading shown on the empty chat screen. The text between the two %s markers is displayed inside a clickable privacy button. First %s renders a shield icon, second %s is an invisible end marker. Keep the word 'private' between both %s markers.
 msgctxt "Empty state heading in Duck.ai chat mode"
 msgid "All chats are %sprivate%s"
+msgstr ""
+
+#. Paragraph in the Privacy & Terms section of the About & Legal page in Duck.ai settings, summarizing how chats are anonymized and are not stored or used to train chat models.
+msgctxt "Privacy & Terms section description on the Duck.ai settings page"
+msgid ""
+"All chats are anonymized by DuckDuckGo, and your conversations are not used "
+"to train chat models by DuckDuckGo or the model providers"
 msgstr ""
 
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1545,6 +1557,12 @@ msgstr ""
 #. Confirmation message after location service is enabled.
 msgctxt "precise_user_location"
 msgid "Anonymous location enabled"
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Anonymously generates answers for search queries based on web content. "
+"Choose how often you want it to appear, or disable it completely."
 msgstr ""
 
 #. Instant Answer tab name
@@ -1769,6 +1787,11 @@ msgstr ""
 
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse
 msgid "Ask a follow-up with Duck.ai"
+msgstr ""
+
+#. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
+msgctxt "Page suggestion chip label"
+msgid "Ask about this page"
 msgstr ""
 
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2093,6 +2116,11 @@ msgstr ""
 msgid "Barcode"
 msgstr "Barcode"
 
+#. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Based on this page, is this course worth taking?"
+msgstr ""
+
 msgctxt "settings"
 msgid "Basic"
 msgstr "Basic"
@@ -2124,6 +2152,13 @@ msgstr ""
 #. Placeholder text displayed while the assistant waits for the user to choose an action.
 msgctxt "Assistant response placeholder"
 msgid "Before continuing..."
+msgstr ""
+
+#. Explains that before storing the report, DuckDuckGo will anonymize the conversation by removing PII like names, email addresses, and identifying metadata.
+msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
+msgid ""
+"Before storing this report, DuckDuckGo will anonymize your conversation by "
+"removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
 #. Label that's displayed next to a past start date below a web search result.
@@ -2382,6 +2417,11 @@ msgstr "Brazil"
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Break Points Won"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Break this down into clear, numbered steps."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -2741,6 +2781,11 @@ msgstr "Careers"
 #. Text of a button that performs a search for the cast of a particular movie or tv show
 msgctxt "Movie/TV Show Title instant answer"
 msgid "Cast"
+msgstr ""
+
+#. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Cast & Crew"
 msgstr ""
 
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -4097,6 +4142,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Create a shopping list with quantities from this recipe."
+msgstr ""
+
 #. Placeholder text displayed in the input field when starting a new image generation session.
 msgctxt "Placeholder text for the image generation input field"
 msgid "Create an image of a cute duck..."
@@ -4623,6 +4673,10 @@ msgstr ""
 msgid "Dictation limit reached"
 msgstr ""
 
+#. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
+msgid "Dictation temporarily unavailable"
+msgstr ""
+
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
@@ -4867,6 +4921,20 @@ msgctxt "precise_user_location"
 msgid "Done"
 msgstr ""
 
+#. Message shown in a modal after DuckDuckGo browser users disable AI features in Settings. The first two placeholders bold noai.duckduckgo.com. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
+"filtered out. %sLearn More%s"
+msgstr ""
+
+#. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
+"and AI images filtered out. %sLearn more%s"
+msgstr ""
+
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Double Faults"
@@ -4957,6 +5025,16 @@ msgctxt "Full sentence for writing an email"
 msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
+msgstr ""
+
+#. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Draft a cover letter"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Draft a cover letter for this job."
 msgstr ""
 
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -5096,6 +5174,14 @@ msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
 msgstr ""
 
+#. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
+msgctxt "About section description on the Duck.ai settings page"
+msgid ""
+"Duck.ai is created by DuckDuckGo. We're an independent online protection "
+"company for anyone who wants to take back control of their personal "
+"information."
+msgstr ""
+
 #. Title shown when an update is required before proceeding.
 msgctxt "duckai_migration"
 msgid "Duck.ai is moving domains"
@@ -5129,6 +5215,12 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Duck.ai lets you chat privately with popular AI models. Disabling it hides "
+"Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
 
 msgctxt "settings"
@@ -5895,6 +5987,16 @@ msgstr ""
 msgid "Eritrea"
 msgstr ""
 
+#. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Estimate the nutrition"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Estimate the nutritional information for this recipe."
+msgstr ""
+
 msgid "Estonia"
 msgstr "Estonia"
 
@@ -5939,10 +6041,50 @@ msgctxt "merchant promotion product ad extension"
 msgid "Expires in 1 day"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain the accepted answer in simple terms."
+msgstr ""
+
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
+msgstr ""
+
+#. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain the top answer"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this in simple, plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this paper"
+msgstr ""
+
+#. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this repo"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this research paper in plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this simply"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain what this repository does and how to use it."
 msgstr ""
 
 #. Label to show if song lyrics contain explicit content
@@ -6173,6 +6315,11 @@ msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
 msgstr ""
 
+msgctxt "settings"
+msgid ""
+"Filters out known AI spam sites from image search results. %sLearn More%s"
+msgstr ""
+
 #. Label for the final score of a sporting event.
 msgid "Final"
 msgstr "Final"
@@ -6212,6 +6359,11 @@ msgstr ""
 #. Short description shown below the 'Web Search' label in the Tools dropdown.
 msgctxt "Subtitle for the Web Search tool entry in the Tools dropdown menu"
 msgid "Find current information"
+msgstr ""
+
+#. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Find me alternatives"
 msgstr ""
 
 #. Button that searches for results closer to the user's current location.
@@ -6602,6 +6754,11 @@ msgstr ""
 msgid "Generate More"
 msgstr ""
 
+#. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Generate a shopping list"
+msgstr ""
+
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
 msgid "Generate a short answer from the web"
 msgstr ""
@@ -6836,6 +6993,11 @@ msgstr ""
 #. Text for a button inviting users to give it a try for the Duck.ai product. On click, they're taken to the Duck.ai page.
 msgctxt "Onboarding welcome screen button text"
 msgid "Give it a Try"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Give me a quick background on this person."
 msgstr ""
 
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -7199,6 +7361,16 @@ msgstr ""
 #. Link to a page with information about sharing DuckDuckGo with friends.
 msgid "Help Spread Privacy"
 msgstr "Help Spread Privacy"
+
+#. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Help me prep for the interview"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Help me tailor my resume for this job."
+msgstr ""
 
 #. Title of a SERP popup that invites users to take a survey (desktop only)
 msgctxt "User survey popup"
@@ -7619,6 +7791,13 @@ msgstr ""
 #. Text displayed on the button on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
 msgctxt "Onboarding terms screen button text"
 msgid "I Agree"
+msgstr ""
+
+#. Text for the button that takes the user to the external DuckDuckGo login subscription page.
+msgctxt ""
+"Text for the I already have a subscription button in the Duck.ai settings "
+"page"
+msgid "I Already Have a Subscription"
 msgstr ""
 
 #. Text for the button that takes the user to the login subscription page.
@@ -8074,6 +8253,11 @@ msgctxt "Sidemenu browser promo"
 msgid "Install Mac Browser"
 msgstr ""
 
+#. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
+msgctxt "settings"
+msgid "Install Now"
+msgstr ""
+
 #. Text of a button to install the DuckDuckGo app
 msgctxt "Serp footer content"
 msgid "Install Our App"
@@ -8153,9 +8337,36 @@ msgctxt "cloudsave"
 msgid "Is deleted data really deleted?"
 msgstr "Is deleted data really deleted?"
 
+#. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is it worth taking?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this place any good?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"Is this place any good? Summarize its reputation based on reviews and "
+"ratings."
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "Is this video helpful?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this worth watching?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Is this worth watching? Give me a spoiler-free take."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -8653,6 +8864,11 @@ msgstr "Link font:"
 msgid "Links:"
 msgstr "Links:"
 
+#. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "List the tools, materials, or prerequisites I need for this."
+msgstr ""
+
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
 msgid "Listen"
 msgstr "Listen"
@@ -8985,6 +9201,11 @@ msgstr ""
 #. Label for linke navigating to site exclusion feature on Settings page
 msgctxt "Exclusion message manage sites button"
 msgid "Manage blocked sites"
+msgstr ""
+
+#. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
+msgctxt "setting"
+msgid "Manage in Browser Settings"
 msgstr ""
 
 #. Link to the site exclusion settings page
@@ -11290,6 +11511,11 @@ msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
+msgid "Please describe why the chat response is harmful or illegal. (optional)"
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
+msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
 msgstr ""
 
@@ -11308,6 +11534,13 @@ msgctxt "Modal disclaimer text"
 msgid ""
 "Please note: starting a new chat with any model will delete your current "
 "chat session."
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
+msgctxt "Feedback prompt"
+msgid ""
+"Please paste your prompt and the problematic output (with any personal "
+"information removed) and describe why the content is harmful or illegal."
 msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -11692,6 +11925,11 @@ msgctxt "settings"
 msgid "Privacy"
 msgstr "Privacy"
 
+#. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
+msgctxt "Section heading on the Duck.ai settings page"
+msgid "Privacy & Terms"
+msgstr ""
+
 msgid "Privacy Blog"
 msgstr "Privacy Blog"
 
@@ -11745,6 +11983,11 @@ msgstr ""
 
 #. Text used in other strings to link to the Privacy Policy and Terms of Service content.
 msgctxt "Copy used to compose link in sentences"
+msgid "Privacy Policy and Terms of Service"
+msgstr ""
+
+#. Text for a button that links to the terms of use and privacy policy page.
+msgctxt "Secondary button text in active privacy modal"
 msgid "Privacy Policy and Terms of Service"
 msgstr ""
 
@@ -12153,6 +12396,26 @@ msgctxt "Brief for recommending a book"
 msgid "Recommend a book"
 msgstr ""
 
+#. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar books"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar books."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar movies or shows."
+msgstr ""
+
+#. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar titles"
+msgstr ""
+
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
 msgid "Recording failed. Please try again."
 msgstr ""
@@ -12472,6 +12735,14 @@ msgstr ""
 msgid "Republic of Moldova"
 msgstr ""
 
+#. Note indicating that sharing the conversation is mandatory when reporting harmful or illegal content. Rendered alongside the standard share label (DUCKCHAT_RESPONSE_FEEDBACK_SHARE_PROMPT_RESPONSE_LABEL), not replacing it.
+msgctxt ""
+"Note shown under the share-content switch label on the Duck.ai response "
+"feedback form when the user has selected Harmful or Illegal as the feedback "
+"reason"
+msgid "Required for harmful or illegal reports"
+msgstr ""
+
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
 msgctxt "Description for extended reasoning mode in Duck.ai"
 msgid "Researches before responding"
@@ -12657,6 +12928,11 @@ msgstr "Reviews"
 #. Label above a list of customer reviews of a business.
 msgctxt "maps_places"
 msgid "Reviews"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Rewrite this recipe scaled for a different number of servings."
 msgstr ""
 
 msgid "Romania"
@@ -13700,6 +13976,11 @@ msgctxt "Setup button for native sync flow"
 msgid "Set Up Now"
 msgstr ""
 
+#. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
+msgctxt "Encrypted storage setup button shown in native browsers"
+msgid "Set Up Sync & Backup"
+msgstr ""
+
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
 msgctxt "Title for the Sync & Backup intro screen"
 msgid "Set Up Sync & Backup"
@@ -13842,6 +14123,12 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
+msgctxt ""
+"Label beside the share-content switch on the Duck.ai response feedback form"
+msgid "Share this conversation with DuckDuckGo"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -14856,6 +15143,21 @@ msgctxt "Brief for suggesting a blog post title"
 msgid "Suggest a title for a blog post"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest related articles or topics worth exploring next."
+msgstr ""
+
+#. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Suggest related articles to explore"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest some alternatives to this product."
+msgstr ""
+
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
 msgctxt "directions"
 msgid "Suggestions:"
@@ -14865,9 +15167,84 @@ msgctxt "noresults"
 msgid "Suggestions:"
 msgstr "Suggestions:"
 
+#. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Sum up the reviews"
+msgstr ""
+
 #. A short title for the a message asking the AI to summarize a text.
 msgctxt "Title for the summarize message"
 msgid "Summarize"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize the Q&As"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the background and notable work of this person."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the key details of this event."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the questions and answers on this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize their background"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this book"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this book."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this discussion"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this discussion thread."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this video"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this video."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize what the reviews say."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -15122,6 +15499,11 @@ msgstr ""
 msgid "Syria"
 msgstr ""
 
+#. Text for a button that enables the theme to follow the operating system's color scheme preference.
+msgctxt "System theme button for theme selector"
+msgid "System"
+msgstr ""
+
 #. Abbreviation indicating this is the total score for a game
 msgctxt "Sports module"
 msgid "T"
@@ -15145,6 +15527,11 @@ msgctxt "language_name"
 msgid "Tahitian"
 msgstr ""
 
+#. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Tailor my resume"
+msgstr ""
+
 msgid "Taiwan"
 msgstr "Taiwan"
 
@@ -15166,6 +15553,12 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "Take control of your personal data!"
+msgstr ""
+
+#. Description for the Feedback section of the Duck.ai settings page, asking the user to take an anonymous survey to let us know how we can make Duck.ai better.
+msgctxt "Feedback section description on the Duck.ai settings page"
+msgid ""
+"Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
 
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -15410,6 +15803,11 @@ msgstr ""
 #. https://duck.co/media/files/theme.png
 msgid "Theme"
 msgstr "Theme"
+
+#. Text for the theme selector label that allows users to switch between Light and dark theme.
+msgctxt "Label for the theme selector feature"
+msgid "Theme"
+msgstr ""
 
 #. http://i.imgur.com/LpFhb1e.png
 msgctxt "settings"
@@ -16064,6 +16462,16 @@ msgid ""
 "movie theatre?”"
 msgstr ""
 
+#. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Translate this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
+msgctxt "Page suggestion prompt"
+msgid "Translate this page into %s."
+msgstr ""
+
 #. Placeholder text for a region that will display translated text.
 msgctxt "translations_module"
 msgid "Translation"
@@ -16178,6 +16586,11 @@ msgstr ""
 #. Call-to-action button for the subscription promo in the SERP sidemenu.
 msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
+msgstr ""
+
+#. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
+msgctxt "settings"
+msgid "Try It Now"
 msgstr ""
 
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -16372,6 +16785,20 @@ msgstr "Try: %s"
 msgctxt "new user poll"
 msgid "Trying DuckDuckGo again"
 msgstr "Trying DuckDuckGo again"
+
+#. Message shown in a modal after supported third-party browser users disable AI features in Settings. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+#. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
 
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
 msgctxt "Assistant response placeholder"
@@ -16974,6 +17401,11 @@ msgstr ""
 msgid "Uruguay"
 msgstr ""
 
+#. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
+msgctxt "Navigation label on the Duck.ai settings page"
+msgid "Usage"
+msgstr ""
+
 #. A feedback suggestion
 msgctxt "Feedback prompt"
 msgid "Usage limit"
@@ -17324,6 +17756,11 @@ msgstr ""
 msgid "Wales"
 msgstr ""
 
+#. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Walk me through the steps"
+msgstr ""
+
 #. Label for walking directions on a map.
 msgctxt "directions"
 msgid "Walking"
@@ -17414,6 +17851,16 @@ msgstr ""
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
+msgstr ""
+
+#. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
+msgctxt ""
+"Inline warning shown below the share-content toggle when the user selects "
+"Harmful or Illegal but has not enabled sharing"
+msgid ""
+"We can only fix what we can see. To report a harmful or illegal response, "
+"please share this conversation with DuckDuckGo so we can investigate and "
+"address the issue."
 msgstr ""
 
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -17839,6 +18286,87 @@ msgid ""
 "experience."
 msgstr ""
 
+#. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the counterarguments?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the hours & location?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key contributions of this paper?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key contributions?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key details?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key points covered in this video?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key points?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key takeaways from this article?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key takeaways?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key things I will learn from this course?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main counterarguments or criticisms of this?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main questions this page answers?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the must-try dishes here?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"What are the opening hours, location, and contact details for this place?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the pros and cons of this product?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the pros and cons?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
 msgctxt "feedback form"
 msgid "What bothered you most?"
@@ -17922,6 +18450,11 @@ msgctxt "Full sentence for defining a term"
 msgid "What does atria mean in the context of a medical article?"
 msgstr ""
 
+#. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What does this answer?"
+msgstr ""
+
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
@@ -17931,6 +18464,11 @@ msgstr ""
 msgctxt "cloudsave"
 msgid "What information gets saved?"
 msgstr "What information gets saved?"
+
+#. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What interview questions might come up for this role?"
+msgstr ""
 
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
@@ -17942,6 +18480,11 @@ msgstr ""
 #. Text for a prompt suggestion for looking up the capital city of Albania.
 msgctxt "Full sentence for looking up basic facts"
 msgid "What is the capital city of Albania?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What is the overall verdict and rating for this?"
 msgstr ""
 
 #. Link to a page with additional information.
@@ -17962,6 +18505,11 @@ msgctxt "maps_places"
 msgid "What people say:"
 msgstr ""
 
+#. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What should I order?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
 msgctxt "feedback form"
 msgid "What stood out?"
@@ -17970,6 +18518,16 @@ msgstr ""
 #. Question on a feedback form for a negative feedback response.
 msgctxt "feedback form"
 msgid "What was wrong with the response? (optional)"
+msgstr ""
+
+#. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I learn?"
+msgstr ""
+
+#. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I need?"
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -17984,6 +18542,11 @@ msgstr ""
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
 msgctxt "SERP footer content"
 msgid "What's New"
+msgstr ""
+
+#. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What's the verdict?"
 msgstr ""
 
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -18025,6 +18588,11 @@ msgctxt "Feedback prompt"
 msgid "Which features are missing? (Optional)"
 msgstr ""
 
+#. An invitation for users to leave feedback
+msgctxt "Feedback prompt"
+msgid "Which features are missing? (optional)"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
 msgid "White"
 msgstr "White"
@@ -18037,6 +18605,16 @@ msgstr "White"
 #. Link to an about us page.
 msgid "Who We Are"
 msgstr "Who We Are"
+
+#. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Who are the main cast and crew, and what else are they known for?"
+msgstr ""
+
+#. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Who is this person?"
+msgstr ""
 
 #. Header above a collection of privacy-related links.
 msgid "Why Privacy"

--- a/locales/en_CA/LC_MESSAGES/duckduckgo.po
+++ b/locales/en_CA/LC_MESSAGES/duckduckgo.po
@@ -1161,6 +1161,11 @@ msgctxt "feedback form"
 msgid "Address is incorrect"
 msgstr ""
 
+#. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Adjust the servings"
+msgstr ""
+
 #. as in multiple advertisements
 msgid "Ads"
 msgstr ""
@@ -1333,6 +1338,13 @@ msgstr ""
 #. Heading shown on the empty chat screen. The text between the two %s markers is displayed inside a clickable privacy button. First %s renders a shield icon, second %s is an invisible end marker. Keep the word 'private' between both %s markers.
 msgctxt "Empty state heading in Duck.ai chat mode"
 msgid "All chats are %sprivate%s"
+msgstr ""
+
+#. Paragraph in the Privacy & Terms section of the About & Legal page in Duck.ai settings, summarizing how chats are anonymized and are not stored or used to train chat models.
+msgctxt "Privacy & Terms section description on the Duck.ai settings page"
+msgid ""
+"All chats are anonymized by DuckDuckGo, and your conversations are not used "
+"to train chat models by DuckDuckGo or the model providers"
 msgstr ""
 
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1545,6 +1557,12 @@ msgstr ""
 #. Confirmation message after location service is enabled.
 msgctxt "precise_user_location"
 msgid "Anonymous location enabled"
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Anonymously generates answers for search queries based on web content. "
+"Choose how often you want it to appear, or disable it completely."
 msgstr ""
 
 #. Instant Answer tab name
@@ -1769,6 +1787,11 @@ msgstr ""
 
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse
 msgid "Ask a follow-up with Duck.ai"
+msgstr ""
+
+#. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
+msgctxt "Page suggestion chip label"
+msgid "Ask about this page"
 msgstr ""
 
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2093,6 +2116,11 @@ msgstr ""
 msgid "Barcode"
 msgstr "Barcode"
 
+#. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Based on this page, is this course worth taking?"
+msgstr ""
+
 msgctxt "settings"
 msgid "Basic"
 msgstr "Basic"
@@ -2124,6 +2152,13 @@ msgstr ""
 #. Placeholder text displayed while the assistant waits for the user to choose an action.
 msgctxt "Assistant response placeholder"
 msgid "Before continuing..."
+msgstr ""
+
+#. Explains that before storing the report, DuckDuckGo will anonymize the conversation by removing PII like names, email addresses, and identifying metadata.
+msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
+msgid ""
+"Before storing this report, DuckDuckGo will anonymize your conversation by "
+"removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
 #. Label that's displayed next to a past start date below a web search result.
@@ -2382,6 +2417,11 @@ msgstr "Brazil"
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Break Points Won"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Break this down into clear, numbered steps."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -2741,6 +2781,11 @@ msgstr "Careers"
 #. Text of a button that performs a search for the cast of a particular movie or tv show
 msgctxt "Movie/TV Show Title instant answer"
 msgid "Cast"
+msgstr ""
+
+#. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Cast & Crew"
 msgstr ""
 
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -4097,6 +4142,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Create a shopping list with quantities from this recipe."
+msgstr ""
+
 #. Placeholder text displayed in the input field when starting a new image generation session.
 msgctxt "Placeholder text for the image generation input field"
 msgid "Create an image of a cute duck..."
@@ -4623,6 +4673,10 @@ msgstr ""
 msgid "Dictation limit reached"
 msgstr ""
 
+#. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
+msgid "Dictation temporarily unavailable"
+msgstr ""
+
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
@@ -4867,6 +4921,20 @@ msgctxt "precise_user_location"
 msgid "Done"
 msgstr ""
 
+#. Message shown in a modal after DuckDuckGo browser users disable AI features in Settings. The first two placeholders bold noai.duckduckgo.com. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
+"filtered out. %sLearn More%s"
+msgstr ""
+
+#. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
+"and AI images filtered out. %sLearn more%s"
+msgstr ""
+
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Double Faults"
@@ -4957,6 +5025,16 @@ msgctxt "Full sentence for writing an email"
 msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
+msgstr ""
+
+#. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Draft a cover letter"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Draft a cover letter for this job."
 msgstr ""
 
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -5096,6 +5174,14 @@ msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
 msgstr ""
 
+#. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
+msgctxt "About section description on the Duck.ai settings page"
+msgid ""
+"Duck.ai is created by DuckDuckGo. We're an independent online protection "
+"company for anyone who wants to take back control of their personal "
+"information."
+msgstr ""
+
 #. Title shown when an update is required before proceeding.
 msgctxt "duckai_migration"
 msgid "Duck.ai is moving domains"
@@ -5129,6 +5215,12 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Duck.ai lets you chat privately with popular AI models. Disabling it hides "
+"Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
 
 msgctxt "settings"
@@ -5895,6 +5987,16 @@ msgstr ""
 msgid "Eritrea"
 msgstr ""
 
+#. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Estimate the nutrition"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Estimate the nutritional information for this recipe."
+msgstr ""
+
 msgid "Estonia"
 msgstr "Estonia"
 
@@ -5939,10 +6041,50 @@ msgctxt "merchant promotion product ad extension"
 msgid "Expires in 1 day"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain the accepted answer in simple terms."
+msgstr ""
+
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
+msgstr ""
+
+#. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain the top answer"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this in simple, plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this paper"
+msgstr ""
+
+#. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this repo"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this research paper in plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this simply"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain what this repository does and how to use it."
 msgstr ""
 
 #. Label to show if song lyrics contain explicit content
@@ -6173,6 +6315,11 @@ msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
 msgstr ""
 
+msgctxt "settings"
+msgid ""
+"Filters out known AI spam sites from image search results. %sLearn More%s"
+msgstr ""
+
 #. Label for the final score of a sporting event.
 msgid "Final"
 msgstr "Final"
@@ -6212,6 +6359,11 @@ msgstr ""
 #. Short description shown below the 'Web Search' label in the Tools dropdown.
 msgctxt "Subtitle for the Web Search tool entry in the Tools dropdown menu"
 msgid "Find current information"
+msgstr ""
+
+#. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Find me alternatives"
 msgstr ""
 
 #. Button that searches for results closer to the user's current location.
@@ -6602,6 +6754,11 @@ msgstr ""
 msgid "Generate More"
 msgstr ""
 
+#. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Generate a shopping list"
+msgstr ""
+
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
 msgid "Generate a short answer from the web"
 msgstr ""
@@ -6836,6 +6993,11 @@ msgstr ""
 #. Text for a button inviting users to give it a try for the Duck.ai product. On click, they're taken to the Duck.ai page.
 msgctxt "Onboarding welcome screen button text"
 msgid "Give it a Try"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Give me a quick background on this person."
 msgstr ""
 
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -7199,6 +7361,16 @@ msgstr ""
 #. Link to a page with information about sharing DuckDuckGo with friends.
 msgid "Help Spread Privacy"
 msgstr "Help Spread Privacy"
+
+#. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Help me prep for the interview"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Help me tailor my resume for this job."
+msgstr ""
 
 #. Title of a SERP popup that invites users to take a survey (desktop only)
 msgctxt "User survey popup"
@@ -7619,6 +7791,13 @@ msgstr ""
 #. Text displayed on the button on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
 msgctxt "Onboarding terms screen button text"
 msgid "I Agree"
+msgstr ""
+
+#. Text for the button that takes the user to the external DuckDuckGo login subscription page.
+msgctxt ""
+"Text for the I already have a subscription button in the Duck.ai settings "
+"page"
+msgid "I Already Have a Subscription"
 msgstr ""
 
 #. Text for the button that takes the user to the login subscription page.
@@ -8074,6 +8253,11 @@ msgctxt "Sidemenu browser promo"
 msgid "Install Mac Browser"
 msgstr ""
 
+#. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
+msgctxt "settings"
+msgid "Install Now"
+msgstr ""
+
 #. Text of a button to install the DuckDuckGo app
 msgctxt "Serp footer content"
 msgid "Install Our App"
@@ -8153,9 +8337,36 @@ msgctxt "cloudsave"
 msgid "Is deleted data really deleted?"
 msgstr "Is deleted data really deleted?"
 
+#. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is it worth taking?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this place any good?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"Is this place any good? Summarize its reputation based on reviews and "
+"ratings."
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "Is this video helpful?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this worth watching?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Is this worth watching? Give me a spoiler-free take."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -8653,6 +8864,11 @@ msgstr " Link font:"
 msgid "Links:"
 msgstr "Links:"
 
+#. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "List the tools, materials, or prerequisites I need for this."
+msgstr ""
+
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
 msgid "Listen"
 msgstr "Listen"
@@ -8985,6 +9201,11 @@ msgstr ""
 #. Label for linke navigating to site exclusion feature on Settings page
 msgctxt "Exclusion message manage sites button"
 msgid "Manage blocked sites"
+msgstr ""
+
+#. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
+msgctxt "setting"
+msgid "Manage in Browser Settings"
 msgstr ""
 
 #. Link to the site exclusion settings page
@@ -11290,6 +11511,11 @@ msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
+msgid "Please describe why the chat response is harmful or illegal. (optional)"
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
+msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
 msgstr ""
 
@@ -11308,6 +11534,13 @@ msgctxt "Modal disclaimer text"
 msgid ""
 "Please note: starting a new chat with any model will delete your current "
 "chat session."
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
+msgctxt "Feedback prompt"
+msgid ""
+"Please paste your prompt and the problematic output (with any personal "
+"information removed) and describe why the content is harmful or illegal."
 msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -11692,6 +11925,11 @@ msgctxt "settings"
 msgid "Privacy"
 msgstr "Privacy"
 
+#. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
+msgctxt "Section heading on the Duck.ai settings page"
+msgid "Privacy & Terms"
+msgstr ""
+
 msgid "Privacy Blog"
 msgstr "Privacy Blog"
 
@@ -11745,6 +11983,11 @@ msgstr ""
 
 #. Text used in other strings to link to the Privacy Policy and Terms of Service content.
 msgctxt "Copy used to compose link in sentences"
+msgid "Privacy Policy and Terms of Service"
+msgstr ""
+
+#. Text for a button that links to the terms of use and privacy policy page.
+msgctxt "Secondary button text in active privacy modal"
 msgid "Privacy Policy and Terms of Service"
 msgstr ""
 
@@ -12153,6 +12396,26 @@ msgctxt "Brief for recommending a book"
 msgid "Recommend a book"
 msgstr ""
 
+#. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar books"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar books."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar movies or shows."
+msgstr ""
+
+#. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar titles"
+msgstr ""
+
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
 msgid "Recording failed. Please try again."
 msgstr ""
@@ -12472,6 +12735,14 @@ msgstr ""
 msgid "Republic of Moldova"
 msgstr ""
 
+#. Note indicating that sharing the conversation is mandatory when reporting harmful or illegal content. Rendered alongside the standard share label (DUCKCHAT_RESPONSE_FEEDBACK_SHARE_PROMPT_RESPONSE_LABEL), not replacing it.
+msgctxt ""
+"Note shown under the share-content switch label on the Duck.ai response "
+"feedback form when the user has selected Harmful or Illegal as the feedback "
+"reason"
+msgid "Required for harmful or illegal reports"
+msgstr ""
+
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
 msgctxt "Description for extended reasoning mode in Duck.ai"
 msgid "Researches before responding"
@@ -12657,6 +12928,11 @@ msgstr "Reviews"
 #. Label above a list of customer reviews of a business.
 msgctxt "maps_places"
 msgid "Reviews"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Rewrite this recipe scaled for a different number of servings."
 msgstr ""
 
 msgid "Romania"
@@ -13700,6 +13976,11 @@ msgctxt "Setup button for native sync flow"
 msgid "Set Up Now"
 msgstr ""
 
+#. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
+msgctxt "Encrypted storage setup button shown in native browsers"
+msgid "Set Up Sync & Backup"
+msgstr ""
+
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
 msgctxt "Title for the Sync & Backup intro screen"
 msgid "Set Up Sync & Backup"
@@ -13842,6 +14123,12 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
+msgctxt ""
+"Label beside the share-content switch on the Duck.ai response feedback form"
+msgid "Share this conversation with DuckDuckGo"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -14856,6 +15143,21 @@ msgctxt "Brief for suggesting a blog post title"
 msgid "Suggest a title for a blog post"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest related articles or topics worth exploring next."
+msgstr ""
+
+#. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Suggest related articles to explore"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest some alternatives to this product."
+msgstr ""
+
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
 msgctxt "directions"
 msgid "Suggestions:"
@@ -14865,9 +15167,84 @@ msgctxt "noresults"
 msgid "Suggestions:"
 msgstr "Suggestions:"
 
+#. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Sum up the reviews"
+msgstr ""
+
 #. A short title for the a message asking the AI to summarize a text.
 msgctxt "Title for the summarize message"
 msgid "Summarize"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize the Q&As"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the background and notable work of this person."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the key details of this event."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the questions and answers on this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize their background"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this book"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this book."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this discussion"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this discussion thread."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this video"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this video."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize what the reviews say."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -15122,6 +15499,11 @@ msgstr ""
 msgid "Syria"
 msgstr ""
 
+#. Text for a button that enables the theme to follow the operating system's color scheme preference.
+msgctxt "System theme button for theme selector"
+msgid "System"
+msgstr ""
+
 #. Abbreviation indicating this is the total score for a game
 msgctxt "Sports module"
 msgid "T"
@@ -15145,6 +15527,11 @@ msgctxt "language_name"
 msgid "Tahitian"
 msgstr ""
 
+#. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Tailor my resume"
+msgstr ""
+
 msgid "Taiwan"
 msgstr "Taiwan"
 
@@ -15166,6 +15553,12 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "Take control of your personal data!"
+msgstr ""
+
+#. Description for the Feedback section of the Duck.ai settings page, asking the user to take an anonymous survey to let us know how we can make Duck.ai better.
+msgctxt "Feedback section description on the Duck.ai settings page"
+msgid ""
+"Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
 
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -15410,6 +15803,11 @@ msgstr ""
 #. https://duck.co/media/files/theme.png
 msgid "Theme"
 msgstr "Theme"
+
+#. Text for the theme selector label that allows users to switch between Light and dark theme.
+msgctxt "Label for the theme selector feature"
+msgid "Theme"
+msgstr ""
 
 #. http://i.imgur.com/LpFhb1e.png
 msgctxt "settings"
@@ -16064,6 +16462,16 @@ msgid ""
 "movie theatre?”"
 msgstr ""
 
+#. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Translate this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
+msgctxt "Page suggestion prompt"
+msgid "Translate this page into %s."
+msgstr ""
+
 #. Placeholder text for a region that will display translated text.
 msgctxt "translations_module"
 msgid "Translation"
@@ -16178,6 +16586,11 @@ msgstr ""
 #. Call-to-action button for the subscription promo in the SERP sidemenu.
 msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
+msgstr ""
+
+#. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
+msgctxt "settings"
+msgid "Try It Now"
 msgstr ""
 
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -16372,6 +16785,20 @@ msgstr "Try: %s"
 msgctxt "new user poll"
 msgid "Trying DuckDuckGo again"
 msgstr "Trying DuckDuckGo again"
+
+#. Message shown in a modal after supported third-party browser users disable AI features in Settings. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+#. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
 
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
 msgctxt "Assistant response placeholder"
@@ -16974,6 +17401,11 @@ msgstr ""
 msgid "Uruguay"
 msgstr ""
 
+#. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
+msgctxt "Navigation label on the Duck.ai settings page"
+msgid "Usage"
+msgstr ""
+
 #. A feedback suggestion
 msgctxt "Feedback prompt"
 msgid "Usage limit"
@@ -17324,6 +17756,11 @@ msgstr ""
 msgid "Wales"
 msgstr ""
 
+#. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Walk me through the steps"
+msgstr ""
+
 #. Label for walking directions on a map.
 msgctxt "directions"
 msgid "Walking"
@@ -17414,6 +17851,16 @@ msgstr ""
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
+msgstr ""
+
+#. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
+msgctxt ""
+"Inline warning shown below the share-content toggle when the user selects "
+"Harmful or Illegal but has not enabled sharing"
+msgid ""
+"We can only fix what we can see. To report a harmful or illegal response, "
+"please share this conversation with DuckDuckGo so we can investigate and "
+"address the issue."
 msgstr ""
 
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -17839,6 +18286,87 @@ msgid ""
 "experience."
 msgstr ""
 
+#. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the counterarguments?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the hours & location?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key contributions of this paper?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key contributions?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key details?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key points covered in this video?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key points?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key takeaways from this article?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key takeaways?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key things I will learn from this course?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main counterarguments or criticisms of this?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main questions this page answers?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the must-try dishes here?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"What are the opening hours, location, and contact details for this place?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the pros and cons of this product?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the pros and cons?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
 msgctxt "feedback form"
 msgid "What bothered you most?"
@@ -17922,6 +18450,11 @@ msgctxt "Full sentence for defining a term"
 msgid "What does atria mean in the context of a medical article?"
 msgstr ""
 
+#. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What does this answer?"
+msgstr ""
+
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
@@ -17931,6 +18464,11 @@ msgstr ""
 msgctxt "cloudsave"
 msgid "What information gets saved?"
 msgstr "What information gets saved?"
+
+#. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What interview questions might come up for this role?"
+msgstr ""
 
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
@@ -17942,6 +18480,11 @@ msgstr ""
 #. Text for a prompt suggestion for looking up the capital city of Albania.
 msgctxt "Full sentence for looking up basic facts"
 msgid "What is the capital city of Albania?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What is the overall verdict and rating for this?"
 msgstr ""
 
 #. Link to a page with additional information.
@@ -17962,6 +18505,11 @@ msgctxt "maps_places"
 msgid "What people say:"
 msgstr ""
 
+#. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What should I order?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
 msgctxt "feedback form"
 msgid "What stood out?"
@@ -17970,6 +18518,16 @@ msgstr ""
 #. Question on a feedback form for a negative feedback response.
 msgctxt "feedback form"
 msgid "What was wrong with the response? (optional)"
+msgstr ""
+
+#. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I learn?"
+msgstr ""
+
+#. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I need?"
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -17984,6 +18542,11 @@ msgstr ""
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
 msgctxt "SERP footer content"
 msgid "What's New"
+msgstr ""
+
+#. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What's the verdict?"
 msgstr ""
 
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -18025,6 +18588,11 @@ msgctxt "Feedback prompt"
 msgid "Which features are missing? (Optional)"
 msgstr ""
 
+#. An invitation for users to leave feedback
+msgctxt "Feedback prompt"
+msgid "Which features are missing? (optional)"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
 msgid "White"
 msgstr "White"
@@ -18037,6 +18605,16 @@ msgstr "White"
 #. Link to an about us page.
 msgid "Who We Are"
 msgstr "Who We Are"
+
+#. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Who are the main cast and crew, and what else are they known for?"
+msgstr ""
+
+#. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Who is this person?"
+msgstr ""
 
 #. Header above a collection of privacy-related links.
 msgid "Why Privacy"

--- a/locales/en_GB/LC_MESSAGES/duckduckgo.po
+++ b/locales/en_GB/LC_MESSAGES/duckduckgo.po
@@ -1161,6 +1161,11 @@ msgctxt "feedback form"
 msgid "Address is incorrect"
 msgstr ""
 
+#. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Adjust the servings"
+msgstr ""
+
 #. as in multiple advertisements
 msgid "Ads"
 msgstr ""
@@ -1333,6 +1338,13 @@ msgstr ""
 #. Heading shown on the empty chat screen. The text between the two %s markers is displayed inside a clickable privacy button. First %s renders a shield icon, second %s is an invisible end marker. Keep the word 'private' between both %s markers.
 msgctxt "Empty state heading in Duck.ai chat mode"
 msgid "All chats are %sprivate%s"
+msgstr ""
+
+#. Paragraph in the Privacy & Terms section of the About & Legal page in Duck.ai settings, summarizing how chats are anonymized and are not stored or used to train chat models.
+msgctxt "Privacy & Terms section description on the Duck.ai settings page"
+msgid ""
+"All chats are anonymized by DuckDuckGo, and your conversations are not used "
+"to train chat models by DuckDuckGo or the model providers"
 msgstr ""
 
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1545,6 +1557,12 @@ msgstr ""
 #. Confirmation message after location service is enabled.
 msgctxt "precise_user_location"
 msgid "Anonymous location enabled"
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Anonymously generates answers for search queries based on web content. "
+"Choose how often you want it to appear, or disable it completely."
 msgstr ""
 
 #. Instant Answer tab name
@@ -1769,6 +1787,11 @@ msgstr ""
 
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse
 msgid "Ask a follow-up with Duck.ai"
+msgstr ""
+
+#. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
+msgctxt "Page suggestion chip label"
+msgid "Ask about this page"
 msgstr ""
 
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2093,6 +2116,11 @@ msgstr ""
 msgid "Barcode"
 msgstr "Barcode"
 
+#. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Based on this page, is this course worth taking?"
+msgstr ""
+
 msgctxt "settings"
 msgid "Basic"
 msgstr "Basic"
@@ -2124,6 +2152,13 @@ msgstr ""
 #. Placeholder text displayed while the assistant waits for the user to choose an action.
 msgctxt "Assistant response placeholder"
 msgid "Before continuing..."
+msgstr ""
+
+#. Explains that before storing the report, DuckDuckGo will anonymize the conversation by removing PII like names, email addresses, and identifying metadata.
+msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
+msgid ""
+"Before storing this report, DuckDuckGo will anonymize your conversation by "
+"removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
 #. Label that's displayed next to a past start date below a web search result.
@@ -2382,6 +2417,11 @@ msgstr "Brazil"
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Break Points Won"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Break this down into clear, numbered steps."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -2741,6 +2781,11 @@ msgstr "Careers"
 #. Text of a button that performs a search for the cast of a particular movie or tv show
 msgctxt "Movie/TV Show Title instant answer"
 msgid "Cast"
+msgstr ""
+
+#. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Cast & Crew"
 msgstr ""
 
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -4097,6 +4142,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Create a shopping list with quantities from this recipe."
+msgstr ""
+
 #. Placeholder text displayed in the input field when starting a new image generation session.
 msgctxt "Placeholder text for the image generation input field"
 msgid "Create an image of a cute duck..."
@@ -4623,6 +4673,10 @@ msgstr ""
 msgid "Dictation limit reached"
 msgstr ""
 
+#. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
+msgid "Dictation temporarily unavailable"
+msgstr ""
+
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
@@ -4867,6 +4921,20 @@ msgctxt "precise_user_location"
 msgid "Done"
 msgstr ""
 
+#. Message shown in a modal after DuckDuckGo browser users disable AI features in Settings. The first two placeholders bold noai.duckduckgo.com. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
+"filtered out. %sLearn More%s"
+msgstr ""
+
+#. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
+"and AI images filtered out. %sLearn more%s"
+msgstr ""
+
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Double Faults"
@@ -4957,6 +5025,16 @@ msgctxt "Full sentence for writing an email"
 msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
+msgstr ""
+
+#. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Draft a cover letter"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Draft a cover letter for this job."
 msgstr ""
 
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -5096,6 +5174,14 @@ msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
 msgstr ""
 
+#. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
+msgctxt "About section description on the Duck.ai settings page"
+msgid ""
+"Duck.ai is created by DuckDuckGo. We're an independent online protection "
+"company for anyone who wants to take back control of their personal "
+"information."
+msgstr ""
+
 #. Title shown when an update is required before proceeding.
 msgctxt "duckai_migration"
 msgid "Duck.ai is moving domains"
@@ -5129,6 +5215,12 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Duck.ai lets you chat privately with popular AI models. Disabling it hides "
+"Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
 
 msgctxt "settings"
@@ -5895,6 +5987,16 @@ msgstr ""
 msgid "Eritrea"
 msgstr ""
 
+#. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Estimate the nutrition"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Estimate the nutritional information for this recipe."
+msgstr ""
+
 msgid "Estonia"
 msgstr "Estonia"
 
@@ -5939,10 +6041,50 @@ msgctxt "merchant promotion product ad extension"
 msgid "Expires in 1 day"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain the accepted answer in simple terms."
+msgstr ""
+
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
+msgstr ""
+
+#. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain the top answer"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this in simple, plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this paper"
+msgstr ""
+
+#. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this repo"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this research paper in plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this simply"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain what this repository does and how to use it."
 msgstr ""
 
 #. Label to show if song lyrics contain explicit content
@@ -6173,6 +6315,11 @@ msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
 msgstr ""
 
+msgctxt "settings"
+msgid ""
+"Filters out known AI spam sites from image search results. %sLearn More%s"
+msgstr ""
+
 #. Label for the final score of a sporting event.
 msgid "Final"
 msgstr "Final"
@@ -6212,6 +6359,11 @@ msgstr ""
 #. Short description shown below the 'Web Search' label in the Tools dropdown.
 msgctxt "Subtitle for the Web Search tool entry in the Tools dropdown menu"
 msgid "Find current information"
+msgstr ""
+
+#. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Find me alternatives"
 msgstr ""
 
 #. Button that searches for results closer to the user's current location.
@@ -6602,6 +6754,11 @@ msgstr ""
 msgid "Generate More"
 msgstr ""
 
+#. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Generate a shopping list"
+msgstr ""
+
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
 msgid "Generate a short answer from the web"
 msgstr ""
@@ -6836,6 +6993,11 @@ msgstr ""
 #. Text for a button inviting users to give it a try for the Duck.ai product. On click, they're taken to the Duck.ai page.
 msgctxt "Onboarding welcome screen button text"
 msgid "Give it a Try"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Give me a quick background on this person."
 msgstr ""
 
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -7199,6 +7361,16 @@ msgstr ""
 #. Link to a page with information about sharing DuckDuckGo with friends.
 msgid "Help Spread Privacy"
 msgstr "Help Spread Privacy"
+
+#. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Help me prep for the interview"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Help me tailor my resume for this job."
+msgstr ""
 
 #. Title of a SERP popup that invites users to take a survey (desktop only)
 msgctxt "User survey popup"
@@ -7619,6 +7791,13 @@ msgstr ""
 #. Text displayed on the button on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
 msgctxt "Onboarding terms screen button text"
 msgid "I Agree"
+msgstr ""
+
+#. Text for the button that takes the user to the external DuckDuckGo login subscription page.
+msgctxt ""
+"Text for the I already have a subscription button in the Duck.ai settings "
+"page"
+msgid "I Already Have a Subscription"
 msgstr ""
 
 #. Text for the button that takes the user to the login subscription page.
@@ -8074,6 +8253,11 @@ msgctxt "Sidemenu browser promo"
 msgid "Install Mac Browser"
 msgstr ""
 
+#. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
+msgctxt "settings"
+msgid "Install Now"
+msgstr ""
+
 #. Text of a button to install the DuckDuckGo app
 msgctxt "Serp footer content"
 msgid "Install Our App"
@@ -8153,9 +8337,36 @@ msgctxt "cloudsave"
 msgid "Is deleted data really deleted?"
 msgstr "Is deleted data really deleted?"
 
+#. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is it worth taking?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this place any good?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"Is this place any good? Summarize its reputation based on reviews and "
+"ratings."
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "Is this video helpful?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this worth watching?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Is this worth watching? Give me a spoiler-free take."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -8653,6 +8864,11 @@ msgstr "Link font:"
 msgid "Links:"
 msgstr "Links:"
 
+#. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "List the tools, materials, or prerequisites I need for this."
+msgstr ""
+
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
 msgid "Listen"
 msgstr "Listen"
@@ -8985,6 +9201,11 @@ msgstr ""
 #. Label for linke navigating to site exclusion feature on Settings page
 msgctxt "Exclusion message manage sites button"
 msgid "Manage blocked sites"
+msgstr ""
+
+#. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
+msgctxt "setting"
+msgid "Manage in Browser Settings"
 msgstr ""
 
 #. Link to the site exclusion settings page
@@ -11290,6 +11511,11 @@ msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
+msgid "Please describe why the chat response is harmful or illegal. (optional)"
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
+msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
 msgstr ""
 
@@ -11308,6 +11534,13 @@ msgctxt "Modal disclaimer text"
 msgid ""
 "Please note: starting a new chat with any model will delete your current "
 "chat session."
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
+msgctxt "Feedback prompt"
+msgid ""
+"Please paste your prompt and the problematic output (with any personal "
+"information removed) and describe why the content is harmful or illegal."
 msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -11692,6 +11925,11 @@ msgctxt "settings"
 msgid "Privacy"
 msgstr "Privacy"
 
+#. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
+msgctxt "Section heading on the Duck.ai settings page"
+msgid "Privacy & Terms"
+msgstr ""
+
 msgid "Privacy Blog"
 msgstr "Privacy Blog"
 
@@ -11745,6 +11983,11 @@ msgstr ""
 
 #. Text used in other strings to link to the Privacy Policy and Terms of Service content.
 msgctxt "Copy used to compose link in sentences"
+msgid "Privacy Policy and Terms of Service"
+msgstr ""
+
+#. Text for a button that links to the terms of use and privacy policy page.
+msgctxt "Secondary button text in active privacy modal"
 msgid "Privacy Policy and Terms of Service"
 msgstr ""
 
@@ -12153,6 +12396,26 @@ msgctxt "Brief for recommending a book"
 msgid "Recommend a book"
 msgstr ""
 
+#. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar books"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar books."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar movies or shows."
+msgstr ""
+
+#. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar titles"
+msgstr ""
+
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
 msgid "Recording failed. Please try again."
 msgstr ""
@@ -12472,6 +12735,14 @@ msgstr ""
 msgid "Republic of Moldova"
 msgstr ""
 
+#. Note indicating that sharing the conversation is mandatory when reporting harmful or illegal content. Rendered alongside the standard share label (DUCKCHAT_RESPONSE_FEEDBACK_SHARE_PROMPT_RESPONSE_LABEL), not replacing it.
+msgctxt ""
+"Note shown under the share-content switch label on the Duck.ai response "
+"feedback form when the user has selected Harmful or Illegal as the feedback "
+"reason"
+msgid "Required for harmful or illegal reports"
+msgstr ""
+
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
 msgctxt "Description for extended reasoning mode in Duck.ai"
 msgid "Researches before responding"
@@ -12657,6 +12928,11 @@ msgstr "Reviews"
 #. Label above a list of customer reviews of a business.
 msgctxt "maps_places"
 msgid "Reviews"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Rewrite this recipe scaled for a different number of servings."
 msgstr ""
 
 msgid "Romania"
@@ -13700,6 +13976,11 @@ msgctxt "Setup button for native sync flow"
 msgid "Set Up Now"
 msgstr ""
 
+#. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
+msgctxt "Encrypted storage setup button shown in native browsers"
+msgid "Set Up Sync & Backup"
+msgstr ""
+
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
 msgctxt "Title for the Sync & Backup intro screen"
 msgid "Set Up Sync & Backup"
@@ -13842,6 +14123,12 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
+msgctxt ""
+"Label beside the share-content switch on the Duck.ai response feedback form"
+msgid "Share this conversation with DuckDuckGo"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -14856,6 +15143,21 @@ msgctxt "Brief for suggesting a blog post title"
 msgid "Suggest a title for a blog post"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest related articles or topics worth exploring next."
+msgstr ""
+
+#. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Suggest related articles to explore"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest some alternatives to this product."
+msgstr ""
+
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
 msgctxt "directions"
 msgid "Suggestions:"
@@ -14865,9 +15167,84 @@ msgctxt "noresults"
 msgid "Suggestions:"
 msgstr "Suggestions:"
 
+#. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Sum up the reviews"
+msgstr ""
+
 #. A short title for the a message asking the AI to summarize a text.
 msgctxt "Title for the summarize message"
 msgid "Summarize"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize the Q&As"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the background and notable work of this person."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the key details of this event."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the questions and answers on this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize their background"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this book"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this book."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this discussion"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this discussion thread."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this video"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this video."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize what the reviews say."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -15122,6 +15499,11 @@ msgstr ""
 msgid "Syria"
 msgstr ""
 
+#. Text for a button that enables the theme to follow the operating system's color scheme preference.
+msgctxt "System theme button for theme selector"
+msgid "System"
+msgstr ""
+
 #. Abbreviation indicating this is the total score for a game
 msgctxt "Sports module"
 msgid "T"
@@ -15145,6 +15527,11 @@ msgctxt "language_name"
 msgid "Tahitian"
 msgstr ""
 
+#. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Tailor my resume"
+msgstr ""
+
 msgid "Taiwan"
 msgstr "Taiwan"
 
@@ -15166,6 +15553,12 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "Take control of your personal data!"
+msgstr ""
+
+#. Description for the Feedback section of the Duck.ai settings page, asking the user to take an anonymous survey to let us know how we can make Duck.ai better.
+msgctxt "Feedback section description on the Duck.ai settings page"
+msgid ""
+"Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
 
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -15410,6 +15803,11 @@ msgstr ""
 #. https://duck.co/media/files/theme.png
 msgid "Theme"
 msgstr "Theme"
+
+#. Text for the theme selector label that allows users to switch between Light and dark theme.
+msgctxt "Label for the theme selector feature"
+msgid "Theme"
+msgstr ""
 
 #. http://i.imgur.com/LpFhb1e.png
 msgctxt "settings"
@@ -16064,6 +16462,16 @@ msgid ""
 "movie theatre?”"
 msgstr ""
 
+#. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Translate this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
+msgctxt "Page suggestion prompt"
+msgid "Translate this page into %s."
+msgstr ""
+
 #. Placeholder text for a region that will display translated text.
 msgctxt "translations_module"
 msgid "Translation"
@@ -16178,6 +16586,11 @@ msgstr ""
 #. Call-to-action button for the subscription promo in the SERP sidemenu.
 msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
+msgstr ""
+
+#. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
+msgctxt "settings"
+msgid "Try It Now"
 msgstr ""
 
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -16372,6 +16785,20 @@ msgstr "Try: %s"
 msgctxt "new user poll"
 msgid "Trying DuckDuckGo again"
 msgstr "Trying DuckDuckGo again"
+
+#. Message shown in a modal after supported third-party browser users disable AI features in Settings. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+#. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
 
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
 msgctxt "Assistant response placeholder"
@@ -16974,6 +17401,11 @@ msgstr ""
 msgid "Uruguay"
 msgstr ""
 
+#. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
+msgctxt "Navigation label on the Duck.ai settings page"
+msgid "Usage"
+msgstr ""
+
 #. A feedback suggestion
 msgctxt "Feedback prompt"
 msgid "Usage limit"
@@ -17324,6 +17756,11 @@ msgstr ""
 msgid "Wales"
 msgstr ""
 
+#. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Walk me through the steps"
+msgstr ""
+
 #. Label for walking directions on a map.
 msgctxt "directions"
 msgid "Walking"
@@ -17414,6 +17851,16 @@ msgstr ""
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
+msgstr ""
+
+#. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
+msgctxt ""
+"Inline warning shown below the share-content toggle when the user selects "
+"Harmful or Illegal but has not enabled sharing"
+msgid ""
+"We can only fix what we can see. To report a harmful or illegal response, "
+"please share this conversation with DuckDuckGo so we can investigate and "
+"address the issue."
 msgstr ""
 
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -17839,6 +18286,87 @@ msgid ""
 "experience."
 msgstr ""
 
+#. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the counterarguments?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the hours & location?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key contributions of this paper?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key contributions?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key details?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key points covered in this video?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key points?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key takeaways from this article?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key takeaways?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key things I will learn from this course?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main counterarguments or criticisms of this?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main questions this page answers?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the must-try dishes here?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"What are the opening hours, location, and contact details for this place?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the pros and cons of this product?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the pros and cons?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
 msgctxt "feedback form"
 msgid "What bothered you most?"
@@ -17922,6 +18450,11 @@ msgctxt "Full sentence for defining a term"
 msgid "What does atria mean in the context of a medical article?"
 msgstr ""
 
+#. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What does this answer?"
+msgstr ""
+
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
@@ -17931,6 +18464,11 @@ msgstr ""
 msgctxt "cloudsave"
 msgid "What information gets saved?"
 msgstr "What information gets saved?"
+
+#. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What interview questions might come up for this role?"
+msgstr ""
 
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
@@ -17942,6 +18480,11 @@ msgstr ""
 #. Text for a prompt suggestion for looking up the capital city of Albania.
 msgctxt "Full sentence for looking up basic facts"
 msgid "What is the capital city of Albania?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What is the overall verdict and rating for this?"
 msgstr ""
 
 #. Link to a page with additional information.
@@ -17962,6 +18505,11 @@ msgctxt "maps_places"
 msgid "What people say:"
 msgstr ""
 
+#. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What should I order?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
 msgctxt "feedback form"
 msgid "What stood out?"
@@ -17970,6 +18518,16 @@ msgstr ""
 #. Question on a feedback form for a negative feedback response.
 msgctxt "feedback form"
 msgid "What was wrong with the response? (optional)"
+msgstr ""
+
+#. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I learn?"
+msgstr ""
+
+#. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I need?"
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -17984,6 +18542,11 @@ msgstr ""
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
 msgctxt "SERP footer content"
 msgid "What's New"
+msgstr ""
+
+#. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What's the verdict?"
 msgstr ""
 
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -18025,6 +18588,11 @@ msgctxt "Feedback prompt"
 msgid "Which features are missing? (Optional)"
 msgstr ""
 
+#. An invitation for users to leave feedback
+msgctxt "Feedback prompt"
+msgid "Which features are missing? (optional)"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
 msgid "White"
 msgstr "White"
@@ -18037,6 +18605,16 @@ msgstr "White"
 #. Link to an about us page.
 msgid "Who We Are"
 msgstr "Who We Are"
+
+#. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Who are the main cast and crew, and what else are they known for?"
+msgstr ""
+
+#. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Who is this person?"
+msgstr ""
 
 #. Header above a collection of privacy-related links.
 msgid "Why Privacy"

--- a/locales/en_US/LC_MESSAGES/duckduckgo.po
+++ b/locales/en_US/LC_MESSAGES/duckduckgo.po
@@ -1159,6 +1159,11 @@ msgctxt "feedback form"
 msgid "Address is incorrect"
 msgstr ""
 
+#. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Adjust the servings"
+msgstr ""
+
 #. as in multiple advertisements
 msgid "Ads"
 msgstr ""
@@ -1330,6 +1335,13 @@ msgstr ""
 #. Heading shown on the empty chat screen. The text between the two %s markers is displayed inside a clickable privacy button. First %s renders a shield icon, second %s is an invisible end marker. Keep the word 'private' between both %s markers.
 msgctxt "Empty state heading in Duck.ai chat mode"
 msgid "All chats are %sprivate%s"
+msgstr ""
+
+#. Paragraph in the Privacy & Terms section of the About & Legal page in Duck.ai settings, summarizing how chats are anonymized and are not stored or used to train chat models.
+msgctxt "Privacy & Terms section description on the Duck.ai settings page"
+msgid ""
+"All chats are anonymized by DuckDuckGo, and your conversations are not used "
+"to train chat models by DuckDuckGo or the model providers"
 msgstr ""
 
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1542,6 +1554,12 @@ msgstr ""
 #. Confirmation message after location service is enabled.
 msgctxt "precise_user_location"
 msgid "Anonymous location enabled"
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Anonymously generates answers for search queries based on web content. "
+"Choose how often you want it to appear, or disable it completely."
 msgstr ""
 
 #. Instant Answer tab name
@@ -1764,6 +1782,11 @@ msgstr ""
 
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse
 msgid "Ask a follow-up with Duck.ai"
+msgstr ""
+
+#. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
+msgctxt "Page suggestion chip label"
+msgid "Ask about this page"
 msgstr ""
 
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2088,6 +2111,11 @@ msgstr ""
 msgid "Barcode"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Based on this page, is this course worth taking?"
+msgstr ""
+
 msgctxt "settings"
 msgid "Basic"
 msgstr ""
@@ -2119,6 +2147,13 @@ msgstr ""
 #. Placeholder text displayed while the assistant waits for the user to choose an action.
 msgctxt "Assistant response placeholder"
 msgid "Before continuing..."
+msgstr ""
+
+#. Explains that before storing the report, DuckDuckGo will anonymize the conversation by removing PII like names, email addresses, and identifying metadata.
+msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
+msgid ""
+"Before storing this report, DuckDuckGo will anonymize your conversation by "
+"removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
 #. Label that's displayed next to a past start date below a web search result.
@@ -2377,6 +2412,11 @@ msgstr ""
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Break Points Won"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Break this down into clear, numbered steps."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -2736,6 +2776,11 @@ msgstr ""
 #. Text of a button that performs a search for the cast of a particular movie or tv show
 msgctxt "Movie/TV Show Title instant answer"
 msgid "Cast"
+msgstr ""
+
+#. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Cast & Crew"
 msgstr ""
 
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -4085,6 +4130,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Create a shopping list with quantities from this recipe."
+msgstr ""
+
 #. Placeholder text displayed in the input field when starting a new image generation session.
 msgctxt "Placeholder text for the image generation input field"
 msgid "Create an image of a cute duck..."
@@ -4611,6 +4661,10 @@ msgstr ""
 msgid "Dictation limit reached"
 msgstr ""
 
+#. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
+msgid "Dictation temporarily unavailable"
+msgstr ""
+
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
@@ -4855,6 +4909,20 @@ msgctxt "precise_user_location"
 msgid "Done"
 msgstr ""
 
+#. Message shown in a modal after DuckDuckGo browser users disable AI features in Settings. The first two placeholders bold noai.duckduckgo.com. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
+"filtered out. %sLearn More%s"
+msgstr ""
+
+#. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
+"and AI images filtered out. %sLearn more%s"
+msgstr ""
+
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Double Faults"
@@ -4945,6 +5013,16 @@ msgctxt "Full sentence for writing an email"
 msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
+msgstr ""
+
+#. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Draft a cover letter"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Draft a cover letter for this job."
 msgstr ""
 
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -5084,6 +5162,14 @@ msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
 msgstr ""
 
+#. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
+msgctxt "About section description on the Duck.ai settings page"
+msgid ""
+"Duck.ai is created by DuckDuckGo. We're an independent online protection "
+"company for anyone who wants to take back control of their personal "
+"information."
+msgstr ""
+
 #. Title shown when an update is required before proceeding.
 msgctxt "duckai_migration"
 msgid "Duck.ai is moving domains"
@@ -5117,6 +5203,12 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Duck.ai lets you chat privately with popular AI models. Disabling it hides "
+"Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
 
 msgctxt "settings"
@@ -5882,6 +5974,16 @@ msgstr ""
 msgid "Eritrea"
 msgstr ""
 
+#. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Estimate the nutrition"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Estimate the nutritional information for this recipe."
+msgstr ""
+
 msgid "Estonia"
 msgstr ""
 
@@ -5926,10 +6028,50 @@ msgctxt "merchant promotion product ad extension"
 msgid "Expires in 1 day"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain the accepted answer in simple terms."
+msgstr ""
+
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
+msgstr ""
+
+#. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain the top answer"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this in simple, plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this paper"
+msgstr ""
+
+#. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this repo"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this research paper in plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this simply"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain what this repository does and how to use it."
 msgstr ""
 
 #. Label to show if song lyrics contain explicit content
@@ -6158,6 +6300,11 @@ msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
 msgstr ""
 
+msgctxt "settings"
+msgid ""
+"Filters out known AI spam sites from image search results. %sLearn More%s"
+msgstr ""
+
 #. Label for the final score of a sporting event.
 msgid "Final"
 msgstr ""
@@ -6197,6 +6344,11 @@ msgstr ""
 #. Short description shown below the 'Web Search' label in the Tools dropdown.
 msgctxt "Subtitle for the Web Search tool entry in the Tools dropdown menu"
 msgid "Find current information"
+msgstr ""
+
+#. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Find me alternatives"
 msgstr ""
 
 #. Button that searches for results closer to the user's current location.
@@ -6587,6 +6739,11 @@ msgstr ""
 msgid "Generate More"
 msgstr ""
 
+#. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Generate a shopping list"
+msgstr ""
+
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
 msgid "Generate a short answer from the web"
 msgstr ""
@@ -6821,6 +6978,11 @@ msgstr ""
 #. Text for a button inviting users to give it a try for the Duck.ai product. On click, they're taken to the Duck.ai page.
 msgctxt "Onboarding welcome screen button text"
 msgid "Give it a Try"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Give me a quick background on this person."
 msgstr ""
 
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -7183,6 +7345,16 @@ msgstr ""
 
 #. Link to a page with information about sharing DuckDuckGo with friends.
 msgid "Help Spread Privacy"
+msgstr ""
+
+#. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Help me prep for the interview"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Help me tailor my resume for this job."
 msgstr ""
 
 #. Title of a SERP popup that invites users to take a survey (desktop only)
@@ -7602,6 +7774,13 @@ msgstr ""
 #. Text displayed on the button on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
 msgctxt "Onboarding terms screen button text"
 msgid "I Agree"
+msgstr ""
+
+#. Text for the button that takes the user to the external DuckDuckGo login subscription page.
+msgctxt ""
+"Text for the I already have a subscription button in the Duck.ai settings "
+"page"
+msgid "I Already Have a Subscription"
 msgstr ""
 
 #. Text for the button that takes the user to the login subscription page.
@@ -8052,6 +8231,11 @@ msgctxt "Sidemenu browser promo"
 msgid "Install Mac Browser"
 msgstr ""
 
+#. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
+msgctxt "settings"
+msgid "Install Now"
+msgstr ""
+
 #. Text of a button to install the DuckDuckGo app
 msgctxt "Serp footer content"
 msgid "Install Our App"
@@ -8131,9 +8315,36 @@ msgctxt "cloudsave"
 msgid "Is deleted data really deleted?"
 msgstr ""
 
+#. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is it worth taking?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this place any good?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"Is this place any good? Summarize its reputation based on reviews and "
+"ratings."
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "Is this video helpful?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this worth watching?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Is this worth watching? Give me a spoiler-free take."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -8630,6 +8841,11 @@ msgstr ""
 msgid "Links:"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "List the tools, materials, or prerequisites I need for this."
+msgstr ""
+
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
 msgid "Listen"
 msgstr ""
@@ -8962,6 +9178,11 @@ msgstr ""
 #. Label for linke navigating to site exclusion feature on Settings page
 msgctxt "Exclusion message manage sites button"
 msgid "Manage blocked sites"
+msgstr ""
+
+#. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
+msgctxt "setting"
+msgid "Manage in Browser Settings"
 msgstr ""
 
 #. Link to the site exclusion settings page
@@ -11259,6 +11480,11 @@ msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
+msgid "Please describe why the chat response is harmful or illegal. (optional)"
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
+msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
 msgstr ""
 
@@ -11277,6 +11503,13 @@ msgctxt "Modal disclaimer text"
 msgid ""
 "Please note: starting a new chat with any model will delete your current "
 "chat session."
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
+msgctxt "Feedback prompt"
+msgid ""
+"Please paste your prompt and the problematic output (with any personal "
+"information removed) and describe why the content is harmful or illegal."
 msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -11661,6 +11894,11 @@ msgctxt "settings"
 msgid "Privacy"
 msgstr ""
 
+#. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
+msgctxt "Section heading on the Duck.ai settings page"
+msgid "Privacy & Terms"
+msgstr ""
+
 msgid "Privacy Blog"
 msgstr ""
 
@@ -11714,6 +11952,11 @@ msgstr ""
 
 #. Text used in other strings to link to the Privacy Policy and Terms of Service content.
 msgctxt "Copy used to compose link in sentences"
+msgid "Privacy Policy and Terms of Service"
+msgstr ""
+
+#. Text for a button that links to the terms of use and privacy policy page.
+msgctxt "Secondary button text in active privacy modal"
 msgid "Privacy Policy and Terms of Service"
 msgstr ""
 
@@ -12122,6 +12365,26 @@ msgctxt "Brief for recommending a book"
 msgid "Recommend a book"
 msgstr ""
 
+#. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar books"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar books."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar movies or shows."
+msgstr ""
+
+#. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar titles"
+msgstr ""
+
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
 msgid "Recording failed. Please try again."
 msgstr ""
@@ -12441,6 +12704,14 @@ msgstr ""
 msgid "Republic of Moldova"
 msgstr ""
 
+#. Note indicating that sharing the conversation is mandatory when reporting harmful or illegal content. Rendered alongside the standard share label (DUCKCHAT_RESPONSE_FEEDBACK_SHARE_PROMPT_RESPONSE_LABEL), not replacing it.
+msgctxt ""
+"Note shown under the share-content switch label on the Duck.ai response "
+"feedback form when the user has selected Harmful or Illegal as the feedback "
+"reason"
+msgid "Required for harmful or illegal reports"
+msgstr ""
+
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
 msgctxt "Description for extended reasoning mode in Duck.ai"
 msgid "Researches before responding"
@@ -12626,6 +12897,11 @@ msgstr ""
 #. Label above a list of customer reviews of a business.
 msgctxt "maps_places"
 msgid "Reviews"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Rewrite this recipe scaled for a different number of servings."
 msgstr ""
 
 msgid "Romania"
@@ -13661,6 +13937,11 @@ msgctxt "Setup button for native sync flow"
 msgid "Set Up Now"
 msgstr ""
 
+#. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
+msgctxt "Encrypted storage setup button shown in native browsers"
+msgid "Set Up Sync & Backup"
+msgstr ""
+
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
 msgctxt "Title for the Sync & Backup intro screen"
 msgid "Set Up Sync & Backup"
@@ -13803,6 +14084,12 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
+msgctxt ""
+"Label beside the share-content switch on the Duck.ai response feedback form"
+msgid "Share this conversation with DuckDuckGo"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -14817,6 +15104,21 @@ msgctxt "Brief for suggesting a blog post title"
 msgid "Suggest a title for a blog post"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest related articles or topics worth exploring next."
+msgstr ""
+
+#. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Suggest related articles to explore"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest some alternatives to this product."
+msgstr ""
+
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
 msgctxt "directions"
 msgid "Suggestions:"
@@ -14826,9 +15128,84 @@ msgctxt "noresults"
 msgid "Suggestions:"
 msgstr ""
 
+#. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Sum up the reviews"
+msgstr ""
+
 #. A short title for the a message asking the AI to summarize a text.
 msgctxt "Title for the summarize message"
 msgid "Summarize"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize the Q&As"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the background and notable work of this person."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the key details of this event."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the questions and answers on this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize their background"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this book"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this book."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this discussion"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this discussion thread."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this video"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this video."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize what the reviews say."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -15083,6 +15460,11 @@ msgstr ""
 msgid "Syria"
 msgstr ""
 
+#. Text for a button that enables the theme to follow the operating system's color scheme preference.
+msgctxt "System theme button for theme selector"
+msgid "System"
+msgstr ""
+
 #. Abbreviation indicating this is the total score for a game
 msgctxt "Sports module"
 msgid "T"
@@ -15106,6 +15488,11 @@ msgctxt "language_name"
 msgid "Tahitian"
 msgstr ""
 
+#. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Tailor my resume"
+msgstr ""
+
 msgid "Taiwan"
 msgstr ""
 
@@ -15127,6 +15514,12 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "Take control of your personal data!"
+msgstr ""
+
+#. Description for the Feedback section of the Duck.ai settings page, asking the user to take an anonymous survey to let us know how we can make Duck.ai better.
+msgctxt "Feedback section description on the Duck.ai settings page"
+msgid ""
+"Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
 
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -15369,6 +15762,11 @@ msgstr ""
 
 #. Title for the theme menu:
 #. https://duck.co/media/files/theme.png
+msgid "Theme"
+msgstr ""
+
+#. Text for the theme selector label that allows users to switch between Light and dark theme.
+msgctxt "Label for the theme selector feature"
 msgid "Theme"
 msgstr ""
 
@@ -16022,6 +16420,16 @@ msgid ""
 "movie theatre?”"
 msgstr ""
 
+#. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Translate this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
+msgctxt "Page suggestion prompt"
+msgid "Translate this page into %s."
+msgstr ""
+
 #. Placeholder text for a region that will display translated text.
 msgctxt "translations_module"
 msgid "Translation"
@@ -16136,6 +16544,11 @@ msgstr ""
 #. Call-to-action button for the subscription promo in the SERP sidemenu.
 msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
+msgstr ""
+
+#. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
+msgctxt "settings"
+msgid "Try It Now"
 msgstr ""
 
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -16329,6 +16742,20 @@ msgstr ""
 #. Response a user can select in a feedback form, indicating that they're trying DuckDuckGo again.
 msgctxt "new user poll"
 msgid "Trying DuckDuckGo again"
+msgstr ""
+
+#. Message shown in a modal after supported third-party browser users disable AI features in Settings. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+#. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
 msgstr ""
 
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -16929,6 +17356,11 @@ msgstr ""
 msgid "Uruguay"
 msgstr ""
 
+#. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
+msgctxt "Navigation label on the Duck.ai settings page"
+msgid "Usage"
+msgstr ""
+
 #. A feedback suggestion
 msgctxt "Feedback prompt"
 msgid "Usage limit"
@@ -17277,6 +17709,11 @@ msgstr ""
 msgid "Wales"
 msgstr ""
 
+#. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Walk me through the steps"
+msgstr ""
+
 #. Label for walking directions on a map.
 msgctxt "directions"
 msgid "Walking"
@@ -17367,6 +17804,16 @@ msgstr ""
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
+msgstr ""
+
+#. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
+msgctxt ""
+"Inline warning shown below the share-content toggle when the user selects "
+"Harmful or Illegal but has not enabled sharing"
+msgid ""
+"We can only fix what we can see. To report a harmful or illegal response, "
+"please share this conversation with DuckDuckGo so we can investigate and "
+"address the issue."
 msgstr ""
 
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -17786,6 +18233,87 @@ msgid ""
 "experience."
 msgstr ""
 
+#. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the counterarguments?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the hours & location?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key contributions of this paper?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key contributions?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key details?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key points covered in this video?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key points?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key takeaways from this article?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key takeaways?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key things I will learn from this course?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main counterarguments or criticisms of this?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main questions this page answers?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the must-try dishes here?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"What are the opening hours, location, and contact details for this place?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the pros and cons of this product?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the pros and cons?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
 msgctxt "feedback form"
 msgid "What bothered you most?"
@@ -17869,6 +18397,11 @@ msgctxt "Full sentence for defining a term"
 msgid "What does atria mean in the context of a medical article?"
 msgstr ""
 
+#. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What does this answer?"
+msgstr ""
+
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
@@ -17877,6 +18410,11 @@ msgstr ""
 #. Header above a list of types of information that gets saved by the cloud save feature.
 msgctxt "cloudsave"
 msgid "What information gets saved?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What interview questions might come up for this role?"
 msgstr ""
 
 #. Text explaining how the cloud save feature works.
@@ -17889,6 +18427,11 @@ msgstr ""
 #. Text for a prompt suggestion for looking up the capital city of Albania.
 msgctxt "Full sentence for looking up basic facts"
 msgid "What is the capital city of Albania?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What is the overall verdict and rating for this?"
 msgstr ""
 
 #. Link to a page with additional information.
@@ -17909,6 +18452,11 @@ msgctxt "maps_places"
 msgid "What people say:"
 msgstr ""
 
+#. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What should I order?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
 msgctxt "feedback form"
 msgid "What stood out?"
@@ -17917,6 +18465,16 @@ msgstr ""
 #. Question on a feedback form for a negative feedback response.
 msgctxt "feedback form"
 msgid "What was wrong with the response? (optional)"
+msgstr ""
+
+#. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I learn?"
+msgstr ""
+
+#. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I need?"
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -17931,6 +18489,11 @@ msgstr ""
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
 msgctxt "SERP footer content"
 msgid "What's New"
+msgstr ""
+
+#. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What's the verdict?"
 msgstr ""
 
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -17972,6 +18535,11 @@ msgctxt "Feedback prompt"
 msgid "Which features are missing? (Optional)"
 msgstr ""
 
+#. An invitation for users to leave feedback
+msgctxt "Feedback prompt"
+msgid "Which features are missing? (optional)"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
 msgid "White"
 msgstr ""
@@ -17983,6 +18551,16 @@ msgstr ""
 
 #. Link to an about us page.
 msgid "Who We Are"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Who are the main cast and crew, and what else are they known for?"
+msgstr ""
+
+#. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Who is this person?"
 msgstr ""
 
 #. Header above a collection of privacy-related links.

--- a/locales/eo_XX/LC_MESSAGES/duckduckgo.po
+++ b/locales/eo_XX/LC_MESSAGES/duckduckgo.po
@@ -1165,6 +1165,11 @@ msgctxt "feedback form"
 msgid "Address is incorrect"
 msgstr ""
 
+#. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Adjust the servings"
+msgstr ""
+
 #. as in multiple advertisements
 msgid "Ads"
 msgstr "Reklamoj"
@@ -1338,6 +1343,13 @@ msgstr ""
 #. Heading shown on the empty chat screen. The text between the two %s markers is displayed inside a clickable privacy button. First %s renders a shield icon, second %s is an invisible end marker. Keep the word 'private' between both %s markers.
 msgctxt "Empty state heading in Duck.ai chat mode"
 msgid "All chats are %sprivate%s"
+msgstr ""
+
+#. Paragraph in the Privacy & Terms section of the About & Legal page in Duck.ai settings, summarizing how chats are anonymized and are not stored or used to train chat models.
+msgctxt "Privacy & Terms section description on the Duck.ai settings page"
+msgid ""
+"All chats are anonymized by DuckDuckGo, and your conversations are not used "
+"to train chat models by DuckDuckGo or the model providers"
 msgstr ""
 
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1550,6 +1562,12 @@ msgstr ""
 #. Confirmation message after location service is enabled.
 msgctxt "precise_user_location"
 msgid "Anonymous location enabled"
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Anonymously generates answers for search queries based on web content. "
+"Choose how often you want it to appear, or disable it completely."
 msgstr ""
 
 #. Instant Answer tab name
@@ -1775,6 +1793,11 @@ msgstr ""
 
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse
 msgid "Ask a follow-up with Duck.ai"
+msgstr ""
+
+#. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
+msgctxt "Page suggestion chip label"
+msgid "Ask about this page"
 msgstr ""
 
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2099,6 +2122,11 @@ msgstr ""
 msgid "Barcode"
 msgstr "Strikodo"
 
+#. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Based on this page, is this course worth taking?"
+msgstr ""
+
 msgctxt "settings"
 msgid "Basic"
 msgstr "Baza"
@@ -2130,6 +2158,13 @@ msgstr ""
 #. Placeholder text displayed while the assistant waits for the user to choose an action.
 msgctxt "Assistant response placeholder"
 msgid "Before continuing..."
+msgstr ""
+
+#. Explains that before storing the report, DuckDuckGo will anonymize the conversation by removing PII like names, email addresses, and identifying metadata.
+msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
+msgid ""
+"Before storing this report, DuckDuckGo will anonymize your conversation by "
+"removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
 #. Label that's displayed next to a past start date below a web search result.
@@ -2388,6 +2423,11 @@ msgstr "Brazilo"
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Break Points Won"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Break this down into clear, numbered steps."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -2747,6 +2787,11 @@ msgstr "Karieroj"
 #. Text of a button that performs a search for the cast of a particular movie or tv show
 msgctxt "Movie/TV Show Title instant answer"
 msgid "Cast"
+msgstr ""
+
+#. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Cast & Crew"
 msgstr ""
 
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -4106,6 +4151,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Create a shopping list with quantities from this recipe."
+msgstr ""
+
 #. Placeholder text displayed in the input field when starting a new image generation session.
 msgctxt "Placeholder text for the image generation input field"
 msgid "Create an image of a cute duck..."
@@ -4632,6 +4682,10 @@ msgstr ""
 msgid "Dictation limit reached"
 msgstr ""
 
+#. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
+msgid "Dictation temporarily unavailable"
+msgstr ""
+
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
@@ -4876,6 +4930,20 @@ msgctxt "precise_user_location"
 msgid "Done"
 msgstr "Preta"
 
+#. Message shown in a modal after DuckDuckGo browser users disable AI features in Settings. The first two placeholders bold noai.duckduckgo.com. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
+"filtered out. %sLearn More%s"
+msgstr ""
+
+#. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
+"and AI images filtered out. %sLearn more%s"
+msgstr ""
+
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Double Faults"
@@ -4966,6 +5034,16 @@ msgctxt "Full sentence for writing an email"
 msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
+msgstr ""
+
+#. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Draft a cover letter"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Draft a cover letter for this job."
 msgstr ""
 
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -5105,6 +5183,14 @@ msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
 msgstr ""
 
+#. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
+msgctxt "About section description on the Duck.ai settings page"
+msgid ""
+"Duck.ai is created by DuckDuckGo. We're an independent online protection "
+"company for anyone who wants to take back control of their personal "
+"information."
+msgstr ""
+
 #. Title shown when an update is required before proceeding.
 msgctxt "duckai_migration"
 msgid "Duck.ai is moving domains"
@@ -5138,6 +5224,12 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Duck.ai lets you chat privately with popular AI models. Disabling it hides "
+"Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
 
 msgctxt "settings"
@@ -5904,6 +5996,16 @@ msgstr ""
 msgid "Eritrea"
 msgstr ""
 
+#. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Estimate the nutrition"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Estimate the nutritional information for this recipe."
+msgstr ""
+
 msgid "Estonia"
 msgstr "Estonio"
 
@@ -5948,10 +6050,50 @@ msgctxt "merchant promotion product ad extension"
 msgid "Expires in 1 day"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain the accepted answer in simple terms."
+msgstr ""
+
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
+msgstr ""
+
+#. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain the top answer"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this in simple, plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this paper"
+msgstr ""
+
+#. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this repo"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this research paper in plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this simply"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain what this repository does and how to use it."
 msgstr ""
 
 #. Label to show if song lyrics contain explicit content
@@ -6182,6 +6324,11 @@ msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
 msgstr ""
 
+msgctxt "settings"
+msgid ""
+"Filters out known AI spam sites from image search results. %sLearn More%s"
+msgstr ""
+
 #. Label for the final score of a sporting event.
 msgid "Final"
 msgstr "Fina"
@@ -6221,6 +6368,11 @@ msgstr ""
 #. Short description shown below the 'Web Search' label in the Tools dropdown.
 msgctxt "Subtitle for the Web Search tool entry in the Tools dropdown menu"
 msgid "Find current information"
+msgstr ""
+
+#. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Find me alternatives"
 msgstr ""
 
 #. Button that searches for results closer to the user's current location.
@@ -6611,6 +6763,11 @@ msgstr ""
 msgid "Generate More"
 msgstr ""
 
+#. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Generate a shopping list"
+msgstr ""
+
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
 msgid "Generate a short answer from the web"
 msgstr ""
@@ -6845,6 +7002,11 @@ msgstr ""
 #. Text for a button inviting users to give it a try for the Duck.ai product. On click, they're taken to the Duck.ai page.
 msgctxt "Onboarding welcome screen button text"
 msgid "Give it a Try"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Give me a quick background on this person."
 msgstr ""
 
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -7208,6 +7370,16 @@ msgstr ""
 #. Link to a page with information about sharing DuckDuckGo with friends.
 msgid "Help Spread Privacy"
 msgstr "Helpu Disvastigi Privatecon"
+
+#. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Help me prep for the interview"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Help me tailor my resume for this job."
+msgstr ""
 
 #. Title of a SERP popup that invites users to take a survey (desktop only)
 msgctxt "User survey popup"
@@ -7628,6 +7800,13 @@ msgstr ""
 #. Text displayed on the button on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
 msgctxt "Onboarding terms screen button text"
 msgid "I Agree"
+msgstr ""
+
+#. Text for the button that takes the user to the external DuckDuckGo login subscription page.
+msgctxt ""
+"Text for the I already have a subscription button in the Duck.ai settings "
+"page"
+msgid "I Already Have a Subscription"
 msgstr ""
 
 #. Text for the button that takes the user to the login subscription page.
@@ -8083,6 +8262,11 @@ msgctxt "Sidemenu browser promo"
 msgid "Install Mac Browser"
 msgstr ""
 
+#. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
+msgctxt "settings"
+msgid "Install Now"
+msgstr ""
+
 #. Text of a button to install the DuckDuckGo app
 msgctxt "Serp footer content"
 msgid "Install Our App"
@@ -8162,9 +8346,36 @@ msgctxt "cloudsave"
 msgid "Is deleted data really deleted?"
 msgstr "Ĉu forigitaj datumoj vere estas forigitaj?"
 
+#. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is it worth taking?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this place any good?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"Is this place any good? Summarize its reputation based on reviews and "
+"ratings."
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "Is this video helpful?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this worth watching?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Is this worth watching? Give me a spoiler-free take."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -8662,6 +8873,11 @@ msgstr "Tiparo de ligiloj:"
 msgid "Links:"
 msgstr "Ligiloj:"
 
+#. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "List the tools, materials, or prerequisites I need for this."
+msgstr ""
+
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
 msgid "Listen"
 msgstr "Aŭskultu"
@@ -8994,6 +9210,11 @@ msgstr ""
 #. Label for linke navigating to site exclusion feature on Settings page
 msgctxt "Exclusion message manage sites button"
 msgid "Manage blocked sites"
+msgstr ""
+
+#. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
+msgctxt "setting"
+msgid "Manage in Browser Settings"
 msgstr ""
 
 #. Link to the site exclusion settings page
@@ -11299,6 +11520,11 @@ msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
+msgid "Please describe why the chat response is harmful or illegal. (optional)"
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
+msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
 msgstr ""
 
@@ -11317,6 +11543,13 @@ msgctxt "Modal disclaimer text"
 msgid ""
 "Please note: starting a new chat with any model will delete your current "
 "chat session."
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
+msgctxt "Feedback prompt"
+msgid ""
+"Please paste your prompt and the problematic output (with any personal "
+"information removed) and describe why the content is harmful or illegal."
 msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -11701,6 +11934,11 @@ msgctxt "settings"
 msgid "Privacy"
 msgstr "Privateco"
 
+#. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
+msgctxt "Section heading on the Duck.ai settings page"
+msgid "Privacy & Terms"
+msgstr ""
+
 msgid "Privacy Blog"
 msgstr "Blogo Pri Privateco"
 
@@ -11754,6 +11992,11 @@ msgstr ""
 
 #. Text used in other strings to link to the Privacy Policy and Terms of Service content.
 msgctxt "Copy used to compose link in sentences"
+msgid "Privacy Policy and Terms of Service"
+msgstr ""
+
+#. Text for a button that links to the terms of use and privacy policy page.
+msgctxt "Secondary button text in active privacy modal"
 msgid "Privacy Policy and Terms of Service"
 msgstr ""
 
@@ -12162,6 +12405,26 @@ msgctxt "Brief for recommending a book"
 msgid "Recommend a book"
 msgstr ""
 
+#. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar books"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar books."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar movies or shows."
+msgstr ""
+
+#. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar titles"
+msgstr ""
+
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
 msgid "Recording failed. Please try again."
 msgstr ""
@@ -12481,6 +12744,14 @@ msgstr ""
 msgid "Republic of Moldova"
 msgstr ""
 
+#. Note indicating that sharing the conversation is mandatory when reporting harmful or illegal content. Rendered alongside the standard share label (DUCKCHAT_RESPONSE_FEEDBACK_SHARE_PROMPT_RESPONSE_LABEL), not replacing it.
+msgctxt ""
+"Note shown under the share-content switch label on the Duck.ai response "
+"feedback form when the user has selected Harmful or Illegal as the feedback "
+"reason"
+msgid "Required for harmful or illegal reports"
+msgstr ""
+
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
 msgctxt "Description for extended reasoning mode in Duck.ai"
 msgid "Researches before responding"
@@ -12667,6 +12938,11 @@ msgstr "Recenzoj"
 msgctxt "maps_places"
 msgid "Reviews"
 msgstr "Recenzoj"
+
+#. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Rewrite this recipe scaled for a different number of servings."
+msgstr ""
 
 msgid "Romania"
 msgstr "Rumanio"
@@ -13710,6 +13986,11 @@ msgctxt "Setup button for native sync flow"
 msgid "Set Up Now"
 msgstr ""
 
+#. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
+msgctxt "Encrypted storage setup button shown in native browsers"
+msgid "Set Up Sync & Backup"
+msgstr ""
+
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
 msgctxt "Title for the Sync & Backup intro screen"
 msgid "Set Up Sync & Backup"
@@ -13852,6 +14133,12 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
+msgctxt ""
+"Label beside the share-content switch on the Duck.ai response feedback form"
+msgid "Share this conversation with DuckDuckGo"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -14868,6 +15155,21 @@ msgctxt "Brief for suggesting a blog post title"
 msgid "Suggest a title for a blog post"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest related articles or topics worth exploring next."
+msgstr ""
+
+#. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Suggest related articles to explore"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest some alternatives to this product."
+msgstr ""
+
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
 msgctxt "directions"
 msgid "Suggestions:"
@@ -14877,9 +15179,84 @@ msgctxt "noresults"
 msgid "Suggestions:"
 msgstr "Sugestoj:"
 
+#. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Sum up the reviews"
+msgstr ""
+
 #. A short title for the a message asking the AI to summarize a text.
 msgctxt "Title for the summarize message"
 msgid "Summarize"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize the Q&As"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the background and notable work of this person."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the key details of this event."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the questions and answers on this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize their background"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this book"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this book."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this discussion"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this discussion thread."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this video"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this video."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize what the reviews say."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -15134,6 +15511,11 @@ msgstr ""
 msgid "Syria"
 msgstr ""
 
+#. Text for a button that enables the theme to follow the operating system's color scheme preference.
+msgctxt "System theme button for theme selector"
+msgid "System"
+msgstr ""
+
 #. Abbreviation indicating this is the total score for a game
 msgctxt "Sports module"
 msgid "T"
@@ -15157,6 +15539,11 @@ msgctxt "language_name"
 msgid "Tahitian"
 msgstr ""
 
+#. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Tailor my resume"
+msgstr ""
+
 msgid "Taiwan"
 msgstr "Tajvano"
 
@@ -15178,6 +15565,12 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "Take control of your personal data!"
+msgstr ""
+
+#. Description for the Feedback section of the Duck.ai settings page, asking the user to take an anonymous survey to let us know how we can make Duck.ai better.
+msgctxt "Feedback section description on the Duck.ai settings page"
+msgid ""
+"Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
 
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -15425,6 +15818,11 @@ msgstr ""
 #. https://duck.co/media/files/theme.png
 msgid "Theme"
 msgstr "Etoso"
+
+#. Text for the theme selector label that allows users to switch between Light and dark theme.
+msgctxt "Label for the theme selector feature"
+msgid "Theme"
+msgstr ""
 
 #. http://i.imgur.com/LpFhb1e.png
 msgctxt "settings"
@@ -16081,6 +16479,16 @@ msgid ""
 "movie theatre?”"
 msgstr ""
 
+#. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Translate this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
+msgctxt "Page suggestion prompt"
+msgid "Translate this page into %s."
+msgstr ""
+
 #. Placeholder text for a region that will display translated text.
 msgctxt "translations_module"
 msgid "Translation"
@@ -16195,6 +16603,11 @@ msgstr ""
 #. Call-to-action button for the subscription promo in the SERP sidemenu.
 msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
+msgstr ""
+
+#. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
+msgctxt "settings"
+msgid "Try It Now"
 msgstr ""
 
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -16389,6 +16802,20 @@ msgstr "Provu: %s"
 msgctxt "new user poll"
 msgid "Trying DuckDuckGo again"
 msgstr "Provas DuckDuckGo denove"
+
+#. Message shown in a modal after supported third-party browser users disable AI features in Settings. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+#. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
 
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
 msgctxt "Assistant response placeholder"
@@ -16991,6 +17418,11 @@ msgstr ""
 msgid "Uruguay"
 msgstr ""
 
+#. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
+msgctxt "Navigation label on the Duck.ai settings page"
+msgid "Usage"
+msgstr ""
+
 #. A feedback suggestion
 msgctxt "Feedback prompt"
 msgid "Usage limit"
@@ -17341,6 +17773,11 @@ msgstr ""
 msgid "Wales"
 msgstr ""
 
+#. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Walk me through the steps"
+msgstr ""
+
 #. Label for walking directions on a map.
 msgctxt "directions"
 msgid "Walking"
@@ -17431,6 +17868,16 @@ msgstr ""
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
+msgstr ""
+
+#. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
+msgctxt ""
+"Inline warning shown below the share-content toggle when the user selects "
+"Harmful or Illegal but has not enabled sharing"
+msgid ""
+"We can only fix what we can see. To report a harmful or illegal response, "
+"please share this conversation with DuckDuckGo so we can investigate and "
+"address the issue."
 msgstr ""
 
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -17856,6 +18303,87 @@ msgid ""
 "experience."
 msgstr ""
 
+#. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the counterarguments?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the hours & location?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key contributions of this paper?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key contributions?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key details?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key points covered in this video?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key points?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key takeaways from this article?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key takeaways?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key things I will learn from this course?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main counterarguments or criticisms of this?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main questions this page answers?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the must-try dishes here?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"What are the opening hours, location, and contact details for this place?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the pros and cons of this product?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the pros and cons?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
 msgctxt "feedback form"
 msgid "What bothered you most?"
@@ -17939,6 +18467,11 @@ msgctxt "Full sentence for defining a term"
 msgid "What does atria mean in the context of a medical article?"
 msgstr ""
 
+#. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What does this answer?"
+msgstr ""
+
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
@@ -17948,6 +18481,11 @@ msgstr ""
 msgctxt "cloudsave"
 msgid "What information gets saved?"
 msgstr "Kiaj informoj konserviĝas?"
+
+#. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What interview questions might come up for this role?"
+msgstr ""
 
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
@@ -17959,6 +18497,11 @@ msgstr ""
 #. Text for a prompt suggestion for looking up the capital city of Albania.
 msgctxt "Full sentence for looking up basic facts"
 msgid "What is the capital city of Albania?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What is the overall verdict and rating for this?"
 msgstr ""
 
 #. Link to a page with additional information.
@@ -17979,6 +18522,11 @@ msgctxt "maps_places"
 msgid "What people say:"
 msgstr ""
 
+#. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What should I order?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
 msgctxt "feedback form"
 msgid "What stood out?"
@@ -17987,6 +18535,16 @@ msgstr ""
 #. Question on a feedback form for a negative feedback response.
 msgctxt "feedback form"
 msgid "What was wrong with the response? (optional)"
+msgstr ""
+
+#. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I learn?"
+msgstr ""
+
+#. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I need?"
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -18001,6 +18559,11 @@ msgstr ""
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
 msgctxt "SERP footer content"
 msgid "What's New"
+msgstr ""
+
+#. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What's the verdict?"
 msgstr ""
 
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -18042,6 +18605,11 @@ msgctxt "Feedback prompt"
 msgid "Which features are missing? (Optional)"
 msgstr ""
 
+#. An invitation for users to leave feedback
+msgctxt "Feedback prompt"
+msgid "Which features are missing? (optional)"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
 msgid "White"
 msgstr "Blanka"
@@ -18054,6 +18622,16 @@ msgstr "Blanka"
 #. Link to an about us page.
 msgid "Who We Are"
 msgstr "Kiuj Ni Estas"
+
+#. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Who are the main cast and crew, and what else are they known for?"
+msgstr ""
+
+#. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Who is this person?"
+msgstr ""
 
 #. Header above a collection of privacy-related links.
 msgid "Why Privacy"

--- a/locales/es_AR/LC_MESSAGES/duckduckgo.po
+++ b/locales/es_AR/LC_MESSAGES/duckduckgo.po
@@ -1161,6 +1161,11 @@ msgctxt "feedback form"
 msgid "Address is incorrect"
 msgstr ""
 
+#. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Adjust the servings"
+msgstr ""
+
 #. as in multiple advertisements
 msgid "Ads"
 msgstr ""
@@ -1334,6 +1339,13 @@ msgstr ""
 #. Heading shown on the empty chat screen. The text between the two %s markers is displayed inside a clickable privacy button. First %s renders a shield icon, second %s is an invisible end marker. Keep the word 'private' between both %s markers.
 msgctxt "Empty state heading in Duck.ai chat mode"
 msgid "All chats are %sprivate%s"
+msgstr ""
+
+#. Paragraph in the Privacy & Terms section of the About & Legal page in Duck.ai settings, summarizing how chats are anonymized and are not stored or used to train chat models.
+msgctxt "Privacy & Terms section description on the Duck.ai settings page"
+msgid ""
+"All chats are anonymized by DuckDuckGo, and your conversations are not used "
+"to train chat models by DuckDuckGo or the model providers"
 msgstr ""
 
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1546,6 +1558,12 @@ msgstr ""
 #. Confirmation message after location service is enabled.
 msgctxt "precise_user_location"
 msgid "Anonymous location enabled"
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Anonymously generates answers for search queries based on web content. "
+"Choose how often you want it to appear, or disable it completely."
 msgstr ""
 
 #. Instant Answer tab name
@@ -1771,6 +1789,11 @@ msgstr ""
 
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse
 msgid "Ask a follow-up with Duck.ai"
+msgstr ""
+
+#. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
+msgctxt "Page suggestion chip label"
+msgid "Ask about this page"
 msgstr ""
 
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2095,6 +2118,11 @@ msgstr ""
 msgid "Barcode"
 msgstr "Código de barras"
 
+#. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Based on this page, is this course worth taking?"
+msgstr ""
+
 msgctxt "settings"
 msgid "Basic"
 msgstr "Básico"
@@ -2126,6 +2154,13 @@ msgstr ""
 #. Placeholder text displayed while the assistant waits for the user to choose an action.
 msgctxt "Assistant response placeholder"
 msgid "Before continuing..."
+msgstr ""
+
+#. Explains that before storing the report, DuckDuckGo will anonymize the conversation by removing PII like names, email addresses, and identifying metadata.
+msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
+msgid ""
+"Before storing this report, DuckDuckGo will anonymize your conversation by "
+"removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
 #. Label that's displayed next to a past start date below a web search result.
@@ -2384,6 +2419,11 @@ msgstr "Brasil"
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Break Points Won"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Break this down into clear, numbered steps."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -2743,6 +2783,11 @@ msgstr "Empleos"
 #. Text of a button that performs a search for the cast of a particular movie or tv show
 msgctxt "Movie/TV Show Title instant answer"
 msgid "Cast"
+msgstr ""
+
+#. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Cast & Crew"
 msgstr ""
 
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -4114,6 +4159,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Create a shopping list with quantities from this recipe."
+msgstr ""
+
 #. Placeholder text displayed in the input field when starting a new image generation session.
 msgctxt "Placeholder text for the image generation input field"
 msgid "Create an image of a cute duck..."
@@ -4640,6 +4690,10 @@ msgstr ""
 msgid "Dictation limit reached"
 msgstr ""
 
+#. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
+msgid "Dictation temporarily unavailable"
+msgstr ""
+
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
@@ -4884,6 +4938,20 @@ msgctxt "precise_user_location"
 msgid "Done"
 msgstr "Hecho"
 
+#. Message shown in a modal after DuckDuckGo browser users disable AI features in Settings. The first two placeholders bold noai.duckduckgo.com. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
+"filtered out. %sLearn More%s"
+msgstr ""
+
+#. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
+"and AI images filtered out. %sLearn more%s"
+msgstr ""
+
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Double Faults"
@@ -4974,6 +5042,16 @@ msgctxt "Full sentence for writing an email"
 msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
+msgstr ""
+
+#. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Draft a cover letter"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Draft a cover letter for this job."
 msgstr ""
 
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -5113,6 +5191,14 @@ msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
 msgstr ""
 
+#. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
+msgctxt "About section description on the Duck.ai settings page"
+msgid ""
+"Duck.ai is created by DuckDuckGo. We're an independent online protection "
+"company for anyone who wants to take back control of their personal "
+"information."
+msgstr ""
+
 #. Title shown when an update is required before proceeding.
 msgctxt "duckai_migration"
 msgid "Duck.ai is moving domains"
@@ -5146,6 +5232,12 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Duck.ai lets you chat privately with popular AI models. Disabling it hides "
+"Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
 
 msgctxt "settings"
@@ -5913,6 +6005,16 @@ msgstr ""
 msgid "Eritrea"
 msgstr ""
 
+#. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Estimate the nutrition"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Estimate the nutritional information for this recipe."
+msgstr ""
+
 msgid "Estonia"
 msgstr ""
 
@@ -5957,10 +6059,50 @@ msgctxt "merchant promotion product ad extension"
 msgid "Expires in 1 day"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain the accepted answer in simple terms."
+msgstr ""
+
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
+msgstr ""
+
+#. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain the top answer"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this in simple, plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this paper"
+msgstr ""
+
+#. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this repo"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this research paper in plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this simply"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain what this repository does and how to use it."
 msgstr ""
 
 #. Label to show if song lyrics contain explicit content
@@ -6191,6 +6333,11 @@ msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
 msgstr ""
 
+msgctxt "settings"
+msgid ""
+"Filters out known AI spam sites from image search results. %sLearn More%s"
+msgstr ""
+
 #. Label for the final score of a sporting event.
 msgid "Final"
 msgstr ""
@@ -6232,6 +6379,11 @@ msgstr ""
 #. Short description shown below the 'Web Search' label in the Tools dropdown.
 msgctxt "Subtitle for the Web Search tool entry in the Tools dropdown menu"
 msgid "Find current information"
+msgstr ""
+
+#. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Find me alternatives"
 msgstr ""
 
 #. Button that searches for results closer to the user's current location.
@@ -6622,6 +6774,11 @@ msgstr ""
 msgid "Generate More"
 msgstr ""
 
+#. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Generate a shopping list"
+msgstr ""
+
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
 msgid "Generate a short answer from the web"
 msgstr ""
@@ -6856,6 +7013,11 @@ msgstr ""
 #. Text for a button inviting users to give it a try for the Duck.ai product. On click, they're taken to the Duck.ai page.
 msgctxt "Onboarding welcome screen button text"
 msgid "Give it a Try"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Give me a quick background on this person."
 msgstr ""
 
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -7219,6 +7381,16 @@ msgstr ""
 #. Link to a page with information about sharing DuckDuckGo with friends.
 msgid "Help Spread Privacy"
 msgstr "Ayudá a difundir la privacidad"
+
+#. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Help me prep for the interview"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Help me tailor my resume for this job."
+msgstr ""
 
 #. Title of a SERP popup that invites users to take a survey (desktop only)
 msgctxt "User survey popup"
@@ -7641,6 +7813,13 @@ msgstr ""
 #. Text displayed on the button on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
 msgctxt "Onboarding terms screen button text"
 msgid "I Agree"
+msgstr ""
+
+#. Text for the button that takes the user to the external DuckDuckGo login subscription page.
+msgctxt ""
+"Text for the I already have a subscription button in the Duck.ai settings "
+"page"
+msgid "I Already Have a Subscription"
 msgstr ""
 
 #. Text for the button that takes the user to the login subscription page.
@@ -8100,6 +8279,11 @@ msgctxt "Sidemenu browser promo"
 msgid "Install Mac Browser"
 msgstr ""
 
+#. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
+msgctxt "settings"
+msgid "Install Now"
+msgstr ""
+
 #. Text of a button to install the DuckDuckGo app
 msgctxt "Serp footer content"
 msgid "Install Our App"
@@ -8179,9 +8363,36 @@ msgctxt "cloudsave"
 msgid "Is deleted data really deleted?"
 msgstr "Los datos son eliminados completamente?"
 
+#. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is it worth taking?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this place any good?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"Is this place any good? Summarize its reputation based on reviews and "
+"ratings."
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "Is this video helpful?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this worth watching?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Is this worth watching? Give me a spoiler-free take."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -8682,6 +8893,11 @@ msgstr "Fuente del link:"
 msgid "Links:"
 msgstr "Hipervínculos:"
 
+#. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "List the tools, materials, or prerequisites I need for this."
+msgstr ""
+
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
 msgid "Listen"
 msgstr "Escuchar"
@@ -9016,6 +9232,11 @@ msgstr ""
 #. Label for linke navigating to site exclusion feature on Settings page
 msgctxt "Exclusion message manage sites button"
 msgid "Manage blocked sites"
+msgstr ""
+
+#. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
+msgctxt "setting"
+msgid "Manage in Browser Settings"
 msgstr ""
 
 #. Link to the site exclusion settings page
@@ -11321,6 +11542,11 @@ msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
+msgid "Please describe why the chat response is harmful or illegal. (optional)"
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
+msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
 msgstr ""
 
@@ -11339,6 +11565,13 @@ msgctxt "Modal disclaimer text"
 msgid ""
 "Please note: starting a new chat with any model will delete your current "
 "chat session."
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
+msgctxt "Feedback prompt"
+msgid ""
+"Please paste your prompt and the problematic output (with any personal "
+"information removed) and describe why the content is harmful or illegal."
 msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -11723,6 +11956,11 @@ msgctxt "settings"
 msgid "Privacy"
 msgstr "Privacidad"
 
+#. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
+msgctxt "Section heading on the Duck.ai settings page"
+msgid "Privacy & Terms"
+msgstr ""
+
 msgid "Privacy Blog"
 msgstr "Blog sobre privacidad"
 
@@ -11776,6 +12014,11 @@ msgstr ""
 
 #. Text used in other strings to link to the Privacy Policy and Terms of Service content.
 msgctxt "Copy used to compose link in sentences"
+msgid "Privacy Policy and Terms of Service"
+msgstr ""
+
+#. Text for a button that links to the terms of use and privacy policy page.
+msgctxt "Secondary button text in active privacy modal"
 msgid "Privacy Policy and Terms of Service"
 msgstr ""
 
@@ -12184,6 +12427,26 @@ msgctxt "Brief for recommending a book"
 msgid "Recommend a book"
 msgstr ""
 
+#. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar books"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar books."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar movies or shows."
+msgstr ""
+
+#. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar titles"
+msgstr ""
+
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
 msgid "Recording failed. Please try again."
 msgstr ""
@@ -12503,6 +12766,14 @@ msgstr ""
 msgid "Republic of Moldova"
 msgstr ""
 
+#. Note indicating that sharing the conversation is mandatory when reporting harmful or illegal content. Rendered alongside the standard share label (DUCKCHAT_RESPONSE_FEEDBACK_SHARE_PROMPT_RESPONSE_LABEL), not replacing it.
+msgctxt ""
+"Note shown under the share-content switch label on the Duck.ai response "
+"feedback form when the user has selected Harmful or Illegal as the feedback "
+"reason"
+msgid "Required for harmful or illegal reports"
+msgstr ""
+
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
 msgctxt "Description for extended reasoning mode in Duck.ai"
 msgid "Researches before responding"
@@ -12688,6 +12959,11 @@ msgstr "Reseñas"
 #. Label above a list of customer reviews of a business.
 msgctxt "maps_places"
 msgid "Reviews"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Rewrite this recipe scaled for a different number of servings."
 msgstr ""
 
 msgid "Romania"
@@ -13740,6 +14016,11 @@ msgctxt "Setup button for native sync flow"
 msgid "Set Up Now"
 msgstr ""
 
+#. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
+msgctxt "Encrypted storage setup button shown in native browsers"
+msgid "Set Up Sync & Backup"
+msgstr ""
+
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
 msgctxt "Title for the Sync & Backup intro screen"
 msgid "Set Up Sync & Backup"
@@ -13884,6 +14165,12 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
+msgctxt ""
+"Label beside the share-content switch on the Duck.ai response feedback form"
+msgid "Share this conversation with DuckDuckGo"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -14899,6 +15186,21 @@ msgctxt "Brief for suggesting a blog post title"
 msgid "Suggest a title for a blog post"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest related articles or topics worth exploring next."
+msgstr ""
+
+#. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Suggest related articles to explore"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest some alternatives to this product."
+msgstr ""
+
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
 msgctxt "directions"
 msgid "Suggestions:"
@@ -14908,9 +15210,84 @@ msgctxt "noresults"
 msgid "Suggestions:"
 msgstr "Sugerencias:"
 
+#. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Sum up the reviews"
+msgstr ""
+
 #. A short title for the a message asking the AI to summarize a text.
 msgctxt "Title for the summarize message"
 msgid "Summarize"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize the Q&As"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the background and notable work of this person."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the key details of this event."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the questions and answers on this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize their background"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this book"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this book."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this discussion"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this discussion thread."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this video"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this video."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize what the reviews say."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -15165,6 +15542,11 @@ msgstr ""
 msgid "Syria"
 msgstr ""
 
+#. Text for a button that enables the theme to follow the operating system's color scheme preference.
+msgctxt "System theme button for theme selector"
+msgid "System"
+msgstr ""
+
 #. Abbreviation indicating this is the total score for a game
 msgctxt "Sports module"
 msgid "T"
@@ -15188,6 +15570,11 @@ msgctxt "language_name"
 msgid "Tahitian"
 msgstr ""
 
+#. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Tailor my resume"
+msgstr ""
+
 msgid "Taiwan"
 msgstr "Taiwán"
 
@@ -15209,6 +15596,12 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "Take control of your personal data!"
+msgstr ""
+
+#. Description for the Feedback section of the Duck.ai settings page, asking the user to take an anonymous survey to let us know how we can make Duck.ai better.
+msgctxt "Feedback section description on the Duck.ai settings page"
+msgid ""
+"Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
 
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -15453,6 +15846,11 @@ msgstr ""
 #. https://duck.co/media/files/theme.png
 msgid "Theme"
 msgstr "Tema"
+
+#. Text for the theme selector label that allows users to switch between Light and dark theme.
+msgctxt "Label for the theme selector feature"
+msgid "Theme"
+msgstr ""
 
 #. http://i.imgur.com/LpFhb1e.png
 msgctxt "settings"
@@ -16110,6 +16508,16 @@ msgid ""
 "movie theatre?”"
 msgstr ""
 
+#. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Translate this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
+msgctxt "Page suggestion prompt"
+msgid "Translate this page into %s."
+msgstr ""
+
 #. Placeholder text for a region that will display translated text.
 msgctxt "translations_module"
 msgid "Translation"
@@ -16224,6 +16632,11 @@ msgstr ""
 #. Call-to-action button for the subscription promo in the SERP sidemenu.
 msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
+msgstr ""
+
+#. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
+msgctxt "settings"
+msgid "Try It Now"
 msgstr ""
 
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -16419,6 +16832,20 @@ msgstr "Probá %s"
 msgctxt "new user poll"
 msgid "Trying DuckDuckGo again"
 msgstr "Probando DuckDuckGo de nuevo"
+
+#. Message shown in a modal after supported third-party browser users disable AI features in Settings. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+#. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
 
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
 msgctxt "Assistant response placeholder"
@@ -17027,6 +17454,11 @@ msgstr ""
 msgid "Uruguay"
 msgstr ""
 
+#. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
+msgctxt "Navigation label on the Duck.ai settings page"
+msgid "Usage"
+msgstr ""
+
 #. A feedback suggestion
 msgctxt "Feedback prompt"
 msgid "Usage limit"
@@ -17378,6 +17810,11 @@ msgstr ""
 msgid "Wales"
 msgstr ""
 
+#. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Walk me through the steps"
+msgstr ""
+
 #. Label for walking directions on a map.
 msgctxt "directions"
 msgid "Walking"
@@ -17468,6 +17905,16 @@ msgstr ""
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
+msgstr ""
+
+#. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
+msgctxt ""
+"Inline warning shown below the share-content toggle when the user selects "
+"Harmful or Illegal but has not enabled sharing"
+msgid ""
+"We can only fix what we can see. To report a harmful or illegal response, "
+"please share this conversation with DuckDuckGo so we can investigate and "
+"address the issue."
 msgstr ""
 
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -17894,6 +18341,87 @@ msgid ""
 "experience."
 msgstr ""
 
+#. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the counterarguments?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the hours & location?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key contributions of this paper?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key contributions?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key details?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key points covered in this video?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key points?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key takeaways from this article?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key takeaways?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key things I will learn from this course?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main counterarguments or criticisms of this?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main questions this page answers?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the must-try dishes here?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"What are the opening hours, location, and contact details for this place?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the pros and cons of this product?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the pros and cons?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
 msgctxt "feedback form"
 msgid "What bothered you most?"
@@ -17977,6 +18505,11 @@ msgctxt "Full sentence for defining a term"
 msgid "What does atria mean in the context of a medical article?"
 msgstr ""
 
+#. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What does this answer?"
+msgstr ""
+
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
@@ -17986,6 +18519,11 @@ msgstr ""
 msgctxt "cloudsave"
 msgid "What information gets saved?"
 msgstr "Qué información se guarda?"
+
+#. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What interview questions might come up for this role?"
+msgstr ""
 
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
@@ -17997,6 +18535,11 @@ msgstr ""
 #. Text for a prompt suggestion for looking up the capital city of Albania.
 msgctxt "Full sentence for looking up basic facts"
 msgid "What is the capital city of Albania?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What is the overall verdict and rating for this?"
 msgstr ""
 
 #. Link to a page with additional information.
@@ -18017,6 +18560,11 @@ msgctxt "maps_places"
 msgid "What people say:"
 msgstr ""
 
+#. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What should I order?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
 msgctxt "feedback form"
 msgid "What stood out?"
@@ -18025,6 +18573,16 @@ msgstr ""
 #. Question on a feedback form for a negative feedback response.
 msgctxt "feedback form"
 msgid "What was wrong with the response? (optional)"
+msgstr ""
+
+#. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I learn?"
+msgstr ""
+
+#. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I need?"
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -18039,6 +18597,11 @@ msgstr ""
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
 msgctxt "SERP footer content"
 msgid "What's New"
+msgstr ""
+
+#. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What's the verdict?"
 msgstr ""
 
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -18082,6 +18645,11 @@ msgctxt "Feedback prompt"
 msgid "Which features are missing? (Optional)"
 msgstr ""
 
+#. An invitation for users to leave feedback
+msgctxt "Feedback prompt"
+msgid "Which features are missing? (optional)"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
 msgid "White"
 msgstr "Blanco"
@@ -18094,6 +18662,16 @@ msgstr "Blanco"
 #. Link to an about us page.
 msgid "Who We Are"
 msgstr "Quiénes somos"
+
+#. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Who are the main cast and crew, and what else are they known for?"
+msgstr ""
+
+#. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Who is this person?"
+msgstr ""
 
 #. Header above a collection of privacy-related links.
 msgid "Why Privacy"

--- a/locales/es_CL/LC_MESSAGES/duckduckgo.po
+++ b/locales/es_CL/LC_MESSAGES/duckduckgo.po
@@ -1159,6 +1159,11 @@ msgctxt "feedback form"
 msgid "Address is incorrect"
 msgstr ""
 
+#. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Adjust the servings"
+msgstr ""
+
 #. as in multiple advertisements
 msgid "Ads"
 msgstr ""
@@ -1332,6 +1337,13 @@ msgstr ""
 #. Heading shown on the empty chat screen. The text between the two %s markers is displayed inside a clickable privacy button. First %s renders a shield icon, second %s is an invisible end marker. Keep the word 'private' between both %s markers.
 msgctxt "Empty state heading in Duck.ai chat mode"
 msgid "All chats are %sprivate%s"
+msgstr ""
+
+#. Paragraph in the Privacy & Terms section of the About & Legal page in Duck.ai settings, summarizing how chats are anonymized and are not stored or used to train chat models.
+msgctxt "Privacy & Terms section description on the Duck.ai settings page"
+msgid ""
+"All chats are anonymized by DuckDuckGo, and your conversations are not used "
+"to train chat models by DuckDuckGo or the model providers"
 msgstr ""
 
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1544,6 +1556,12 @@ msgstr ""
 #. Confirmation message after location service is enabled.
 msgctxt "precise_user_location"
 msgid "Anonymous location enabled"
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Anonymously generates answers for search queries based on web content. "
+"Choose how often you want it to appear, or disable it completely."
 msgstr ""
 
 #. Instant Answer tab name
@@ -1766,6 +1784,11 @@ msgstr ""
 
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse
 msgid "Ask a follow-up with Duck.ai"
+msgstr ""
+
+#. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
+msgctxt "Page suggestion chip label"
+msgid "Ask about this page"
 msgstr ""
 
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2090,6 +2113,11 @@ msgstr ""
 msgid "Barcode"
 msgstr "Código de Barra"
 
+#. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Based on this page, is this course worth taking?"
+msgstr ""
+
 msgctxt "settings"
 msgid "Basic"
 msgstr "Básico"
@@ -2121,6 +2149,13 @@ msgstr ""
 #. Placeholder text displayed while the assistant waits for the user to choose an action.
 msgctxt "Assistant response placeholder"
 msgid "Before continuing..."
+msgstr ""
+
+#. Explains that before storing the report, DuckDuckGo will anonymize the conversation by removing PII like names, email addresses, and identifying metadata.
+msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
+msgid ""
+"Before storing this report, DuckDuckGo will anonymize your conversation by "
+"removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
 #. Label that's displayed next to a past start date below a web search result.
@@ -2379,6 +2414,11 @@ msgstr "Brasil"
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Break Points Won"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Break this down into clear, numbered steps."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -2738,6 +2778,11 @@ msgstr "Carreras"
 #. Text of a button that performs a search for the cast of a particular movie or tv show
 msgctxt "Movie/TV Show Title instant answer"
 msgid "Cast"
+msgstr ""
+
+#. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Cast & Crew"
 msgstr ""
 
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -4101,6 +4146,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Create a shopping list with quantities from this recipe."
+msgstr ""
+
 #. Placeholder text displayed in the input field when starting a new image generation session.
 msgctxt "Placeholder text for the image generation input field"
 msgid "Create an image of a cute duck..."
@@ -4627,6 +4677,10 @@ msgstr ""
 msgid "Dictation limit reached"
 msgstr ""
 
+#. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
+msgid "Dictation temporarily unavailable"
+msgstr ""
+
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
@@ -4871,6 +4925,20 @@ msgctxt "precise_user_location"
 msgid "Done"
 msgstr "Hecho"
 
+#. Message shown in a modal after DuckDuckGo browser users disable AI features in Settings. The first two placeholders bold noai.duckduckgo.com. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
+"filtered out. %sLearn More%s"
+msgstr ""
+
+#. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
+"and AI images filtered out. %sLearn more%s"
+msgstr ""
+
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Double Faults"
@@ -4961,6 +5029,16 @@ msgctxt "Full sentence for writing an email"
 msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
+msgstr ""
+
+#. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Draft a cover letter"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Draft a cover letter for this job."
 msgstr ""
 
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -5100,6 +5178,14 @@ msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
 msgstr ""
 
+#. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
+msgctxt "About section description on the Duck.ai settings page"
+msgid ""
+"Duck.ai is created by DuckDuckGo. We're an independent online protection "
+"company for anyone who wants to take back control of their personal "
+"information."
+msgstr ""
+
 #. Title shown when an update is required before proceeding.
 msgctxt "duckai_migration"
 msgid "Duck.ai is moving domains"
@@ -5133,6 +5219,12 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Duck.ai lets you chat privately with popular AI models. Disabling it hides "
+"Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
 
 msgctxt "settings"
@@ -5900,6 +5992,16 @@ msgstr ""
 msgid "Eritrea"
 msgstr ""
 
+#. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Estimate the nutrition"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Estimate the nutritional information for this recipe."
+msgstr ""
+
 msgid "Estonia"
 msgstr ""
 
@@ -5944,10 +6046,50 @@ msgctxt "merchant promotion product ad extension"
 msgid "Expires in 1 day"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain the accepted answer in simple terms."
+msgstr ""
+
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
+msgstr ""
+
+#. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain the top answer"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this in simple, plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this paper"
+msgstr ""
+
+#. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this repo"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this research paper in plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this simply"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain what this repository does and how to use it."
 msgstr ""
 
 #. Label to show if song lyrics contain explicit content
@@ -6178,6 +6320,11 @@ msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
 msgstr ""
 
+msgctxt "settings"
+msgid ""
+"Filters out known AI spam sites from image search results. %sLearn More%s"
+msgstr ""
+
 #. Label for the final score of a sporting event.
 msgid "Final"
 msgstr ""
@@ -6218,6 +6365,11 @@ msgstr ""
 #. Short description shown below the 'Web Search' label in the Tools dropdown.
 msgctxt "Subtitle for the Web Search tool entry in the Tools dropdown menu"
 msgid "Find current information"
+msgstr ""
+
+#. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Find me alternatives"
 msgstr ""
 
 #. Button that searches for results closer to the user's current location.
@@ -6608,6 +6760,11 @@ msgstr ""
 msgid "Generate More"
 msgstr ""
 
+#. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Generate a shopping list"
+msgstr ""
+
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
 msgid "Generate a short answer from the web"
 msgstr ""
@@ -6842,6 +6999,11 @@ msgstr ""
 #. Text for a button inviting users to give it a try for the Duck.ai product. On click, they're taken to the Duck.ai page.
 msgctxt "Onboarding welcome screen button text"
 msgid "Give it a Try"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Give me a quick background on this person."
 msgstr ""
 
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -7204,6 +7366,16 @@ msgstr ""
 
 #. Link to a page with information about sharing DuckDuckGo with friends.
 msgid "Help Spread Privacy"
+msgstr ""
+
+#. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Help me prep for the interview"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Help me tailor my resume for this job."
 msgstr ""
 
 #. Title of a SERP popup that invites users to take a survey (desktop only)
@@ -7623,6 +7795,13 @@ msgstr ""
 #. Text displayed on the button on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
 msgctxt "Onboarding terms screen button text"
 msgid "I Agree"
+msgstr ""
+
+#. Text for the button that takes the user to the external DuckDuckGo login subscription page.
+msgctxt ""
+"Text for the I already have a subscription button in the Duck.ai settings "
+"page"
+msgid "I Already Have a Subscription"
 msgstr ""
 
 #. Text for the button that takes the user to the login subscription page.
@@ -8079,6 +8258,11 @@ msgctxt "Sidemenu browser promo"
 msgid "Install Mac Browser"
 msgstr ""
 
+#. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
+msgctxt "settings"
+msgid "Install Now"
+msgstr ""
+
 #. Text of a button to install the DuckDuckGo app
 msgctxt "Serp footer content"
 msgid "Install Our App"
@@ -8158,9 +8342,36 @@ msgctxt "cloudsave"
 msgid "Is deleted data really deleted?"
 msgstr "¿En verdad los datos son borrados?"
 
+#. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is it worth taking?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this place any good?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"Is this place any good? Summarize its reputation based on reviews and "
+"ratings."
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "Is this video helpful?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this worth watching?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Is this worth watching? Give me a spoiler-free take."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -8657,6 +8868,11 @@ msgstr "Fuente del enlace:"
 msgid "Links:"
 msgstr "Enlaces:"
 
+#. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "List the tools, materials, or prerequisites I need for this."
+msgstr ""
+
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
 msgid "Listen"
 msgstr "Escuchar"
@@ -8991,6 +9207,11 @@ msgstr ""
 #. Label for linke navigating to site exclusion feature on Settings page
 msgctxt "Exclusion message manage sites button"
 msgid "Manage blocked sites"
+msgstr ""
+
+#. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
+msgctxt "setting"
+msgid "Manage in Browser Settings"
 msgstr ""
 
 #. Link to the site exclusion settings page
@@ -11296,6 +11517,11 @@ msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
+msgid "Please describe why the chat response is harmful or illegal. (optional)"
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
+msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
 msgstr ""
 
@@ -11314,6 +11540,13 @@ msgctxt "Modal disclaimer text"
 msgid ""
 "Please note: starting a new chat with any model will delete your current "
 "chat session."
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
+msgctxt "Feedback prompt"
+msgid ""
+"Please paste your prompt and the problematic output (with any personal "
+"information removed) and describe why the content is harmful or illegal."
 msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -11698,6 +11931,11 @@ msgctxt "settings"
 msgid "Privacy"
 msgstr "Privacidad"
 
+#. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
+msgctxt "Section heading on the Duck.ai settings page"
+msgid "Privacy & Terms"
+msgstr ""
+
 msgid "Privacy Blog"
 msgstr ""
 
@@ -11751,6 +11989,11 @@ msgstr ""
 
 #. Text used in other strings to link to the Privacy Policy and Terms of Service content.
 msgctxt "Copy used to compose link in sentences"
+msgid "Privacy Policy and Terms of Service"
+msgstr ""
+
+#. Text for a button that links to the terms of use and privacy policy page.
+msgctxt "Secondary button text in active privacy modal"
 msgid "Privacy Policy and Terms of Service"
 msgstr ""
 
@@ -12159,6 +12402,26 @@ msgctxt "Brief for recommending a book"
 msgid "Recommend a book"
 msgstr ""
 
+#. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar books"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar books."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar movies or shows."
+msgstr ""
+
+#. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar titles"
+msgstr ""
+
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
 msgid "Recording failed. Please try again."
 msgstr ""
@@ -12479,6 +12742,14 @@ msgstr ""
 msgid "Republic of Moldova"
 msgstr ""
 
+#. Note indicating that sharing the conversation is mandatory when reporting harmful or illegal content. Rendered alongside the standard share label (DUCKCHAT_RESPONSE_FEEDBACK_SHARE_PROMPT_RESPONSE_LABEL), not replacing it.
+msgctxt ""
+"Note shown under the share-content switch label on the Duck.ai response "
+"feedback form when the user has selected Harmful or Illegal as the feedback "
+"reason"
+msgid "Required for harmful or illegal reports"
+msgstr ""
+
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
 msgctxt "Description for extended reasoning mode in Duck.ai"
 msgid "Researches before responding"
@@ -12664,6 +12935,11 @@ msgstr "Revisiones"
 #. Label above a list of customer reviews of a business.
 msgctxt "maps_places"
 msgid "Reviews"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Rewrite this recipe scaled for a different number of servings."
 msgstr ""
 
 msgid "Romania"
@@ -13716,6 +13992,11 @@ msgctxt "Setup button for native sync flow"
 msgid "Set Up Now"
 msgstr ""
 
+#. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
+msgctxt "Encrypted storage setup button shown in native browsers"
+msgid "Set Up Sync & Backup"
+msgstr ""
+
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
 msgctxt "Title for the Sync & Backup intro screen"
 msgid "Set Up Sync & Backup"
@@ -13860,6 +14141,12 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
+msgctxt ""
+"Label beside the share-content switch on the Duck.ai response feedback form"
+msgid "Share this conversation with DuckDuckGo"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -14874,6 +15161,21 @@ msgctxt "Brief for suggesting a blog post title"
 msgid "Suggest a title for a blog post"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest related articles or topics worth exploring next."
+msgstr ""
+
+#. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Suggest related articles to explore"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest some alternatives to this product."
+msgstr ""
+
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
 msgctxt "directions"
 msgid "Suggestions:"
@@ -14883,9 +15185,84 @@ msgctxt "noresults"
 msgid "Suggestions:"
 msgstr ""
 
+#. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Sum up the reviews"
+msgstr ""
+
 #. A short title for the a message asking the AI to summarize a text.
 msgctxt "Title for the summarize message"
 msgid "Summarize"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize the Q&As"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the background and notable work of this person."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the key details of this event."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the questions and answers on this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize their background"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this book"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this book."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this discussion"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this discussion thread."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this video"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this video."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize what the reviews say."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -15140,6 +15517,11 @@ msgstr ""
 msgid "Syria"
 msgstr ""
 
+#. Text for a button that enables the theme to follow the operating system's color scheme preference.
+msgctxt "System theme button for theme selector"
+msgid "System"
+msgstr ""
+
 #. Abbreviation indicating this is the total score for a game
 msgctxt "Sports module"
 msgid "T"
@@ -15163,6 +15545,11 @@ msgctxt "language_name"
 msgid "Tahitian"
 msgstr ""
 
+#. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Tailor my resume"
+msgstr ""
+
 msgid "Taiwan"
 msgstr ""
 
@@ -15184,6 +15571,12 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "Take control of your personal data!"
+msgstr ""
+
+#. Description for the Feedback section of the Duck.ai settings page, asking the user to take an anonymous survey to let us know how we can make Duck.ai better.
+msgctxt "Feedback section description on the Duck.ai settings page"
+msgid ""
+"Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
 
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -15428,6 +15821,11 @@ msgstr ""
 #. https://duck.co/media/files/theme.png
 msgid "Theme"
 msgstr "Tema"
+
+#. Text for the theme selector label that allows users to switch between Light and dark theme.
+msgctxt "Label for the theme selector feature"
+msgid "Theme"
+msgstr ""
 
 #. http://i.imgur.com/LpFhb1e.png
 msgctxt "settings"
@@ -16081,6 +16479,16 @@ msgid ""
 "movie theatre?”"
 msgstr ""
 
+#. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Translate this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
+msgctxt "Page suggestion prompt"
+msgid "Translate this page into %s."
+msgstr ""
+
 #. Placeholder text for a region that will display translated text.
 msgctxt "translations_module"
 msgid "Translation"
@@ -16195,6 +16603,11 @@ msgstr ""
 #. Call-to-action button for the subscription promo in the SERP sidemenu.
 msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
+msgstr ""
+
+#. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
+msgctxt "settings"
+msgid "Try It Now"
 msgstr ""
 
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -16389,6 +16802,20 @@ msgstr "Intenta: %s"
 #. Response a user can select in a feedback form, indicating that they're trying DuckDuckGo again.
 msgctxt "new user poll"
 msgid "Trying DuckDuckGo again"
+msgstr ""
+
+#. Message shown in a modal after supported third-party browser users disable AI features in Settings. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+#. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
 msgstr ""
 
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -16998,6 +17425,11 @@ msgstr ""
 msgid "Uruguay"
 msgstr ""
 
+#. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
+msgctxt "Navigation label on the Duck.ai settings page"
+msgid "Usage"
+msgstr ""
+
 #. A feedback suggestion
 msgctxt "Feedback prompt"
 msgid "Usage limit"
@@ -17346,6 +17778,11 @@ msgstr ""
 msgid "Wales"
 msgstr ""
 
+#. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Walk me through the steps"
+msgstr ""
+
 #. Label for walking directions on a map.
 msgctxt "directions"
 msgid "Walking"
@@ -17436,6 +17873,16 @@ msgstr ""
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
+msgstr ""
+
+#. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
+msgctxt ""
+"Inline warning shown below the share-content toggle when the user selects "
+"Harmful or Illegal but has not enabled sharing"
+msgid ""
+"We can only fix what we can see. To report a harmful or illegal response, "
+"please share this conversation with DuckDuckGo so we can investigate and "
+"address the issue."
 msgstr ""
 
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -17857,6 +18304,87 @@ msgid ""
 "experience."
 msgstr ""
 
+#. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the counterarguments?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the hours & location?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key contributions of this paper?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key contributions?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key details?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key points covered in this video?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key points?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key takeaways from this article?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key takeaways?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key things I will learn from this course?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main counterarguments or criticisms of this?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main questions this page answers?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the must-try dishes here?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"What are the opening hours, location, and contact details for this place?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the pros and cons of this product?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the pros and cons?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
 msgctxt "feedback form"
 msgid "What bothered you most?"
@@ -17940,6 +18468,11 @@ msgctxt "Full sentence for defining a term"
 msgid "What does atria mean in the context of a medical article?"
 msgstr ""
 
+#. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What does this answer?"
+msgstr ""
+
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
@@ -17949,6 +18482,11 @@ msgstr ""
 msgctxt "cloudsave"
 msgid "What information gets saved?"
 msgstr "¿Qué información queda guardada?"
+
+#. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What interview questions might come up for this role?"
+msgstr ""
 
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
@@ -17960,6 +18498,11 @@ msgstr ""
 #. Text for a prompt suggestion for looking up the capital city of Albania.
 msgctxt "Full sentence for looking up basic facts"
 msgid "What is the capital city of Albania?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What is the overall verdict and rating for this?"
 msgstr ""
 
 #. Link to a page with additional information.
@@ -17980,6 +18523,11 @@ msgctxt "maps_places"
 msgid "What people say:"
 msgstr ""
 
+#. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What should I order?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
 msgctxt "feedback form"
 msgid "What stood out?"
@@ -17988,6 +18536,16 @@ msgstr ""
 #. Question on a feedback form for a negative feedback response.
 msgctxt "feedback form"
 msgid "What was wrong with the response? (optional)"
+msgstr ""
+
+#. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I learn?"
+msgstr ""
+
+#. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I need?"
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -18002,6 +18560,11 @@ msgstr ""
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
 msgctxt "SERP footer content"
 msgid "What's New"
+msgstr ""
+
+#. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What's the verdict?"
 msgstr ""
 
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -18043,6 +18606,11 @@ msgctxt "Feedback prompt"
 msgid "Which features are missing? (Optional)"
 msgstr ""
 
+#. An invitation for users to leave feedback
+msgctxt "Feedback prompt"
+msgid "Which features are missing? (optional)"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
 msgid "White"
 msgstr "Blanco"
@@ -18054,6 +18622,16 @@ msgstr ""
 
 #. Link to an about us page.
 msgid "Who We Are"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Who are the main cast and crew, and what else are they known for?"
+msgstr ""
+
+#. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Who is this person?"
 msgstr ""
 
 #. Header above a collection of privacy-related links.

--- a/locales/es_CO/LC_MESSAGES/duckduckgo.po
+++ b/locales/es_CO/LC_MESSAGES/duckduckgo.po
@@ -1161,6 +1161,11 @@ msgctxt "feedback form"
 msgid "Address is incorrect"
 msgstr ""
 
+#. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Adjust the servings"
+msgstr ""
+
 #. as in multiple advertisements
 msgid "Ads"
 msgstr ""
@@ -1334,6 +1339,13 @@ msgstr ""
 #. Heading shown on the empty chat screen. The text between the two %s markers is displayed inside a clickable privacy button. First %s renders a shield icon, second %s is an invisible end marker. Keep the word 'private' between both %s markers.
 msgctxt "Empty state heading in Duck.ai chat mode"
 msgid "All chats are %sprivate%s"
+msgstr ""
+
+#. Paragraph in the Privacy & Terms section of the About & Legal page in Duck.ai settings, summarizing how chats are anonymized and are not stored or used to train chat models.
+msgctxt "Privacy & Terms section description on the Duck.ai settings page"
+msgid ""
+"All chats are anonymized by DuckDuckGo, and your conversations are not used "
+"to train chat models by DuckDuckGo or the model providers"
 msgstr ""
 
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1546,6 +1558,12 @@ msgstr ""
 #. Confirmation message after location service is enabled.
 msgctxt "precise_user_location"
 msgid "Anonymous location enabled"
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Anonymously generates answers for search queries based on web content. "
+"Choose how often you want it to appear, or disable it completely."
 msgstr ""
 
 #. Instant Answer tab name
@@ -1770,6 +1788,11 @@ msgstr ""
 
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse
 msgid "Ask a follow-up with Duck.ai"
+msgstr ""
+
+#. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
+msgctxt "Page suggestion chip label"
+msgid "Ask about this page"
 msgstr ""
 
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2094,6 +2117,11 @@ msgstr ""
 msgid "Barcode"
 msgstr "Código de barras"
 
+#. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Based on this page, is this course worth taking?"
+msgstr ""
+
 msgctxt "settings"
 msgid "Basic"
 msgstr "Básico"
@@ -2125,6 +2153,13 @@ msgstr ""
 #. Placeholder text displayed while the assistant waits for the user to choose an action.
 msgctxt "Assistant response placeholder"
 msgid "Before continuing..."
+msgstr ""
+
+#. Explains that before storing the report, DuckDuckGo will anonymize the conversation by removing PII like names, email addresses, and identifying metadata.
+msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
+msgid ""
+"Before storing this report, DuckDuckGo will anonymize your conversation by "
+"removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
 #. Label that's displayed next to a past start date below a web search result.
@@ -2383,6 +2418,11 @@ msgstr "Brasil"
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Break Points Won"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Break this down into clear, numbered steps."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -2742,6 +2782,11 @@ msgstr "Ofertas laborales"
 #. Text of a button that performs a search for the cast of a particular movie or tv show
 msgctxt "Movie/TV Show Title instant answer"
 msgid "Cast"
+msgstr ""
+
+#. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Cast & Crew"
 msgstr ""
 
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -4109,6 +4154,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Create a shopping list with quantities from this recipe."
+msgstr ""
+
 #. Placeholder text displayed in the input field when starting a new image generation session.
 msgctxt "Placeholder text for the image generation input field"
 msgid "Create an image of a cute duck..."
@@ -4635,6 +4685,10 @@ msgstr ""
 msgid "Dictation limit reached"
 msgstr ""
 
+#. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
+msgid "Dictation temporarily unavailable"
+msgstr ""
+
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
@@ -4879,6 +4933,20 @@ msgctxt "precise_user_location"
 msgid "Done"
 msgstr "Hecho"
 
+#. Message shown in a modal after DuckDuckGo browser users disable AI features in Settings. The first two placeholders bold noai.duckduckgo.com. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
+"filtered out. %sLearn More%s"
+msgstr ""
+
+#. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
+"and AI images filtered out. %sLearn more%s"
+msgstr ""
+
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Double Faults"
@@ -4969,6 +5037,16 @@ msgctxt "Full sentence for writing an email"
 msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
+msgstr ""
+
+#. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Draft a cover letter"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Draft a cover letter for this job."
 msgstr ""
 
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -5108,6 +5186,14 @@ msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
 msgstr ""
 
+#. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
+msgctxt "About section description on the Duck.ai settings page"
+msgid ""
+"Duck.ai is created by DuckDuckGo. We're an independent online protection "
+"company for anyone who wants to take back control of their personal "
+"information."
+msgstr ""
+
 #. Title shown when an update is required before proceeding.
 msgctxt "duckai_migration"
 msgid "Duck.ai is moving domains"
@@ -5141,6 +5227,12 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Duck.ai lets you chat privately with popular AI models. Disabling it hides "
+"Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
 
 msgctxt "settings"
@@ -5908,6 +6000,16 @@ msgstr ""
 msgid "Eritrea"
 msgstr ""
 
+#. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Estimate the nutrition"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Estimate the nutritional information for this recipe."
+msgstr ""
+
 msgid "Estonia"
 msgstr ""
 
@@ -5952,10 +6054,50 @@ msgctxt "merchant promotion product ad extension"
 msgid "Expires in 1 day"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain the accepted answer in simple terms."
+msgstr ""
+
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
+msgstr ""
+
+#. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain the top answer"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this in simple, plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this paper"
+msgstr ""
+
+#. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this repo"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this research paper in plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this simply"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain what this repository does and how to use it."
 msgstr ""
 
 #. Label to show if song lyrics contain explicit content
@@ -6186,6 +6328,11 @@ msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
 msgstr ""
 
+msgctxt "settings"
+msgid ""
+"Filters out known AI spam sites from image search results. %sLearn More%s"
+msgstr ""
+
 #. Label for the final score of a sporting event.
 msgid "Final"
 msgstr ""
@@ -6227,6 +6374,11 @@ msgstr ""
 #. Short description shown below the 'Web Search' label in the Tools dropdown.
 msgctxt "Subtitle for the Web Search tool entry in the Tools dropdown menu"
 msgid "Find current information"
+msgstr ""
+
+#. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Find me alternatives"
 msgstr ""
 
 #. Button that searches for results closer to the user's current location.
@@ -6617,6 +6769,11 @@ msgstr ""
 msgid "Generate More"
 msgstr ""
 
+#. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Generate a shopping list"
+msgstr ""
+
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
 msgid "Generate a short answer from the web"
 msgstr ""
@@ -6851,6 +7008,11 @@ msgstr ""
 #. Text for a button inviting users to give it a try for the Duck.ai product. On click, they're taken to the Duck.ai page.
 msgctxt "Onboarding welcome screen button text"
 msgid "Give it a Try"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Give me a quick background on this person."
 msgstr ""
 
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -7213,6 +7375,16 @@ msgstr ""
 
 #. Link to a page with information about sharing DuckDuckGo with friends.
 msgid "Help Spread Privacy"
+msgstr ""
+
+#. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Help me prep for the interview"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Help me tailor my resume for this job."
 msgstr ""
 
 #. Title of a SERP popup that invites users to take a survey (desktop only)
@@ -7632,6 +7804,13 @@ msgstr ""
 #. Text displayed on the button on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
 msgctxt "Onboarding terms screen button text"
 msgid "I Agree"
+msgstr ""
+
+#. Text for the button that takes the user to the external DuckDuckGo login subscription page.
+msgctxt ""
+"Text for the I already have a subscription button in the Duck.ai settings "
+"page"
+msgid "I Already Have a Subscription"
 msgstr ""
 
 #. Text for the button that takes the user to the login subscription page.
@@ -8089,6 +8268,11 @@ msgctxt "Sidemenu browser promo"
 msgid "Install Mac Browser"
 msgstr ""
 
+#. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
+msgctxt "settings"
+msgid "Install Now"
+msgstr ""
+
 #. Text of a button to install the DuckDuckGo app
 msgctxt "Serp footer content"
 msgid "Install Our App"
@@ -8168,9 +8352,36 @@ msgctxt "cloudsave"
 msgid "Is deleted data really deleted?"
 msgstr "¿Los datos borrados realmente están borrados?"
 
+#. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is it worth taking?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this place any good?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"Is this place any good? Summarize its reputation based on reviews and "
+"ratings."
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "Is this video helpful?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this worth watching?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Is this worth watching? Give me a spoiler-free take."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -8667,6 +8878,11 @@ msgstr "Fuente del link:"
 msgid "Links:"
 msgstr "Links"
 
+#. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "List the tools, materials, or prerequisites I need for this."
+msgstr ""
+
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
 msgid "Listen"
 msgstr "Escucha"
@@ -9001,6 +9217,11 @@ msgstr ""
 #. Label for linke navigating to site exclusion feature on Settings page
 msgctxt "Exclusion message manage sites button"
 msgid "Manage blocked sites"
+msgstr ""
+
+#. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
+msgctxt "setting"
+msgid "Manage in Browser Settings"
 msgstr ""
 
 #. Link to the site exclusion settings page
@@ -11306,6 +11527,11 @@ msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
+msgid "Please describe why the chat response is harmful or illegal. (optional)"
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
+msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
 msgstr ""
 
@@ -11324,6 +11550,13 @@ msgctxt "Modal disclaimer text"
 msgid ""
 "Please note: starting a new chat with any model will delete your current "
 "chat session."
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
+msgctxt "Feedback prompt"
+msgid ""
+"Please paste your prompt and the problematic output (with any personal "
+"information removed) and describe why the content is harmful or illegal."
 msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -11708,6 +11941,11 @@ msgctxt "settings"
 msgid "Privacy"
 msgstr "Privacidad"
 
+#. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
+msgctxt "Section heading on the Duck.ai settings page"
+msgid "Privacy & Terms"
+msgstr ""
+
 msgid "Privacy Blog"
 msgstr ""
 
@@ -11761,6 +11999,11 @@ msgstr ""
 
 #. Text used in other strings to link to the Privacy Policy and Terms of Service content.
 msgctxt "Copy used to compose link in sentences"
+msgid "Privacy Policy and Terms of Service"
+msgstr ""
+
+#. Text for a button that links to the terms of use and privacy policy page.
+msgctxt "Secondary button text in active privacy modal"
 msgid "Privacy Policy and Terms of Service"
 msgstr ""
 
@@ -12169,6 +12412,26 @@ msgctxt "Brief for recommending a book"
 msgid "Recommend a book"
 msgstr ""
 
+#. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar books"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar books."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar movies or shows."
+msgstr ""
+
+#. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar titles"
+msgstr ""
+
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
 msgid "Recording failed. Please try again."
 msgstr ""
@@ -12488,6 +12751,14 @@ msgstr ""
 msgid "Republic of Moldova"
 msgstr ""
 
+#. Note indicating that sharing the conversation is mandatory when reporting harmful or illegal content. Rendered alongside the standard share label (DUCKCHAT_RESPONSE_FEEDBACK_SHARE_PROMPT_RESPONSE_LABEL), not replacing it.
+msgctxt ""
+"Note shown under the share-content switch label on the Duck.ai response "
+"feedback form when the user has selected Harmful or Illegal as the feedback "
+"reason"
+msgid "Required for harmful or illegal reports"
+msgstr ""
+
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
 msgctxt "Description for extended reasoning mode in Duck.ai"
 msgid "Researches before responding"
@@ -12673,6 +12944,11 @@ msgstr "Reseñas"
 #. Label above a list of customer reviews of a business.
 msgctxt "maps_places"
 msgid "Reviews"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Rewrite this recipe scaled for a different number of servings."
 msgstr ""
 
 msgid "Romania"
@@ -13724,6 +14000,11 @@ msgctxt "Setup button for native sync flow"
 msgid "Set Up Now"
 msgstr ""
 
+#. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
+msgctxt "Encrypted storage setup button shown in native browsers"
+msgid "Set Up Sync & Backup"
+msgstr ""
+
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
 msgctxt "Title for the Sync & Backup intro screen"
 msgid "Set Up Sync & Backup"
@@ -13869,6 +14150,12 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
+msgctxt ""
+"Label beside the share-content switch on the Duck.ai response feedback form"
+msgid "Share this conversation with DuckDuckGo"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -14883,6 +15170,21 @@ msgctxt "Brief for suggesting a blog post title"
 msgid "Suggest a title for a blog post"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest related articles or topics worth exploring next."
+msgstr ""
+
+#. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Suggest related articles to explore"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest some alternatives to this product."
+msgstr ""
+
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
 msgctxt "directions"
 msgid "Suggestions:"
@@ -14892,9 +15194,84 @@ msgctxt "noresults"
 msgid "Suggestions:"
 msgstr ""
 
+#. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Sum up the reviews"
+msgstr ""
+
 #. A short title for the a message asking the AI to summarize a text.
 msgctxt "Title for the summarize message"
 msgid "Summarize"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize the Q&As"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the background and notable work of this person."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the key details of this event."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the questions and answers on this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize their background"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this book"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this book."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this discussion"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this discussion thread."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this video"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this video."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize what the reviews say."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -15149,6 +15526,11 @@ msgstr ""
 msgid "Syria"
 msgstr ""
 
+#. Text for a button that enables the theme to follow the operating system's color scheme preference.
+msgctxt "System theme button for theme selector"
+msgid "System"
+msgstr ""
+
 #. Abbreviation indicating this is the total score for a game
 msgctxt "Sports module"
 msgid "T"
@@ -15172,6 +15554,11 @@ msgctxt "language_name"
 msgid "Tahitian"
 msgstr ""
 
+#. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Tailor my resume"
+msgstr ""
+
 msgid "Taiwan"
 msgstr ""
 
@@ -15193,6 +15580,12 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "Take control of your personal data!"
+msgstr ""
+
+#. Description for the Feedback section of the Duck.ai settings page, asking the user to take an anonymous survey to let us know how we can make Duck.ai better.
+msgctxt "Feedback section description on the Duck.ai settings page"
+msgid ""
+"Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
 
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -15437,6 +15830,11 @@ msgstr ""
 #. https://duck.co/media/files/theme.png
 msgid "Theme"
 msgstr "Tema"
+
+#. Text for the theme selector label that allows users to switch between Light and dark theme.
+msgctxt "Label for the theme selector feature"
+msgid "Theme"
+msgstr ""
 
 #. http://i.imgur.com/LpFhb1e.png
 msgctxt "settings"
@@ -16090,6 +16488,16 @@ msgid ""
 "movie theatre?”"
 msgstr ""
 
+#. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Translate this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
+msgctxt "Page suggestion prompt"
+msgid "Translate this page into %s."
+msgstr ""
+
 #. Placeholder text for a region that will display translated text.
 msgctxt "translations_module"
 msgid "Translation"
@@ -16204,6 +16612,11 @@ msgstr ""
 #. Call-to-action button for the subscription promo in the SERP sidemenu.
 msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
+msgstr ""
+
+#. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
+msgctxt "settings"
+msgid "Try It Now"
 msgstr ""
 
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -16399,6 +16812,20 @@ msgstr "Intenta: %s"
 msgctxt "new user poll"
 msgid "Trying DuckDuckGo again"
 msgstr "Probando DuckDuckGo otra vez"
+
+#. Message shown in a modal after supported third-party browser users disable AI features in Settings. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+#. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
 
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
 msgctxt "Assistant response placeholder"
@@ -17006,6 +17433,11 @@ msgstr ""
 msgid "Uruguay"
 msgstr ""
 
+#. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
+msgctxt "Navigation label on the Duck.ai settings page"
+msgid "Usage"
+msgstr ""
+
 #. A feedback suggestion
 msgctxt "Feedback prompt"
 msgid "Usage limit"
@@ -17356,6 +17788,11 @@ msgstr ""
 msgid "Wales"
 msgstr ""
 
+#. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Walk me through the steps"
+msgstr ""
+
 #. Label for walking directions on a map.
 msgctxt "directions"
 msgid "Walking"
@@ -17446,6 +17883,16 @@ msgstr ""
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
+msgstr ""
+
+#. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
+msgctxt ""
+"Inline warning shown below the share-content toggle when the user selects "
+"Harmful or Illegal but has not enabled sharing"
+msgid ""
+"We can only fix what we can see. To report a harmful or illegal response, "
+"please share this conversation with DuckDuckGo so we can investigate and "
+"address the issue."
 msgstr ""
 
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -17871,6 +18318,87 @@ msgid ""
 "experience."
 msgstr ""
 
+#. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the counterarguments?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the hours & location?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key contributions of this paper?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key contributions?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key details?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key points covered in this video?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key points?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key takeaways from this article?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key takeaways?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key things I will learn from this course?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main counterarguments or criticisms of this?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main questions this page answers?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the must-try dishes here?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"What are the opening hours, location, and contact details for this place?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the pros and cons of this product?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the pros and cons?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
 msgctxt "feedback form"
 msgid "What bothered you most?"
@@ -17954,6 +18482,11 @@ msgctxt "Full sentence for defining a term"
 msgid "What does atria mean in the context of a medical article?"
 msgstr ""
 
+#. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What does this answer?"
+msgstr ""
+
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
@@ -17963,6 +18496,11 @@ msgstr ""
 msgctxt "cloudsave"
 msgid "What information gets saved?"
 msgstr "¿Qué información se guarda?"
+
+#. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What interview questions might come up for this role?"
+msgstr ""
 
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
@@ -17974,6 +18512,11 @@ msgstr ""
 #. Text for a prompt suggestion for looking up the capital city of Albania.
 msgctxt "Full sentence for looking up basic facts"
 msgid "What is the capital city of Albania?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What is the overall verdict and rating for this?"
 msgstr ""
 
 #. Link to a page with additional information.
@@ -17994,6 +18537,11 @@ msgctxt "maps_places"
 msgid "What people say:"
 msgstr ""
 
+#. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What should I order?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
 msgctxt "feedback form"
 msgid "What stood out?"
@@ -18002,6 +18550,16 @@ msgstr ""
 #. Question on a feedback form for a negative feedback response.
 msgctxt "feedback form"
 msgid "What was wrong with the response? (optional)"
+msgstr ""
+
+#. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I learn?"
+msgstr ""
+
+#. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I need?"
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -18016,6 +18574,11 @@ msgstr ""
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
 msgctxt "SERP footer content"
 msgid "What's New"
+msgstr ""
+
+#. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What's the verdict?"
 msgstr ""
 
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -18058,6 +18621,11 @@ msgctxt "Feedback prompt"
 msgid "Which features are missing? (Optional)"
 msgstr ""
 
+#. An invitation for users to leave feedback
+msgctxt "Feedback prompt"
+msgid "Which features are missing? (optional)"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
 msgid "White"
 msgstr "Blanco"
@@ -18069,6 +18637,16 @@ msgstr "Blanco"
 
 #. Link to an about us page.
 msgid "Who We Are"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Who are the main cast and crew, and what else are they known for?"
+msgstr ""
+
+#. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Who is this person?"
 msgstr ""
 
 #. Header above a collection of privacy-related links.

--- a/locales/es_CR/LC_MESSAGES/duckduckgo.po
+++ b/locales/es_CR/LC_MESSAGES/duckduckgo.po
@@ -1159,6 +1159,11 @@ msgctxt "feedback form"
 msgid "Address is incorrect"
 msgstr ""
 
+#. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Adjust the servings"
+msgstr ""
+
 #. as in multiple advertisements
 msgid "Ads"
 msgstr ""
@@ -1330,6 +1335,13 @@ msgstr ""
 #. Heading shown on the empty chat screen. The text between the two %s markers is displayed inside a clickable privacy button. First %s renders a shield icon, second %s is an invisible end marker. Keep the word 'private' between both %s markers.
 msgctxt "Empty state heading in Duck.ai chat mode"
 msgid "All chats are %sprivate%s"
+msgstr ""
+
+#. Paragraph in the Privacy & Terms section of the About & Legal page in Duck.ai settings, summarizing how chats are anonymized and are not stored or used to train chat models.
+msgctxt "Privacy & Terms section description on the Duck.ai settings page"
+msgid ""
+"All chats are anonymized by DuckDuckGo, and your conversations are not used "
+"to train chat models by DuckDuckGo or the model providers"
 msgstr ""
 
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1542,6 +1554,12 @@ msgstr ""
 #. Confirmation message after location service is enabled.
 msgctxt "precise_user_location"
 msgid "Anonymous location enabled"
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Anonymously generates answers for search queries based on web content. "
+"Choose how often you want it to appear, or disable it completely."
 msgstr ""
 
 #. Instant Answer tab name
@@ -1764,6 +1782,11 @@ msgstr ""
 
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse
 msgid "Ask a follow-up with Duck.ai"
+msgstr ""
+
+#. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
+msgctxt "Page suggestion chip label"
+msgid "Ask about this page"
 msgstr ""
 
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2088,6 +2111,11 @@ msgstr ""
 msgid "Barcode"
 msgstr "Código de barras"
 
+#. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Based on this page, is this course worth taking?"
+msgstr ""
+
 msgctxt "settings"
 msgid "Basic"
 msgstr "Básico"
@@ -2119,6 +2147,13 @@ msgstr ""
 #. Placeholder text displayed while the assistant waits for the user to choose an action.
 msgctxt "Assistant response placeholder"
 msgid "Before continuing..."
+msgstr ""
+
+#. Explains that before storing the report, DuckDuckGo will anonymize the conversation by removing PII like names, email addresses, and identifying metadata.
+msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
+msgid ""
+"Before storing this report, DuckDuckGo will anonymize your conversation by "
+"removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
 #. Label that's displayed next to a past start date below a web search result.
@@ -2377,6 +2412,11 @@ msgstr ""
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Break Points Won"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Break this down into clear, numbered steps."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -2736,6 +2776,11 @@ msgstr ""
 #. Text of a button that performs a search for the cast of a particular movie or tv show
 msgctxt "Movie/TV Show Title instant answer"
 msgid "Cast"
+msgstr ""
+
+#. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Cast & Crew"
 msgstr ""
 
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -4088,6 +4133,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Create a shopping list with quantities from this recipe."
+msgstr ""
+
 #. Placeholder text displayed in the input field when starting a new image generation session.
 msgctxt "Placeholder text for the image generation input field"
 msgid "Create an image of a cute duck..."
@@ -4614,6 +4664,10 @@ msgstr ""
 msgid "Dictation limit reached"
 msgstr ""
 
+#. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
+msgid "Dictation temporarily unavailable"
+msgstr ""
+
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
@@ -4858,6 +4912,20 @@ msgctxt "precise_user_location"
 msgid "Done"
 msgstr "Hecho"
 
+#. Message shown in a modal after DuckDuckGo browser users disable AI features in Settings. The first two placeholders bold noai.duckduckgo.com. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
+"filtered out. %sLearn More%s"
+msgstr ""
+
+#. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
+"and AI images filtered out. %sLearn more%s"
+msgstr ""
+
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Double Faults"
@@ -4948,6 +5016,16 @@ msgctxt "Full sentence for writing an email"
 msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
+msgstr ""
+
+#. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Draft a cover letter"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Draft a cover letter for this job."
 msgstr ""
 
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -5087,6 +5165,14 @@ msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
 msgstr ""
 
+#. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
+msgctxt "About section description on the Duck.ai settings page"
+msgid ""
+"Duck.ai is created by DuckDuckGo. We're an independent online protection "
+"company for anyone who wants to take back control of their personal "
+"information."
+msgstr ""
+
 #. Title shown when an update is required before proceeding.
 msgctxt "duckai_migration"
 msgid "Duck.ai is moving domains"
@@ -5120,6 +5206,12 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Duck.ai lets you chat privately with popular AI models. Disabling it hides "
+"Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
 
 msgctxt "settings"
@@ -5885,6 +5977,16 @@ msgstr ""
 msgid "Eritrea"
 msgstr ""
 
+#. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Estimate the nutrition"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Estimate the nutritional information for this recipe."
+msgstr ""
+
 msgid "Estonia"
 msgstr ""
 
@@ -5929,10 +6031,50 @@ msgctxt "merchant promotion product ad extension"
 msgid "Expires in 1 day"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain the accepted answer in simple terms."
+msgstr ""
+
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
+msgstr ""
+
+#. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain the top answer"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this in simple, plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this paper"
+msgstr ""
+
+#. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this repo"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this research paper in plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this simply"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain what this repository does and how to use it."
 msgstr ""
 
 #. Label to show if song lyrics contain explicit content
@@ -6163,6 +6305,11 @@ msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
 msgstr ""
 
+msgctxt "settings"
+msgid ""
+"Filters out known AI spam sites from image search results. %sLearn More%s"
+msgstr ""
+
 #. Label for the final score of a sporting event.
 msgid "Final"
 msgstr ""
@@ -6202,6 +6349,11 @@ msgstr ""
 #. Short description shown below the 'Web Search' label in the Tools dropdown.
 msgctxt "Subtitle for the Web Search tool entry in the Tools dropdown menu"
 msgid "Find current information"
+msgstr ""
+
+#. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Find me alternatives"
 msgstr ""
 
 #. Button that searches for results closer to the user's current location.
@@ -6592,6 +6744,11 @@ msgstr ""
 msgid "Generate More"
 msgstr ""
 
+#. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Generate a shopping list"
+msgstr ""
+
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
 msgid "Generate a short answer from the web"
 msgstr ""
@@ -6826,6 +6983,11 @@ msgstr ""
 #. Text for a button inviting users to give it a try for the Duck.ai product. On click, they're taken to the Duck.ai page.
 msgctxt "Onboarding welcome screen button text"
 msgid "Give it a Try"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Give me a quick background on this person."
 msgstr ""
 
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -7188,6 +7350,16 @@ msgstr ""
 
 #. Link to a page with information about sharing DuckDuckGo with friends.
 msgid "Help Spread Privacy"
+msgstr ""
+
+#. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Help me prep for the interview"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Help me tailor my resume for this job."
 msgstr ""
 
 #. Title of a SERP popup that invites users to take a survey (desktop only)
@@ -7607,6 +7779,13 @@ msgstr ""
 #. Text displayed on the button on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
 msgctxt "Onboarding terms screen button text"
 msgid "I Agree"
+msgstr ""
+
+#. Text for the button that takes the user to the external DuckDuckGo login subscription page.
+msgctxt ""
+"Text for the I already have a subscription button in the Duck.ai settings "
+"page"
+msgid "I Already Have a Subscription"
 msgstr ""
 
 #. Text for the button that takes the user to the login subscription page.
@@ -8061,6 +8240,11 @@ msgctxt "Sidemenu browser promo"
 msgid "Install Mac Browser"
 msgstr ""
 
+#. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
+msgctxt "settings"
+msgid "Install Now"
+msgstr ""
+
 #. Text of a button to install the DuckDuckGo app
 msgctxt "Serp footer content"
 msgid "Install Our App"
@@ -8140,9 +8324,36 @@ msgctxt "cloudsave"
 msgid "Is deleted data really deleted?"
 msgstr "¿Son los datos realmente eliminados?"
 
+#. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is it worth taking?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this place any good?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"Is this place any good? Summarize its reputation based on reviews and "
+"ratings."
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "Is this video helpful?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this worth watching?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Is this worth watching? Give me a spoiler-free take."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -8639,6 +8850,11 @@ msgstr "Fuente del enlace"
 msgid "Links:"
 msgstr "Enlaces:"
 
+#. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "List the tools, materials, or prerequisites I need for this."
+msgstr ""
+
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
 msgid "Listen"
 msgstr "Escuchar"
@@ -8971,6 +9187,11 @@ msgstr ""
 #. Label for linke navigating to site exclusion feature on Settings page
 msgctxt "Exclusion message manage sites button"
 msgid "Manage blocked sites"
+msgstr ""
+
+#. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
+msgctxt "setting"
+msgid "Manage in Browser Settings"
 msgstr ""
 
 #. Link to the site exclusion settings page
@@ -11268,6 +11489,11 @@ msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
+msgid "Please describe why the chat response is harmful or illegal. (optional)"
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
+msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
 msgstr ""
 
@@ -11286,6 +11512,13 @@ msgctxt "Modal disclaimer text"
 msgid ""
 "Please note: starting a new chat with any model will delete your current "
 "chat session."
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
+msgctxt "Feedback prompt"
+msgid ""
+"Please paste your prompt and the problematic output (with any personal "
+"information removed) and describe why the content is harmful or illegal."
 msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -11670,6 +11903,11 @@ msgctxt "settings"
 msgid "Privacy"
 msgstr "Privacidad"
 
+#. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
+msgctxt "Section heading on the Duck.ai settings page"
+msgid "Privacy & Terms"
+msgstr ""
+
 msgid "Privacy Blog"
 msgstr ""
 
@@ -11723,6 +11961,11 @@ msgstr ""
 
 #. Text used in other strings to link to the Privacy Policy and Terms of Service content.
 msgctxt "Copy used to compose link in sentences"
+msgid "Privacy Policy and Terms of Service"
+msgstr ""
+
+#. Text for a button that links to the terms of use and privacy policy page.
+msgctxt "Secondary button text in active privacy modal"
 msgid "Privacy Policy and Terms of Service"
 msgstr ""
 
@@ -12131,6 +12374,26 @@ msgctxt "Brief for recommending a book"
 msgid "Recommend a book"
 msgstr ""
 
+#. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar books"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar books."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar movies or shows."
+msgstr ""
+
+#. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar titles"
+msgstr ""
+
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
 msgid "Recording failed. Please try again."
 msgstr ""
@@ -12450,6 +12713,14 @@ msgstr ""
 msgid "Republic of Moldova"
 msgstr ""
 
+#. Note indicating that sharing the conversation is mandatory when reporting harmful or illegal content. Rendered alongside the standard share label (DUCKCHAT_RESPONSE_FEEDBACK_SHARE_PROMPT_RESPONSE_LABEL), not replacing it.
+msgctxt ""
+"Note shown under the share-content switch label on the Duck.ai response "
+"feedback form when the user has selected Harmful or Illegal as the feedback "
+"reason"
+msgid "Required for harmful or illegal reports"
+msgstr ""
+
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
 msgctxt "Description for extended reasoning mode in Duck.ai"
 msgid "Researches before responding"
@@ -12635,6 +12906,11 @@ msgstr "Críticas"
 #. Label above a list of customer reviews of a business.
 msgctxt "maps_places"
 msgid "Reviews"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Rewrite this recipe scaled for a different number of servings."
 msgstr ""
 
 msgid "Romania"
@@ -13672,6 +13948,11 @@ msgctxt "Setup button for native sync flow"
 msgid "Set Up Now"
 msgstr ""
 
+#. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
+msgctxt "Encrypted storage setup button shown in native browsers"
+msgid "Set Up Sync & Backup"
+msgstr ""
+
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
 msgctxt "Title for the Sync & Backup intro screen"
 msgid "Set Up Sync & Backup"
@@ -13816,6 +14097,12 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
+msgctxt ""
+"Label beside the share-content switch on the Duck.ai response feedback form"
+msgid "Share this conversation with DuckDuckGo"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -14830,6 +15117,21 @@ msgctxt "Brief for suggesting a blog post title"
 msgid "Suggest a title for a blog post"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest related articles or topics worth exploring next."
+msgstr ""
+
+#. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Suggest related articles to explore"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest some alternatives to this product."
+msgstr ""
+
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
 msgctxt "directions"
 msgid "Suggestions:"
@@ -14839,9 +15141,84 @@ msgctxt "noresults"
 msgid "Suggestions:"
 msgstr ""
 
+#. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Sum up the reviews"
+msgstr ""
+
 #. A short title for the a message asking the AI to summarize a text.
 msgctxt "Title for the summarize message"
 msgid "Summarize"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize the Q&As"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the background and notable work of this person."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the key details of this event."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the questions and answers on this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize their background"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this book"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this book."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this discussion"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this discussion thread."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this video"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this video."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize what the reviews say."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -15096,6 +15473,11 @@ msgstr ""
 msgid "Syria"
 msgstr ""
 
+#. Text for a button that enables the theme to follow the operating system's color scheme preference.
+msgctxt "System theme button for theme selector"
+msgid "System"
+msgstr ""
+
 #. Abbreviation indicating this is the total score for a game
 msgctxt "Sports module"
 msgid "T"
@@ -15119,6 +15501,11 @@ msgctxt "language_name"
 msgid "Tahitian"
 msgstr ""
 
+#. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Tailor my resume"
+msgstr ""
+
 msgid "Taiwan"
 msgstr ""
 
@@ -15140,6 +15527,12 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "Take control of your personal data!"
+msgstr ""
+
+#. Description for the Feedback section of the Duck.ai settings page, asking the user to take an anonymous survey to let us know how we can make Duck.ai better.
+msgctxt "Feedback section description on the Duck.ai settings page"
+msgid ""
+"Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
 
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -15384,6 +15777,11 @@ msgstr ""
 #. https://duck.co/media/files/theme.png
 msgid "Theme"
 msgstr "Tema"
+
+#. Text for the theme selector label that allows users to switch between Light and dark theme.
+msgctxt "Label for the theme selector feature"
+msgid "Theme"
+msgstr ""
 
 #. http://i.imgur.com/LpFhb1e.png
 msgctxt "settings"
@@ -16035,6 +16433,16 @@ msgid ""
 "movie theatre?”"
 msgstr ""
 
+#. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Translate this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
+msgctxt "Page suggestion prompt"
+msgid "Translate this page into %s."
+msgstr ""
+
 #. Placeholder text for a region that will display translated text.
 msgctxt "translations_module"
 msgid "Translation"
@@ -16149,6 +16557,11 @@ msgstr ""
 #. Call-to-action button for the subscription promo in the SERP sidemenu.
 msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
+msgstr ""
+
+#. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
+msgctxt "settings"
+msgid "Try It Now"
 msgstr ""
 
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -16343,6 +16756,20 @@ msgstr "Trate: %s"
 #. Response a user can select in a feedback form, indicating that they're trying DuckDuckGo again.
 msgctxt "new user poll"
 msgid "Trying DuckDuckGo again"
+msgstr ""
+
+#. Message shown in a modal after supported third-party browser users disable AI features in Settings. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+#. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
 msgstr ""
 
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -16943,6 +17370,11 @@ msgstr ""
 msgid "Uruguay"
 msgstr ""
 
+#. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
+msgctxt "Navigation label on the Duck.ai settings page"
+msgid "Usage"
+msgstr ""
+
 #. A feedback suggestion
 msgctxt "Feedback prompt"
 msgid "Usage limit"
@@ -17291,6 +17723,11 @@ msgstr ""
 msgid "Wales"
 msgstr ""
 
+#. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Walk me through the steps"
+msgstr ""
+
 #. Label for walking directions on a map.
 msgctxt "directions"
 msgid "Walking"
@@ -17381,6 +17818,16 @@ msgstr ""
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
+msgstr ""
+
+#. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
+msgctxt ""
+"Inline warning shown below the share-content toggle when the user selects "
+"Harmful or Illegal but has not enabled sharing"
+msgid ""
+"We can only fix what we can see. To report a harmful or illegal response, "
+"please share this conversation with DuckDuckGo so we can investigate and "
+"address the issue."
 msgstr ""
 
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -17800,6 +18247,87 @@ msgid ""
 "experience."
 msgstr ""
 
+#. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the counterarguments?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the hours & location?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key contributions of this paper?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key contributions?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key details?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key points covered in this video?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key points?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key takeaways from this article?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key takeaways?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key things I will learn from this course?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main counterarguments or criticisms of this?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main questions this page answers?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the must-try dishes here?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"What are the opening hours, location, and contact details for this place?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the pros and cons of this product?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the pros and cons?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
 msgctxt "feedback form"
 msgid "What bothered you most?"
@@ -17883,6 +18411,11 @@ msgctxt "Full sentence for defining a term"
 msgid "What does atria mean in the context of a medical article?"
 msgstr ""
 
+#. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What does this answer?"
+msgstr ""
+
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
@@ -17892,6 +18425,11 @@ msgstr ""
 msgctxt "cloudsave"
 msgid "What information gets saved?"
 msgstr "¿Cuál información se guarda?"
+
+#. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What interview questions might come up for this role?"
+msgstr ""
 
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
@@ -17903,6 +18441,11 @@ msgstr ""
 #. Text for a prompt suggestion for looking up the capital city of Albania.
 msgctxt "Full sentence for looking up basic facts"
 msgid "What is the capital city of Albania?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What is the overall verdict and rating for this?"
 msgstr ""
 
 #. Link to a page with additional information.
@@ -17923,6 +18466,11 @@ msgctxt "maps_places"
 msgid "What people say:"
 msgstr ""
 
+#. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What should I order?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
 msgctxt "feedback form"
 msgid "What stood out?"
@@ -17931,6 +18479,16 @@ msgstr ""
 #. Question on a feedback form for a negative feedback response.
 msgctxt "feedback form"
 msgid "What was wrong with the response? (optional)"
+msgstr ""
+
+#. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I learn?"
+msgstr ""
+
+#. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I need?"
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -17945,6 +18503,11 @@ msgstr ""
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
 msgctxt "SERP footer content"
 msgid "What's New"
+msgstr ""
+
+#. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What's the verdict?"
 msgstr ""
 
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -17986,6 +18549,11 @@ msgctxt "Feedback prompt"
 msgid "Which features are missing? (Optional)"
 msgstr ""
 
+#. An invitation for users to leave feedback
+msgctxt "Feedback prompt"
+msgid "Which features are missing? (optional)"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
 msgid "White"
 msgstr "Blanco"
@@ -17997,6 +18565,16 @@ msgstr ""
 
 #. Link to an about us page.
 msgid "Who We Are"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Who are the main cast and crew, and what else are they known for?"
+msgstr ""
+
+#. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Who is this person?"
 msgstr ""
 
 #. Header above a collection of privacy-related links.

--- a/locales/es_EC/LC_MESSAGES/duckduckgo.po
+++ b/locales/es_EC/LC_MESSAGES/duckduckgo.po
@@ -1159,6 +1159,11 @@ msgctxt "feedback form"
 msgid "Address is incorrect"
 msgstr ""
 
+#. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Adjust the servings"
+msgstr ""
+
 #. as in multiple advertisements
 msgid "Ads"
 msgstr ""
@@ -1330,6 +1335,13 @@ msgstr ""
 #. Heading shown on the empty chat screen. The text between the two %s markers is displayed inside a clickable privacy button. First %s renders a shield icon, second %s is an invisible end marker. Keep the word 'private' between both %s markers.
 msgctxt "Empty state heading in Duck.ai chat mode"
 msgid "All chats are %sprivate%s"
+msgstr ""
+
+#. Paragraph in the Privacy & Terms section of the About & Legal page in Duck.ai settings, summarizing how chats are anonymized and are not stored or used to train chat models.
+msgctxt "Privacy & Terms section description on the Duck.ai settings page"
+msgid ""
+"All chats are anonymized by DuckDuckGo, and your conversations are not used "
+"to train chat models by DuckDuckGo or the model providers"
 msgstr ""
 
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1542,6 +1554,12 @@ msgstr ""
 #. Confirmation message after location service is enabled.
 msgctxt "precise_user_location"
 msgid "Anonymous location enabled"
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Anonymously generates answers for search queries based on web content. "
+"Choose how often you want it to appear, or disable it completely."
 msgstr ""
 
 #. Instant Answer tab name
@@ -1764,6 +1782,11 @@ msgstr ""
 
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse
 msgid "Ask a follow-up with Duck.ai"
+msgstr ""
+
+#. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
+msgctxt "Page suggestion chip label"
+msgid "Ask about this page"
 msgstr ""
 
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2088,6 +2111,11 @@ msgstr ""
 msgid "Barcode"
 msgstr "Código de Barras"
 
+#. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Based on this page, is this course worth taking?"
+msgstr ""
+
 msgctxt "settings"
 msgid "Basic"
 msgstr "Básico"
@@ -2119,6 +2147,13 @@ msgstr ""
 #. Placeholder text displayed while the assistant waits for the user to choose an action.
 msgctxt "Assistant response placeholder"
 msgid "Before continuing..."
+msgstr ""
+
+#. Explains that before storing the report, DuckDuckGo will anonymize the conversation by removing PII like names, email addresses, and identifying metadata.
+msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
+msgid ""
+"Before storing this report, DuckDuckGo will anonymize your conversation by "
+"removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
 #. Label that's displayed next to a past start date below a web search result.
@@ -2377,6 +2412,11 @@ msgstr ""
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Break Points Won"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Break this down into clear, numbered steps."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -2736,6 +2776,11 @@ msgstr ""
 #. Text of a button that performs a search for the cast of a particular movie or tv show
 msgctxt "Movie/TV Show Title instant answer"
 msgid "Cast"
+msgstr ""
+
+#. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Cast & Crew"
 msgstr ""
 
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -4092,6 +4137,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Create a shopping list with quantities from this recipe."
+msgstr ""
+
 #. Placeholder text displayed in the input field when starting a new image generation session.
 msgctxt "Placeholder text for the image generation input field"
 msgid "Create an image of a cute duck..."
@@ -4618,6 +4668,10 @@ msgstr ""
 msgid "Dictation limit reached"
 msgstr ""
 
+#. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
+msgid "Dictation temporarily unavailable"
+msgstr ""
+
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
@@ -4862,6 +4916,20 @@ msgctxt "precise_user_location"
 msgid "Done"
 msgstr "Hecho"
 
+#. Message shown in a modal after DuckDuckGo browser users disable AI features in Settings. The first two placeholders bold noai.duckduckgo.com. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
+"filtered out. %sLearn More%s"
+msgstr ""
+
+#. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
+"and AI images filtered out. %sLearn more%s"
+msgstr ""
+
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Double Faults"
@@ -4952,6 +5020,16 @@ msgctxt "Full sentence for writing an email"
 msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
+msgstr ""
+
+#. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Draft a cover letter"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Draft a cover letter for this job."
 msgstr ""
 
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -5091,6 +5169,14 @@ msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
 msgstr ""
 
+#. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
+msgctxt "About section description on the Duck.ai settings page"
+msgid ""
+"Duck.ai is created by DuckDuckGo. We're an independent online protection "
+"company for anyone who wants to take back control of their personal "
+"information."
+msgstr ""
+
 #. Title shown when an update is required before proceeding.
 msgctxt "duckai_migration"
 msgid "Duck.ai is moving domains"
@@ -5124,6 +5210,12 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Duck.ai lets you chat privately with popular AI models. Disabling it hides "
+"Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
 
 msgctxt "settings"
@@ -5890,6 +5982,16 @@ msgstr ""
 msgid "Eritrea"
 msgstr ""
 
+#. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Estimate the nutrition"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Estimate the nutritional information for this recipe."
+msgstr ""
+
 msgid "Estonia"
 msgstr ""
 
@@ -5934,10 +6036,50 @@ msgctxt "merchant promotion product ad extension"
 msgid "Expires in 1 day"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain the accepted answer in simple terms."
+msgstr ""
+
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
+msgstr ""
+
+#. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain the top answer"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this in simple, plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this paper"
+msgstr ""
+
+#. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this repo"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this research paper in plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this simply"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain what this repository does and how to use it."
 msgstr ""
 
 #. Label to show if song lyrics contain explicit content
@@ -6168,6 +6310,11 @@ msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
 msgstr ""
 
+msgctxt "settings"
+msgid ""
+"Filters out known AI spam sites from image search results. %sLearn More%s"
+msgstr ""
+
 #. Label for the final score of a sporting event.
 msgid "Final"
 msgstr ""
@@ -6209,6 +6356,11 @@ msgstr ""
 #. Short description shown below the 'Web Search' label in the Tools dropdown.
 msgctxt "Subtitle for the Web Search tool entry in the Tools dropdown menu"
 msgid "Find current information"
+msgstr ""
+
+#. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Find me alternatives"
 msgstr ""
 
 #. Button that searches for results closer to the user's current location.
@@ -6599,6 +6751,11 @@ msgstr ""
 msgid "Generate More"
 msgstr ""
 
+#. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Generate a shopping list"
+msgstr ""
+
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
 msgid "Generate a short answer from the web"
 msgstr ""
@@ -6833,6 +6990,11 @@ msgstr ""
 #. Text for a button inviting users to give it a try for the Duck.ai product. On click, they're taken to the Duck.ai page.
 msgctxt "Onboarding welcome screen button text"
 msgid "Give it a Try"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Give me a quick background on this person."
 msgstr ""
 
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -7195,6 +7357,16 @@ msgstr ""
 
 #. Link to a page with information about sharing DuckDuckGo with friends.
 msgid "Help Spread Privacy"
+msgstr ""
+
+#. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Help me prep for the interview"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Help me tailor my resume for this job."
 msgstr ""
 
 #. Title of a SERP popup that invites users to take a survey (desktop only)
@@ -7614,6 +7786,13 @@ msgstr ""
 #. Text displayed on the button on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
 msgctxt "Onboarding terms screen button text"
 msgid "I Agree"
+msgstr ""
+
+#. Text for the button that takes the user to the external DuckDuckGo login subscription page.
+msgctxt ""
+"Text for the I already have a subscription button in the Duck.ai settings "
+"page"
+msgid "I Already Have a Subscription"
 msgstr ""
 
 #. Text for the button that takes the user to the login subscription page.
@@ -8068,6 +8247,11 @@ msgctxt "Sidemenu browser promo"
 msgid "Install Mac Browser"
 msgstr ""
 
+#. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
+msgctxt "settings"
+msgid "Install Now"
+msgstr ""
+
 #. Text of a button to install the DuckDuckGo app
 msgctxt "Serp footer content"
 msgid "Install Our App"
@@ -8147,9 +8331,36 @@ msgctxt "cloudsave"
 msgid "Is deleted data really deleted?"
 msgstr "¿Los datos eliminados realmente son eliminados?"
 
+#. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is it worth taking?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this place any good?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"Is this place any good? Summarize its reputation based on reviews and "
+"ratings."
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "Is this video helpful?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this worth watching?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Is this worth watching? Give me a spoiler-free take."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -8646,6 +8857,11 @@ msgstr "Fuente del enlace:"
 msgid "Links:"
 msgstr "Enlaces:"
 
+#. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "List the tools, materials, or prerequisites I need for this."
+msgstr ""
+
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
 msgid "Listen"
 msgstr "Escuchar"
@@ -8978,6 +9194,11 @@ msgstr ""
 #. Label for linke navigating to site exclusion feature on Settings page
 msgctxt "Exclusion message manage sites button"
 msgid "Manage blocked sites"
+msgstr ""
+
+#. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
+msgctxt "setting"
+msgid "Manage in Browser Settings"
 msgstr ""
 
 #. Link to the site exclusion settings page
@@ -11277,6 +11498,11 @@ msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
+msgid "Please describe why the chat response is harmful or illegal. (optional)"
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
+msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
 msgstr ""
 
@@ -11295,6 +11521,13 @@ msgctxt "Modal disclaimer text"
 msgid ""
 "Please note: starting a new chat with any model will delete your current "
 "chat session."
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
+msgctxt "Feedback prompt"
+msgid ""
+"Please paste your prompt and the problematic output (with any personal "
+"information removed) and describe why the content is harmful or illegal."
 msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -11679,6 +11912,11 @@ msgctxt "settings"
 msgid "Privacy"
 msgstr "Privacidad"
 
+#. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
+msgctxt "Section heading on the Duck.ai settings page"
+msgid "Privacy & Terms"
+msgstr ""
+
 msgid "Privacy Blog"
 msgstr ""
 
@@ -11732,6 +11970,11 @@ msgstr ""
 
 #. Text used in other strings to link to the Privacy Policy and Terms of Service content.
 msgctxt "Copy used to compose link in sentences"
+msgid "Privacy Policy and Terms of Service"
+msgstr ""
+
+#. Text for a button that links to the terms of use and privacy policy page.
+msgctxt "Secondary button text in active privacy modal"
 msgid "Privacy Policy and Terms of Service"
 msgstr ""
 
@@ -12140,6 +12383,26 @@ msgctxt "Brief for recommending a book"
 msgid "Recommend a book"
 msgstr ""
 
+#. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar books"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar books."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar movies or shows."
+msgstr ""
+
+#. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar titles"
+msgstr ""
+
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
 msgid "Recording failed. Please try again."
 msgstr ""
@@ -12460,6 +12723,14 @@ msgstr ""
 msgid "Republic of Moldova"
 msgstr ""
 
+#. Note indicating that sharing the conversation is mandatory when reporting harmful or illegal content. Rendered alongside the standard share label (DUCKCHAT_RESPONSE_FEEDBACK_SHARE_PROMPT_RESPONSE_LABEL), not replacing it.
+msgctxt ""
+"Note shown under the share-content switch label on the Duck.ai response "
+"feedback form when the user has selected Harmful or Illegal as the feedback "
+"reason"
+msgid "Required for harmful or illegal reports"
+msgstr ""
+
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
 msgctxt "Description for extended reasoning mode in Duck.ai"
 msgid "Researches before responding"
@@ -12645,6 +12916,11 @@ msgstr "Opiniones"
 #. Label above a list of customer reviews of a business.
 msgctxt "maps_places"
 msgid "Reviews"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Rewrite this recipe scaled for a different number of servings."
 msgstr ""
 
 msgid "Romania"
@@ -13686,6 +13962,11 @@ msgctxt "Setup button for native sync flow"
 msgid "Set Up Now"
 msgstr ""
 
+#. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
+msgctxt "Encrypted storage setup button shown in native browsers"
+msgid "Set Up Sync & Backup"
+msgstr ""
+
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
 msgctxt "Title for the Sync & Backup intro screen"
 msgid "Set Up Sync & Backup"
@@ -13830,6 +14111,12 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
+msgctxt ""
+"Label beside the share-content switch on the Duck.ai response feedback form"
+msgid "Share this conversation with DuckDuckGo"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -14844,6 +15131,21 @@ msgctxt "Brief for suggesting a blog post title"
 msgid "Suggest a title for a blog post"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest related articles or topics worth exploring next."
+msgstr ""
+
+#. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Suggest related articles to explore"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest some alternatives to this product."
+msgstr ""
+
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
 msgctxt "directions"
 msgid "Suggestions:"
@@ -14853,9 +15155,84 @@ msgctxt "noresults"
 msgid "Suggestions:"
 msgstr ""
 
+#. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Sum up the reviews"
+msgstr ""
+
 #. A short title for the a message asking the AI to summarize a text.
 msgctxt "Title for the summarize message"
 msgid "Summarize"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize the Q&As"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the background and notable work of this person."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the key details of this event."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the questions and answers on this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize their background"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this book"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this book."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this discussion"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this discussion thread."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this video"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this video."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize what the reviews say."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -15110,6 +15487,11 @@ msgstr ""
 msgid "Syria"
 msgstr ""
 
+#. Text for a button that enables the theme to follow the operating system's color scheme preference.
+msgctxt "System theme button for theme selector"
+msgid "System"
+msgstr ""
+
 #. Abbreviation indicating this is the total score for a game
 msgctxt "Sports module"
 msgid "T"
@@ -15133,6 +15515,11 @@ msgctxt "language_name"
 msgid "Tahitian"
 msgstr ""
 
+#. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Tailor my resume"
+msgstr ""
+
 msgid "Taiwan"
 msgstr ""
 
@@ -15154,6 +15541,12 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "Take control of your personal data!"
+msgstr ""
+
+#. Description for the Feedback section of the Duck.ai settings page, asking the user to take an anonymous survey to let us know how we can make Duck.ai better.
+msgctxt "Feedback section description on the Duck.ai settings page"
+msgid ""
+"Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
 
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -15398,6 +15791,11 @@ msgstr ""
 #. https://duck.co/media/files/theme.png
 msgid "Theme"
 msgstr "Temas"
+
+#. Text for the theme selector label that allows users to switch between Light and dark theme.
+msgctxt "Label for the theme selector feature"
+msgid "Theme"
+msgstr ""
 
 #. http://i.imgur.com/LpFhb1e.png
 msgctxt "settings"
@@ -16051,6 +16449,16 @@ msgid ""
 "movie theatre?”"
 msgstr ""
 
+#. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Translate this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
+msgctxt "Page suggestion prompt"
+msgid "Translate this page into %s."
+msgstr ""
+
 #. Placeholder text for a region that will display translated text.
 msgctxt "translations_module"
 msgid "Translation"
@@ -16165,6 +16573,11 @@ msgstr ""
 #. Call-to-action button for the subscription promo in the SERP sidemenu.
 msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
+msgstr ""
+
+#. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
+msgctxt "settings"
+msgid "Try It Now"
 msgstr ""
 
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -16359,6 +16772,20 @@ msgstr "Intentar: %s"
 #. Response a user can select in a feedback form, indicating that they're trying DuckDuckGo again.
 msgctxt "new user poll"
 msgid "Trying DuckDuckGo again"
+msgstr ""
+
+#. Message shown in a modal after supported third-party browser users disable AI features in Settings. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+#. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
 msgstr ""
 
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -16962,6 +17389,11 @@ msgstr ""
 msgid "Uruguay"
 msgstr ""
 
+#. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
+msgctxt "Navigation label on the Duck.ai settings page"
+msgid "Usage"
+msgstr ""
+
 #. A feedback suggestion
 msgctxt "Feedback prompt"
 msgid "Usage limit"
@@ -17311,6 +17743,11 @@ msgstr ""
 msgid "Wales"
 msgstr ""
 
+#. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Walk me through the steps"
+msgstr ""
+
 #. Label for walking directions on a map.
 msgctxt "directions"
 msgid "Walking"
@@ -17401,6 +17838,16 @@ msgstr ""
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
+msgstr ""
+
+#. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
+msgctxt ""
+"Inline warning shown below the share-content toggle when the user selects "
+"Harmful or Illegal but has not enabled sharing"
+msgid ""
+"We can only fix what we can see. To report a harmful or illegal response, "
+"please share this conversation with DuckDuckGo so we can investigate and "
+"address the issue."
 msgstr ""
 
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -17826,6 +18273,87 @@ msgid ""
 "experience."
 msgstr ""
 
+#. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the counterarguments?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the hours & location?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key contributions of this paper?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key contributions?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key details?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key points covered in this video?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key points?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key takeaways from this article?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key takeaways?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key things I will learn from this course?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main counterarguments or criticisms of this?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main questions this page answers?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the must-try dishes here?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"What are the opening hours, location, and contact details for this place?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the pros and cons of this product?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the pros and cons?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
 msgctxt "feedback form"
 msgid "What bothered you most?"
@@ -17909,6 +18437,11 @@ msgctxt "Full sentence for defining a term"
 msgid "What does atria mean in the context of a medical article?"
 msgstr ""
 
+#. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What does this answer?"
+msgstr ""
+
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
@@ -17918,6 +18451,11 @@ msgstr ""
 msgctxt "cloudsave"
 msgid "What information gets saved?"
 msgstr "¿Que información se guarda?"
+
+#. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What interview questions might come up for this role?"
+msgstr ""
 
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
@@ -17929,6 +18467,11 @@ msgstr ""
 #. Text for a prompt suggestion for looking up the capital city of Albania.
 msgctxt "Full sentence for looking up basic facts"
 msgid "What is the capital city of Albania?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What is the overall verdict and rating for this?"
 msgstr ""
 
 #. Link to a page with additional information.
@@ -17949,6 +18492,11 @@ msgctxt "maps_places"
 msgid "What people say:"
 msgstr ""
 
+#. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What should I order?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
 msgctxt "feedback form"
 msgid "What stood out?"
@@ -17957,6 +18505,16 @@ msgstr ""
 #. Question on a feedback form for a negative feedback response.
 msgctxt "feedback form"
 msgid "What was wrong with the response? (optional)"
+msgstr ""
+
+#. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I learn?"
+msgstr ""
+
+#. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I need?"
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -17971,6 +18529,11 @@ msgstr ""
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
 msgctxt "SERP footer content"
 msgid "What's New"
+msgstr ""
+
+#. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What's the verdict?"
 msgstr ""
 
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -18012,6 +18575,11 @@ msgctxt "Feedback prompt"
 msgid "Which features are missing? (Optional)"
 msgstr ""
 
+#. An invitation for users to leave feedback
+msgctxt "Feedback prompt"
+msgid "Which features are missing? (optional)"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
 msgid "White"
 msgstr "Blanco"
@@ -18024,6 +18592,16 @@ msgstr "Blanco"
 #. Link to an about us page.
 msgid "Who We Are"
 msgstr "Quiénes somos"
+
+#. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Who are the main cast and crew, and what else are they known for?"
+msgstr ""
+
+#. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Who is this person?"
+msgstr ""
 
 #. Header above a collection of privacy-related links.
 msgid "Why Privacy"

--- a/locales/es_ES/LC_MESSAGES/duckduckgo.po
+++ b/locales/es_ES/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: es_ES\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -416,7 +416,8 @@ msgstr "%1$s palabras"
 #. Instructions on which buttons and options the user has to click in order to add the DuckDuckGo extension to their browser.
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
-msgstr "%1$sPulsa %2$sAñadir%3$sMarcar %4$sPermitir%5$s y luego %6$sAceptar%7$s"
+msgstr ""
+"%1$sPulsa %2$sAñadir%3$sMarcar %4$sPermitir%5$s y luego %6$sAceptar%7$s"
 
 # Firefox, obsolete
 # smartling.placeholder_format=C
@@ -1443,6 +1444,12 @@ msgid "Address is incorrect"
 msgstr "La dirección es incorrecta"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Adjust the servings"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. as in multiple advertisements
 msgid "Ads"
 msgstr "Anuncios"
@@ -1654,6 +1661,14 @@ msgstr "Todos los chats son %1$s. La IA puede cometer errores."
 msgctxt "Empty state heading in Duck.ai chat mode"
 msgid "All chats are %sprivate%s"
 msgstr "Todos los chats son %1$sprivados%2$s"
+
+# smartling.placeholder_format=C
+#. Paragraph in the Privacy & Terms section of the About & Legal page in Duck.ai settings, summarizing how chats are anonymized and are not stored or used to train chat models.
+msgctxt "Privacy & Terms section description on the Duck.ai settings page"
+msgid ""
+"All chats are anonymized by DuckDuckGo, and your conversations are not used "
+"to train chat models by DuckDuckGo or the model providers"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1928,6 +1943,13 @@ msgid "Anonymous location enabled"
 msgstr "Ubicación anónima activada"
 
 # smartling.placeholder_format=C
+msgctxt "settings"
+msgid ""
+"Anonymously generates answers for search queries based on web content. "
+"Choose how often you want it to appear, or disable it completely."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Instant Answer tab name
 msgid "Answer"
 msgstr "Respuesta"
@@ -2072,19 +2094,22 @@ msgstr "¿Sigues ahí?"
 msgctxt "Body text for clear all chats confirmation modal"
 msgid ""
 "Are you sure you want to clear all of your chats? This cannot be undone."
-msgstr "¿Seguro que quieres borrar todos tus chats? Esta acción no se puede deshacer."
+msgstr ""
+"¿Seguro que quieres borrar todos tus chats? Esta acción no se puede deshacer."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that asks the user if they want to clear the conversation.
 msgctxt "Modal body for clearing conversation"
 msgid "Are you sure you want to clear this conversation and start a new one?"
-msgstr "¿Estás seguro de que quieres eliminar esta conversación y empezar una nueva?"
+msgstr ""
+"¿Estás seguro de que quieres eliminar esta conversación y empezar una nueva?"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to delete their current chat, explaining that this action cannot be undone.
 msgctxt "Body text for delete chat confirmation modal"
 msgid "Are you sure you want to delete this chat? This cannot be undone."
-msgstr "¿Seguro que quieres borrar este chat? Esta acción no se puede deshacer."
+msgstr ""
+"¿Seguro que quieres borrar este chat? Esta acción no se puede deshacer."
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to disable chat history, with a warning that it will also delete currently saved chats including pinned chats.
@@ -2205,6 +2230,12 @@ msgstr "Haz una pregunta de seguimiento"
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse
 msgid "Ask a follow-up with Duck.ai"
 msgstr "Solicita un seguimiento con Duck.ai"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
+msgctxt "Page suggestion chip label"
+msgid "Ask about this page"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2626,6 +2657,12 @@ msgid "Barcode"
 msgstr "Código de barras"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Based on this page, is this course worth taking?"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Basic"
 msgstr "Básico"
@@ -2664,6 +2701,14 @@ msgstr "Bateador"
 msgctxt "Assistant response placeholder"
 msgid "Before continuing..."
 msgstr "Antes de continuar..."
+
+# smartling.placeholder_format=C
+#. Explains that before storing the report, DuckDuckGo will anonymize the conversation by removing PII like names, email addresses, and identifying metadata.
+msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
+msgid ""
+"Before storing this report, DuckDuckGo will anonymize your conversation by "
+"removing PII like names, email addresses, and identifying metadata."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -2980,6 +3025,12 @@ msgstr "Brasil"
 msgctxt "Sports module"
 msgid "Break Points Won"
 msgstr "Puntos de quiebre ganados"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Break this down into clear, numbered steps."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -3433,6 +3484,12 @@ msgstr "Oportunidades de trabajo"
 msgctxt "Movie/TV Show Title instant answer"
 msgid "Cast"
 msgstr "Reparto"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Cast & Crew"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -4290,7 +4347,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click %sPrivacy and Services%s in the left sidebar."
-msgstr "Pulsa %1$sPrivacidad y servicios%2$s en la barra lateral de la izquierda."
+msgstr ""
+"Pulsa %1$sPrivacidad y servicios%2$s en la barra lateral de la izquierda."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -4317,7 +4375,8 @@ msgstr "Haz clic en %1$sAjustes%2$s en el menú desplegable."
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
-msgstr "Pulsa %1$sUse las actuales páginas%2$s y, a continuación, %3$sAceptar%4$s."
+msgstr ""
+"Pulsa %1$sUse las actuales páginas%2$s y, a continuación, %3$sAceptar%4$s."
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -4450,7 +4509,8 @@ msgstr "Haz clic en el %1$sicono de permisos%2$s en la barra de direcciones"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to search using DuckDuckGo.
 msgid "Click the Duck icon at the top of your browser to search!"
-msgstr "¡Pulsa el icono del pato en la parte superior del navegador para buscar!"
+msgstr ""
+"¡Pulsa el icono del pato en la parte superior del navegador para buscar!"
 
 #  UC Browser on Android
 # smartling.placeholder_format=C
@@ -5038,7 +5098,8 @@ msgstr "Copiar"
 # smartling.placeholder_format=C
 #. Instructions on how to change the default search engine
 msgid "Copy &amp; paste %sabout:preferences#search%s into the address bar"
-msgstr "Copia y pega %1$sabout:preferences#search%2$s en la barra de direcciones"
+msgstr ""
+"Copia y pega %1$sabout:preferences#search%2$s en la barra de direcciones"
 
 # smartling.placeholder_format=C
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
@@ -5154,6 +5215,12 @@ msgstr "Crear imagen"
 msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr "Crear imagen"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Create a shopping list with quantities from this recipe."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed in the input field when starting a new image generation session.
@@ -5679,7 +5746,8 @@ msgstr "¿Borrar los chats más antiguos para liberar espacio de almacenamiento?
 #. Title shown when user has reached the file storage sync quota (5GB).
 msgctxt "Sync file storage limit modal title"
 msgid "Delete oldest chats with attachments to free up storage?"
-msgstr "¿Eliminar los chats más antiguos con archivos adjuntos para liberar espacio?"
+msgstr ""
+"¿Eliminar los chats más antiguos con archivos adjuntos para liberar espacio?"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to delete all recent chats.
@@ -5788,12 +5856,18 @@ msgstr "Dictado en Duck.ai"
 # smartling.placeholder_format=C
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
-msgstr "Anonimizamos el dictado y nunca lo utilizamos para entrenar modelos de IA."
+msgstr ""
+"Anonimizamos el dictado y nunca lo utilizamos para entrenar modelos de IA."
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
 msgid "Dictation limit reached"
 msgstr "Se ha alcanzado el límite de dictado"
+
+# smartling.placeholder_format=C
+#. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
+msgid "Dictation temporarily unavailable"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
@@ -6096,6 +6170,22 @@ msgid "Done"
 msgstr "Hecho"
 
 # smartling.placeholder_format=C
+#. Message shown in a modal after DuckDuckGo browser users disable AI features in Settings. The first two placeholders bold noai.duckduckgo.com. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
+"filtered out. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
+"and AI images filtered out. %sLearn more%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Double Faults"
@@ -6210,6 +6300,18 @@ msgstr ""
 "Redacta un correo electrónico conciso y detallado para un proveedor "
 "solicitando un presupuesto para los servicios de reparación de "
 "refrigeradores domésticos."
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Draft a cover letter"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Draft a cover letter for this job."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -6387,7 +6489,17 @@ msgstr ""
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
-msgstr "¡Duck.ai es mejor en nuestro navegador privado y gratuito de DuckDuckGo!"
+msgstr ""
+"¡Duck.ai es mejor en nuestro navegador privado y gratuito de DuckDuckGo!"
+
+# smartling.placeholder_format=C
+#. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
+msgctxt "About section description on the Duck.ai settings page"
+msgid ""
+"Duck.ai is created by DuckDuckGo. We're an independent online protection "
+"company for anyone who wants to take back control of their personal "
+"information."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
@@ -6434,7 +6546,15 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
-msgstr "Duck.ai no está disponible temporalmente. Inténtalo de nuevo más tarde."
+msgstr ""
+"Duck.ai no está disponible temporalmente. Inténtalo de nuevo más tarde."
+
+# smartling.placeholder_format=C
+msgctxt "settings"
+msgid ""
+"Duck.ai lets you chat privately with popular AI models. Disabling it hides "
+"Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -7356,7 +7476,8 @@ msgstr "Asegúrate de que tu navegador tenga permitido el acceso a la ubicación
 #. Tells how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed location access."
-msgstr "Asegúrate de que tu navegador tenga permitido el acceso a la ubicación."
+msgstr ""
+"Asegúrate de que tu navegador tenga permitido el acceso a la ubicación."
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -7444,11 +7565,24 @@ msgstr "Guinea Ecuatorial"
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Erase your browsing data in a flash with our %sFire Button%s"
-msgstr "Borra tus datos de navegación en un instante con nuestro %1$sFire Button%2$s"
+msgstr ""
+"Borra tus datos de navegación en un instante con nuestro %1$sFire Button%2$s"
 
 # smartling.placeholder_format=C
 msgid "Eritrea"
 msgstr "Eritrea"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Estimate the nutrition"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Estimate the nutritional information for this recipe."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Estonia"
@@ -7507,6 +7641,12 @@ msgid "Expires in 1 day"
 msgstr "Caduca en 1 día"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain the accepted answer in simple terms."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
@@ -7514,6 +7654,48 @@ msgid ""
 msgstr ""
 "Explícame los conceptos fundamentales de los agujeros negros a nivel de "
 "educación secundaria."
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain the top answer"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this in simple, plain language."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this paper"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this repo"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this research paper in plain language."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this simply"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain what this repository does and how to use it."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label to show if song lyrics contain explicit content
@@ -7537,7 +7719,8 @@ msgstr "Letras explícitas"
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
-msgstr "Explora las últimas actualizaciones de productos y funciones de DuckDuckGo."
+msgstr ""
+"Explora las últimas actualizaciones de productos y funciones de DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Links to a page that provides a list of DuckDuckGo product updates
@@ -7802,6 +7985,12 @@ msgstr ""
 "imágenes. %1$sMás información%2$s"
 
 # smartling.placeholder_format=C
+msgctxt "settings"
+msgid ""
+"Filters out known AI spam sites from image search results. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the final score of a sporting event.
 msgid "Final"
 msgstr "Final"
@@ -7828,7 +8017,8 @@ msgstr "Asesor financiero"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Find %sDuckDuckGo%s and click%sMake default%s"
-msgstr "Busca %1$sDuckDuckGo%2$s y haz clic en %3$sEstablecer como predeterminado%4$s"
+msgstr ""
+"Busca %1$sDuckDuckGo%2$s y haz clic en %3$sEstablecer como predeterminado%4$s"
 
 # smartling.placeholder_format=C
 #. Sentence shown after export, includes a placeholder for one or more filenames with bold formatting for the filename(s).
@@ -7855,6 +8045,12 @@ msgstr "Encuentra una palabra mejor"
 msgctxt "Subtitle for the Web Search tool entry in the Tools dropdown menu"
 msgid "Find current information"
 msgstr "Busca información actualizada"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Find me alternatives"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button that searches for results closer to the user's current location.
@@ -8052,7 +8248,8 @@ msgstr "Chats gratuitos y privados, anonimizados por nosotros"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr "Chats gratuitos y privados, anonimizados por nosotros. No se requiere cuenta."
+msgstr ""
+"Chats gratuitos y privados, anonimizados por nosotros. No se requiere cuenta."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -8082,7 +8279,8 @@ msgstr "Libre de compartir y usar comercialmente"
 #. Description text explaining how to free up sync storage. Pinned chats are chats the user has explicitly marked to keep.
 msgctxt "Sync limit modal description"
 msgid "Free up space by deleting your chats. Pinned chats will not be deleted."
-msgstr "Libera espacio eliminando tus chats. Los chats anclados no se eliminarán."
+msgstr ""
+"Libera espacio eliminando tus chats. Los chats anclados no se eliminarán."
 
 # smartling.placeholder_format=C
 #. Indicates that this streaming service is free to watch but shows ads
@@ -8163,9 +8361,9 @@ msgid ""
 "<strong>Check for Updates...</strong>, then select <strong>Install Update</"
 "strong>."
 msgstr ""
-"En la barra de menú de la aplicación en Mac, selecciona "
-"<strong>DuckDuckGo</strong> &gt; <strong>Buscar actualizaciones...</strong> "
-"y, a continuación, selecciona <strong>Instalar actualización</strong>."
+"En la barra de menú de la aplicación en Mac, selecciona <strong>DuckDuckGo</"
+"strong> &gt; <strong>Buscar actualizaciones...</strong> y, a continuación, "
+"selecciona <strong>Instalar actualización</strong>."
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -8331,6 +8529,12 @@ msgstr "Generar imagen"
 #. Text for the button that generates more of an answer from duckassist when the answer has come from a collapsed state
 msgid "Generate More"
 msgstr "Genera más"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Generate a shopping list"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
@@ -8624,6 +8828,12 @@ msgstr "Pruébalo"
 msgctxt "Onboarding welcome screen button text"
 msgid "Give it a Try"
 msgstr "Pruébalo"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Give me a quick background on this person."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9072,6 +9282,18 @@ msgid "Help Spread Privacy"
 msgstr "Ayuda a difundir la privacidad"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Help me prep for the interview"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Help me tailor my resume for this job."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title of a SERP popup that invites users to take a survey (desktop only)
 msgctxt "User survey popup"
 msgid "Help us improve DuckDuckGo"
@@ -9429,7 +9651,8 @@ msgstr "Falta el horario"
 #. This is the name of a user setting
 msgctxt "settings"
 msgid "Hover, Module, and Dropdown Background Color"
-msgstr "Color de fondo al pasar el cursor, de los módulos y de los desplegables"
+msgstr ""
+"Color de fondo al pasar el cursor, de los módulos y de los desplegables"
 
 # smartling.placeholder_format=C
 #. Label for a pill-shaped tab below the empty-state Duck.ai chat input. Clicking it opens a panel that explains how Duck.ai protects user privacy.
@@ -9514,13 +9737,15 @@ msgstr "Cómo funciona"
 #. Header for the assist settings modal where the user can choose how often they want AI-assisted answers to appear.
 msgctxt "duckassist"
 msgid "How much do you want AI-assisted answers to appear?"
-msgstr "¿Con qué frecuencia quieres que aparezcan las respuestas asistidas por IA?"
+msgstr ""
+"¿Con qué frecuencia quieres que aparezcan las respuestas asistidas por IA?"
 
 # smartling.placeholder_format=C
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
 msgctxt "Duck.ai settings usage section"
 msgid "How much of your daily and weekly limits you've used so far."
-msgstr "Qué parte de tus límites diarios y semanales has utilizado hasta ahora."
+msgstr ""
+"Qué parte de tus límites diarios y semanales has utilizado hasta ahora."
 
 # smartling.placeholder_format=C
 #. A header for the feedback form in the assist negative feedback flow. The user is being asked to update how often they want AI-assisted answers to appear.
@@ -9587,6 +9812,14 @@ msgstr "Huracán"
 msgctxt "Onboarding terms screen button text"
 msgid "I Agree"
 msgstr "De acuerdo"
+
+# smartling.placeholder_format=C
+#. Text for the button that takes the user to the external DuckDuckGo login subscription page.
+msgctxt ""
+"Text for the I already have a subscription button in the Duck.ai settings "
+"page"
+msgid "I Already Have a Subscription"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the button that takes the user to the login subscription page.
@@ -9767,7 +10000,8 @@ msgstr ""
 msgid ""
 "If you want to use DuckDuckGo without JavaScript, please use our %s or %s "
 "versions."
-msgstr "Si quieres usar DuckDuckGo sin JavaScript, usa nuestra versión %1$s o %2$s."
+msgstr ""
+"Si quieres usar DuckDuckGo sin JavaScript, usa nuestra versión %1$s o %2$s."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -9814,8 +10048,8 @@ msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
 msgstr ""
-"Las indicaciones para las imágenes deben cumplir con las directrices de "
-"Duck.ai %1$s."
+"Las indicaciones para las imágenes deben cumplir con las directrices de Duck."
+"ai %1$s."
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -10169,6 +10403,12 @@ msgid "Install Mac Browser"
 msgstr "Instalar navegador Mac"
 
 # smartling.placeholder_format=C
+#. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
+msgctxt "settings"
+msgid "Install Now"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of a button to install the DuckDuckGo app
 msgctxt "Serp footer content"
 msgid "Install Our App"
@@ -10266,10 +10506,42 @@ msgid "Is deleted data really deleted?"
 msgstr "¿Se borran realmente los datos eliminados?"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is it worth taking?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this place any good?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"Is this place any good? Summarize its reputation based on reviews and "
+"ratings."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "Is this video helpful?"
 msgstr "¿Es útil este vídeo?"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this worth watching?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Is this worth watching? Give me a spoiler-free take."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -10691,7 +10963,8 @@ msgstr "Obtén más información sobre la protección de privacidad activa"
 # smartling.placeholder_format=C
 msgctxt "showcase_newsletter"
 msgid "Learn about online privacy right in your inbox."
-msgstr "Más información sobre la privacidad en Internet en tu bandeja de entrada."
+msgstr ""
+"Más información sobre la privacidad en Internet en tu bandeja de entrada."
 
 # smartling.placeholder_format=C
 #. Link to a page with more information about how DuckDuckGo settings are managed.
@@ -10883,6 +11156,12 @@ msgstr "Fuente para enlaces:"
 #. https://duckduckgo.com/params under "Color Settings"
 msgid "Links:"
 msgstr "Enlaces:"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "List the tools, materials, or prerequisites I need for this."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -11291,6 +11570,12 @@ msgstr "Administra tu suscripción"
 msgctxt "Exclusion message manage sites button"
 msgid "Manage blocked sites"
 msgstr "Gestionar sitios bloqueados"
+
+# smartling.placeholder_format=C
+#. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
+msgctxt "setting"
+msgid "Manage in Browser Settings"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to the site exclusion settings page
@@ -14131,8 +14416,15 @@ msgstr ""
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
+msgid "Please describe why the chat response is harmful or illegal. (optional)"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
+msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
-msgstr "Describe por qué la respuesta del chat es ilegal o perjudicial. (Opcional)"
+msgstr ""
+"Describe por qué la respuesta del chat es ilegal o perjudicial. (Opcional)"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to enter their passphrase.
@@ -14155,6 +14447,14 @@ msgid ""
 msgstr ""
 "Ten en cuenta que si inicias un nuevo chat con cualquier modelo, se borrará "
 "tu sesión de chat actual."
+
+# smartling.placeholder_format=C
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
+msgctxt "Feedback prompt"
+msgid ""
+"Please paste your prompt and the problematic output (with any personal "
+"information removed) and describe why the content is harmful or illegal."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -14624,6 +14924,12 @@ msgid "Privacy"
 msgstr "Privacidad"
 
 # smartling.placeholder_format=C
+#. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
+msgctxt "Section heading on the Duck.ai settings page"
+msgid "Privacy & Terms"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Privacy Blog"
 msgstr "Blog sobre privacidad"
 
@@ -14692,6 +14998,12 @@ msgstr "Política de privacidad y condiciones de uso"
 msgctxt "Copy used to compose link in sentences"
 msgid "Privacy Policy and Terms of Service"
 msgstr "Política de privacidad y condiciones del servicio"
+
+# smartling.placeholder_format=C
+#. Text for a button that links to the terms of use and privacy policy page.
+msgctxt "Secondary button text in active privacy modal"
+msgid "Privacy Policy and Terms of Service"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title displayed on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
@@ -14865,7 +15177,8 @@ msgstr "Pedir confirmación"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Prompt me to use my approximate location to get nearby results."
-msgstr "Pedirme utilizar mi ubicación aproximada para obtener mejores resultados."
+msgstr ""
+"Pedirme utilizar mi ubicación aproximada para obtener mejores resultados."
 
 # smartling.placeholder_format=C
 #. DuckDuckGo Email Protection removes trackers from emails
@@ -15192,6 +15505,30 @@ msgstr "Recetas de %1$s%2$s%3$s"
 msgctxt "Brief for recommending a book"
 msgid "Recommend a book"
 msgstr "Recomendar un libro"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar books"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar books."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar movies or shows."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar titles"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
@@ -15596,6 +15933,15 @@ msgid "Republic of Moldova"
 msgstr "República de Moldavia"
 
 # smartling.placeholder_format=C
+#. Note indicating that sharing the conversation is mandatory when reporting harmful or illegal content. Rendered alongside the standard share label (DUCKCHAT_RESPONSE_FEEDBACK_SHARE_PROMPT_RESPONSE_LABEL), not replacing it.
+msgctxt ""
+"Note shown under the share-content switch label on the Duck.ai response "
+"feedback form when the user has selected Harmful or Illegal as the feedback "
+"reason"
+msgid "Required for harmful or illegal reports"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
 msgctxt "Description for extended reasoning mode in Duck.ai"
 msgid "Researches before responding"
@@ -15831,6 +16177,12 @@ msgstr "Reseñas"
 msgctxt "maps_places"
 msgid "Reviews"
 msgstr "Reseñas"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Rewrite this recipe scaled for a different number of servings."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Romania"
@@ -16109,7 +16461,8 @@ msgstr ""
 #. Short text for native DDG browser users explaining how Chat History stores up to 30 of their most recent chats locally on their device.
 msgctxt "Short description for Chat History feature on native DDG browsers"
 msgid "Save up to 30 of your most recent chats locally on your device."
-msgstr "Guarda hasta 30 de tus chats más recientes localmente en tu dispositivo."
+msgstr ""
+"Guarda hasta 30 de tus chats más recientes localmente en tu dispositivo."
 
 # smartling.placeholder_format=C
 #. Desktop/mobile intro modal body under the title per Sync Chats Figma (choose step).
@@ -16617,7 +16970,8 @@ msgstr "Semanas de la temporada"
 #. Description shown in the Sync & Backup settings section when sync is not yet enabled, explaining the feature.
 msgctxt "Description for sync and backup feature"
 msgid "Securely save and sync your chats across all your devices."
-msgstr "Guarda y sincroniza tus chats de forma segura en todos tus dispositivos."
+msgstr ""
+"Guarda y sincroniza tus chats de forma segura en todos tus dispositivos."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -16834,7 +17188,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
-msgstr "Selecciona %1$sDuckDuckGo%2$s y pulsa %3$sAgregar como predeterminado%4$s."
+msgstr ""
+"Selecciona %1$sDuckDuckGo%2$s y pulsa %3$sAgregar como predeterminado%4$s."
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
@@ -16933,7 +17288,8 @@ msgstr "Selecciona %1$sMotor de búsqueda%2$s"
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"
-msgstr "Selecciona %1$sMotor de búsqueda%2$s y, a continuación, %3$sOtros...%4$s"
+msgstr ""
+"Selecciona %1$sMotor de búsqueda%2$s y, a continuación, %3$sOtros...%4$s"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -16958,7 +17314,8 @@ msgstr "Selecciona %1$sAjustes%2$s en el menú desplegable."
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sAdvanced settings%s"
-msgstr "Selecciona %1$sAjustes%2$s y, a continuación, %3$sAjustes avanzados%4$s"
+msgstr ""
+"Selecciona %1$sAjustes%2$s y, a continuación, %3$sAjustes avanzados%4$s"
 
 # smartling.placeholder_format=C
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -16973,7 +17330,8 @@ msgstr ""
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sSearch Engine%s"
-msgstr "Selecciona %1$sAjustes%2$s y, a continuación, %3$sMotor de búsqueda%4$s"
+msgstr ""
+"Selecciona %1$sAjustes%2$s y, a continuación, %3$sMotor de búsqueda%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -17186,6 +17544,12 @@ msgid "Set Up Now"
 msgstr "Configura ahora"
 
 # smartling.placeholder_format=C
+#. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
+msgctxt "Encrypted storage setup button shown in native browsers"
+msgid "Set Up Sync & Backup"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
 msgctxt "Title for the Sync & Backup intro screen"
 msgid "Set Up Sync & Backup"
@@ -17365,6 +17729,13 @@ msgstr "Compartir URL de la página"
 msgctxt "feedback form"
 msgid "Share positive feedback"
 msgstr "Compartir comentarios positivos"
+
+# smartling.placeholder_format=C
+#. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
+msgctxt ""
+"Label beside the share-content switch on the Duck.ai response feedback form"
+msgid "Share this conversation with DuckDuckGo"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -17622,7 +17993,8 @@ msgstr "Mostrar todos los resultados"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show answers more often. (You can also %sturn them off%s.)"
-msgstr "Mostrar respuestas con más frecuencia. (También puedes %1$sapagarlas%2$s.)"
+msgstr ""
+"Mostrar respuestas con más frecuencia. (También puedes %1$sapagarlas%2$s.)"
 
 # smartling.placeholder_format=C
 #. Accessible label for the button that reveals a popover listing multiple citation sources in Duck.ai chat responses.
@@ -17774,7 +18146,8 @@ msgstr "Muestra recordatorios ocasionales para añadir DuckDuckGo al navegador"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr "Muestra recordatorios ocasionales para añadir DuckDuckGo a tus dispositivos"
+msgstr ""
+"Muestra recordatorios ocasionales para añadir DuckDuckGo a tus dispositivos"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -17787,7 +18160,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows page numbers at result page breaks"
-msgstr "Muestra los números de página en los saltos de página de los resultados"
+msgstr ""
+"Muestra los números de página en los saltos de página de los resultados"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -17800,7 +18174,8 @@ msgstr ""
 #. http://i.imgur.com/94erFcS.png
 msgctxt "settings"
 msgid "Shows suggestions under the search box as you type"
-msgstr "Muestra sugerencias debajo del cuadro de búsqueda a medida que escribes"
+msgstr ""
+"Muestra sugerencias debajo del cuadro de búsqueda a medida que escribes"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -17905,7 +18280,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Sites you block will be hidden from all your search results"
-msgstr "Los sitios que bloquees se ocultarán de todos tus resultados de búsqueda"
+msgstr ""
+"Los sitios que bloquees se ocultarán de todos tus resultados de búsqueda"
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes full name (tooltip)
@@ -18099,7 +18475,8 @@ msgstr "Lo sentimos, se ha producido un error inesperado."
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
 msgid "Sorry, no relevant information was found in our search."
-msgstr "Lo sentimos, no se ha encontrado información relevante en nuestra búsqueda."
+msgstr ""
+"Lo sentimos, no se ha encontrado información relevante en nuestra búsqueda."
 
 # smartling.placeholder_format=C
 #. Indicates that there were no search results for a user's search.
@@ -18460,7 +18837,8 @@ msgstr "Detén a los rastreadores ocultos que acechan en otros sitios web."
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop most hidden trackers lurking on other websites."
-msgstr "Detén a la mayoría de rastreadores ocultos que acechan en otros sitios web."
+msgstr ""
+"Detén a la mayoría de rastreadores ocultos que acechan en otros sitios web."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18630,6 +19008,24 @@ msgid "Suggest a title for a blog post"
 msgstr "Sugerir un título para una publicación de blog"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest related articles or topics worth exploring next."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Suggest related articles to explore"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest some alternatives to this product."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
 msgctxt "directions"
 msgid "Suggestions:"
@@ -18641,10 +19037,100 @@ msgid "Suggestions:"
 msgstr "Sugerencias:"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Sum up the reviews"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A short title for the a message asking the AI to summarize a text.
 msgctxt "Title for the summarize message"
 msgid "Summarize"
 msgstr "Resumir"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize the Q&As"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the background and notable work of this person."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the key details of this event."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the questions and answers on this page."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize their background"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this book"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this book."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this discussion"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this discussion thread."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this page"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this page."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this video"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this video."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize what the reviews say."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -18940,7 +19426,8 @@ msgstr "Sincronizar con otro dispositivo"
 #. Title shown when sync service is temporarily unavailable.
 msgctxt "Sync unavailable modal title"
 msgid "Sync and Backup is temporarily unavailable"
-msgstr "La sincronización y la copia de seguridad no están disponibles temporalmente"
+msgstr ""
+"La sincronización y la copia de seguridad no están disponibles temporalmente"
 
 # smartling.placeholder_format=C
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
@@ -18971,6 +19458,12 @@ msgid "Syria"
 msgstr "Siria"
 
 # smartling.placeholder_format=C
+#. Text for a button that enables the theme to follow the operating system's color scheme preference.
+msgctxt "System theme button for theme selector"
+msgid "System"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Abbreviation indicating this is the total score for a game
 msgctxt "Sports module"
 msgid "T"
@@ -18997,6 +19490,12 @@ msgstr "Televisión"
 msgctxt "language_name"
 msgid "Tahitian"
 msgstr "Tahitiano"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Tailor my resume"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Taiwan"
@@ -19026,6 +19525,13 @@ msgstr "Toma el control de tus datos personales"
 msgctxt "homepage ATB modal"
 msgid "Take control of your personal data!"
 msgstr "Toma el control de tus datos personales"
+
+# smartling.placeholder_format=C
+#. Description for the Feedback section of the Duck.ai settings page, asking the user to take an anonymous survey to let us know how we can make Duck.ai better.
+msgctxt "Feedback section description on the Duck.ai settings page"
+msgid ""
+"Take this anonymous survey to let us know how we can make Duck.ai better."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -19333,6 +19839,12 @@ msgid "Theme"
 msgstr "Tema"
 
 # smartling.placeholder_format=C
+#. Text for the theme selector label that allows users to switch between Light and dark theme.
+msgctxt "Label for the theme selector feature"
+msgid "Theme"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. http://i.imgur.com/LpFhb1e.png
 msgctxt "settings"
 msgid "Theme"
@@ -19384,7 +19896,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Error message for explore more questions when a retryable error occurs (timeout, network)
 msgid "There's been an issue loading this answer. Please try again."
-msgstr "Se ha producido un problema al cargar esta respuesta. Inténtalo de nuevo."
+msgstr ""
+"Se ha producido un problema al cargar esta respuesta. Inténtalo de nuevo."
 
 # smartling.placeholder_format=C
 #. Instant Answer Tab Name
@@ -19522,13 +20035,15 @@ msgstr ""
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
-msgstr "Este archivo es demasiado grande. El tamaño máximo del archivo es de %1$s MB"
+msgstr ""
+"Este archivo es demasiado grande. El tamaño máximo del archivo es de %1$s MB"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB."
-msgstr "Este archivo es demasiado grande. El tamaño máximo del archivo es de %1$s MB."
+msgstr ""
+"Este archivo es demasiado grande. El tamaño máximo del archivo es de %1$s MB."
 
 # smartling.placeholder_format=C
 #. Generic error message displayed when the user tries to upload an unsupported file type and we cannot determine the accepted types
@@ -19548,7 +20063,8 @@ msgctxt ""
 "Error message when an uploaded file type is not supported, with list ending "
 "in or"
 msgid "This file type is not supported, please attach a %s or %s"
-msgstr "Este tipo de archivo no es compatible, por favor adjunta un %1$s o %2$s"
+msgstr ""
+"Este tipo de archivo no es compatible, por favor adjunta un %1$s o %2$s"
 
 # smartling.placeholder_format=C
 #. Error message for unsupported file type when multiple types are accepted. First placeholder is a comma-separated list of all accepted types except the last (e.g. PNG, JPG, WebP, GIF). Second placeholder is the last accepted type (e.g. PDF). Full example: This file type is not supported, please attach a PNG, JPG, WebP, GIF or PDF
@@ -19556,7 +20072,8 @@ msgctxt ""
 "Error message when an uploaded file type is not supported, with list ending "
 "in or"
 msgid "This file type is not supported, please attach a %s or %s."
-msgstr "Este tipo de archivo no es compatible, por favor adjunta un %1$s o %2$s."
+msgstr ""
+"Este tipo de archivo no es compatible, por favor adjunta un %1$s o %2$s."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to upload an unsupported file type and we know which types are accepted. Placeholder is a single accepted type. E.g. This file type is not supported, please attach a PDF
@@ -19752,7 +20269,8 @@ msgstr ""
 #. Message explaining what will happen when the user deletes an image.
 msgctxt "Confirmation message in delete image modal"
 msgid "This will delete your selected image. This cannot be undone."
-msgstr "Esto eliminará tu imagen seleccionada. Esta acción no se puede deshacer."
+msgstr ""
+"Esto eliminará tu imagen seleccionada. Esta acción no se puede deshacer."
 
 # smartling.placeholder_format=C
 #. Confirmation message asking if the user is sure they want to reset all of their settings.
@@ -20159,7 +20677,8 @@ msgctxt "Full sentence for translating text"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr "Traduce esta frase del español al francés: «¿Cómo ir al cine más cercano?»"
+msgstr ""
+"Traduce esta frase del español al francés: «¿Cómo ir al cine más cercano?»"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for translating a sentence into another language. Translate the whole sentence and please use target language instead of 'English' and modify the sentence to translate into 'English' instead of 'French'. Example: 'Translate this {target language} sentence into English: “How do I get to the nearest movie theatre?”'
@@ -20167,7 +20686,20 @@ msgctxt "Full sentence for translating text prompt"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr "Traduce esta frase del español al inglés: «¿Cómo ir al cine más cercano?»"
+msgstr ""
+"Traduce esta frase del español al inglés: «¿Cómo ir al cine más cercano?»"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Translate this page"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
+msgctxt "Page suggestion prompt"
+msgid "Translate this page into %s."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder text for a region that will display translated text.
@@ -20311,6 +20843,12 @@ msgid "Try Free"
 msgstr "Prueba gratis"
 
 # smartling.placeholder_format=C
+#. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
+msgctxt "settings"
+msgid "Try It Now"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
 msgctxt "Promotional CTA for new AI models"
 msgid "Try Now"
@@ -20374,14 +20912,16 @@ msgstr ""
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
 msgctxt "precise_user_location"
 msgid "Try enabling anonymous location for more accurate results."
-msgstr "Prueba a activar la ubicación anónima para obtener resultados más precisos."
+msgstr ""
+"Prueba a activar la ubicación anónima para obtener resultados más precisos."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the screen of the onboarding where the user picks a chat model.
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr "Intenta experimentar con cada modelo, ya que ofrecerán diferentes respuestas."
+msgstr ""
+"Intenta experimentar con cada modelo, ya que ofrecerán diferentes respuestas."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
@@ -20511,13 +21051,15 @@ msgstr "Prueba %1$s y %2$s de código abierto recientemente añadidos"
 #. Text for a promotional card that encourages users to try the recently added open-source AI models Llama 3.1 and Mixtral.
 msgctxt "Promotional text for new AI models"
 msgid "Try the recently added open-source Llama 3.1 and Mixtral"
-msgstr "Prueba los recientemente añadidos de código abierto Llama 3.1 y Mixtral"
+msgstr ""
+"Prueba los recientemente añadidos de código abierto Llama 3.1 y Mixtral"
 
 # smartling.placeholder_format=C
 #. Message displayed to suggest the user to try the provided prompts or enter their own.
 msgctxt "Prompt suggestion message"
 msgid "Try these prompts to get started or enter your own prompt below"
-msgstr "Prueba uno de estos mensajes o introduce tu propio mensaje a continuación"
+msgstr ""
+"Prueba uno de estos mensajes o introduce tu propio mensaje a continuación"
 
 # smartling.placeholder_format=C
 #. Description for the empty state displayed when searching recent chats in Duck.ai returns no results, suggesting the user rephrase their search query.
@@ -20543,6 +21085,22 @@ msgstr "Prueba con: %1$s"
 msgctxt "new user poll"
 msgid "Trying DuckDuckGo again"
 msgstr "Estoy probando DuckDuckGo de nuevo"
+
+# smartling.placeholder_format=C
+#. Message shown in a modal after supported third-party browser users disable AI features in Settings. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -20860,7 +21418,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sOpen with%s select %sA specific page or pages%s"
-msgstr "En %1$sAbrir con%2$s, selecciona %3$sUna o varias páginas específicas%4$s"
+msgstr ""
+"En %1$sAbrir con%2$s, selecciona %3$sUna o varias páginas específicas%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -21034,7 +21593,8 @@ msgctxt ""
 "Text shown in the subscription promo card, with a trailing call-to-action "
 "link."
 msgid "Unlock more capable AI models with a DuckDuckGo subscription. %s"
-msgstr "Desbloquea modelos de IA más capaces con una suscripción a DuckDuckGo. %1$s"
+msgstr ""
+"Desbloquea modelos de IA más capaces con una suscripción a DuckDuckGo. %1$s"
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to unmute the microphone.
@@ -21296,6 +21856,12 @@ msgstr "Urdu"
 # smartling.placeholder_format=C
 msgid "Uruguay"
 msgstr "Uruguay"
+
+# smartling.placeholder_format=C
+#. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
+msgctxt "Navigation label on the Duck.ai settings page"
+msgid "Usage"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -21576,7 +22142,8 @@ msgctxt "mobile promotion on desktop"
 msgid ""
 "Visit %sDuckDuckGo.com%s on your tablet or phone and follow the provided "
 "instructions."
-msgstr "Visita %1$sDuckDuckGo.com%2$s en tu móvil o tablet y sigue las instrucciones."
+msgstr ""
+"Visita %1$sDuckDuckGo.com%2$s en tu móvil o tablet y sigue las instrucciones."
 
 # smartling.placeholder_format=C
 #. Primary button to visit Duck.ai.
@@ -21745,6 +22312,12 @@ msgid "Wales"
 msgstr "Gales"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Walk me through the steps"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for walking directions on a map.
 msgctxt "directions"
 msgid "Walking"
@@ -21864,6 +22437,17 @@ msgstr ""
 "precisos."
 
 # smartling.placeholder_format=C
+#. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
+msgctxt ""
+"Inline warning shown below the share-content toggle when the user selects "
+"Harmful or Illegal but has not enabled sharing"
+msgid ""
+"We can only fix what we can see. To report a harmful or illegal response, "
+"please share this conversation with DuckDuckGo so we can investigate and "
+"address the issue."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
 msgctxt ""
 "Inline warning shown below the share-content toggle when the user selects "
@@ -21903,7 +22487,8 @@ msgstr "No te perseguimos con anuncios."
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
 msgid "We don't store usernames or any personally identifiable information."
-msgstr "No almacenamos nombres de usuario ni información personal identificable."
+msgstr ""
+"No almacenamos nombres de usuario ni información personal identificable."
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -22062,12 +22647,14 @@ msgstr ""
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
-msgstr "Confiamos en tus comentarios anónimos para mejorar DuckDuckGo para todos."
+msgstr ""
+"Confiamos en tus comentarios anónimos para mejorar DuckDuckGo para todos."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We stop anyone from getting your search history, including us."
-msgstr "Impedimos que nadie acceda a tu historial de búsquedas, ni siquiera nosotros."
+msgstr ""
+"Impedimos que nadie acceda a tu historial de búsquedas, ni siquiera nosotros."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -22295,7 +22882,8 @@ msgstr ""
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai, it's time to import your chats"
-msgstr "¡Te damos la bienvenida al nuevo Duck.ai! Es hora de importar tus chats."
+msgstr ""
+"¡Te damos la bienvenida al nuevo Duck.ai! Es hora de importar tus chats."
 
 # smartling.placeholder_format=C
 #. Welcome message for new DuckDuckGo users.
@@ -22336,7 +22924,8 @@ msgstr "Conferencia Oeste"
 #. Inform the users that "something" went wrong and we are unable to show any results.
 msgctxt "noresults"
 msgid "We’re currently experiencing an issue with DuckDuckGo Search."
-msgstr "En estos momentos, estamos experimentando un problema con DuckDuckGo Search."
+msgstr ""
+"En estos momentos, estamos experimentando un problema con DuckDuckGo Search."
 
 # smartling.placeholder_format=C
 #. Inform the users that "something" went wrong even though we were able to show some organic results.
@@ -22425,6 +23014,103 @@ msgstr ""
 "integraciones de Duck.ai y las protecciones de privacidad. Que sea breve, "
 "sencillo y fácil de entender para personas con o sin mucha experiencia en "
 "inteligencia artificial o conocimientos técnicos."
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the counterarguments?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the hours & location?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key contributions of this paper?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key contributions?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key details?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key points covered in this video?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key points?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key takeaways from this article?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key takeaways?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key things I will learn from this course?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main counterarguments or criticisms of this?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main questions this page answers?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the must-try dishes here?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"What are the opening hours, location, and contact details for this place?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the pros and cons of this product?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the pros and cons?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
@@ -22527,6 +23213,12 @@ msgid "What does atria mean in the context of a medical article?"
 msgstr "¿Qué significa aurícula en el contexto de un artículo médico?"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What does this answer?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
@@ -22537,6 +23229,12 @@ msgstr "¿Qué función te gustaría que añadiéramos? (opcional)"
 msgctxt "cloudsave"
 msgid "What information gets saved?"
 msgstr "¿Qué información se guarda?"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What interview questions might come up for this role?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -22553,6 +23251,12 @@ msgstr ""
 msgctxt "Full sentence for looking up basic facts"
 msgid "What is the capital city of Albania?"
 msgstr "¿Cuál es la capital de Albania?"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What is the overall verdict and rating for this?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to a page with additional information.
@@ -22577,6 +23281,12 @@ msgid "What people say:"
 msgstr "Opiniones:"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What should I order?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
 msgctxt "feedback form"
 msgid "What stood out?"
@@ -22589,6 +23299,18 @@ msgid "What was wrong with the response? (optional)"
 msgstr "¿Qué ha fallado en la respuesta? (opcional)"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I learn?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I need?"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid "What would you like to provide feedback on?"
 msgstr "¿Sobre qué te gustaría dar tu opinión?"
@@ -22597,13 +23319,20 @@ msgstr "¿Sobre qué te gustaría dar tu opinión?"
 #. Explains the benefits of using our custom video player, the Duck Player
 msgid ""
 "What you watch in DuckDuckGo won't influence your recommendations on YouTube."
-msgstr "Lo que veas en DuckDuckGo no influirá en tus recomendaciones en YouTube."
+msgstr ""
+"Lo que veas en DuckDuckGo no influirá en tus recomendaciones en YouTube."
 
 # smartling.placeholder_format=C
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
 msgctxt "SERP footer content"
 msgid "What's New"
 msgstr "Novedades"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What's the verdict?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -22623,7 +23352,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "When enabled, Duck.ai will show instant answers in the chat."
-msgstr "Cuando esté activado, Duck.ai mostrará respuestas instantáneas en el chat."
+msgstr ""
+"Cuando esté activado, Duck.ai mostrará respuestas instantáneas en el chat."
 
 # smartling.placeholder_format=C
 #. Text of a button that performs a search for the available streaming services that show a particular movie or tv show
@@ -22641,7 +23371,8 @@ msgstr "Dónde ver <strong>%1$s</strong>"
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Where it says Homepage click %sSet to Current Page%s."
-msgstr "Donde pone Página de inicio pulsa en %1$sEstablecer como página actual%2$s."
+msgstr ""
+"Donde pone Página de inicio pulsa en %1$sEstablecer como página actual%2$s."
 
 # smartling.placeholder_format=C
 #. Heading of a module showing what streaming services are showing a movie or series, e.g. Where to Watch The Matrix
@@ -22654,6 +23385,12 @@ msgstr "Dónde ver <strong>%1$s</strong>"
 msgctxt "Feedback prompt"
 msgid "Which features are missing? (Optional)"
 msgstr "¿Qué funcionalidades faltan? (Opcional)"
+
+# smartling.placeholder_format=C
+#. An invitation for users to leave feedback
+msgctxt "Feedback prompt"
+msgid "Which features are missing? (optional)"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
@@ -22670,6 +23407,18 @@ msgstr "Blanco"
 #. Link to an about us page.
 msgid "Who We Are"
 msgstr "Quiénes somos"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Who are the main cast and crew, and what else are they known for?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Who is this person?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Header above a collection of privacy-related links.
@@ -23262,7 +24011,8 @@ msgstr "Puedes empezar de cero en este nuevo dominio (duck.ai)."
 #. Text explaining the benefits of the cloud save feature.
 msgctxt "cloudsave"
 msgid "You can store several sets of settings for different purposes."
-msgstr "Puedes almacenar varios conjuntos de ajustes para diferentes propósitos."
+msgstr ""
+"Puedes almacenar varios conjuntos de ajustes para diferentes propósitos."
 
 # smartling.placeholder_format=C
 #. Instructions for user once they've failed the bot challenge
@@ -23335,7 +24085,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
 msgid "You won't see this message again unless you clear your browser data."
-msgstr "No volverás a ver este mensaje a menos que borres los datos de tu navegador."
+msgstr ""
+"No volverás a ver este mensaje a menos que borres los datos de tu navegador."
 
 # smartling.placeholder_format=C
 #. The second paragraph of a pop up where we explain how to update the browser manually.
@@ -23428,12 +24179,14 @@ msgstr "Has alcanzado la duración máxima del chat de voz para una sola sesión
 msgctxt "voice chat limit modal"
 msgid ""
 "You've reached the voice chat limit for today. Please try again tomorrow."
-msgstr "Has alcanzado el límite de chat de voz para hoy. Inténtalo de nuevo mañana."
+msgstr ""
+"Has alcanzado el límite de chat de voz para hoy. Inténtalo de nuevo mañana."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
 msgid "You've reached your dictation usage limit. Try again later."
-msgstr "Has alcanzado tu límite de uso de dictado. Inténtalo de nuevo más tarde."
+msgstr ""
+"Has alcanzado tu límite de uso de dictado. Inténtalo de nuevo más tarde."
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.

--- a/locales/es_ES/LC_MESSAGES/duckduckgo.po
+++ b/locales/es_ES/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: es_ES\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -416,8 +416,7 @@ msgstr "%1$s palabras"
 #. Instructions on which buttons and options the user has to click in order to add the DuckDuckGo extension to their browser.
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
-msgstr ""
-"%1$sPulsa %2$sAñadir%3$sMarcar %4$sPermitir%5$s y luego %6$sAceptar%7$s"
+msgstr "%1$sPulsa %2$sAñadir%3$sMarcar %4$sPermitir%5$s y luego %6$sAceptar%7$s"
 
 # Firefox, obsolete
 # smartling.placeholder_format=C
@@ -1447,7 +1446,7 @@ msgstr "La dirección es incorrecta"
 #. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Adjust the servings"
-msgstr ""
+msgstr "Ajusta las porciones"
 
 # smartling.placeholder_format=C
 #. as in multiple advertisements
@@ -1669,6 +1668,9 @@ msgid ""
 "All chats are anonymized by DuckDuckGo, and your conversations are not used "
 "to train chat models by DuckDuckGo or the model providers"
 msgstr ""
+"Todos los chats son anonimizados por DuckDuckGo y tus conversaciones no son "
+"utilizadas para entrenar modelos de chat por DuckDuckGo o los proveedores de "
+"modelos"
 
 # smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1948,6 +1950,9 @@ msgid ""
 "Anonymously generates answers for search queries based on web content. "
 "Choose how often you want it to appear, or disable it completely."
 msgstr ""
+"Genera respuestas de forma anónima para consultas de búsqueda basadas en "
+"contenido web. Elige con qué frecuencia deseas que aparezca, o desactívalo "
+"por completo."
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -2094,22 +2099,19 @@ msgstr "¿Sigues ahí?"
 msgctxt "Body text for clear all chats confirmation modal"
 msgid ""
 "Are you sure you want to clear all of your chats? This cannot be undone."
-msgstr ""
-"¿Seguro que quieres borrar todos tus chats? Esta acción no se puede deshacer."
+msgstr "¿Seguro que quieres borrar todos tus chats? Esta acción no se puede deshacer."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that asks the user if they want to clear the conversation.
 msgctxt "Modal body for clearing conversation"
 msgid "Are you sure you want to clear this conversation and start a new one?"
-msgstr ""
-"¿Estás seguro de que quieres eliminar esta conversación y empezar una nueva?"
+msgstr "¿Estás seguro de que quieres eliminar esta conversación y empezar una nueva?"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to delete their current chat, explaining that this action cannot be undone.
 msgctxt "Body text for delete chat confirmation modal"
 msgid "Are you sure you want to delete this chat? This cannot be undone."
-msgstr ""
-"¿Seguro que quieres borrar este chat? Esta acción no se puede deshacer."
+msgstr "¿Seguro que quieres borrar este chat? Esta acción no se puede deshacer."
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to disable chat history, with a warning that it will also delete currently saved chats including pinned chats.
@@ -2235,7 +2237,7 @@ msgstr "Solicita un seguimiento con Duck.ai"
 #. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
 msgctxt "Page suggestion chip label"
 msgid "Ask about this page"
-msgstr ""
+msgstr "Pregunta sobre esta página"
 
 # smartling.placeholder_format=C
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2660,7 +2662,7 @@ msgstr "Código de barras"
 #. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Based on this page, is this course worth taking?"
-msgstr ""
+msgstr "Según esta página, ¿merece la pena que hagas este curso?"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2709,6 +2711,9 @@ msgid ""
 "Before storing this report, DuckDuckGo will anonymize your conversation by "
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
+"Antes de almacenar este informe, DuckDuckGo anonimizará tu conversación "
+"eliminando información personal como nombres, direcciones de correo "
+"electrónico y metadatos identificativos."
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -3030,7 +3035,7 @@ msgstr "Puntos de quiebre ganados"
 #. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Break this down into clear, numbered steps."
-msgstr ""
+msgstr "Divide esto en pasos claros y numerados."
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -3489,7 +3494,7 @@ msgstr "Reparto"
 #. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Cast & Crew"
-msgstr ""
+msgstr "Reparto y equipo"
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -4347,8 +4352,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click %sPrivacy and Services%s in the left sidebar."
-msgstr ""
-"Pulsa %1$sPrivacidad y servicios%2$s en la barra lateral de la izquierda."
+msgstr "Pulsa %1$sPrivacidad y servicios%2$s en la barra lateral de la izquierda."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -4375,8 +4379,7 @@ msgstr "Haz clic en %1$sAjustes%2$s en el menú desplegable."
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
-msgstr ""
-"Pulsa %1$sUse las actuales páginas%2$s y, a continuación, %3$sAceptar%4$s."
+msgstr "Pulsa %1$sUse las actuales páginas%2$s y, a continuación, %3$sAceptar%4$s."
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -4509,8 +4512,7 @@ msgstr "Haz clic en el %1$sicono de permisos%2$s en la barra de direcciones"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to search using DuckDuckGo.
 msgid "Click the Duck icon at the top of your browser to search!"
-msgstr ""
-"¡Pulsa el icono del pato en la parte superior del navegador para buscar!"
+msgstr "¡Pulsa el icono del pato en la parte superior del navegador para buscar!"
 
 #  UC Browser on Android
 # smartling.placeholder_format=C
@@ -5098,8 +5100,7 @@ msgstr "Copiar"
 # smartling.placeholder_format=C
 #. Instructions on how to change the default search engine
 msgid "Copy &amp; paste %sabout:preferences#search%s into the address bar"
-msgstr ""
-"Copia y pega %1$sabout:preferences#search%2$s en la barra de direcciones"
+msgstr "Copia y pega %1$sabout:preferences#search%2$s en la barra de direcciones"
 
 # smartling.placeholder_format=C
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
@@ -5220,7 +5221,7 @@ msgstr "Crear imagen"
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
-msgstr ""
+msgstr "Crea una lista de la compra con las cantidades de esta receta."
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed in the input field when starting a new image generation session.
@@ -5746,8 +5747,7 @@ msgstr "¿Borrar los chats más antiguos para liberar espacio de almacenamiento?
 #. Title shown when user has reached the file storage sync quota (5GB).
 msgctxt "Sync file storage limit modal title"
 msgid "Delete oldest chats with attachments to free up storage?"
-msgstr ""
-"¿Eliminar los chats más antiguos con archivos adjuntos para liberar espacio?"
+msgstr "¿Eliminar los chats más antiguos con archivos adjuntos para liberar espacio?"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to delete all recent chats.
@@ -5856,8 +5856,7 @@ msgstr "Dictado en Duck.ai"
 # smartling.placeholder_format=C
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
-msgstr ""
-"Anonimizamos el dictado y nunca lo utilizamos para entrenar modelos de IA."
+msgstr "Anonimizamos el dictado y nunca lo utilizamos para entrenar modelos de IA."
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
@@ -5867,7 +5866,7 @@ msgstr "Se ha alcanzado el límite de dictado"
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
 msgid "Dictation temporarily unavailable"
-msgstr ""
+msgstr "Dictado temporalmente no disponible"
 
 # smartling.placeholder_format=C
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
@@ -6176,6 +6175,8 @@ msgid ""
 "Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
 "filtered out. %sLearn More%s"
 msgstr ""
+"¿No quieres IA? %1$snoai.duckduckgo.com%2$s no ofrece funciones de IA y "
+"filtra las imágenes generadas por IA. %3$sMás información%4$s"
 
 # smartling.placeholder_format=C
 #. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
@@ -6184,6 +6185,8 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
+"¿No quieres IA? Visita %1$snoai.duckduckgo.com%2$s para buscar sin funciones "
+"de IA y con las imágenes generadas por IA filtradas. %3$sMás información%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6305,13 +6308,13 @@ msgstr ""
 #. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Draft a cover letter"
-msgstr ""
+msgstr "Redacta una carta de presentación"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Draft a cover letter for this job."
-msgstr ""
+msgstr "Redacta una carta de presentación para este trabajo."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -6489,8 +6492,7 @@ msgstr ""
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
-msgstr ""
-"¡Duck.ai es mejor en nuestro navegador privado y gratuito de DuckDuckGo!"
+msgstr "¡Duck.ai es mejor en nuestro navegador privado y gratuito de DuckDuckGo!"
 
 # smartling.placeholder_format=C
 #. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
@@ -6500,6 +6502,9 @@ msgid ""
 "company for anyone who wants to take back control of their personal "
 "information."
 msgstr ""
+"Duck.ai ha sido creado por DuckDuckGo. Somos una empresa independiente de "
+"protección en línea para quienes quieren recuperar el control de su "
+"información personal."
 
 # smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
@@ -6546,8 +6551,7 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
-msgstr ""
-"Duck.ai no está disponible temporalmente. Inténtalo de nuevo más tarde."
+msgstr "Duck.ai no está disponible temporalmente. Inténtalo de nuevo más tarde."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6555,6 +6559,9 @@ msgid ""
 "Duck.ai lets you chat privately with popular AI models. Disabling it hides "
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
+"Duck.ai te permite chatear en privado con modelos de IA populares. Al "
+"desactivarlo, se ocultan los botones y enlaces de Duck.ai, pero puedes "
+"seguir visitando %1$sduck.ai%2$s directamente."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -7476,8 +7483,7 @@ msgstr "Asegúrate de que tu navegador tenga permitido el acceso a la ubicación
 #. Tells how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed location access."
-msgstr ""
-"Asegúrate de que tu navegador tenga permitido el acceso a la ubicación."
+msgstr "Asegúrate de que tu navegador tenga permitido el acceso a la ubicación."
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -7565,8 +7571,7 @@ msgstr "Guinea Ecuatorial"
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Erase your browsing data in a flash with our %sFire Button%s"
-msgstr ""
-"Borra tus datos de navegación en un instante con nuestro %1$sFire Button%2$s"
+msgstr "Borra tus datos de navegación en un instante con nuestro %1$sFire Button%2$s"
 
 # smartling.placeholder_format=C
 msgid "Eritrea"
@@ -7576,13 +7581,13 @@ msgstr "Eritrea"
 #. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Estimate the nutrition"
-msgstr ""
+msgstr "Estima la nutrición"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Estimate the nutritional information for this recipe."
-msgstr ""
+msgstr "Estima la información nutricional de esta receta."
 
 # smartling.placeholder_format=C
 msgid "Estonia"
@@ -7644,7 +7649,7 @@ msgstr "Caduca en 1 día"
 #. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain the accepted answer in simple terms."
-msgstr ""
+msgstr "Explica la respuesta aceptada en términos sencillos."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
@@ -7659,43 +7664,43 @@ msgstr ""
 #. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain the top answer"
-msgstr ""
+msgstr "Explica la respuesta principal"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain this in simple, plain language."
-msgstr ""
+msgstr "Explica esto con un lenguaje sencillo y claro."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain this paper"
-msgstr ""
+msgstr "Explica este artículo"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain this repo"
-msgstr ""
+msgstr "Explica este repositorio"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain this research paper in plain language."
-msgstr ""
+msgstr "Explica este artículo de investigación en lenguaje sencillo."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain this simply"
-msgstr ""
+msgstr "Explica esto de forma sencilla"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain what this repository does and how to use it."
-msgstr ""
+msgstr "Explica qué hace este repositorio y cómo utilizarlo."
 
 # smartling.placeholder_format=C
 #. Label to show if song lyrics contain explicit content
@@ -7719,8 +7724,7 @@ msgstr "Letras explícitas"
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
-msgstr ""
-"Explora las últimas actualizaciones de productos y funciones de DuckDuckGo."
+msgstr "Explora las últimas actualizaciones de productos y funciones de DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Links to a page that provides a list of DuckDuckGo product updates
@@ -7989,6 +7993,8 @@ msgctxt "settings"
 msgid ""
 "Filters out known AI spam sites from image search results. %sLearn More%s"
 msgstr ""
+"Filtra los sitios de spam de IA conocidos de los resultados de búsqueda de "
+"imágenes. %1$sMás información%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the final score of a sporting event.
@@ -8017,8 +8023,7 @@ msgstr "Asesor financiero"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Find %sDuckDuckGo%s and click%sMake default%s"
-msgstr ""
-"Busca %1$sDuckDuckGo%2$s y haz clic en %3$sEstablecer como predeterminado%4$s"
+msgstr "Busca %1$sDuckDuckGo%2$s y haz clic en %3$sEstablecer como predeterminado%4$s"
 
 # smartling.placeholder_format=C
 #. Sentence shown after export, includes a placeholder for one or more filenames with bold formatting for the filename(s).
@@ -8050,7 +8055,7 @@ msgstr "Busca información actualizada"
 #. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Find me alternatives"
-msgstr ""
+msgstr "Búscame alternativas"
 
 # smartling.placeholder_format=C
 #. Button that searches for results closer to the user's current location.
@@ -8248,8 +8253,7 @@ msgstr "Chats gratuitos y privados, anonimizados por nosotros"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr ""
-"Chats gratuitos y privados, anonimizados por nosotros. No se requiere cuenta."
+msgstr "Chats gratuitos y privados, anonimizados por nosotros. No se requiere cuenta."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -8279,8 +8283,7 @@ msgstr "Libre de compartir y usar comercialmente"
 #. Description text explaining how to free up sync storage. Pinned chats are chats the user has explicitly marked to keep.
 msgctxt "Sync limit modal description"
 msgid "Free up space by deleting your chats. Pinned chats will not be deleted."
-msgstr ""
-"Libera espacio eliminando tus chats. Los chats anclados no se eliminarán."
+msgstr "Libera espacio eliminando tus chats. Los chats anclados no se eliminarán."
 
 # smartling.placeholder_format=C
 #. Indicates that this streaming service is free to watch but shows ads
@@ -8361,9 +8364,9 @@ msgid ""
 "<strong>Check for Updates...</strong>, then select <strong>Install Update</"
 "strong>."
 msgstr ""
-"En la barra de menú de la aplicación en Mac, selecciona <strong>DuckDuckGo</"
-"strong> &gt; <strong>Buscar actualizaciones...</strong> y, a continuación, "
-"selecciona <strong>Instalar actualización</strong>."
+"En la barra de menú de la aplicación en Mac, selecciona "
+"<strong>DuckDuckGo</strong> &gt; <strong>Buscar actualizaciones...</strong> "
+"y, a continuación, selecciona <strong>Instalar actualización</strong>."
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -8534,7 +8537,7 @@ msgstr "Genera más"
 #. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Generate a shopping list"
-msgstr ""
+msgstr "Genera una lista de la compra"
 
 # smartling.placeholder_format=C
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
@@ -8833,7 +8836,7 @@ msgstr "Pruébalo"
 #. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Give me a quick background on this person."
-msgstr ""
+msgstr "Dame un resumen rápido sobre esta persona."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9285,13 +9288,13 @@ msgstr "Ayuda a difundir la privacidad"
 #. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Help me prep for the interview"
-msgstr ""
+msgstr "Ayúdame a prepararme para la entrevista"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Help me tailor my resume for this job."
-msgstr ""
+msgstr "Ayúdame a adaptar mi currículum para este trabajo."
 
 # smartling.placeholder_format=C
 #. Title of a SERP popup that invites users to take a survey (desktop only)
@@ -9651,8 +9654,7 @@ msgstr "Falta el horario"
 #. This is the name of a user setting
 msgctxt "settings"
 msgid "Hover, Module, and Dropdown Background Color"
-msgstr ""
-"Color de fondo al pasar el cursor, de los módulos y de los desplegables"
+msgstr "Color de fondo al pasar el cursor, de los módulos y de los desplegables"
 
 # smartling.placeholder_format=C
 #. Label for a pill-shaped tab below the empty-state Duck.ai chat input. Clicking it opens a panel that explains how Duck.ai protects user privacy.
@@ -9737,15 +9739,13 @@ msgstr "Cómo funciona"
 #. Header for the assist settings modal where the user can choose how often they want AI-assisted answers to appear.
 msgctxt "duckassist"
 msgid "How much do you want AI-assisted answers to appear?"
-msgstr ""
-"¿Con qué frecuencia quieres que aparezcan las respuestas asistidas por IA?"
+msgstr "¿Con qué frecuencia quieres que aparezcan las respuestas asistidas por IA?"
 
 # smartling.placeholder_format=C
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
 msgctxt "Duck.ai settings usage section"
 msgid "How much of your daily and weekly limits you've used so far."
-msgstr ""
-"Qué parte de tus límites diarios y semanales has utilizado hasta ahora."
+msgstr "Qué parte de tus límites diarios y semanales has utilizado hasta ahora."
 
 # smartling.placeholder_format=C
 #. A header for the feedback form in the assist negative feedback flow. The user is being asked to update how often they want AI-assisted answers to appear.
@@ -9819,7 +9819,7 @@ msgctxt ""
 "Text for the I already have a subscription button in the Duck.ai settings "
 "page"
 msgid "I Already Have a Subscription"
-msgstr ""
+msgstr "Ya tengo una suscripción"
 
 # smartling.placeholder_format=C
 #. Text for the button that takes the user to the login subscription page.
@@ -10000,8 +10000,7 @@ msgstr ""
 msgid ""
 "If you want to use DuckDuckGo without JavaScript, please use our %s or %s "
 "versions."
-msgstr ""
-"Si quieres usar DuckDuckGo sin JavaScript, usa nuestra versión %1$s o %2$s."
+msgstr "Si quieres usar DuckDuckGo sin JavaScript, usa nuestra versión %1$s o %2$s."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -10048,8 +10047,8 @@ msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
 msgstr ""
-"Las indicaciones para las imágenes deben cumplir con las directrices de Duck."
-"ai %1$s."
+"Las indicaciones para las imágenes deben cumplir con las directrices de "
+"Duck.ai %1$s."
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -10406,7 +10405,7 @@ msgstr "Instalar navegador Mac"
 #. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
 msgctxt "settings"
 msgid "Install Now"
-msgstr ""
+msgstr "Instalar ahora"
 
 # smartling.placeholder_format=C
 #. Text of a button to install the DuckDuckGo app
@@ -10509,13 +10508,13 @@ msgstr "¿Se borran realmente los datos eliminados?"
 #. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Is it worth taking?"
-msgstr ""
+msgstr "¿Merece la pena hacerlo?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Is this place any good?"
-msgstr ""
+msgstr "¿Es bueno este sitio?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
@@ -10524,6 +10523,8 @@ msgid ""
 "Is this place any good? Summarize its reputation based on reviews and "
 "ratings."
 msgstr ""
+"¿Es bueno este sitio? Resume su reputación basándote en las reseñas y "
+"valoraciones."
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -10535,13 +10536,13 @@ msgstr "¿Es útil este vídeo?"
 #. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Is this worth watching?"
-msgstr ""
+msgstr "¿Merece la pena verlo?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Is this worth watching? Give me a spoiler-free take."
-msgstr ""
+msgstr "¿Merece la pena verlo? Dame una opinión sin spoilers."
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -10963,8 +10964,7 @@ msgstr "Obtén más información sobre la protección de privacidad activa"
 # smartling.placeholder_format=C
 msgctxt "showcase_newsletter"
 msgid "Learn about online privacy right in your inbox."
-msgstr ""
-"Más información sobre la privacidad en Internet en tu bandeja de entrada."
+msgstr "Más información sobre la privacidad en Internet en tu bandeja de entrada."
 
 # smartling.placeholder_format=C
 #. Link to a page with more information about how DuckDuckGo settings are managed.
@@ -11162,6 +11162,8 @@ msgstr "Enlaces:"
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
 msgstr ""
+"Enumera las herramientas, los materiales o los requisitos previos que "
+"necesito para esto."
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -11575,7 +11577,7 @@ msgstr "Gestionar sitios bloqueados"
 #. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
 msgctxt "setting"
 msgid "Manage in Browser Settings"
-msgstr ""
+msgstr "Gestionar en los ajustes del navegador"
 
 # smartling.placeholder_format=C
 #. Link to the site exclusion settings page
@@ -14417,14 +14419,13 @@ msgstr ""
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is harmful or illegal. (optional)"
-msgstr ""
+msgstr "Describe por qué la respuesta del chat es perjudicial o ilegal. (opcional)"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
-msgstr ""
-"Describe por qué la respuesta del chat es ilegal o perjudicial. (Opcional)"
+msgstr "Describe por qué la respuesta del chat es ilegal o perjudicial. (Opcional)"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to enter their passphrase.
@@ -14455,6 +14456,8 @@ msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is harmful or illegal."
 msgstr ""
+"Pega tu mensaje y el resultado que da problemas (quitando cualquier "
+"información personal) y describe por qué el contenido es dañino o ilegal."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -14927,7 +14930,7 @@ msgstr "Privacidad"
 #. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
 msgctxt "Section heading on the Duck.ai settings page"
 msgid "Privacy & Terms"
-msgstr ""
+msgstr "Privacidad y condiciones"
 
 # smartling.placeholder_format=C
 msgid "Privacy Blog"
@@ -15003,7 +15006,7 @@ msgstr "Política de privacidad y condiciones del servicio"
 #. Text for a button that links to the terms of use and privacy policy page.
 msgctxt "Secondary button text in active privacy modal"
 msgid "Privacy Policy and Terms of Service"
-msgstr ""
+msgstr "Política de privacidad y condiciones del servicio"
 
 # smartling.placeholder_format=C
 #. Title displayed on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
@@ -15177,8 +15180,7 @@ msgstr "Pedir confirmación"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Prompt me to use my approximate location to get nearby results."
-msgstr ""
-"Pedirme utilizar mi ubicación aproximada para obtener mejores resultados."
+msgstr "Pedirme utilizar mi ubicación aproximada para obtener mejores resultados."
 
 # smartling.placeholder_format=C
 #. DuckDuckGo Email Protection removes trackers from emails
@@ -15510,25 +15512,25 @@ msgstr "Recomendar un libro"
 #. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Recommend similar books"
-msgstr ""
+msgstr "Recomienda libros similares"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Recommend similar books."
-msgstr ""
+msgstr "Recomienda libros similares."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Recommend similar movies or shows."
-msgstr ""
+msgstr "Recomienda películas o programas similares."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Recommend similar titles"
-msgstr ""
+msgstr "Recomienda títulos similares"
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
@@ -15939,7 +15941,7 @@ msgctxt ""
 "feedback form when the user has selected Harmful or Illegal as the feedback "
 "reason"
 msgid "Required for harmful or illegal reports"
-msgstr ""
+msgstr "Obligatorio para denunciar contenido dañino o ilegal"
 
 # smartling.placeholder_format=C
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
@@ -16182,7 +16184,7 @@ msgstr "Reseñas"
 #. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Rewrite this recipe scaled for a different number of servings."
-msgstr ""
+msgstr "Reescribe esta receta ajustándola para un número diferente de raciones."
 
 # smartling.placeholder_format=C
 msgid "Romania"
@@ -16461,8 +16463,7 @@ msgstr ""
 #. Short text for native DDG browser users explaining how Chat History stores up to 30 of their most recent chats locally on their device.
 msgctxt "Short description for Chat History feature on native DDG browsers"
 msgid "Save up to 30 of your most recent chats locally on your device."
-msgstr ""
-"Guarda hasta 30 de tus chats más recientes localmente en tu dispositivo."
+msgstr "Guarda hasta 30 de tus chats más recientes localmente en tu dispositivo."
 
 # smartling.placeholder_format=C
 #. Desktop/mobile intro modal body under the title per Sync Chats Figma (choose step).
@@ -16970,8 +16971,7 @@ msgstr "Semanas de la temporada"
 #. Description shown in the Sync & Backup settings section when sync is not yet enabled, explaining the feature.
 msgctxt "Description for sync and backup feature"
 msgid "Securely save and sync your chats across all your devices."
-msgstr ""
-"Guarda y sincroniza tus chats de forma segura en todos tus dispositivos."
+msgstr "Guarda y sincroniza tus chats de forma segura en todos tus dispositivos."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17188,8 +17188,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
-msgstr ""
-"Selecciona %1$sDuckDuckGo%2$s y pulsa %3$sAgregar como predeterminado%4$s."
+msgstr "Selecciona %1$sDuckDuckGo%2$s y pulsa %3$sAgregar como predeterminado%4$s."
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
@@ -17288,8 +17287,7 @@ msgstr "Selecciona %1$sMotor de búsqueda%2$s"
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"
-msgstr ""
-"Selecciona %1$sMotor de búsqueda%2$s y, a continuación, %3$sOtros...%4$s"
+msgstr "Selecciona %1$sMotor de búsqueda%2$s y, a continuación, %3$sOtros...%4$s"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -17314,8 +17312,7 @@ msgstr "Selecciona %1$sAjustes%2$s en el menú desplegable."
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sAdvanced settings%s"
-msgstr ""
-"Selecciona %1$sAjustes%2$s y, a continuación, %3$sAjustes avanzados%4$s"
+msgstr "Selecciona %1$sAjustes%2$s y, a continuación, %3$sAjustes avanzados%4$s"
 
 # smartling.placeholder_format=C
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -17330,8 +17327,7 @@ msgstr ""
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sSearch Engine%s"
-msgstr ""
-"Selecciona %1$sAjustes%2$s y, a continuación, %3$sMotor de búsqueda%4$s"
+msgstr "Selecciona %1$sAjustes%2$s y, a continuación, %3$sMotor de búsqueda%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -17547,7 +17543,7 @@ msgstr "Configura ahora"
 #. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
 msgctxt "Encrypted storage setup button shown in native browsers"
 msgid "Set Up Sync & Backup"
-msgstr ""
+msgstr "Configurar Sync & Backup"
 
 # smartling.placeholder_format=C
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
@@ -17735,7 +17731,7 @@ msgstr "Compartir comentarios positivos"
 msgctxt ""
 "Label beside the share-content switch on the Duck.ai response feedback form"
 msgid "Share this conversation with DuckDuckGo"
-msgstr ""
+msgstr "Comparte esta conversación con DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -17993,8 +17989,7 @@ msgstr "Mostrar todos los resultados"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show answers more often. (You can also %sturn them off%s.)"
-msgstr ""
-"Mostrar respuestas con más frecuencia. (También puedes %1$sapagarlas%2$s.)"
+msgstr "Mostrar respuestas con más frecuencia. (También puedes %1$sapagarlas%2$s.)"
 
 # smartling.placeholder_format=C
 #. Accessible label for the button that reveals a popover listing multiple citation sources in Duck.ai chat responses.
@@ -18146,8 +18141,7 @@ msgstr "Muestra recordatorios ocasionales para añadir DuckDuckGo al navegador"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr ""
-"Muestra recordatorios ocasionales para añadir DuckDuckGo a tus dispositivos"
+msgstr "Muestra recordatorios ocasionales para añadir DuckDuckGo a tus dispositivos"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18160,8 +18154,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows page numbers at result page breaks"
-msgstr ""
-"Muestra los números de página en los saltos de página de los resultados"
+msgstr "Muestra los números de página en los saltos de página de los resultados"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18174,8 +18167,7 @@ msgstr ""
 #. http://i.imgur.com/94erFcS.png
 msgctxt "settings"
 msgid "Shows suggestions under the search box as you type"
-msgstr ""
-"Muestra sugerencias debajo del cuadro de búsqueda a medida que escribes"
+msgstr "Muestra sugerencias debajo del cuadro de búsqueda a medida que escribes"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18280,8 +18272,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Sites you block will be hidden from all your search results"
-msgstr ""
-"Los sitios que bloquees se ocultarán de todos tus resultados de búsqueda"
+msgstr "Los sitios que bloquees se ocultarán de todos tus resultados de búsqueda"
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes full name (tooltip)
@@ -18475,8 +18466,7 @@ msgstr "Lo sentimos, se ha producido un error inesperado."
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
 msgid "Sorry, no relevant information was found in our search."
-msgstr ""
-"Lo sentimos, no se ha encontrado información relevante en nuestra búsqueda."
+msgstr "Lo sentimos, no se ha encontrado información relevante en nuestra búsqueda."
 
 # smartling.placeholder_format=C
 #. Indicates that there were no search results for a user's search.
@@ -18837,8 +18827,7 @@ msgstr "Detén a los rastreadores ocultos que acechan en otros sitios web."
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop most hidden trackers lurking on other websites."
-msgstr ""
-"Detén a la mayoría de rastreadores ocultos que acechan en otros sitios web."
+msgstr "Detén a la mayoría de rastreadores ocultos que acechan en otros sitios web."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19012,18 +19001,20 @@ msgstr "Sugerir un título para una publicación de blog"
 msgctxt "Page suggestion prompt"
 msgid "Suggest related articles or topics worth exploring next."
 msgstr ""
+"Sugiere artículos o temas relacionados que valga la pena explorar a "
+"continuación."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Suggest related articles to explore"
-msgstr ""
+msgstr "Sugiere artículos relacionados para explorar"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Suggest some alternatives to this product."
-msgstr ""
+msgstr "Sugiere algunas alternativas a este producto."
 
 # smartling.placeholder_format=C
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
@@ -19040,7 +19031,7 @@ msgstr "Sugerencias:"
 #. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Sum up the reviews"
-msgstr ""
+msgstr "Resume las reseñas"
 
 # smartling.placeholder_format=C
 #. A short title for the a message asking the AI to summarize a text.
@@ -19052,85 +19043,85 @@ msgstr "Resumir"
 #. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize the Q&As"
-msgstr ""
+msgstr "Resume las preguntas y respuestas"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the background and notable work of this person."
-msgstr ""
+msgstr "Resume la trayectoria y el trabajo notable de esta persona."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the key details of this event."
-msgstr ""
+msgstr "Resume los detalles clave de este evento."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the questions and answers on this page."
-msgstr ""
+msgstr "Resume las preguntas y respuestas de esta página."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize their background"
-msgstr ""
+msgstr "Resume sus antecedentes"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this book"
-msgstr ""
+msgstr "Resume este libro"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this book."
-msgstr ""
+msgstr "Resume este libro."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this discussion"
-msgstr ""
+msgstr "Resume este debate"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this discussion thread."
-msgstr ""
+msgstr "Resume este hilo de discusión."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this page"
-msgstr ""
+msgstr "Resume esta página"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this page."
-msgstr ""
+msgstr "Resumir esta página."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this video"
-msgstr ""
+msgstr "Resume este vídeo"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this video."
-msgstr ""
+msgstr "Resume este vídeo."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize what the reviews say."
-msgstr ""
+msgstr "Resume lo que dicen las opiniones."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -19426,8 +19417,7 @@ msgstr "Sincronizar con otro dispositivo"
 #. Title shown when sync service is temporarily unavailable.
 msgctxt "Sync unavailable modal title"
 msgid "Sync and Backup is temporarily unavailable"
-msgstr ""
-"La sincronización y la copia de seguridad no están disponibles temporalmente"
+msgstr "La sincronización y la copia de seguridad no están disponibles temporalmente"
 
 # smartling.placeholder_format=C
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
@@ -19461,7 +19451,7 @@ msgstr "Siria"
 #. Text for a button that enables the theme to follow the operating system's color scheme preference.
 msgctxt "System theme button for theme selector"
 msgid "System"
-msgstr ""
+msgstr "Sistema"
 
 # smartling.placeholder_format=C
 #. Abbreviation indicating this is the total score for a game
@@ -19495,7 +19485,7 @@ msgstr "Tahitiano"
 #. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Tailor my resume"
-msgstr ""
+msgstr "Adapta mi currículum"
 
 # smartling.placeholder_format=C
 msgid "Taiwan"
@@ -19531,7 +19521,7 @@ msgstr "Toma el control de tus datos personales"
 msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
-msgstr ""
+msgstr "Responde a esta encuesta anónima para decirnos cómo podemos mejorar Duck.ai."
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -19842,7 +19832,7 @@ msgstr "Tema"
 #. Text for the theme selector label that allows users to switch between Light and dark theme.
 msgctxt "Label for the theme selector feature"
 msgid "Theme"
-msgstr ""
+msgstr "Tema"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/LpFhb1e.png
@@ -19896,8 +19886,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Error message for explore more questions when a retryable error occurs (timeout, network)
 msgid "There's been an issue loading this answer. Please try again."
-msgstr ""
-"Se ha producido un problema al cargar esta respuesta. Inténtalo de nuevo."
+msgstr "Se ha producido un problema al cargar esta respuesta. Inténtalo de nuevo."
 
 # smartling.placeholder_format=C
 #. Instant Answer Tab Name
@@ -20035,15 +20024,13 @@ msgstr ""
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
-msgstr ""
-"Este archivo es demasiado grande. El tamaño máximo del archivo es de %1$s MB"
+msgstr "Este archivo es demasiado grande. El tamaño máximo del archivo es de %1$s MB"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB."
-msgstr ""
-"Este archivo es demasiado grande. El tamaño máximo del archivo es de %1$s MB."
+msgstr "Este archivo es demasiado grande. El tamaño máximo del archivo es de %1$s MB."
 
 # smartling.placeholder_format=C
 #. Generic error message displayed when the user tries to upload an unsupported file type and we cannot determine the accepted types
@@ -20063,8 +20050,7 @@ msgctxt ""
 "Error message when an uploaded file type is not supported, with list ending "
 "in or"
 msgid "This file type is not supported, please attach a %s or %s"
-msgstr ""
-"Este tipo de archivo no es compatible, por favor adjunta un %1$s o %2$s"
+msgstr "Este tipo de archivo no es compatible, por favor adjunta un %1$s o %2$s"
 
 # smartling.placeholder_format=C
 #. Error message for unsupported file type when multiple types are accepted. First placeholder is a comma-separated list of all accepted types except the last (e.g. PNG, JPG, WebP, GIF). Second placeholder is the last accepted type (e.g. PDF). Full example: This file type is not supported, please attach a PNG, JPG, WebP, GIF or PDF
@@ -20072,8 +20058,7 @@ msgctxt ""
 "Error message when an uploaded file type is not supported, with list ending "
 "in or"
 msgid "This file type is not supported, please attach a %s or %s."
-msgstr ""
-"Este tipo de archivo no es compatible, por favor adjunta un %1$s o %2$s."
+msgstr "Este tipo de archivo no es compatible, por favor adjunta un %1$s o %2$s."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to upload an unsupported file type and we know which types are accepted. Placeholder is a single accepted type. E.g. This file type is not supported, please attach a PDF
@@ -20269,8 +20254,7 @@ msgstr ""
 #. Message explaining what will happen when the user deletes an image.
 msgctxt "Confirmation message in delete image modal"
 msgid "This will delete your selected image. This cannot be undone."
-msgstr ""
-"Esto eliminará tu imagen seleccionada. Esta acción no se puede deshacer."
+msgstr "Esto eliminará tu imagen seleccionada. Esta acción no se puede deshacer."
 
 # smartling.placeholder_format=C
 #. Confirmation message asking if the user is sure they want to reset all of their settings.
@@ -20677,8 +20661,7 @@ msgctxt "Full sentence for translating text"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr ""
-"Traduce esta frase del español al francés: «¿Cómo ir al cine más cercano?»"
+msgstr "Traduce esta frase del español al francés: «¿Cómo ir al cine más cercano?»"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for translating a sentence into another language. Translate the whole sentence and please use target language instead of 'English' and modify the sentence to translate into 'English' instead of 'French'. Example: 'Translate this {target language} sentence into English: “How do I get to the nearest movie theatre?”'
@@ -20686,20 +20669,19 @@ msgctxt "Full sentence for translating text prompt"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr ""
-"Traduce esta frase del español al inglés: «¿Cómo ir al cine más cercano?»"
+msgstr "Traduce esta frase del español al inglés: «¿Cómo ir al cine más cercano?»"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Translate this page"
-msgstr ""
+msgstr "Traducir esta página"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
 msgctxt "Page suggestion prompt"
 msgid "Translate this page into %s."
-msgstr ""
+msgstr "Traduce esta página al %1$s."
 
 # smartling.placeholder_format=C
 #. Placeholder text for a region that will display translated text.
@@ -20846,7 +20828,7 @@ msgstr "Prueba gratis"
 #. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
 msgctxt "settings"
 msgid "Try It Now"
-msgstr ""
+msgstr "Pruébalo ahora"
 
 # smartling.placeholder_format=C
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -20912,16 +20894,14 @@ msgstr ""
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
 msgctxt "precise_user_location"
 msgid "Try enabling anonymous location for more accurate results."
-msgstr ""
-"Prueba a activar la ubicación anónima para obtener resultados más precisos."
+msgstr "Prueba a activar la ubicación anónima para obtener resultados más precisos."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the screen of the onboarding where the user picks a chat model.
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr ""
-"Intenta experimentar con cada modelo, ya que ofrecerán diferentes respuestas."
+msgstr "Intenta experimentar con cada modelo, ya que ofrecerán diferentes respuestas."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
@@ -21051,15 +21031,13 @@ msgstr "Prueba %1$s y %2$s de código abierto recientemente añadidos"
 #. Text for a promotional card that encourages users to try the recently added open-source AI models Llama 3.1 and Mixtral.
 msgctxt "Promotional text for new AI models"
 msgid "Try the recently added open-source Llama 3.1 and Mixtral"
-msgstr ""
-"Prueba los recientemente añadidos de código abierto Llama 3.1 y Mixtral"
+msgstr "Prueba los recientemente añadidos de código abierto Llama 3.1 y Mixtral"
 
 # smartling.placeholder_format=C
 #. Message displayed to suggest the user to try the provided prompts or enter their own.
 msgctxt "Prompt suggestion message"
 msgid "Try these prompts to get started or enter your own prompt below"
-msgstr ""
-"Prueba uno de estos mensajes o introduce tu propio mensaje a continuación"
+msgstr "Prueba uno de estos mensajes o introduce tu propio mensaje a continuación"
 
 # smartling.placeholder_format=C
 #. Description for the empty state displayed when searching recent chats in Duck.ai returns no results, suggesting the user rephrase their search query.
@@ -21093,6 +21071,8 @@ msgid ""
 "Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
+"¿Quieres desactivar las funciones de la IA? Instala la extensión de búsqueda "
+"%1$sDuckDuckGo No AI%2$s para recordar tus ajustes. %3$sMás información%4$s"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -21101,6 +21081,9 @@ msgid ""
 "Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
+"¿Quieres desactivar las funciones de la IA? Cambia a la extensión de "
+"búsqueda %1$sDuckDuckGo No AI%2$s para recordar tus ajustes. %3$sMás "
+"información%4$s"
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -21418,8 +21401,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sOpen with%s select %sA specific page or pages%s"
-msgstr ""
-"En %1$sAbrir con%2$s, selecciona %3$sUna o varias páginas específicas%4$s"
+msgstr "En %1$sAbrir con%2$s, selecciona %3$sUna o varias páginas específicas%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -21593,8 +21575,7 @@ msgctxt ""
 "Text shown in the subscription promo card, with a trailing call-to-action "
 "link."
 msgid "Unlock more capable AI models with a DuckDuckGo subscription. %s"
-msgstr ""
-"Desbloquea modelos de IA más capaces con una suscripción a DuckDuckGo. %1$s"
+msgstr "Desbloquea modelos de IA más capaces con una suscripción a DuckDuckGo. %1$s"
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to unmute the microphone.
@@ -21861,7 +21842,7 @@ msgstr "Uruguay"
 #. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
 msgctxt "Navigation label on the Duck.ai settings page"
 msgid "Usage"
-msgstr ""
+msgstr "Uso"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -22142,8 +22123,7 @@ msgctxt "mobile promotion on desktop"
 msgid ""
 "Visit %sDuckDuckGo.com%s on your tablet or phone and follow the provided "
 "instructions."
-msgstr ""
-"Visita %1$sDuckDuckGo.com%2$s en tu móvil o tablet y sigue las instrucciones."
+msgstr "Visita %1$sDuckDuckGo.com%2$s en tu móvil o tablet y sigue las instrucciones."
 
 # smartling.placeholder_format=C
 #. Primary button to visit Duck.ai.
@@ -22315,7 +22295,7 @@ msgstr "Gales"
 #. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Walk me through the steps"
-msgstr ""
+msgstr "Explícame paso a paso cómo hacerlo"
 
 # smartling.placeholder_format=C
 #. Label for walking directions on a map.
@@ -22446,6 +22426,9 @@ msgid ""
 "please share this conversation with DuckDuckGo so we can investigate and "
 "address the issue."
 msgstr ""
+"Solo podemos arreglar lo que podemos ver. Para informar de una respuesta "
+"dañina o ilegal, comparte esta conversación con DuckDuckGo para que podamos "
+"investigar y abordar el problema."
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -22487,8 +22470,7 @@ msgstr "No te perseguimos con anuncios."
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
 msgid "We don't store usernames or any personally identifiable information."
-msgstr ""
-"No almacenamos nombres de usuario ni información personal identificable."
+msgstr "No almacenamos nombres de usuario ni información personal identificable."
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -22647,14 +22629,12 @@ msgstr ""
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
-msgstr ""
-"Confiamos en tus comentarios anónimos para mejorar DuckDuckGo para todos."
+msgstr "Confiamos en tus comentarios anónimos para mejorar DuckDuckGo para todos."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We stop anyone from getting your search history, including us."
-msgstr ""
-"Impedimos que nadie acceda a tu historial de búsquedas, ni siquiera nosotros."
+msgstr "Impedimos que nadie acceda a tu historial de búsquedas, ni siquiera nosotros."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -22882,8 +22862,7 @@ msgstr ""
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai, it's time to import your chats"
-msgstr ""
-"¡Te damos la bienvenida al nuevo Duck.ai! Es hora de importar tus chats."
+msgstr "¡Te damos la bienvenida al nuevo Duck.ai! Es hora de importar tus chats."
 
 # smartling.placeholder_format=C
 #. Welcome message for new DuckDuckGo users.
@@ -22924,8 +22903,7 @@ msgstr "Conferencia Oeste"
 #. Inform the users that "something" went wrong and we are unable to show any results.
 msgctxt "noresults"
 msgid "We’re currently experiencing an issue with DuckDuckGo Search."
-msgstr ""
-"En estos momentos, estamos experimentando un problema con DuckDuckGo Search."
+msgstr "En estos momentos, estamos experimentando un problema con DuckDuckGo Search."
 
 # smartling.placeholder_format=C
 #. Inform the users that "something" went wrong even though we were able to show some organic results.
@@ -23019,79 +22997,79 @@ msgstr ""
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the counterarguments?"
-msgstr ""
+msgstr "¿Cuáles son los argumentos en contra?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the hours & location?"
-msgstr ""
+msgstr "¿Cuáles son el horario y la ubicación?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key contributions of this paper?"
-msgstr ""
+msgstr "¿Cuáles son las contribuciones clave de este artículo?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key contributions?"
-msgstr ""
+msgstr "¿Cuáles son las contribuciones clave?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key details?"
-msgstr ""
+msgstr "¿Cuáles son los detalles clave?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key points covered in this video?"
-msgstr ""
+msgstr "¿Cuáles son los puntos clave que se tratan en este vídeo?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key points?"
-msgstr ""
+msgstr "¿Cuáles son los puntos clave?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key takeaways from this article?"
-msgstr ""
+msgstr "¿Cuáles son los puntos clave de este artículo?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key takeaways?"
-msgstr ""
+msgstr "¿Cuáles son los puntos clave?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key things I will learn from this course?"
-msgstr ""
+msgstr "¿Cuáles son las enseñanzas clave que aprenderé en este curso?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the main counterarguments or criticisms of this?"
-msgstr ""
+msgstr "¿Cuáles son los principales argumentos en contra o críticas a esto?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the main questions this page answers?"
-msgstr ""
+msgstr "¿Cuáles son las preguntas principales que responde esta página?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the must-try dishes here?"
-msgstr ""
+msgstr "¿Cuáles son los platos imprescindibles aquí?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
@@ -23099,18 +23077,20 @@ msgctxt "Page suggestion prompt"
 msgid ""
 "What are the opening hours, location, and contact details for this place?"
 msgstr ""
+"¿Cuáles son el horario de apertura, la ubicación y los datos de contacto de "
+"este lugar?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the pros and cons of this product?"
-msgstr ""
+msgstr "¿Cuáles son los pros y los contras de este producto?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the pros and cons?"
-msgstr ""
+msgstr "¿Cuáles son los pros y los contras?"
 
 # smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
@@ -23216,7 +23196,7 @@ msgstr "¿Qué significa aurícula en el contexto de un artículo médico?"
 #. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What does this answer?"
-msgstr ""
+msgstr "¿A qué responde esto?"
 
 # smartling.placeholder_format=C
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
@@ -23234,7 +23214,7 @@ msgstr "¿Qué información se guarda?"
 #. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What interview questions might come up for this role?"
-msgstr ""
+msgstr "¿Qué preguntas de entrevista podrían surgir para esta posición?"
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -23256,7 +23236,7 @@ msgstr "¿Cuál es la capital de Albania?"
 #. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What is the overall verdict and rating for this?"
-msgstr ""
+msgstr "¿Cuál es el veredicto y la calificación general de esto?"
 
 # smartling.placeholder_format=C
 #. Link to a page with additional information.
@@ -23284,7 +23264,7 @@ msgstr "Opiniones:"
 #. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What should I order?"
-msgstr ""
+msgstr "¿Qué debo pedir?"
 
 # smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
@@ -23302,13 +23282,13 @@ msgstr "¿Qué ha fallado en la respuesta? (opcional)"
 #. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What will I learn?"
-msgstr ""
+msgstr "¿Qué aprenderé?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What will I need?"
-msgstr ""
+msgstr "¿Qué necesitaré?"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -23319,8 +23299,7 @@ msgstr "¿Sobre qué te gustaría dar tu opinión?"
 #. Explains the benefits of using our custom video player, the Duck Player
 msgid ""
 "What you watch in DuckDuckGo won't influence your recommendations on YouTube."
-msgstr ""
-"Lo que veas en DuckDuckGo no influirá en tus recomendaciones en YouTube."
+msgstr "Lo que veas en DuckDuckGo no influirá en tus recomendaciones en YouTube."
 
 # smartling.placeholder_format=C
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
@@ -23332,7 +23311,7 @@ msgstr "Novedades"
 #. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What's the verdict?"
-msgstr ""
+msgstr "¿Cuál es el veredicto?"
 
 # smartling.placeholder_format=C
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -23352,8 +23331,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "When enabled, Duck.ai will show instant answers in the chat."
-msgstr ""
-"Cuando esté activado, Duck.ai mostrará respuestas instantáneas en el chat."
+msgstr "Cuando esté activado, Duck.ai mostrará respuestas instantáneas en el chat."
 
 # smartling.placeholder_format=C
 #. Text of a button that performs a search for the available streaming services that show a particular movie or tv show
@@ -23371,8 +23349,7 @@ msgstr "Dónde ver <strong>%1$s</strong>"
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Where it says Homepage click %sSet to Current Page%s."
-msgstr ""
-"Donde pone Página de inicio pulsa en %1$sEstablecer como página actual%2$s."
+msgstr "Donde pone Página de inicio pulsa en %1$sEstablecer como página actual%2$s."
 
 # smartling.placeholder_format=C
 #. Heading of a module showing what streaming services are showing a movie or series, e.g. Where to Watch The Matrix
@@ -23390,7 +23367,7 @@ msgstr "¿Qué funcionalidades faltan? (Opcional)"
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Which features are missing? (optional)"
-msgstr ""
+msgstr "¿Qué funcionalidades faltan? (opcional)"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
@@ -23413,12 +23390,14 @@ msgstr "Quiénes somos"
 msgctxt "Page suggestion prompt"
 msgid "Who are the main cast and crew, and what else are they known for?"
 msgstr ""
+"¿Quiénes son los principales miembros del reparto y del equipo, y por qué "
+"más se los conoce?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Who is this person?"
-msgstr ""
+msgstr "¿Quién es esta persona?"
 
 # smartling.placeholder_format=C
 #. Header above a collection of privacy-related links.
@@ -24011,8 +23990,7 @@ msgstr "Puedes empezar de cero en este nuevo dominio (duck.ai)."
 #. Text explaining the benefits of the cloud save feature.
 msgctxt "cloudsave"
 msgid "You can store several sets of settings for different purposes."
-msgstr ""
-"Puedes almacenar varios conjuntos de ajustes para diferentes propósitos."
+msgstr "Puedes almacenar varios conjuntos de ajustes para diferentes propósitos."
 
 # smartling.placeholder_format=C
 #. Instructions for user once they've failed the bot challenge
@@ -24085,8 +24063,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
 msgid "You won't see this message again unless you clear your browser data."
-msgstr ""
-"No volverás a ver este mensaje a menos que borres los datos de tu navegador."
+msgstr "No volverás a ver este mensaje a menos que borres los datos de tu navegador."
 
 # smartling.placeholder_format=C
 #. The second paragraph of a pop up where we explain how to update the browser manually.
@@ -24179,14 +24156,12 @@ msgstr "Has alcanzado la duración máxima del chat de voz para una sola sesión
 msgctxt "voice chat limit modal"
 msgid ""
 "You've reached the voice chat limit for today. Please try again tomorrow."
-msgstr ""
-"Has alcanzado el límite de chat de voz para hoy. Inténtalo de nuevo mañana."
+msgstr "Has alcanzado el límite de chat de voz para hoy. Inténtalo de nuevo mañana."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
 msgid "You've reached your dictation usage limit. Try again later."
-msgstr ""
-"Has alcanzado tu límite de uso de dictado. Inténtalo de nuevo más tarde."
+msgstr "Has alcanzado tu límite de uso de dictado. Inténtalo de nuevo más tarde."
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.

--- a/locales/es_MX/LC_MESSAGES/duckduckgo.po
+++ b/locales/es_MX/LC_MESSAGES/duckduckgo.po
@@ -1163,6 +1163,11 @@ msgctxt "feedback form"
 msgid "Address is incorrect"
 msgstr ""
 
+#. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Adjust the servings"
+msgstr ""
+
 #. as in multiple advertisements
 msgid "Ads"
 msgstr "Anuncios"
@@ -1335,6 +1340,13 @@ msgstr ""
 #. Heading shown on the empty chat screen. The text between the two %s markers is displayed inside a clickable privacy button. First %s renders a shield icon, second %s is an invisible end marker. Keep the word 'private' between both %s markers.
 msgctxt "Empty state heading in Duck.ai chat mode"
 msgid "All chats are %sprivate%s"
+msgstr ""
+
+#. Paragraph in the Privacy & Terms section of the About & Legal page in Duck.ai settings, summarizing how chats are anonymized and are not stored or used to train chat models.
+msgctxt "Privacy & Terms section description on the Duck.ai settings page"
+msgid ""
+"All chats are anonymized by DuckDuckGo, and your conversations are not used "
+"to train chat models by DuckDuckGo or the model providers"
 msgstr ""
 
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1547,6 +1559,12 @@ msgstr ""
 #. Confirmation message after location service is enabled.
 msgctxt "precise_user_location"
 msgid "Anonymous location enabled"
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Anonymously generates answers for search queries based on web content. "
+"Choose how often you want it to appear, or disable it completely."
 msgstr ""
 
 #. Instant Answer tab name
@@ -1772,6 +1790,11 @@ msgstr ""
 
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse
 msgid "Ask a follow-up with Duck.ai"
+msgstr ""
+
+#. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
+msgctxt "Page suggestion chip label"
+msgid "Ask about this page"
 msgstr ""
 
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2097,6 +2120,11 @@ msgstr ""
 msgid "Barcode"
 msgstr "Código de Barras"
 
+#. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Based on this page, is this course worth taking?"
+msgstr ""
+
 msgctxt "settings"
 msgid "Basic"
 msgstr "Básico"
@@ -2128,6 +2156,13 @@ msgstr ""
 #. Placeholder text displayed while the assistant waits for the user to choose an action.
 msgctxt "Assistant response placeholder"
 msgid "Before continuing..."
+msgstr ""
+
+#. Explains that before storing the report, DuckDuckGo will anonymize the conversation by removing PII like names, email addresses, and identifying metadata.
+msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
+msgid ""
+"Before storing this report, DuckDuckGo will anonymize your conversation by "
+"removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
 #. Label that's displayed next to a past start date below a web search result.
@@ -2386,6 +2421,11 @@ msgstr "Brasil"
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Break Points Won"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Break this down into clear, numbered steps."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -2751,6 +2791,11 @@ msgstr "Trabajos"
 #. Text of a button that performs a search for the cast of a particular movie or tv show
 msgctxt "Movie/TV Show Title instant answer"
 msgid "Cast"
+msgstr ""
+
+#. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Cast & Crew"
 msgstr ""
 
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -4118,6 +4163,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Create a shopping list with quantities from this recipe."
+msgstr ""
+
 #. Placeholder text displayed in the input field when starting a new image generation session.
 msgctxt "Placeholder text for the image generation input field"
 msgid "Create an image of a cute duck..."
@@ -4644,6 +4694,10 @@ msgstr ""
 msgid "Dictation limit reached"
 msgstr ""
 
+#. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
+msgid "Dictation temporarily unavailable"
+msgstr ""
+
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
@@ -4888,6 +4942,20 @@ msgctxt "precise_user_location"
 msgid "Done"
 msgstr "Hecho"
 
+#. Message shown in a modal after DuckDuckGo browser users disable AI features in Settings. The first two placeholders bold noai.duckduckgo.com. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
+"filtered out. %sLearn More%s"
+msgstr ""
+
+#. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
+"and AI images filtered out. %sLearn more%s"
+msgstr ""
+
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Double Faults"
@@ -4978,6 +5046,16 @@ msgctxt "Full sentence for writing an email"
 msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
+msgstr ""
+
+#. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Draft a cover letter"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Draft a cover letter for this job."
 msgstr ""
 
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -5117,6 +5195,14 @@ msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
 msgstr ""
 
+#. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
+msgctxt "About section description on the Duck.ai settings page"
+msgid ""
+"Duck.ai is created by DuckDuckGo. We're an independent online protection "
+"company for anyone who wants to take back control of their personal "
+"information."
+msgstr ""
+
 #. Title shown when an update is required before proceeding.
 msgctxt "duckai_migration"
 msgid "Duck.ai is moving domains"
@@ -5150,6 +5236,12 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Duck.ai lets you chat privately with popular AI models. Disabling it hides "
+"Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
 
 msgctxt "settings"
@@ -5917,6 +6009,16 @@ msgstr ""
 msgid "Eritrea"
 msgstr ""
 
+#. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Estimate the nutrition"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Estimate the nutritional information for this recipe."
+msgstr ""
+
 msgid "Estonia"
 msgstr "Estonia"
 
@@ -5961,10 +6063,50 @@ msgctxt "merchant promotion product ad extension"
 msgid "Expires in 1 day"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain the accepted answer in simple terms."
+msgstr ""
+
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
+msgstr ""
+
+#. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain the top answer"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this in simple, plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this paper"
+msgstr ""
+
+#. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this repo"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this research paper in plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this simply"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain what this repository does and how to use it."
 msgstr ""
 
 #. Label to show if song lyrics contain explicit content
@@ -6195,6 +6337,11 @@ msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
 msgstr ""
 
+msgctxt "settings"
+msgid ""
+"Filters out known AI spam sites from image search results. %sLearn More%s"
+msgstr ""
+
 #. Label for the final score of a sporting event.
 msgid "Final"
 msgstr "Final"
@@ -6236,6 +6383,11 @@ msgstr ""
 #. Short description shown below the 'Web Search' label in the Tools dropdown.
 msgctxt "Subtitle for the Web Search tool entry in the Tools dropdown menu"
 msgid "Find current information"
+msgstr ""
+
+#. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Find me alternatives"
 msgstr ""
 
 #. Button that searches for results closer to the user's current location.
@@ -6626,6 +6778,11 @@ msgstr ""
 msgid "Generate More"
 msgstr ""
 
+#. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Generate a shopping list"
+msgstr ""
+
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
 msgid "Generate a short answer from the web"
 msgstr ""
@@ -6862,6 +7019,11 @@ msgstr ""
 #. Text for a button inviting users to give it a try for the Duck.ai product. On click, they're taken to the Duck.ai page.
 msgctxt "Onboarding welcome screen button text"
 msgid "Give it a Try"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Give me a quick background on this person."
 msgstr ""
 
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -7225,6 +7387,16 @@ msgstr ""
 #. Link to a page with information about sharing DuckDuckGo with friends.
 msgid "Help Spread Privacy"
 msgstr "Ayuda a Difundir la Privacidad"
+
+#. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Help me prep for the interview"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Help me tailor my resume for this job."
+msgstr ""
 
 #. Title of a SERP popup that invites users to take a survey (desktop only)
 msgctxt "User survey popup"
@@ -7647,6 +7819,13 @@ msgstr ""
 #. Text displayed on the button on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
 msgctxt "Onboarding terms screen button text"
 msgid "I Agree"
+msgstr ""
+
+#. Text for the button that takes the user to the external DuckDuckGo login subscription page.
+msgctxt ""
+"Text for the I already have a subscription button in the Duck.ai settings "
+"page"
+msgid "I Already Have a Subscription"
 msgstr ""
 
 #. Text for the button that takes the user to the login subscription page.
@@ -8105,6 +8284,11 @@ msgctxt "Sidemenu browser promo"
 msgid "Install Mac Browser"
 msgstr ""
 
+#. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
+msgctxt "settings"
+msgid "Install Now"
+msgstr ""
+
 #. Text of a button to install the DuckDuckGo app
 msgctxt "Serp footer content"
 msgid "Install Our App"
@@ -8184,9 +8368,36 @@ msgctxt "cloudsave"
 msgid "Is deleted data really deleted?"
 msgstr "Los datos eliminados, ¿Son realmente eliminados?"
 
+#. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is it worth taking?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this place any good?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"Is this place any good? Summarize its reputation based on reviews and "
+"ratings."
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "Is this video helpful?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this worth watching?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Is this worth watching? Give me a spoiler-free take."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -8686,6 +8897,11 @@ msgstr "Fuente del enlace:"
 msgid "Links:"
 msgstr "Enlaces:"
 
+#. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "List the tools, materials, or prerequisites I need for this."
+msgstr ""
+
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
 msgid "Listen"
 msgstr "Escuchar"
@@ -9020,6 +9236,11 @@ msgstr ""
 #. Label for linke navigating to site exclusion feature on Settings page
 msgctxt "Exclusion message manage sites button"
 msgid "Manage blocked sites"
+msgstr ""
+
+#. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
+msgctxt "setting"
+msgid "Manage in Browser Settings"
 msgstr ""
 
 #. Link to the site exclusion settings page
@@ -11330,6 +11551,11 @@ msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
+msgid "Please describe why the chat response is harmful or illegal. (optional)"
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
+msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
 msgstr ""
 
@@ -11348,6 +11574,13 @@ msgctxt "Modal disclaimer text"
 msgid ""
 "Please note: starting a new chat with any model will delete your current "
 "chat session."
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
+msgctxt "Feedback prompt"
+msgid ""
+"Please paste your prompt and the problematic output (with any personal "
+"information removed) and describe why the content is harmful or illegal."
 msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -11734,6 +11967,11 @@ msgctxt "settings"
 msgid "Privacy"
 msgstr "Privacidad"
 
+#. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
+msgctxt "Section heading on the Duck.ai settings page"
+msgid "Privacy & Terms"
+msgstr ""
+
 msgid "Privacy Blog"
 msgstr "Blog de Privacidad"
 
@@ -11787,6 +12025,11 @@ msgstr ""
 
 #. Text used in other strings to link to the Privacy Policy and Terms of Service content.
 msgctxt "Copy used to compose link in sentences"
+msgid "Privacy Policy and Terms of Service"
+msgstr ""
+
+#. Text for a button that links to the terms of use and privacy policy page.
+msgctxt "Secondary button text in active privacy modal"
 msgid "Privacy Policy and Terms of Service"
 msgstr ""
 
@@ -12195,6 +12438,26 @@ msgctxt "Brief for recommending a book"
 msgid "Recommend a book"
 msgstr ""
 
+#. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar books"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar books."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar movies or shows."
+msgstr ""
+
+#. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar titles"
+msgstr ""
+
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
 msgid "Recording failed. Please try again."
 msgstr ""
@@ -12514,6 +12777,14 @@ msgstr ""
 msgid "Republic of Moldova"
 msgstr ""
 
+#. Note indicating that sharing the conversation is mandatory when reporting harmful or illegal content. Rendered alongside the standard share label (DUCKCHAT_RESPONSE_FEEDBACK_SHARE_PROMPT_RESPONSE_LABEL), not replacing it.
+msgctxt ""
+"Note shown under the share-content switch label on the Duck.ai response "
+"feedback form when the user has selected Harmful or Illegal as the feedback "
+"reason"
+msgid "Required for harmful or illegal reports"
+msgstr ""
+
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
 msgctxt "Description for extended reasoning mode in Duck.ai"
 msgid "Researches before responding"
@@ -12700,6 +12971,11 @@ msgstr "Reseñas"
 msgctxt "maps_places"
 msgid "Reviews"
 msgstr "Reseñas"
+
+#. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Rewrite this recipe scaled for a different number of servings."
+msgstr ""
 
 msgid "Romania"
 msgstr "Rumania"
@@ -13753,6 +14029,11 @@ msgctxt "Setup button for native sync flow"
 msgid "Set Up Now"
 msgstr ""
 
+#. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
+msgctxt "Encrypted storage setup button shown in native browsers"
+msgid "Set Up Sync & Backup"
+msgstr ""
+
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
 msgctxt "Title for the Sync & Backup intro screen"
 msgid "Set Up Sync & Backup"
@@ -13897,6 +14178,12 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
+msgctxt ""
+"Label beside the share-content switch on the Duck.ai response feedback form"
+msgid "Share this conversation with DuckDuckGo"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -14912,6 +15199,21 @@ msgctxt "Brief for suggesting a blog post title"
 msgid "Suggest a title for a blog post"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest related articles or topics worth exploring next."
+msgstr ""
+
+#. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Suggest related articles to explore"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest some alternatives to this product."
+msgstr ""
+
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
 msgctxt "directions"
 msgid "Suggestions:"
@@ -14921,9 +15223,84 @@ msgctxt "noresults"
 msgid "Suggestions:"
 msgstr "Sugerencias:"
 
+#. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Sum up the reviews"
+msgstr ""
+
 #. A short title for the a message asking the AI to summarize a text.
 msgctxt "Title for the summarize message"
 msgid "Summarize"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize the Q&As"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the background and notable work of this person."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the key details of this event."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the questions and answers on this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize their background"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this book"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this book."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this discussion"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this discussion thread."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this video"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this video."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize what the reviews say."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -15178,6 +15555,11 @@ msgstr ""
 msgid "Syria"
 msgstr ""
 
+#. Text for a button that enables the theme to follow the operating system's color scheme preference.
+msgctxt "System theme button for theme selector"
+msgid "System"
+msgstr ""
+
 #. Abbreviation indicating this is the total score for a game
 msgctxt "Sports module"
 msgid "T"
@@ -15201,6 +15583,11 @@ msgctxt "language_name"
 msgid "Tahitian"
 msgstr ""
 
+#. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Tailor my resume"
+msgstr ""
+
 msgid "Taiwan"
 msgstr "Taiwan"
 
@@ -15222,6 +15609,12 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "Take control of your personal data!"
+msgstr ""
+
+#. Description for the Feedback section of the Duck.ai settings page, asking the user to take an anonymous survey to let us know how we can make Duck.ai better.
+msgctxt "Feedback section description on the Duck.ai settings page"
+msgid ""
+"Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
 
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -15469,6 +15862,11 @@ msgstr ""
 #. https://duck.co/media/files/theme.png
 msgid "Theme"
 msgstr "Tema"
+
+#. Text for the theme selector label that allows users to switch between Light and dark theme.
+msgctxt "Label for the theme selector feature"
+msgid "Theme"
+msgstr ""
 
 #. http://i.imgur.com/LpFhb1e.png
 msgctxt "settings"
@@ -16125,6 +16523,16 @@ msgid ""
 "movie theatre?”"
 msgstr ""
 
+#. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Translate this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
+msgctxt "Page suggestion prompt"
+msgid "Translate this page into %s."
+msgstr ""
+
 #. Placeholder text for a region that will display translated text.
 msgctxt "translations_module"
 msgid "Translation"
@@ -16239,6 +16647,11 @@ msgstr ""
 #. Call-to-action button for the subscription promo in the SERP sidemenu.
 msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
+msgstr ""
+
+#. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
+msgctxt "settings"
+msgid "Try It Now"
 msgstr ""
 
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -16435,6 +16848,20 @@ msgstr "Prueba: %s"
 msgctxt "new user poll"
 msgid "Trying DuckDuckGo again"
 msgstr "Probando DuckDuckGo de nuevo"
+
+#. Message shown in a modal after supported third-party browser users disable AI features in Settings. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+#. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
 
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
 msgctxt "Assistant response placeholder"
@@ -17047,6 +17474,11 @@ msgstr ""
 msgid "Uruguay"
 msgstr ""
 
+#. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
+msgctxt "Navigation label on the Duck.ai settings page"
+msgid "Usage"
+msgstr ""
+
 #. A feedback suggestion
 msgctxt "Feedback prompt"
 msgid "Usage limit"
@@ -17398,6 +17830,11 @@ msgstr ""
 msgid "Wales"
 msgstr ""
 
+#. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Walk me through the steps"
+msgstr ""
+
 #. Label for walking directions on a map.
 msgctxt "directions"
 msgid "Walking"
@@ -17488,6 +17925,16 @@ msgstr ""
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
+msgstr ""
+
+#. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
+msgctxt ""
+"Inline warning shown below the share-content toggle when the user selects "
+"Harmful or Illegal but has not enabled sharing"
+msgid ""
+"We can only fix what we can see. To report a harmful or illegal response, "
+"please share this conversation with DuckDuckGo so we can investigate and "
+"address the issue."
 msgstr ""
 
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -17915,6 +18362,87 @@ msgid ""
 "experience."
 msgstr ""
 
+#. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the counterarguments?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the hours & location?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key contributions of this paper?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key contributions?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key details?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key points covered in this video?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key points?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key takeaways from this article?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key takeaways?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key things I will learn from this course?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main counterarguments or criticisms of this?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main questions this page answers?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the must-try dishes here?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"What are the opening hours, location, and contact details for this place?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the pros and cons of this product?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the pros and cons?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
 msgctxt "feedback form"
 msgid "What bothered you most?"
@@ -17998,6 +18526,11 @@ msgctxt "Full sentence for defining a term"
 msgid "What does atria mean in the context of a medical article?"
 msgstr ""
 
+#. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What does this answer?"
+msgstr ""
+
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
@@ -18007,6 +18540,11 @@ msgstr ""
 msgctxt "cloudsave"
 msgid "What information gets saved?"
 msgstr "¿Qué información es guardada?"
+
+#. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What interview questions might come up for this role?"
+msgstr ""
 
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
@@ -18018,6 +18556,11 @@ msgstr ""
 #. Text for a prompt suggestion for looking up the capital city of Albania.
 msgctxt "Full sentence for looking up basic facts"
 msgid "What is the capital city of Albania?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What is the overall verdict and rating for this?"
 msgstr ""
 
 #. Link to a page with additional information.
@@ -18038,6 +18581,11 @@ msgctxt "maps_places"
 msgid "What people say:"
 msgstr ""
 
+#. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What should I order?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
 msgctxt "feedback form"
 msgid "What stood out?"
@@ -18046,6 +18594,16 @@ msgstr ""
 #. Question on a feedback form for a negative feedback response.
 msgctxt "feedback form"
 msgid "What was wrong with the response? (optional)"
+msgstr ""
+
+#. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I learn?"
+msgstr ""
+
+#. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I need?"
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -18060,6 +18618,11 @@ msgstr ""
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
 msgctxt "SERP footer content"
 msgid "What's New"
+msgstr ""
+
+#. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What's the verdict?"
 msgstr ""
 
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -18102,6 +18665,11 @@ msgctxt "Feedback prompt"
 msgid "Which features are missing? (Optional)"
 msgstr ""
 
+#. An invitation for users to leave feedback
+msgctxt "Feedback prompt"
+msgid "Which features are missing? (optional)"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
 msgid "White"
 msgstr "Blanco"
@@ -18114,6 +18682,16 @@ msgstr "Blanco"
 #. Link to an about us page.
 msgid "Who We Are"
 msgstr "Quiénes Somos"
+
+#. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Who are the main cast and crew, and what else are they known for?"
+msgstr ""
+
+#. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Who is this person?"
+msgstr ""
 
 #. Header above a collection of privacy-related links.
 msgid "Why Privacy"

--- a/locales/es_PE/LC_MESSAGES/duckduckgo.po
+++ b/locales/es_PE/LC_MESSAGES/duckduckgo.po
@@ -1159,6 +1159,11 @@ msgctxt "feedback form"
 msgid "Address is incorrect"
 msgstr ""
 
+#. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Adjust the servings"
+msgstr ""
+
 #. as in multiple advertisements
 msgid "Ads"
 msgstr ""
@@ -1332,6 +1337,13 @@ msgstr ""
 #. Heading shown on the empty chat screen. The text between the two %s markers is displayed inside a clickable privacy button. First %s renders a shield icon, second %s is an invisible end marker. Keep the word 'private' between both %s markers.
 msgctxt "Empty state heading in Duck.ai chat mode"
 msgid "All chats are %sprivate%s"
+msgstr ""
+
+#. Paragraph in the Privacy & Terms section of the About & Legal page in Duck.ai settings, summarizing how chats are anonymized and are not stored or used to train chat models.
+msgctxt "Privacy & Terms section description on the Duck.ai settings page"
+msgid ""
+"All chats are anonymized by DuckDuckGo, and your conversations are not used "
+"to train chat models by DuckDuckGo or the model providers"
 msgstr ""
 
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1544,6 +1556,12 @@ msgstr ""
 #. Confirmation message after location service is enabled.
 msgctxt "precise_user_location"
 msgid "Anonymous location enabled"
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Anonymously generates answers for search queries based on web content. "
+"Choose how often you want it to appear, or disable it completely."
 msgstr ""
 
 #. Instant Answer tab name
@@ -1766,6 +1784,11 @@ msgstr ""
 
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse
 msgid "Ask a follow-up with Duck.ai"
+msgstr ""
+
+#. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
+msgctxt "Page suggestion chip label"
+msgid "Ask about this page"
 msgstr ""
 
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2090,6 +2113,11 @@ msgstr ""
 msgid "Barcode"
 msgstr "Código de barras"
 
+#. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Based on this page, is this course worth taking?"
+msgstr ""
+
 msgctxt "settings"
 msgid "Basic"
 msgstr "Básico"
@@ -2121,6 +2149,13 @@ msgstr ""
 #. Placeholder text displayed while the assistant waits for the user to choose an action.
 msgctxt "Assistant response placeholder"
 msgid "Before continuing..."
+msgstr ""
+
+#. Explains that before storing the report, DuckDuckGo will anonymize the conversation by removing PII like names, email addresses, and identifying metadata.
+msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
+msgid ""
+"Before storing this report, DuckDuckGo will anonymize your conversation by "
+"removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
 #. Label that's displayed next to a past start date below a web search result.
@@ -2379,6 +2414,11 @@ msgstr ""
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Break Points Won"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Break this down into clear, numbered steps."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -2738,6 +2778,11 @@ msgstr ""
 #. Text of a button that performs a search for the cast of a particular movie or tv show
 msgctxt "Movie/TV Show Title instant answer"
 msgid "Cast"
+msgstr ""
+
+#. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Cast & Crew"
 msgstr ""
 
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -4097,6 +4142,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Create a shopping list with quantities from this recipe."
+msgstr ""
+
 #. Placeholder text displayed in the input field when starting a new image generation session.
 msgctxt "Placeholder text for the image generation input field"
 msgid "Create an image of a cute duck..."
@@ -4623,6 +4673,10 @@ msgstr ""
 msgid "Dictation limit reached"
 msgstr ""
 
+#. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
+msgid "Dictation temporarily unavailable"
+msgstr ""
+
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
@@ -4867,6 +4921,20 @@ msgctxt "precise_user_location"
 msgid "Done"
 msgstr "Hecho"
 
+#. Message shown in a modal after DuckDuckGo browser users disable AI features in Settings. The first two placeholders bold noai.duckduckgo.com. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
+"filtered out. %sLearn More%s"
+msgstr ""
+
+#. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
+"and AI images filtered out. %sLearn more%s"
+msgstr ""
+
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Double Faults"
@@ -4957,6 +5025,16 @@ msgctxt "Full sentence for writing an email"
 msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
+msgstr ""
+
+#. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Draft a cover letter"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Draft a cover letter for this job."
 msgstr ""
 
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -5096,6 +5174,14 @@ msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
 msgstr ""
 
+#. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
+msgctxt "About section description on the Duck.ai settings page"
+msgid ""
+"Duck.ai is created by DuckDuckGo. We're an independent online protection "
+"company for anyone who wants to take back control of their personal "
+"information."
+msgstr ""
+
 #. Title shown when an update is required before proceeding.
 msgctxt "duckai_migration"
 msgid "Duck.ai is moving domains"
@@ -5129,6 +5215,12 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Duck.ai lets you chat privately with popular AI models. Disabling it hides "
+"Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
 
 msgctxt "settings"
@@ -5894,6 +5986,16 @@ msgstr ""
 msgid "Eritrea"
 msgstr ""
 
+#. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Estimate the nutrition"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Estimate the nutritional information for this recipe."
+msgstr ""
+
 msgid "Estonia"
 msgstr ""
 
@@ -5938,10 +6040,50 @@ msgctxt "merchant promotion product ad extension"
 msgid "Expires in 1 day"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain the accepted answer in simple terms."
+msgstr ""
+
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
+msgstr ""
+
+#. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain the top answer"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this in simple, plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this paper"
+msgstr ""
+
+#. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this repo"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this research paper in plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this simply"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain what this repository does and how to use it."
 msgstr ""
 
 #. Label to show if song lyrics contain explicit content
@@ -6172,6 +6314,11 @@ msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
 msgstr ""
 
+msgctxt "settings"
+msgid ""
+"Filters out known AI spam sites from image search results. %sLearn More%s"
+msgstr ""
+
 #. Label for the final score of a sporting event.
 msgid "Final"
 msgstr ""
@@ -6211,6 +6358,11 @@ msgstr ""
 #. Short description shown below the 'Web Search' label in the Tools dropdown.
 msgctxt "Subtitle for the Web Search tool entry in the Tools dropdown menu"
 msgid "Find current information"
+msgstr ""
+
+#. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Find me alternatives"
 msgstr ""
 
 #. Button that searches for results closer to the user's current location.
@@ -6601,6 +6753,11 @@ msgstr ""
 msgid "Generate More"
 msgstr ""
 
+#. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Generate a shopping list"
+msgstr ""
+
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
 msgid "Generate a short answer from the web"
 msgstr ""
@@ -6835,6 +6992,11 @@ msgstr ""
 #. Text for a button inviting users to give it a try for the Duck.ai product. On click, they're taken to the Duck.ai page.
 msgctxt "Onboarding welcome screen button text"
 msgid "Give it a Try"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Give me a quick background on this person."
 msgstr ""
 
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -7197,6 +7359,16 @@ msgstr ""
 
 #. Link to a page with information about sharing DuckDuckGo with friends.
 msgid "Help Spread Privacy"
+msgstr ""
+
+#. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Help me prep for the interview"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Help me tailor my resume for this job."
 msgstr ""
 
 #. Title of a SERP popup that invites users to take a survey (desktop only)
@@ -7616,6 +7788,13 @@ msgstr ""
 #. Text displayed on the button on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
 msgctxt "Onboarding terms screen button text"
 msgid "I Agree"
+msgstr ""
+
+#. Text for the button that takes the user to the external DuckDuckGo login subscription page.
+msgctxt ""
+"Text for the I already have a subscription button in the Duck.ai settings "
+"page"
+msgid "I Already Have a Subscription"
 msgstr ""
 
 #. Text for the button that takes the user to the login subscription page.
@@ -8071,6 +8250,11 @@ msgctxt "Sidemenu browser promo"
 msgid "Install Mac Browser"
 msgstr ""
 
+#. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
+msgctxt "settings"
+msgid "Install Now"
+msgstr ""
+
 #. Text of a button to install the DuckDuckGo app
 msgctxt "Serp footer content"
 msgid "Install Our App"
@@ -8150,9 +8334,36 @@ msgctxt "cloudsave"
 msgid "Is deleted data really deleted?"
 msgstr "¿Los datos borrados están realmente borrados?"
 
+#. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is it worth taking?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this place any good?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"Is this place any good? Summarize its reputation based on reviews and "
+"ratings."
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "Is this video helpful?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this worth watching?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Is this worth watching? Give me a spoiler-free take."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -8649,6 +8860,11 @@ msgstr "Fuente del link:"
 msgid "Links:"
 msgstr "Enlaces:"
 
+#. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "List the tools, materials, or prerequisites I need for this."
+msgstr ""
+
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
 msgid "Listen"
 msgstr "Escuchar"
@@ -8981,6 +9197,11 @@ msgstr ""
 #. Label for linke navigating to site exclusion feature on Settings page
 msgctxt "Exclusion message manage sites button"
 msgid "Manage blocked sites"
+msgstr ""
+
+#. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
+msgctxt "setting"
+msgid "Manage in Browser Settings"
 msgstr ""
 
 #. Link to the site exclusion settings page
@@ -11280,6 +11501,11 @@ msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
+msgid "Please describe why the chat response is harmful or illegal. (optional)"
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
+msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
 msgstr ""
 
@@ -11298,6 +11524,13 @@ msgctxt "Modal disclaimer text"
 msgid ""
 "Please note: starting a new chat with any model will delete your current "
 "chat session."
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
+msgctxt "Feedback prompt"
+msgid ""
+"Please paste your prompt and the problematic output (with any personal "
+"information removed) and describe why the content is harmful or illegal."
 msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -11682,6 +11915,11 @@ msgctxt "settings"
 msgid "Privacy"
 msgstr "Privacidad"
 
+#. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
+msgctxt "Section heading on the Duck.ai settings page"
+msgid "Privacy & Terms"
+msgstr ""
+
 msgid "Privacy Blog"
 msgstr ""
 
@@ -11735,6 +11973,11 @@ msgstr ""
 
 #. Text used in other strings to link to the Privacy Policy and Terms of Service content.
 msgctxt "Copy used to compose link in sentences"
+msgid "Privacy Policy and Terms of Service"
+msgstr ""
+
+#. Text for a button that links to the terms of use and privacy policy page.
+msgctxt "Secondary button text in active privacy modal"
 msgid "Privacy Policy and Terms of Service"
 msgstr ""
 
@@ -12143,6 +12386,26 @@ msgctxt "Brief for recommending a book"
 msgid "Recommend a book"
 msgstr ""
 
+#. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar books"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar books."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar movies or shows."
+msgstr ""
+
+#. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar titles"
+msgstr ""
+
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
 msgid "Recording failed. Please try again."
 msgstr ""
@@ -12462,6 +12725,14 @@ msgstr ""
 msgid "Republic of Moldova"
 msgstr ""
 
+#. Note indicating that sharing the conversation is mandatory when reporting harmful or illegal content. Rendered alongside the standard share label (DUCKCHAT_RESPONSE_FEEDBACK_SHARE_PROMPT_RESPONSE_LABEL), not replacing it.
+msgctxt ""
+"Note shown under the share-content switch label on the Duck.ai response "
+"feedback form when the user has selected Harmful or Illegal as the feedback "
+"reason"
+msgid "Required for harmful or illegal reports"
+msgstr ""
+
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
 msgctxt "Description for extended reasoning mode in Duck.ai"
 msgid "Researches before responding"
@@ -12647,6 +12918,11 @@ msgstr "Comentarios"
 #. Label above a list of customer reviews of a business.
 msgctxt "maps_places"
 msgid "Reviews"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Rewrite this recipe scaled for a different number of servings."
 msgstr ""
 
 msgid "Romania"
@@ -13692,6 +13968,11 @@ msgctxt "Setup button for native sync flow"
 msgid "Set Up Now"
 msgstr ""
 
+#. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
+msgctxt "Encrypted storage setup button shown in native browsers"
+msgid "Set Up Sync & Backup"
+msgstr ""
+
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
 msgctxt "Title for the Sync & Backup intro screen"
 msgid "Set Up Sync & Backup"
@@ -13836,6 +14117,12 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
+msgctxt ""
+"Label beside the share-content switch on the Duck.ai response feedback form"
+msgid "Share this conversation with DuckDuckGo"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -14851,6 +15138,21 @@ msgctxt "Brief for suggesting a blog post title"
 msgid "Suggest a title for a blog post"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest related articles or topics worth exploring next."
+msgstr ""
+
+#. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Suggest related articles to explore"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest some alternatives to this product."
+msgstr ""
+
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
 msgctxt "directions"
 msgid "Suggestions:"
@@ -14860,9 +15162,84 @@ msgctxt "noresults"
 msgid "Suggestions:"
 msgstr ""
 
+#. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Sum up the reviews"
+msgstr ""
+
 #. A short title for the a message asking the AI to summarize a text.
 msgctxt "Title for the summarize message"
 msgid "Summarize"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize the Q&As"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the background and notable work of this person."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the key details of this event."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the questions and answers on this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize their background"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this book"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this book."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this discussion"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this discussion thread."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this video"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this video."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize what the reviews say."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -15117,6 +15494,11 @@ msgstr ""
 msgid "Syria"
 msgstr ""
 
+#. Text for a button that enables the theme to follow the operating system's color scheme preference.
+msgctxt "System theme button for theme selector"
+msgid "System"
+msgstr ""
+
 #. Abbreviation indicating this is the total score for a game
 msgctxt "Sports module"
 msgid "T"
@@ -15140,6 +15522,11 @@ msgctxt "language_name"
 msgid "Tahitian"
 msgstr ""
 
+#. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Tailor my resume"
+msgstr ""
+
 msgid "Taiwan"
 msgstr ""
 
@@ -15161,6 +15548,12 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "Take control of your personal data!"
+msgstr ""
+
+#. Description for the Feedback section of the Duck.ai settings page, asking the user to take an anonymous survey to let us know how we can make Duck.ai better.
+msgctxt "Feedback section description on the Duck.ai settings page"
+msgid ""
+"Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
 
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -15405,6 +15798,11 @@ msgstr ""
 #. https://duck.co/media/files/theme.png
 msgid "Theme"
 msgstr "Tema"
+
+#. Text for the theme selector label that allows users to switch between Light and dark theme.
+msgctxt "Label for the theme selector feature"
+msgid "Theme"
+msgstr ""
 
 #. http://i.imgur.com/LpFhb1e.png
 msgctxt "settings"
@@ -16058,6 +16456,16 @@ msgid ""
 "movie theatre?”"
 msgstr ""
 
+#. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Translate this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
+msgctxt "Page suggestion prompt"
+msgid "Translate this page into %s."
+msgstr ""
+
 #. Placeholder text for a region that will display translated text.
 msgctxt "translations_module"
 msgid "Translation"
@@ -16172,6 +16580,11 @@ msgstr ""
 #. Call-to-action button for the subscription promo in the SERP sidemenu.
 msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
+msgstr ""
+
+#. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
+msgctxt "settings"
+msgid "Try It Now"
 msgstr ""
 
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -16366,6 +16779,20 @@ msgstr "Prueba: %s"
 #. Response a user can select in a feedback form, indicating that they're trying DuckDuckGo again.
 msgctxt "new user poll"
 msgid "Trying DuckDuckGo again"
+msgstr ""
+
+#. Message shown in a modal after supported third-party browser users disable AI features in Settings. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+#. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
 msgstr ""
 
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -16970,6 +17397,11 @@ msgstr ""
 msgid "Uruguay"
 msgstr ""
 
+#. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
+msgctxt "Navigation label on the Duck.ai settings page"
+msgid "Usage"
+msgstr ""
+
 #. A feedback suggestion
 msgctxt "Feedback prompt"
 msgid "Usage limit"
@@ -17318,6 +17750,11 @@ msgstr ""
 msgid "Wales"
 msgstr ""
 
+#. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Walk me through the steps"
+msgstr ""
+
 #. Label for walking directions on a map.
 msgctxt "directions"
 msgid "Walking"
@@ -17408,6 +17845,16 @@ msgstr ""
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
+msgstr ""
+
+#. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
+msgctxt ""
+"Inline warning shown below the share-content toggle when the user selects "
+"Harmful or Illegal but has not enabled sharing"
+msgid ""
+"We can only fix what we can see. To report a harmful or illegal response, "
+"please share this conversation with DuckDuckGo so we can investigate and "
+"address the issue."
 msgstr ""
 
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -17827,6 +18274,87 @@ msgid ""
 "experience."
 msgstr ""
 
+#. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the counterarguments?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the hours & location?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key contributions of this paper?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key contributions?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key details?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key points covered in this video?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key points?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key takeaways from this article?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key takeaways?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key things I will learn from this course?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main counterarguments or criticisms of this?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main questions this page answers?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the must-try dishes here?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"What are the opening hours, location, and contact details for this place?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the pros and cons of this product?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the pros and cons?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
 msgctxt "feedback form"
 msgid "What bothered you most?"
@@ -17910,6 +18438,11 @@ msgctxt "Full sentence for defining a term"
 msgid "What does atria mean in the context of a medical article?"
 msgstr ""
 
+#. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What does this answer?"
+msgstr ""
+
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
@@ -17919,6 +18452,11 @@ msgstr ""
 msgctxt "cloudsave"
 msgid "What information gets saved?"
 msgstr "¿Qué información fue guardada?"
+
+#. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What interview questions might come up for this role?"
+msgstr ""
 
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
@@ -17930,6 +18468,11 @@ msgstr ""
 #. Text for a prompt suggestion for looking up the capital city of Albania.
 msgctxt "Full sentence for looking up basic facts"
 msgid "What is the capital city of Albania?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What is the overall verdict and rating for this?"
 msgstr ""
 
 #. Link to a page with additional information.
@@ -17950,6 +18493,11 @@ msgctxt "maps_places"
 msgid "What people say:"
 msgstr ""
 
+#. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What should I order?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
 msgctxt "feedback form"
 msgid "What stood out?"
@@ -17958,6 +18506,16 @@ msgstr ""
 #. Question on a feedback form for a negative feedback response.
 msgctxt "feedback form"
 msgid "What was wrong with the response? (optional)"
+msgstr ""
+
+#. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I learn?"
+msgstr ""
+
+#. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I need?"
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -17972,6 +18530,11 @@ msgstr ""
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
 msgctxt "SERP footer content"
 msgid "What's New"
+msgstr ""
+
+#. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What's the verdict?"
 msgstr ""
 
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -18013,6 +18576,11 @@ msgctxt "Feedback prompt"
 msgid "Which features are missing? (Optional)"
 msgstr ""
 
+#. An invitation for users to leave feedback
+msgctxt "Feedback prompt"
+msgid "Which features are missing? (optional)"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
 msgid "White"
 msgstr "Blanco"
@@ -18024,6 +18592,16 @@ msgstr ""
 
 #. Link to an about us page.
 msgid "Who We Are"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Who are the main cast and crew, and what else are they known for?"
+msgstr ""
+
+#. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Who is this person?"
 msgstr ""
 
 #. Header above a collection of privacy-related links.

--- a/locales/es_UY/LC_MESSAGES/duckduckgo.po
+++ b/locales/es_UY/LC_MESSAGES/duckduckgo.po
@@ -1159,6 +1159,11 @@ msgctxt "feedback form"
 msgid "Address is incorrect"
 msgstr ""
 
+#. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Adjust the servings"
+msgstr ""
+
 #. as in multiple advertisements
 msgid "Ads"
 msgstr ""
@@ -1330,6 +1335,13 @@ msgstr ""
 #. Heading shown on the empty chat screen. The text between the two %s markers is displayed inside a clickable privacy button. First %s renders a shield icon, second %s is an invisible end marker. Keep the word 'private' between both %s markers.
 msgctxt "Empty state heading in Duck.ai chat mode"
 msgid "All chats are %sprivate%s"
+msgstr ""
+
+#. Paragraph in the Privacy & Terms section of the About & Legal page in Duck.ai settings, summarizing how chats are anonymized and are not stored or used to train chat models.
+msgctxt "Privacy & Terms section description on the Duck.ai settings page"
+msgid ""
+"All chats are anonymized by DuckDuckGo, and your conversations are not used "
+"to train chat models by DuckDuckGo or the model providers"
 msgstr ""
 
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1542,6 +1554,12 @@ msgstr ""
 #. Confirmation message after location service is enabled.
 msgctxt "precise_user_location"
 msgid "Anonymous location enabled"
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Anonymously generates answers for search queries based on web content. "
+"Choose how often you want it to appear, or disable it completely."
 msgstr ""
 
 #. Instant Answer tab name
@@ -1764,6 +1782,11 @@ msgstr ""
 
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse
 msgid "Ask a follow-up with Duck.ai"
+msgstr ""
+
+#. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
+msgctxt "Page suggestion chip label"
+msgid "Ask about this page"
 msgstr ""
 
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2088,6 +2111,11 @@ msgstr ""
 msgid "Barcode"
 msgstr "Código de barras"
 
+#. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Based on this page, is this course worth taking?"
+msgstr ""
+
 msgctxt "settings"
 msgid "Basic"
 msgstr ""
@@ -2119,6 +2147,13 @@ msgstr ""
 #. Placeholder text displayed while the assistant waits for the user to choose an action.
 msgctxt "Assistant response placeholder"
 msgid "Before continuing..."
+msgstr ""
+
+#. Explains that before storing the report, DuckDuckGo will anonymize the conversation by removing PII like names, email addresses, and identifying metadata.
+msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
+msgid ""
+"Before storing this report, DuckDuckGo will anonymize your conversation by "
+"removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
 #. Label that's displayed next to a past start date below a web search result.
@@ -2377,6 +2412,11 @@ msgstr ""
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Break Points Won"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Break this down into clear, numbered steps."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -2736,6 +2776,11 @@ msgstr ""
 #. Text of a button that performs a search for the cast of a particular movie or tv show
 msgctxt "Movie/TV Show Title instant answer"
 msgid "Cast"
+msgstr ""
+
+#. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Cast & Crew"
 msgstr ""
 
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -4087,6 +4132,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Create a shopping list with quantities from this recipe."
+msgstr ""
+
 #. Placeholder text displayed in the input field when starting a new image generation session.
 msgctxt "Placeholder text for the image generation input field"
 msgid "Create an image of a cute duck..."
@@ -4613,6 +4663,10 @@ msgstr ""
 msgid "Dictation limit reached"
 msgstr ""
 
+#. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
+msgid "Dictation temporarily unavailable"
+msgstr ""
+
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
@@ -4857,6 +4911,20 @@ msgctxt "precise_user_location"
 msgid "Done"
 msgstr "Hecho"
 
+#. Message shown in a modal after DuckDuckGo browser users disable AI features in Settings. The first two placeholders bold noai.duckduckgo.com. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
+"filtered out. %sLearn More%s"
+msgstr ""
+
+#. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
+"and AI images filtered out. %sLearn more%s"
+msgstr ""
+
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Double Faults"
@@ -4947,6 +5015,16 @@ msgctxt "Full sentence for writing an email"
 msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
+msgstr ""
+
+#. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Draft a cover letter"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Draft a cover letter for this job."
 msgstr ""
 
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -5086,6 +5164,14 @@ msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
 msgstr ""
 
+#. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
+msgctxt "About section description on the Duck.ai settings page"
+msgid ""
+"Duck.ai is created by DuckDuckGo. We're an independent online protection "
+"company for anyone who wants to take back control of their personal "
+"information."
+msgstr ""
+
 #. Title shown when an update is required before proceeding.
 msgctxt "duckai_migration"
 msgid "Duck.ai is moving domains"
@@ -5119,6 +5205,12 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Duck.ai lets you chat privately with popular AI models. Disabling it hides "
+"Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
 
 msgctxt "settings"
@@ -5884,6 +5976,16 @@ msgstr ""
 msgid "Eritrea"
 msgstr ""
 
+#. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Estimate the nutrition"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Estimate the nutritional information for this recipe."
+msgstr ""
+
 msgid "Estonia"
 msgstr ""
 
@@ -5928,10 +6030,50 @@ msgctxt "merchant promotion product ad extension"
 msgid "Expires in 1 day"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain the accepted answer in simple terms."
+msgstr ""
+
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
+msgstr ""
+
+#. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain the top answer"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this in simple, plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this paper"
+msgstr ""
+
+#. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this repo"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this research paper in plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this simply"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain what this repository does and how to use it."
 msgstr ""
 
 #. Label to show if song lyrics contain explicit content
@@ -6162,6 +6304,11 @@ msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
 msgstr ""
 
+msgctxt "settings"
+msgid ""
+"Filters out known AI spam sites from image search results. %sLearn More%s"
+msgstr ""
+
 #. Label for the final score of a sporting event.
 msgid "Final"
 msgstr ""
@@ -6201,6 +6348,11 @@ msgstr ""
 #. Short description shown below the 'Web Search' label in the Tools dropdown.
 msgctxt "Subtitle for the Web Search tool entry in the Tools dropdown menu"
 msgid "Find current information"
+msgstr ""
+
+#. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Find me alternatives"
 msgstr ""
 
 #. Button that searches for results closer to the user's current location.
@@ -6591,6 +6743,11 @@ msgstr ""
 msgid "Generate More"
 msgstr ""
 
+#. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Generate a shopping list"
+msgstr ""
+
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
 msgid "Generate a short answer from the web"
 msgstr ""
@@ -6825,6 +6982,11 @@ msgstr ""
 #. Text for a button inviting users to give it a try for the Duck.ai product. On click, they're taken to the Duck.ai page.
 msgctxt "Onboarding welcome screen button text"
 msgid "Give it a Try"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Give me a quick background on this person."
 msgstr ""
 
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -7187,6 +7349,16 @@ msgstr ""
 
 #. Link to a page with information about sharing DuckDuckGo with friends.
 msgid "Help Spread Privacy"
+msgstr ""
+
+#. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Help me prep for the interview"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Help me tailor my resume for this job."
 msgstr ""
 
 #. Title of a SERP popup that invites users to take a survey (desktop only)
@@ -7606,6 +7778,13 @@ msgstr ""
 #. Text displayed on the button on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
 msgctxt "Onboarding terms screen button text"
 msgid "I Agree"
+msgstr ""
+
+#. Text for the button that takes the user to the external DuckDuckGo login subscription page.
+msgctxt ""
+"Text for the I already have a subscription button in the Duck.ai settings "
+"page"
+msgid "I Already Have a Subscription"
 msgstr ""
 
 #. Text for the button that takes the user to the login subscription page.
@@ -8058,6 +8237,11 @@ msgctxt "Sidemenu browser promo"
 msgid "Install Mac Browser"
 msgstr ""
 
+#. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
+msgctxt "settings"
+msgid "Install Now"
+msgstr ""
+
 #. Text of a button to install the DuckDuckGo app
 msgctxt "Serp footer content"
 msgid "Install Our App"
@@ -8137,9 +8321,36 @@ msgctxt "cloudsave"
 msgid "Is deleted data really deleted?"
 msgstr "¿Son los datos borrados realmente borrados?"
 
+#. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is it worth taking?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this place any good?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"Is this place any good? Summarize its reputation based on reviews and "
+"ratings."
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "Is this video helpful?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this worth watching?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Is this worth watching? Give me a spoiler-free take."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -8636,6 +8847,11 @@ msgstr "Fuente de vínculos"
 msgid "Links:"
 msgstr "Enlaces:"
 
+#. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "List the tools, materials, or prerequisites I need for this."
+msgstr ""
+
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
 msgid "Listen"
 msgstr "Escuche"
@@ -8968,6 +9184,11 @@ msgstr ""
 #. Label for linke navigating to site exclusion feature on Settings page
 msgctxt "Exclusion message manage sites button"
 msgid "Manage blocked sites"
+msgstr ""
+
+#. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
+msgctxt "setting"
+msgid "Manage in Browser Settings"
 msgstr ""
 
 #. Link to the site exclusion settings page
@@ -11265,6 +11486,11 @@ msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
+msgid "Please describe why the chat response is harmful or illegal. (optional)"
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
+msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
 msgstr ""
 
@@ -11283,6 +11509,13 @@ msgctxt "Modal disclaimer text"
 msgid ""
 "Please note: starting a new chat with any model will delete your current "
 "chat session."
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
+msgctxt "Feedback prompt"
+msgid ""
+"Please paste your prompt and the problematic output (with any personal "
+"information removed) and describe why the content is harmful or illegal."
 msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -11667,6 +11900,11 @@ msgctxt "settings"
 msgid "Privacy"
 msgstr "Privacidad"
 
+#. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
+msgctxt "Section heading on the Duck.ai settings page"
+msgid "Privacy & Terms"
+msgstr ""
+
 msgid "Privacy Blog"
 msgstr ""
 
@@ -11720,6 +11958,11 @@ msgstr ""
 
 #. Text used in other strings to link to the Privacy Policy and Terms of Service content.
 msgctxt "Copy used to compose link in sentences"
+msgid "Privacy Policy and Terms of Service"
+msgstr ""
+
+#. Text for a button that links to the terms of use and privacy policy page.
+msgctxt "Secondary button text in active privacy modal"
 msgid "Privacy Policy and Terms of Service"
 msgstr ""
 
@@ -12128,6 +12371,26 @@ msgctxt "Brief for recommending a book"
 msgid "Recommend a book"
 msgstr ""
 
+#. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar books"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar books."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar movies or shows."
+msgstr ""
+
+#. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar titles"
+msgstr ""
+
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
 msgid "Recording failed. Please try again."
 msgstr ""
@@ -12447,6 +12710,14 @@ msgstr ""
 msgid "Republic of Moldova"
 msgstr ""
 
+#. Note indicating that sharing the conversation is mandatory when reporting harmful or illegal content. Rendered alongside the standard share label (DUCKCHAT_RESPONSE_FEEDBACK_SHARE_PROMPT_RESPONSE_LABEL), not replacing it.
+msgctxt ""
+"Note shown under the share-content switch label on the Duck.ai response "
+"feedback form when the user has selected Harmful or Illegal as the feedback "
+"reason"
+msgid "Required for harmful or illegal reports"
+msgstr ""
+
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
 msgctxt "Description for extended reasoning mode in Duck.ai"
 msgid "Researches before responding"
@@ -12632,6 +12903,11 @@ msgstr "Comentarios"
 #. Label above a list of customer reviews of a business.
 msgctxt "maps_places"
 msgid "Reviews"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Rewrite this recipe scaled for a different number of servings."
 msgstr ""
 
 msgid "Romania"
@@ -13667,6 +13943,11 @@ msgctxt "Setup button for native sync flow"
 msgid "Set Up Now"
 msgstr ""
 
+#. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
+msgctxt "Encrypted storage setup button shown in native browsers"
+msgid "Set Up Sync & Backup"
+msgstr ""
+
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
 msgctxt "Title for the Sync & Backup intro screen"
 msgid "Set Up Sync & Backup"
@@ -13811,6 +14092,12 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
+msgctxt ""
+"Label beside the share-content switch on the Duck.ai response feedback form"
+msgid "Share this conversation with DuckDuckGo"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -14825,6 +15112,21 @@ msgctxt "Brief for suggesting a blog post title"
 msgid "Suggest a title for a blog post"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest related articles or topics worth exploring next."
+msgstr ""
+
+#. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Suggest related articles to explore"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest some alternatives to this product."
+msgstr ""
+
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
 msgctxt "directions"
 msgid "Suggestions:"
@@ -14834,9 +15136,84 @@ msgctxt "noresults"
 msgid "Suggestions:"
 msgstr ""
 
+#. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Sum up the reviews"
+msgstr ""
+
 #. A short title for the a message asking the AI to summarize a text.
 msgctxt "Title for the summarize message"
 msgid "Summarize"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize the Q&As"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the background and notable work of this person."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the key details of this event."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the questions and answers on this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize their background"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this book"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this book."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this discussion"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this discussion thread."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this video"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this video."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize what the reviews say."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -15091,6 +15468,11 @@ msgstr ""
 msgid "Syria"
 msgstr ""
 
+#. Text for a button that enables the theme to follow the operating system's color scheme preference.
+msgctxt "System theme button for theme selector"
+msgid "System"
+msgstr ""
+
 #. Abbreviation indicating this is the total score for a game
 msgctxt "Sports module"
 msgid "T"
@@ -15114,6 +15496,11 @@ msgctxt "language_name"
 msgid "Tahitian"
 msgstr ""
 
+#. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Tailor my resume"
+msgstr ""
+
 msgid "Taiwan"
 msgstr ""
 
@@ -15135,6 +15522,12 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "Take control of your personal data!"
+msgstr ""
+
+#. Description for the Feedback section of the Duck.ai settings page, asking the user to take an anonymous survey to let us know how we can make Duck.ai better.
+msgctxt "Feedback section description on the Duck.ai settings page"
+msgid ""
+"Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
 
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -15379,6 +15772,11 @@ msgstr ""
 #. https://duck.co/media/files/theme.png
 msgid "Theme"
 msgstr "Tema"
+
+#. Text for the theme selector label that allows users to switch between Light and dark theme.
+msgctxt "Label for the theme selector feature"
+msgid "Theme"
+msgstr ""
 
 #. http://i.imgur.com/LpFhb1e.png
 msgctxt "settings"
@@ -16030,6 +16428,16 @@ msgid ""
 "movie theatre?”"
 msgstr ""
 
+#. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Translate this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
+msgctxt "Page suggestion prompt"
+msgid "Translate this page into %s."
+msgstr ""
+
 #. Placeholder text for a region that will display translated text.
 msgctxt "translations_module"
 msgid "Translation"
@@ -16144,6 +16552,11 @@ msgstr ""
 #. Call-to-action button for the subscription promo in the SERP sidemenu.
 msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
+msgstr ""
+
+#. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
+msgctxt "settings"
+msgid "Try It Now"
 msgstr ""
 
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -16338,6 +16751,20 @@ msgstr "Intenta: %s"
 #. Response a user can select in a feedback form, indicating that they're trying DuckDuckGo again.
 msgctxt "new user poll"
 msgid "Trying DuckDuckGo again"
+msgstr ""
+
+#. Message shown in a modal after supported third-party browser users disable AI features in Settings. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+#. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
 msgstr ""
 
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -16938,6 +17365,11 @@ msgstr ""
 msgid "Uruguay"
 msgstr ""
 
+#. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
+msgctxt "Navigation label on the Duck.ai settings page"
+msgid "Usage"
+msgstr ""
+
 #. A feedback suggestion
 msgctxt "Feedback prompt"
 msgid "Usage limit"
@@ -17286,6 +17718,11 @@ msgstr ""
 msgid "Wales"
 msgstr ""
 
+#. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Walk me through the steps"
+msgstr ""
+
 #. Label for walking directions on a map.
 msgctxt "directions"
 msgid "Walking"
@@ -17376,6 +17813,16 @@ msgstr ""
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
+msgstr ""
+
+#. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
+msgctxt ""
+"Inline warning shown below the share-content toggle when the user selects "
+"Harmful or Illegal but has not enabled sharing"
+msgid ""
+"We can only fix what we can see. To report a harmful or illegal response, "
+"please share this conversation with DuckDuckGo so we can investigate and "
+"address the issue."
 msgstr ""
 
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -17795,6 +18242,87 @@ msgid ""
 "experience."
 msgstr ""
 
+#. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the counterarguments?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the hours & location?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key contributions of this paper?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key contributions?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key details?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key points covered in this video?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key points?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key takeaways from this article?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key takeaways?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key things I will learn from this course?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main counterarguments or criticisms of this?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main questions this page answers?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the must-try dishes here?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"What are the opening hours, location, and contact details for this place?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the pros and cons of this product?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the pros and cons?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
 msgctxt "feedback form"
 msgid "What bothered you most?"
@@ -17878,6 +18406,11 @@ msgctxt "Full sentence for defining a term"
 msgid "What does atria mean in the context of a medical article?"
 msgstr ""
 
+#. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What does this answer?"
+msgstr ""
+
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
@@ -17887,6 +18420,11 @@ msgstr ""
 msgctxt "cloudsave"
 msgid "What information gets saved?"
 msgstr "¿Qué información se guarda?"
+
+#. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What interview questions might come up for this role?"
+msgstr ""
 
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
@@ -17898,6 +18436,11 @@ msgstr ""
 #. Text for a prompt suggestion for looking up the capital city of Albania.
 msgctxt "Full sentence for looking up basic facts"
 msgid "What is the capital city of Albania?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What is the overall verdict and rating for this?"
 msgstr ""
 
 #. Link to a page with additional information.
@@ -17918,6 +18461,11 @@ msgctxt "maps_places"
 msgid "What people say:"
 msgstr ""
 
+#. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What should I order?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
 msgctxt "feedback form"
 msgid "What stood out?"
@@ -17926,6 +18474,16 @@ msgstr ""
 #. Question on a feedback form for a negative feedback response.
 msgctxt "feedback form"
 msgid "What was wrong with the response? (optional)"
+msgstr ""
+
+#. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I learn?"
+msgstr ""
+
+#. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I need?"
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -17940,6 +18498,11 @@ msgstr ""
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
 msgctxt "SERP footer content"
 msgid "What's New"
+msgstr ""
+
+#. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What's the verdict?"
 msgstr ""
 
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -17981,6 +18544,11 @@ msgctxt "Feedback prompt"
 msgid "Which features are missing? (Optional)"
 msgstr ""
 
+#. An invitation for users to leave feedback
+msgctxt "Feedback prompt"
+msgid "Which features are missing? (optional)"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
 msgid "White"
 msgstr "Blanco"
@@ -17992,6 +18560,16 @@ msgstr ""
 
 #. Link to an about us page.
 msgid "Who We Are"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Who are the main cast and crew, and what else are they known for?"
+msgstr ""
+
+#. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Who is this person?"
 msgstr ""
 
 #. Header above a collection of privacy-related links.

--- a/locales/es_VE/LC_MESSAGES/duckduckgo.po
+++ b/locales/es_VE/LC_MESSAGES/duckduckgo.po
@@ -1161,6 +1161,11 @@ msgctxt "feedback form"
 msgid "Address is incorrect"
 msgstr ""
 
+#. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Adjust the servings"
+msgstr ""
+
 #. as in multiple advertisements
 msgid "Ads"
 msgstr ""
@@ -1332,6 +1337,13 @@ msgstr ""
 #. Heading shown on the empty chat screen. The text between the two %s markers is displayed inside a clickable privacy button. First %s renders a shield icon, second %s is an invisible end marker. Keep the word 'private' between both %s markers.
 msgctxt "Empty state heading in Duck.ai chat mode"
 msgid "All chats are %sprivate%s"
+msgstr ""
+
+#. Paragraph in the Privacy & Terms section of the About & Legal page in Duck.ai settings, summarizing how chats are anonymized and are not stored or used to train chat models.
+msgctxt "Privacy & Terms section description on the Duck.ai settings page"
+msgid ""
+"All chats are anonymized by DuckDuckGo, and your conversations are not used "
+"to train chat models by DuckDuckGo or the model providers"
 msgstr ""
 
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1544,6 +1556,12 @@ msgstr ""
 #. Confirmation message after location service is enabled.
 msgctxt "precise_user_location"
 msgid "Anonymous location enabled"
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Anonymously generates answers for search queries based on web content. "
+"Choose how often you want it to appear, or disable it completely."
 msgstr ""
 
 #. Instant Answer tab name
@@ -1766,6 +1784,11 @@ msgstr ""
 
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse
 msgid "Ask a follow-up with Duck.ai"
+msgstr ""
+
+#. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
+msgctxt "Page suggestion chip label"
+msgid "Ask about this page"
 msgstr ""
 
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2090,6 +2113,11 @@ msgstr ""
 msgid "Barcode"
 msgstr "Código de Barras"
 
+#. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Based on this page, is this course worth taking?"
+msgstr ""
+
 msgctxt "settings"
 msgid "Basic"
 msgstr "Básico"
@@ -2121,6 +2149,13 @@ msgstr ""
 #. Placeholder text displayed while the assistant waits for the user to choose an action.
 msgctxt "Assistant response placeholder"
 msgid "Before continuing..."
+msgstr ""
+
+#. Explains that before storing the report, DuckDuckGo will anonymize the conversation by removing PII like names, email addresses, and identifying metadata.
+msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
+msgid ""
+"Before storing this report, DuckDuckGo will anonymize your conversation by "
+"removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
 #. Label that's displayed next to a past start date below a web search result.
@@ -2379,6 +2414,11 @@ msgstr ""
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Break Points Won"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Break this down into clear, numbered steps."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -2738,6 +2778,11 @@ msgstr ""
 #. Text of a button that performs a search for the cast of a particular movie or tv show
 msgctxt "Movie/TV Show Title instant answer"
 msgid "Cast"
+msgstr ""
+
+#. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Cast & Crew"
 msgstr ""
 
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -4094,6 +4139,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Create a shopping list with quantities from this recipe."
+msgstr ""
+
 #. Placeholder text displayed in the input field when starting a new image generation session.
 msgctxt "Placeholder text for the image generation input field"
 msgid "Create an image of a cute duck..."
@@ -4620,6 +4670,10 @@ msgstr ""
 msgid "Dictation limit reached"
 msgstr ""
 
+#. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
+msgid "Dictation temporarily unavailable"
+msgstr ""
+
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
@@ -4864,6 +4918,20 @@ msgctxt "precise_user_location"
 msgid "Done"
 msgstr "Hecho"
 
+#. Message shown in a modal after DuckDuckGo browser users disable AI features in Settings. The first two placeholders bold noai.duckduckgo.com. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
+"filtered out. %sLearn More%s"
+msgstr ""
+
+#. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
+"and AI images filtered out. %sLearn more%s"
+msgstr ""
+
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Double Faults"
@@ -4954,6 +5022,16 @@ msgctxt "Full sentence for writing an email"
 msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
+msgstr ""
+
+#. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Draft a cover letter"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Draft a cover letter for this job."
 msgstr ""
 
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -5093,6 +5171,14 @@ msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
 msgstr ""
 
+#. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
+msgctxt "About section description on the Duck.ai settings page"
+msgid ""
+"Duck.ai is created by DuckDuckGo. We're an independent online protection "
+"company for anyone who wants to take back control of their personal "
+"information."
+msgstr ""
+
 #. Title shown when an update is required before proceeding.
 msgctxt "duckai_migration"
 msgid "Duck.ai is moving domains"
@@ -5126,6 +5212,12 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Duck.ai lets you chat privately with popular AI models. Disabling it hides "
+"Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
 
 msgctxt "settings"
@@ -5891,6 +5983,16 @@ msgstr ""
 msgid "Eritrea"
 msgstr ""
 
+#. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Estimate the nutrition"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Estimate the nutritional information for this recipe."
+msgstr ""
+
 msgid "Estonia"
 msgstr ""
 
@@ -5935,10 +6037,50 @@ msgctxt "merchant promotion product ad extension"
 msgid "Expires in 1 day"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain the accepted answer in simple terms."
+msgstr ""
+
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
+msgstr ""
+
+#. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain the top answer"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this in simple, plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this paper"
+msgstr ""
+
+#. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this repo"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this research paper in plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this simply"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain what this repository does and how to use it."
 msgstr ""
 
 #. Label to show if song lyrics contain explicit content
@@ -6169,6 +6311,11 @@ msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
 msgstr ""
 
+msgctxt "settings"
+msgid ""
+"Filters out known AI spam sites from image search results. %sLearn More%s"
+msgstr ""
+
 #. Label for the final score of a sporting event.
 msgid "Final"
 msgstr ""
@@ -6210,6 +6357,11 @@ msgstr ""
 #. Short description shown below the 'Web Search' label in the Tools dropdown.
 msgctxt "Subtitle for the Web Search tool entry in the Tools dropdown menu"
 msgid "Find current information"
+msgstr ""
+
+#. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Find me alternatives"
 msgstr ""
 
 #. Button that searches for results closer to the user's current location.
@@ -6600,6 +6752,11 @@ msgstr ""
 msgid "Generate More"
 msgstr ""
 
+#. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Generate a shopping list"
+msgstr ""
+
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
 msgid "Generate a short answer from the web"
 msgstr ""
@@ -6834,6 +6991,11 @@ msgstr ""
 #. Text for a button inviting users to give it a try for the Duck.ai product. On click, they're taken to the Duck.ai page.
 msgctxt "Onboarding welcome screen button text"
 msgid "Give it a Try"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Give me a quick background on this person."
 msgstr ""
 
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -7196,6 +7358,16 @@ msgstr ""
 
 #. Link to a page with information about sharing DuckDuckGo with friends.
 msgid "Help Spread Privacy"
+msgstr ""
+
+#. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Help me prep for the interview"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Help me tailor my resume for this job."
 msgstr ""
 
 #. Title of a SERP popup that invites users to take a survey (desktop only)
@@ -7615,6 +7787,13 @@ msgstr ""
 #. Text displayed on the button on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
 msgctxt "Onboarding terms screen button text"
 msgid "I Agree"
+msgstr ""
+
+#. Text for the button that takes the user to the external DuckDuckGo login subscription page.
+msgctxt ""
+"Text for the I already have a subscription button in the Duck.ai settings "
+"page"
+msgid "I Already Have a Subscription"
 msgstr ""
 
 #. Text for the button that takes the user to the login subscription page.
@@ -8069,6 +8248,11 @@ msgctxt "Sidemenu browser promo"
 msgid "Install Mac Browser"
 msgstr ""
 
+#. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
+msgctxt "settings"
+msgid "Install Now"
+msgstr ""
+
 #. Text of a button to install the DuckDuckGo app
 msgctxt "Serp footer content"
 msgid "Install Our App"
@@ -8148,9 +8332,36 @@ msgctxt "cloudsave"
 msgid "Is deleted data really deleted?"
 msgstr "¿Los datos eliminados se eliminan realmente?"
 
+#. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is it worth taking?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this place any good?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"Is this place any good? Summarize its reputation based on reviews and "
+"ratings."
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "Is this video helpful?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this worth watching?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Is this worth watching? Give me a spoiler-free take."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -8647,6 +8858,11 @@ msgstr "Enlace fuente:"
 msgid "Links:"
 msgstr "Enlaces:"
 
+#. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "List the tools, materials, or prerequisites I need for this."
+msgstr ""
+
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
 msgid "Listen"
 msgstr "Escuchar"
@@ -8979,6 +9195,11 @@ msgstr ""
 #. Label for linke navigating to site exclusion feature on Settings page
 msgctxt "Exclusion message manage sites button"
 msgid "Manage blocked sites"
+msgstr ""
+
+#. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
+msgctxt "setting"
+msgid "Manage in Browser Settings"
 msgstr ""
 
 #. Link to the site exclusion settings page
@@ -11278,6 +11499,11 @@ msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
+msgid "Please describe why the chat response is harmful or illegal. (optional)"
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
+msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
 msgstr ""
 
@@ -11296,6 +11522,13 @@ msgctxt "Modal disclaimer text"
 msgid ""
 "Please note: starting a new chat with any model will delete your current "
 "chat session."
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
+msgctxt "Feedback prompt"
+msgid ""
+"Please paste your prompt and the problematic output (with any personal "
+"information removed) and describe why the content is harmful or illegal."
 msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -11680,6 +11913,11 @@ msgctxt "settings"
 msgid "Privacy"
 msgstr "Privacidad"
 
+#. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
+msgctxt "Section heading on the Duck.ai settings page"
+msgid "Privacy & Terms"
+msgstr ""
+
 msgid "Privacy Blog"
 msgstr ""
 
@@ -11733,6 +11971,11 @@ msgstr ""
 
 #. Text used in other strings to link to the Privacy Policy and Terms of Service content.
 msgctxt "Copy used to compose link in sentences"
+msgid "Privacy Policy and Terms of Service"
+msgstr ""
+
+#. Text for a button that links to the terms of use and privacy policy page.
+msgctxt "Secondary button text in active privacy modal"
 msgid "Privacy Policy and Terms of Service"
 msgstr ""
 
@@ -12141,6 +12384,26 @@ msgctxt "Brief for recommending a book"
 msgid "Recommend a book"
 msgstr ""
 
+#. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar books"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar books."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar movies or shows."
+msgstr ""
+
+#. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar titles"
+msgstr ""
+
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
 msgid "Recording failed. Please try again."
 msgstr ""
@@ -12460,6 +12723,14 @@ msgstr ""
 msgid "Republic of Moldova"
 msgstr ""
 
+#. Note indicating that sharing the conversation is mandatory when reporting harmful or illegal content. Rendered alongside the standard share label (DUCKCHAT_RESPONSE_FEEDBACK_SHARE_PROMPT_RESPONSE_LABEL), not replacing it.
+msgctxt ""
+"Note shown under the share-content switch label on the Duck.ai response "
+"feedback form when the user has selected Harmful or Illegal as the feedback "
+"reason"
+msgid "Required for harmful or illegal reports"
+msgstr ""
+
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
 msgctxt "Description for extended reasoning mode in Duck.ai"
 msgid "Researches before responding"
@@ -12645,6 +12916,11 @@ msgstr "Comentarios"
 #. Label above a list of customer reviews of a business.
 msgctxt "maps_places"
 msgid "Reviews"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Rewrite this recipe scaled for a different number of servings."
 msgstr ""
 
 msgid "Romania"
@@ -13684,6 +13960,11 @@ msgctxt "Setup button for native sync flow"
 msgid "Set Up Now"
 msgstr ""
 
+#. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
+msgctxt "Encrypted storage setup button shown in native browsers"
+msgid "Set Up Sync & Backup"
+msgstr ""
+
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
 msgctxt "Title for the Sync & Backup intro screen"
 msgid "Set Up Sync & Backup"
@@ -13828,6 +14109,12 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
+msgctxt ""
+"Label beside the share-content switch on the Duck.ai response feedback form"
+msgid "Share this conversation with DuckDuckGo"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -14844,6 +15131,21 @@ msgctxt "Brief for suggesting a blog post title"
 msgid "Suggest a title for a blog post"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest related articles or topics worth exploring next."
+msgstr ""
+
+#. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Suggest related articles to explore"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest some alternatives to this product."
+msgstr ""
+
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
 msgctxt "directions"
 msgid "Suggestions:"
@@ -14853,9 +15155,84 @@ msgctxt "noresults"
 msgid "Suggestions:"
 msgstr ""
 
+#. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Sum up the reviews"
+msgstr ""
+
 #. A short title for the a message asking the AI to summarize a text.
 msgctxt "Title for the summarize message"
 msgid "Summarize"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize the Q&As"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the background and notable work of this person."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the key details of this event."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the questions and answers on this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize their background"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this book"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this book."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this discussion"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this discussion thread."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this video"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this video."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize what the reviews say."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -15110,6 +15487,11 @@ msgstr ""
 msgid "Syria"
 msgstr ""
 
+#. Text for a button that enables the theme to follow the operating system's color scheme preference.
+msgctxt "System theme button for theme selector"
+msgid "System"
+msgstr ""
+
 #. Abbreviation indicating this is the total score for a game
 msgctxt "Sports module"
 msgid "T"
@@ -15133,6 +15515,11 @@ msgctxt "language_name"
 msgid "Tahitian"
 msgstr ""
 
+#. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Tailor my resume"
+msgstr ""
+
 msgid "Taiwan"
 msgstr ""
 
@@ -15154,6 +15541,12 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "Take control of your personal data!"
+msgstr ""
+
+#. Description for the Feedback section of the Duck.ai settings page, asking the user to take an anonymous survey to let us know how we can make Duck.ai better.
+msgctxt "Feedback section description on the Duck.ai settings page"
+msgid ""
+"Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
 
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -15398,6 +15791,11 @@ msgstr ""
 #. https://duck.co/media/files/theme.png
 msgid "Theme"
 msgstr "Tema"
+
+#. Text for the theme selector label that allows users to switch between Light and dark theme.
+msgctxt "Label for the theme selector feature"
+msgid "Theme"
+msgstr ""
 
 #. http://i.imgur.com/LpFhb1e.png
 msgctxt "settings"
@@ -16049,6 +16447,16 @@ msgid ""
 "movie theatre?”"
 msgstr ""
 
+#. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Translate this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
+msgctxt "Page suggestion prompt"
+msgid "Translate this page into %s."
+msgstr ""
+
 #. Placeholder text for a region that will display translated text.
 msgctxt "translations_module"
 msgid "Translation"
@@ -16163,6 +16571,11 @@ msgstr ""
 #. Call-to-action button for the subscription promo in the SERP sidemenu.
 msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
+msgstr ""
+
+#. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
+msgctxt "settings"
+msgid "Try It Now"
 msgstr ""
 
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -16357,6 +16770,20 @@ msgstr "Intentar: %s"
 #. Response a user can select in a feedback form, indicating that they're trying DuckDuckGo again.
 msgctxt "new user poll"
 msgid "Trying DuckDuckGo again"
+msgstr ""
+
+#. Message shown in a modal after supported third-party browser users disable AI features in Settings. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+#. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
 msgstr ""
 
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -16959,6 +17386,11 @@ msgstr ""
 msgid "Uruguay"
 msgstr ""
 
+#. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
+msgctxt "Navigation label on the Duck.ai settings page"
+msgid "Usage"
+msgstr ""
+
 #. A feedback suggestion
 msgctxt "Feedback prompt"
 msgid "Usage limit"
@@ -17307,6 +17739,11 @@ msgstr ""
 msgid "Wales"
 msgstr ""
 
+#. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Walk me through the steps"
+msgstr ""
+
 #. Label for walking directions on a map.
 msgctxt "directions"
 msgid "Walking"
@@ -17397,6 +17834,16 @@ msgstr ""
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
+msgstr ""
+
+#. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
+msgctxt ""
+"Inline warning shown below the share-content toggle when the user selects "
+"Harmful or Illegal but has not enabled sharing"
+msgid ""
+"We can only fix what we can see. To report a harmful or illegal response, "
+"please share this conversation with DuckDuckGo so we can investigate and "
+"address the issue."
 msgstr ""
 
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -17816,6 +18263,87 @@ msgid ""
 "experience."
 msgstr ""
 
+#. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the counterarguments?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the hours & location?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key contributions of this paper?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key contributions?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key details?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key points covered in this video?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key points?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key takeaways from this article?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key takeaways?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key things I will learn from this course?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main counterarguments or criticisms of this?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main questions this page answers?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the must-try dishes here?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"What are the opening hours, location, and contact details for this place?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the pros and cons of this product?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the pros and cons?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
 msgctxt "feedback form"
 msgid "What bothered you most?"
@@ -17899,6 +18427,11 @@ msgctxt "Full sentence for defining a term"
 msgid "What does atria mean in the context of a medical article?"
 msgstr ""
 
+#. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What does this answer?"
+msgstr ""
+
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
@@ -17908,6 +18441,11 @@ msgstr ""
 msgctxt "cloudsave"
 msgid "What information gets saved?"
 msgstr "¿Qué información es guardada?"
+
+#. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What interview questions might come up for this role?"
+msgstr ""
 
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
@@ -17919,6 +18457,11 @@ msgstr ""
 #. Text for a prompt suggestion for looking up the capital city of Albania.
 msgctxt "Full sentence for looking up basic facts"
 msgid "What is the capital city of Albania?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What is the overall verdict and rating for this?"
 msgstr ""
 
 #. Link to a page with additional information.
@@ -17939,6 +18482,11 @@ msgctxt "maps_places"
 msgid "What people say:"
 msgstr ""
 
+#. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What should I order?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
 msgctxt "feedback form"
 msgid "What stood out?"
@@ -17947,6 +18495,16 @@ msgstr ""
 #. Question on a feedback form for a negative feedback response.
 msgctxt "feedback form"
 msgid "What was wrong with the response? (optional)"
+msgstr ""
+
+#. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I learn?"
+msgstr ""
+
+#. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I need?"
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -17961,6 +18519,11 @@ msgstr ""
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
 msgctxt "SERP footer content"
 msgid "What's New"
+msgstr ""
+
+#. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What's the verdict?"
 msgstr ""
 
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -18002,6 +18565,11 @@ msgctxt "Feedback prompt"
 msgid "Which features are missing? (Optional)"
 msgstr ""
 
+#. An invitation for users to leave feedback
+msgctxt "Feedback prompt"
+msgid "Which features are missing? (optional)"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
 msgid "White"
 msgstr "Blanco"
@@ -18013,6 +18581,16 @@ msgstr ""
 
 #. Link to an about us page.
 msgid "Who We Are"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Who are the main cast and crew, and what else are they known for?"
+msgstr ""
+
+#. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Who is this person?"
 msgstr ""
 
 #. Header above a collection of privacy-related links.

--- a/locales/et_EE/LC_MESSAGES/duckduckgo.po
+++ b/locales/et_EE/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: et_EE\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -416,8 +416,7 @@ msgstr "%1$s sõna"
 #. Instructions on which buttons and options the user has to click in order to add the DuckDuckGo extension to their browser.
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
-msgstr ""
-"%1$sKlõpsa %2$sLisa%3$sKontrolli %4$sLuba%5$s, seejärel klõpsa %6$sOK%7$s"
+msgstr "%1$sKlõpsa %2$sLisa%3$sKontrolli %4$sLuba%5$s, seejärel klõpsa %6$sOK%7$s"
 
 # Firefox, obsolete
 # smartling.placeholder_format=C
@@ -1440,7 +1439,7 @@ msgstr "Aadress on vale"
 #. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Adjust the servings"
-msgstr ""
+msgstr "Kohanda portsjonid"
 
 # smartling.placeholder_format=C
 #. as in multiple advertisements
@@ -1662,6 +1661,8 @@ msgid ""
 "All chats are anonymized by DuckDuckGo, and your conversations are not used "
 "to train chat models by DuckDuckGo or the model providers"
 msgstr ""
+"DuckDuckGo muudab kõik vestlused anonüümseks ja DuckDuckGo ega mudelite "
+"pakkujad ei kasuta teie vestlusi vestlusmudelite treenimiseks"
 
 # smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1940,6 +1941,8 @@ msgid ""
 "Anonymously generates answers for search queries based on web content. "
 "Choose how often you want it to appear, or disable it completely."
 msgstr ""
+"Genereerib otsingupäringutele anonüümselt vastuseid veebisisu põhjal. Vali, "
+"kui tihti soovid, et see kuvataks, või lülita see täielikult välja."
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -2227,7 +2230,7 @@ msgstr "Küsi Duck.ai abil järelküsimusi"
 #. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
 msgctxt "Page suggestion chip label"
 msgid "Ask about this page"
-msgstr ""
+msgstr "Küsi selle lehekülje kohta"
 
 # smartling.placeholder_format=C
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2295,8 +2298,8 @@ msgstr ""
 "mõnedele otsingutele, tuginedes asjakohase veebisisu kokkuvõttele. Saate "
 "valida, kui tihti soovite Assisti kuvada: mitte kunagi (eemaldab "
 "otsingutulemustest täielikult Assisti kasutajaliidese), nõudmisel (AI-toega "
-"vastuseid kuvatakse ainult siis, kui klõpsate nuppu Assist), mõnikord (AI-"
-"toega vastuseid kuvatakse ainult siis, kui need on väga asjakohased) või "
+"vastuseid kuvatakse ainult siis, kui klõpsate nuppu Assist), mõnikord "
+"(AI-toega vastuseid kuvatakse ainult siis, kui need on väga asjakohased) või "
 "sageli (kuvatakse sagedamini laiema otsingute valiku puhul). Praegu on AI "
 "abil genereeritud vastused saadaval ainult USA (ingliskeelses) piirkonnas."
 
@@ -2407,8 +2410,7 @@ msgstr "Heli ei salvestata meie ega OpenAI poolt pärast vestluse lõppu."
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat is transcribed."
-msgstr ""
-"Heli ei salvestata meie ega OpenAI poolt pärast vestluse transkribeerimist."
+msgstr "Heli ei salvestata meie ega OpenAI poolt pärast vestluse transkribeerimist."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when MediaRecorder API is unavailable.
@@ -2650,7 +2652,7 @@ msgstr "Vöötkood"
 #. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Based on this page, is this course worth taking?"
-msgstr ""
+msgstr "Kas see kursus on selle lehe põhjal läbimist väärt?"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2699,6 +2701,9 @@ msgid ""
 "Before storing this report, DuckDuckGo will anonymize your conversation by "
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
+"Enne selle aruande salvestamist muudab DuckDuckGo sinu vestluse anonüümseks, "
+"eemaldades automaatselt isikuandmeid nagu nimed, e-posti aadressid ja "
+"tuvastavad metaandmed."
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -3020,7 +3025,7 @@ msgstr "Võidetud murdepunktid"
 #. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Break this down into clear, numbered steps."
-msgstr ""
+msgstr "Jaota see selgeteks nummerdatud sammudeks."
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -3481,7 +3486,7 @@ msgstr "Osatäitjad"
 #. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Cast & Crew"
-msgstr ""
+msgstr "Osatäitjad ja võttemeeskond"
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -4259,9 +4264,9 @@ msgid ""
 "%sDuck.ai%s, our private AI chat service that supports chat models from "
 "OpenAI, Anthropic, and more."
 msgstr ""
-"Teema süvenemiseks klõpsake nuppu \"Veel\" ja esitage lisaküsimusi %1$sDuck."
-"ai%2$skaudu, meie privaatne AI-vestlusteenus, mis toetab vestlusmudeleid "
-"OpenAI, Anthropic ja teised."
+"Teema süvenemiseks klõpsake nuppu \"Veel\" ja esitage lisaküsimusi "
+"%1$sDuck.ai%2$skaudu, meie privaatne AI-vestlusteenus, mis toetab "
+"vestlusmudeleid OpenAI, Anthropic ja teised."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4320,8 +4325,7 @@ msgstr "Klõpsa %1$sSiia%2$s, et laadida alla DuckDuckGo laiend"
 # smartling.placeholder_format=C
 #. Link to download the DuckDuckGo browser extension.
 msgid "Click %sOpen%s to download and open the DuckDuckGo Safari extension"
-msgstr ""
-"Klõpsa %1$sAva%2$s, et laadida alla ja avada DuckDuckGo Safari laiendus"
+msgstr "Klõpsa %1$sAva%2$s, et laadida alla ja avada DuckDuckGo Safari laiendus"
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -5192,7 +5196,7 @@ msgstr "Loo pilt"
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
-msgstr ""
+msgstr "Loo selle retsepti põhjal kogustega ostunimekiri."
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed in the input field when starting a new image generation session.
@@ -5449,8 +5453,7 @@ msgstr "Päevane piirang on saavutatud"
 #. Displayed when the user has reached a fixed daily Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Daily usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Päevane kasutuspiirang on saavutatud. Saad seda vestlust jätkata pärast %1$s."
+msgstr "Päevane kasutuspiirang on saavutatud. Saad seda vestlust jätkata pärast %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable daily Duck.ai usage limit and can opt in to continue using the weekly limit.
@@ -5829,8 +5832,8 @@ msgstr "Dikteerimine Duck.ai-s"
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
 msgstr ""
-"Dikteerimine on meie poolt anonümiseeritud ja seda ei kasutata kunagi AI-"
-"mudelite koolitamiseks."
+"Dikteerimine on meie poolt anonümiseeritud ja seda ei kasutata kunagi "
+"AI-mudelite koolitamiseks."
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
@@ -5840,7 +5843,7 @@ msgstr "Dikteerimislimiit on saavutatud"
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
 msgid "Dictation temporarily unavailable"
-msgstr ""
+msgstr "Dikteerimine pole ajutiselt saadaval"
 
 # smartling.placeholder_format=C
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
@@ -6149,6 +6152,9 @@ msgid ""
 "Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
 "filtered out. %sLearn More%s"
 msgstr ""
+"Ei soovi tehisintellekti? %1$snoai.duckduckgo.com%2$s ei paku "
+"tehisintellekti funktsioone ja tehisintellekti pildid on välja filtreeritud. "
+"%3$sLisateave%4$s"
 
 # smartling.placeholder_format=C
 #. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
@@ -6157,6 +6163,9 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
+"Ei soovi tehisintellekti? Külasta veebilehte %1$snoai.duckduckgo.com%2$s ,et "
+"otsida ilma tehisintellekti funktsioonideta ja filtreeritud tehisintellekti "
+"piltidega. %3$sLisateave%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6276,13 +6285,13 @@ msgstr ""
 #. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Draft a cover letter"
-msgstr ""
+msgstr "Koosta kaaskiri"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Draft a cover letter for this job."
-msgstr ""
+msgstr "Koosta selle töö jaoks kaaskiri."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -6468,6 +6477,8 @@ msgid ""
 "company for anyone who wants to take back control of their personal "
 "information."
 msgstr ""
+"Duck.ai on loonud DuckDuckGo. Oleme sõltumatu veebikaitseettevõte kõikidele, "
+"kes tahavad oma isikliku teabe üle kontrolli tagasi saada."
 
 # smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
@@ -6520,6 +6531,9 @@ msgid ""
 "Duck.ai lets you chat privately with popular AI models. Disabling it hides "
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
+"Duck.ai võimaldab sul populaarsete tehisintellekti mudelitega privaatselt "
+"vestelda. Selle väljalülitamine peidab Duck.ai nupud ja lingid, kuid saad "
+"endiselt külastada %1$sduck.ai%2$s-d otse."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6641,9 +6655,9 @@ msgid ""
 "%sDuckDuckGo AI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI, and Anthropic, and more."
 msgstr ""
-"DuckAssist ei saa järelküsimustele vastata, kuid pakume ka privaatset AI-"
-"põhist vestlusteenust %1$sDuckDuckGo AI Chat%2$s, mis toetab vestlusmudeleid "
-"OpenAI, Anthropic ja teisi."
+"DuckAssist ei saa järelküsimustele vastata, kuid pakume ka privaatset "
+"AI-põhist vestlusteenust %1$sDuckDuckGo AI Chat%2$s, mis toetab "
+"vestlusmudeleid OpenAI, Anthropic ja teisi."
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6652,8 +6666,8 @@ msgid ""
 "DuckDuckGo %sAI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI and Anthropic."
 msgstr ""
-"DuckAssist ei saa järelküsimustele vastata, kuid pakume ka privaatset AI-"
-"põhist vestlusteenust DuckDuckGo %1$sAI Chat%2$s, mis toetab OpenAI ja "
+"DuckAssist ei saa järelküsimustele vastata, kuid pakume ka privaatset "
+"AI-põhist vestlusteenust DuckDuckGo %1$sAI Chat%2$s, mis toetab OpenAI ja "
 "Anthropicu vestlusmudeleid."
 
 # smartling.placeholder_format=C
@@ -6759,8 +6773,7 @@ msgctxt "Error message for VQD error"
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. Please refresh the page and "
 "try again."
-msgstr ""
-"DuckDuckGo AI Chat pole ajutiselt saadaval. Värskenda lehte ja proovi uuesti."
+msgstr "DuckDuckGo AI Chat pole ajutiselt saadaval. Värskenda lehte ja proovi uuesti."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -7516,13 +7529,13 @@ msgstr "Eritrea"
 #. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Estimate the nutrition"
-msgstr ""
+msgstr "Hinda toiteväärtust"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Estimate the nutritional information for this recipe."
-msgstr ""
+msgstr "Hinda selle retsepti toiteväärtust."
 
 # smartling.placeholder_format=C
 msgid "Estonia"
@@ -7558,8 +7571,7 @@ msgstr "Laienda kaarti"
 #. Subtitle for the Collaborations promotional card at the bottom of search results. Describes the branded merchandise line. 'Give a duck' is a wordplay on the DuckDuckGo brand name.
 msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
-msgstr ""
-"Asjatundlikult loodud tooted inimestele, kes tõesti hoolivad privaatsusest."
+msgstr "Asjatundlikult loodud tooted inimestele, kes tõesti hoolivad privaatsusest."
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
@@ -7583,7 +7595,7 @@ msgstr "Aegub ühe päeva pärast"
 #. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain the accepted answer in simple terms."
-msgstr ""
+msgstr "Selgita aktsepteeritud vastust lihtsate sõnadega."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
@@ -7596,43 +7608,43 @@ msgstr "Selgita mulle mustade aukude põhitõdesid keskkooli tasemel."
 #. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain the top answer"
-msgstr ""
+msgstr "Selgita esimest vastust"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain this in simple, plain language."
-msgstr ""
+msgstr "Selgita seda lihtsalt ja arusaadavalt."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain this paper"
-msgstr ""
+msgstr "Selgita seda artiklit"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain this repo"
-msgstr ""
+msgstr "Selgita seda repo't"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain this research paper in plain language."
-msgstr ""
+msgstr "Selgita seda uurimistööd lihtsas keeles."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain this simply"
-msgstr ""
+msgstr "Selgita seda lihtsalt"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain what this repository does and how to use it."
-msgstr ""
+msgstr "Selgita, mida see repositoorium teeb ja kuidas seda kasutada."
 
 # smartling.placeholder_format=C
 #. Label to show if song lyrics contain explicit content
@@ -7920,6 +7932,8 @@ msgctxt "settings"
 msgid ""
 "Filters out known AI spam sites from image search results. %sLearn More%s"
 msgstr ""
+"Filtreerib pildiotsingu tulemustest välja teadaolevad tehisintellekti "
+"rämpsposti saidid. %1$sLisateave%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the final score of a sporting event.
@@ -7978,7 +7992,7 @@ msgstr "Praeguse teabe leidmine"
 #. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Find me alternatives"
-msgstr ""
+msgstr "Leia mulle alternatiive"
 
 # smartling.placeholder_format=C
 #. Button that searches for results closer to the user's current location.
@@ -8175,8 +8189,7 @@ msgstr "Meie poolt anonüümistatud tasuta ja privaatsed vestlused"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr ""
-"Meie poolt anonüümistatud tasuta ja privaatsed vestlused. Konto pole vajalik."
+msgstr "Meie poolt anonüümistatud tasuta ja privaatsed vestlused. Konto pole vajalik."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -8206,8 +8219,7 @@ msgstr "Tasuta jagatavad ja kaubanduslikult kasutatavad"
 #. Description text explaining how to free up sync storage. Pinned chats are chats the user has explicitly marked to keep.
 msgctxt "Sync limit modal description"
 msgid "Free up space by deleting your chats. Pinned chats will not be deleted."
-msgstr ""
-"Vabasta ruumi oma vestluste kustutamisega. Kinnitatud vestlusi ei kustutata."
+msgstr "Vabasta ruumi oma vestluste kustutamisega. Kinnitatud vestlusi ei kustutata."
 
 # smartling.placeholder_format=C
 #. Indicates that this streaming service is free to watch but shows ads
@@ -8461,7 +8473,7 @@ msgstr "Genereeri rohkem"
 #. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Generate a shopping list"
-msgstr ""
+msgstr "Loo ostunimekiri"
 
 # smartling.placeholder_format=C
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
@@ -8760,7 +8772,7 @@ msgstr "Proovi järele"
 #. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Give me a quick background on this person."
-msgstr ""
+msgstr "Anna mulle selle isiku kohta lühike ülevaade."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9212,13 +9224,13 @@ msgstr "Aita jagada privaatsust"
 #. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Help me prep for the interview"
-msgstr ""
+msgstr "Aita mul intervjuuks valmistuda"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Help me tailor my resume for this job."
-msgstr ""
+msgstr "Aita mul kohandada oma CV selle töökoha jaoks."
 
 # smartling.placeholder_format=C
 #. Title of a SERP popup that invites users to take a survey (desktop only)
@@ -9667,8 +9679,7 @@ msgstr "Kui tihti soovid, et ilmuksid AI-toega vastused?"
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
 msgctxt "Duck.ai settings usage section"
 msgid "How much of your daily and weekly limits you've used so far."
-msgstr ""
-"Kui suurt osa oma päevastest ja nädalapiirangutest sa seni kasutanud oled."
+msgstr "Kui suurt osa oma päevastest ja nädalapiirangutest sa seni kasutanud oled."
 
 # smartling.placeholder_format=C
 #. A header for the feedback form in the assist negative feedback flow. The user is being asked to update how often they want AI-assisted answers to appear.
@@ -9742,7 +9753,7 @@ msgctxt ""
 "Text for the I already have a subscription button in the Duck.ai settings "
 "page"
 msgid "I Already Have a Subscription"
-msgstr ""
+msgstr "Mul on juba tellimus"
 
 # smartling.placeholder_format=C
 #. Text for the button that takes the user to the login subscription page.
@@ -10319,7 +10330,7 @@ msgstr "Installi Maci brauserisse"
 #. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
 msgctxt "settings"
 msgid "Install Now"
-msgstr ""
+msgstr "Installi kohe"
 
 # smartling.placeholder_format=C
 #. Text of a button to install the DuckDuckGo app
@@ -10422,13 +10433,13 @@ msgstr "Kas kustutatud andmed on tõepoolest kustutatud?"
 #. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Is it worth taking?"
-msgstr ""
+msgstr "Kas sellest tasub osa võtta?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Is this place any good?"
-msgstr ""
+msgstr "Kas see koht on üldse hea?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
@@ -10437,6 +10448,8 @@ msgid ""
 "Is this place any good? Summarize its reputation based on reviews and "
 "ratings."
 msgstr ""
+"Kas see koht on üldse hea? Tee kokkuvõte selle mainest arvustuste ja "
+"hinnangute põhjal."
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -10448,13 +10461,13 @@ msgstr "Kas sellest videost on abi?"
 #. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Is this worth watching?"
-msgstr ""
+msgstr "Kas seda tasub vaadata?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Is this worth watching? Give me a spoiler-free take."
-msgstr ""
+msgstr "Kas seda tasub vaadata? Anna mulle ülevaade ilma sisu avaldamata."
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -10486,8 +10499,7 @@ msgstr "See on kiire, tasuta ja pakub sulle veelgi suuremat võrgukaitset."
 msgctxt "settings"
 msgid ""
 "It's okay to (very infrequently) ask me about my experience using DuckDuckGo"
-msgstr ""
-"Mulle sobib, kui küsite (väga harva) minu DuckDuckGo kasutuskogemuse kohta"
+msgstr "Mulle sobib, kui küsite (väga harva) minu DuckDuckGo kasutuskogemuse kohta"
 
 # smartling.placeholder_format=C
 #. The name of the Italian language
@@ -11069,7 +11081,7 @@ msgstr "Lingid:"
 #. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
-msgstr ""
+msgstr "Loetle tööriistad, materjalid või eeltingimused, mida ma selleks vajan."
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -11360,8 +11372,7 @@ msgstr "Veendu, et kõik sõnad on korrektselt kirjutatud."
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Make sure to check %s\"Make this my default search provider\"%s"
-msgstr ""
-"Veendu, et märkisid %1$s„Muuda see minu vaikimisi otsingupakkujaks“%2$s"
+msgstr "Veendu, et märkisid %1$s„Muuda see minu vaikimisi otsingupakkujaks“%2$s"
 
 # smartling.placeholder_format=C
 #. Message prompting users to check the spelling of their search term.
@@ -11482,7 +11493,7 @@ msgstr "Blokeeritud saitide haldamine"
 #. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
 msgctxt "setting"
 msgid "Manage in Browser Settings"
-msgstr ""
+msgstr "Halda brauseri seadetes"
 
 # smartling.placeholder_format=C
 #. Link to the site exclusion settings page
@@ -13344,8 +13355,7 @@ msgctxt "translations_module"
 msgid ""
 "Oops! An unexpected error occurred while translating this text. Please try "
 "again later."
-msgstr ""
-"Oih! Selle teksti tõlkimisel tekkis ootamatu viga. Proovi hiljem uuesti."
+msgstr "Oih! Selle teksti tõlkimisel tekkis ootamatu viga. Proovi hiljem uuesti."
 
 # smartling.placeholder_format=C
 #. Title shown in a fatal error modal when Duck.ai fails to load.
@@ -14228,8 +14238,7 @@ msgstr "Vali konkreetne probleem"
 #. Header instructing the user to follow the instructions for their ad blocker
 msgid ""
 "Pick your ad blocker and follow the instructions to allow ads on DuckDuckGo."
-msgstr ""
-"Vali oma reklaamiblokeerija ja järgi juhiseid, et lubada DuckDuckGo reklaame."
+msgstr "Vali oma reklaamiblokeerija ja järgi juhiseid, et lubada DuckDuckGo reklaame."
 
 # smartling.placeholder_format=C
 #. Text for a button that pins a chat, as in it will it will add the chat to the pinned chats list.
@@ -14307,21 +14316,19 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this search was made by a "
 "human."
-msgstr ""
-"Soorita järgmine ülesanne, et kinnitada, et selle otsingu tegi inimene."
+msgstr "Soorita järgmine ülesanne, et kinnitada, et selle otsingu tegi inimene."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is harmful or illegal. (optional)"
-msgstr ""
+msgstr "Kirjelda, miks vestluse vastus on kahjulik või ebaseaduslik. (valikuline)"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
-msgstr ""
-"Kirjeldage, miks vestluse vastus on ebaseaduslik või kahjulik. (Valikuline)"
+msgstr "Kirjeldage, miks vestluse vastus on ebaseaduslik või kahjulik. (Valikuline)"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to enter their passphrase.
@@ -14352,6 +14359,8 @@ msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is harmful or illegal."
 msgstr ""
+"Kleebi oma päring ja problemaatiline väljund (ilma isikuandmeteta) ning "
+"kirjelda, miks sisu on kahjulik või ebaseaduslik."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -14824,7 +14833,7 @@ msgstr "Privaatsus"
 #. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
 msgctxt "Section heading on the Duck.ai settings page"
 msgid "Privacy & Terms"
-msgstr ""
+msgstr "Privaatsus ja tingimused"
 
 # smartling.placeholder_format=C
 msgid "Privacy Blog"
@@ -14900,7 +14909,7 @@ msgstr "Privaatsuspoliitika ja teenusetingimused"
 #. Text for a button that links to the terms of use and privacy policy page.
 msgctxt "Secondary button text in active privacy modal"
 msgid "Privacy Policy and Terms of Service"
-msgstr ""
+msgstr "Privaatsuspoliitika ja teenusetingimused"
 
 # smartling.placeholder_format=C
 #. Title displayed on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
@@ -15408,25 +15417,25 @@ msgstr "Soovita raamatut"
 #. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Recommend similar books"
-msgstr ""
+msgstr "Soovita sarnaseid raamatuid"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Recommend similar books."
-msgstr ""
+msgstr "Soovita sarnaseid raamatuid."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Recommend similar movies or shows."
-msgstr ""
+msgstr "Soovita sarnaseid filme või sarju."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Recommend similar titles"
-msgstr ""
+msgstr "Soovita sarnaseid teoseid"
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
@@ -15837,7 +15846,7 @@ msgctxt ""
 "feedback form when the user has selected Harmful or Illegal as the feedback "
 "reason"
 msgid "Required for harmful or illegal reports"
-msgstr ""
+msgstr "Nõutav kahjulikust või ebaseaduslikust sisust teatamisel"
 
 # smartling.placeholder_format=C
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
@@ -16009,8 +16018,7 @@ msgstr "Tulemused ei sisalda blokeeritud saitide teavet."
 #. Message that appears when results exclude blocked sites
 msgctxt "Blocked sites filter disclaimer"
 msgid "Results exclude your blocked sites, which you can manage in your %s."
-msgstr ""
-"Tulemused välistavad sinu blokeeritud saidid, mida saad hallata oma %1$s-s."
+msgstr "Tulemused välistavad sinu blokeeritud saidid, mida saad hallata oma %1$s-s."
 
 # smartling.placeholder_format=C
 #. A label showing the source of the results, e.g. "Results from Reddit"
@@ -16081,7 +16089,7 @@ msgstr "Arvustused"
 #. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Rewrite this recipe scaled for a different number of servings."
-msgstr ""
+msgstr "Kirjuta see retsept ümber, kohandades seda teistsugusele portsjonite arvule."
 
 # smartling.placeholder_format=C
 msgid "Romania"
@@ -16367,8 +16375,7 @@ msgstr "Salvesta oma seadmesse kuni 30 viimast vestlust."
 msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
-msgstr ""
-"Salvesta oma Duck.ai vestlused seadmete vahel otsast lõpuni krüptimisega."
+msgstr "Salvesta oma Duck.ai vestlused seadmete vahel otsast lõpuni krüptimisega."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -16527,8 +16534,7 @@ msgstr "Keri alla ja leia loendist %1$soma brauser%2$s."
 #. Tells users which setting to change to enable location service.
 msgctxt "precise_user_location"
 msgid "Scroll down to %sDuckDuckGo%s and allow it to use your location."
-msgstr ""
-"Keri alla suvandini %1$sDuckDuckGo%2$s ja luba sellel oma asukohta kasutada."
+msgstr "Keri alla suvandini %1$sDuckDuckGo%2$s ja luba sellel oma asukohta kasutada."
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -16910,8 +16916,7 @@ msgstr ""
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
 msgctxt "Sync feature benefit description"
 msgid "Securely stored on DuckDuckGo's server with end-to-end encryption."
-msgstr ""
-"Turvaliselt salvestatud DuckDuckGo serverisse otspunktide krüptimisega."
+msgstr "Turvaliselt salvestatud DuckDuckGo serverisse otspunktide krüptimisega."
 
 # smartling.placeholder_format=C
 #. List item explaining that synced chats are stored with end-to-end encryption on DuckDuckGo's server and only the user can access them.
@@ -17065,8 +17070,7 @@ msgstr "Vali Safari menüüst %1$sSelle veebisaidi seadistamine...%2$s."
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
-msgstr ""
-"Vali %1$sKohanda%2$s ja sisesta %3$shttps://duckduckgo.com%4$s sisendväljale"
+msgstr "Vali %1$sKohanda%2$s ja sisesta %3$shttps://duckduckgo.com%4$s sisendväljale"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
@@ -17409,7 +17413,7 @@ msgstr "Seadista nüüd"
 #. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
 msgctxt "Encrypted storage setup button shown in native browsers"
 msgid "Set Up Sync & Backup"
-msgstr ""
+msgstr "Seadista Sync & Backup"
 
 # smartling.placeholder_format=C
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
@@ -17447,8 +17451,7 @@ msgstr ""
 #. Prompt for the user to indicate their location on a map, to enable more relevant search results.
 msgctxt "precise_user_location"
 msgid "Set your location manually, or ensure Location Services is enabled."
-msgstr ""
-"Määra oma asukoht käsitsi või veendu, et asukohateenused oleksid lubatud."
+msgstr "Määra oma asukoht käsitsi või veendu, et asukohateenused oleksid lubatud."
 
 # smartling.placeholder_format=C
 #. In the top dropdown menu  ("More" > "Settings")
@@ -17502,8 +17505,7 @@ msgstr "Jaga"
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "Share DuckDuckGo and help friends take their privacy back!"
-msgstr ""
-"Jaga rakendust DuckDuckGo ja aita sõpradel oma privaatsus tagasi saada!"
+msgstr "Jaga rakendust DuckDuckGo ja aita sõpradel oma privaatsus tagasi saada!"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button that opens a feedback modal when clicked.
@@ -17530,8 +17532,8 @@ msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
 msgstr ""
-"Jaga linna tasemel asukohta TI-mudelitega, et parandada asjakohasust. Duck."
-"ai ei avalda meile ega TI-mudelitele kunagi teie täpset asukohta."
+"Jaga linna tasemel asukohta TI-mudelitega, et parandada asjakohasust. "
+"Duck.ai ei avalda meile ega TI-mudelitele kunagi teie täpset asukohta."
 
 # smartling.placeholder_format=C
 #. Menu option to share feedback about a result
@@ -17596,7 +17598,7 @@ msgstr "Anna positiivset tagasisidet"
 msgctxt ""
 "Label beside the share-content switch on the Duck.ai response feedback form"
 msgid "Share this conversation with DuckDuckGo"
-msgstr ""
+msgstr "Jaga seda vestlust DuckDuckGo-ga"
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -18423,8 +18425,7 @@ msgstr "Algtekst kustutatud"
 msgctxt "Error message for summary selection input limit"
 msgid ""
 "Source text is too long to summarize. Try again with a shorter selection."
-msgstr ""
-"Algtekst on liiga pikk, et seda kokku võtta. Proovi uuesti lühema valikuga."
+msgstr "Algtekst on liiga pikk, et seda kokku võtta. Proovi uuesti lühema valikuga."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under Interface Settings.in the end. It is a header
@@ -18851,19 +18852,19 @@ msgstr "Soovita pealkirja blogipostituse jaoks"
 #. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Suggest related articles or topics worth exploring next."
-msgstr ""
+msgstr "Soovita seotud artikleid või teemasid, mida tasub järgmisena uurida."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Suggest related articles to explore"
-msgstr ""
+msgstr "Soovita seotud artikleid, mida uurida"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Suggest some alternatives to this product."
-msgstr ""
+msgstr "Soovita sellele tootele alternatiive."
 
 # smartling.placeholder_format=C
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
@@ -18880,7 +18881,7 @@ msgstr "Soovitused:"
 #. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Sum up the reviews"
-msgstr ""
+msgstr "Võta arvustused kokku"
 
 # smartling.placeholder_format=C
 #. A short title for the a message asking the AI to summarize a text.
@@ -18892,85 +18893,85 @@ msgstr "Tee kokkuvõte"
 #. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize the Q&As"
-msgstr ""
+msgstr "Tee küsimustest ja vastustest kokkuvõte"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the background and notable work of this person."
-msgstr ""
+msgstr "Tee kokkuvõte selle isiku taustast ja tähelepanuväärsest tööst."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the key details of this event."
-msgstr ""
+msgstr "Tee selle sündmuse põhiandmetest kokkuvõte."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the questions and answers on this page."
-msgstr ""
+msgstr "Tee selle lehe küsimustest ja vastustest kokkuvõte."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize their background"
-msgstr ""
+msgstr "Tee nende taustast kokkuvõte"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this book"
-msgstr ""
+msgstr "Tee sellest raamatu kokkuvõte"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this book."
-msgstr ""
+msgstr "Tee sellest raamatust kokkuvõte."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this discussion"
-msgstr ""
+msgstr "Tee arutelust kokkuvõte"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this discussion thread."
-msgstr ""
+msgstr "Tee sellest aruteluteemast kokkuvõte."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this page"
-msgstr ""
+msgstr "Tee selle lehekülje kokkuvõte"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this page."
-msgstr ""
+msgstr "Tee selle lehekülje kokkuvõte."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this video"
-msgstr ""
+msgstr "Tee sellest videost kokkuvõte"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this video."
-msgstr ""
+msgstr "Tee sellest videost kokkuvõte."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize what the reviews say."
-msgstr ""
+msgstr "Võta kokku, mida arvustused ütlevad."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -19303,7 +19304,7 @@ msgstr "Süüria"
 #. Text for a button that enables the theme to follow the operating system's color scheme preference.
 msgctxt "System theme button for theme selector"
 msgid "System"
-msgstr ""
+msgstr "Süsteem"
 
 # smartling.placeholder_format=C
 #. Abbreviation indicating this is the total score for a game
@@ -19337,7 +19338,7 @@ msgstr "tahiti keel"
 #. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Tailor my resume"
-msgstr ""
+msgstr "Kohanda minu CV-d"
 
 # smartling.placeholder_format=C
 msgid "Taiwan"
@@ -19374,6 +19375,8 @@ msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
+"Täida see anonüümne küsitlus ja anna meile teada, kuidas saaksime Duck.ai "
+"paremaks muuta."
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -19638,8 +19641,7 @@ msgstr ""
 msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider deletes any data associated with this chat within 30 days."
-msgstr ""
-"Mudelipakkuja kustutab kõik selle vestlusega seotud andmed 30 päeva jooksul."
+msgstr "Mudelipakkuja kustutab kõik selle vestlusega seotud andmed 30 päeva jooksul."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers.
@@ -19683,7 +19685,7 @@ msgstr "Teema"
 #. Text for the theme selector label that allows users to switch between Light and dark theme.
 msgctxt "Label for the theme selector feature"
 msgid "Theme"
-msgstr ""
+msgstr "Teema"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/LpFhb1e.png
@@ -19789,8 +19791,7 @@ msgctxt "AI Chat: Error message for when a model is removed"
 msgid ""
 "This AI model is no longer available. Try starting a new chat with a "
 "different model."
-msgstr ""
-"See AI mudel pole enam saadaval. Proovi alustada uut vestlust teise mudeliga."
+msgstr "See AI mudel pole enam saadaval. Proovi alustada uut vestlust teise mudeliga."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is no longer supported because it has been upgraded to a newest version.
@@ -20062,8 +20063,7 @@ msgstr "See tõlge on vale"
 # smartling.placeholder_format=C
 #. Label indicating that the video can't be played on the current page, and only on the website that owns the vide. The placeholder is the name of the website that owns the video.
 msgid "This video is not yet able to be watched here. You can watch it on %s."
-msgstr ""
-"Seda videot ei saa veel siin vaadata. Sa saad seda vaadata saidil %1$s."
+msgstr "Seda videot ei saa veel siin vaadata. Sa saad seda vaadata saidil %1$s."
 
 # smartling.placeholder_format=C
 #. Message indicating that a website is not using an encrypted connection and is not secure.
@@ -20183,8 +20183,7 @@ msgstr "Soovitused"
 
 # smartling.placeholder_format=C
 msgid "Tired of being tracked online? %sWe can help.%s"
-msgstr ""
-"Oled väsinud sellest, et sind võrgus jälitatakse? %1$sMeie saame aidata.%2$s"
+msgstr "Oled väsinud sellest, et sind võrgus jälitatakse? %1$sMeie saame aidata.%2$s"
 
 # smartling.placeholder_format=C
 #. This is the name of a user setting
@@ -20242,8 +20241,8 @@ msgid ""
 "you originally used to set up Sync."
 msgstr ""
 "Sünkroonitud andmete taastamiseks vajad taastamiskoodi, mille salvestasid "
-"sünkroonimise esmakordsel seadistamisel. See kood võis olla salvestatud PDF-"
-"vormingus seadmesse, milles sa sünkroonimise algselt seadistasid."
+"sünkroonimise esmakordsel seadistamisel. See kood võis olla salvestatud "
+"PDF-vormingus seadmesse, milles sa sünkroonimise algselt seadistasid."
 
 # smartling.placeholder_format=C
 #. Body text explaining that the user needs to update their DDG browser before migration can proceed.
@@ -20518,13 +20517,13 @@ msgstr ""
 #. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Translate this page"
-msgstr ""
+msgstr "Tõlgi see leht"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
 msgctxt "Page suggestion prompt"
 msgid "Translate this page into %s."
-msgstr ""
+msgstr "Tõlgi see leht keelde %1$s."
 
 # smartling.placeholder_format=C
 #. Placeholder text for a region that will display translated text.
@@ -20626,8 +20625,7 @@ msgstr "Proovi %1$s, et selliseid sõnumeid enam ei näeks."
 #. Text for a promotional card that encourages users to try the encrypted AI model whose inference runs in a confidential environment so the model provider cannot access user data. %s is replaced with the model's full display name (e.g. 'GPT-OSS 120B').
 msgctxt "Promotional text for encrypted AI model"
 msgid "Try %s, our first model with zero provider visibility."
-msgstr ""
-"Proovi mudelit %1$s, meie esimest mudelit null teenusepakkuja nähtavusega."
+msgstr "Proovi mudelit %1$s, meie esimest mudelit null teenusepakkuja nähtavusega."
 
 # smartling.placeholder_format=C
 msgid "Try %sDuck.ai%s, our private AI chat service:"
@@ -20672,7 +20670,7 @@ msgstr "Proovi tasuta"
 #. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
 msgctxt "settings"
 msgid "Try It Now"
-msgstr ""
+msgstr "Proovi kohe"
 
 # smartling.placeholder_format=C
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -20730,8 +20728,7 @@ msgstr "Proovi teisi märksõnu."
 # smartling.placeholder_format=C
 #. Prompt encouraging the user to turn off their ad blocker to see more results for their query.
 msgid "Try disabling your ad blocker on DuckDuckGo to see more results."
-msgstr ""
-"Rohkemate tulemuste nägemiseks proovi DuckDuckGo reklaamiblokeerija keelata."
+msgstr "Rohkemate tulemuste nägemiseks proovi DuckDuckGo reklaamiblokeerija keelata."
 
 # smartling.placeholder_format=C
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
@@ -20916,6 +20913,8 @@ msgid ""
 "Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
+"Kas soovid tehisintellekti funktsioonid keelata? Paigalda %1$sDuckDuckGo No "
+"AI%2$s otsingulaiendus, et oma sätted meelde jätta. %3$sLisateave%4$s"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -20924,6 +20923,8 @@ msgid ""
 "Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
+"Kas soovid tehisintellekti funktsioonid keelata? Vaheta %1$sDuckDuckGo No "
+"AI%2$s otsingulaiendusele, et oma sätted meelde jätta. %3$sLisateave%4$s"
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -21042,8 +21043,7 @@ msgstr "Täpsemate tulemuste saamiseks lülita sisse suvand „Täpne asukoht“
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on “Use precise location” for more accurate results."
-msgstr ""
-"Täpsemate tulemuste saamiseks lülita sisse suvand „Kasuta täpset asukohta“."
+msgstr "Täpsemate tulemuste saamiseks lülita sisse suvand „Kasuta täpset asukohta“."
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Create Image' label in the Tools dropdown.
@@ -21235,8 +21235,8 @@ msgstr ""
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
 msgstr ""
-"Jaotisest %1$sKäivitamisel%2$s vali %3$sAvaleht%4$s ja sisesta: https://"
-"duckduckgo.com"
+"Jaotisest %1$sKäivitamisel%2$s vali %3$sAvaleht%4$s ja sisesta: "
+"https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -21676,7 +21676,7 @@ msgstr "Uruguay"
 #. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
 msgctxt "Navigation label on the Duck.ai settings page"
 msgid "Usage"
-msgstr ""
+msgstr "Kasutamine"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -21734,8 +21734,7 @@ msgstr "Kasuta DuckDuckGo privaatset otsingut"
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Use DuckDuckGo private search on your iPad, iPhone, or Android!"
-msgstr ""
-"Kasuta DuckDuckGo privaatsest otsingut oma iPadis, iPhone'is või Androidis!"
+msgstr "Kasuta DuckDuckGo privaatsest otsingut oma iPadis, iPhone'is või Androidis!"
 
 # smartling.placeholder_format=C
 #. User clicks this button to share their device's location
@@ -22131,7 +22130,7 @@ msgstr "Wales"
 #. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Walk me through the steps"
-msgstr ""
+msgstr "Juhenda mind samm-sammult"
 
 # smartling.placeholder_format=C
 #. Label for walking directions on a map.
@@ -22260,6 +22259,9 @@ msgid ""
 "please share this conversation with DuckDuckGo so we can investigate and "
 "address the issue."
 msgstr ""
+"Me saame parandada ainult seda, mida me näeme. Kahjuliku või ebaseadusliku "
+"vastuse teatamiseks jaga seda vestlust DuckDuckGo-ga, et saaksime probleemi "
+"uurida ja sellega tegeleda."
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -22299,8 +22301,7 @@ msgstr "Me ei jälita sind reklaamidega."
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
 msgid "We don't store usernames or any personally identifiable information."
-msgstr ""
-"Me ei salvesta kasutajanimesid ega isikut tuvastada võimaldavat teavet."
+msgstr "Me ei salvesta kasutajanimesid ega isikut tuvastada võimaldavat teavet."
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -22460,8 +22461,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We stop anyone from getting your search history, including us."
-msgstr ""
-"Me ei lase kellelgi, sealhulgas meil endil, sinu otsinguajalugu vaadata."
+msgstr "Me ei lase kellelgi, sealhulgas meil endil, sinu otsinguajalugu vaadata."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -22623,8 +22623,7 @@ msgstr "Oled jõudnud nädala piiranguni"
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Weekly usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Nädala kasutuspiirang on saavutatud. Saad seda vestlust jätkata pärast %1$s."
+msgstr "Nädala kasutuspiirang on saavutatud. Saad seda vestlust jätkata pärast %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable weekly Duck.ai usage limit and can opt in to continue using the monthly limit.
@@ -22818,98 +22817,98 @@ msgstr ""
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the counterarguments?"
-msgstr ""
+msgstr "Millised on vastuväited?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the hours & location?"
-msgstr ""
+msgstr "Millised on lahtiolekuajad ja asukoht?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key contributions of this paper?"
-msgstr ""
+msgstr "Millised on selle artikli peamised panused?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key contributions?"
-msgstr ""
+msgstr "Millised on peamised panused?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key details?"
-msgstr ""
+msgstr "Millised on peamised üksikasjad?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key points covered in this video?"
-msgstr ""
+msgstr "Millised on selle video peamised punktid?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key points?"
-msgstr ""
+msgstr "Millised on põhipunktid?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key takeaways from this article?"
-msgstr ""
+msgstr "Millised on selle artikli peamised järeldused?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key takeaways?"
-msgstr ""
+msgstr "Millised on peamised järeldused?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key things I will learn from this course?"
-msgstr ""
+msgstr "Millised on peamised asjad, mida ma sellest kursusest õpin?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the main counterarguments or criticisms of this?"
-msgstr ""
+msgstr "Millised on selle peamised vastuväited või kriitika?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the main questions this page answers?"
-msgstr ""
+msgstr "Millistele peamistele küsimustele see leht vastab?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the must-try dishes here?"
-msgstr ""
+msgstr "Milliseid roogi peab siin kindlasti proovima?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid ""
 "What are the opening hours, location, and contact details for this place?"
-msgstr ""
+msgstr "Millised on selle koha lahtiolekuajad, asukoht ja kontaktandmed?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the pros and cons of this product?"
-msgstr ""
+msgstr "Millised on selle toote plussid ja miinused?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the pros and cons?"
-msgstr ""
+msgstr "Millised on plussid ja miinused?"
 
 # smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
@@ -23015,7 +23014,7 @@ msgstr "Mida tähendab aatrium meditsiinilise artikli kontekstis?"
 #. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What does this answer?"
-msgstr ""
+msgstr "Millele see vastab?"
 
 # smartling.placeholder_format=C
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
@@ -23033,7 +23032,7 @@ msgstr "Missugune informatsioon salvestatakse?"
 #. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What interview questions might come up for this role?"
-msgstr ""
+msgstr "Millised töövestluse küsimused võivad selle rolli puhul ette tulla?"
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -23055,7 +23054,7 @@ msgstr "Mis on Albaania pealinn?"
 #. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What is the overall verdict and rating for this?"
-msgstr ""
+msgstr "Milline on selle üldine hinnang ja reiting?"
 
 # smartling.placeholder_format=C
 #. Link to a page with additional information.
@@ -23083,7 +23082,7 @@ msgstr "Mida rahvas räägib:"
 #. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What should I order?"
-msgstr ""
+msgstr "Mida peaksin tellima?"
 
 # smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
@@ -23101,13 +23100,13 @@ msgstr "Mis oli vastuse puhul valesti? (valikuline)"
 #. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What will I learn?"
-msgstr ""
+msgstr "Mida ma õpin?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What will I need?"
-msgstr ""
+msgstr "Mida mul vaja läheb?"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -23130,7 +23129,7 @@ msgstr "Mida on uut"
 #. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What's the verdict?"
-msgstr ""
+msgstr "Mis on otsus?"
 
 # smartling.placeholder_format=C
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -23186,7 +23185,7 @@ msgstr "Millised funktsioonid on puudu? (Valikuline)"
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Which features are missing? (optional)"
-msgstr ""
+msgstr "Millised funktsioonid on puudu? (valikuline)"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
@@ -23209,12 +23208,14 @@ msgstr "Kes me oleme"
 msgctxt "Page suggestion prompt"
 msgid "Who are the main cast and crew, and what else are they known for?"
 msgstr ""
+"Kes on peamised näitlejad ja võttegrupi liikmed ning mille poolest neid veel "
+"teatakse?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Who is this person?"
-msgstr ""
+msgstr "Kes see inimene on?"
 
 # smartling.placeholder_format=C
 #. Header above a collection of privacy-related links.
@@ -23606,8 +23607,7 @@ msgctxt "Disclaimer bellow chat input - desktop"
 msgid ""
 "You are chatting with %s. AI chats may display inaccurate or offensive "
 "information."
-msgstr ""
-"Vestled %1$s-ga. AI-vestlused võivad kuvada ebatäpset või solvavat teavet."
+msgstr "Vestled %1$s-ga. AI-vestlused võivad kuvada ebatäpset või solvavat teavet."
 
 # smartling.placeholder_format=C
 #. Provide users with the ability to retry their search on a different search engine. First placeholder will be a link with the text "try your search again" OR "try your search later". Second is a URL to the !bangs page: https://duckduckgo.com/bangs.
@@ -23647,8 +23647,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgid "You can also use %sDuck.ai%s to answer questions or summarize text."
 msgstr ""
-"Küsimustele vastamiseks või teksti kokkuvõtmiseks võite kasutada ka %1$sDuck."
-"ai%2$s."
+"Küsimustele vastamiseks või teksti kokkuvõtmiseks võite kasutada ka "
+"%1$sDuck.ai%2$s."
 
 # smartling.placeholder_format=C
 msgid ""
@@ -23710,8 +23710,7 @@ msgstr "Selle meeldetuletuse saad peita suvandis %1$sOtsingu seaded%2$s"
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
-msgstr ""
-"Nüüd saad sellesse seadmesse salvestada kuni 100 vestlust. Vestle edasi!"
+msgstr "Nüüd saad sellesse seadmesse salvestada kuni 100 vestlust. Vestle edasi!"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -23878,8 +23877,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
 msgid "You won't see this message again unless you clear your browser data."
-msgstr ""
-"Sa ei näe seda sõnumit enam, kui sa ei kustuta oma veebilehitseja andmeid."
+msgstr "Sa ei näe seda sõnumit enam, kui sa ei kustuta oma veebilehitseja andmeid."
 
 # smartling.placeholder_format=C
 #. The second paragraph of a pop up where we explain how to update the browser manually.
@@ -23957,8 +23955,7 @@ msgctxt "Error message for user limit"
 msgid ""
 "You've reached the maximum number of messages for the moment. Please try "
 "again later."
-msgstr ""
-"Oled hetkel saavutanud maksimaalse sõnumite arvu. Proovi hiljem uuesti."
+msgstr "Oled hetkel saavutanud maksimaalse sõnumite arvu. Proovi hiljem uuesti."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -23971,8 +23968,7 @@ msgstr "Oled saavutanud ühe seansi maksimaalse häälvestluse kestuse."
 msgctxt "voice chat limit modal"
 msgid ""
 "You've reached the voice chat limit for today. Please try again tomorrow."
-msgstr ""
-"Oled jõudnud tänase päeva häälvestluse limiidini. Palun proovi homme uuesti."
+msgstr "Oled jõudnud tänase päeva häälvestluse limiidini. Palun proovi homme uuesti."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
@@ -24090,8 +24086,7 @@ msgstr "Sinu brauser näitab, kui oled seda linki külastanud"
 # smartling.placeholder_format=C
 msgctxt "new tab page"
 msgid "Your browser provides a list of your most-visited sites."
-msgstr ""
-"Sinu brauser esitab sinu kõige sagedamini külastatavate saitide loetelu."
+msgstr "Sinu brauser esitab sinu kõige sagedamini külastatavate saitide loetelu."
 
 # smartling.placeholder_format=C
 #. Used as a description in a menu
@@ -24133,8 +24128,8 @@ msgstr "Sinu vestlused salvestatakse nüüd."
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never saved or used to train AI models"
 msgstr ""
-"Sinu vestlused on privaatsed ja neid ei salvestata ega kasutata kunagi AI-"
-"mudelite treenimiseks"
+"Sinu vestlused on privaatsed ja neid ei salvestata ega kasutata kunagi "
+"AI-mudelite treenimiseks"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.

--- a/locales/et_EE/LC_MESSAGES/duckduckgo.po
+++ b/locales/et_EE/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: et_EE\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -416,7 +416,8 @@ msgstr "%1$s sõna"
 #. Instructions on which buttons and options the user has to click in order to add the DuckDuckGo extension to their browser.
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
-msgstr "%1$sKlõpsa %2$sLisa%3$sKontrolli %4$sLuba%5$s, seejärel klõpsa %6$sOK%7$s"
+msgstr ""
+"%1$sKlõpsa %2$sLisa%3$sKontrolli %4$sLuba%5$s, seejärel klõpsa %6$sOK%7$s"
 
 # Firefox, obsolete
 # smartling.placeholder_format=C
@@ -1436,6 +1437,12 @@ msgid "Address is incorrect"
 msgstr "Aadress on vale"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Adjust the servings"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. as in multiple advertisements
 msgid "Ads"
 msgstr "Reklaamid"
@@ -1647,6 +1654,14 @@ msgstr "Kõik vestlused on %1$s. AI võib teha vigu."
 msgctxt "Empty state heading in Duck.ai chat mode"
 msgid "All chats are %sprivate%s"
 msgstr "Kõik vestlused on %1$sprivaatsed%2$s"
+
+# smartling.placeholder_format=C
+#. Paragraph in the Privacy & Terms section of the About & Legal page in Duck.ai settings, summarizing how chats are anonymized and are not stored or used to train chat models.
+msgctxt "Privacy & Terms section description on the Duck.ai settings page"
+msgid ""
+"All chats are anonymized by DuckDuckGo, and your conversations are not used "
+"to train chat models by DuckDuckGo or the model providers"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1918,6 +1933,13 @@ msgstr ""
 msgctxt "precise_user_location"
 msgid "Anonymous location enabled"
 msgstr "Anonüümne asukoht on lubatud"
+
+# smartling.placeholder_format=C
+msgctxt "settings"
+msgid ""
+"Anonymously generates answers for search queries based on web content. "
+"Choose how often you want it to appear, or disable it completely."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -2202,6 +2224,12 @@ msgid "Ask a follow-up with Duck.ai"
 msgstr "Küsi Duck.ai abil järelküsimusi"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
+msgctxt "Page suggestion chip label"
+msgid "Ask about this page"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
 msgctxt "Title for the page context onboarding modal"
 msgid "Ask about this page"
@@ -2267,8 +2295,8 @@ msgstr ""
 "mõnedele otsingutele, tuginedes asjakohase veebisisu kokkuvõttele. Saate "
 "valida, kui tihti soovite Assisti kuvada: mitte kunagi (eemaldab "
 "otsingutulemustest täielikult Assisti kasutajaliidese), nõudmisel (AI-toega "
-"vastuseid kuvatakse ainult siis, kui klõpsate nuppu Assist), mõnikord "
-"(AI-toega vastuseid kuvatakse ainult siis, kui need on väga asjakohased) või "
+"vastuseid kuvatakse ainult siis, kui klõpsate nuppu Assist), mõnikord (AI-"
+"toega vastuseid kuvatakse ainult siis, kui need on väga asjakohased) või "
 "sageli (kuvatakse sagedamini laiema otsingute valiku puhul). Praegu on AI "
 "abil genereeritud vastused saadaval ainult USA (ingliskeelses) piirkonnas."
 
@@ -2379,7 +2407,8 @@ msgstr "Heli ei salvestata meie ega OpenAI poolt pärast vestluse lõppu."
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat is transcribed."
-msgstr "Heli ei salvestata meie ega OpenAI poolt pärast vestluse transkribeerimist."
+msgstr ""
+"Heli ei salvestata meie ega OpenAI poolt pärast vestluse transkribeerimist."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when MediaRecorder API is unavailable.
@@ -2618,6 +2647,12 @@ msgid "Barcode"
 msgstr "Vöötkood"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Based on this page, is this course worth taking?"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Basic"
 msgstr "Põhiline"
@@ -2656,6 +2691,14 @@ msgstr "Lööja"
 msgctxt "Assistant response placeholder"
 msgid "Before continuing..."
 msgstr "Enne kui jätkad..."
+
+# smartling.placeholder_format=C
+#. Explains that before storing the report, DuckDuckGo will anonymize the conversation by removing PII like names, email addresses, and identifying metadata.
+msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
+msgid ""
+"Before storing this report, DuckDuckGo will anonymize your conversation by "
+"removing PII like names, email addresses, and identifying metadata."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -2972,6 +3015,12 @@ msgstr "Brasiilia"
 msgctxt "Sports module"
 msgid "Break Points Won"
 msgstr "Võidetud murdepunktid"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Break this down into clear, numbered steps."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -3427,6 +3476,12 @@ msgstr "Vabad töökohad"
 msgctxt "Movie/TV Show Title instant answer"
 msgid "Cast"
 msgstr "Osatäitjad"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Cast & Crew"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -4204,9 +4259,9 @@ msgid ""
 "%sDuck.ai%s, our private AI chat service that supports chat models from "
 "OpenAI, Anthropic, and more."
 msgstr ""
-"Teema süvenemiseks klõpsake nuppu \"Veel\" ja esitage lisaküsimusi "
-"%1$sDuck.ai%2$skaudu, meie privaatne AI-vestlusteenus, mis toetab "
-"vestlusmudeleid OpenAI, Anthropic ja teised."
+"Teema süvenemiseks klõpsake nuppu \"Veel\" ja esitage lisaküsimusi %1$sDuck."
+"ai%2$skaudu, meie privaatne AI-vestlusteenus, mis toetab vestlusmudeleid "
+"OpenAI, Anthropic ja teised."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4265,7 +4320,8 @@ msgstr "Klõpsa %1$sSiia%2$s, et laadida alla DuckDuckGo laiend"
 # smartling.placeholder_format=C
 #. Link to download the DuckDuckGo browser extension.
 msgid "Click %sOpen%s to download and open the DuckDuckGo Safari extension"
-msgstr "Klõpsa %1$sAva%2$s, et laadida alla ja avada DuckDuckGo Safari laiendus"
+msgstr ""
+"Klõpsa %1$sAva%2$s, et laadida alla ja avada DuckDuckGo Safari laiendus"
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -5133,6 +5189,12 @@ msgid "Create Image"
 msgstr "Loo pilt"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Create a shopping list with quantities from this recipe."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text displayed in the input field when starting a new image generation session.
 msgctxt "Placeholder text for the image generation input field"
 msgid "Create an image of a cute duck..."
@@ -5387,7 +5449,8 @@ msgstr "Päevane piirang on saavutatud"
 #. Displayed when the user has reached a fixed daily Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Daily usage limit reached. You can continue this chat after %s."
-msgstr "Päevane kasutuspiirang on saavutatud. Saad seda vestlust jätkata pärast %1$s."
+msgstr ""
+"Päevane kasutuspiirang on saavutatud. Saad seda vestlust jätkata pärast %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable daily Duck.ai usage limit and can opt in to continue using the weekly limit.
@@ -5766,13 +5829,18 @@ msgstr "Dikteerimine Duck.ai-s"
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
 msgstr ""
-"Dikteerimine on meie poolt anonümiseeritud ja seda ei kasutata kunagi "
-"AI-mudelite koolitamiseks."
+"Dikteerimine on meie poolt anonümiseeritud ja seda ei kasutata kunagi AI-"
+"mudelite koolitamiseks."
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
 msgid "Dictation limit reached"
 msgstr "Dikteerimislimiit on saavutatud"
+
+# smartling.placeholder_format=C
+#. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
+msgid "Dictation temporarily unavailable"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
@@ -6075,6 +6143,22 @@ msgid "Done"
 msgstr "Valmis"
 
 # smartling.placeholder_format=C
+#. Message shown in a modal after DuckDuckGo browser users disable AI features in Settings. The first two placeholders bold noai.duckduckgo.com. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
+"filtered out. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
+"and AI images filtered out. %sLearn more%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Double Faults"
@@ -6187,6 +6271,18 @@ msgid ""
 msgstr ""
 "Koosta lühike ja üksikasjalik e-kiri müüjale, et küsida kodukülmiku "
 "remonditeenuste hinnapakkumist."
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Draft a cover letter"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Draft a cover letter for this job."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -6365,6 +6461,15 @@ msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
 msgstr "Duck.ai on parim meie privaatses ja tasuta DuckDuckGo brauseris!"
 
 # smartling.placeholder_format=C
+#. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
+msgctxt "About section description on the Duck.ai settings page"
+msgid ""
+"Duck.ai is created by DuckDuckGo. We're an independent online protection "
+"company for anyone who wants to take back control of their personal "
+"information."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
 msgctxt "duckai_migration"
 msgid "Duck.ai is moving domains"
@@ -6408,6 +6513,13 @@ msgstr "Duck.ai pole ajutiselt saadaval. Värskendage lehte ja proovige uuesti."
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
 msgstr "Duck.ai pole ajutiselt saadaval. Proovige hiljem uuesti."
+
+# smartling.placeholder_format=C
+msgctxt "settings"
+msgid ""
+"Duck.ai lets you chat privately with popular AI models. Disabling it hides "
+"Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6529,9 +6641,9 @@ msgid ""
 "%sDuckDuckGo AI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI, and Anthropic, and more."
 msgstr ""
-"DuckAssist ei saa järelküsimustele vastata, kuid pakume ka privaatset "
-"AI-põhist vestlusteenust %1$sDuckDuckGo AI Chat%2$s, mis toetab "
-"vestlusmudeleid OpenAI, Anthropic ja teisi."
+"DuckAssist ei saa järelküsimustele vastata, kuid pakume ka privaatset AI-"
+"põhist vestlusteenust %1$sDuckDuckGo AI Chat%2$s, mis toetab vestlusmudeleid "
+"OpenAI, Anthropic ja teisi."
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6540,8 +6652,8 @@ msgid ""
 "DuckDuckGo %sAI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI and Anthropic."
 msgstr ""
-"DuckAssist ei saa järelküsimustele vastata, kuid pakume ka privaatset "
-"AI-põhist vestlusteenust DuckDuckGo %1$sAI Chat%2$s, mis toetab OpenAI ja "
+"DuckAssist ei saa järelküsimustele vastata, kuid pakume ka privaatset AI-"
+"põhist vestlusteenust DuckDuckGo %1$sAI Chat%2$s, mis toetab OpenAI ja "
 "Anthropicu vestlusmudeleid."
 
 # smartling.placeholder_format=C
@@ -6647,7 +6759,8 @@ msgctxt "Error message for VQD error"
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. Please refresh the page and "
 "try again."
-msgstr "DuckDuckGo AI Chat pole ajutiselt saadaval. Värskenda lehte ja proovi uuesti."
+msgstr ""
+"DuckDuckGo AI Chat pole ajutiselt saadaval. Värskenda lehte ja proovi uuesti."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -7400,6 +7513,18 @@ msgid "Eritrea"
 msgstr "Eritrea"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Estimate the nutrition"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Estimate the nutritional information for this recipe."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Estonia"
 msgstr "Eesti"
 
@@ -7433,7 +7558,8 @@ msgstr "Laienda kaarti"
 #. Subtitle for the Collaborations promotional card at the bottom of search results. Describes the branded merchandise line. 'Give a duck' is a wordplay on the DuckDuckGo brand name.
 msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
-msgstr "Asjatundlikult loodud tooted inimestele, kes tõesti hoolivad privaatsusest."
+msgstr ""
+"Asjatundlikult loodud tooted inimestele, kes tõesti hoolivad privaatsusest."
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
@@ -7454,11 +7580,59 @@ msgid "Expires in 1 day"
 msgstr "Aegub ühe päeva pärast"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain the accepted answer in simple terms."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
 msgstr "Selgita mulle mustade aukude põhitõdesid keskkooli tasemel."
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain the top answer"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this in simple, plain language."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this paper"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this repo"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this research paper in plain language."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this simply"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain what this repository does and how to use it."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label to show if song lyrics contain explicit content
@@ -7742,6 +7916,12 @@ msgstr ""
 "%1$sLisateave%2$s"
 
 # smartling.placeholder_format=C
+msgctxt "settings"
+msgid ""
+"Filters out known AI spam sites from image search results. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the final score of a sporting event.
 msgid "Final"
 msgstr "Lõplik"
@@ -7793,6 +7973,12 @@ msgstr "Leia parem sõna"
 msgctxt "Subtitle for the Web Search tool entry in the Tools dropdown menu"
 msgid "Find current information"
 msgstr "Praeguse teabe leidmine"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Find me alternatives"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button that searches for results closer to the user's current location.
@@ -7989,7 +8175,8 @@ msgstr "Meie poolt anonüümistatud tasuta ja privaatsed vestlused"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr "Meie poolt anonüümistatud tasuta ja privaatsed vestlused. Konto pole vajalik."
+msgstr ""
+"Meie poolt anonüümistatud tasuta ja privaatsed vestlused. Konto pole vajalik."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -8019,7 +8206,8 @@ msgstr "Tasuta jagatavad ja kaubanduslikult kasutatavad"
 #. Description text explaining how to free up sync storage. Pinned chats are chats the user has explicitly marked to keep.
 msgctxt "Sync limit modal description"
 msgid "Free up space by deleting your chats. Pinned chats will not be deleted."
-msgstr "Vabasta ruumi oma vestluste kustutamisega. Kinnitatud vestlusi ei kustutata."
+msgstr ""
+"Vabasta ruumi oma vestluste kustutamisega. Kinnitatud vestlusi ei kustutata."
 
 # smartling.placeholder_format=C
 #. Indicates that this streaming service is free to watch but shows ads
@@ -8268,6 +8456,12 @@ msgstr "Genereeri pilt"
 #. Text for the button that generates more of an answer from duckassist when the answer has come from a collapsed state
 msgid "Generate More"
 msgstr "Genereeri rohkem"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Generate a shopping list"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
@@ -8561,6 +8755,12 @@ msgstr "Proovi järele"
 msgctxt "Onboarding welcome screen button text"
 msgid "Give it a Try"
 msgstr "Proovi järele"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Give me a quick background on this person."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9009,6 +9209,18 @@ msgid "Help Spread Privacy"
 msgstr "Aita jagada privaatsust"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Help me prep for the interview"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Help me tailor my resume for this job."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title of a SERP popup that invites users to take a survey (desktop only)
 msgctxt "User survey popup"
 msgid "Help us improve DuckDuckGo"
@@ -9455,7 +9667,8 @@ msgstr "Kui tihti soovid, et ilmuksid AI-toega vastused?"
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
 msgctxt "Duck.ai settings usage section"
 msgid "How much of your daily and weekly limits you've used so far."
-msgstr "Kui suurt osa oma päevastest ja nädalapiirangutest sa seni kasutanud oled."
+msgstr ""
+"Kui suurt osa oma päevastest ja nädalapiirangutest sa seni kasutanud oled."
 
 # smartling.placeholder_format=C
 #. A header for the feedback form in the assist negative feedback flow. The user is being asked to update how often they want AI-assisted answers to appear.
@@ -9522,6 +9735,14 @@ msgstr "Orkaan"
 msgctxt "Onboarding terms screen button text"
 msgid "I Agree"
 msgstr "Olen nõus"
+
+# smartling.placeholder_format=C
+#. Text for the button that takes the user to the external DuckDuckGo login subscription page.
+msgctxt ""
+"Text for the I already have a subscription button in the Duck.ai settings "
+"page"
+msgid "I Already Have a Subscription"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the button that takes the user to the login subscription page.
@@ -10095,6 +10316,12 @@ msgid "Install Mac Browser"
 msgstr "Installi Maci brauserisse"
 
 # smartling.placeholder_format=C
+#. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
+msgctxt "settings"
+msgid "Install Now"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of a button to install the DuckDuckGo app
 msgctxt "Serp footer content"
 msgid "Install Our App"
@@ -10192,10 +10419,42 @@ msgid "Is deleted data really deleted?"
 msgstr "Kas kustutatud andmed on tõepoolest kustutatud?"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is it worth taking?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this place any good?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"Is this place any good? Summarize its reputation based on reviews and "
+"ratings."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "Is this video helpful?"
 msgstr "Kas sellest videost on abi?"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this worth watching?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Is this worth watching? Give me a spoiler-free take."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -10227,7 +10486,8 @@ msgstr "See on kiire, tasuta ja pakub sulle veelgi suuremat võrgukaitset."
 msgctxt "settings"
 msgid ""
 "It's okay to (very infrequently) ask me about my experience using DuckDuckGo"
-msgstr "Mulle sobib, kui küsite (väga harva) minu DuckDuckGo kasutuskogemuse kohta"
+msgstr ""
+"Mulle sobib, kui küsite (väga harva) minu DuckDuckGo kasutuskogemuse kohta"
 
 # smartling.placeholder_format=C
 #. The name of the Italian language
@@ -10806,6 +11066,12 @@ msgid "Links:"
 msgstr "Lingid:"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "List the tools, materials, or prerequisites I need for this."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
 msgid "Listen"
 msgstr "Kuula"
@@ -11094,7 +11360,8 @@ msgstr "Veendu, et kõik sõnad on korrektselt kirjutatud."
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Make sure to check %s\"Make this my default search provider\"%s"
-msgstr "Veendu, et märkisid %1$s„Muuda see minu vaikimisi otsingupakkujaks“%2$s"
+msgstr ""
+"Veendu, et märkisid %1$s„Muuda see minu vaikimisi otsingupakkujaks“%2$s"
 
 # smartling.placeholder_format=C
 #. Message prompting users to check the spelling of their search term.
@@ -11210,6 +11477,12 @@ msgstr "Halda oma tellimust"
 msgctxt "Exclusion message manage sites button"
 msgid "Manage blocked sites"
 msgstr "Blokeeritud saitide haldamine"
+
+# smartling.placeholder_format=C
+#. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
+msgctxt "setting"
+msgid "Manage in Browser Settings"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to the site exclusion settings page
@@ -13071,7 +13344,8 @@ msgctxt "translations_module"
 msgid ""
 "Oops! An unexpected error occurred while translating this text. Please try "
 "again later."
-msgstr "Oih! Selle teksti tõlkimisel tekkis ootamatu viga. Proovi hiljem uuesti."
+msgstr ""
+"Oih! Selle teksti tõlkimisel tekkis ootamatu viga. Proovi hiljem uuesti."
 
 # smartling.placeholder_format=C
 #. Title shown in a fatal error modal when Duck.ai fails to load.
@@ -13954,7 +14228,8 @@ msgstr "Vali konkreetne probleem"
 #. Header instructing the user to follow the instructions for their ad blocker
 msgid ""
 "Pick your ad blocker and follow the instructions to allow ads on DuckDuckGo."
-msgstr "Vali oma reklaamiblokeerija ja järgi juhiseid, et lubada DuckDuckGo reklaame."
+msgstr ""
+"Vali oma reklaamiblokeerija ja järgi juhiseid, et lubada DuckDuckGo reklaame."
 
 # smartling.placeholder_format=C
 #. Text for a button that pins a chat, as in it will it will add the chat to the pinned chats list.
@@ -14032,13 +14307,21 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this search was made by a "
 "human."
-msgstr "Soorita järgmine ülesanne, et kinnitada, et selle otsingu tegi inimene."
+msgstr ""
+"Soorita järgmine ülesanne, et kinnitada, et selle otsingu tegi inimene."
+
+# smartling.placeholder_format=C
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
+msgctxt "Feedback prompt"
+msgid "Please describe why the chat response is harmful or illegal. (optional)"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
-msgstr "Kirjeldage, miks vestluse vastus on ebaseaduslik või kahjulik. (Valikuline)"
+msgstr ""
+"Kirjeldage, miks vestluse vastus on ebaseaduslik või kahjulik. (Valikuline)"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to enter their passphrase.
@@ -14061,6 +14344,14 @@ msgid ""
 msgstr ""
 "Pane tähele: uue vestluse alustamine mis tahes mudeliga kustutab sinu "
 "praeguse vestlusseansi."
+
+# smartling.placeholder_format=C
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
+msgctxt "Feedback prompt"
+msgid ""
+"Please paste your prompt and the problematic output (with any personal "
+"information removed) and describe why the content is harmful or illegal."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -14530,6 +14821,12 @@ msgid "Privacy"
 msgstr "Privaatsus"
 
 # smartling.placeholder_format=C
+#. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
+msgctxt "Section heading on the Duck.ai settings page"
+msgid "Privacy & Terms"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Privacy Blog"
 msgstr "Privaatsuse blogi"
 
@@ -14598,6 +14895,12 @@ msgstr "Privaatsuspoliitika ja kasutustingimused"
 msgctxt "Copy used to compose link in sentences"
 msgid "Privacy Policy and Terms of Service"
 msgstr "Privaatsuspoliitika ja teenusetingimused"
+
+# smartling.placeholder_format=C
+#. Text for a button that links to the terms of use and privacy policy page.
+msgctxt "Secondary button text in active privacy modal"
+msgid "Privacy Policy and Terms of Service"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title displayed on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
@@ -15102,6 +15405,30 @@ msgid "Recommend a book"
 msgstr "Soovita raamatut"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar books"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar books."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar movies or shows."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar titles"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
 msgid "Recording failed. Please try again."
 msgstr "Salvestamine ebaõnnestus. Proovi uuesti."
@@ -15504,6 +15831,15 @@ msgid "Republic of Moldova"
 msgstr "Moldova Vabariik"
 
 # smartling.placeholder_format=C
+#. Note indicating that sharing the conversation is mandatory when reporting harmful or illegal content. Rendered alongside the standard share label (DUCKCHAT_RESPONSE_FEEDBACK_SHARE_PROMPT_RESPONSE_LABEL), not replacing it.
+msgctxt ""
+"Note shown under the share-content switch label on the Duck.ai response "
+"feedback form when the user has selected Harmful or Illegal as the feedback "
+"reason"
+msgid "Required for harmful or illegal reports"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
 msgctxt "Description for extended reasoning mode in Duck.ai"
 msgid "Researches before responding"
@@ -15673,7 +16009,8 @@ msgstr "Tulemused ei sisalda blokeeritud saitide teavet."
 #. Message that appears when results exclude blocked sites
 msgctxt "Blocked sites filter disclaimer"
 msgid "Results exclude your blocked sites, which you can manage in your %s."
-msgstr "Tulemused välistavad sinu blokeeritud saidid, mida saad hallata oma %1$s-s."
+msgstr ""
+"Tulemused välistavad sinu blokeeritud saidid, mida saad hallata oma %1$s-s."
 
 # smartling.placeholder_format=C
 #. A label showing the source of the results, e.g. "Results from Reddit"
@@ -15739,6 +16076,12 @@ msgstr "Arvustused"
 msgctxt "maps_places"
 msgid "Reviews"
 msgstr "Arvustused"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Rewrite this recipe scaled for a different number of servings."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Romania"
@@ -16024,7 +16367,8 @@ msgstr "Salvesta oma seadmesse kuni 30 viimast vestlust."
 msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
-msgstr "Salvesta oma Duck.ai vestlused seadmete vahel otsast lõpuni krüptimisega."
+msgstr ""
+"Salvesta oma Duck.ai vestlused seadmete vahel otsast lõpuni krüptimisega."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -16183,7 +16527,8 @@ msgstr "Keri alla ja leia loendist %1$soma brauser%2$s."
 #. Tells users which setting to change to enable location service.
 msgctxt "precise_user_location"
 msgid "Scroll down to %sDuckDuckGo%s and allow it to use your location."
-msgstr "Keri alla suvandini %1$sDuckDuckGo%2$s ja luba sellel oma asukohta kasutada."
+msgstr ""
+"Keri alla suvandini %1$sDuckDuckGo%2$s ja luba sellel oma asukohta kasutada."
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -16565,7 +16910,8 @@ msgstr ""
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
 msgctxt "Sync feature benefit description"
 msgid "Securely stored on DuckDuckGo's server with end-to-end encryption."
-msgstr "Turvaliselt salvestatud DuckDuckGo serverisse otspunktide krüptimisega."
+msgstr ""
+"Turvaliselt salvestatud DuckDuckGo serverisse otspunktide krüptimisega."
 
 # smartling.placeholder_format=C
 #. List item explaining that synced chats are stored with end-to-end encryption on DuckDuckGo's server and only the user can access them.
@@ -16719,7 +17065,8 @@ msgstr "Vali Safari menüüst %1$sSelle veebisaidi seadistamine...%2$s."
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
-msgstr "Vali %1$sKohanda%2$s ja sisesta %3$shttps://duckduckgo.com%4$s sisendväljale"
+msgstr ""
+"Vali %1$sKohanda%2$s ja sisesta %3$shttps://duckduckgo.com%4$s sisendväljale"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
@@ -17059,6 +17406,12 @@ msgid "Set Up Now"
 msgstr "Seadista nüüd"
 
 # smartling.placeholder_format=C
+#. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
+msgctxt "Encrypted storage setup button shown in native browsers"
+msgid "Set Up Sync & Backup"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
 msgctxt "Title for the Sync & Backup intro screen"
 msgid "Set Up Sync & Backup"
@@ -17094,7 +17447,8 @@ msgstr ""
 #. Prompt for the user to indicate their location on a map, to enable more relevant search results.
 msgctxt "precise_user_location"
 msgid "Set your location manually, or ensure Location Services is enabled."
-msgstr "Määra oma asukoht käsitsi või veendu, et asukohateenused oleksid lubatud."
+msgstr ""
+"Määra oma asukoht käsitsi või veendu, et asukohateenused oleksid lubatud."
 
 # smartling.placeholder_format=C
 #. In the top dropdown menu  ("More" > "Settings")
@@ -17148,7 +17502,8 @@ msgstr "Jaga"
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "Share DuckDuckGo and help friends take their privacy back!"
-msgstr "Jaga rakendust DuckDuckGo ja aita sõpradel oma privaatsus tagasi saada!"
+msgstr ""
+"Jaga rakendust DuckDuckGo ja aita sõpradel oma privaatsus tagasi saada!"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button that opens a feedback modal when clicked.
@@ -17175,8 +17530,8 @@ msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
 msgstr ""
-"Jaga linna tasemel asukohta TI-mudelitega, et parandada asjakohasust. "
-"Duck.ai ei avalda meile ega TI-mudelitele kunagi teie täpset asukohta."
+"Jaga linna tasemel asukohta TI-mudelitega, et parandada asjakohasust. Duck."
+"ai ei avalda meile ega TI-mudelitele kunagi teie täpset asukohta."
 
 # smartling.placeholder_format=C
 #. Menu option to share feedback about a result
@@ -17235,6 +17590,13 @@ msgstr "Jaga lehekülje URL-i"
 msgctxt "feedback form"
 msgid "Share positive feedback"
 msgstr "Anna positiivset tagasisidet"
+
+# smartling.placeholder_format=C
+#. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
+msgctxt ""
+"Label beside the share-content switch on the Duck.ai response feedback form"
+msgid "Share this conversation with DuckDuckGo"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -18061,7 +18423,8 @@ msgstr "Algtekst kustutatud"
 msgctxt "Error message for summary selection input limit"
 msgid ""
 "Source text is too long to summarize. Try again with a shorter selection."
-msgstr "Algtekst on liiga pikk, et seda kokku võtta. Proovi uuesti lühema valikuga."
+msgstr ""
+"Algtekst on liiga pikk, et seda kokku võtta. Proovi uuesti lühema valikuga."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under Interface Settings.in the end. It is a header
@@ -18485,6 +18848,24 @@ msgid "Suggest a title for a blog post"
 msgstr "Soovita pealkirja blogipostituse jaoks"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest related articles or topics worth exploring next."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Suggest related articles to explore"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest some alternatives to this product."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
 msgctxt "directions"
 msgid "Suggestions:"
@@ -18496,10 +18877,100 @@ msgid "Suggestions:"
 msgstr "Soovitused:"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Sum up the reviews"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A short title for the a message asking the AI to summarize a text.
 msgctxt "Title for the summarize message"
 msgid "Summarize"
 msgstr "Tee kokkuvõte"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize the Q&As"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the background and notable work of this person."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the key details of this event."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the questions and answers on this page."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize their background"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this book"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this book."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this discussion"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this discussion thread."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this page"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this page."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this video"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this video."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize what the reviews say."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -18829,6 +19300,12 @@ msgid "Syria"
 msgstr "Süüria"
 
 # smartling.placeholder_format=C
+#. Text for a button that enables the theme to follow the operating system's color scheme preference.
+msgctxt "System theme button for theme selector"
+msgid "System"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Abbreviation indicating this is the total score for a game
 msgctxt "Sports module"
 msgid "T"
@@ -18855,6 +19332,12 @@ msgstr "TV"
 msgctxt "language_name"
 msgid "Tahitian"
 msgstr "tahiti keel"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Tailor my resume"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Taiwan"
@@ -18884,6 +19367,13 @@ msgstr "Kaitse aktiivselt oma isikuandmeid"
 msgctxt "homepage ATB modal"
 msgid "Take control of your personal data!"
 msgstr "Saavuta oma isikuandmete üle kontroll!"
+
+# smartling.placeholder_format=C
+#. Description for the Feedback section of the Duck.ai settings page, asking the user to take an anonymous survey to let us know how we can make Duck.ai better.
+msgctxt "Feedback section description on the Duck.ai settings page"
+msgid ""
+"Take this anonymous survey to let us know how we can make Duck.ai better."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -19148,7 +19638,8 @@ msgstr ""
 msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider deletes any data associated with this chat within 30 days."
-msgstr "Mudelipakkuja kustutab kõik selle vestlusega seotud andmed 30 päeva jooksul."
+msgstr ""
+"Mudelipakkuja kustutab kõik selle vestlusega seotud andmed 30 päeva jooksul."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers.
@@ -19187,6 +19678,12 @@ msgstr "Serveril ilmnes tõrge ja see ei suutnud teie päringut täita."
 #. https://duck.co/media/files/theme.png
 msgid "Theme"
 msgstr "Teema"
+
+# smartling.placeholder_format=C
+#. Text for the theme selector label that allows users to switch between Light and dark theme.
+msgctxt "Label for the theme selector feature"
+msgid "Theme"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/LpFhb1e.png
@@ -19292,7 +19789,8 @@ msgctxt "AI Chat: Error message for when a model is removed"
 msgid ""
 "This AI model is no longer available. Try starting a new chat with a "
 "different model."
-msgstr "See AI mudel pole enam saadaval. Proovi alustada uut vestlust teise mudeliga."
+msgstr ""
+"See AI mudel pole enam saadaval. Proovi alustada uut vestlust teise mudeliga."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is no longer supported because it has been upgraded to a newest version.
@@ -19564,7 +20062,8 @@ msgstr "See tõlge on vale"
 # smartling.placeholder_format=C
 #. Label indicating that the video can't be played on the current page, and only on the website that owns the vide. The placeholder is the name of the website that owns the video.
 msgid "This video is not yet able to be watched here. You can watch it on %s."
-msgstr "Seda videot ei saa veel siin vaadata. Sa saad seda vaadata saidil %1$s."
+msgstr ""
+"Seda videot ei saa veel siin vaadata. Sa saad seda vaadata saidil %1$s."
 
 # smartling.placeholder_format=C
 #. Message indicating that a website is not using an encrypted connection and is not secure.
@@ -19684,7 +20183,8 @@ msgstr "Soovitused"
 
 # smartling.placeholder_format=C
 msgid "Tired of being tracked online? %sWe can help.%s"
-msgstr "Oled väsinud sellest, et sind võrgus jälitatakse? %1$sMeie saame aidata.%2$s"
+msgstr ""
+"Oled väsinud sellest, et sind võrgus jälitatakse? %1$sMeie saame aidata.%2$s"
 
 # smartling.placeholder_format=C
 #. This is the name of a user setting
@@ -19742,8 +20242,8 @@ msgid ""
 "you originally used to set up Sync."
 msgstr ""
 "Sünkroonitud andmete taastamiseks vajad taastamiskoodi, mille salvestasid "
-"sünkroonimise esmakordsel seadistamisel. See kood võis olla salvestatud "
-"PDF-vormingus seadmesse, milles sa sünkroonimise algselt seadistasid."
+"sünkroonimise esmakordsel seadistamisel. See kood võis olla salvestatud PDF-"
+"vormingus seadmesse, milles sa sünkroonimise algselt seadistasid."
 
 # smartling.placeholder_format=C
 #. Body text explaining that the user needs to update their DDG browser before migration can proceed.
@@ -20015,6 +20515,18 @@ msgstr ""
 "kinno?”"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Translate this page"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
+msgctxt "Page suggestion prompt"
+msgid "Translate this page into %s."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text for a region that will display translated text.
 msgctxt "translations_module"
 msgid "Translation"
@@ -20114,7 +20626,8 @@ msgstr "Proovi %1$s, et selliseid sõnumeid enam ei näeks."
 #. Text for a promotional card that encourages users to try the encrypted AI model whose inference runs in a confidential environment so the model provider cannot access user data. %s is replaced with the model's full display name (e.g. 'GPT-OSS 120B').
 msgctxt "Promotional text for encrypted AI model"
 msgid "Try %s, our first model with zero provider visibility."
-msgstr "Proovi mudelit %1$s, meie esimest mudelit null teenusepakkuja nähtavusega."
+msgstr ""
+"Proovi mudelit %1$s, meie esimest mudelit null teenusepakkuja nähtavusega."
 
 # smartling.placeholder_format=C
 msgid "Try %sDuck.ai%s, our private AI chat service:"
@@ -20154,6 +20667,12 @@ msgstr "Proovi uuesti"
 msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
 msgstr "Proovi tasuta"
+
+# smartling.placeholder_format=C
+#. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
+msgctxt "settings"
+msgid "Try It Now"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -20211,7 +20730,8 @@ msgstr "Proovi teisi märksõnu."
 # smartling.placeholder_format=C
 #. Prompt encouraging the user to turn off their ad blocker to see more results for their query.
 msgid "Try disabling your ad blocker on DuckDuckGo to see more results."
-msgstr "Rohkemate tulemuste nägemiseks proovi DuckDuckGo reklaamiblokeerija keelata."
+msgstr ""
+"Rohkemate tulemuste nägemiseks proovi DuckDuckGo reklaamiblokeerija keelata."
 
 # smartling.placeholder_format=C
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
@@ -20390,6 +20910,22 @@ msgid "Trying DuckDuckGo again"
 msgstr "Proovin DuckDuckGo'd uuesti"
 
 # smartling.placeholder_format=C
+#. Message shown in a modal after supported third-party browser users disable AI features in Settings. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
 msgctxt "Assistant response placeholder"
 msgid "Trying with %s"
@@ -20506,7 +21042,8 @@ msgstr "Täpsemate tulemuste saamiseks lülita sisse suvand „Täpne asukoht“
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on “Use precise location” for more accurate results."
-msgstr "Täpsemate tulemuste saamiseks lülita sisse suvand „Kasuta täpset asukohta“."
+msgstr ""
+"Täpsemate tulemuste saamiseks lülita sisse suvand „Kasuta täpset asukohta“."
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Create Image' label in the Tools dropdown.
@@ -20698,8 +21235,8 @@ msgstr ""
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
 msgstr ""
-"Jaotisest %1$sKäivitamisel%2$s vali %3$sAvaleht%4$s ja sisesta: "
-"https://duckduckgo.com"
+"Jaotisest %1$sKäivitamisel%2$s vali %3$sAvaleht%4$s ja sisesta: https://"
+"duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -21136,6 +21673,12 @@ msgid "Uruguay"
 msgstr "Uruguay"
 
 # smartling.placeholder_format=C
+#. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
+msgctxt "Navigation label on the Duck.ai settings page"
+msgid "Usage"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A feedback suggestion
 msgctxt "Feedback prompt"
 msgid "Usage limit"
@@ -21191,7 +21734,8 @@ msgstr "Kasuta DuckDuckGo privaatset otsingut"
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Use DuckDuckGo private search on your iPad, iPhone, or Android!"
-msgstr "Kasuta DuckDuckGo privaatsest otsingut oma iPadis, iPhone'is või Androidis!"
+msgstr ""
+"Kasuta DuckDuckGo privaatsest otsingut oma iPadis, iPhone'is või Androidis!"
 
 # smartling.placeholder_format=C
 #. User clicks this button to share their device's location
@@ -21584,6 +22128,12 @@ msgid "Wales"
 msgstr "Wales"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Walk me through the steps"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for walking directions on a map.
 msgctxt "directions"
 msgid "Walking"
@@ -21701,6 +22251,17 @@ msgstr ""
 "tulemusi."
 
 # smartling.placeholder_format=C
+#. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
+msgctxt ""
+"Inline warning shown below the share-content toggle when the user selects "
+"Harmful or Illegal but has not enabled sharing"
+msgid ""
+"We can only fix what we can see. To report a harmful or illegal response, "
+"please share this conversation with DuckDuckGo so we can investigate and "
+"address the issue."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
 msgctxt ""
 "Inline warning shown below the share-content toggle when the user selects "
@@ -21738,7 +22299,8 @@ msgstr "Me ei jälita sind reklaamidega."
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
 msgid "We don't store usernames or any personally identifiable information."
-msgstr "Me ei salvesta kasutajanimesid ega isikut tuvastada võimaldavat teavet."
+msgstr ""
+"Me ei salvesta kasutajanimesid ega isikut tuvastada võimaldavat teavet."
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -21898,7 +22460,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We stop anyone from getting your search history, including us."
-msgstr "Me ei lase kellelgi, sealhulgas meil endil, sinu otsinguajalugu vaadata."
+msgstr ""
+"Me ei lase kellelgi, sealhulgas meil endil, sinu otsinguajalugu vaadata."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -22060,7 +22623,8 @@ msgstr "Oled jõudnud nädala piiranguni"
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Weekly usage limit reached. You can continue this chat after %s."
-msgstr "Nädala kasutuspiirang on saavutatud. Saad seda vestlust jätkata pärast %1$s."
+msgstr ""
+"Nädala kasutuspiirang on saavutatud. Saad seda vestlust jätkata pärast %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable weekly Duck.ai usage limit and can opt in to continue using the monthly limit.
@@ -22251,6 +22815,103 @@ msgstr ""
 "kogemusi TI-ga, kui ka neile, kellel selliseid kogemusi ei ole."
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the counterarguments?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the hours & location?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key contributions of this paper?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key contributions?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key details?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key points covered in this video?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key points?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key takeaways from this article?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key takeaways?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key things I will learn from this course?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main counterarguments or criticisms of this?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main questions this page answers?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the must-try dishes here?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"What are the opening hours, location, and contact details for this place?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the pros and cons of this product?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the pros and cons?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
 msgctxt "feedback form"
 msgid "What bothered you most?"
@@ -22351,6 +23012,12 @@ msgid "What does atria mean in the context of a medical article?"
 msgstr "Mida tähendab aatrium meditsiinilise artikli kontekstis?"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What does this answer?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
@@ -22361,6 +23028,12 @@ msgstr "Millist funktsiooni soovitate lisada? (valikuline)"
 msgctxt "cloudsave"
 msgid "What information gets saved?"
 msgstr "Missugune informatsioon salvestatakse?"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What interview questions might come up for this role?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -22377,6 +23050,12 @@ msgstr ""
 msgctxt "Full sentence for looking up basic facts"
 msgid "What is the capital city of Albania?"
 msgstr "Mis on Albaania pealinn?"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What is the overall verdict and rating for this?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to a page with additional information.
@@ -22401,6 +23080,12 @@ msgid "What people say:"
 msgstr "Mida rahvas räägib:"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What should I order?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
 msgctxt "feedback form"
 msgid "What stood out?"
@@ -22411,6 +23096,18 @@ msgstr "Mis silma jäi?"
 msgctxt "feedback form"
 msgid "What was wrong with the response? (optional)"
 msgstr "Mis oli vastuse puhul valesti? (valikuline)"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I learn?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I need?"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -22428,6 +23125,12 @@ msgstr "See, mida sa DuckDuckGos vaatad, ei mõjuta sinu YouTube'i soovitusi."
 msgctxt "SERP footer content"
 msgid "What's New"
 msgstr "Mida on uut"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What's the verdict?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -22480,6 +23183,12 @@ msgid "Which features are missing? (Optional)"
 msgstr "Millised funktsioonid on puudu? (Valikuline)"
 
 # smartling.placeholder_format=C
+#. An invitation for users to leave feedback
+msgctxt "Feedback prompt"
+msgid "Which features are missing? (optional)"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
 msgid "White"
 msgstr "Valge"
@@ -22494,6 +23203,18 @@ msgstr "Valge"
 #. Link to an about us page.
 msgid "Who We Are"
 msgstr "Kes me oleme"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Who are the main cast and crew, and what else are they known for?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Who is this person?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Header above a collection of privacy-related links.
@@ -22885,7 +23606,8 @@ msgctxt "Disclaimer bellow chat input - desktop"
 msgid ""
 "You are chatting with %s. AI chats may display inaccurate or offensive "
 "information."
-msgstr "Vestled %1$s-ga. AI-vestlused võivad kuvada ebatäpset või solvavat teavet."
+msgstr ""
+"Vestled %1$s-ga. AI-vestlused võivad kuvada ebatäpset või solvavat teavet."
 
 # smartling.placeholder_format=C
 #. Provide users with the ability to retry their search on a different search engine. First placeholder will be a link with the text "try your search again" OR "try your search later". Second is a URL to the !bangs page: https://duckduckgo.com/bangs.
@@ -22925,8 +23647,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgid "You can also use %sDuck.ai%s to answer questions or summarize text."
 msgstr ""
-"Küsimustele vastamiseks või teksti kokkuvõtmiseks võite kasutada ka "
-"%1$sDuck.ai%2$s."
+"Küsimustele vastamiseks või teksti kokkuvõtmiseks võite kasutada ka %1$sDuck."
+"ai%2$s."
 
 # smartling.placeholder_format=C
 msgid ""
@@ -22988,7 +23710,8 @@ msgstr "Selle meeldetuletuse saad peita suvandis %1$sOtsingu seaded%2$s"
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
-msgstr "Nüüd saad sellesse seadmesse salvestada kuni 100 vestlust. Vestle edasi!"
+msgstr ""
+"Nüüd saad sellesse seadmesse salvestada kuni 100 vestlust. Vestle edasi!"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -23155,7 +23878,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
 msgid "You won't see this message again unless you clear your browser data."
-msgstr "Sa ei näe seda sõnumit enam, kui sa ei kustuta oma veebilehitseja andmeid."
+msgstr ""
+"Sa ei näe seda sõnumit enam, kui sa ei kustuta oma veebilehitseja andmeid."
 
 # smartling.placeholder_format=C
 #. The second paragraph of a pop up where we explain how to update the browser manually.
@@ -23233,7 +23957,8 @@ msgctxt "Error message for user limit"
 msgid ""
 "You've reached the maximum number of messages for the moment. Please try "
 "again later."
-msgstr "Oled hetkel saavutanud maksimaalse sõnumite arvu. Proovi hiljem uuesti."
+msgstr ""
+"Oled hetkel saavutanud maksimaalse sõnumite arvu. Proovi hiljem uuesti."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -23246,7 +23971,8 @@ msgstr "Oled saavutanud ühe seansi maksimaalse häälvestluse kestuse."
 msgctxt "voice chat limit modal"
 msgid ""
 "You've reached the voice chat limit for today. Please try again tomorrow."
-msgstr "Oled jõudnud tänase päeva häälvestluse limiidini. Palun proovi homme uuesti."
+msgstr ""
+"Oled jõudnud tänase päeva häälvestluse limiidini. Palun proovi homme uuesti."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
@@ -23364,7 +24090,8 @@ msgstr "Sinu brauser näitab, kui oled seda linki külastanud"
 # smartling.placeholder_format=C
 msgctxt "new tab page"
 msgid "Your browser provides a list of your most-visited sites."
-msgstr "Sinu brauser esitab sinu kõige sagedamini külastatavate saitide loetelu."
+msgstr ""
+"Sinu brauser esitab sinu kõige sagedamini külastatavate saitide loetelu."
 
 # smartling.placeholder_format=C
 #. Used as a description in a menu
@@ -23406,8 +24133,8 @@ msgstr "Sinu vestlused salvestatakse nüüd."
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never saved or used to train AI models"
 msgstr ""
-"Sinu vestlused on privaatsed ja neid ei salvestata ega kasutata kunagi "
-"AI-mudelite treenimiseks"
+"Sinu vestlused on privaatsed ja neid ei salvestata ega kasutata kunagi AI-"
+"mudelite treenimiseks"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.

--- a/locales/eu_ES/LC_MESSAGES/duckduckgo.po
+++ b/locales/eu_ES/LC_MESSAGES/duckduckgo.po
@@ -1159,6 +1159,11 @@ msgctxt "feedback form"
 msgid "Address is incorrect"
 msgstr ""
 
+#. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Adjust the servings"
+msgstr ""
+
 #. as in multiple advertisements
 msgid "Ads"
 msgstr ""
@@ -1330,6 +1335,13 @@ msgstr ""
 #. Heading shown on the empty chat screen. The text between the two %s markers is displayed inside a clickable privacy button. First %s renders a shield icon, second %s is an invisible end marker. Keep the word 'private' between both %s markers.
 msgctxt "Empty state heading in Duck.ai chat mode"
 msgid "All chats are %sprivate%s"
+msgstr ""
+
+#. Paragraph in the Privacy & Terms section of the About & Legal page in Duck.ai settings, summarizing how chats are anonymized and are not stored or used to train chat models.
+msgctxt "Privacy & Terms section description on the Duck.ai settings page"
+msgid ""
+"All chats are anonymized by DuckDuckGo, and your conversations are not used "
+"to train chat models by DuckDuckGo or the model providers"
 msgstr ""
 
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1542,6 +1554,12 @@ msgstr ""
 #. Confirmation message after location service is enabled.
 msgctxt "precise_user_location"
 msgid "Anonymous location enabled"
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Anonymously generates answers for search queries based on web content. "
+"Choose how often you want it to appear, or disable it completely."
 msgstr ""
 
 #. Instant Answer tab name
@@ -1764,6 +1782,11 @@ msgstr ""
 
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse
 msgid "Ask a follow-up with Duck.ai"
+msgstr ""
+
+#. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
+msgctxt "Page suggestion chip label"
+msgid "Ask about this page"
 msgstr ""
 
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2088,6 +2111,11 @@ msgstr ""
 msgid "Barcode"
 msgstr "Barra kodea"
 
+#. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Based on this page, is this course worth taking?"
+msgstr ""
+
 msgctxt "settings"
 msgid "Basic"
 msgstr ""
@@ -2119,6 +2147,13 @@ msgstr ""
 #. Placeholder text displayed while the assistant waits for the user to choose an action.
 msgctxt "Assistant response placeholder"
 msgid "Before continuing..."
+msgstr ""
+
+#. Explains that before storing the report, DuckDuckGo will anonymize the conversation by removing PII like names, email addresses, and identifying metadata.
+msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
+msgid ""
+"Before storing this report, DuckDuckGo will anonymize your conversation by "
+"removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
 #. Label that's displayed next to a past start date below a web search result.
@@ -2377,6 +2412,11 @@ msgstr ""
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Break Points Won"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Break this down into clear, numbered steps."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -2736,6 +2776,11 @@ msgstr ""
 #. Text of a button that performs a search for the cast of a particular movie or tv show
 msgctxt "Movie/TV Show Title instant answer"
 msgid "Cast"
+msgstr ""
+
+#. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Cast & Crew"
 msgstr ""
 
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -4087,6 +4132,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Create a shopping list with quantities from this recipe."
+msgstr ""
+
 #. Placeholder text displayed in the input field when starting a new image generation session.
 msgctxt "Placeholder text for the image generation input field"
 msgid "Create an image of a cute duck..."
@@ -4613,6 +4663,10 @@ msgstr ""
 msgid "Dictation limit reached"
 msgstr ""
 
+#. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
+msgid "Dictation temporarily unavailable"
+msgstr ""
+
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
@@ -4857,6 +4911,20 @@ msgctxt "precise_user_location"
 msgid "Done"
 msgstr ""
 
+#. Message shown in a modal after DuckDuckGo browser users disable AI features in Settings. The first two placeholders bold noai.duckduckgo.com. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
+"filtered out. %sLearn More%s"
+msgstr ""
+
+#. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
+"and AI images filtered out. %sLearn more%s"
+msgstr ""
+
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Double Faults"
@@ -4947,6 +5015,16 @@ msgctxt "Full sentence for writing an email"
 msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
+msgstr ""
+
+#. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Draft a cover letter"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Draft a cover letter for this job."
 msgstr ""
 
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -5086,6 +5164,14 @@ msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
 msgstr ""
 
+#. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
+msgctxt "About section description on the Duck.ai settings page"
+msgid ""
+"Duck.ai is created by DuckDuckGo. We're an independent online protection "
+"company for anyone who wants to take back control of their personal "
+"information."
+msgstr ""
+
 #. Title shown when an update is required before proceeding.
 msgctxt "duckai_migration"
 msgid "Duck.ai is moving domains"
@@ -5119,6 +5205,12 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Duck.ai lets you chat privately with popular AI models. Disabling it hides "
+"Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
 
 msgctxt "settings"
@@ -5884,6 +5976,16 @@ msgstr ""
 msgid "Eritrea"
 msgstr ""
 
+#. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Estimate the nutrition"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Estimate the nutritional information for this recipe."
+msgstr ""
+
 msgid "Estonia"
 msgstr ""
 
@@ -5928,10 +6030,50 @@ msgctxt "merchant promotion product ad extension"
 msgid "Expires in 1 day"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain the accepted answer in simple terms."
+msgstr ""
+
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
+msgstr ""
+
+#. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain the top answer"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this in simple, plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this paper"
+msgstr ""
+
+#. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this repo"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this research paper in plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this simply"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain what this repository does and how to use it."
 msgstr ""
 
 #. Label to show if song lyrics contain explicit content
@@ -6162,6 +6304,11 @@ msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
 msgstr ""
 
+msgctxt "settings"
+msgid ""
+"Filters out known AI spam sites from image search results. %sLearn More%s"
+msgstr ""
+
 #. Label for the final score of a sporting event.
 msgid "Final"
 msgstr ""
@@ -6201,6 +6348,11 @@ msgstr ""
 #. Short description shown below the 'Web Search' label in the Tools dropdown.
 msgctxt "Subtitle for the Web Search tool entry in the Tools dropdown menu"
 msgid "Find current information"
+msgstr ""
+
+#. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Find me alternatives"
 msgstr ""
 
 #. Button that searches for results closer to the user's current location.
@@ -6591,6 +6743,11 @@ msgstr ""
 msgid "Generate More"
 msgstr ""
 
+#. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Generate a shopping list"
+msgstr ""
+
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
 msgid "Generate a short answer from the web"
 msgstr ""
@@ -6825,6 +6982,11 @@ msgstr ""
 #. Text for a button inviting users to give it a try for the Duck.ai product. On click, they're taken to the Duck.ai page.
 msgctxt "Onboarding welcome screen button text"
 msgid "Give it a Try"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Give me a quick background on this person."
 msgstr ""
 
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -7187,6 +7349,16 @@ msgstr ""
 
 #. Link to a page with information about sharing DuckDuckGo with friends.
 msgid "Help Spread Privacy"
+msgstr ""
+
+#. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Help me prep for the interview"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Help me tailor my resume for this job."
 msgstr ""
 
 #. Title of a SERP popup that invites users to take a survey (desktop only)
@@ -7606,6 +7778,13 @@ msgstr ""
 #. Text displayed on the button on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
 msgctxt "Onboarding terms screen button text"
 msgid "I Agree"
+msgstr ""
+
+#. Text for the button that takes the user to the external DuckDuckGo login subscription page.
+msgctxt ""
+"Text for the I already have a subscription button in the Duck.ai settings "
+"page"
+msgid "I Already Have a Subscription"
 msgstr ""
 
 #. Text for the button that takes the user to the login subscription page.
@@ -8058,6 +8237,11 @@ msgctxt "Sidemenu browser promo"
 msgid "Install Mac Browser"
 msgstr ""
 
+#. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
+msgctxt "settings"
+msgid "Install Now"
+msgstr ""
+
 #. Text of a button to install the DuckDuckGo app
 msgctxt "Serp footer content"
 msgid "Install Our App"
@@ -8137,9 +8321,36 @@ msgctxt "cloudsave"
 msgid "Is deleted data really deleted?"
 msgstr "Ezabatutako datuak egitan ezabatzen dira?"
 
+#. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is it worth taking?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this place any good?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"Is this place any good? Summarize its reputation based on reviews and "
+"ratings."
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "Is this video helpful?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this worth watching?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Is this worth watching? Give me a spoiler-free take."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -8636,6 +8847,11 @@ msgstr "Esteken letra-tipoa:"
 msgid "Links:"
 msgstr "Estekak:"
 
+#. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "List the tools, materials, or prerequisites I need for this."
+msgstr ""
+
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
 msgid "Listen"
 msgstr "Entzun"
@@ -8968,6 +9184,11 @@ msgstr ""
 #. Label for linke navigating to site exclusion feature on Settings page
 msgctxt "Exclusion message manage sites button"
 msgid "Manage blocked sites"
+msgstr ""
+
+#. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
+msgctxt "setting"
+msgid "Manage in Browser Settings"
 msgstr ""
 
 #. Link to the site exclusion settings page
@@ -11265,6 +11486,11 @@ msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
+msgid "Please describe why the chat response is harmful or illegal. (optional)"
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
+msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
 msgstr ""
 
@@ -11283,6 +11509,13 @@ msgctxt "Modal disclaimer text"
 msgid ""
 "Please note: starting a new chat with any model will delete your current "
 "chat session."
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
+msgctxt "Feedback prompt"
+msgid ""
+"Please paste your prompt and the problematic output (with any personal "
+"information removed) and describe why the content is harmful or illegal."
 msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -11667,6 +11900,11 @@ msgctxt "settings"
 msgid "Privacy"
 msgstr "pribatutasun"
 
+#. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
+msgctxt "Section heading on the Duck.ai settings page"
+msgid "Privacy & Terms"
+msgstr ""
+
 msgid "Privacy Blog"
 msgstr ""
 
@@ -11720,6 +11958,11 @@ msgstr ""
 
 #. Text used in other strings to link to the Privacy Policy and Terms of Service content.
 msgctxt "Copy used to compose link in sentences"
+msgid "Privacy Policy and Terms of Service"
+msgstr ""
+
+#. Text for a button that links to the terms of use and privacy policy page.
+msgctxt "Secondary button text in active privacy modal"
 msgid "Privacy Policy and Terms of Service"
 msgstr ""
 
@@ -12128,6 +12371,26 @@ msgctxt "Brief for recommending a book"
 msgid "Recommend a book"
 msgstr ""
 
+#. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar books"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar books."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar movies or shows."
+msgstr ""
+
+#. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar titles"
+msgstr ""
+
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
 msgid "Recording failed. Please try again."
 msgstr ""
@@ -12447,6 +12710,14 @@ msgstr ""
 msgid "Republic of Moldova"
 msgstr ""
 
+#. Note indicating that sharing the conversation is mandatory when reporting harmful or illegal content. Rendered alongside the standard share label (DUCKCHAT_RESPONSE_FEEDBACK_SHARE_PROMPT_RESPONSE_LABEL), not replacing it.
+msgctxt ""
+"Note shown under the share-content switch label on the Duck.ai response "
+"feedback form when the user has selected Harmful or Illegal as the feedback "
+"reason"
+msgid "Required for harmful or illegal reports"
+msgstr ""
+
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
 msgctxt "Description for extended reasoning mode in Duck.ai"
 msgid "Researches before responding"
@@ -12632,6 +12903,11 @@ msgstr "Berrikuspenak"
 #. Label above a list of customer reviews of a business.
 msgctxt "maps_places"
 msgid "Reviews"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Rewrite this recipe scaled for a different number of servings."
 msgstr ""
 
 msgid "Romania"
@@ -13669,6 +13945,11 @@ msgctxt "Setup button for native sync flow"
 msgid "Set Up Now"
 msgstr ""
 
+#. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
+msgctxt "Encrypted storage setup button shown in native browsers"
+msgid "Set Up Sync & Backup"
+msgstr ""
+
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
 msgctxt "Title for the Sync & Backup intro screen"
 msgid "Set Up Sync & Backup"
@@ -13811,6 +14092,12 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
+msgctxt ""
+"Label beside the share-content switch on the Duck.ai response feedback form"
+msgid "Share this conversation with DuckDuckGo"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -14825,6 +15112,21 @@ msgctxt "Brief for suggesting a blog post title"
 msgid "Suggest a title for a blog post"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest related articles or topics worth exploring next."
+msgstr ""
+
+#. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Suggest related articles to explore"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest some alternatives to this product."
+msgstr ""
+
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
 msgctxt "directions"
 msgid "Suggestions:"
@@ -14834,9 +15136,84 @@ msgctxt "noresults"
 msgid "Suggestions:"
 msgstr ""
 
+#. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Sum up the reviews"
+msgstr ""
+
 #. A short title for the a message asking the AI to summarize a text.
 msgctxt "Title for the summarize message"
 msgid "Summarize"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize the Q&As"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the background and notable work of this person."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the key details of this event."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the questions and answers on this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize their background"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this book"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this book."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this discussion"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this discussion thread."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this video"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this video."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize what the reviews say."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -15091,6 +15468,11 @@ msgstr ""
 msgid "Syria"
 msgstr ""
 
+#. Text for a button that enables the theme to follow the operating system's color scheme preference.
+msgctxt "System theme button for theme selector"
+msgid "System"
+msgstr ""
+
 #. Abbreviation indicating this is the total score for a game
 msgctxt "Sports module"
 msgid "T"
@@ -15114,6 +15496,11 @@ msgctxt "language_name"
 msgid "Tahitian"
 msgstr ""
 
+#. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Tailor my resume"
+msgstr ""
+
 msgid "Taiwan"
 msgstr ""
 
@@ -15135,6 +15522,12 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "Take control of your personal data!"
+msgstr ""
+
+#. Description for the Feedback section of the Duck.ai settings page, asking the user to take an anonymous survey to let us know how we can make Duck.ai better.
+msgctxt "Feedback section description on the Duck.ai settings page"
+msgid ""
+"Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
 
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -15379,6 +15772,11 @@ msgstr ""
 #. https://duck.co/media/files/theme.png
 msgid "Theme"
 msgstr "Gaia"
+
+#. Text for the theme selector label that allows users to switch between Light and dark theme.
+msgctxt "Label for the theme selector feature"
+msgid "Theme"
+msgstr ""
 
 #. http://i.imgur.com/LpFhb1e.png
 msgctxt "settings"
@@ -16030,6 +16428,16 @@ msgid ""
 "movie theatre?”"
 msgstr ""
 
+#. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Translate this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
+msgctxt "Page suggestion prompt"
+msgid "Translate this page into %s."
+msgstr ""
+
 #. Placeholder text for a region that will display translated text.
 msgctxt "translations_module"
 msgid "Translation"
@@ -16144,6 +16552,11 @@ msgstr ""
 #. Call-to-action button for the subscription promo in the SERP sidemenu.
 msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
+msgstr ""
+
+#. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
+msgctxt "settings"
+msgid "Try It Now"
 msgstr ""
 
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -16337,6 +16750,20 @@ msgstr "Saiatu: %s"
 #. Response a user can select in a feedback form, indicating that they're trying DuckDuckGo again.
 msgctxt "new user poll"
 msgid "Trying DuckDuckGo again"
+msgstr ""
+
+#. Message shown in a modal after supported third-party browser users disable AI features in Settings. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+#. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
 msgstr ""
 
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -16937,6 +17364,11 @@ msgstr ""
 msgid "Uruguay"
 msgstr ""
 
+#. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
+msgctxt "Navigation label on the Duck.ai settings page"
+msgid "Usage"
+msgstr ""
+
 #. A feedback suggestion
 msgctxt "Feedback prompt"
 msgid "Usage limit"
@@ -17285,6 +17717,11 @@ msgstr ""
 msgid "Wales"
 msgstr ""
 
+#. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Walk me through the steps"
+msgstr ""
+
 #. Label for walking directions on a map.
 msgctxt "directions"
 msgid "Walking"
@@ -17375,6 +17812,16 @@ msgstr ""
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
+msgstr ""
+
+#. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
+msgctxt ""
+"Inline warning shown below the share-content toggle when the user selects "
+"Harmful or Illegal but has not enabled sharing"
+msgid ""
+"We can only fix what we can see. To report a harmful or illegal response, "
+"please share this conversation with DuckDuckGo so we can investigate and "
+"address the issue."
 msgstr ""
 
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -17794,6 +18241,87 @@ msgid ""
 "experience."
 msgstr ""
 
+#. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the counterarguments?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the hours & location?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key contributions of this paper?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key contributions?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key details?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key points covered in this video?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key points?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key takeaways from this article?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key takeaways?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key things I will learn from this course?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main counterarguments or criticisms of this?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main questions this page answers?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the must-try dishes here?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"What are the opening hours, location, and contact details for this place?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the pros and cons of this product?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the pros and cons?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
 msgctxt "feedback form"
 msgid "What bothered you most?"
@@ -17877,6 +18405,11 @@ msgctxt "Full sentence for defining a term"
 msgid "What does atria mean in the context of a medical article?"
 msgstr ""
 
+#. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What does this answer?"
+msgstr ""
+
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
@@ -17886,6 +18419,11 @@ msgstr ""
 msgctxt "cloudsave"
 msgid "What information gets saved?"
 msgstr "Zer argibide gordetzen dira?"
+
+#. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What interview questions might come up for this role?"
+msgstr ""
 
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
@@ -17897,6 +18435,11 @@ msgstr ""
 #. Text for a prompt suggestion for looking up the capital city of Albania.
 msgctxt "Full sentence for looking up basic facts"
 msgid "What is the capital city of Albania?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What is the overall verdict and rating for this?"
 msgstr ""
 
 #. Link to a page with additional information.
@@ -17917,6 +18460,11 @@ msgctxt "maps_places"
 msgid "What people say:"
 msgstr ""
 
+#. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What should I order?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
 msgctxt "feedback form"
 msgid "What stood out?"
@@ -17925,6 +18473,16 @@ msgstr ""
 #. Question on a feedback form for a negative feedback response.
 msgctxt "feedback form"
 msgid "What was wrong with the response? (optional)"
+msgstr ""
+
+#. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I learn?"
+msgstr ""
+
+#. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I need?"
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -17939,6 +18497,11 @@ msgstr ""
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
 msgctxt "SERP footer content"
 msgid "What's New"
+msgstr ""
+
+#. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What's the verdict?"
 msgstr ""
 
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -17980,6 +18543,11 @@ msgctxt "Feedback prompt"
 msgid "Which features are missing? (Optional)"
 msgstr ""
 
+#. An invitation for users to leave feedback
+msgctxt "Feedback prompt"
+msgid "Which features are missing? (optional)"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
 msgid "White"
 msgstr "Zuria"
@@ -17991,6 +18559,16 @@ msgstr ""
 
 #. Link to an about us page.
 msgid "Who We Are"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Who are the main cast and crew, and what else are they known for?"
+msgstr ""
+
+#. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Who is this person?"
 msgstr ""
 
 #. Header above a collection of privacy-related links.

--- a/locales/fa_IR/LC_MESSAGES/duckduckgo.po
+++ b/locales/fa_IR/LC_MESSAGES/duckduckgo.po
@@ -1168,6 +1168,11 @@ msgctxt "feedback form"
 msgid "Address is incorrect"
 msgstr ""
 
+#. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Adjust the servings"
+msgstr ""
+
 #. as in multiple advertisements
 msgid "Ads"
 msgstr "تبلیغات"
@@ -1340,6 +1345,13 @@ msgstr ""
 #. Heading shown on the empty chat screen. The text between the two %s markers is displayed inside a clickable privacy button. First %s renders a shield icon, second %s is an invisible end marker. Keep the word 'private' between both %s markers.
 msgctxt "Empty state heading in Duck.ai chat mode"
 msgid "All chats are %sprivate%s"
+msgstr ""
+
+#. Paragraph in the Privacy & Terms section of the About & Legal page in Duck.ai settings, summarizing how chats are anonymized and are not stored or used to train chat models.
+msgctxt "Privacy & Terms section description on the Duck.ai settings page"
+msgid ""
+"All chats are anonymized by DuckDuckGo, and your conversations are not used "
+"to train chat models by DuckDuckGo or the model providers"
 msgstr ""
 
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1555,6 +1567,12 @@ msgstr ""
 #. Confirmation message after location service is enabled.
 msgctxt "precise_user_location"
 msgid "Anonymous location enabled"
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Anonymously generates answers for search queries based on web content. "
+"Choose how often you want it to appear, or disable it completely."
 msgstr ""
 
 #. Instant Answer tab name
@@ -1779,6 +1797,11 @@ msgstr ""
 
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse
 msgid "Ask a follow-up with Duck.ai"
+msgstr ""
+
+#. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
+msgctxt "Page suggestion chip label"
+msgid "Ask about this page"
 msgstr ""
 
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2105,6 +2128,11 @@ msgstr ""
 msgid "Barcode"
 msgstr "بارکد"
 
+#. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Based on this page, is this course worth taking?"
+msgstr ""
+
 msgctxt "settings"
 msgid "Basic"
 msgstr "ابتدایی"
@@ -2136,6 +2164,13 @@ msgstr ""
 #. Placeholder text displayed while the assistant waits for the user to choose an action.
 msgctxt "Assistant response placeholder"
 msgid "Before continuing..."
+msgstr ""
+
+#. Explains that before storing the report, DuckDuckGo will anonymize the conversation by removing PII like names, email addresses, and identifying metadata.
+msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
+msgid ""
+"Before storing this report, DuckDuckGo will anonymize your conversation by "
+"removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
 #. Label that's displayed next to a past start date below a web search result.
@@ -2394,6 +2429,11 @@ msgstr "برزیل"
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Break Points Won"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Break this down into clear, numbered steps."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -2753,6 +2793,11 @@ msgstr "مشاغل"
 #. Text of a button that performs a search for the cast of a particular movie or tv show
 msgctxt "Movie/TV Show Title instant answer"
 msgid "Cast"
+msgstr ""
+
+#. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Cast & Crew"
 msgstr ""
 
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -4115,6 +4160,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Create a shopping list with quantities from this recipe."
+msgstr ""
+
 #. Placeholder text displayed in the input field when starting a new image generation session.
 msgctxt "Placeholder text for the image generation input field"
 msgid "Create an image of a cute duck..."
@@ -4641,6 +4691,10 @@ msgstr ""
 msgid "Dictation limit reached"
 msgstr ""
 
+#. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
+msgid "Dictation temporarily unavailable"
+msgstr ""
+
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
@@ -4887,6 +4941,20 @@ msgctxt "precise_user_location"
 msgid "Done"
 msgstr ""
 
+#. Message shown in a modal after DuckDuckGo browser users disable AI features in Settings. The first two placeholders bold noai.duckduckgo.com. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
+"filtered out. %sLearn More%s"
+msgstr ""
+
+#. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
+"and AI images filtered out. %sLearn more%s"
+msgstr ""
+
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Double Faults"
@@ -4977,6 +5045,16 @@ msgctxt "Full sentence for writing an email"
 msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
+msgstr ""
+
+#. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Draft a cover letter"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Draft a cover letter for this job."
 msgstr ""
 
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -5116,6 +5194,14 @@ msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
 msgstr ""
 
+#. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
+msgctxt "About section description on the Duck.ai settings page"
+msgid ""
+"Duck.ai is created by DuckDuckGo. We're an independent online protection "
+"company for anyone who wants to take back control of their personal "
+"information."
+msgstr ""
+
 #. Title shown when an update is required before proceeding.
 msgctxt "duckai_migration"
 msgid "Duck.ai is moving domains"
@@ -5149,6 +5235,12 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Duck.ai lets you chat privately with popular AI models. Disabling it hides "
+"Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
 
 msgctxt "settings"
@@ -5930,6 +6022,16 @@ msgstr ""
 msgid "Eritrea"
 msgstr ""
 
+#. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Estimate the nutrition"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Estimate the nutritional information for this recipe."
+msgstr ""
+
 msgid "Estonia"
 msgstr "استونی"
 
@@ -5974,10 +6076,50 @@ msgctxt "merchant promotion product ad extension"
 msgid "Expires in 1 day"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain the accepted answer in simple terms."
+msgstr ""
+
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
+msgstr ""
+
+#. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain the top answer"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this in simple, plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this paper"
+msgstr ""
+
+#. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this repo"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this research paper in plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this simply"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain what this repository does and how to use it."
 msgstr ""
 
 #. Label to show if song lyrics contain explicit content
@@ -6208,6 +6350,11 @@ msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
 msgstr ""
 
+msgctxt "settings"
+msgid ""
+"Filters out known AI spam sites from image search results. %sLearn More%s"
+msgstr ""
+
 #. Label for the final score of a sporting event.
 msgid "Final"
 msgstr "نهایی"
@@ -6251,6 +6398,11 @@ msgstr ""
 #. Short description shown below the 'Web Search' label in the Tools dropdown.
 msgctxt "Subtitle for the Web Search tool entry in the Tools dropdown menu"
 msgid "Find current information"
+msgstr ""
+
+#. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Find me alternatives"
 msgstr ""
 
 #. Button that searches for results closer to the user's current location.
@@ -6641,6 +6793,11 @@ msgstr ""
 msgid "Generate More"
 msgstr ""
 
+#. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Generate a shopping list"
+msgstr ""
+
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
 msgid "Generate a short answer from the web"
 msgstr ""
@@ -6875,6 +7032,11 @@ msgstr ""
 #. Text for a button inviting users to give it a try for the Duck.ai product. On click, they're taken to the Duck.ai page.
 msgctxt "Onboarding welcome screen button text"
 msgid "Give it a Try"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Give me a quick background on this person."
 msgstr ""
 
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -7241,6 +7403,16 @@ msgstr ""
 
 #. Link to a page with information about sharing DuckDuckGo with friends.
 msgid "Help Spread Privacy"
+msgstr ""
+
+#. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Help me prep for the interview"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Help me tailor my resume for this job."
 msgstr ""
 
 #. Title of a SERP popup that invites users to take a survey (desktop only)
@@ -7666,6 +7838,13 @@ msgstr ""
 #. Text displayed on the button on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
 msgctxt "Onboarding terms screen button text"
 msgid "I Agree"
+msgstr ""
+
+#. Text for the button that takes the user to the external DuckDuckGo login subscription page.
+msgctxt ""
+"Text for the I already have a subscription button in the Duck.ai settings "
+"page"
+msgid "I Already Have a Subscription"
 msgstr ""
 
 #. Text for the button that takes the user to the login subscription page.
@@ -8131,6 +8310,11 @@ msgctxt "Sidemenu browser promo"
 msgid "Install Mac Browser"
 msgstr ""
 
+#. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
+msgctxt "settings"
+msgid "Install Now"
+msgstr ""
+
 #. Text of a button to install the DuckDuckGo app
 msgctxt "Serp footer content"
 msgid "Install Our App"
@@ -8210,9 +8394,36 @@ msgctxt "cloudsave"
 msgid "Is deleted data really deleted?"
 msgstr "آیا اطلاعات پاک شده واقعا پاک شده اند؟"
 
+#. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is it worth taking?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this place any good?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"Is this place any good? Summarize its reputation based on reviews and "
+"ratings."
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "Is this video helpful?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this worth watching?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Is this worth watching? Give me a spoiler-free take."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -8711,6 +8922,11 @@ msgstr "فونت پیوند ها:"
 msgid "Links:"
 msgstr "پیوند ها:"
 
+#. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "List the tools, materials, or prerequisites I need for this."
+msgstr ""
+
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
 msgid "Listen"
 msgstr "گوش دهید"
@@ -9045,6 +9261,11 @@ msgstr ""
 #. Label for linke navigating to site exclusion feature on Settings page
 msgctxt "Exclusion message manage sites button"
 msgid "Manage blocked sites"
+msgstr ""
+
+#. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
+msgctxt "setting"
+msgid "Manage in Browser Settings"
 msgstr ""
 
 #. Link to the site exclusion settings page
@@ -11352,6 +11573,11 @@ msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
+msgid "Please describe why the chat response is harmful or illegal. (optional)"
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
+msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
 msgstr ""
 
@@ -11370,6 +11596,13 @@ msgctxt "Modal disclaimer text"
 msgid ""
 "Please note: starting a new chat with any model will delete your current "
 "chat session."
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
+msgctxt "Feedback prompt"
+msgid ""
+"Please paste your prompt and the problematic output (with any personal "
+"information removed) and describe why the content is harmful or illegal."
 msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -11754,6 +11987,11 @@ msgctxt "settings"
 msgid "Privacy"
 msgstr "حریم شخصی"
 
+#. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
+msgctxt "Section heading on the Duck.ai settings page"
+msgid "Privacy & Terms"
+msgstr ""
+
 msgid "Privacy Blog"
 msgstr ""
 
@@ -11807,6 +12045,11 @@ msgstr ""
 
 #. Text used in other strings to link to the Privacy Policy and Terms of Service content.
 msgctxt "Copy used to compose link in sentences"
+msgid "Privacy Policy and Terms of Service"
+msgstr ""
+
+#. Text for a button that links to the terms of use and privacy policy page.
+msgctxt "Secondary button text in active privacy modal"
 msgid "Privacy Policy and Terms of Service"
 msgstr ""
 
@@ -12215,6 +12458,26 @@ msgctxt "Brief for recommending a book"
 msgid "Recommend a book"
 msgstr ""
 
+#. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar books"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar books."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar movies or shows."
+msgstr ""
+
+#. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar titles"
+msgstr ""
+
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
 msgid "Recording failed. Please try again."
 msgstr ""
@@ -12535,6 +12798,14 @@ msgstr ""
 msgid "Republic of Moldova"
 msgstr ""
 
+#. Note indicating that sharing the conversation is mandatory when reporting harmful or illegal content. Rendered alongside the standard share label (DUCKCHAT_RESPONSE_FEEDBACK_SHARE_PROMPT_RESPONSE_LABEL), not replacing it.
+msgctxt ""
+"Note shown under the share-content switch label on the Duck.ai response "
+"feedback form when the user has selected Harmful or Illegal as the feedback "
+"reason"
+msgid "Required for harmful or illegal reports"
+msgstr ""
+
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
 msgctxt "Description for extended reasoning mode in Duck.ai"
 msgid "Researches before responding"
@@ -12720,6 +12991,11 @@ msgstr "بررسی‌ها"
 #. Label above a list of customer reviews of a business.
 msgctxt "maps_places"
 msgid "Reviews"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Rewrite this recipe scaled for a different number of servings."
 msgstr ""
 
 msgid "Romania"
@@ -13776,6 +14052,11 @@ msgctxt "Setup button for native sync flow"
 msgid "Set Up Now"
 msgstr ""
 
+#. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
+msgctxt "Encrypted storage setup button shown in native browsers"
+msgid "Set Up Sync & Backup"
+msgstr ""
+
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
 msgctxt "Title for the Sync & Backup intro screen"
 msgid "Set Up Sync & Backup"
@@ -13922,6 +14203,12 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
+msgctxt ""
+"Label beside the share-content switch on the Duck.ai response feedback form"
+msgid "Share this conversation with DuckDuckGo"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -14938,6 +15225,21 @@ msgctxt "Brief for suggesting a blog post title"
 msgid "Suggest a title for a blog post"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest related articles or topics worth exploring next."
+msgstr ""
+
+#. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Suggest related articles to explore"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest some alternatives to this product."
+msgstr ""
+
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
 msgctxt "directions"
 msgid "Suggestions:"
@@ -14947,9 +15249,84 @@ msgctxt "noresults"
 msgid "Suggestions:"
 msgstr ""
 
+#. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Sum up the reviews"
+msgstr ""
+
 #. A short title for the a message asking the AI to summarize a text.
 msgctxt "Title for the summarize message"
 msgid "Summarize"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize the Q&As"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the background and notable work of this person."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the key details of this event."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the questions and answers on this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize their background"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this book"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this book."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this discussion"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this discussion thread."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this video"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this video."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize what the reviews say."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -15206,6 +15583,11 @@ msgstr ""
 msgid "Syria"
 msgstr ""
 
+#. Text for a button that enables the theme to follow the operating system's color scheme preference.
+msgctxt "System theme button for theme selector"
+msgid "System"
+msgstr ""
+
 #. Abbreviation indicating this is the total score for a game
 msgctxt "Sports module"
 msgid "T"
@@ -15229,6 +15611,11 @@ msgctxt "language_name"
 msgid "Tahitian"
 msgstr ""
 
+#. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Tailor my resume"
+msgstr ""
+
 msgid "Taiwan"
 msgstr "تایوان"
 
@@ -15250,6 +15637,12 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "Take control of your personal data!"
+msgstr ""
+
+#. Description for the Feedback section of the Duck.ai settings page, asking the user to take an anonymous survey to let us know how we can make Duck.ai better.
+msgctxt "Feedback section description on the Duck.ai settings page"
+msgid ""
+"Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
 
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -15494,6 +15887,11 @@ msgstr ""
 #. https://duck.co/media/files/theme.png
 msgid "Theme"
 msgstr "تم"
+
+#. Text for the theme selector label that allows users to switch between Light and dark theme.
+msgctxt "Label for the theme selector feature"
+msgid "Theme"
+msgstr ""
 
 #. http://i.imgur.com/LpFhb1e.png
 msgctxt "settings"
@@ -16151,6 +16549,16 @@ msgid ""
 "movie theatre?”"
 msgstr ""
 
+#. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Translate this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
+msgctxt "Page suggestion prompt"
+msgid "Translate this page into %s."
+msgstr ""
+
 #. Placeholder text for a region that will display translated text.
 msgctxt "translations_module"
 msgid "Translation"
@@ -16265,6 +16673,11 @@ msgstr ""
 #. Call-to-action button for the subscription promo in the SERP sidemenu.
 msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
+msgstr ""
+
+#. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
+msgctxt "settings"
+msgid "Try It Now"
 msgstr ""
 
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -16461,6 +16874,20 @@ msgstr "این را امتحان کنید: %s"
 msgctxt "new user poll"
 msgid "Trying DuckDuckGo again"
 msgstr "امتحان دوباره داک‌داک‌گو"
+
+#. Message shown in a modal after supported third-party browser users disable AI features in Settings. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+#. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
 
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
 msgctxt "Assistant response placeholder"
@@ -17067,6 +17494,11 @@ msgstr ""
 msgid "Uruguay"
 msgstr ""
 
+#. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
+msgctxt "Navigation label on the Duck.ai settings page"
+msgid "Usage"
+msgstr ""
+
 #. A feedback suggestion
 msgctxt "Feedback prompt"
 msgid "Usage limit"
@@ -17421,6 +17853,11 @@ msgstr ""
 msgid "Wales"
 msgstr ""
 
+#. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Walk me through the steps"
+msgstr ""
+
 #. Label for walking directions on a map.
 msgctxt "directions"
 msgid "Walking"
@@ -17511,6 +17948,16 @@ msgstr ""
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
+msgstr ""
+
+#. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
+msgctxt ""
+"Inline warning shown below the share-content toggle when the user selects "
+"Harmful or Illegal but has not enabled sharing"
+msgid ""
+"We can only fix what we can see. To report a harmful or illegal response, "
+"please share this conversation with DuckDuckGo so we can investigate and "
+"address the issue."
 msgstr ""
 
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -17938,6 +18385,87 @@ msgid ""
 "experience."
 msgstr ""
 
+#. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the counterarguments?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the hours & location?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key contributions of this paper?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key contributions?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key details?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key points covered in this video?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key points?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key takeaways from this article?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key takeaways?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key things I will learn from this course?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main counterarguments or criticisms of this?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main questions this page answers?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the must-try dishes here?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"What are the opening hours, location, and contact details for this place?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the pros and cons of this product?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the pros and cons?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
 msgctxt "feedback form"
 msgid "What bothered you most?"
@@ -18021,6 +18549,11 @@ msgctxt "Full sentence for defining a term"
 msgid "What does atria mean in the context of a medical article?"
 msgstr ""
 
+#. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What does this answer?"
+msgstr ""
+
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
@@ -18030,6 +18563,11 @@ msgstr ""
 msgctxt "cloudsave"
 msgid "What information gets saved?"
 msgstr "چه اطّلاعاتی ذخیره می‌شوند؟"
+
+#. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What interview questions might come up for this role?"
+msgstr ""
 
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
@@ -18041,6 +18579,11 @@ msgstr ""
 #. Text for a prompt suggestion for looking up the capital city of Albania.
 msgctxt "Full sentence for looking up basic facts"
 msgid "What is the capital city of Albania?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What is the overall verdict and rating for this?"
 msgstr ""
 
 #. Link to a page with additional information.
@@ -18063,6 +18606,11 @@ msgctxt "maps_places"
 msgid "What people say:"
 msgstr ""
 
+#. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What should I order?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
 msgctxt "feedback form"
 msgid "What stood out?"
@@ -18071,6 +18619,16 @@ msgstr ""
 #. Question on a feedback form for a negative feedback response.
 msgctxt "feedback form"
 msgid "What was wrong with the response? (optional)"
+msgstr ""
+
+#. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I learn?"
+msgstr ""
+
+#. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I need?"
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -18085,6 +18643,11 @@ msgstr ""
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
 msgctxt "SERP footer content"
 msgid "What's New"
+msgstr ""
+
+#. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What's the verdict?"
 msgstr ""
 
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -18126,6 +18689,11 @@ msgctxt "Feedback prompt"
 msgid "Which features are missing? (Optional)"
 msgstr ""
 
+#. An invitation for users to leave feedback
+msgctxt "Feedback prompt"
+msgid "Which features are missing? (optional)"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
 msgid "White"
 msgstr "سپید"
@@ -18137,6 +18705,16 @@ msgstr "سفید"
 
 #. Link to an about us page.
 msgid "Who We Are"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Who are the main cast and crew, and what else are they known for?"
+msgstr ""
+
+#. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Who is this person?"
 msgstr ""
 
 #. Header above a collection of privacy-related links.

--- a/locales/fi_FI/LC_MESSAGES/duckduckgo.po
+++ b/locales/fi_FI/LC_MESSAGES/duckduckgo.po
@@ -1435,6 +1435,12 @@ msgid "Address is incorrect"
 msgstr "Osoite on väärä"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Adjust the servings"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. as in multiple advertisements
 msgid "Ads"
 msgstr "Mainokset"
@@ -1646,6 +1652,14 @@ msgstr "Kaikki keskustelut ovat %1$s. Tekoäly voi tehdä virheitä."
 msgctxt "Empty state heading in Duck.ai chat mode"
 msgid "All chats are %sprivate%s"
 msgstr "Kaikki keskustelut ovat %1$syksityisiä%2$s"
+
+# smartling.placeholder_format=C
+#. Paragraph in the Privacy & Terms section of the About & Legal page in Duck.ai settings, summarizing how chats are anonymized and are not stored or used to train chat models.
+msgctxt "Privacy & Terms section description on the Duck.ai settings page"
+msgid ""
+"All chats are anonymized by DuckDuckGo, and your conversations are not used "
+"to train chat models by DuckDuckGo or the model providers"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1917,6 +1931,13 @@ msgstr ""
 msgctxt "precise_user_location"
 msgid "Anonymous location enabled"
 msgstr "Anonyymi sijainti käytössä"
+
+# smartling.placeholder_format=C
+msgctxt "settings"
+msgid ""
+"Anonymously generates answers for search queries based on web content. "
+"Choose how often you want it to appear, or disable it completely."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -2195,6 +2216,12 @@ msgstr "Esitä jatkokysymys"
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse
 msgid "Ask a follow-up with Duck.ai"
 msgstr "Esitä jatkokysymys Duck.ai:lle"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
+msgctxt "Page suggestion chip label"
+msgid "Ask about this page"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2614,6 +2641,12 @@ msgid "Barcode"
 msgstr "Viivakoodi"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Based on this page, is this course worth taking?"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Basic"
 msgstr "Perus"
@@ -2652,6 +2685,14 @@ msgstr "Lyöjä"
 msgctxt "Assistant response placeholder"
 msgid "Before continuing..."
 msgstr "Ennen kuin jatkat..."
+
+# smartling.placeholder_format=C
+#. Explains that before storing the report, DuckDuckGo will anonymize the conversation by removing PII like names, email addresses, and identifying metadata.
+msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
+msgid ""
+"Before storing this report, DuckDuckGo will anonymize your conversation by "
+"removing PII like names, email addresses, and identifying metadata."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -2968,6 +3009,12 @@ msgstr "Brasilia"
 msgctxt "Sports module"
 msgid "Break Points Won"
 msgstr "Murtopallot voitettu"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Break this down into clear, numbered steps."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -3424,6 +3471,12 @@ msgstr "Työpaikat"
 msgctxt "Movie/TV Show Title instant answer"
 msgid "Cast"
 msgstr "Näyttelijät"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Cast & Crew"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -5135,6 +5188,12 @@ msgid "Create Image"
 msgstr "Luo kuva"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Create a shopping list with quantities from this recipe."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text displayed in the input field when starting a new image generation session.
 msgctxt "Placeholder text for the image generation input field"
 msgid "Create an image of a cute duck..."
@@ -5779,6 +5838,11 @@ msgid "Dictation limit reached"
 msgstr "Saneluraja saavutettu"
 
 # smartling.placeholder_format=C
+#. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
+msgid "Dictation temporarily unavailable"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
@@ -6081,6 +6145,22 @@ msgid "Done"
 msgstr "Valmis"
 
 # smartling.placeholder_format=C
+#. Message shown in a modal after DuckDuckGo browser users disable AI features in Settings. The first two placeholders bold noai.duckduckgo.com. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
+"filtered out. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
+"and AI images filtered out. %sLearn more%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Double Faults"
@@ -6193,6 +6273,18 @@ msgid ""
 msgstr ""
 "Luo tiivis ja yksityiskohtainen sähköpostiviesti, jossa pyydetään tarjousta "
 "jääkaapin korjauksesta."
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Draft a cover letter"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Draft a cover letter for this job."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -6372,6 +6464,15 @@ msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
+msgctxt "About section description on the Duck.ai settings page"
+msgid ""
+"Duck.ai is created by DuckDuckGo. We're an independent online protection "
+"company for anyone who wants to take back control of their personal "
+"information."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
 msgctxt "duckai_migration"
 msgid "Duck.ai is moving domains"
@@ -6416,6 +6517,13 @@ msgstr ""
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
 msgstr "Duck.ai on tilapäisesti poissa käytöstä. Yritä myöhemmin uudelleen."
+
+# smartling.placeholder_format=C
+msgctxt "settings"
+msgid ""
+"Duck.ai lets you chat privately with popular AI models. Disabling it hides "
+"Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -7413,6 +7521,18 @@ msgid "Eritrea"
 msgstr "Eritrea"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Estimate the nutrition"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Estimate the nutritional information for this recipe."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Estonia"
 msgstr "Viro"
 
@@ -7469,11 +7589,59 @@ msgid "Expires in 1 day"
 msgstr "Voimassaoloaika päättyy 1 päivän kuluttua"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain the accepted answer in simple terms."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
 msgstr "Selitä minulle mustien aukkojen peruskäsitteet lukiotasoisesti."
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain the top answer"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this in simple, plain language."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this paper"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this repo"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this research paper in plain language."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this simply"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain what this repository does and how to use it."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label to show if song lyrics contain explicit content
@@ -7755,6 +7923,12 @@ msgstr ""
 "Suodattaa pois tekoälyn luomat kuvat kuvahaun tuloksista. %1$sLue Lisää%2$s"
 
 # smartling.placeholder_format=C
+msgctxt "settings"
+msgid ""
+"Filters out known AI spam sites from image search results. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the final score of a sporting event.
 msgid "Final"
 msgstr "Lopullinen"
@@ -7806,6 +7980,12 @@ msgstr "Etsi parempi sana"
 msgctxt "Subtitle for the Web Search tool entry in the Tools dropdown menu"
 msgid "Find current information"
 msgstr "Löydä ajankohtaiset tiedot"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Find me alternatives"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button that searches for results closer to the user's current location.
@@ -8288,6 +8468,12 @@ msgid "Generate More"
 msgstr "Luo enemmän"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Generate a shopping list"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
 msgid "Generate a short answer from the web"
 msgstr "Luo lyhyt vastaus verkkosisällöstä"
@@ -8579,6 +8765,12 @@ msgstr "Kokeile sitä"
 msgctxt "Onboarding welcome screen button text"
 msgid "Give it a Try"
 msgstr "Kokeile sitä"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Give me a quick background on this person."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9025,6 +9217,18 @@ msgstr "Auta levittämään DuckDuckGon ilosanomaa!"
 #. Link to a page with information about sharing DuckDuckGo with friends.
 msgid "Help Spread Privacy"
 msgstr "Levitä tietoa yksityisyydestä"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Help me prep for the interview"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Help me tailor my resume for this job."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title of a SERP popup that invites users to take a survey (desktop only)
@@ -9542,6 +9746,14 @@ msgstr "Hurrikaani"
 msgctxt "Onboarding terms screen button text"
 msgid "I Agree"
 msgstr "Hyväksyn"
+
+# smartling.placeholder_format=C
+#. Text for the button that takes the user to the external DuckDuckGo login subscription page.
+msgctxt ""
+"Text for the I already have a subscription button in the Duck.ai settings "
+"page"
+msgid "I Already Have a Subscription"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the button that takes the user to the login subscription page.
@@ -10118,6 +10330,12 @@ msgid "Install Mac Browser"
 msgstr "Asenna Mac-selain"
 
 # smartling.placeholder_format=C
+#. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
+msgctxt "settings"
+msgid "Install Now"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of a button to install the DuckDuckGo app
 msgctxt "Serp footer content"
 msgid "Install Our App"
@@ -10215,10 +10433,42 @@ msgid "Is deleted data really deleted?"
 msgstr "Onko poistettu data oikeasti poistettu?"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is it worth taking?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this place any good?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"Is this place any good? Summarize its reputation based on reviews and "
+"ratings."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "Is this video helpful?"
 msgstr "Onko tästä videosta apua?"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this worth watching?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Is this worth watching? Give me a spoiler-free take."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -10831,6 +11081,12 @@ msgid "Links:"
 msgstr "Linkit:"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "List the tools, materials, or prerequisites I need for this."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
 msgid "Listen"
 msgstr "Kuuntele"
@@ -11237,6 +11493,12 @@ msgstr "Hallitse tilaustasi"
 msgctxt "Exclusion message manage sites button"
 msgid "Manage blocked sites"
 msgstr "Hallinnoi estettyjä sivustoja."
+
+# smartling.placeholder_format=C
+#. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
+msgctxt "setting"
+msgid "Manage in Browser Settings"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to the site exclusion settings page
@@ -14068,6 +14330,12 @@ msgstr ""
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
+msgid "Please describe why the chat response is harmful or illegal. (optional)"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
+msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
 msgstr ""
 "Kuvaile, miksi keskusteluvastaus on laiton tai haitallinen. (Valinnainen)"
@@ -14093,6 +14361,14 @@ msgid ""
 msgstr ""
 "Huomaa: uuden keskustelun aloittaminen minkä tahansa mallin kanssa poistaa "
 "nykyisen chat-istuntosi."
+
+# smartling.placeholder_format=C
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
+msgctxt "Feedback prompt"
+msgid ""
+"Please paste your prompt and the problematic output (with any personal "
+"information removed) and describe why the content is harmful or illegal."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -14561,6 +14837,12 @@ msgid "Privacy"
 msgstr "Yksityisyys"
 
 # smartling.placeholder_format=C
+#. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
+msgctxt "Section heading on the Duck.ai settings page"
+msgid "Privacy & Terms"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Privacy Blog"
 msgstr "Yksityisyysblogi"
 
@@ -14629,6 +14911,12 @@ msgstr "Tietosuojakäytäntö ja käyttöehdot"
 msgctxt "Copy used to compose link in sentences"
 msgid "Privacy Policy and Terms of Service"
 msgstr "Tietosuojakäytäntö ja palveluehdot"
+
+# smartling.placeholder_format=C
+#. Text for a button that links to the terms of use and privacy policy page.
+msgctxt "Secondary button text in active privacy modal"
+msgid "Privacy Policy and Terms of Service"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title displayed on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
@@ -15133,6 +15421,30 @@ msgid "Recommend a book"
 msgstr "Suosittele kirjaa"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar books"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar books."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar movies or shows."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar titles"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
 msgid "Recording failed. Please try again."
 msgstr "Tallennus epäonnistui. Yritä uudelleen."
@@ -15536,6 +15848,15 @@ msgid "Republic of Moldova"
 msgstr "Moldova"
 
 # smartling.placeholder_format=C
+#. Note indicating that sharing the conversation is mandatory when reporting harmful or illegal content. Rendered alongside the standard share label (DUCKCHAT_RESPONSE_FEEDBACK_SHARE_PROMPT_RESPONSE_LABEL), not replacing it.
+msgctxt ""
+"Note shown under the share-content switch label on the Duck.ai response "
+"feedback form when the user has selected Harmful or Illegal as the feedback "
+"reason"
+msgid "Required for harmful or illegal reports"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
 msgctxt "Description for extended reasoning mode in Duck.ai"
 msgid "Researches before responding"
@@ -15772,6 +16093,12 @@ msgstr "Arvostelut"
 msgctxt "maps_places"
 msgid "Reviews"
 msgstr "Arvostelut"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Rewrite this recipe scaled for a different number of servings."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Romania"
@@ -17103,6 +17430,12 @@ msgid "Set Up Now"
 msgstr "Määritä nyt"
 
 # smartling.placeholder_format=C
+#. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
+msgctxt "Encrypted storage setup button shown in native browsers"
+msgid "Set Up Sync & Backup"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
 msgctxt "Title for the Sync & Backup intro screen"
 msgid "Set Up Sync & Backup"
@@ -17283,6 +17616,13 @@ msgstr "Jaa sivun URL"
 msgctxt "feedback form"
 msgid "Share positive feedback"
 msgstr "Anna positiivista palautetta"
+
+# smartling.placeholder_format=C
+#. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
+msgctxt ""
+"Label beside the share-content switch on the Duck.ai response feedback form"
+msgid "Share this conversation with DuckDuckGo"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -18538,6 +18878,24 @@ msgid "Suggest a title for a blog post"
 msgstr "Ehdota otsikkoa blogikirjoitukselle"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest related articles or topics worth exploring next."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Suggest related articles to explore"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest some alternatives to this product."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
 msgctxt "directions"
 msgid "Suggestions:"
@@ -18549,10 +18907,100 @@ msgid "Suggestions:"
 msgstr "Ehdotuksia:"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Sum up the reviews"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A short title for the a message asking the AI to summarize a text.
 msgctxt "Title for the summarize message"
 msgid "Summarize"
 msgstr "Tee yhteenveto"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize the Q&As"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the background and notable work of this person."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the key details of this event."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the questions and answers on this page."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize their background"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this book"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this book."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this discussion"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this discussion thread."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this page"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this page."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this video"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this video."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize what the reviews say."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -18881,6 +19329,12 @@ msgid "Syria"
 msgstr "Syyria"
 
 # smartling.placeholder_format=C
+#. Text for a button that enables the theme to follow the operating system's color scheme preference.
+msgctxt "System theme button for theme selector"
+msgid "System"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Abbreviation indicating this is the total score for a game
 msgctxt "Sports module"
 msgid "T"
@@ -18907,6 +19361,12 @@ msgstr "TV"
 msgctxt "language_name"
 msgid "Tahitian"
 msgstr "Tahiti"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Tailor my resume"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Taiwan"
@@ -18936,6 +19396,13 @@ msgstr "Pidä omat henkilötietosi hallinnassasi"
 msgctxt "homepage ATB modal"
 msgid "Take control of your personal data!"
 msgstr "Hallitse omia henkilötietojasi!"
+
+# smartling.placeholder_format=C
+#. Description for the Feedback section of the Duck.ai settings page, asking the user to take an anonymous survey to let us know how we can make Duck.ai better.
+msgctxt "Feedback section description on the Duck.ai settings page"
+msgid ""
+"Take this anonymous survey to let us know how we can make Duck.ai better."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -19245,6 +19712,12 @@ msgstr ""
 #. https://duck.co/media/files/theme.png
 msgid "Theme"
 msgstr "Teema"
+
+# smartling.placeholder_format=C
+#. Text for the theme selector label that allows users to switch between Light and dark theme.
+msgctxt "Label for the theme selector feature"
+msgid "Theme"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/LpFhb1e.png
@@ -20084,6 +20557,18 @@ msgstr ""
 "elokuvateatteriin?”"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Translate this page"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
+msgctxt "Page suggestion prompt"
+msgid "Translate this page into %s."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text for a region that will display translated text.
 msgctxt "translations_module"
 msgid "Translation"
@@ -20225,6 +20710,12 @@ msgstr "Yritä uudelleen"
 msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
 msgstr "Kokeile maksutta"
+
+# smartling.placeholder_format=C
+#. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
+msgctxt "settings"
+msgid "Try It Now"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -20462,6 +20953,22 @@ msgstr "Kokeile: %1$s"
 msgctxt "new user poll"
 msgid "Trying DuckDuckGo again"
 msgstr "Yritetään DuckDuckGoa uudelleen"
+
+# smartling.placeholder_format=C
+#. Message shown in a modal after supported third-party browser users disable AI features in Settings. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -21222,6 +21729,12 @@ msgid "Uruguay"
 msgstr "Uruguay"
 
 # smartling.placeholder_format=C
+#. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
+msgctxt "Navigation label on the Duck.ai settings page"
+msgid "Usage"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A feedback suggestion
 msgctxt "Feedback prompt"
 msgid "Usage limit"
@@ -21666,6 +22179,12 @@ msgid "Wales"
 msgstr "Wales"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Walk me through the steps"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for walking directions on a map.
 msgctxt "directions"
 msgid "Walking"
@@ -21782,6 +22301,17 @@ msgid "We can anonymize%s your location%s to show you more accurate results."
 msgstr ""
 "Voimme anonymisoida%1$s sijaintisi%2$s näyttääksemme sinulle tarkempia "
 "tuloksia."
+
+# smartling.placeholder_format=C
+#. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
+msgctxt ""
+"Inline warning shown below the share-content toggle when the user selects "
+"Harmful or Illegal but has not enabled sharing"
+msgid ""
+"We can only fix what we can see. To report a harmful or illegal response, "
+"please share this conversation with DuckDuckGo so we can investigate and "
+"address the issue."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -22335,6 +22865,103 @@ msgid ""
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the counterarguments?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the hours & location?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key contributions of this paper?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key contributions?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key details?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key points covered in this video?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key points?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key takeaways from this article?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key takeaways?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key things I will learn from this course?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main counterarguments or criticisms of this?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main questions this page answers?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the must-try dishes here?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"What are the opening hours, location, and contact details for this place?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the pros and cons of this product?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the pros and cons?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
 msgctxt "feedback form"
 msgid "What bothered you most?"
@@ -22435,6 +23062,12 @@ msgid "What does atria mean in the context of a medical article?"
 msgstr "Mitä \"eteinen\" tarkoittaa lääketieteellisen artikkelin yhteydessä?"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What does this answer?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
@@ -22445,6 +23078,12 @@ msgstr "Minkä ominaisuuden haluaisit meidän lisäävän? (valinnainen)"
 msgctxt "cloudsave"
 msgid "What information gets saved?"
 msgstr "Mitä tietoja talletetaan?"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What interview questions might come up for this role?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -22461,6 +23100,12 @@ msgstr ""
 msgctxt "Full sentence for looking up basic facts"
 msgid "What is the capital city of Albania?"
 msgstr "Mikä on Albanian pääkaupunki?"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What is the overall verdict and rating for this?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to a page with additional information.
@@ -22485,6 +23130,12 @@ msgid "What people say:"
 msgstr "Mitä ihmiset sanovat:"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What should I order?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
 msgctxt "feedback form"
 msgid "What stood out?"
@@ -22495,6 +23146,18 @@ msgstr "Mikä erottui edukseen?"
 msgctxt "feedback form"
 msgid "What was wrong with the response? (optional)"
 msgstr "Mikä vastauksessa oli vikana? (Valinnainen)"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I learn?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I need?"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -22512,6 +23175,12 @@ msgstr "Se, mitä katsot DuckDuckGossa, ei vaikuta suosituksiisi YouTubessa."
 msgctxt "SERP footer content"
 msgid "What's New"
 msgstr "Mitä uutta"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What's the verdict?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -22563,6 +23232,12 @@ msgid "Which features are missing? (Optional)"
 msgstr "Mitkä ominaisuudet puuttuvat? (Valinnainen)"
 
 # smartling.placeholder_format=C
+#. An invitation for users to leave feedback
+msgctxt "Feedback prompt"
+msgid "Which features are missing? (optional)"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
 msgid "White"
 msgstr "Valkoinen"
@@ -22577,6 +23252,18 @@ msgstr "Valkoinen"
 #. Link to an about us page.
 msgid "Who We Are"
 msgstr "Keitä olemme"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Who are the main cast and crew, and what else are they known for?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Who is this person?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Header above a collection of privacy-related links.

--- a/locales/fr_BE/LC_MESSAGES/duckduckgo.po
+++ b/locales/fr_BE/LC_MESSAGES/duckduckgo.po
@@ -1159,6 +1159,11 @@ msgctxt "feedback form"
 msgid "Address is incorrect"
 msgstr ""
 
+#. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Adjust the servings"
+msgstr ""
+
 #. as in multiple advertisements
 msgid "Ads"
 msgstr ""
@@ -1332,6 +1337,13 @@ msgstr ""
 #. Heading shown on the empty chat screen. The text between the two %s markers is displayed inside a clickable privacy button. First %s renders a shield icon, second %s is an invisible end marker. Keep the word 'private' between both %s markers.
 msgctxt "Empty state heading in Duck.ai chat mode"
 msgid "All chats are %sprivate%s"
+msgstr ""
+
+#. Paragraph in the Privacy & Terms section of the About & Legal page in Duck.ai settings, summarizing how chats are anonymized and are not stored or used to train chat models.
+msgctxt "Privacy & Terms section description on the Duck.ai settings page"
+msgid ""
+"All chats are anonymized by DuckDuckGo, and your conversations are not used "
+"to train chat models by DuckDuckGo or the model providers"
 msgstr ""
 
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1544,6 +1556,12 @@ msgstr ""
 #. Confirmation message after location service is enabled.
 msgctxt "precise_user_location"
 msgid "Anonymous location enabled"
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Anonymously generates answers for search queries based on web content. "
+"Choose how often you want it to appear, or disable it completely."
 msgstr ""
 
 #. Instant Answer tab name
@@ -1766,6 +1784,11 @@ msgstr ""
 
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse
 msgid "Ask a follow-up with Duck.ai"
+msgstr ""
+
+#. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
+msgctxt "Page suggestion chip label"
+msgid "Ask about this page"
 msgstr ""
 
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2090,6 +2113,11 @@ msgstr ""
 msgid "Barcode"
 msgstr "Code barre"
 
+#. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Based on this page, is this course worth taking?"
+msgstr ""
+
 msgctxt "settings"
 msgid "Basic"
 msgstr "Basique"
@@ -2121,6 +2149,13 @@ msgstr ""
 #. Placeholder text displayed while the assistant waits for the user to choose an action.
 msgctxt "Assistant response placeholder"
 msgid "Before continuing..."
+msgstr ""
+
+#. Explains that before storing the report, DuckDuckGo will anonymize the conversation by removing PII like names, email addresses, and identifying metadata.
+msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
+msgid ""
+"Before storing this report, DuckDuckGo will anonymize your conversation by "
+"removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
 #. Label that's displayed next to a past start date below a web search result.
@@ -2379,6 +2414,11 @@ msgstr "Brésil"
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Break Points Won"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Break this down into clear, numbered steps."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -2738,6 +2778,11 @@ msgstr "Carrières"
 #. Text of a button that performs a search for the cast of a particular movie or tv show
 msgctxt "Movie/TV Show Title instant answer"
 msgid "Cast"
+msgstr ""
+
+#. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Cast & Crew"
 msgstr ""
 
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -4103,6 +4148,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Create a shopping list with quantities from this recipe."
+msgstr ""
+
 #. Placeholder text displayed in the input field when starting a new image generation session.
 msgctxt "Placeholder text for the image generation input field"
 msgid "Create an image of a cute duck..."
@@ -4629,6 +4679,10 @@ msgstr ""
 msgid "Dictation limit reached"
 msgstr ""
 
+#. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
+msgid "Dictation temporarily unavailable"
+msgstr ""
+
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
@@ -4873,6 +4927,20 @@ msgctxt "precise_user_location"
 msgid "Done"
 msgstr ""
 
+#. Message shown in a modal after DuckDuckGo browser users disable AI features in Settings. The first two placeholders bold noai.duckduckgo.com. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
+"filtered out. %sLearn More%s"
+msgstr ""
+
+#. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
+"and AI images filtered out. %sLearn more%s"
+msgstr ""
+
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Double Faults"
@@ -4963,6 +5031,16 @@ msgctxt "Full sentence for writing an email"
 msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
+msgstr ""
+
+#. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Draft a cover letter"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Draft a cover letter for this job."
 msgstr ""
 
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -5102,6 +5180,14 @@ msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
 msgstr ""
 
+#. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
+msgctxt "About section description on the Duck.ai settings page"
+msgid ""
+"Duck.ai is created by DuckDuckGo. We're an independent online protection "
+"company for anyone who wants to take back control of their personal "
+"information."
+msgstr ""
+
 #. Title shown when an update is required before proceeding.
 msgctxt "duckai_migration"
 msgid "Duck.ai is moving domains"
@@ -5135,6 +5221,12 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Duck.ai lets you chat privately with popular AI models. Disabling it hides "
+"Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
 
 msgctxt "settings"
@@ -5904,6 +5996,16 @@ msgstr ""
 msgid "Eritrea"
 msgstr ""
 
+#. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Estimate the nutrition"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Estimate the nutritional information for this recipe."
+msgstr ""
+
 msgid "Estonia"
 msgstr "Estonie"
 
@@ -5948,10 +6050,50 @@ msgctxt "merchant promotion product ad extension"
 msgid "Expires in 1 day"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain the accepted answer in simple terms."
+msgstr ""
+
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
+msgstr ""
+
+#. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain the top answer"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this in simple, plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this paper"
+msgstr ""
+
+#. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this repo"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this research paper in plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this simply"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain what this repository does and how to use it."
 msgstr ""
 
 #. Label to show if song lyrics contain explicit content
@@ -6182,6 +6324,11 @@ msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
 msgstr ""
 
+msgctxt "settings"
+msgid ""
+"Filters out known AI spam sites from image search results. %sLearn More%s"
+msgstr ""
+
 #. Label for the final score of a sporting event.
 msgid "Final"
 msgstr ""
@@ -6221,6 +6368,11 @@ msgstr ""
 #. Short description shown below the 'Web Search' label in the Tools dropdown.
 msgctxt "Subtitle for the Web Search tool entry in the Tools dropdown menu"
 msgid "Find current information"
+msgstr ""
+
+#. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Find me alternatives"
 msgstr ""
 
 #. Button that searches for results closer to the user's current location.
@@ -6611,6 +6763,11 @@ msgstr ""
 msgid "Generate More"
 msgstr ""
 
+#. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Generate a shopping list"
+msgstr ""
+
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
 msgid "Generate a short answer from the web"
 msgstr ""
@@ -6845,6 +7002,11 @@ msgstr ""
 #. Text for a button inviting users to give it a try for the Duck.ai product. On click, they're taken to the Duck.ai page.
 msgctxt "Onboarding welcome screen button text"
 msgid "Give it a Try"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Give me a quick background on this person."
 msgstr ""
 
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -7207,6 +7369,16 @@ msgstr ""
 
 #. Link to a page with information about sharing DuckDuckGo with friends.
 msgid "Help Spread Privacy"
+msgstr ""
+
+#. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Help me prep for the interview"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Help me tailor my resume for this job."
 msgstr ""
 
 #. Title of a SERP popup that invites users to take a survey (desktop only)
@@ -7628,6 +7800,13 @@ msgstr ""
 #. Text displayed on the button on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
 msgctxt "Onboarding terms screen button text"
 msgid "I Agree"
+msgstr ""
+
+#. Text for the button that takes the user to the external DuckDuckGo login subscription page.
+msgctxt ""
+"Text for the I already have a subscription button in the Duck.ai settings "
+"page"
+msgid "I Already Have a Subscription"
 msgstr ""
 
 #. Text for the button that takes the user to the login subscription page.
@@ -8086,6 +8265,11 @@ msgctxt "Sidemenu browser promo"
 msgid "Install Mac Browser"
 msgstr ""
 
+#. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
+msgctxt "settings"
+msgid "Install Now"
+msgstr ""
+
 #. Text of a button to install the DuckDuckGo app
 msgctxt "Serp footer content"
 msgid "Install Our App"
@@ -8165,9 +8349,36 @@ msgctxt "cloudsave"
 msgid "Is deleted data really deleted?"
 msgstr "Les données supprimées sont-elles vraiment supprimée ? "
 
+#. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is it worth taking?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this place any good?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"Is this place any good? Summarize its reputation based on reviews and "
+"ratings."
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "Is this video helpful?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this worth watching?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Is this worth watching? Give me a spoiler-free take."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -8664,6 +8875,11 @@ msgstr "Police des liens :"
 msgid "Links:"
 msgstr "Liens :"
 
+#. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "List the tools, materials, or prerequisites I need for this."
+msgstr ""
+
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
 msgid "Listen"
 msgstr "Ecouter"
@@ -8998,6 +9214,11 @@ msgstr ""
 #. Label for linke navigating to site exclusion feature on Settings page
 msgctxt "Exclusion message manage sites button"
 msgid "Manage blocked sites"
+msgstr ""
+
+#. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
+msgctxt "setting"
+msgid "Manage in Browser Settings"
 msgstr ""
 
 #. Link to the site exclusion settings page
@@ -11305,6 +11526,11 @@ msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
+msgid "Please describe why the chat response is harmful or illegal. (optional)"
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
+msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
 msgstr ""
 
@@ -11323,6 +11549,13 @@ msgctxt "Modal disclaimer text"
 msgid ""
 "Please note: starting a new chat with any model will delete your current "
 "chat session."
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
+msgctxt "Feedback prompt"
+msgid ""
+"Please paste your prompt and the problematic output (with any personal "
+"information removed) and describe why the content is harmful or illegal."
 msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -11707,6 +11940,11 @@ msgctxt "settings"
 msgid "Privacy"
 msgstr "Confidentialité"
 
+#. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
+msgctxt "Section heading on the Duck.ai settings page"
+msgid "Privacy & Terms"
+msgstr ""
+
 msgid "Privacy Blog"
 msgstr ""
 
@@ -11760,6 +11998,11 @@ msgstr ""
 
 #. Text used in other strings to link to the Privacy Policy and Terms of Service content.
 msgctxt "Copy used to compose link in sentences"
+msgid "Privacy Policy and Terms of Service"
+msgstr ""
+
+#. Text for a button that links to the terms of use and privacy policy page.
+msgctxt "Secondary button text in active privacy modal"
 msgid "Privacy Policy and Terms of Service"
 msgstr ""
 
@@ -12168,6 +12411,26 @@ msgctxt "Brief for recommending a book"
 msgid "Recommend a book"
 msgstr ""
 
+#. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar books"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar books."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar movies or shows."
+msgstr ""
+
+#. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar titles"
+msgstr ""
+
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
 msgid "Recording failed. Please try again."
 msgstr ""
@@ -12488,6 +12751,14 @@ msgstr ""
 msgid "Republic of Moldova"
 msgstr ""
 
+#. Note indicating that sharing the conversation is mandatory when reporting harmful or illegal content. Rendered alongside the standard share label (DUCKCHAT_RESPONSE_FEEDBACK_SHARE_PROMPT_RESPONSE_LABEL), not replacing it.
+msgctxt ""
+"Note shown under the share-content switch label on the Duck.ai response "
+"feedback form when the user has selected Harmful or Illegal as the feedback "
+"reason"
+msgid "Required for harmful or illegal reports"
+msgstr ""
+
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
 msgctxt "Description for extended reasoning mode in Duck.ai"
 msgid "Researches before responding"
@@ -12673,6 +12944,11 @@ msgstr "Evaluations"
 #. Label above a list of customer reviews of a business.
 msgctxt "maps_places"
 msgid "Reviews"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Rewrite this recipe scaled for a different number of servings."
 msgstr ""
 
 msgid "Romania"
@@ -13728,6 +14004,11 @@ msgctxt "Setup button for native sync flow"
 msgid "Set Up Now"
 msgstr ""
 
+#. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
+msgctxt "Encrypted storage setup button shown in native browsers"
+msgid "Set Up Sync & Backup"
+msgstr ""
+
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
 msgctxt "Title for the Sync & Backup intro screen"
 msgid "Set Up Sync & Backup"
@@ -13872,6 +14153,12 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
+msgctxt ""
+"Label beside the share-content switch on the Duck.ai response feedback form"
+msgid "Share this conversation with DuckDuckGo"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -14888,6 +15175,21 @@ msgctxt "Brief for suggesting a blog post title"
 msgid "Suggest a title for a blog post"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest related articles or topics worth exploring next."
+msgstr ""
+
+#. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Suggest related articles to explore"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest some alternatives to this product."
+msgstr ""
+
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
 msgctxt "directions"
 msgid "Suggestions:"
@@ -14897,9 +15199,84 @@ msgctxt "noresults"
 msgid "Suggestions:"
 msgstr ""
 
+#. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Sum up the reviews"
+msgstr ""
+
 #. A short title for the a message asking the AI to summarize a text.
 msgctxt "Title for the summarize message"
 msgid "Summarize"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize the Q&As"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the background and notable work of this person."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the key details of this event."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the questions and answers on this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize their background"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this book"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this book."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this discussion"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this discussion thread."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this video"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this video."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize what the reviews say."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -15154,6 +15531,11 @@ msgstr ""
 msgid "Syria"
 msgstr ""
 
+#. Text for a button that enables the theme to follow the operating system's color scheme preference.
+msgctxt "System theme button for theme selector"
+msgid "System"
+msgstr ""
+
 #. Abbreviation indicating this is the total score for a game
 msgctxt "Sports module"
 msgid "T"
@@ -15177,6 +15559,11 @@ msgctxt "language_name"
 msgid "Tahitian"
 msgstr ""
 
+#. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Tailor my resume"
+msgstr ""
+
 msgid "Taiwan"
 msgstr ""
 
@@ -15198,6 +15585,12 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "Take control of your personal data!"
+msgstr ""
+
+#. Description for the Feedback section of the Duck.ai settings page, asking the user to take an anonymous survey to let us know how we can make Duck.ai better.
+msgctxt "Feedback section description on the Duck.ai settings page"
+msgid ""
+"Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
 
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -15442,6 +15835,11 @@ msgstr ""
 #. https://duck.co/media/files/theme.png
 msgid "Theme"
 msgstr "Thème"
+
+#. Text for the theme selector label that allows users to switch between Light and dark theme.
+msgctxt "Label for the theme selector feature"
+msgid "Theme"
+msgstr ""
 
 #. http://i.imgur.com/LpFhb1e.png
 msgctxt "settings"
@@ -16094,6 +16492,16 @@ msgid ""
 "movie theatre?”"
 msgstr ""
 
+#. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Translate this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
+msgctxt "Page suggestion prompt"
+msgid "Translate this page into %s."
+msgstr ""
+
 #. Placeholder text for a region that will display translated text.
 msgctxt "translations_module"
 msgid "Translation"
@@ -16208,6 +16616,11 @@ msgstr ""
 #. Call-to-action button for the subscription promo in the SERP sidemenu.
 msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
+msgstr ""
+
+#. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
+msgctxt "settings"
+msgid "Try It Now"
 msgstr ""
 
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -16402,6 +16815,20 @@ msgstr "Essayez: %s"
 msgctxt "new user poll"
 msgid "Trying DuckDuckGo again"
 msgstr "Essayez de nouveau DuckDuckGo"
+
+#. Message shown in a modal after supported third-party browser users disable AI features in Settings. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+#. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
 
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
 msgctxt "Assistant response placeholder"
@@ -17010,6 +17437,11 @@ msgstr ""
 msgid "Uruguay"
 msgstr ""
 
+#. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
+msgctxt "Navigation label on the Duck.ai settings page"
+msgid "Usage"
+msgstr ""
+
 #. A feedback suggestion
 msgctxt "Feedback prompt"
 msgid "Usage limit"
@@ -17362,6 +17794,11 @@ msgstr ""
 msgid "Wales"
 msgstr ""
 
+#. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Walk me through the steps"
+msgstr ""
+
 #. Label for walking directions on a map.
 msgctxt "directions"
 msgid "Walking"
@@ -17452,6 +17889,16 @@ msgstr ""
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
+msgstr ""
+
+#. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
+msgctxt ""
+"Inline warning shown below the share-content toggle when the user selects "
+"Harmful or Illegal but has not enabled sharing"
+msgid ""
+"We can only fix what we can see. To report a harmful or illegal response, "
+"please share this conversation with DuckDuckGo so we can investigate and "
+"address the issue."
 msgstr ""
 
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -17878,6 +18325,87 @@ msgid ""
 "experience."
 msgstr ""
 
+#. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the counterarguments?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the hours & location?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key contributions of this paper?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key contributions?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key details?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key points covered in this video?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key points?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key takeaways from this article?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key takeaways?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key things I will learn from this course?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main counterarguments or criticisms of this?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main questions this page answers?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the must-try dishes here?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"What are the opening hours, location, and contact details for this place?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the pros and cons of this product?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the pros and cons?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
 msgctxt "feedback form"
 msgid "What bothered you most?"
@@ -17961,6 +18489,11 @@ msgctxt "Full sentence for defining a term"
 msgid "What does atria mean in the context of a medical article?"
 msgstr ""
 
+#. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What does this answer?"
+msgstr ""
+
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
@@ -17970,6 +18503,11 @@ msgstr ""
 msgctxt "cloudsave"
 msgid "What information gets saved?"
 msgstr "Quelles informations sont sauvegardées ?"
+
+#. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What interview questions might come up for this role?"
+msgstr ""
 
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
@@ -17981,6 +18519,11 @@ msgstr ""
 #. Text for a prompt suggestion for looking up the capital city of Albania.
 msgctxt "Full sentence for looking up basic facts"
 msgid "What is the capital city of Albania?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What is the overall verdict and rating for this?"
 msgstr ""
 
 #. Link to a page with additional information.
@@ -18001,6 +18544,11 @@ msgctxt "maps_places"
 msgid "What people say:"
 msgstr ""
 
+#. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What should I order?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
 msgctxt "feedback form"
 msgid "What stood out?"
@@ -18009,6 +18557,16 @@ msgstr ""
 #. Question on a feedback form for a negative feedback response.
 msgctxt "feedback form"
 msgid "What was wrong with the response? (optional)"
+msgstr ""
+
+#. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I learn?"
+msgstr ""
+
+#. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I need?"
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -18023,6 +18581,11 @@ msgstr ""
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
 msgctxt "SERP footer content"
 msgid "What's New"
+msgstr ""
+
+#. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What's the verdict?"
 msgstr ""
 
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -18064,6 +18627,11 @@ msgctxt "Feedback prompt"
 msgid "Which features are missing? (Optional)"
 msgstr ""
 
+#. An invitation for users to leave feedback
+msgctxt "Feedback prompt"
+msgid "Which features are missing? (optional)"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
 msgid "White"
 msgstr "Blanc"
@@ -18075,6 +18643,16 @@ msgstr "Blanc"
 
 #. Link to an about us page.
 msgid "Who We Are"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Who are the main cast and crew, and what else are they known for?"
+msgstr ""
+
+#. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Who is this person?"
 msgstr ""
 
 #. Header above a collection of privacy-related links.

--- a/locales/fr_CA/LC_MESSAGES/duckduckgo.po
+++ b/locales/fr_CA/LC_MESSAGES/duckduckgo.po
@@ -1160,6 +1160,11 @@ msgctxt "feedback form"
 msgid "Address is incorrect"
 msgstr ""
 
+#. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Adjust the servings"
+msgstr ""
+
 #. as in multiple advertisements
 msgid "Ads"
 msgstr ""
@@ -1333,6 +1338,13 @@ msgstr ""
 #. Heading shown on the empty chat screen. The text between the two %s markers is displayed inside a clickable privacy button. First %s renders a shield icon, second %s is an invisible end marker. Keep the word 'private' between both %s markers.
 msgctxt "Empty state heading in Duck.ai chat mode"
 msgid "All chats are %sprivate%s"
+msgstr ""
+
+#. Paragraph in the Privacy & Terms section of the About & Legal page in Duck.ai settings, summarizing how chats are anonymized and are not stored or used to train chat models.
+msgctxt "Privacy & Terms section description on the Duck.ai settings page"
+msgid ""
+"All chats are anonymized by DuckDuckGo, and your conversations are not used "
+"to train chat models by DuckDuckGo or the model providers"
 msgstr ""
 
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1547,6 +1559,12 @@ msgstr ""
 #. Confirmation message after location service is enabled.
 msgctxt "precise_user_location"
 msgid "Anonymous location enabled"
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Anonymously generates answers for search queries based on web content. "
+"Choose how often you want it to appear, or disable it completely."
 msgstr ""
 
 #. Instant Answer tab name
@@ -1769,6 +1787,11 @@ msgstr ""
 
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse
 msgid "Ask a follow-up with Duck.ai"
+msgstr ""
+
+#. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
+msgctxt "Page suggestion chip label"
+msgid "Ask about this page"
 msgstr ""
 
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2093,6 +2116,11 @@ msgstr ""
 msgid "Barcode"
 msgstr "Code à barres"
 
+#. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Based on this page, is this course worth taking?"
+msgstr ""
+
 msgctxt "settings"
 msgid "Basic"
 msgstr "De base"
@@ -2124,6 +2152,13 @@ msgstr ""
 #. Placeholder text displayed while the assistant waits for the user to choose an action.
 msgctxt "Assistant response placeholder"
 msgid "Before continuing..."
+msgstr ""
+
+#. Explains that before storing the report, DuckDuckGo will anonymize the conversation by removing PII like names, email addresses, and identifying metadata.
+msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
+msgid ""
+"Before storing this report, DuckDuckGo will anonymize your conversation by "
+"removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
 #. Label that's displayed next to a past start date below a web search result.
@@ -2382,6 +2417,11 @@ msgstr "Brésil"
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Break Points Won"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Break this down into clear, numbered steps."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -2741,6 +2781,11 @@ msgstr "Carrières"
 #. Text of a button that performs a search for the cast of a particular movie or tv show
 msgctxt "Movie/TV Show Title instant answer"
 msgid "Cast"
+msgstr ""
+
+#. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Cast & Crew"
 msgstr ""
 
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -4107,6 +4152,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Create a shopping list with quantities from this recipe."
+msgstr ""
+
 #. Placeholder text displayed in the input field when starting a new image generation session.
 msgctxt "Placeholder text for the image generation input field"
 msgid "Create an image of a cute duck..."
@@ -4633,6 +4683,10 @@ msgstr ""
 msgid "Dictation limit reached"
 msgstr ""
 
+#. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
+msgid "Dictation temporarily unavailable"
+msgstr ""
+
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
@@ -4877,6 +4931,20 @@ msgctxt "precise_user_location"
 msgid "Done"
 msgstr "Terminé"
 
+#. Message shown in a modal after DuckDuckGo browser users disable AI features in Settings. The first two placeholders bold noai.duckduckgo.com. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
+"filtered out. %sLearn More%s"
+msgstr ""
+
+#. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
+"and AI images filtered out. %sLearn more%s"
+msgstr ""
+
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Double Faults"
@@ -4967,6 +5035,16 @@ msgctxt "Full sentence for writing an email"
 msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
+msgstr ""
+
+#. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Draft a cover letter"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Draft a cover letter for this job."
 msgstr ""
 
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -5106,6 +5184,14 @@ msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
 msgstr ""
 
+#. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
+msgctxt "About section description on the Duck.ai settings page"
+msgid ""
+"Duck.ai is created by DuckDuckGo. We're an independent online protection "
+"company for anyone who wants to take back control of their personal "
+"information."
+msgstr ""
+
 #. Title shown when an update is required before proceeding.
 msgctxt "duckai_migration"
 msgid "Duck.ai is moving domains"
@@ -5139,6 +5225,12 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Duck.ai lets you chat privately with popular AI models. Disabling it hides "
+"Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
 
 msgctxt "settings"
@@ -5905,6 +5997,16 @@ msgstr ""
 msgid "Eritrea"
 msgstr ""
 
+#. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Estimate the nutrition"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Estimate the nutritional information for this recipe."
+msgstr ""
+
 msgid "Estonia"
 msgstr "Estonie"
 
@@ -5949,10 +6051,50 @@ msgctxt "merchant promotion product ad extension"
 msgid "Expires in 1 day"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain the accepted answer in simple terms."
+msgstr ""
+
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
+msgstr ""
+
+#. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain the top answer"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this in simple, plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this paper"
+msgstr ""
+
+#. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this repo"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this research paper in plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this simply"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain what this repository does and how to use it."
 msgstr ""
 
 #. Label to show if song lyrics contain explicit content
@@ -6183,6 +6325,11 @@ msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
 msgstr ""
 
+msgctxt "settings"
+msgid ""
+"Filters out known AI spam sites from image search results. %sLearn More%s"
+msgstr ""
+
 #. Label for the final score of a sporting event.
 msgid "Final"
 msgstr ""
@@ -6222,6 +6369,11 @@ msgstr ""
 #. Short description shown below the 'Web Search' label in the Tools dropdown.
 msgctxt "Subtitle for the Web Search tool entry in the Tools dropdown menu"
 msgid "Find current information"
+msgstr ""
+
+#. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Find me alternatives"
 msgstr ""
 
 #. Button that searches for results closer to the user's current location.
@@ -6612,6 +6764,11 @@ msgstr ""
 msgid "Generate More"
 msgstr ""
 
+#. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Generate a shopping list"
+msgstr ""
+
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
 msgid "Generate a short answer from the web"
 msgstr ""
@@ -6846,6 +7003,11 @@ msgstr ""
 #. Text for a button inviting users to give it a try for the Duck.ai product. On click, they're taken to the Duck.ai page.
 msgctxt "Onboarding welcome screen button text"
 msgid "Give it a Try"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Give me a quick background on this person."
 msgstr ""
 
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -7208,6 +7370,16 @@ msgstr ""
 
 #. Link to a page with information about sharing DuckDuckGo with friends.
 msgid "Help Spread Privacy"
+msgstr ""
+
+#. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Help me prep for the interview"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Help me tailor my resume for this job."
 msgstr ""
 
 #. Title of a SERP popup that invites users to take a survey (desktop only)
@@ -7629,6 +7801,13 @@ msgstr ""
 #. Text displayed on the button on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
 msgctxt "Onboarding terms screen button text"
 msgid "I Agree"
+msgstr ""
+
+#. Text for the button that takes the user to the external DuckDuckGo login subscription page.
+msgctxt ""
+"Text for the I already have a subscription button in the Duck.ai settings "
+"page"
+msgid "I Already Have a Subscription"
 msgstr ""
 
 #. Text for the button that takes the user to the login subscription page.
@@ -8088,6 +8267,11 @@ msgctxt "Sidemenu browser promo"
 msgid "Install Mac Browser"
 msgstr ""
 
+#. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
+msgctxt "settings"
+msgid "Install Now"
+msgstr ""
+
 #. Text of a button to install the DuckDuckGo app
 msgctxt "Serp footer content"
 msgid "Install Our App"
@@ -8167,9 +8351,36 @@ msgctxt "cloudsave"
 msgid "Is deleted data really deleted?"
 msgstr "Est-ce que les données supprimées sont vraiment supprimées?"
 
+#. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is it worth taking?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this place any good?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"Is this place any good? Summarize its reputation based on reviews and "
+"ratings."
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "Is this video helpful?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this worth watching?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Is this worth watching? Give me a spoiler-free take."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -8667,6 +8878,11 @@ msgstr "Police des liens:"
 msgid "Links:"
 msgstr "Liens"
 
+#. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "List the tools, materials, or prerequisites I need for this."
+msgstr ""
+
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
 msgid "Listen"
 msgstr "Écouter"
@@ -9003,6 +9219,11 @@ msgstr ""
 #. Label for linke navigating to site exclusion feature on Settings page
 msgctxt "Exclusion message manage sites button"
 msgid "Manage blocked sites"
+msgstr ""
+
+#. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
+msgctxt "setting"
+msgid "Manage in Browser Settings"
 msgstr ""
 
 #. Link to the site exclusion settings page
@@ -11308,6 +11529,11 @@ msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
+msgid "Please describe why the chat response is harmful or illegal. (optional)"
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
+msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
 msgstr ""
 
@@ -11326,6 +11552,13 @@ msgctxt "Modal disclaimer text"
 msgid ""
 "Please note: starting a new chat with any model will delete your current "
 "chat session."
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
+msgctxt "Feedback prompt"
+msgid ""
+"Please paste your prompt and the problematic output (with any personal "
+"information removed) and describe why the content is harmful or illegal."
 msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -11710,6 +11943,11 @@ msgctxt "settings"
 msgid "Privacy"
 msgstr "confidentialité"
 
+#. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
+msgctxt "Section heading on the Duck.ai settings page"
+msgid "Privacy & Terms"
+msgstr ""
+
 msgid "Privacy Blog"
 msgstr ""
 
@@ -11763,6 +12001,11 @@ msgstr ""
 
 #. Text used in other strings to link to the Privacy Policy and Terms of Service content.
 msgctxt "Copy used to compose link in sentences"
+msgid "Privacy Policy and Terms of Service"
+msgstr ""
+
+#. Text for a button that links to the terms of use and privacy policy page.
+msgctxt "Secondary button text in active privacy modal"
 msgid "Privacy Policy and Terms of Service"
 msgstr ""
 
@@ -12171,6 +12414,26 @@ msgctxt "Brief for recommending a book"
 msgid "Recommend a book"
 msgstr ""
 
+#. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar books"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar books."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar movies or shows."
+msgstr ""
+
+#. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar titles"
+msgstr ""
+
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
 msgid "Recording failed. Please try again."
 msgstr ""
@@ -12491,6 +12754,14 @@ msgstr ""
 msgid "Republic of Moldova"
 msgstr ""
 
+#. Note indicating that sharing the conversation is mandatory when reporting harmful or illegal content. Rendered alongside the standard share label (DUCKCHAT_RESPONSE_FEEDBACK_SHARE_PROMPT_RESPONSE_LABEL), not replacing it.
+msgctxt ""
+"Note shown under the share-content switch label on the Duck.ai response "
+"feedback form when the user has selected Harmful or Illegal as the feedback "
+"reason"
+msgid "Required for harmful or illegal reports"
+msgstr ""
+
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
 msgctxt "Description for extended reasoning mode in Duck.ai"
 msgid "Researches before responding"
@@ -12676,6 +12947,11 @@ msgstr "Critiques"
 #. Label above a list of customer reviews of a business.
 msgctxt "maps_places"
 msgid "Reviews"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Rewrite this recipe scaled for a different number of servings."
 msgstr ""
 
 msgid "Romania"
@@ -13727,6 +14003,11 @@ msgctxt "Setup button for native sync flow"
 msgid "Set Up Now"
 msgstr ""
 
+#. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
+msgctxt "Encrypted storage setup button shown in native browsers"
+msgid "Set Up Sync & Backup"
+msgstr ""
+
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
 msgctxt "Title for the Sync & Backup intro screen"
 msgid "Set Up Sync & Backup"
@@ -13873,6 +14154,12 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
+msgctxt ""
+"Label beside the share-content switch on the Duck.ai response feedback form"
+msgid "Share this conversation with DuckDuckGo"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -14887,6 +15174,21 @@ msgctxt "Brief for suggesting a blog post title"
 msgid "Suggest a title for a blog post"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest related articles or topics worth exploring next."
+msgstr ""
+
+#. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Suggest related articles to explore"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest some alternatives to this product."
+msgstr ""
+
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
 msgctxt "directions"
 msgid "Suggestions:"
@@ -14896,9 +15198,84 @@ msgctxt "noresults"
 msgid "Suggestions:"
 msgstr ""
 
+#. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Sum up the reviews"
+msgstr ""
+
 #. A short title for the a message asking the AI to summarize a text.
 msgctxt "Title for the summarize message"
 msgid "Summarize"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize the Q&As"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the background and notable work of this person."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the key details of this event."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the questions and answers on this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize their background"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this book"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this book."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this discussion"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this discussion thread."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this video"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this video."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize what the reviews say."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -15153,6 +15530,11 @@ msgstr ""
 msgid "Syria"
 msgstr ""
 
+#. Text for a button that enables the theme to follow the operating system's color scheme preference.
+msgctxt "System theme button for theme selector"
+msgid "System"
+msgstr ""
+
 #. Abbreviation indicating this is the total score for a game
 msgctxt "Sports module"
 msgid "T"
@@ -15176,6 +15558,11 @@ msgctxt "language_name"
 msgid "Tahitian"
 msgstr ""
 
+#. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Tailor my resume"
+msgstr ""
+
 msgid "Taiwan"
 msgstr ""
 
@@ -15197,6 +15584,12 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "Take control of your personal data!"
+msgstr ""
+
+#. Description for the Feedback section of the Duck.ai settings page, asking the user to take an anonymous survey to let us know how we can make Duck.ai better.
+msgctxt "Feedback section description on the Duck.ai settings page"
+msgid ""
+"Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
 
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -15441,6 +15834,11 @@ msgstr ""
 #. https://duck.co/media/files/theme.png
 msgid "Theme"
 msgstr "Thème"
+
+#. Text for the theme selector label that allows users to switch between Light and dark theme.
+msgctxt "Label for the theme selector feature"
+msgid "Theme"
+msgstr ""
 
 #. http://i.imgur.com/LpFhb1e.png
 msgctxt "settings"
@@ -16094,6 +16492,16 @@ msgid ""
 "movie theatre?”"
 msgstr ""
 
+#. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Translate this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
+msgctxt "Page suggestion prompt"
+msgid "Translate this page into %s."
+msgstr ""
+
 #. Placeholder text for a region that will display translated text.
 msgctxt "translations_module"
 msgid "Translation"
@@ -16208,6 +16616,11 @@ msgstr ""
 #. Call-to-action button for the subscription promo in the SERP sidemenu.
 msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
+msgstr ""
+
+#. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
+msgctxt "settings"
+msgid "Try It Now"
 msgstr ""
 
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -16403,6 +16816,20 @@ msgstr "Essayez: %s"
 msgctxt "new user poll"
 msgid "Trying DuckDuckGo again"
 msgstr "Essayez DuckDuckGo à nouveau"
+
+#. Message shown in a modal after supported third-party browser users disable AI features in Settings. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+#. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
 
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
 msgctxt "Assistant response placeholder"
@@ -17012,6 +17439,11 @@ msgstr ""
 msgid "Uruguay"
 msgstr ""
 
+#. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
+msgctxt "Navigation label on the Duck.ai settings page"
+msgid "Usage"
+msgstr ""
+
 #. A feedback suggestion
 msgctxt "Feedback prompt"
 msgid "Usage limit"
@@ -17364,6 +17796,11 @@ msgstr ""
 msgid "Wales"
 msgstr ""
 
+#. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Walk me through the steps"
+msgstr ""
+
 #. Label for walking directions on a map.
 msgctxt "directions"
 msgid "Walking"
@@ -17454,6 +17891,16 @@ msgstr ""
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
+msgstr ""
+
+#. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
+msgctxt ""
+"Inline warning shown below the share-content toggle when the user selects "
+"Harmful or Illegal but has not enabled sharing"
+msgid ""
+"We can only fix what we can see. To report a harmful or illegal response, "
+"please share this conversation with DuckDuckGo so we can investigate and "
+"address the issue."
 msgstr ""
 
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -17883,6 +18330,87 @@ msgid ""
 "experience."
 msgstr ""
 
+#. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the counterarguments?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the hours & location?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key contributions of this paper?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key contributions?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key details?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key points covered in this video?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key points?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key takeaways from this article?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key takeaways?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key things I will learn from this course?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main counterarguments or criticisms of this?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main questions this page answers?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the must-try dishes here?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"What are the opening hours, location, and contact details for this place?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the pros and cons of this product?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the pros and cons?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
 msgctxt "feedback form"
 msgid "What bothered you most?"
@@ -17966,6 +18494,11 @@ msgctxt "Full sentence for defining a term"
 msgid "What does atria mean in the context of a medical article?"
 msgstr ""
 
+#. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What does this answer?"
+msgstr ""
+
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
@@ -17975,6 +18508,11 @@ msgstr ""
 msgctxt "cloudsave"
 msgid "What information gets saved?"
 msgstr "Quels informations sont enregistrées ?"
+
+#. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What interview questions might come up for this role?"
+msgstr ""
 
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
@@ -17986,6 +18524,11 @@ msgstr ""
 #. Text for a prompt suggestion for looking up the capital city of Albania.
 msgctxt "Full sentence for looking up basic facts"
 msgid "What is the capital city of Albania?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What is the overall verdict and rating for this?"
 msgstr ""
 
 #. Link to a page with additional information.
@@ -18006,6 +18549,11 @@ msgctxt "maps_places"
 msgid "What people say:"
 msgstr ""
 
+#. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What should I order?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
 msgctxt "feedback form"
 msgid "What stood out?"
@@ -18014,6 +18562,16 @@ msgstr ""
 #. Question on a feedback form for a negative feedback response.
 msgctxt "feedback form"
 msgid "What was wrong with the response? (optional)"
+msgstr ""
+
+#. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I learn?"
+msgstr ""
+
+#. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I need?"
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -18028,6 +18586,11 @@ msgstr ""
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
 msgctxt "SERP footer content"
 msgid "What's New"
+msgstr ""
+
+#. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What's the verdict?"
 msgstr ""
 
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -18070,6 +18633,11 @@ msgctxt "Feedback prompt"
 msgid "Which features are missing? (Optional)"
 msgstr ""
 
+#. An invitation for users to leave feedback
+msgctxt "Feedback prompt"
+msgid "Which features are missing? (optional)"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
 msgid "White"
 msgstr "Blanc"
@@ -18082,6 +18650,16 @@ msgstr "Blanc"
 #. Link to an about us page.
 msgid "Who We Are"
 msgstr "Qui nous sommes"
+
+#. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Who are the main cast and crew, and what else are they known for?"
+msgstr ""
+
+#. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Who is this person?"
+msgstr ""
 
 #. Header above a collection of privacy-related links.
 msgid "Why Privacy"

--- a/locales/fr_CH/LC_MESSAGES/duckduckgo.po
+++ b/locales/fr_CH/LC_MESSAGES/duckduckgo.po
@@ -1159,6 +1159,11 @@ msgctxt "feedback form"
 msgid "Address is incorrect"
 msgstr ""
 
+#. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Adjust the servings"
+msgstr ""
+
 #. as in multiple advertisements
 msgid "Ads"
 msgstr ""
@@ -1332,6 +1337,13 @@ msgstr ""
 #. Heading shown on the empty chat screen. The text between the two %s markers is displayed inside a clickable privacy button. First %s renders a shield icon, second %s is an invisible end marker. Keep the word 'private' between both %s markers.
 msgctxt "Empty state heading in Duck.ai chat mode"
 msgid "All chats are %sprivate%s"
+msgstr ""
+
+#. Paragraph in the Privacy & Terms section of the About & Legal page in Duck.ai settings, summarizing how chats are anonymized and are not stored or used to train chat models.
+msgctxt "Privacy & Terms section description on the Duck.ai settings page"
+msgid ""
+"All chats are anonymized by DuckDuckGo, and your conversations are not used "
+"to train chat models by DuckDuckGo or the model providers"
 msgstr ""
 
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1544,6 +1556,12 @@ msgstr ""
 #. Confirmation message after location service is enabled.
 msgctxt "precise_user_location"
 msgid "Anonymous location enabled"
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Anonymously generates answers for search queries based on web content. "
+"Choose how often you want it to appear, or disable it completely."
 msgstr ""
 
 #. Instant Answer tab name
@@ -1766,6 +1784,11 @@ msgstr ""
 
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse
 msgid "Ask a follow-up with Duck.ai"
+msgstr ""
+
+#. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
+msgctxt "Page suggestion chip label"
+msgid "Ask about this page"
 msgstr ""
 
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2090,6 +2113,11 @@ msgstr ""
 msgid "Barcode"
 msgstr "Code-barres"
 
+#. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Based on this page, is this course worth taking?"
+msgstr ""
+
 msgctxt "settings"
 msgid "Basic"
 msgstr "Basique"
@@ -2121,6 +2149,13 @@ msgstr ""
 #. Placeholder text displayed while the assistant waits for the user to choose an action.
 msgctxt "Assistant response placeholder"
 msgid "Before continuing..."
+msgstr ""
+
+#. Explains that before storing the report, DuckDuckGo will anonymize the conversation by removing PII like names, email addresses, and identifying metadata.
+msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
+msgid ""
+"Before storing this report, DuckDuckGo will anonymize your conversation by "
+"removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
 #. Label that's displayed next to a past start date below a web search result.
@@ -2379,6 +2414,11 @@ msgstr "Brésil"
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Break Points Won"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Break this down into clear, numbered steps."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -2738,6 +2778,11 @@ msgstr "Offres d'emploi"
 #. Text of a button that performs a search for the cast of a particular movie or tv show
 msgctxt "Movie/TV Show Title instant answer"
 msgid "Cast"
+msgstr ""
+
+#. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Cast & Crew"
 msgstr ""
 
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -4103,6 +4148,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Create a shopping list with quantities from this recipe."
+msgstr ""
+
 #. Placeholder text displayed in the input field when starting a new image generation session.
 msgctxt "Placeholder text for the image generation input field"
 msgid "Create an image of a cute duck..."
@@ -4629,6 +4679,10 @@ msgstr ""
 msgid "Dictation limit reached"
 msgstr ""
 
+#. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
+msgid "Dictation temporarily unavailable"
+msgstr ""
+
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
@@ -4873,6 +4927,20 @@ msgctxt "precise_user_location"
 msgid "Done"
 msgstr "Terminé"
 
+#. Message shown in a modal after DuckDuckGo browser users disable AI features in Settings. The first two placeholders bold noai.duckduckgo.com. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
+"filtered out. %sLearn More%s"
+msgstr ""
+
+#. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
+"and AI images filtered out. %sLearn more%s"
+msgstr ""
+
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Double Faults"
@@ -4963,6 +5031,16 @@ msgctxt "Full sentence for writing an email"
 msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
+msgstr ""
+
+#. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Draft a cover letter"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Draft a cover letter for this job."
 msgstr ""
 
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -5102,6 +5180,14 @@ msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
 msgstr ""
 
+#. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
+msgctxt "About section description on the Duck.ai settings page"
+msgid ""
+"Duck.ai is created by DuckDuckGo. We're an independent online protection "
+"company for anyone who wants to take back control of their personal "
+"information."
+msgstr ""
+
 #. Title shown when an update is required before proceeding.
 msgctxt "duckai_migration"
 msgid "Duck.ai is moving domains"
@@ -5135,6 +5221,12 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Duck.ai lets you chat privately with popular AI models. Disabling it hides "
+"Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
 
 msgctxt "settings"
@@ -5901,6 +5993,16 @@ msgstr ""
 msgid "Eritrea"
 msgstr ""
 
+#. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Estimate the nutrition"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Estimate the nutritional information for this recipe."
+msgstr ""
+
 msgid "Estonia"
 msgstr "Estonie"
 
@@ -5945,10 +6047,50 @@ msgctxt "merchant promotion product ad extension"
 msgid "Expires in 1 day"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain the accepted answer in simple terms."
+msgstr ""
+
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
+msgstr ""
+
+#. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain the top answer"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this in simple, plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this paper"
+msgstr ""
+
+#. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this repo"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this research paper in plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this simply"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain what this repository does and how to use it."
 msgstr ""
 
 #. Label to show if song lyrics contain explicit content
@@ -6179,6 +6321,11 @@ msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
 msgstr ""
 
+msgctxt "settings"
+msgid ""
+"Filters out known AI spam sites from image search results. %sLearn More%s"
+msgstr ""
+
 #. Label for the final score of a sporting event.
 msgid "Final"
 msgstr ""
@@ -6219,6 +6366,11 @@ msgstr ""
 #. Short description shown below the 'Web Search' label in the Tools dropdown.
 msgctxt "Subtitle for the Web Search tool entry in the Tools dropdown menu"
 msgid "Find current information"
+msgstr ""
+
+#. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Find me alternatives"
 msgstr ""
 
 #. Button that searches for results closer to the user's current location.
@@ -6609,6 +6761,11 @@ msgstr ""
 msgid "Generate More"
 msgstr ""
 
+#. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Generate a shopping list"
+msgstr ""
+
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
 msgid "Generate a short answer from the web"
 msgstr ""
@@ -6843,6 +7000,11 @@ msgstr ""
 #. Text for a button inviting users to give it a try for the Duck.ai product. On click, they're taken to the Duck.ai page.
 msgctxt "Onboarding welcome screen button text"
 msgid "Give it a Try"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Give me a quick background on this person."
 msgstr ""
 
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -7205,6 +7367,16 @@ msgstr ""
 
 #. Link to a page with information about sharing DuckDuckGo with friends.
 msgid "Help Spread Privacy"
+msgstr ""
+
+#. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Help me prep for the interview"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Help me tailor my resume for this job."
 msgstr ""
 
 #. Title of a SERP popup that invites users to take a survey (desktop only)
@@ -7624,6 +7796,13 @@ msgstr ""
 #. Text displayed on the button on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
 msgctxt "Onboarding terms screen button text"
 msgid "I Agree"
+msgstr ""
+
+#. Text for the button that takes the user to the external DuckDuckGo login subscription page.
+msgctxt ""
+"Text for the I already have a subscription button in the Duck.ai settings "
+"page"
+msgid "I Already Have a Subscription"
 msgstr ""
 
 #. Text for the button that takes the user to the login subscription page.
@@ -8081,6 +8260,11 @@ msgctxt "Sidemenu browser promo"
 msgid "Install Mac Browser"
 msgstr ""
 
+#. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
+msgctxt "settings"
+msgid "Install Now"
+msgstr ""
+
 #. Text of a button to install the DuckDuckGo app
 msgctxt "Serp footer content"
 msgid "Install Our App"
@@ -8160,9 +8344,36 @@ msgctxt "cloudsave"
 msgid "Is deleted data really deleted?"
 msgstr "Est-ce que les données supprimées le sont réellement?"
 
+#. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is it worth taking?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this place any good?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"Is this place any good? Summarize its reputation based on reviews and "
+"ratings."
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "Is this video helpful?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this worth watching?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Is this worth watching? Give me a spoiler-free take."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -8659,6 +8870,11 @@ msgstr "Police des liens :"
 msgid "Links:"
 msgstr "Liens :"
 
+#. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "List the tools, materials, or prerequisites I need for this."
+msgstr ""
+
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
 msgid "Listen"
 msgstr "Écouter"
@@ -8994,6 +9210,11 @@ msgstr ""
 #. Label for linke navigating to site exclusion feature on Settings page
 msgctxt "Exclusion message manage sites button"
 msgid "Manage blocked sites"
+msgstr ""
+
+#. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
+msgctxt "setting"
+msgid "Manage in Browser Settings"
 msgstr ""
 
 #. Link to the site exclusion settings page
@@ -11299,6 +11520,11 @@ msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
+msgid "Please describe why the chat response is harmful or illegal. (optional)"
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
+msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
 msgstr ""
 
@@ -11317,6 +11543,13 @@ msgctxt "Modal disclaimer text"
 msgid ""
 "Please note: starting a new chat with any model will delete your current "
 "chat session."
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
+msgctxt "Feedback prompt"
+msgid ""
+"Please paste your prompt and the problematic output (with any personal "
+"information removed) and describe why the content is harmful or illegal."
 msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -11701,6 +11934,11 @@ msgctxt "settings"
 msgid "Privacy"
 msgstr "Vie privée"
 
+#. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
+msgctxt "Section heading on the Duck.ai settings page"
+msgid "Privacy & Terms"
+msgstr ""
+
 msgid "Privacy Blog"
 msgstr ""
 
@@ -11754,6 +11992,11 @@ msgstr ""
 
 #. Text used in other strings to link to the Privacy Policy and Terms of Service content.
 msgctxt "Copy used to compose link in sentences"
+msgid "Privacy Policy and Terms of Service"
+msgstr ""
+
+#. Text for a button that links to the terms of use and privacy policy page.
+msgctxt "Secondary button text in active privacy modal"
 msgid "Privacy Policy and Terms of Service"
 msgstr ""
 
@@ -12162,6 +12405,26 @@ msgctxt "Brief for recommending a book"
 msgid "Recommend a book"
 msgstr ""
 
+#. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar books"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar books."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar movies or shows."
+msgstr ""
+
+#. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar titles"
+msgstr ""
+
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
 msgid "Recording failed. Please try again."
 msgstr ""
@@ -12482,6 +12745,14 @@ msgstr ""
 msgid "Republic of Moldova"
 msgstr ""
 
+#. Note indicating that sharing the conversation is mandatory when reporting harmful or illegal content. Rendered alongside the standard share label (DUCKCHAT_RESPONSE_FEEDBACK_SHARE_PROMPT_RESPONSE_LABEL), not replacing it.
+msgctxt ""
+"Note shown under the share-content switch label on the Duck.ai response "
+"feedback form when the user has selected Harmful or Illegal as the feedback "
+"reason"
+msgid "Required for harmful or illegal reports"
+msgstr ""
+
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
 msgctxt "Description for extended reasoning mode in Duck.ai"
 msgid "Researches before responding"
@@ -12667,6 +12938,11 @@ msgstr "Commentaires"
 #. Label above a list of customer reviews of a business.
 msgctxt "maps_places"
 msgid "Reviews"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Rewrite this recipe scaled for a different number of servings."
 msgstr ""
 
 msgid "Romania"
@@ -13719,6 +13995,11 @@ msgctxt "Setup button for native sync flow"
 msgid "Set Up Now"
 msgstr ""
 
+#. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
+msgctxt "Encrypted storage setup button shown in native browsers"
+msgid "Set Up Sync & Backup"
+msgstr ""
+
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
 msgctxt "Title for the Sync & Backup intro screen"
 msgid "Set Up Sync & Backup"
@@ -13863,6 +14144,12 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
+msgctxt ""
+"Label beside the share-content switch on the Duck.ai response feedback form"
+msgid "Share this conversation with DuckDuckGo"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -14879,6 +15166,21 @@ msgctxt "Brief for suggesting a blog post title"
 msgid "Suggest a title for a blog post"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest related articles or topics worth exploring next."
+msgstr ""
+
+#. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Suggest related articles to explore"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest some alternatives to this product."
+msgstr ""
+
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
 msgctxt "directions"
 msgid "Suggestions:"
@@ -14888,9 +15190,84 @@ msgctxt "noresults"
 msgid "Suggestions:"
 msgstr ""
 
+#. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Sum up the reviews"
+msgstr ""
+
 #. A short title for the a message asking the AI to summarize a text.
 msgctxt "Title for the summarize message"
 msgid "Summarize"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize the Q&As"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the background and notable work of this person."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the key details of this event."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the questions and answers on this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize their background"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this book"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this book."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this discussion"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this discussion thread."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this video"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this video."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize what the reviews say."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -15145,6 +15522,11 @@ msgstr ""
 msgid "Syria"
 msgstr ""
 
+#. Text for a button that enables the theme to follow the operating system's color scheme preference.
+msgctxt "System theme button for theme selector"
+msgid "System"
+msgstr ""
+
 #. Abbreviation indicating this is the total score for a game
 msgctxt "Sports module"
 msgid "T"
@@ -15168,6 +15550,11 @@ msgctxt "language_name"
 msgid "Tahitian"
 msgstr ""
 
+#. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Tailor my resume"
+msgstr ""
+
 msgid "Taiwan"
 msgstr "Taïwan"
 
@@ -15189,6 +15576,12 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "Take control of your personal data!"
+msgstr ""
+
+#. Description for the Feedback section of the Duck.ai settings page, asking the user to take an anonymous survey to let us know how we can make Duck.ai better.
+msgctxt "Feedback section description on the Duck.ai settings page"
+msgid ""
+"Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
 
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -15433,6 +15826,11 @@ msgstr ""
 #. https://duck.co/media/files/theme.png
 msgid "Theme"
 msgstr "Thème"
+
+#. Text for the theme selector label that allows users to switch between Light and dark theme.
+msgctxt "Label for the theme selector feature"
+msgid "Theme"
+msgstr ""
 
 #. http://i.imgur.com/LpFhb1e.png
 msgctxt "settings"
@@ -16086,6 +16484,16 @@ msgid ""
 "movie theatre?”"
 msgstr ""
 
+#. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Translate this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
+msgctxt "Page suggestion prompt"
+msgid "Translate this page into %s."
+msgstr ""
+
 #. Placeholder text for a region that will display translated text.
 msgctxt "translations_module"
 msgid "Translation"
@@ -16200,6 +16608,11 @@ msgstr ""
 #. Call-to-action button for the subscription promo in the SERP sidemenu.
 msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
+msgstr ""
+
+#. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
+msgctxt "settings"
+msgid "Try It Now"
 msgstr ""
 
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -16394,6 +16807,20 @@ msgstr "Essayez: %s"
 #. Response a user can select in a feedback form, indicating that they're trying DuckDuckGo again.
 msgctxt "new user poll"
 msgid "Trying DuckDuckGo again"
+msgstr ""
+
+#. Message shown in a modal after supported third-party browser users disable AI features in Settings. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+#. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
 msgstr ""
 
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -17003,6 +17430,11 @@ msgstr ""
 msgid "Uruguay"
 msgstr ""
 
+#. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
+msgctxt "Navigation label on the Duck.ai settings page"
+msgid "Usage"
+msgstr ""
+
 #. A feedback suggestion
 msgctxt "Feedback prompt"
 msgid "Usage limit"
@@ -17351,6 +17783,11 @@ msgstr ""
 msgid "Wales"
 msgstr ""
 
+#. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Walk me through the steps"
+msgstr ""
+
 #. Label for walking directions on a map.
 msgctxt "directions"
 msgid "Walking"
@@ -17441,6 +17878,16 @@ msgstr ""
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
+msgstr ""
+
+#. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
+msgctxt ""
+"Inline warning shown below the share-content toggle when the user selects "
+"Harmful or Illegal but has not enabled sharing"
+msgid ""
+"We can only fix what we can see. To report a harmful or illegal response, "
+"please share this conversation with DuckDuckGo so we can investigate and "
+"address the issue."
 msgstr ""
 
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -17864,6 +18311,87 @@ msgid ""
 "experience."
 msgstr ""
 
+#. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the counterarguments?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the hours & location?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key contributions of this paper?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key contributions?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key details?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key points covered in this video?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key points?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key takeaways from this article?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key takeaways?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key things I will learn from this course?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main counterarguments or criticisms of this?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main questions this page answers?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the must-try dishes here?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"What are the opening hours, location, and contact details for this place?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the pros and cons of this product?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the pros and cons?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
 msgctxt "feedback form"
 msgid "What bothered you most?"
@@ -17947,6 +18475,11 @@ msgctxt "Full sentence for defining a term"
 msgid "What does atria mean in the context of a medical article?"
 msgstr ""
 
+#. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What does this answer?"
+msgstr ""
+
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
@@ -17956,6 +18489,11 @@ msgstr ""
 msgctxt "cloudsave"
 msgid "What information gets saved?"
 msgstr "Quelles informations sont sauvegardées ?"
+
+#. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What interview questions might come up for this role?"
+msgstr ""
 
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
@@ -17967,6 +18505,11 @@ msgstr ""
 #. Text for a prompt suggestion for looking up the capital city of Albania.
 msgctxt "Full sentence for looking up basic facts"
 msgid "What is the capital city of Albania?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What is the overall verdict and rating for this?"
 msgstr ""
 
 #. Link to a page with additional information.
@@ -17987,6 +18530,11 @@ msgctxt "maps_places"
 msgid "What people say:"
 msgstr ""
 
+#. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What should I order?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
 msgctxt "feedback form"
 msgid "What stood out?"
@@ -17995,6 +18543,16 @@ msgstr ""
 #. Question on a feedback form for a negative feedback response.
 msgctxt "feedback form"
 msgid "What was wrong with the response? (optional)"
+msgstr ""
+
+#. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I learn?"
+msgstr ""
+
+#. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I need?"
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -18009,6 +18567,11 @@ msgstr ""
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
 msgctxt "SERP footer content"
 msgid "What's New"
+msgstr ""
+
+#. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What's the verdict?"
 msgstr ""
 
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -18051,6 +18614,11 @@ msgctxt "Feedback prompt"
 msgid "Which features are missing? (Optional)"
 msgstr ""
 
+#. An invitation for users to leave feedback
+msgctxt "Feedback prompt"
+msgid "Which features are missing? (optional)"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
 msgid "White"
 msgstr "Blanc"
@@ -18062,6 +18630,16 @@ msgstr "Blanc"
 
 #. Link to an about us page.
 msgid "Who We Are"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Who are the main cast and crew, and what else are they known for?"
+msgstr ""
+
+#. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Who is this person?"
 msgstr ""
 
 #. Header above a collection of privacy-related links.

--- a/locales/fr_FR/LC_MESSAGES/duckduckgo.po
+++ b/locales/fr_FR/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: fr_FR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -941,8 +941,8 @@ msgstr ""
 "AI Chat vous permet d'avoir des conversations anonymes avec des modèles de "
 "chat IA tiers. La désactivation de cette option masquera la fonctionnalité "
 "AI Chat sur DuckDuckGo Search. Vous pouvez toujours accéder à l'AI Chat "
-"lorsque ce paramètre est désactivé en consultant %1$sduckduckgo.com/"
-"aichat%2$s."
+"lorsque ce paramètre est désactivé en consultant "
+"%1$sduckduckgo.com/aichat%2$s."
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -1359,8 +1359,7 @@ msgstr "Ajouter un champ de recherche %1$s à votre site !"
 #. Prompt to add locations on a map in order to get directions.
 msgctxt "directions"
 msgid "Add a starting point and destination to find a route."
-msgstr ""
-"Ajoutez un lieu de départ et une destination pour trouver un itinéraire."
+msgstr "Ajoutez un lieu de départ et une destination pour trouver un itinéraire."
 
 # smartling.placeholder_format=C
 #. Label on the AI model card indicating the model supports file uploads.
@@ -1450,7 +1449,7 @@ msgstr "Adresse erronée"
 #. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Adjust the servings"
-msgstr ""
+msgstr "Ajuster les portions"
 
 # smartling.placeholder_format=C
 #. as in multiple advertisements
@@ -1674,6 +1673,9 @@ msgid ""
 "All chats are anonymized by DuckDuckGo, and your conversations are not used "
 "to train chat models by DuckDuckGo or the model providers"
 msgstr ""
+"Toutes les discussions sont anonymisées par DuckDuckGo, et vos conversations "
+"ne sont pas utilisées par DuckDuckGo ni par les fournisseurs de modèles pour "
+"entraîner des modèles de chat"
 
 # smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1954,6 +1956,9 @@ msgid ""
 "Anonymously generates answers for search queries based on web content. "
 "Choose how often you want it to appear, or disable it completely."
 msgstr ""
+"Génère anonymement des réponses aux requêtes de recherche basées sur le "
+"contenu Web. Choisissez la fréquence à laquelle vous souhaitez voir l'option "
+"apparaître, ou désactivez-la complètement."
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -2108,8 +2113,7 @@ msgstr ""
 #. Body text of the modal that asks the user if they want to clear the conversation.
 msgctxt "Modal body for clearing conversation"
 msgid "Are you sure you want to clear this conversation and start a new one?"
-msgstr ""
-"Voulez-vous vraiment effacer cette conversation et en commencer une autre ?"
+msgstr "Voulez-vous vraiment effacer cette conversation et en commencer une autre ?"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to delete their current chat, explaining that this action cannot be undone.
@@ -2244,7 +2248,7 @@ msgstr "Demander un suivi avec Duck.ai"
 #. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
 msgctxt "Page suggestion chip label"
 msgid "Ask about this page"
-msgstr ""
+msgstr "Posez des questions sur cette page"
 
 # smartling.placeholder_format=C
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2415,21 +2419,18 @@ msgstr "Audio"
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat ends."
-msgstr ""
-"Une fois le chat terminé, le son n'est conservé ni par nous ni par OpenAI."
+msgstr "Une fois le chat terminé, le son n'est conservé ni par nous ni par OpenAI."
 
 # smartling.placeholder_format=C
 #. Description in consent disclaimer informing that audio from the voice chat session is not stored by us or by OpenAI after the voice chat ends.
 msgctxt "voice chat"
 msgid "Audio is not stored by us or by OpenAI after the chat ends."
-msgstr ""
-"Une fois le chat terminé, le son n'est conservé ni par nous ni par OpenAI."
+msgstr "Une fois le chat terminé, le son n'est conservé ni par nous ni par OpenAI."
 
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat is transcribed."
-msgstr ""
-"Une fois le chat transcrit, le son n'est conservé ni par nous ni par OpenAI."
+msgstr "Une fois le chat transcrit, le son n'est conservé ni par nous ni par OpenAI."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when MediaRecorder API is unavailable.
@@ -2675,7 +2676,7 @@ msgstr "Code-barres"
 #. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Based on this page, is this course worth taking?"
-msgstr ""
+msgstr "D'après cette page, est-ce que ce cours vaut la peine d'être suivi ?"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2724,6 +2725,9 @@ msgid ""
 "Before storing this report, DuckDuckGo will anonymize your conversation by "
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
+"Avant de stocker ce rapport, DuckDuckGo anonymisera votre conversation en "
+"supprimant les données à caractère personnel comme les noms, les adresses "
+"e-mail et les métadonnées d'identification."
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -2849,8 +2853,7 @@ msgstr "Bloquez les traqueurs d'e-mails et masquez votre adresse."
 # smartling.placeholder_format=C
 #. A disclaimer about AI-generated images in search results
 msgid "Block list is not exhaustive and may contain inaccuracies."
-msgstr ""
-"La liste de blocage n'est pas exhaustive et peut contenir des inexactitudes."
+msgstr "La liste de blocage n'est pas exhaustive et peut contenir des inexactitudes."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -2866,8 +2869,7 @@ msgstr "Bloquer ce site dans tous les résultats"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Block trackers and take control of your personal data"
-msgstr ""
-"Bloquez les traqueurs et prenez le contrôle de vos données personnelles"
+msgstr "Bloquez les traqueurs et prenez le contrôle de vos données personnelles"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -3047,7 +3049,7 @@ msgstr "Balles de break gagnées"
 #. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Break this down into clear, numbered steps."
-msgstr ""
+msgstr "Décompose cela en étapes claires et numérotées."
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -3215,8 +3217,7 @@ msgstr "En cliquant sur « %1$s », vous acceptez nos %2$s."
 msgctxt ""
 "Copy stating agreement to Duck.ai Privacy Policy and Terms of Service."
 msgid "By clicking “%s,” you accept Duck.ai’s %s and %s."
-msgstr ""
-"En cliquant sur « %1$s », vous acceptez la %2$s et les %3$s de Duck.ai."
+msgstr "En cliquant sur « %1$s », vous acceptez la %2$s et les %3$s de Duck.ai."
 
 # smartling.placeholder_format=C
 #. Text stating agreement to Duck.ai Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'By clicking “Agree and Continue,” you accept Duck.ai’s Privacy Policy and Terms of Service.'
@@ -3514,7 +3515,7 @@ msgstr "Distribution"
 #. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Cast & Crew"
-msgstr ""
+msgstr "Casting et équipe"
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -3601,8 +3602,7 @@ msgstr "Change l'affichage de l'URL des résultats"
 #. This is the description of a user setting
 msgctxt "settings"
 msgid "Changes how the header is displayed and its behavior as you scroll"
-msgstr ""
-"Change l'affichage de l'en-tête ainsi que son comportement lors du défilement"
+msgstr "Change l'affichage de l'en-tête ainsi que son comportement lors du défilement"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/mcZdcaF.png
@@ -4053,8 +4053,7 @@ msgstr "Choix de modèles d'IA, y compris %1$s et %2$s"
 # smartling.placeholder_format=C
 #. As in 'Choose to keep DuckDuckGo as your default search engine'. Placeholders are for markup, you can ignore them.
 msgid "Choose %skeep it%s to continue protecting your privacy."
-msgstr ""
-"Choisissez %1$sConserver%2$s pour continuer à protéger votre confidentialité."
+msgstr "Choisissez %1$sConserver%2$s pour continuer à protéger votre confidentialité."
 
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
@@ -4406,8 +4405,7 @@ msgstr "Cliquez sur %1$sParamètres%2$s dans le menu déroulant."
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
-msgstr ""
-"Cliquez sur %1$sUtiliser les pages Web actuelles%2$s puis sur %3$sOK%4$s."
+msgstr "Cliquez sur %1$sUtiliser les pages Web actuelles%2$s puis sur %3$sOK%4$s."
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -5257,7 +5255,7 @@ msgstr "Créer une image"
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
-msgstr ""
+msgstr "Crée une liste de courses avec les quantités de cette recette."
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed in the input field when starting a new image generation session.
@@ -5811,8 +5809,7 @@ msgstr "Discussions supprimées"
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
 msgctxt "settings"
 msgid "Deleting cookies will reset these settings."
-msgstr ""
-"La suppression des cookies aura pour effet de réinitialiser ces paramètres."
+msgstr "La suppression des cookies aura pour effet de réinitialiser ces paramètres."
 
 # smartling.placeholder_format=C
 msgid "Democratic People's Republic of Korea"
@@ -5834,8 +5831,7 @@ msgstr "Décrivez les modifications en fonction de l'image"
 #. Placeholder text displayed in the input field when the user can make follow-up edits to a generated image.
 msgctxt "Placeholder text for the image generation input field for follow-ups"
 msgid "Describe changes to continue editing this image"
-msgstr ""
-"Décrivez les modifications souhaitées pour continuer à modifier cette image"
+msgstr "Décrivez les modifications souhaitées pour continuer à modifier cette image"
 
 # smartling.placeholder_format=C
 #. Title shown when the user first enters Image Generation mode, prompting them to describe the image they want to create.
@@ -5910,7 +5906,7 @@ msgstr "Limite de dictée atteinte"
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
 msgid "Dictation temporarily unavailable"
-msgstr ""
+msgstr "Dictée temporairement indisponible"
 
 # smartling.placeholder_format=C
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
@@ -5999,8 +5995,7 @@ msgstr "Désactiver et déconnecter"
 #. Title of a modal that asks the user if they want to turn off chat history and disconnect from Sync & Backup.
 msgctxt "Modal header for disabling chat history and disconnecting sync"
 msgid "Disable chat history and disconnect from Sync & Backup?"
-msgstr ""
-"Désactiver l'historique des discussions et se déconnecter de Sync & Backup ?"
+msgstr "Désactiver l'historique des discussions et se déconnecter de Sync & Backup ?"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to turn off the chat history feature.
@@ -6220,6 +6215,9 @@ msgid ""
 "Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
 "filtered out. %sLearn More%s"
 msgstr ""
+"Vous ne voulez pas d'IA ? %1$snoai.duckduckgo.com%2$s n'offre aucune "
+"fonctionnalité d'IA et les images générées par l'IA sont filtrées. %3$sEn "
+"savoir plus%4$s"
 
 # smartling.placeholder_format=C
 #. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
@@ -6228,6 +6226,9 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
+"Vous ne voulez pas d'IA ? Visitez %1$snoai.duckduckgo.com%2$s pour effectuer "
+"des recherches sans fonctionnalités d'IA et en filtrant les images générées "
+"par l'IA. %3$sEn savoir plus%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6347,13 +6348,13 @@ msgstr ""
 #. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Draft a cover letter"
-msgstr ""
+msgstr "Rédiger une lettre de motivation"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Draft a cover letter for this job."
-msgstr ""
+msgstr "Rédige une lettre de motivation pour ce poste."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -6530,8 +6531,7 @@ msgstr ""
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
-msgstr ""
-"Duck.ai fonctionne mieux dans notre navigateur DuckDuckGo privé et gratuit !"
+msgstr "Duck.ai fonctionne mieux dans notre navigateur DuckDuckGo privé et gratuit !"
 
 # smartling.placeholder_format=C
 #. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
@@ -6541,6 +6541,9 @@ msgid ""
 "company for anyone who wants to take back control of their personal "
 "information."
 msgstr ""
+"Duck.ai est une création de DuckDuckGo. Nous sommes une entreprise "
+"indépendante de protection en ligne pour tous ceux qui veulent reprendre le "
+"contrôle de leurs informations personnelles."
 
 # smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
@@ -6595,6 +6598,9 @@ msgid ""
 "Duck.ai lets you chat privately with popular AI models. Disabling it hides "
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
+"Duck.ai te permet de discuter en privé avec des modèles d'IA populaires. Le "
+"désactiver masque les boutons et liens Duck.ai, mais tu peux toujours "
+"visiter %1$sduck.ai%2$s directement."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6616,8 +6622,7 @@ msgstr ""
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
 msgctxt "Disclaimer text at the bottom of the feedback form."
 msgid "Duck.ai may display inaccurate or offensive information."
-msgstr ""
-"Duck.ai est susceptible d'afficher des informations inexactes ou offensantes."
+msgstr "Duck.ai est susceptible d'afficher des informations inexactes ou offensantes."
 
 # smartling.placeholder_format=C
 #. Error modal body line 2.
@@ -6633,8 +6638,7 @@ msgstr ""
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
 msgctxt "Promotional text for PDF upload feature"
 msgid "Duck.ai now can read and analyze PDFs. Give it a try!"
-msgstr ""
-"Duck.ai peut désormais lire et analyser des PDF. Essayez par vous-même !"
+msgstr "Duck.ai peut désormais lire et analyser des PDF. Essayez par vous-même !"
 
 # smartling.placeholder_format=C
 #. Disclaimer text shown above the chat input only when coming from a DuckAssist grounded response into ungrounded models.
@@ -7262,8 +7266,7 @@ msgstr "Activer les fonctionnalités d'IA"
 #. Text explaining how to enable the cloud save feature.
 msgctxt "cloudsave"
 msgid "Enable Cloud Save by entering your existing passphrase."
-msgstr ""
-"Activez la sauvegarde dans le cloud en saisissant votre phrase de passe."
+msgstr "Activez la sauvegarde dans le cloud en saisissant votre phrase de passe."
 
 # smartling.placeholder_format=C
 #. Primary button text in the dictation privacy consent modal to enable dictation.
@@ -7518,15 +7521,13 @@ msgstr ""
 #. Tells how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed location access"
-msgstr ""
-"Assurez-vous que votre navigateur est autorisé à accéder à la localisation"
+msgstr "Assurez-vous que votre navigateur est autorisé à accéder à la localisation"
 
 # smartling.placeholder_format=C
 #. Tells how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed location access."
-msgstr ""
-"Vérifiez que votre navigateur est autorisé à accéder à la localisation."
+msgstr "Vérifiez que votre navigateur est autorisé à accéder à la localisation."
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -7627,13 +7628,13 @@ msgstr "Érythrée"
 #. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Estimate the nutrition"
-msgstr ""
+msgstr "Estimer la nutrition"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Estimate the nutritional information for this recipe."
-msgstr ""
+msgstr "Estime les informations nutritionnelles de cette recette."
 
 # smartling.placeholder_format=C
 msgid "Estonia"
@@ -7695,7 +7696,7 @@ msgstr "Expire dans 1 jour"
 #. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain the accepted answer in simple terms."
-msgstr ""
+msgstr "Explique la réponse acceptée en termes simples."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
@@ -7708,43 +7709,43 @@ msgstr "Explique-moi le concept de trou noir au niveau lycée."
 #. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain the top answer"
-msgstr ""
+msgstr "Expliquer la réponse principale"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain this in simple, plain language."
-msgstr ""
+msgstr "Explique ça en termes simples et clairs."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain this paper"
-msgstr ""
+msgstr "Expliquer cet article"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain this repo"
-msgstr ""
+msgstr "Explique ce référentiel"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain this research paper in plain language."
-msgstr ""
+msgstr "Explique cet article de recherche en termes simples."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain this simply"
-msgstr ""
+msgstr "Expliquer cela simplement"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain what this repository does and how to use it."
-msgstr ""
+msgstr "Expliquez ce que fait ce référentiel et comment l'utiliser."
 
 # smartling.placeholder_format=C
 #. Label to show if song lyrics contain explicit content
@@ -7942,8 +7943,8 @@ msgid ""
 "Feel free to adjust the settings below. Then, just copy and paste the code "
 "into your website."
 msgstr ""
-"Ajustez les paramètres ci-dessous comme bon vous semble. Ensuite, copiez-"
-"collez le code dans votre site."
+"Ajustez les paramètres ci-dessous comme bon vous semble. Ensuite, "
+"copiez-collez le code dans votre site."
 
 # smartling.placeholder_format=C
 msgid "Fiji"
@@ -8020,8 +8021,7 @@ msgstr "Filtres inefficaces"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Filters out AI-generated images from image search results"
-msgstr ""
-"Filtre les images générées par l'IA des résultats de recherche d'images"
+msgstr "Filtre les images générées par l'IA des résultats de recherche d'images"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -8036,6 +8036,8 @@ msgctxt "settings"
 msgid ""
 "Filters out known AI spam sites from image search results. %sLearn More%s"
 msgstr ""
+"Filtre les sites de spam IA connus dans les résultats de recherche d'images. "
+"%1$sEn savoir plus%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the final score of a sporting event.
@@ -8076,8 +8078,7 @@ msgstr "Vous trouverez <b>%1$s</b> dans votre dossier de téléchargements"
 # smartling.placeholder_format=C
 #. Tells users how to change their default search engine to DuckDuckGo.
 msgid "Find DuckDuckGo in the displayed list and click %sMake Default%s"
-msgstr ""
-"Cherchez DuckDuckGo dans la liste et cliquez sur %1$sDéfinir par défaut%2$s"
+msgstr "Cherchez DuckDuckGo dans la liste et cliquez sur %1$sDéfinir par défaut%2$s"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for finding a better word.
@@ -8095,7 +8096,7 @@ msgstr "Trouver des informations actuelles"
 #. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Find me alternatives"
-msgstr ""
+msgstr "Trouve-moi des alternatives"
 
 # smartling.placeholder_format=C
 #. Button that searches for results closer to the user's current location.
@@ -8188,8 +8189,7 @@ msgstr ""
 #. Privacy reassurance and instructions intro.
 msgctxt "duckai_migration"
 msgid "Follow these steps to move your chats to the new Duck.ai"
-msgstr ""
-"Suivez ces étapes pour déplacer vos discussions vers le nouveau Duck.ai"
+msgstr "Suivez ces étapes pour déplacer vos discussions vers le nouveau Duck.ai"
 
 # smartling.placeholder_format=C
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse on mobile
@@ -8410,8 +8410,8 @@ msgid ""
 "strong>."
 msgstr ""
 "Dans la barre de menu de l'application sur Mac, sélectionnez "
-"<strong>DuckDuckGo</strong> &gt; <strong>Rechercher des mises à jour…</"
-"strong>, puis sélectionnez <strong>Installer la mise à jour</strong>."
+"<strong>DuckDuckGo</strong> &gt; <strong>Rechercher des mises à "
+"jour…</strong>, puis sélectionnez <strong>Installer la mise à jour</strong>."
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -8582,7 +8582,7 @@ msgstr "Générer plus"
 #. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Generate a shopping list"
-msgstr ""
+msgstr "Générer une liste de courses"
 
 # smartling.placeholder_format=C
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
@@ -8885,14 +8885,13 @@ msgstr "Essayez par vous-même"
 #. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Give me a quick background on this person."
-msgstr ""
+msgstr "Donne-moi un bref aperçu de cette personne."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
-msgstr ""
-"Accédez à %1$sConfidentialité et sécurité > Services de localisation%2$s"
+msgstr "Accédez à %1$sConfidentialité et sécurité > Services de localisation%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9157,8 +9156,7 @@ msgstr "Guatemala"
 #. Text for a prompt suggestion for guiding through the basic steps of replacing a window wiper.
 msgctxt "Full sentence for learning a new skill"
 msgid "Guide me through the basic steps of replacing a window wiper."
-msgstr ""
-"Explique-moi les principales étapes à suivre pour remplacer un essuie-glace."
+msgstr "Explique-moi les principales étapes à suivre pour remplacer un essuie-glace."
 
 # smartling.placeholder_format=C
 msgid "Guinea"
@@ -9340,13 +9338,13 @@ msgstr "Aidez-nous à promouvoir la vie privée"
 #. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Help me prep for the interview"
-msgstr ""
+msgstr "Aide-moi à me préparer pour l'entretien"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Help me tailor my resume for this job."
-msgstr ""
+msgstr "Aide-moi à adapter mon CV pour ce poste."
 
 # smartling.placeholder_format=C
 #. Title of a SERP popup that invites users to take a survey (desktop only)
@@ -9358,8 +9356,7 @@ msgstr "Aide-nous à améliorer DuckDuckGo"
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Help us improve DuckDuckGo searches with your feedback"
-msgstr ""
-"Aidez-nous à améliorer les recherches DuckDuckGo grâce à vos commentaires"
+msgstr "Aidez-nous à améliorer les recherches DuckDuckGo grâce à vos commentaires"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -9417,8 +9414,7 @@ msgstr "Aidez votre famille et vos ami(e)s à rejoindre le côté Duck !"
 #. Text description for the Spread card in the SERP footer
 msgctxt "footer_card"
 msgid "Help your friends and family take back their privacy!"
-msgstr ""
-"Aidez vos amis et votre famille à reprendre le contrôle de leur vie privée !"
+msgstr "Aidez vos amis et votre famille à reprendre le contrôle de leur vie privée !"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -9814,8 +9810,7 @@ msgstr "À quelle fréquence souhaitez-vous voir des réponses %1$s ?"
 #. A header for the feedback form in the assist negative feedback flow. The user is being asked to update how often they want AI-assisted answers to appear.
 msgctxt "duckassist"
 msgid "How often do you want to see AI-assisted answers?"
-msgstr ""
-"À quelle fréquence souhaitez-vous voir des réponses assistées par l’IA ?"
+msgstr "À quelle fréquence souhaitez-vous voir des réponses assistées par l’IA ?"
 
 # smartling.placeholder_format=C
 #. Section title above the frequency radio options in the Search Assist settings modal.
@@ -9877,7 +9872,7 @@ msgctxt ""
 "Text for the I already have a subscription button in the Duck.ai settings "
 "page"
 msgid "I Already Have a Subscription"
-msgstr ""
+msgstr "J'ai déjà un abonnement"
 
 # smartling.placeholder_format=C
 #. Text for the button that takes the user to the login subscription page.
@@ -10104,8 +10099,7 @@ msgstr "Les prompts d’image doivent respecter les %1$s"
 msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
-msgstr ""
-"Les prompts relatifs aux images doivent être conformes aux %1$s de Duck.ai."
+msgstr "Les prompts relatifs aux images doivent être conformes aux %1$s de Duck.ai."
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -10462,7 +10456,7 @@ msgstr "Installer le navigateur Mac"
 #. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
 msgctxt "settings"
 msgid "Install Now"
-msgstr ""
+msgstr "Installer"
 
 # smartling.placeholder_format=C
 #. Text of a button to install the DuckDuckGo app
@@ -10565,13 +10559,13 @@ msgstr "Les données supprimées sont-elles réellement supprimées ?"
 #. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Is it worth taking?"
-msgstr ""
+msgstr "Ça vaut le coup ?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Is this place any good?"
-msgstr ""
+msgstr "Cet endroit est-il bien ?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
@@ -10580,6 +10574,8 @@ msgid ""
 "Is this place any good? Summarize its reputation based on reviews and "
 "ratings."
 msgstr ""
+"Cet endroit est-il bien ? Résume sa réputation en te basant sur les avis et "
+"les notes."
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -10591,13 +10587,13 @@ msgstr "Cette vidéo est-elle utile ?"
 #. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Is this worth watching?"
-msgstr ""
+msgstr "Ça vaut le coup de regarder ?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Is this worth watching? Give me a spoiler-free take."
-msgstr ""
+msgstr "Ça vaut le coup de regarder ? Donne-moi un avis sans spoiler."
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -10623,8 +10619,7 @@ msgstr "Cela peut prendre quelques minutes."
 #. Body text of a card that promotes installing the DuckDuckGo desktop browser.
 msgctxt "new tab page"
 msgid "It's fast, free, and gives you even more online protection."
-msgstr ""
-"Il est rapide, gratuit et vous offre encore plus de protection en ligne."
+msgstr "Il est rapide, gratuit et vous offre encore plus de protection en ligne."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -11217,7 +11212,7 @@ msgstr "Liens :"
 #. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
-msgstr ""
+msgstr "Liste les outils, le matériel ou les prérequis dont j'ai besoin pour cela."
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -11633,7 +11628,7 @@ msgstr "Gérer les sites bloqués"
 #. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
 msgctxt "setting"
 msgid "Manage in Browser Settings"
-msgstr ""
+msgstr "Gérer dans les paramètres du navigateur"
 
 # smartling.placeholder_format=C
 #. Link to the site exclusion settings page
@@ -13395,8 +13390,7 @@ msgstr "Oman"
 #. http://i.imgur.com/zQWKLIm.png
 msgctxt "settings"
 msgid "Omits objectionable (mostly adult) material"
-msgstr ""
-"Omet le contenu à caractère sensible (principalement du contenu pour adulte)"
+msgstr "Omet le contenu à caractère sensible (principalement du contenu pour adulte)"
 
 # smartling.placeholder_format=C
 msgid "On"
@@ -13577,8 +13571,7 @@ msgstr "Ouvrir %1$sParamètres%2$s"
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open 'Location', and ensure location is %senabled%s."
-msgstr ""
-"Ouvrez « Localisation » et vérifiez que la localisation est %1$sactivée%2$s."
+msgstr "Ouvrez « Localisation » et vérifiez que la localisation est %1$sactivée%2$s."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -13721,8 +13714,7 @@ msgstr "Ouvrir le volet « Comment fonctionne Duck.ai »"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open the Safari menu and select %sSettings for DuckDuckGo...%s"
-msgstr ""
-"Ouvrez le menu Safari et sélectionnez %1$sRéglages pour DuckDuckGo...%2$s"
+msgstr "Ouvrez le menu Safari et sélectionnez %1$sRéglages pour DuckDuckGo...%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the time a business opens. For example: 'Opens at 10am'
@@ -14484,6 +14476,8 @@ msgstr ""
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is harmful or illegal. (optional)"
 msgstr ""
+"Veuillez expliquer pourquoi la réponse du chat est dangereuse ou illégale. "
+"(facultatif)"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
@@ -14522,6 +14516,9 @@ msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is harmful or illegal."
 msgstr ""
+"Veuillez coller votre prompt et les résultats problématiques (en retirant "
+"toute information personnelle), et expliquer pourquoi le contenu est "
+"dangereux ou illégal."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -14995,7 +14992,7 @@ msgstr "Confidentialité"
 #. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
 msgctxt "Section heading on the Duck.ai settings page"
 msgid "Privacy & Terms"
-msgstr ""
+msgstr "Confidentialité et conditions"
 
 # smartling.placeholder_format=C
 msgid "Privacy Blog"
@@ -15071,7 +15068,7 @@ msgstr "Politique de confidentialité et conditions d'utilisation"
 #. Text for a button that links to the terms of use and privacy policy page.
 msgctxt "Secondary button text in active privacy modal"
 msgid "Privacy Policy and Terms of Service"
-msgstr ""
+msgstr "Politique de confidentialité et conditions d'utilisation"
 
 # smartling.placeholder_format=C
 #. Title displayed on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
@@ -15581,25 +15578,25 @@ msgstr "Recommander un livre"
 #. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Recommend similar books"
-msgstr ""
+msgstr "Recommander des livres similaires"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Recommend similar books."
-msgstr ""
+msgstr "Recommande des livres similaires."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Recommend similar movies or shows."
-msgstr ""
+msgstr "Recommande des films ou des séries similaires."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Recommend similar titles"
-msgstr ""
+msgstr "Recommander des titres similaires"
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
@@ -15825,8 +15822,7 @@ msgstr "Mémoriser mon choix"
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings
 msgid "Remember my choice (this can be changed in %s%s%sSettings%s)"
-msgstr ""
-"Se souvenir de mon choix (peut être changé dans %1$s%2$s%3$sParamètres%4$s)"
+msgstr "Se souvenir de mon choix (peut être changé dans %1$s%2$s%3$sParamètres%4$s)"
 
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
@@ -16013,7 +16009,7 @@ msgctxt ""
 "feedback form when the user has selected Harmful or Illegal as the feedback "
 "reason"
 msgid "Required for harmful or illegal reports"
-msgstr ""
+msgstr "Obligatoire pour les signalements de contenu dangereux ou illégal"
 
 # smartling.placeholder_format=C
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
@@ -16258,7 +16254,7 @@ msgstr "Avis"
 #. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Rewrite this recipe scaled for a different number of servings."
-msgstr ""
+msgstr "Réécris cette recette pour l'adapter à un nombre de portions différent."
 
 # smartling.placeholder_format=C
 msgid "Romania"
@@ -16709,8 +16705,7 @@ msgstr ""
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Scroll down and locate %syour browser%s in the list."
-msgstr ""
-"Faites défiler la liste vers le bas et localisez %1$svotre navigateur%2$s."
+msgstr "Faites défiler la liste vers le bas et localisez %1$svotre navigateur%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service.
@@ -17267,35 +17262,31 @@ msgstr "Sélectionner %1$s%2$s%3$s, puis %4$sMoteur de recherche%5$s"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %s'Setting for this Website...'%s from the Safari menu."
-msgstr ""
-"Sélectionnez %1$s« Réglages pour ce site Web... »%2$s dans le menu Safari."
+msgstr "Sélectionnez %1$s« Réglages pour ce site Web... »%2$s dans le menu Safari."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
 msgstr ""
-"Selectionnez %1$sPersonnaliser%2$s et saisissez %3$shttps://duckduckgo."
-"com%4$s dans le champ de saisie"
+"Selectionnez %1$sPersonnaliser%2$s et saisissez "
+"%3$shttps://duckduckgo.com%4$s dans le champ de saisie"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
-msgstr ""
-"Sélectionnez %1$sDuckDuckGo%2$s, puis cliquez sur %3$sAjouter par défaut%4$s!"
+msgstr "Sélectionnez %1$sDuckDuckGo%2$s, puis cliquez sur %3$sAjouter par défaut%4$s!"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s"
-msgstr ""
-"Sélectionnez %1$sDuckDuckGo%2$s et cliquez sur %3$sDéfinir par défaut%4$s"
+msgstr "Sélectionnez %1$sDuckDuckGo%2$s et cliquez sur %3$sDéfinir par défaut%4$s"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s."
-msgstr ""
-"Sélectionnez %1$sDuckDuckGo%2$s et cliquez sur %3$sDéfinir par défaut%4$s."
+msgstr "Sélectionnez %1$sDuckDuckGo%2$s et cliquez sur %3$sDéfinir par défaut%4$s."
 
 #  Firefox 33
 # smartling.placeholder_format=C
@@ -17336,8 +17327,7 @@ msgstr "Sélectionnez %1$sDuckDuckGo%2$s!"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Select %sEdit Search Engines...%sin the dropdown"
-msgstr ""
-"Sélectionnez %1$sModifier les moteurs de recherche…%2$sdans le menu déroulant"
+msgstr "Sélectionnez %1$sModifier les moteurs de recherche…%2$sdans le menu déroulant"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -17411,8 +17401,7 @@ msgstr "Sélectionnez %1$sRéglages%2$s, puis %3$sRéglages avancés%4$s"
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sDefault search engine%s"
-msgstr ""
-"Sélectionnez %1$sRéglages%2$s, puis %3$sMoteur de recherche par défaut%4$s"
+msgstr "Sélectionnez %1$sRéglages%2$s, puis %3$sMoteur de recherche par défaut%4$s"
 
 #  Chrome/Firefox on Android
 # smartling.placeholder_format=C
@@ -17473,8 +17462,7 @@ msgstr "Sélectionnez tous les carrés contenant un canard :"
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select an option to %sallow%s location access"
-msgstr ""
-"Sélectionnez une option pour %1$sautoriser%2$s l'accès à la localisation"
+msgstr "Sélectionnez une option pour %1$sautoriser%2$s l'accès à la localisation"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -17509,8 +17497,7 @@ msgstr "Texte sélectionné de %1$s"
 #. Displayed when the user's text selection exceeds the maximum message size for AI tools (summary, translation, etc.).
 msgctxt "Error message for selection input limit"
 msgid "Selected text is too long. Try again with a shorter selection."
-msgstr ""
-"Le texte sélectionné est trop long. Réessayez avec une sélection plus courte."
+msgstr "Le texte sélectionné est trop long. Réessayez avec une sélection plus courte."
 
 # smartling.placeholder_format=C
 #. Label for the semi-finals knockout stage in e.g. the soccer World Cup
@@ -17635,7 +17622,7 @@ msgstr "Configurer maintenant"
 #. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
 msgctxt "Encrypted storage setup button shown in native browsers"
 msgid "Set Up Sync & Backup"
-msgstr ""
+msgstr "Configurer Sync & Backup"
 
 # smartling.placeholder_format=C
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
@@ -17823,7 +17810,7 @@ msgstr "Partager des commentaires positifs"
 msgctxt ""
 "Label beside the share-content switch on the Duck.ai response feedback form"
 msgid "Share this conversation with DuckDuckGo"
-msgstr ""
+msgstr "Partager cette conversation avec DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -18284,8 +18271,7 @@ msgstr "Montre l'arrière-plan du bouton de recherche"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message on top of the search results page"
-msgstr ""
-"Affiche un message de bienvenue en haut de la page des résultats de recherche"
+msgstr "Affiche un message de bienvenue en haut de la page des résultats de recherche"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18484,8 +18470,7 @@ msgstr "Résolvez des problèmes complexes grâce au mode de raisonnement !"
 #. Text for a promotional card that encourages users to try the reasoning mode on complex problems which thinks longer to hopefully provide a more accurate answer.
 msgctxt "Promotional text for reasoning mode"
 msgid "Solve complex problems with the new reasoning mode!"
-msgstr ""
-"Résolvez des problèmes complexes grâce au nouveau mode de raisonnement !"
+msgstr "Résolvez des problèmes complexes grâce au nouveau mode de raisonnement !"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that encourages users to try the reasoning mode on complex problems which thinks longer to hopefully provide a more accurate answer.
@@ -18545,8 +18530,7 @@ msgstr "Parfois"
 #. Generic error message shown when the image generation model cannot process the user's request.
 msgctxt "Error message from the image generation model"
 msgid "Sorry I can't help, please describe your image in a different way."
-msgstr ""
-"Désolé, je ne peux pas vous aider, veuillez décrire votre image différemment."
+msgstr "Désolé, je ne peux pas vous aider, veuillez décrire votre image différemment."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -18879,8 +18863,7 @@ msgstr "Reste sur DuckDuckGo"
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletter."
-msgstr ""
-"Restez protégé(e) et informé(e) avec notre newsletter sur la confidentialité."
+msgstr "Restez protégé(e) et informé(e) avec notre newsletter sur la confidentialité."
 
 # smartling.placeholder_format=C
 #. Prompt to subscribe to a newsletter.
@@ -18935,8 +18918,7 @@ msgstr "Arrêtez les traqueurs qui se cachent sur d'autres sites Web."
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop most hidden trackers lurking on other websites."
-msgstr ""
-"Arrêtez la plupart des traqueurs qui se cachent sur d'autres sites Web."
+msgstr "Arrêtez la plupart des traqueurs qui se cachent sur d'autres sites Web."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19026,8 +19008,8 @@ msgid ""
 "Subscribe to DuckDuckGo to unlock higher limits in Duck.ai, or come back "
 "later to create more images."
 msgstr ""
-"Abonnez-vous à DuckDuckGo pour débloquer des limites plus élevées dans Duck."
-"ai, ou revenez plus tard pour créer plus d'images."
+"Abonnez-vous à DuckDuckGo pour débloquer des limites plus élevées dans "
+"Duck.ai, ou revenez plus tard pour créer plus d'images."
 
 # smartling.placeholder_format=C
 #. Description shown to free users who have reached their image generation limit, encouraging them to subscribe.
@@ -19110,18 +19092,20 @@ msgstr "Suggérer un titre pour un article de blog"
 msgctxt "Page suggestion prompt"
 msgid "Suggest related articles or topics worth exploring next."
 msgstr ""
+"Suggère des articles ou des sujets connexes qui valent la peine d’être "
+"explorés ensuite."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Suggest related articles to explore"
-msgstr ""
+msgstr "Suggérer des articles connexes à explorer"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Suggest some alternatives to this product."
-msgstr ""
+msgstr "Suggère quelques alternatives à ce produit."
 
 # smartling.placeholder_format=C
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
@@ -19138,7 +19122,7 @@ msgstr "Suggestions :"
 #. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Sum up the reviews"
-msgstr ""
+msgstr "Résumer les avis"
 
 # smartling.placeholder_format=C
 #. A short title for the a message asking the AI to summarize a text.
@@ -19150,85 +19134,85 @@ msgstr "Résumer"
 #. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize the Q&As"
-msgstr ""
+msgstr "Résumer les questions et réponses"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the background and notable work of this person."
-msgstr ""
+msgstr "Résume le parcours et les travaux notables de cette personne."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the key details of this event."
-msgstr ""
+msgstr "Résume les détails clés de cet événement."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the questions and answers on this page."
-msgstr ""
+msgstr "Résume les questions et réponses sur cette page."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize their background"
-msgstr ""
+msgstr "Résumer leur parcours"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this book"
-msgstr ""
+msgstr "Résumer ce livre"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this book."
-msgstr ""
+msgstr "Résume ce livre."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this discussion"
-msgstr ""
+msgstr "Résumer cette discussion"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this discussion thread."
-msgstr ""
+msgstr "Résume ce fil de discussion."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this page"
-msgstr ""
+msgstr "Résumer cette page"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this page."
-msgstr ""
+msgstr "Résume cette page."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this video"
-msgstr ""
+msgstr "Résumer cette vidéo"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this video."
-msgstr ""
+msgstr "Résume cette vidéo."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize what the reviews say."
-msgstr ""
+msgstr "Résume ce que disent les avis."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -19508,8 +19492,8 @@ msgstr ""
 "%1$s\n"
 "\n"
 "Comment fonctionne ce code ?\n"
-"1. Accédez à Duck.ai dans votre navigateur et ouvrez les paramètres de Duck."
-"ai.\n"
+"1. Accédez à Duck.ai dans votre navigateur et ouvrez les paramètres de "
+"Duck.ai.\n"
 "2. Sélectionnez « Activer Sync & Backup », puis « Récupérer les données "
 "synchronisées »\n"
 "3. Copiez le code de récupération ci-dessus et collez-le là où il est écrit "
@@ -19563,7 +19547,7 @@ msgstr "Syrie"
 #. Text for a button that enables the theme to follow the operating system's color scheme preference.
 msgctxt "System theme button for theme selector"
 msgid "System"
-msgstr ""
+msgstr "Système"
 
 # smartling.placeholder_format=C
 #. Abbreviation indicating this is the total score for a game
@@ -19597,7 +19581,7 @@ msgstr "Tahitien"
 #. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Tailor my resume"
-msgstr ""
+msgstr "Personnaliser mon CV"
 
 # smartling.placeholder_format=C
 msgid "Taiwan"
@@ -19634,6 +19618,8 @@ msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
+"Réponds à ce sondage anonyme pour nous dire comment nous pouvons améliorer "
+"Duck.ai."
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -19832,15 +19818,13 @@ msgstr "Merci pour vos commentaires !"
 #. Inform the users that "something" went wrong and we are unable to show any results.
 msgctxt "noresults"
 msgid "Thanks for your patience while we get our ducks in a row!"
-msgstr ""
-"Merci pour votre patience pendant que nous mettons les choses en ordre !"
+msgstr "Merci pour votre patience pendant que nous mettons les choses en ordre !"
 
 # smartling.placeholder_format=C
 #. Inform the users that "something" went wrong and we are unable to show any results.
 msgctxt "noresults"
 msgid "Thanks for your patience while we get our ducks in a row."
-msgstr ""
-"Merci pour votre patience pendant que nous mettons les choses en ordre."
+msgstr "Merci pour votre patience pendant que nous mettons les choses en ordre."
 
 # smartling.placeholder_format=C
 #. Message indicating that the open lock icon in the address bar means that a website is not secure.
@@ -19885,8 +19869,7 @@ msgstr "Les fichiers joints dépassent la limite totale de taille de %1$s Mo."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the server rejects corrupt or unrecognized audio.
 msgid "The audio could not be processed. Please try recording again."
-msgstr ""
-"L'audio n'a pas pu être traité. Veuillez essayer d'enregistrer à nouveau."
+msgstr "L'audio n'a pas pu être traité. Veuillez essayer d'enregistrer à nouveau."
 
 # smartling.placeholder_format=C
 #. Second paragraph explaining where the encryption key is stored on the entry screen.
@@ -19911,8 +19894,7 @@ msgstr ""
 #. Description explaining that the AI model provider does not store any chat data on their servers.
 msgctxt "Privacy claim description in Duck.ai chat"
 msgid "The model provider does not save this chat on their servers."
-msgstr ""
-"Le fournisseur de modèles n'enregistre pas cette discussion sur ses serveurs."
+msgstr "Le fournisseur de modèles n'enregistre pas cette discussion sur ses serveurs."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers.
@@ -19950,7 +19932,7 @@ msgstr "Thème"
 #. Text for the theme selector label that allows users to switch between Light and dark theme.
 msgctxt "Label for the theme selector feature"
 msgid "Theme"
-msgstr ""
+msgstr "Thème"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/LpFhb1e.png
@@ -19972,8 +19954,7 @@ msgstr "Thèmes"
 #. Inform the users that "something" went wrong and we are unable to show any results.
 msgctxt "noresults"
 msgid "There was an error displaying the search results."
-msgstr ""
-"Une erreur s'est produite lors de l'affichage des résultats de recherche."
+msgstr "Une erreur s'est produite lors de l'affichage des résultats de recherche."
 
 # smartling.placeholder_format=C
 #. Error message displayed when there was an issue in saving the chat locally to the browser's storage
@@ -20146,15 +20127,13 @@ msgstr ""
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
-msgstr ""
-"Ce fichier est trop volumineux. La taille maximale du fichier est de %1$s Mo"
+msgstr "Ce fichier est trop volumineux. La taille maximale du fichier est de %1$s Mo"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB."
-msgstr ""
-"Ce fichier est trop volumineux. La taille maximale du fichier est de %1$s Mo."
+msgstr "Ce fichier est trop volumineux. La taille maximale du fichier est de %1$s Mo."
 
 # smartling.placeholder_format=C
 #. Generic error message displayed when the user tries to upload an unsupported file type and we cannot determine the accepted types
@@ -20192,8 +20171,7 @@ msgstr ""
 #. Error message displayed when the user tries to upload an unsupported file type and we know which types are accepted. Placeholder is a single accepted type. E.g. This file type is not supported, please attach a PDF
 msgctxt "Error message when an uploaded file type is not supported"
 msgid "This file type is not supported, please attach a %s."
-msgstr ""
-"Ce type de fichier n’est pas pris en charge ; veuillez joindre un %1$s."
+msgstr "Ce type de fichier n’est pas pris en charge ; veuillez joindre un %1$s."
 
 # smartling.placeholder_format=C
 #. Generic error message displayed when the user tries to upload an unsupported file type and we cannot determine the accepted types
@@ -20256,8 +20234,8 @@ msgid ""
 "Other model providers follow a zero data retention model."
 msgstr ""
 "Ce fournisseur de modèles supprime les données associées à cette discussion "
-"dans les 30 jours. D'autres fournisseurs de modèles suivent un modèle de non-"
-"conservation des données."
+"dans les 30 jours. D'autres fournisseurs de modèles suivent un modèle de "
+"non-conservation des données."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers, and that other providers may retain chat data for a limited time instead.
@@ -20363,8 +20341,7 @@ msgstr ""
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr ""
-"Cette page web n'utilise pas de connexion sécurisée et cryptée (HTTPS)."
+msgstr "Cette page web n'utilise pas de connexion sécurisée et cryptée (HTTPS)."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -20505,8 +20482,7 @@ msgstr "Souligner le titre"
 # smartling.placeholder_format=C
 #. Informative header on a list of steps for the user to take to disable their adblocker
 msgid "To allowlist DuckDuckGo in other ad blocker extensions:"
-msgstr ""
-"Pour autoriser DuckDuckGo dans d'autres extensions de blocage de publicités :"
+msgstr "Pour autoriser DuckDuckGo dans d'autres extensions de blocage de publicités :"
 
 # smartling.placeholder_format=C
 #. Text stating agreement to Duck.ai Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'To continue, you must agree to Duck.ai’s Privacy Policy and Terms of Service'
@@ -20520,8 +20496,7 @@ msgstr "Pour continuer, vous devez accepter la %1$s et les %2$s de Duck.ai"
 msgctxt ""
 "Copy stating agreement to AI Chat Privacy Policy and Terms of Service."
 msgid "To continue, you must agree to DuckDuckGo AI Chat’s %s and %s"
-msgstr ""
-"Pour continuer, vous devez accepter la %1$s et les %2$s de DuckDuckGo AI Chat"
+msgstr "Pour continuer, vous devez accepter la %1$s et les %2$s de DuckDuckGo AI Chat"
 
 # smartling.placeholder_format=C
 #. Instructions for how to print driving directions.
@@ -20821,13 +20796,13 @@ msgstr ""
 #. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Translate this page"
-msgstr ""
+msgstr "Traduis cette page"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
 msgctxt "Page suggestion prompt"
 msgid "Translate this page into %s."
-msgstr ""
+msgstr "Traduis cette page en %1$s."
 
 # smartling.placeholder_format=C
 #. Placeholder text for a region that will display translated text.
@@ -20929,8 +20904,7 @@ msgstr "Essayez %1$s pour ne plus voir de messages comme celui-ci."
 #. Text for a promotional card that encourages users to try the encrypted AI model whose inference runs in a confidential environment so the model provider cannot access user data. %s is replaced with the model's full display name (e.g. 'GPT-OSS 120B').
 msgctxt "Promotional text for encrypted AI model"
 msgid "Try %s, our first model with zero provider visibility."
-msgstr ""
-"Essayez %1$s, notre premier modèle sans aucune visibilité du fournisseur."
+msgstr "Essayez %1$s, notre premier modèle sans aucune visibilité du fournisseur."
 
 # smartling.placeholder_format=C
 msgid "Try %sDuck.ai%s, our private AI chat service:"
@@ -20975,7 +20949,7 @@ msgstr "Essayer gratuitement"
 #. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
 msgctxt "settings"
 msgid "Try It Now"
-msgstr ""
+msgstr "Essayer maintenant"
 
 # smartling.placeholder_format=C
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -21041,16 +21015,14 @@ msgstr ""
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
 msgctxt "precise_user_location"
 msgid "Try enabling anonymous location for more accurate results."
-msgstr ""
-"Essayez d'activer la géolocalisation anonyme pour des résultats plus précis."
+msgstr "Essayez d'activer la géolocalisation anonyme pour des résultats plus précis."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the screen of the onboarding where the user picks a chat model.
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr ""
-"N’hésitez pas à essayer chaque modèle pour obtenir des réponses différentes."
+msgstr "N’hésitez pas à essayer chaque modèle pour obtenir des réponses différentes."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
@@ -21182,15 +21154,13 @@ msgstr "Essayez les logiciels open source %1$s et %2$s récemment ajoutés"
 #. Text for a promotional card that encourages users to try the recently added open-source AI models Llama 3.1 and Mixtral.
 msgctxt "Promotional text for new AI models"
 msgid "Try the recently added open-source Llama 3.1 and Mixtral"
-msgstr ""
-"Essayez les logiciels open source Llama 3.1 et Mixtral récemment ajoutés"
+msgstr "Essayez les logiciels open source Llama 3.1 et Mixtral récemment ajoutés"
 
 # smartling.placeholder_format=C
 #. Message displayed to suggest the user to try the provided prompts or enter their own.
 msgctxt "Prompt suggestion message"
 msgid "Try these prompts to get started or enter your own prompt below"
-msgstr ""
-"Essayez ces prompts pour commencer ou saisissez les vôtres ci-dessous :"
+msgstr "Essayez ces prompts pour commencer ou saisissez les vôtres ci-dessous :"
 
 # smartling.placeholder_format=C
 #. Description for the empty state displayed when searching recent chats in Duck.ai returns no results, suggesting the user rephrase their search query.
@@ -21198,8 +21168,7 @@ msgctxt ""
 "Description shown when a chat search in Duck.ai returns no matching chats, "
 "suggesting the user rephrase their query"
 msgid "Try using a different search term or phrase."
-msgstr ""
-"Essayez d'utiliser un autre terme ou une autre expression de recherche."
+msgstr "Essayez d'utiliser un autre terme ou une autre expression de recherche."
 
 # smartling.placeholder_format=C
 #. In the context of an AI Chat, text prompting the user to try their prompt with a different AI model.
@@ -21225,6 +21194,9 @@ msgid ""
 "Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
+"Vous essayez de désactiver les fonctionnalités d'IA ? Installez l'extension "
+"de recherche %1$sDuckDuckGo No AI%2$s pour mémoriser vos paramètres. %3$sEn "
+"savoir plus%4$s"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -21233,6 +21205,9 @@ msgid ""
 "Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
+"Vous essayez de désactiver les fonctionnalités d'IA ? Passez à l'extension "
+"de recherche %1$sDuckDuckGo No AI%2$s pour mémoriser vos paramètres. %3$sEn "
+"savoir plus%4$s"
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -21351,8 +21326,7 @@ msgstr "Activez la « position exacte » pour des résultats plus précis."
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on “Use precise location” for more accurate results."
-msgstr ""
-"Activez « Utiliser la position exacte » pour des résultats plus précis."
+msgstr "Activez « Utiliser la position exacte » pour des résultats plus précis."
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Create Image' label in the Tools dropdown.
@@ -21545,20 +21519,18 @@ msgstr ""
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
 msgstr ""
-"Sous %1$sAu démarrage%2$s, séléctionnez %3$sPage d'accueil%4$s et "
-"saisissez : https://duckduckgo.com"
+"Sous %1$sAu démarrage%2$s, séléctionnez %3$sPage d'accueil%4$s et saisissez "
+": https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sOpen with%s select %sA specific page or pages%s"
-msgstr ""
-"Sous %1$sOuvrir avec%2$s, sélectionnez %3$sUne ou des pages spécifiques%4$s"
+msgstr "Sous %1$sOuvrir avec%2$s, sélectionnez %3$sUne ou des pages spécifiques%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
-msgstr ""
-"Sous %1$sDÉMARRAGE > Page d'accueil%2$s saisissez : https://duckduckgo.com"
+msgstr "Sous %1$sDÉMARRAGE > Page d'accueil%2$s saisissez : https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -22001,7 +21973,7 @@ msgstr "Uruguay"
 #. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
 msgctxt "Navigation label on the Duck.ai settings page"
 msgid "Usage"
-msgstr ""
+msgstr "Utilisation"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -22236,8 +22208,7 @@ msgstr "Voir les prix de votre séjour"
 # smartling.placeholder_format=C
 #. A description for the ads tooltip that explains that viewing ads is privacy protected by DuckDuckGo.
 msgid "Viewing ads is privacy protected by DuckDuckGo."
-msgstr ""
-"DuckDuckGo protège la confidentialité lors de la consultation des publicités."
+msgstr "DuckDuckGo protège la confidentialité lors de la consultation des publicités."
 
 # smartling.placeholder_format=C
 msgctxt "Ads GDPR, internal use only. Do not change"
@@ -22317,9 +22288,9 @@ msgid ""
 "On” under Sync & Backup and select “Sync With Another Device”. Or scan the "
 "QR on your Recovery PDF."
 msgstr ""
-"Visitez Duck.ai dans votre autre navigateur et ouvrez les paramètres de Duck."
-"ai. Sélectionnez « Activer » sous Sync & Backup, puis « Synchroniser avec un "
-"autre appareil ». Ou scannez le code QR figurant sur votre PDF de "
+"Visitez Duck.ai dans votre autre navigateur et ouvrez les paramètres de "
+"Duck.ai. Sélectionnez « Activer » sous Sync & Backup, puis « Synchroniser "
+"avec un autre appareil ». Ou scannez le code QR figurant sur votre PDF de "
 "récupération."
 
 # smartling.placeholder_format=C
@@ -22463,7 +22434,7 @@ msgstr "Pays de Galles"
 #. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Walk me through the steps"
-msgstr ""
+msgstr "M'expliquer les étapes"
 
 # smartling.placeholder_format=C
 #. Label for walking directions on a map.
@@ -22594,6 +22565,9 @@ msgid ""
 "please share this conversation with DuckDuckGo so we can investigate and "
 "address the issue."
 msgstr ""
+"Seuls les problèmes que nous voyons peuvent être résolus. Pour signaler une "
+"réponse dangereuse ou illégale, veuillez partager cette conversation avec "
+"DuckDuckGo afin que nous puissions enquêter et résoudre le problème."
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -22771,8 +22745,7 @@ msgstr "Nous avons perdu la connexion ; veuillez réessayer plus tard."
 #. We store chats for 15 minutes in the BE. If the user tries to fetch it after the 15 minutes elapsed or if we had an issue saving it we show them this error message so they can re-submit their prompt.
 msgctxt "AI Chat: Error message for unsaved or expired chats saved in sync"
 msgid "We lost the connection. Please try sending your message again."
-msgstr ""
-"Nous avons perdu la connexion. Veuillez réessayer d'envoyer votre message."
+msgstr "Nous avons perdu la connexion. Veuillez réessayer d'envoyer votre message."
 
 # smartling.placeholder_format=C
 #. Message asking the user to disable their ad blocker, with a link to how our ads don't track you. The placeholders are for the start and end tags of that link (e.g. <a href="%">, </a>)
@@ -23035,8 +23008,7 @@ msgstr ""
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai, it's time to import your chats"
-msgstr ""
-"Bienvenue sur le nouveau Duck.ai ; il est temps d'importer vos discussions."
+msgstr "Bienvenue sur le nouveau Duck.ai ; il est temps d'importer vos discussions."
 
 # smartling.placeholder_format=C
 #. Welcome message for new DuckDuckGo users.
@@ -23171,79 +23143,79 @@ msgstr ""
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the counterarguments?"
-msgstr ""
+msgstr "Quels sont les contre-arguments ?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the hours & location?"
-msgstr ""
+msgstr "Quels sont les horaires et la situation géographique ?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key contributions of this paper?"
-msgstr ""
+msgstr "Quelles sont les contributions clés de cet article ?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key contributions?"
-msgstr ""
+msgstr "Quelles sont les contributions clés ?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key details?"
-msgstr ""
+msgstr "Quels sont les détails clés ?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key points covered in this video?"
-msgstr ""
+msgstr "Quels sont les points clés abordés dans cette vidéo ?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key points?"
-msgstr ""
+msgstr "Quels sont les points clés ?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key takeaways from this article?"
-msgstr ""
+msgstr "Quels sont les points clés de cet article ?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key takeaways?"
-msgstr ""
+msgstr "Quels sont les points clés ?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key things I will learn from this course?"
-msgstr ""
+msgstr "Quelles sont les principales choses que ce cours va m'apprendre ?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the main counterarguments or criticisms of this?"
-msgstr ""
+msgstr "Quels sont les principaux contre-arguments ou critiques à ce sujet ?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the main questions this page answers?"
-msgstr ""
+msgstr "Quelles sont les principales questions auxquelles cette page répond ?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the must-try dishes here?"
-msgstr ""
+msgstr "Quels sont les plats incontournables ici ?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
@@ -23251,18 +23223,20 @@ msgctxt "Page suggestion prompt"
 msgid ""
 "What are the opening hours, location, and contact details for this place?"
 msgstr ""
+"Quels sont les horaires d'ouverture, la situation géographique et les "
+"coordonnées de cet endroit ?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the pros and cons of this product?"
-msgstr ""
+msgstr "Quels sont les avantages et les inconvénients de ce produit ?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the pros and cons?"
-msgstr ""
+msgstr "Quels sont les avantages et les inconvénients ?"
 
 # smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
@@ -23368,14 +23342,13 @@ msgstr "Que signifie « atrium » dans le contexte médical ?"
 #. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What does this answer?"
-msgstr ""
+msgstr "À quoi cela répond-il ?"
 
 # smartling.placeholder_format=C
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
-msgstr ""
-"Quelle fonctionnalité souhaiteriez-vous que nous ajoutions ? (facultatif)"
+msgstr "Quelle fonctionnalité souhaiteriez-vous que nous ajoutions ? (facultatif)"
 
 # smartling.placeholder_format=C
 #. Header above a list of types of information that gets saved by the cloud save feature.
@@ -23387,7 +23360,7 @@ msgstr "Quelles informations sont sauvegardées ?"
 #. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What interview questions might come up for this role?"
-msgstr ""
+msgstr "Quelles questions pourraient être posées lors de l'entretien pour ce poste ?"
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -23396,8 +23369,8 @@ msgid ""
 "What is the Cloud Save bookmarklet and how does it differ from the URL "
 "parameter bookmarklet?"
 msgstr ""
-"À quoi sert le bookmarklet de sauvegarde dans le Cloud Save et en quoi est-"
-"il différent du bookmarklet avec URL de paramétrage ?"
+"À quoi sert le bookmarklet de sauvegarde dans le Cloud Save et en quoi "
+"est-il différent du bookmarklet avec URL de paramétrage ?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for looking up the capital city of Albania.
@@ -23409,7 +23382,7 @@ msgstr "Quelle est la capitale de l’Albanie ?"
 #. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What is the overall verdict and rating for this?"
-msgstr ""
+msgstr "Quel est le verdict global et la note pour ceci ?"
 
 # smartling.placeholder_format=C
 #. Link to a page with additional information.
@@ -23437,7 +23410,7 @@ msgstr "Ce que les clients en pensent :"
 #. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What should I order?"
-msgstr ""
+msgstr "Que dois-je commander ?"
 
 # smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
@@ -23455,13 +23428,13 @@ msgstr "Qu'est-ce qui n'allait pas dans la réponse ? (facultatif)"
 #. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What will I learn?"
-msgstr ""
+msgstr "Que vais-je apprendre ?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What will I need?"
-msgstr ""
+msgstr "De quoi aurai-je besoin ?"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -23486,7 +23459,7 @@ msgstr "Nouveautés"
 #. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What's the verdict?"
-msgstr ""
+msgstr "Quel est le verdict ?"
 
 # smartling.placeholder_format=C
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -23544,7 +23517,7 @@ msgstr "Quelles fonctionnalités font défaut ? (Facultatif)"
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Which features are missing? (optional)"
-msgstr ""
+msgstr "Quelles fonctionnalités font défaut ? (facultatif)"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
@@ -23567,12 +23540,14 @@ msgstr "Qui nous sommes"
 msgctxt "Page suggestion prompt"
 msgid "Who are the main cast and crew, and what else are they known for?"
 msgstr ""
+"Qui sont les acteurs principaux et l'équipe, et pour quoi d'autre sont-ils "
+"connus ?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Who is this person?"
-msgstr ""
+msgstr "Qui est cette personne ?"
 
 # smartling.placeholder_format=C
 #. Header above a collection of privacy-related links.
@@ -24037,8 +24012,7 @@ msgstr ""
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
 msgctxt "Third party map app picker feedback dialog"
 msgid "You can change this any time in %sSearch Settings%s"
-msgstr ""
-"Vous pouvez modifier cela à tout moment dans %1$sParamètres de recherche%2$s"
+msgstr "Vous pouvez modifier cela à tout moment dans %1$sParamètres de recherche%2$s"
 
 # smartling.placeholder_format=C
 #. Text explaning how to change a passphrase.
@@ -24060,8 +24034,7 @@ msgstr "Vous pouvez trouver le"
 #. Sentence shown after export, includes a placeholder for one or more filenames with bold formatting for the filename(s).
 msgctxt "duckai_migration"
 msgid "You can find the <b>%s</b> file in your downloads folder."
-msgstr ""
-"Vous trouverez le fichier <b>%1$s</b> dans votre dossier de téléchargements."
+msgstr "Vous trouverez le fichier <b>%1$s</b> dans votre dossier de téléchargements."
 
 # smartling.placeholder_format=C
 #. A link to the settings to where the user can hide the private search reminder from the filter bar of search results
@@ -24334,8 +24307,7 @@ msgstr ""
 #. Description shown when the user has reached the maximum voice chat duration.
 msgctxt "voice chat duration limit modal"
 msgid "You've reached the maximum voice chat duration for a single session."
-msgstr ""
-"Vous avez atteint la durée maximale de chat vocal lors d'une seule session."
+msgstr "Vous avez atteint la durée maximale de chat vocal lors d'une seule session."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the daily voice chat limit.
@@ -24349,8 +24321,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
 msgid "You've reached your dictation usage limit. Try again later."
-msgstr ""
-"Vous avez atteint votre limite d'utilisation de dictée. Réessayez plus tard."
+msgstr "Vous avez atteint votre limite d'utilisation de dictée. Réessayez plus tard."
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -24474,8 +24445,8 @@ msgid ""
 "Your browser provides a list of your most-visited sites. DuckDuckGo never "
 "has access to this data."
 msgstr ""
-"Votre navigateur fournit une liste des sites que vous visitez le plus."
-"DuckDuckGo n'a jamais accès à ces données."
+"Votre navigateur fournit une liste des sites que vous visitez le "
+"plus.DuckDuckGo n'a jamais accès à ces données."
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
@@ -24719,8 +24690,7 @@ msgstr "Vos recherches ne peuvent pas être reliées à vous"
 #. Confirms the recovery succeeded. The Next CTA closes the sheet.
 msgctxt "Body copy on the recover-data success sheet"
 msgid "Your synced chats are being restored to this device."
-msgstr ""
-"Vos discussions synchronisées sont en cours de restauration sur cet appareil."
+msgstr "Vos discussions synchronisées sont en cours de restauration sur cet appareil."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -24788,8 +24758,7 @@ msgstr ""
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
 msgctxt "voice chat limit modal"
 msgid "You’ve reached the voice chat limit for now. Please try again later."
-msgstr ""
-"Vous avez atteint la limite de chat vocal. Veuillez réessayer plus tard."
+msgstr "Vous avez atteint la limite de chat vocal. Veuillez réessayer plus tard."
 
 # smartling.placeholder_format=C
 #. The name of the Yucatec Maya language

--- a/locales/fr_FR/LC_MESSAGES/duckduckgo.po
+++ b/locales/fr_FR/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: fr_FR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -941,8 +941,8 @@ msgstr ""
 "AI Chat vous permet d'avoir des conversations anonymes avec des modèles de "
 "chat IA tiers. La désactivation de cette option masquera la fonctionnalité "
 "AI Chat sur DuckDuckGo Search. Vous pouvez toujours accéder à l'AI Chat "
-"lorsque ce paramètre est désactivé en consultant "
-"%1$sduckduckgo.com/aichat%2$s."
+"lorsque ce paramètre est désactivé en consultant %1$sduckduckgo.com/"
+"aichat%2$s."
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -1359,7 +1359,8 @@ msgstr "Ajouter un champ de recherche %1$s à votre site !"
 #. Prompt to add locations on a map in order to get directions.
 msgctxt "directions"
 msgid "Add a starting point and destination to find a route."
-msgstr "Ajoutez un lieu de départ et une destination pour trouver un itinéraire."
+msgstr ""
+"Ajoutez un lieu de départ et une destination pour trouver un itinéraire."
 
 # smartling.placeholder_format=C
 #. Label on the AI model card indicating the model supports file uploads.
@@ -1444,6 +1445,12 @@ msgstr "Barre d'adresse :"
 msgctxt "feedback form"
 msgid "Address is incorrect"
 msgstr "Adresse erronée"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Adjust the servings"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. as in multiple advertisements
@@ -1659,6 +1666,14 @@ msgstr "Toutes les discussions sont %1$s. L'IA peut faire des erreurs."
 msgctxt "Empty state heading in Duck.ai chat mode"
 msgid "All chats are %sprivate%s"
 msgstr "Toutes les discussions sont %1$sprivées%2$s"
+
+# smartling.placeholder_format=C
+#. Paragraph in the Privacy & Terms section of the About & Legal page in Duck.ai settings, summarizing how chats are anonymized and are not stored or used to train chat models.
+msgctxt "Privacy & Terms section description on the Duck.ai settings page"
+msgid ""
+"All chats are anonymized by DuckDuckGo, and your conversations are not used "
+"to train chat models by DuckDuckGo or the model providers"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1934,6 +1949,13 @@ msgid "Anonymous location enabled"
 msgstr "Localisation anonyme activée"
 
 # smartling.placeholder_format=C
+msgctxt "settings"
+msgid ""
+"Anonymously generates answers for search queries based on web content. "
+"Choose how often you want it to appear, or disable it completely."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Instant Answer tab name
 msgid "Answer"
 msgstr "Réponse"
@@ -2086,7 +2108,8 @@ msgstr ""
 #. Body text of the modal that asks the user if they want to clear the conversation.
 msgctxt "Modal body for clearing conversation"
 msgid "Are you sure you want to clear this conversation and start a new one?"
-msgstr "Voulez-vous vraiment effacer cette conversation et en commencer une autre ?"
+msgstr ""
+"Voulez-vous vraiment effacer cette conversation et en commencer une autre ?"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to delete their current chat, explaining that this action cannot be undone.
@@ -2216,6 +2239,12 @@ msgstr "Poser une question complémentaire"
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse
 msgid "Ask a follow-up with Duck.ai"
 msgstr "Demander un suivi avec Duck.ai"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
+msgctxt "Page suggestion chip label"
+msgid "Ask about this page"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2386,18 +2415,21 @@ msgstr "Audio"
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat ends."
-msgstr "Une fois le chat terminé, le son n'est conservé ni par nous ni par OpenAI."
+msgstr ""
+"Une fois le chat terminé, le son n'est conservé ni par nous ni par OpenAI."
 
 # smartling.placeholder_format=C
 #. Description in consent disclaimer informing that audio from the voice chat session is not stored by us or by OpenAI after the voice chat ends.
 msgctxt "voice chat"
 msgid "Audio is not stored by us or by OpenAI after the chat ends."
-msgstr "Une fois le chat terminé, le son n'est conservé ni par nous ni par OpenAI."
+msgstr ""
+"Une fois le chat terminé, le son n'est conservé ni par nous ni par OpenAI."
 
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat is transcribed."
-msgstr "Une fois le chat transcrit, le son n'est conservé ni par nous ni par OpenAI."
+msgstr ""
+"Une fois le chat transcrit, le son n'est conservé ni par nous ni par OpenAI."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when MediaRecorder API is unavailable.
@@ -2640,6 +2672,12 @@ msgid "Barcode"
 msgstr "Code-barres"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Based on this page, is this course worth taking?"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Basic"
 msgstr "Basique"
@@ -2678,6 +2716,14 @@ msgstr "Batteur"
 msgctxt "Assistant response placeholder"
 msgid "Before continuing..."
 msgstr "Avant de continuer..."
+
+# smartling.placeholder_format=C
+#. Explains that before storing the report, DuckDuckGo will anonymize the conversation by removing PII like names, email addresses, and identifying metadata.
+msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
+msgid ""
+"Before storing this report, DuckDuckGo will anonymize your conversation by "
+"removing PII like names, email addresses, and identifying metadata."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -2803,7 +2849,8 @@ msgstr "Bloquez les traqueurs d'e-mails et masquez votre adresse."
 # smartling.placeholder_format=C
 #. A disclaimer about AI-generated images in search results
 msgid "Block list is not exhaustive and may contain inaccuracies."
-msgstr "La liste de blocage n'est pas exhaustive et peut contenir des inexactitudes."
+msgstr ""
+"La liste de blocage n'est pas exhaustive et peut contenir des inexactitudes."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -2819,7 +2866,8 @@ msgstr "Bloquer ce site dans tous les résultats"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Block trackers and take control of your personal data"
-msgstr "Bloquez les traqueurs et prenez le contrôle de vos données personnelles"
+msgstr ""
+"Bloquez les traqueurs et prenez le contrôle de vos données personnelles"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -2996,6 +3044,12 @@ msgid "Break Points Won"
 msgstr "Balles de break gagnées"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Break this down into clear, numbered steps."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
 msgctxt "Weather IA"
 msgid "Breezy"
@@ -3161,7 +3215,8 @@ msgstr "En cliquant sur « %1$s », vous acceptez nos %2$s."
 msgctxt ""
 "Copy stating agreement to Duck.ai Privacy Policy and Terms of Service."
 msgid "By clicking “%s,” you accept Duck.ai’s %s and %s."
-msgstr "En cliquant sur « %1$s », vous acceptez la %2$s et les %3$s de Duck.ai."
+msgstr ""
+"En cliquant sur « %1$s », vous acceptez la %2$s et les %3$s de Duck.ai."
 
 # smartling.placeholder_format=C
 #. Text stating agreement to Duck.ai Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'By clicking “Agree and Continue,” you accept Duck.ai’s Privacy Policy and Terms of Service.'
@@ -3456,6 +3511,12 @@ msgid "Cast"
 msgstr "Distribution"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Cast & Crew"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
 msgctxt "Tone option label for Casual"
 msgid "Casual"
@@ -3540,7 +3601,8 @@ msgstr "Change l'affichage de l'URL des résultats"
 #. This is the description of a user setting
 msgctxt "settings"
 msgid "Changes how the header is displayed and its behavior as you scroll"
-msgstr "Change l'affichage de l'en-tête ainsi que son comportement lors du défilement"
+msgstr ""
+"Change l'affichage de l'en-tête ainsi que son comportement lors du défilement"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/mcZdcaF.png
@@ -3991,7 +4053,8 @@ msgstr "Choix de modèles d'IA, y compris %1$s et %2$s"
 # smartling.placeholder_format=C
 #. As in 'Choose to keep DuckDuckGo as your default search engine'. Placeholders are for markup, you can ignore them.
 msgid "Choose %skeep it%s to continue protecting your privacy."
-msgstr "Choisissez %1$sConserver%2$s pour continuer à protéger votre confidentialité."
+msgstr ""
+"Choisissez %1$sConserver%2$s pour continuer à protéger votre confidentialité."
 
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
@@ -4343,7 +4406,8 @@ msgstr "Cliquez sur %1$sParamètres%2$s dans le menu déroulant."
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
-msgstr "Cliquez sur %1$sUtiliser les pages Web actuelles%2$s puis sur %3$sOK%4$s."
+msgstr ""
+"Cliquez sur %1$sUtiliser les pages Web actuelles%2$s puis sur %3$sOK%4$s."
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -5190,6 +5254,12 @@ msgid "Create Image"
 msgstr "Créer une image"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Create a shopping list with quantities from this recipe."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text displayed in the input field when starting a new image generation session.
 msgctxt "Placeholder text for the image generation input field"
 msgid "Create an image of a cute duck..."
@@ -5741,7 +5811,8 @@ msgstr "Discussions supprimées"
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
 msgctxt "settings"
 msgid "Deleting cookies will reset these settings."
-msgstr "La suppression des cookies aura pour effet de réinitialiser ces paramètres."
+msgstr ""
+"La suppression des cookies aura pour effet de réinitialiser ces paramètres."
 
 # smartling.placeholder_format=C
 msgid "Democratic People's Republic of Korea"
@@ -5763,7 +5834,8 @@ msgstr "Décrivez les modifications en fonction de l'image"
 #. Placeholder text displayed in the input field when the user can make follow-up edits to a generated image.
 msgctxt "Placeholder text for the image generation input field for follow-ups"
 msgid "Describe changes to continue editing this image"
-msgstr "Décrivez les modifications souhaitées pour continuer à modifier cette image"
+msgstr ""
+"Décrivez les modifications souhaitées pour continuer à modifier cette image"
 
 # smartling.placeholder_format=C
 #. Title shown when the user first enters Image Generation mode, prompting them to describe the image they want to create.
@@ -5834,6 +5906,11 @@ msgstr ""
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
 msgid "Dictation limit reached"
 msgstr "Limite de dictée atteinte"
+
+# smartling.placeholder_format=C
+#. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
+msgid "Dictation temporarily unavailable"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
@@ -5922,7 +5999,8 @@ msgstr "Désactiver et déconnecter"
 #. Title of a modal that asks the user if they want to turn off chat history and disconnect from Sync & Backup.
 msgctxt "Modal header for disabling chat history and disconnecting sync"
 msgid "Disable chat history and disconnect from Sync & Backup?"
-msgstr "Désactiver l'historique des discussions et se déconnecter de Sync & Backup ?"
+msgstr ""
+"Désactiver l'historique des discussions et se déconnecter de Sync & Backup ?"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to turn off the chat history feature.
@@ -6136,6 +6214,22 @@ msgid "Done"
 msgstr "Terminé"
 
 # smartling.placeholder_format=C
+#. Message shown in a modal after DuckDuckGo browser users disable AI features in Settings. The first two placeholders bold noai.duckduckgo.com. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
+"filtered out. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
+"and AI images filtered out. %sLearn more%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Double Faults"
@@ -6248,6 +6342,18 @@ msgid ""
 msgstr ""
 "Rédigez un e-mail en précisant les informations nécessaires afin d'obtenir "
 "un devis pour la réparation d'un réfrigérateur."
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Draft a cover letter"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Draft a cover letter for this job."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -6424,7 +6530,17 @@ msgstr ""
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
-msgstr "Duck.ai fonctionne mieux dans notre navigateur DuckDuckGo privé et gratuit !"
+msgstr ""
+"Duck.ai fonctionne mieux dans notre navigateur DuckDuckGo privé et gratuit !"
+
+# smartling.placeholder_format=C
+#. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
+msgctxt "About section description on the Duck.ai settings page"
+msgid ""
+"Duck.ai is created by DuckDuckGo. We're an independent online protection "
+"company for anyone who wants to take back control of their personal "
+"information."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
@@ -6476,6 +6592,13 @@ msgstr "Duck.ai est temporairement indisponible. Veuillez réessayer plus tard."
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
+"Duck.ai lets you chat privately with popular AI models. Disabling it hides "
+"Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
+msgstr ""
+
+# smartling.placeholder_format=C
+msgctxt "settings"
+msgid ""
 "Duck.ai lets you have anonymous conversations with 3rd-party AI chat models, "
 "including models from OpenAI, Anthropic, and others. Turning this setting "
 "off will hide Duck.ai buttons and links on DuckDuckGo Search. However, you "
@@ -6493,7 +6616,8 @@ msgstr ""
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
 msgctxt "Disclaimer text at the bottom of the feedback form."
 msgid "Duck.ai may display inaccurate or offensive information."
-msgstr "Duck.ai est susceptible d'afficher des informations inexactes ou offensantes."
+msgstr ""
+"Duck.ai est susceptible d'afficher des informations inexactes ou offensantes."
 
 # smartling.placeholder_format=C
 #. Error modal body line 2.
@@ -6509,7 +6633,8 @@ msgstr ""
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
 msgctxt "Promotional text for PDF upload feature"
 msgid "Duck.ai now can read and analyze PDFs. Give it a try!"
-msgstr "Duck.ai peut désormais lire et analyser des PDF. Essayez par vous-même !"
+msgstr ""
+"Duck.ai peut désormais lire et analyser des PDF. Essayez par vous-même !"
 
 # smartling.placeholder_format=C
 #. Disclaimer text shown above the chat input only when coming from a DuckAssist grounded response into ungrounded models.
@@ -7137,7 +7262,8 @@ msgstr "Activer les fonctionnalités d'IA"
 #. Text explaining how to enable the cloud save feature.
 msgctxt "cloudsave"
 msgid "Enable Cloud Save by entering your existing passphrase."
-msgstr "Activez la sauvegarde dans le cloud en saisissant votre phrase de passe."
+msgstr ""
+"Activez la sauvegarde dans le cloud en saisissant votre phrase de passe."
 
 # smartling.placeholder_format=C
 #. Primary button text in the dictation privacy consent modal to enable dictation.
@@ -7392,13 +7518,15 @@ msgstr ""
 #. Tells how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed location access"
-msgstr "Assurez-vous que votre navigateur est autorisé à accéder à la localisation"
+msgstr ""
+"Assurez-vous que votre navigateur est autorisé à accéder à la localisation"
 
 # smartling.placeholder_format=C
 #. Tells how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed location access."
-msgstr "Vérifiez que votre navigateur est autorisé à accéder à la localisation."
+msgstr ""
+"Vérifiez que votre navigateur est autorisé à accéder à la localisation."
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -7496,6 +7624,18 @@ msgid "Eritrea"
 msgstr "Érythrée"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Estimate the nutrition"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Estimate the nutritional information for this recipe."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Estonia"
 msgstr "Estonie"
 
@@ -7552,11 +7692,59 @@ msgid "Expires in 1 day"
 msgstr "Expire dans 1 jour"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain the accepted answer in simple terms."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
 msgstr "Explique-moi le concept de trou noir au niveau lycée."
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain the top answer"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this in simple, plain language."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this paper"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this repo"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this research paper in plain language."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this simply"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain what this repository does and how to use it."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label to show if song lyrics contain explicit content
@@ -7754,8 +7942,8 @@ msgid ""
 "Feel free to adjust the settings below. Then, just copy and paste the code "
 "into your website."
 msgstr ""
-"Ajustez les paramètres ci-dessous comme bon vous semble. Ensuite, "
-"copiez-collez le code dans votre site."
+"Ajustez les paramètres ci-dessous comme bon vous semble. Ensuite, copiez-"
+"collez le code dans votre site."
 
 # smartling.placeholder_format=C
 msgid "Fiji"
@@ -7832,7 +8020,8 @@ msgstr "Filtres inefficaces"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Filters out AI-generated images from image search results"
-msgstr "Filtre les images générées par l'IA des résultats de recherche d'images"
+msgstr ""
+"Filtre les images générées par l'IA des résultats de recherche d'images"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -7841,6 +8030,12 @@ msgid ""
 msgstr ""
 "Filtre les images générées par l’IA dans les résultats de recherche "
 "d’images. %1$sEn savoir plus%2$s"
+
+# smartling.placeholder_format=C
+msgctxt "settings"
+msgid ""
+"Filters out known AI spam sites from image search results. %sLearn More%s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the final score of a sporting event.
@@ -7881,7 +8076,8 @@ msgstr "Vous trouverez <b>%1$s</b> dans votre dossier de téléchargements"
 # smartling.placeholder_format=C
 #. Tells users how to change their default search engine to DuckDuckGo.
 msgid "Find DuckDuckGo in the displayed list and click %sMake Default%s"
-msgstr "Cherchez DuckDuckGo dans la liste et cliquez sur %1$sDéfinir par défaut%2$s"
+msgstr ""
+"Cherchez DuckDuckGo dans la liste et cliquez sur %1$sDéfinir par défaut%2$s"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for finding a better word.
@@ -7894,6 +8090,12 @@ msgstr "Trouver un meilleur mot"
 msgctxt "Subtitle for the Web Search tool entry in the Tools dropdown menu"
 msgid "Find current information"
 msgstr "Trouver des informations actuelles"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Find me alternatives"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button that searches for results closer to the user's current location.
@@ -7986,7 +8188,8 @@ msgstr ""
 #. Privacy reassurance and instructions intro.
 msgctxt "duckai_migration"
 msgid "Follow these steps to move your chats to the new Duck.ai"
-msgstr "Suivez ces étapes pour déplacer vos discussions vers le nouveau Duck.ai"
+msgstr ""
+"Suivez ces étapes pour déplacer vos discussions vers le nouveau Duck.ai"
 
 # smartling.placeholder_format=C
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse on mobile
@@ -8207,8 +8410,8 @@ msgid ""
 "strong>."
 msgstr ""
 "Dans la barre de menu de l'application sur Mac, sélectionnez "
-"<strong>DuckDuckGo</strong> &gt; <strong>Rechercher des mises à "
-"jour…</strong>, puis sélectionnez <strong>Installer la mise à jour</strong>."
+"<strong>DuckDuckGo</strong> &gt; <strong>Rechercher des mises à jour…</"
+"strong>, puis sélectionnez <strong>Installer la mise à jour</strong>."
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -8374,6 +8577,12 @@ msgstr "Générer une image"
 #. Text for the button that generates more of an answer from duckassist when the answer has come from a collapsed state
 msgid "Generate More"
 msgstr "Générer plus"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Generate a shopping list"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
@@ -8673,10 +8882,17 @@ msgid "Give it a Try"
 msgstr "Essayez par vous-même"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Give me a quick background on this person."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
-msgstr "Accédez à %1$sConfidentialité et sécurité > Services de localisation%2$s"
+msgstr ""
+"Accédez à %1$sConfidentialité et sécurité > Services de localisation%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -8941,7 +9157,8 @@ msgstr "Guatemala"
 #. Text for a prompt suggestion for guiding through the basic steps of replacing a window wiper.
 msgctxt "Full sentence for learning a new skill"
 msgid "Guide me through the basic steps of replacing a window wiper."
-msgstr "Explique-moi les principales étapes à suivre pour remplacer un essuie-glace."
+msgstr ""
+"Explique-moi les principales étapes à suivre pour remplacer un essuie-glace."
 
 # smartling.placeholder_format=C
 msgid "Guinea"
@@ -9120,6 +9337,18 @@ msgid "Help Spread Privacy"
 msgstr "Aidez-nous à promouvoir la vie privée"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Help me prep for the interview"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Help me tailor my resume for this job."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title of a SERP popup that invites users to take a survey (desktop only)
 msgctxt "User survey popup"
 msgid "Help us improve DuckDuckGo"
@@ -9129,7 +9358,8 @@ msgstr "Aide-nous à améliorer DuckDuckGo"
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Help us improve DuckDuckGo searches with your feedback"
-msgstr "Aidez-nous à améliorer les recherches DuckDuckGo grâce à vos commentaires"
+msgstr ""
+"Aidez-nous à améliorer les recherches DuckDuckGo grâce à vos commentaires"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -9187,7 +9417,8 @@ msgstr "Aidez votre famille et vos ami(e)s à rejoindre le côté Duck !"
 #. Text description for the Spread card in the SERP footer
 msgctxt "footer_card"
 msgid "Help your friends and family take back their privacy!"
-msgstr "Aidez vos amis et votre famille à reprendre le contrôle de leur vie privée !"
+msgstr ""
+"Aidez vos amis et votre famille à reprendre le contrôle de leur vie privée !"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -9583,7 +9814,8 @@ msgstr "À quelle fréquence souhaitez-vous voir des réponses %1$s ?"
 #. A header for the feedback form in the assist negative feedback flow. The user is being asked to update how often they want AI-assisted answers to appear.
 msgctxt "duckassist"
 msgid "How often do you want to see AI-assisted answers?"
-msgstr "À quelle fréquence souhaitez-vous voir des réponses assistées par l’IA ?"
+msgstr ""
+"À quelle fréquence souhaitez-vous voir des réponses assistées par l’IA ?"
 
 # smartling.placeholder_format=C
 #. Section title above the frequency radio options in the Search Assist settings modal.
@@ -9638,6 +9870,14 @@ msgstr "Ouragan"
 msgctxt "Onboarding terms screen button text"
 msgid "I Agree"
 msgstr "Je suis d'accord"
+
+# smartling.placeholder_format=C
+#. Text for the button that takes the user to the external DuckDuckGo login subscription page.
+msgctxt ""
+"Text for the I already have a subscription button in the Duck.ai settings "
+"page"
+msgid "I Already Have a Subscription"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the button that takes the user to the login subscription page.
@@ -9864,7 +10104,8 @@ msgstr "Les prompts d’image doivent respecter les %1$s"
 msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
-msgstr "Les prompts relatifs aux images doivent être conformes aux %1$s de Duck.ai."
+msgstr ""
+"Les prompts relatifs aux images doivent être conformes aux %1$s de Duck.ai."
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -10218,6 +10459,12 @@ msgid "Install Mac Browser"
 msgstr "Installer le navigateur Mac"
 
 # smartling.placeholder_format=C
+#. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
+msgctxt "settings"
+msgid "Install Now"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of a button to install the DuckDuckGo app
 msgctxt "Serp footer content"
 msgid "Install Our App"
@@ -10315,10 +10562,42 @@ msgid "Is deleted data really deleted?"
 msgstr "Les données supprimées sont-elles réellement supprimées ?"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is it worth taking?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this place any good?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"Is this place any good? Summarize its reputation based on reviews and "
+"ratings."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "Is this video helpful?"
 msgstr "Cette vidéo est-elle utile ?"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this worth watching?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Is this worth watching? Give me a spoiler-free take."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -10344,7 +10623,8 @@ msgstr "Cela peut prendre quelques minutes."
 #. Body text of a card that promotes installing the DuckDuckGo desktop browser.
 msgctxt "new tab page"
 msgid "It's fast, free, and gives you even more online protection."
-msgstr "Il est rapide, gratuit et vous offre encore plus de protection en ligne."
+msgstr ""
+"Il est rapide, gratuit et vous offre encore plus de protection en ligne."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -10934,6 +11214,12 @@ msgid "Links:"
 msgstr "Liens :"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "List the tools, materials, or prerequisites I need for this."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
 msgid "Listen"
 msgstr "Écouter"
@@ -11342,6 +11628,12 @@ msgstr "Gérer votre abonnement"
 msgctxt "Exclusion message manage sites button"
 msgid "Manage blocked sites"
 msgstr "Gérer les sites bloqués"
+
+# smartling.placeholder_format=C
+#. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
+msgctxt "setting"
+msgid "Manage in Browser Settings"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to the site exclusion settings page
@@ -13103,7 +13395,8 @@ msgstr "Oman"
 #. http://i.imgur.com/zQWKLIm.png
 msgctxt "settings"
 msgid "Omits objectionable (mostly adult) material"
-msgstr "Omet le contenu à caractère sensible (principalement du contenu pour adulte)"
+msgstr ""
+"Omet le contenu à caractère sensible (principalement du contenu pour adulte)"
 
 # smartling.placeholder_format=C
 msgid "On"
@@ -13284,7 +13577,8 @@ msgstr "Ouvrir %1$sParamètres%2$s"
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open 'Location', and ensure location is %senabled%s."
-msgstr "Ouvrez « Localisation » et vérifiez que la localisation est %1$sactivée%2$s."
+msgstr ""
+"Ouvrez « Localisation » et vérifiez que la localisation est %1$sactivée%2$s."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -13427,7 +13721,8 @@ msgstr "Ouvrir le volet « Comment fonctionne Duck.ai »"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open the Safari menu and select %sSettings for DuckDuckGo...%s"
-msgstr "Ouvrez le menu Safari et sélectionnez %1$sRéglages pour DuckDuckGo...%2$s"
+msgstr ""
+"Ouvrez le menu Safari et sélectionnez %1$sRéglages pour DuckDuckGo...%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the time a business opens. For example: 'Opens at 10am'
@@ -14187,6 +14482,12 @@ msgstr ""
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
+msgid "Please describe why the chat response is harmful or illegal. (optional)"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
+msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
 msgstr ""
 "Veuillez expliquer pourquoi la réponse du chat est illégale ou dangereuse. "
@@ -14213,6 +14514,14 @@ msgid ""
 msgstr ""
 "Remarque : si vous démarrez un nouveau chat, quel que soit le modèle, votre "
 "session en cours sera supprimée."
+
+# smartling.placeholder_format=C
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
+msgctxt "Feedback prompt"
+msgid ""
+"Please paste your prompt and the problematic output (with any personal "
+"information removed) and describe why the content is harmful or illegal."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -14683,6 +14992,12 @@ msgid "Privacy"
 msgstr "Confidentialité"
 
 # smartling.placeholder_format=C
+#. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
+msgctxt "Section heading on the Duck.ai settings page"
+msgid "Privacy & Terms"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Privacy Blog"
 msgstr "Blog confidentiel"
 
@@ -14751,6 +15066,12 @@ msgstr "Politique de confidentialité et Conditions d’utilisation"
 msgctxt "Copy used to compose link in sentences"
 msgid "Privacy Policy and Terms of Service"
 msgstr "Politique de confidentialité et conditions d'utilisation"
+
+# smartling.placeholder_format=C
+#. Text for a button that links to the terms of use and privacy policy page.
+msgctxt "Secondary button text in active privacy modal"
+msgid "Privacy Policy and Terms of Service"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title displayed on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
@@ -15257,6 +15578,30 @@ msgid "Recommend a book"
 msgstr "Recommander un livre"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar books"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar books."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar movies or shows."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar titles"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
 msgid "Recording failed. Please try again."
 msgstr "L'enregistrement a échoué. Veuillez réessayer."
@@ -15480,7 +15825,8 @@ msgstr "Mémoriser mon choix"
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings
 msgid "Remember my choice (this can be changed in %s%s%sSettings%s)"
-msgstr "Se souvenir de mon choix (peut être changé dans %1$s%2$s%3$sParamètres%4$s)"
+msgstr ""
+"Se souvenir de mon choix (peut être changé dans %1$s%2$s%3$sParamètres%4$s)"
 
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
@@ -15659,6 +16005,15 @@ msgstr ""
 # smartling.placeholder_format=C
 msgid "Republic of Moldova"
 msgstr "République de Moldavie"
+
+# smartling.placeholder_format=C
+#. Note indicating that sharing the conversation is mandatory when reporting harmful or illegal content. Rendered alongside the standard share label (DUCKCHAT_RESPONSE_FEEDBACK_SHARE_PROMPT_RESPONSE_LABEL), not replacing it.
+msgctxt ""
+"Note shown under the share-content switch label on the Duck.ai response "
+"feedback form when the user has selected Harmful or Illegal as the feedback "
+"reason"
+msgid "Required for harmful or illegal reports"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
@@ -15898,6 +16253,12 @@ msgstr "Avis"
 msgctxt "maps_places"
 msgid "Reviews"
 msgstr "Avis"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Rewrite this recipe scaled for a different number of servings."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Romania"
@@ -16348,7 +16709,8 @@ msgstr ""
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Scroll down and locate %syour browser%s in the list."
-msgstr "Faites défiler la liste vers le bas et localisez %1$svotre navigateur%2$s."
+msgstr ""
+"Faites défiler la liste vers le bas et localisez %1$svotre navigateur%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service.
@@ -16905,31 +17267,35 @@ msgstr "Sélectionner %1$s%2$s%3$s, puis %4$sMoteur de recherche%5$s"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %s'Setting for this Website...'%s from the Safari menu."
-msgstr "Sélectionnez %1$s« Réglages pour ce site Web... »%2$s dans le menu Safari."
+msgstr ""
+"Sélectionnez %1$s« Réglages pour ce site Web... »%2$s dans le menu Safari."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
 msgstr ""
-"Selectionnez %1$sPersonnaliser%2$s et saisissez "
-"%3$shttps://duckduckgo.com%4$s dans le champ de saisie"
+"Selectionnez %1$sPersonnaliser%2$s et saisissez %3$shttps://duckduckgo."
+"com%4$s dans le champ de saisie"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
-msgstr "Sélectionnez %1$sDuckDuckGo%2$s, puis cliquez sur %3$sAjouter par défaut%4$s!"
+msgstr ""
+"Sélectionnez %1$sDuckDuckGo%2$s, puis cliquez sur %3$sAjouter par défaut%4$s!"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s"
-msgstr "Sélectionnez %1$sDuckDuckGo%2$s et cliquez sur %3$sDéfinir par défaut%4$s"
+msgstr ""
+"Sélectionnez %1$sDuckDuckGo%2$s et cliquez sur %3$sDéfinir par défaut%4$s"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s."
-msgstr "Sélectionnez %1$sDuckDuckGo%2$s et cliquez sur %3$sDéfinir par défaut%4$s."
+msgstr ""
+"Sélectionnez %1$sDuckDuckGo%2$s et cliquez sur %3$sDéfinir par défaut%4$s."
 
 #  Firefox 33
 # smartling.placeholder_format=C
@@ -16970,7 +17336,8 @@ msgstr "Sélectionnez %1$sDuckDuckGo%2$s!"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Select %sEdit Search Engines...%sin the dropdown"
-msgstr "Sélectionnez %1$sModifier les moteurs de recherche…%2$sdans le menu déroulant"
+msgstr ""
+"Sélectionnez %1$sModifier les moteurs de recherche…%2$sdans le menu déroulant"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -17044,7 +17411,8 @@ msgstr "Sélectionnez %1$sRéglages%2$s, puis %3$sRéglages avancés%4$s"
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sDefault search engine%s"
-msgstr "Sélectionnez %1$sRéglages%2$s, puis %3$sMoteur de recherche par défaut%4$s"
+msgstr ""
+"Sélectionnez %1$sRéglages%2$s, puis %3$sMoteur de recherche par défaut%4$s"
 
 #  Chrome/Firefox on Android
 # smartling.placeholder_format=C
@@ -17105,7 +17473,8 @@ msgstr "Sélectionnez tous les carrés contenant un canard :"
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select an option to %sallow%s location access"
-msgstr "Sélectionnez une option pour %1$sautoriser%2$s l'accès à la localisation"
+msgstr ""
+"Sélectionnez une option pour %1$sautoriser%2$s l'accès à la localisation"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -17140,7 +17509,8 @@ msgstr "Texte sélectionné de %1$s"
 #. Displayed when the user's text selection exceeds the maximum message size for AI tools (summary, translation, etc.).
 msgctxt "Error message for selection input limit"
 msgid "Selected text is too long. Try again with a shorter selection."
-msgstr "Le texte sélectionné est trop long. Réessayez avec une sélection plus courte."
+msgstr ""
+"Le texte sélectionné est trop long. Réessayez avec une sélection plus courte."
 
 # smartling.placeholder_format=C
 #. Label for the semi-finals knockout stage in e.g. the soccer World Cup
@@ -17260,6 +17630,12 @@ msgstr "Configurer"
 msgctxt "Setup button for native sync flow"
 msgid "Set Up Now"
 msgstr "Configurer maintenant"
+
+# smartling.placeholder_format=C
+#. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
+msgctxt "Encrypted storage setup button shown in native browsers"
+msgid "Set Up Sync & Backup"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
@@ -17441,6 +17817,13 @@ msgstr "Partager l'URL de la page"
 msgctxt "feedback form"
 msgid "Share positive feedback"
 msgstr "Partager des commentaires positifs"
+
+# smartling.placeholder_format=C
+#. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
+msgctxt ""
+"Label beside the share-content switch on the Duck.ai response feedback form"
+msgid "Share this conversation with DuckDuckGo"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -17901,7 +18284,8 @@ msgstr "Montre l'arrière-plan du bouton de recherche"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message on top of the search results page"
-msgstr "Affiche un message de bienvenue en haut de la page des résultats de recherche"
+msgstr ""
+"Affiche un message de bienvenue en haut de la page des résultats de recherche"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18100,7 +18484,8 @@ msgstr "Résolvez des problèmes complexes grâce au mode de raisonnement !"
 #. Text for a promotional card that encourages users to try the reasoning mode on complex problems which thinks longer to hopefully provide a more accurate answer.
 msgctxt "Promotional text for reasoning mode"
 msgid "Solve complex problems with the new reasoning mode!"
-msgstr "Résolvez des problèmes complexes grâce au nouveau mode de raisonnement !"
+msgstr ""
+"Résolvez des problèmes complexes grâce au nouveau mode de raisonnement !"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that encourages users to try the reasoning mode on complex problems which thinks longer to hopefully provide a more accurate answer.
@@ -18160,7 +18545,8 @@ msgstr "Parfois"
 #. Generic error message shown when the image generation model cannot process the user's request.
 msgctxt "Error message from the image generation model"
 msgid "Sorry I can't help, please describe your image in a different way."
-msgstr "Désolé, je ne peux pas vous aider, veuillez décrire votre image différemment."
+msgstr ""
+"Désolé, je ne peux pas vous aider, veuillez décrire votre image différemment."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -18493,7 +18879,8 @@ msgstr "Reste sur DuckDuckGo"
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletter."
-msgstr "Restez protégé(e) et informé(e) avec notre newsletter sur la confidentialité."
+msgstr ""
+"Restez protégé(e) et informé(e) avec notre newsletter sur la confidentialité."
 
 # smartling.placeholder_format=C
 #. Prompt to subscribe to a newsletter.
@@ -18548,7 +18935,8 @@ msgstr "Arrêtez les traqueurs qui se cachent sur d'autres sites Web."
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop most hidden trackers lurking on other websites."
-msgstr "Arrêtez la plupart des traqueurs qui se cachent sur d'autres sites Web."
+msgstr ""
+"Arrêtez la plupart des traqueurs qui se cachent sur d'autres sites Web."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18638,8 +19026,8 @@ msgid ""
 "Subscribe to DuckDuckGo to unlock higher limits in Duck.ai, or come back "
 "later to create more images."
 msgstr ""
-"Abonnez-vous à DuckDuckGo pour débloquer des limites plus élevées dans "
-"Duck.ai, ou revenez plus tard pour créer plus d'images."
+"Abonnez-vous à DuckDuckGo pour débloquer des limites plus élevées dans Duck."
+"ai, ou revenez plus tard pour créer plus d'images."
 
 # smartling.placeholder_format=C
 #. Description shown to free users who have reached their image generation limit, encouraging them to subscribe.
@@ -18718,6 +19106,24 @@ msgid "Suggest a title for a blog post"
 msgstr "Suggérer un titre pour un article de blog"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest related articles or topics worth exploring next."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Suggest related articles to explore"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest some alternatives to this product."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
 msgctxt "directions"
 msgid "Suggestions:"
@@ -18729,10 +19135,100 @@ msgid "Suggestions:"
 msgstr "Suggestions :"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Sum up the reviews"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A short title for the a message asking the AI to summarize a text.
 msgctxt "Title for the summarize message"
 msgid "Summarize"
 msgstr "Résumer"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize the Q&As"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the background and notable work of this person."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the key details of this event."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the questions and answers on this page."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize their background"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this book"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this book."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this discussion"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this discussion thread."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this page"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this page."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this video"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this video."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize what the reviews say."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -19012,8 +19508,8 @@ msgstr ""
 "%1$s\n"
 "\n"
 "Comment fonctionne ce code ?\n"
-"1. Accédez à Duck.ai dans votre navigateur et ouvrez les paramètres de "
-"Duck.ai.\n"
+"1. Accédez à Duck.ai dans votre navigateur et ouvrez les paramètres de Duck."
+"ai.\n"
 "2. Sélectionnez « Activer Sync & Backup », puis « Récupérer les données "
 "synchronisées »\n"
 "3. Copiez le code de récupération ci-dessus et collez-le là où il est écrit "
@@ -19064,6 +19560,12 @@ msgid "Syria"
 msgstr "Syrie"
 
 # smartling.placeholder_format=C
+#. Text for a button that enables the theme to follow the operating system's color scheme preference.
+msgctxt "System theme button for theme selector"
+msgid "System"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Abbreviation indicating this is the total score for a game
 msgctxt "Sports module"
 msgid "T"
@@ -19090,6 +19592,12 @@ msgstr "Télévision"
 msgctxt "language_name"
 msgid "Tahitian"
 msgstr "Tahitien"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Tailor my resume"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Taiwan"
@@ -19119,6 +19627,13 @@ msgstr "Reprenez le contrôle de vos données personnelles"
 msgctxt "homepage ATB modal"
 msgid "Take control of your personal data!"
 msgstr "Reprenez le contrôle de vos données personnelles !"
+
+# smartling.placeholder_format=C
+#. Description for the Feedback section of the Duck.ai settings page, asking the user to take an anonymous survey to let us know how we can make Duck.ai better.
+msgctxt "Feedback section description on the Duck.ai settings page"
+msgid ""
+"Take this anonymous survey to let us know how we can make Duck.ai better."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -19317,13 +19832,15 @@ msgstr "Merci pour vos commentaires !"
 #. Inform the users that "something" went wrong and we are unable to show any results.
 msgctxt "noresults"
 msgid "Thanks for your patience while we get our ducks in a row!"
-msgstr "Merci pour votre patience pendant que nous mettons les choses en ordre !"
+msgstr ""
+"Merci pour votre patience pendant que nous mettons les choses en ordre !"
 
 # smartling.placeholder_format=C
 #. Inform the users that "something" went wrong and we are unable to show any results.
 msgctxt "noresults"
 msgid "Thanks for your patience while we get our ducks in a row."
-msgstr "Merci pour votre patience pendant que nous mettons les choses en ordre."
+msgstr ""
+"Merci pour votre patience pendant que nous mettons les choses en ordre."
 
 # smartling.placeholder_format=C
 #. Message indicating that the open lock icon in the address bar means that a website is not secure.
@@ -19368,7 +19885,8 @@ msgstr "Les fichiers joints dépassent la limite totale de taille de %1$s Mo."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the server rejects corrupt or unrecognized audio.
 msgid "The audio could not be processed. Please try recording again."
-msgstr "L'audio n'a pas pu être traité. Veuillez essayer d'enregistrer à nouveau."
+msgstr ""
+"L'audio n'a pas pu être traité. Veuillez essayer d'enregistrer à nouveau."
 
 # smartling.placeholder_format=C
 #. Second paragraph explaining where the encryption key is stored on the entry screen.
@@ -19393,7 +19911,8 @@ msgstr ""
 #. Description explaining that the AI model provider does not store any chat data on their servers.
 msgctxt "Privacy claim description in Duck.ai chat"
 msgid "The model provider does not save this chat on their servers."
-msgstr "Le fournisseur de modèles n'enregistre pas cette discussion sur ses serveurs."
+msgstr ""
+"Le fournisseur de modèles n'enregistre pas cette discussion sur ses serveurs."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers.
@@ -19428,6 +19947,12 @@ msgid "Theme"
 msgstr "Thème"
 
 # smartling.placeholder_format=C
+#. Text for the theme selector label that allows users to switch between Light and dark theme.
+msgctxt "Label for the theme selector feature"
+msgid "Theme"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. http://i.imgur.com/LpFhb1e.png
 msgctxt "settings"
 msgid "Theme"
@@ -19447,7 +19972,8 @@ msgstr "Thèmes"
 #. Inform the users that "something" went wrong and we are unable to show any results.
 msgctxt "noresults"
 msgid "There was an error displaying the search results."
-msgstr "Une erreur s'est produite lors de l'affichage des résultats de recherche."
+msgstr ""
+"Une erreur s'est produite lors de l'affichage des résultats de recherche."
 
 # smartling.placeholder_format=C
 #. Error message displayed when there was an issue in saving the chat locally to the browser's storage
@@ -19620,13 +20146,15 @@ msgstr ""
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
-msgstr "Ce fichier est trop volumineux. La taille maximale du fichier est de %1$s Mo"
+msgstr ""
+"Ce fichier est trop volumineux. La taille maximale du fichier est de %1$s Mo"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB."
-msgstr "Ce fichier est trop volumineux. La taille maximale du fichier est de %1$s Mo."
+msgstr ""
+"Ce fichier est trop volumineux. La taille maximale du fichier est de %1$s Mo."
 
 # smartling.placeholder_format=C
 #. Generic error message displayed when the user tries to upload an unsupported file type and we cannot determine the accepted types
@@ -19664,7 +20192,8 @@ msgstr ""
 #. Error message displayed when the user tries to upload an unsupported file type and we know which types are accepted. Placeholder is a single accepted type. E.g. This file type is not supported, please attach a PDF
 msgctxt "Error message when an uploaded file type is not supported"
 msgid "This file type is not supported, please attach a %s."
-msgstr "Ce type de fichier n’est pas pris en charge ; veuillez joindre un %1$s."
+msgstr ""
+"Ce type de fichier n’est pas pris en charge ; veuillez joindre un %1$s."
 
 # smartling.placeholder_format=C
 #. Generic error message displayed when the user tries to upload an unsupported file type and we cannot determine the accepted types
@@ -19727,8 +20256,8 @@ msgid ""
 "Other model providers follow a zero data retention model."
 msgstr ""
 "Ce fournisseur de modèles supprime les données associées à cette discussion "
-"dans les 30 jours. D'autres fournisseurs de modèles suivent un modèle de "
-"non-conservation des données."
+"dans les 30 jours. D'autres fournisseurs de modèles suivent un modèle de non-"
+"conservation des données."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers, and that other providers may retain chat data for a limited time instead.
@@ -19834,7 +20363,8 @@ msgstr ""
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr "Cette page web n'utilise pas de connexion sécurisée et cryptée (HTTPS)."
+msgstr ""
+"Cette page web n'utilise pas de connexion sécurisée et cryptée (HTTPS)."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -19975,7 +20505,8 @@ msgstr "Souligner le titre"
 # smartling.placeholder_format=C
 #. Informative header on a list of steps for the user to take to disable their adblocker
 msgid "To allowlist DuckDuckGo in other ad blocker extensions:"
-msgstr "Pour autoriser DuckDuckGo dans d'autres extensions de blocage de publicités :"
+msgstr ""
+"Pour autoriser DuckDuckGo dans d'autres extensions de blocage de publicités :"
 
 # smartling.placeholder_format=C
 #. Text stating agreement to Duck.ai Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'To continue, you must agree to Duck.ai’s Privacy Policy and Terms of Service'
@@ -19989,7 +20520,8 @@ msgstr "Pour continuer, vous devez accepter la %1$s et les %2$s de Duck.ai"
 msgctxt ""
 "Copy stating agreement to AI Chat Privacy Policy and Terms of Service."
 msgid "To continue, you must agree to DuckDuckGo AI Chat’s %s and %s"
-msgstr "Pour continuer, vous devez accepter la %1$s et les %2$s de DuckDuckGo AI Chat"
+msgstr ""
+"Pour continuer, vous devez accepter la %1$s et les %2$s de DuckDuckGo AI Chat"
 
 # smartling.placeholder_format=C
 #. Instructions for how to print driving directions.
@@ -20286,6 +20818,18 @@ msgstr ""
 "proche ? »"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Translate this page"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
+msgctxt "Page suggestion prompt"
+msgid "Translate this page into %s."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text for a region that will display translated text.
 msgctxt "translations_module"
 msgid "Translation"
@@ -20385,7 +20929,8 @@ msgstr "Essayez %1$s pour ne plus voir de messages comme celui-ci."
 #. Text for a promotional card that encourages users to try the encrypted AI model whose inference runs in a confidential environment so the model provider cannot access user data. %s is replaced with the model's full display name (e.g. 'GPT-OSS 120B').
 msgctxt "Promotional text for encrypted AI model"
 msgid "Try %s, our first model with zero provider visibility."
-msgstr "Essayez %1$s, notre premier modèle sans aucune visibilité du fournisseur."
+msgstr ""
+"Essayez %1$s, notre premier modèle sans aucune visibilité du fournisseur."
 
 # smartling.placeholder_format=C
 msgid "Try %sDuck.ai%s, our private AI chat service:"
@@ -20425,6 +20970,12 @@ msgstr "Réessayer"
 msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
 msgstr "Essayer gratuitement"
+
+# smartling.placeholder_format=C
+#. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
+msgctxt "settings"
+msgid "Try It Now"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -20490,14 +21041,16 @@ msgstr ""
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
 msgctxt "precise_user_location"
 msgid "Try enabling anonymous location for more accurate results."
-msgstr "Essayez d'activer la géolocalisation anonyme pour des résultats plus précis."
+msgstr ""
+"Essayez d'activer la géolocalisation anonyme pour des résultats plus précis."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the screen of the onboarding where the user picks a chat model.
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr "N’hésitez pas à essayer chaque modèle pour obtenir des réponses différentes."
+msgstr ""
+"N’hésitez pas à essayer chaque modèle pour obtenir des réponses différentes."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
@@ -20629,13 +21182,15 @@ msgstr "Essayez les logiciels open source %1$s et %2$s récemment ajoutés"
 #. Text for a promotional card that encourages users to try the recently added open-source AI models Llama 3.1 and Mixtral.
 msgctxt "Promotional text for new AI models"
 msgid "Try the recently added open-source Llama 3.1 and Mixtral"
-msgstr "Essayez les logiciels open source Llama 3.1 et Mixtral récemment ajoutés"
+msgstr ""
+"Essayez les logiciels open source Llama 3.1 et Mixtral récemment ajoutés"
 
 # smartling.placeholder_format=C
 #. Message displayed to suggest the user to try the provided prompts or enter their own.
 msgctxt "Prompt suggestion message"
 msgid "Try these prompts to get started or enter your own prompt below"
-msgstr "Essayez ces prompts pour commencer ou saisissez les vôtres ci-dessous :"
+msgstr ""
+"Essayez ces prompts pour commencer ou saisissez les vôtres ci-dessous :"
 
 # smartling.placeholder_format=C
 #. Description for the empty state displayed when searching recent chats in Duck.ai returns no results, suggesting the user rephrase their search query.
@@ -20643,7 +21198,8 @@ msgctxt ""
 "Description shown when a chat search in Duck.ai returns no matching chats, "
 "suggesting the user rephrase their query"
 msgid "Try using a different search term or phrase."
-msgstr "Essayez d'utiliser un autre terme ou une autre expression de recherche."
+msgstr ""
+"Essayez d'utiliser un autre terme ou une autre expression de recherche."
 
 # smartling.placeholder_format=C
 #. In the context of an AI Chat, text prompting the user to try their prompt with a different AI model.
@@ -20661,6 +21217,22 @@ msgstr "Essayez : %1$s"
 msgctxt "new user poll"
 msgid "Trying DuckDuckGo again"
 msgstr "Réessayer DuckDuckGo"
+
+# smartling.placeholder_format=C
+#. Message shown in a modal after supported third-party browser users disable AI features in Settings. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -20779,7 +21351,8 @@ msgstr "Activez la « position exacte » pour des résultats plus précis."
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on “Use precise location” for more accurate results."
-msgstr "Activez « Utiliser la position exacte » pour des résultats plus précis."
+msgstr ""
+"Activez « Utiliser la position exacte » pour des résultats plus précis."
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Create Image' label in the Tools dropdown.
@@ -20972,18 +21545,20 @@ msgstr ""
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
 msgstr ""
-"Sous %1$sAu démarrage%2$s, séléctionnez %3$sPage d'accueil%4$s et saisissez "
-": https://duckduckgo.com"
+"Sous %1$sAu démarrage%2$s, séléctionnez %3$sPage d'accueil%4$s et "
+"saisissez : https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sOpen with%s select %sA specific page or pages%s"
-msgstr "Sous %1$sOuvrir avec%2$s, sélectionnez %3$sUne ou des pages spécifiques%4$s"
+msgstr ""
+"Sous %1$sOuvrir avec%2$s, sélectionnez %3$sUne ou des pages spécifiques%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
-msgstr "Sous %1$sDÉMARRAGE > Page d'accueil%2$s saisissez : https://duckduckgo.com"
+msgstr ""
+"Sous %1$sDÉMARRAGE > Page d'accueil%2$s saisissez : https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -21423,6 +21998,12 @@ msgid "Uruguay"
 msgstr "Uruguay"
 
 # smartling.placeholder_format=C
+#. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
+msgctxt "Navigation label on the Duck.ai settings page"
+msgid "Usage"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A feedback suggestion
 msgctxt "Feedback prompt"
 msgid "Usage limit"
@@ -21655,7 +22236,8 @@ msgstr "Voir les prix de votre séjour"
 # smartling.placeholder_format=C
 #. A description for the ads tooltip that explains that viewing ads is privacy protected by DuckDuckGo.
 msgid "Viewing ads is privacy protected by DuckDuckGo."
-msgstr "DuckDuckGo protège la confidentialité lors de la consultation des publicités."
+msgstr ""
+"DuckDuckGo protège la confidentialité lors de la consultation des publicités."
 
 # smartling.placeholder_format=C
 msgctxt "Ads GDPR, internal use only. Do not change"
@@ -21735,9 +22317,9 @@ msgid ""
 "On” under Sync & Backup and select “Sync With Another Device”. Or scan the "
 "QR on your Recovery PDF."
 msgstr ""
-"Visitez Duck.ai dans votre autre navigateur et ouvrez les paramètres de "
-"Duck.ai. Sélectionnez « Activer » sous Sync & Backup, puis « Synchroniser "
-"avec un autre appareil ». Ou scannez le code QR figurant sur votre PDF de "
+"Visitez Duck.ai dans votre autre navigateur et ouvrez les paramètres de Duck."
+"ai. Sélectionnez « Activer » sous Sync & Backup, puis « Synchroniser avec un "
+"autre appareil ». Ou scannez le code QR figurant sur votre PDF de "
 "récupération."
 
 # smartling.placeholder_format=C
@@ -21878,6 +22460,12 @@ msgid "Wales"
 msgstr "Pays de Galles"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Walk me through the steps"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for walking directions on a map.
 msgctxt "directions"
 msgid "Walking"
@@ -21995,6 +22583,17 @@ msgid "We can anonymize%s your location%s to show you more accurate results."
 msgstr ""
 "Nous pouvons anonymiser %1$svotre emplacement%2$s pour vous montrer des "
 "résultats plus précis."
+
+# smartling.placeholder_format=C
+#. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
+msgctxt ""
+"Inline warning shown below the share-content toggle when the user selects "
+"Harmful or Illegal but has not enabled sharing"
+msgid ""
+"We can only fix what we can see. To report a harmful or illegal response, "
+"please share this conversation with DuckDuckGo so we can investigate and "
+"address the issue."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -22172,7 +22771,8 @@ msgstr "Nous avons perdu la connexion ; veuillez réessayer plus tard."
 #. We store chats for 15 minutes in the BE. If the user tries to fetch it after the 15 minutes elapsed or if we had an issue saving it we show them this error message so they can re-submit their prompt.
 msgctxt "AI Chat: Error message for unsaved or expired chats saved in sync"
 msgid "We lost the connection. Please try sending your message again."
-msgstr "Nous avons perdu la connexion. Veuillez réessayer d'envoyer votre message."
+msgstr ""
+"Nous avons perdu la connexion. Veuillez réessayer d'envoyer votre message."
 
 # smartling.placeholder_format=C
 #. Message asking the user to disable their ad blocker, with a link to how our ads don't track you. The placeholders are for the start and end tags of that link (e.g. <a href="%">, </a>)
@@ -22435,7 +23035,8 @@ msgstr ""
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai, it's time to import your chats"
-msgstr "Bienvenue sur le nouveau Duck.ai ; il est temps d'importer vos discussions."
+msgstr ""
+"Bienvenue sur le nouveau Duck.ai ; il est temps d'importer vos discussions."
 
 # smartling.placeholder_format=C
 #. Welcome message for new DuckDuckGo users.
@@ -22567,6 +23168,103 @@ msgstr ""
 "possédant peu ou pas d'expérience technique ou en matière d'IA."
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the counterarguments?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the hours & location?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key contributions of this paper?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key contributions?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key details?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key points covered in this video?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key points?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key takeaways from this article?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key takeaways?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key things I will learn from this course?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main counterarguments or criticisms of this?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main questions this page answers?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the must-try dishes here?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"What are the opening hours, location, and contact details for this place?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the pros and cons of this product?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the pros and cons?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
 msgctxt "feedback form"
 msgid "What bothered you most?"
@@ -22667,10 +23365,17 @@ msgid "What does atria mean in the context of a medical article?"
 msgstr "Que signifie « atrium » dans le contexte médical ?"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What does this answer?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
-msgstr "Quelle fonctionnalité souhaiteriez-vous que nous ajoutions ? (facultatif)"
+msgstr ""
+"Quelle fonctionnalité souhaiteriez-vous que nous ajoutions ? (facultatif)"
 
 # smartling.placeholder_format=C
 #. Header above a list of types of information that gets saved by the cloud save feature.
@@ -22679,20 +23384,32 @@ msgid "What information gets saved?"
 msgstr "Quelles informations sont sauvegardées ?"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What interview questions might come up for this role?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
 msgid ""
 "What is the Cloud Save bookmarklet and how does it differ from the URL "
 "parameter bookmarklet?"
 msgstr ""
-"À quoi sert le bookmarklet de sauvegarde dans le Cloud Save et en quoi "
-"est-il différent du bookmarklet avec URL de paramétrage ?"
+"À quoi sert le bookmarklet de sauvegarde dans le Cloud Save et en quoi est-"
+"il différent du bookmarklet avec URL de paramétrage ?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for looking up the capital city of Albania.
 msgctxt "Full sentence for looking up basic facts"
 msgid "What is the capital city of Albania?"
 msgstr "Quelle est la capitale de l’Albanie ?"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What is the overall verdict and rating for this?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to a page with additional information.
@@ -22717,6 +23434,12 @@ msgid "What people say:"
 msgstr "Ce que les clients en pensent :"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What should I order?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
 msgctxt "feedback form"
 msgid "What stood out?"
@@ -22727,6 +23450,18 @@ msgstr "Qu'est-ce qui vous a plu ?"
 msgctxt "feedback form"
 msgid "What was wrong with the response? (optional)"
 msgstr "Qu'est-ce qui n'allait pas dans la réponse ? (facultatif)"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I learn?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I need?"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -22746,6 +23481,12 @@ msgstr ""
 msgctxt "SERP footer content"
 msgid "What's New"
 msgstr "Nouveautés"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What's the verdict?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -22800,6 +23541,12 @@ msgid "Which features are missing? (Optional)"
 msgstr "Quelles fonctionnalités font défaut ? (Facultatif)"
 
 # smartling.placeholder_format=C
+#. An invitation for users to leave feedback
+msgctxt "Feedback prompt"
+msgid "Which features are missing? (optional)"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
 msgid "White"
 msgstr "Blanc"
@@ -22814,6 +23561,18 @@ msgstr "Blanc"
 #. Link to an about us page.
 msgid "Who We Are"
 msgstr "Qui nous sommes"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Who are the main cast and crew, and what else are they known for?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Who is this person?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Header above a collection of privacy-related links.
@@ -23278,7 +24037,8 @@ msgstr ""
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
 msgctxt "Third party map app picker feedback dialog"
 msgid "You can change this any time in %sSearch Settings%s"
-msgstr "Vous pouvez modifier cela à tout moment dans %1$sParamètres de recherche%2$s"
+msgstr ""
+"Vous pouvez modifier cela à tout moment dans %1$sParamètres de recherche%2$s"
 
 # smartling.placeholder_format=C
 #. Text explaning how to change a passphrase.
@@ -23300,7 +24060,8 @@ msgstr "Vous pouvez trouver le"
 #. Sentence shown after export, includes a placeholder for one or more filenames with bold formatting for the filename(s).
 msgctxt "duckai_migration"
 msgid "You can find the <b>%s</b> file in your downloads folder."
-msgstr "Vous trouverez le fichier <b>%1$s</b> dans votre dossier de téléchargements."
+msgstr ""
+"Vous trouverez le fichier <b>%1$s</b> dans votre dossier de téléchargements."
 
 # smartling.placeholder_format=C
 #. A link to the settings to where the user can hide the private search reminder from the filter bar of search results
@@ -23573,7 +24334,8 @@ msgstr ""
 #. Description shown when the user has reached the maximum voice chat duration.
 msgctxt "voice chat duration limit modal"
 msgid "You've reached the maximum voice chat duration for a single session."
-msgstr "Vous avez atteint la durée maximale de chat vocal lors d'une seule session."
+msgstr ""
+"Vous avez atteint la durée maximale de chat vocal lors d'une seule session."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the daily voice chat limit.
@@ -23587,7 +24349,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
 msgid "You've reached your dictation usage limit. Try again later."
-msgstr "Vous avez atteint votre limite d'utilisation de dictée. Réessayez plus tard."
+msgstr ""
+"Vous avez atteint votre limite d'utilisation de dictée. Réessayez plus tard."
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -23711,8 +24474,8 @@ msgid ""
 "Your browser provides a list of your most-visited sites. DuckDuckGo never "
 "has access to this data."
 msgstr ""
-"Votre navigateur fournit une liste des sites que vous visitez le "
-"plus.DuckDuckGo n'a jamais accès à ces données."
+"Votre navigateur fournit une liste des sites que vous visitez le plus."
+"DuckDuckGo n'a jamais accès à ces données."
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
@@ -23956,7 +24719,8 @@ msgstr "Vos recherches ne peuvent pas être reliées à vous"
 #. Confirms the recovery succeeded. The Next CTA closes the sheet.
 msgctxt "Body copy on the recover-data success sheet"
 msgid "Your synced chats are being restored to this device."
-msgstr "Vos discussions synchronisées sont en cours de restauration sur cet appareil."
+msgstr ""
+"Vos discussions synchronisées sont en cours de restauration sur cet appareil."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -24024,7 +24788,8 @@ msgstr ""
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
 msgctxt "voice chat limit modal"
 msgid "You’ve reached the voice chat limit for now. Please try again later."
-msgstr "Vous avez atteint la limite de chat vocal. Veuillez réessayer plus tard."
+msgstr ""
+"Vous avez atteint la limite de chat vocal. Veuillez réessayer plus tard."
 
 # smartling.placeholder_format=C
 #. The name of the Yucatec Maya language

--- a/locales/ga_IE/LC_MESSAGES/duckduckgo.po
+++ b/locales/ga_IE/LC_MESSAGES/duckduckgo.po
@@ -1169,6 +1169,11 @@ msgctxt "feedback form"
 msgid "Address is incorrect"
 msgstr ""
 
+#. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Adjust the servings"
+msgstr ""
+
 #. as in multiple advertisements
 msgid "Ads"
 msgstr "Fógraí"
@@ -1342,6 +1347,13 @@ msgstr ""
 #. Heading shown on the empty chat screen. The text between the two %s markers is displayed inside a clickable privacy button. First %s renders a shield icon, second %s is an invisible end marker. Keep the word 'private' between both %s markers.
 msgctxt "Empty state heading in Duck.ai chat mode"
 msgid "All chats are %sprivate%s"
+msgstr ""
+
+#. Paragraph in the Privacy & Terms section of the About & Legal page in Duck.ai settings, summarizing how chats are anonymized and are not stored or used to train chat models.
+msgctxt "Privacy & Terms section description on the Duck.ai settings page"
+msgid ""
+"All chats are anonymized by DuckDuckGo, and your conversations are not used "
+"to train chat models by DuckDuckGo or the model providers"
 msgstr ""
 
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1554,6 +1566,12 @@ msgstr ""
 #. Confirmation message after location service is enabled.
 msgctxt "precise_user_location"
 msgid "Anonymous location enabled"
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Anonymously generates answers for search queries based on web content. "
+"Choose how often you want it to appear, or disable it completely."
 msgstr ""
 
 #. Instant Answer tab name
@@ -1779,6 +1797,11 @@ msgstr ""
 
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse
 msgid "Ask a follow-up with Duck.ai"
+msgstr ""
+
+#. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
+msgctxt "Page suggestion chip label"
+msgid "Ask about this page"
 msgstr ""
 
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2103,6 +2126,11 @@ msgstr ""
 msgid "Barcode"
 msgstr "Barrachód"
 
+#. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Based on this page, is this course worth taking?"
+msgstr ""
+
 msgctxt "settings"
 msgid "Basic"
 msgstr "Bunúsach"
@@ -2134,6 +2162,13 @@ msgstr ""
 #. Placeholder text displayed while the assistant waits for the user to choose an action.
 msgctxt "Assistant response placeholder"
 msgid "Before continuing..."
+msgstr ""
+
+#. Explains that before storing the report, DuckDuckGo will anonymize the conversation by removing PII like names, email addresses, and identifying metadata.
+msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
+msgid ""
+"Before storing this report, DuckDuckGo will anonymize your conversation by "
+"removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
 #. Label that's displayed next to a past start date below a web search result.
@@ -2392,6 +2427,11 @@ msgstr "An Bhrasaíl"
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Break Points Won"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Break this down into clear, numbered steps."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -2751,6 +2791,11 @@ msgstr "Gairmeacha"
 #. Text of a button that performs a search for the cast of a particular movie or tv show
 msgctxt "Movie/TV Show Title instant answer"
 msgid "Cast"
+msgstr ""
+
+#. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Cast & Crew"
 msgstr ""
 
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -4123,6 +4168,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Create a shopping list with quantities from this recipe."
+msgstr ""
+
 #. Placeholder text displayed in the input field when starting a new image generation session.
 msgctxt "Placeholder text for the image generation input field"
 msgid "Create an image of a cute duck..."
@@ -4649,6 +4699,10 @@ msgstr ""
 msgid "Dictation limit reached"
 msgstr ""
 
+#. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
+msgid "Dictation temporarily unavailable"
+msgstr ""
+
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
@@ -4894,6 +4948,20 @@ msgctxt "precise_user_location"
 msgid "Done"
 msgstr "Déanta"
 
+#. Message shown in a modal after DuckDuckGo browser users disable AI features in Settings. The first two placeholders bold noai.duckduckgo.com. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
+"filtered out. %sLearn More%s"
+msgstr ""
+
+#. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
+"and AI images filtered out. %sLearn more%s"
+msgstr ""
+
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Double Faults"
@@ -4984,6 +5052,16 @@ msgctxt "Full sentence for writing an email"
 msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
+msgstr ""
+
+#. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Draft a cover letter"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Draft a cover letter for this job."
 msgstr ""
 
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -5123,6 +5201,14 @@ msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
 msgstr ""
 
+#. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
+msgctxt "About section description on the Duck.ai settings page"
+msgid ""
+"Duck.ai is created by DuckDuckGo. We're an independent online protection "
+"company for anyone who wants to take back control of their personal "
+"information."
+msgstr ""
+
 #. Title shown when an update is required before proceeding.
 msgctxt "duckai_migration"
 msgid "Duck.ai is moving domains"
@@ -5156,6 +5242,12 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Duck.ai lets you chat privately with popular AI models. Disabling it hides "
+"Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
 
 msgctxt "settings"
@@ -5925,6 +6017,16 @@ msgstr ""
 msgid "Eritrea"
 msgstr ""
 
+#. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Estimate the nutrition"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Estimate the nutritional information for this recipe."
+msgstr ""
+
 msgid "Estonia"
 msgstr "An Eastóin"
 
@@ -5969,10 +6071,50 @@ msgctxt "merchant promotion product ad extension"
 msgid "Expires in 1 day"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain the accepted answer in simple terms."
+msgstr ""
+
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
+msgstr ""
+
+#. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain the top answer"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this in simple, plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this paper"
+msgstr ""
+
+#. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this repo"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this research paper in plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this simply"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain what this repository does and how to use it."
 msgstr ""
 
 #. Label to show if song lyrics contain explicit content
@@ -6203,6 +6345,11 @@ msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
 msgstr ""
 
+msgctxt "settings"
+msgid ""
+"Filters out known AI spam sites from image search results. %sLearn More%s"
+msgstr ""
+
 #. Label for the final score of a sporting event.
 msgid "Final"
 msgstr "Críochnúil"
@@ -6244,6 +6391,11 @@ msgstr ""
 #. Short description shown below the 'Web Search' label in the Tools dropdown.
 msgctxt "Subtitle for the Web Search tool entry in the Tools dropdown menu"
 msgid "Find current information"
+msgstr ""
+
+#. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Find me alternatives"
 msgstr ""
 
 #. Button that searches for results closer to the user's current location.
@@ -6634,6 +6786,11 @@ msgstr ""
 msgid "Generate More"
 msgstr ""
 
+#. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Generate a shopping list"
+msgstr ""
+
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
 msgid "Generate a short answer from the web"
 msgstr ""
@@ -6868,6 +7025,11 @@ msgstr ""
 #. Text for a button inviting users to give it a try for the Duck.ai product. On click, they're taken to the Duck.ai page.
 msgctxt "Onboarding welcome screen button text"
 msgid "Give it a Try"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Give me a quick background on this person."
 msgstr ""
 
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -7231,6 +7393,16 @@ msgstr ""
 #. Link to a page with information about sharing DuckDuckGo with friends.
 msgid "Help Spread Privacy"
 msgstr "Cuidigh Príobháideachas a Scaipeadh"
+
+#. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Help me prep for the interview"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Help me tailor my resume for this job."
+msgstr ""
 
 #. Title of a SERP popup that invites users to take a survey (desktop only)
 msgctxt "User survey popup"
@@ -7652,6 +7824,13 @@ msgstr ""
 #. Text displayed on the button on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
 msgctxt "Onboarding terms screen button text"
 msgid "I Agree"
+msgstr ""
+
+#. Text for the button that takes the user to the external DuckDuckGo login subscription page.
+msgctxt ""
+"Text for the I already have a subscription button in the Duck.ai settings "
+"page"
+msgid "I Already Have a Subscription"
 msgstr ""
 
 #. Text for the button that takes the user to the login subscription page.
@@ -8111,6 +8290,11 @@ msgctxt "Sidemenu browser promo"
 msgid "Install Mac Browser"
 msgstr ""
 
+#. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
+msgctxt "settings"
+msgid "Install Now"
+msgstr ""
+
 #. Text of a button to install the DuckDuckGo app
 msgctxt "Serp footer content"
 msgid "Install Our App"
@@ -8190,10 +8374,37 @@ msgctxt "cloudsave"
 msgid "Is deleted data really deleted?"
 msgstr "Dáiríre, an scriostar go hiomlán sonraí a scriosadh?"
 
+#. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is it worth taking?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this place any good?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"Is this place any good? Summarize its reputation based on reviews and "
+"ratings."
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "Is this video helpful?"
 msgstr "An bhfuil an físeán seo acrach?"
+
+#. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this worth watching?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Is this worth watching? Give me a spoiler-free take."
+msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
 msgctxt "Weather IA"
@@ -8694,6 +8905,11 @@ msgstr "Clófhoireann an naisc:"
 msgid "Links:"
 msgstr "Naisc:"
 
+#. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "List the tools, materials, or prerequisites I need for this."
+msgstr ""
+
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
 msgid "Listen"
 msgstr "Éist"
@@ -9031,6 +9247,11 @@ msgstr ""
 #. Label for linke navigating to site exclusion feature on Settings page
 msgctxt "Exclusion message manage sites button"
 msgid "Manage blocked sites"
+msgstr ""
+
+#. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
+msgctxt "setting"
+msgid "Manage in Browser Settings"
 msgstr ""
 
 #. Link to the site exclusion settings page
@@ -11338,6 +11559,11 @@ msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
+msgid "Please describe why the chat response is harmful or illegal. (optional)"
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
+msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
 msgstr ""
 
@@ -11356,6 +11582,13 @@ msgctxt "Modal disclaimer text"
 msgid ""
 "Please note: starting a new chat with any model will delete your current "
 "chat session."
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
+msgctxt "Feedback prompt"
+msgid ""
+"Please paste your prompt and the problematic output (with any personal "
+"information removed) and describe why the content is harmful or illegal."
 msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -11741,6 +11974,11 @@ msgctxt "settings"
 msgid "Privacy"
 msgstr "Príobháideacht"
 
+#. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
+msgctxt "Section heading on the Duck.ai settings page"
+msgid "Privacy & Terms"
+msgstr ""
+
 msgid "Privacy Blog"
 msgstr "Blag Príobháideachais"
 
@@ -11794,6 +12032,11 @@ msgstr ""
 
 #. Text used in other strings to link to the Privacy Policy and Terms of Service content.
 msgctxt "Copy used to compose link in sentences"
+msgid "Privacy Policy and Terms of Service"
+msgstr ""
+
+#. Text for a button that links to the terms of use and privacy policy page.
+msgctxt "Secondary button text in active privacy modal"
 msgid "Privacy Policy and Terms of Service"
 msgstr ""
 
@@ -12202,6 +12445,26 @@ msgctxt "Brief for recommending a book"
 msgid "Recommend a book"
 msgstr ""
 
+#. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar books"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar books."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar movies or shows."
+msgstr ""
+
+#. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar titles"
+msgstr ""
+
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
 msgid "Recording failed. Please try again."
 msgstr ""
@@ -12521,6 +12784,14 @@ msgstr ""
 msgid "Republic of Moldova"
 msgstr ""
 
+#. Note indicating that sharing the conversation is mandatory when reporting harmful or illegal content. Rendered alongside the standard share label (DUCKCHAT_RESPONSE_FEEDBACK_SHARE_PROMPT_RESPONSE_LABEL), not replacing it.
+msgctxt ""
+"Note shown under the share-content switch label on the Duck.ai response "
+"feedback form when the user has selected Harmful or Illegal as the feedback "
+"reason"
+msgid "Required for harmful or illegal reports"
+msgstr ""
+
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
 msgctxt "Description for extended reasoning mode in Duck.ai"
 msgid "Researches before responding"
@@ -12707,6 +12978,11 @@ msgstr "Léirmheasanna"
 msgctxt "maps_places"
 msgid "Reviews"
 msgstr "Léirmheasanna"
+
+#. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Rewrite this recipe scaled for a different number of servings."
+msgstr ""
 
 msgid "Romania"
 msgstr "An Rómáin"
@@ -13759,6 +14035,11 @@ msgctxt "Setup button for native sync flow"
 msgid "Set Up Now"
 msgstr ""
 
+#. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
+msgctxt "Encrypted storage setup button shown in native browsers"
+msgid "Set Up Sync & Backup"
+msgstr ""
+
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
 msgctxt "Title for the Sync & Backup intro screen"
 msgid "Set Up Sync & Backup"
@@ -13903,6 +14184,12 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
+msgctxt ""
+"Label beside the share-content switch on the Duck.ai response feedback form"
+msgid "Share this conversation with DuckDuckGo"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -14929,6 +15216,21 @@ msgctxt "Brief for suggesting a blog post title"
 msgid "Suggest a title for a blog post"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest related articles or topics worth exploring next."
+msgstr ""
+
+#. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Suggest related articles to explore"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest some alternatives to this product."
+msgstr ""
+
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
 msgctxt "directions"
 msgid "Suggestions:"
@@ -14938,9 +15240,84 @@ msgctxt "noresults"
 msgid "Suggestions:"
 msgstr "Moltaí:"
 
+#. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Sum up the reviews"
+msgstr ""
+
 #. A short title for the a message asking the AI to summarize a text.
 msgctxt "Title for the summarize message"
 msgid "Summarize"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize the Q&As"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the background and notable work of this person."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the key details of this event."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the questions and answers on this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize their background"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this book"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this book."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this discussion"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this discussion thread."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this video"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this video."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize what the reviews say."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -15196,6 +15573,11 @@ msgstr ""
 msgid "Syria"
 msgstr ""
 
+#. Text for a button that enables the theme to follow the operating system's color scheme preference.
+msgctxt "System theme button for theme selector"
+msgid "System"
+msgstr ""
+
 #. Abbreviation indicating this is the total score for a game
 msgctxt "Sports module"
 msgid "T"
@@ -15219,6 +15601,11 @@ msgctxt "language_name"
 msgid "Tahitian"
 msgstr "Taihítis"
 
+#. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Tailor my resume"
+msgstr ""
+
 msgid "Taiwan"
 msgstr "An Téaváin"
 
@@ -15240,6 +15627,12 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "Take control of your personal data!"
+msgstr ""
+
+#. Description for the Feedback section of the Duck.ai settings page, asking the user to take an anonymous survey to let us know how we can make Duck.ai better.
+msgctxt "Feedback section description on the Duck.ai settings page"
+msgid ""
+"Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
 
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -15489,6 +15882,11 @@ msgstr ""
 #. https://duck.co/media/files/theme.png
 msgid "Theme"
 msgstr "Téama"
+
+#. Text for the theme selector label that allows users to switch between Light and dark theme.
+msgctxt "Label for the theme selector feature"
+msgid "Theme"
+msgstr ""
 
 #. http://i.imgur.com/LpFhb1e.png
 msgctxt "settings"
@@ -16156,6 +16554,16 @@ msgid ""
 "movie theatre?”"
 msgstr ""
 
+#. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Translate this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
+msgctxt "Page suggestion prompt"
+msgid "Translate this page into %s."
+msgstr ""
+
 #. Placeholder text for a region that will display translated text.
 msgctxt "translations_module"
 msgid "Translation"
@@ -16270,6 +16678,11 @@ msgstr ""
 #. Call-to-action button for the subscription promo in the SERP sidemenu.
 msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
+msgstr ""
+
+#. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
+msgctxt "settings"
+msgid "Try It Now"
 msgstr ""
 
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -16465,6 +16878,20 @@ msgstr "Féach: %s"
 msgctxt "new user poll"
 msgid "Trying DuckDuckGo again"
 msgstr "Ag baint feidhm as DuckDuckGo arís"
+
+#. Message shown in a modal after supported third-party browser users disable AI features in Settings. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+#. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
 
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
 msgctxt "Assistant response placeholder"
@@ -17075,6 +17502,11 @@ msgstr "Urdúis"
 msgid "Uruguay"
 msgstr ""
 
+#. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
+msgctxt "Navigation label on the Duck.ai settings page"
+msgid "Usage"
+msgstr ""
+
 #. A feedback suggestion
 msgctxt "Feedback prompt"
 msgid "Usage limit"
@@ -17427,6 +17859,11 @@ msgstr "Ag fuireach leis an Suíomh..."
 msgid "Wales"
 msgstr ""
 
+#. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Walk me through the steps"
+msgstr ""
+
 #. Label for walking directions on a map.
 msgctxt "directions"
 msgid "Walking"
@@ -17517,6 +17954,16 @@ msgstr ""
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
+msgstr ""
+
+#. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
+msgctxt ""
+"Inline warning shown below the share-content toggle when the user selects "
+"Harmful or Illegal but has not enabled sharing"
+msgid ""
+"We can only fix what we can see. To report a harmful or illegal response, "
+"please share this conversation with DuckDuckGo so we can investigate and "
+"address the issue."
 msgstr ""
 
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -17946,6 +18393,87 @@ msgid ""
 "experience."
 msgstr ""
 
+#. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the counterarguments?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the hours & location?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key contributions of this paper?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key contributions?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key details?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key points covered in this video?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key points?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key takeaways from this article?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key takeaways?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key things I will learn from this course?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main counterarguments or criticisms of this?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main questions this page answers?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the must-try dishes here?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"What are the opening hours, location, and contact details for this place?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the pros and cons of this product?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the pros and cons?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
 msgctxt "feedback form"
 msgid "What bothered you most?"
@@ -18029,6 +18557,11 @@ msgctxt "Full sentence for defining a term"
 msgid "What does atria mean in the context of a medical article?"
 msgstr ""
 
+#. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What does this answer?"
+msgstr ""
+
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
@@ -18038,6 +18571,11 @@ msgstr ""
 msgctxt "cloudsave"
 msgid "What information gets saved?"
 msgstr "Cén fhaisnéis a choimeádtar?"
+
+#. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What interview questions might come up for this role?"
+msgstr ""
 
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
@@ -18049,6 +18587,11 @@ msgstr ""
 #. Text for a prompt suggestion for looking up the capital city of Albania.
 msgctxt "Full sentence for looking up basic facts"
 msgid "What is the capital city of Albania?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What is the overall verdict and rating for this?"
 msgstr ""
 
 #. Link to a page with additional information.
@@ -18069,6 +18612,11 @@ msgctxt "maps_places"
 msgid "What people say:"
 msgstr "Cad atá á rá ag daoine:"
 
+#. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What should I order?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
 msgctxt "feedback form"
 msgid "What stood out?"
@@ -18077,6 +18625,16 @@ msgstr ""
 #. Question on a feedback form for a negative feedback response.
 msgctxt "feedback form"
 msgid "What was wrong with the response? (optional)"
+msgstr ""
+
+#. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I learn?"
+msgstr ""
+
+#. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I need?"
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -18091,6 +18649,11 @@ msgstr ""
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
 msgctxt "SERP footer content"
 msgid "What's New"
+msgstr ""
+
+#. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What's the verdict?"
 msgstr ""
 
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -18134,6 +18697,11 @@ msgctxt "Feedback prompt"
 msgid "Which features are missing? (Optional)"
 msgstr ""
 
+#. An invitation for users to leave feedback
+msgctxt "Feedback prompt"
+msgid "Which features are missing? (optional)"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
 msgid "White"
 msgstr "Bán"
@@ -18146,6 +18714,16 @@ msgstr "Bán"
 #. Link to an about us page.
 msgid "Who We Are"
 msgstr "Cé Sinne"
+
+#. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Who are the main cast and crew, and what else are they known for?"
+msgstr ""
+
+#. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Who is this person?"
+msgstr ""
 
 #. Header above a collection of privacy-related links.
 msgid "Why Privacy"

--- a/locales/gd_GB/LC_MESSAGES/duckduckgo.po
+++ b/locales/gd_GB/LC_MESSAGES/duckduckgo.po
@@ -1161,6 +1161,11 @@ msgctxt "feedback form"
 msgid "Address is incorrect"
 msgstr ""
 
+#. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Adjust the servings"
+msgstr ""
+
 #. as in multiple advertisements
 msgid "Ads"
 msgstr ""
@@ -1335,6 +1340,13 @@ msgstr ""
 #. Heading shown on the empty chat screen. The text between the two %s markers is displayed inside a clickable privacy button. First %s renders a shield icon, second %s is an invisible end marker. Keep the word 'private' between both %s markers.
 msgctxt "Empty state heading in Duck.ai chat mode"
 msgid "All chats are %sprivate%s"
+msgstr ""
+
+#. Paragraph in the Privacy & Terms section of the About & Legal page in Duck.ai settings, summarizing how chats are anonymized and are not stored or used to train chat models.
+msgctxt "Privacy & Terms section description on the Duck.ai settings page"
+msgid ""
+"All chats are anonymized by DuckDuckGo, and your conversations are not used "
+"to train chat models by DuckDuckGo or the model providers"
 msgstr ""
 
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1547,6 +1559,12 @@ msgstr ""
 #. Confirmation message after location service is enabled.
 msgctxt "precise_user_location"
 msgid "Anonymous location enabled"
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Anonymously generates answers for search queries based on web content. "
+"Choose how often you want it to appear, or disable it completely."
 msgstr ""
 
 #. Instant Answer tab name
@@ -1769,6 +1787,11 @@ msgstr ""
 
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse
 msgid "Ask a follow-up with Duck.ai"
+msgstr ""
+
+#. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
+msgctxt "Page suggestion chip label"
+msgid "Ask about this page"
 msgstr ""
 
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2093,6 +2116,11 @@ msgstr ""
 msgid "Barcode"
 msgstr "Còd-bhàraichean"
 
+#. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Based on this page, is this course worth taking?"
+msgstr ""
+
 msgctxt "settings"
 msgid "Basic"
 msgstr "Bunasach"
@@ -2124,6 +2152,13 @@ msgstr ""
 #. Placeholder text displayed while the assistant waits for the user to choose an action.
 msgctxt "Assistant response placeholder"
 msgid "Before continuing..."
+msgstr ""
+
+#. Explains that before storing the report, DuckDuckGo will anonymize the conversation by removing PII like names, email addresses, and identifying metadata.
+msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
+msgid ""
+"Before storing this report, DuckDuckGo will anonymize your conversation by "
+"removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
 #. Label that's displayed next to a past start date below a web search result.
@@ -2382,6 +2417,11 @@ msgstr "Braisil"
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Break Points Won"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Break this down into clear, numbered steps."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -2741,6 +2781,11 @@ msgstr "Dreuchdan"
 #. Text of a button that performs a search for the cast of a particular movie or tv show
 msgctxt "Movie/TV Show Title instant answer"
 msgid "Cast"
+msgstr ""
+
+#. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Cast & Crew"
 msgstr ""
 
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -4109,6 +4154,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Create a shopping list with quantities from this recipe."
+msgstr ""
+
 #. Placeholder text displayed in the input field when starting a new image generation session.
 msgctxt "Placeholder text for the image generation input field"
 msgid "Create an image of a cute duck..."
@@ -4635,6 +4685,10 @@ msgstr ""
 msgid "Dictation limit reached"
 msgstr ""
 
+#. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
+msgid "Dictation temporarily unavailable"
+msgstr ""
+
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
@@ -4881,6 +4935,20 @@ msgctxt "precise_user_location"
 msgid "Done"
 msgstr ""
 
+#. Message shown in a modal after DuckDuckGo browser users disable AI features in Settings. The first two placeholders bold noai.duckduckgo.com. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
+"filtered out. %sLearn More%s"
+msgstr ""
+
+#. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
+"and AI images filtered out. %sLearn more%s"
+msgstr ""
+
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Double Faults"
@@ -4971,6 +5039,16 @@ msgctxt "Full sentence for writing an email"
 msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
+msgstr ""
+
+#. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Draft a cover letter"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Draft a cover letter for this job."
 msgstr ""
 
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -5110,6 +5188,14 @@ msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
 msgstr ""
 
+#. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
+msgctxt "About section description on the Duck.ai settings page"
+msgid ""
+"Duck.ai is created by DuckDuckGo. We're an independent online protection "
+"company for anyone who wants to take back control of their personal "
+"information."
+msgstr ""
+
 #. Title shown when an update is required before proceeding.
 msgctxt "duckai_migration"
 msgid "Duck.ai is moving domains"
@@ -5143,6 +5229,12 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Duck.ai lets you chat privately with popular AI models. Disabling it hides "
+"Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
 
 msgctxt "settings"
@@ -5910,6 +6002,16 @@ msgstr ""
 msgid "Eritrea"
 msgstr ""
 
+#. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Estimate the nutrition"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Estimate the nutritional information for this recipe."
+msgstr ""
+
 msgid "Estonia"
 msgstr "An Eastoin"
 
@@ -5954,10 +6056,50 @@ msgctxt "merchant promotion product ad extension"
 msgid "Expires in 1 day"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain the accepted answer in simple terms."
+msgstr ""
+
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
+msgstr ""
+
+#. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain the top answer"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this in simple, plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this paper"
+msgstr ""
+
+#. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this repo"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this research paper in plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this simply"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain what this repository does and how to use it."
 msgstr ""
 
 #. Label to show if song lyrics contain explicit content
@@ -6189,6 +6331,11 @@ msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
 msgstr ""
 
+msgctxt "settings"
+msgid ""
+"Filters out known AI spam sites from image search results. %sLearn More%s"
+msgstr ""
+
 #. Label for the final score of a sporting event.
 msgid "Final"
 msgstr "Deireannach"
@@ -6230,6 +6377,11 @@ msgstr ""
 #. Short description shown below the 'Web Search' label in the Tools dropdown.
 msgctxt "Subtitle for the Web Search tool entry in the Tools dropdown menu"
 msgid "Find current information"
+msgstr ""
+
+#. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Find me alternatives"
 msgstr ""
 
 #. Button that searches for results closer to the user's current location.
@@ -6620,6 +6772,11 @@ msgstr ""
 msgid "Generate More"
 msgstr ""
 
+#. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Generate a shopping list"
+msgstr ""
+
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
 msgid "Generate a short answer from the web"
 msgstr ""
@@ -6854,6 +7011,11 @@ msgstr ""
 #. Text for a button inviting users to give it a try for the Duck.ai product. On click, they're taken to the Duck.ai page.
 msgctxt "Onboarding welcome screen button text"
 msgid "Give it a Try"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Give me a quick background on this person."
 msgstr ""
 
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -7216,6 +7378,16 @@ msgstr ""
 
 #. Link to a page with information about sharing DuckDuckGo with friends.
 msgid "Help Spread Privacy"
+msgstr ""
+
+#. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Help me prep for the interview"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Help me tailor my resume for this job."
 msgstr ""
 
 #. Title of a SERP popup that invites users to take a survey (desktop only)
@@ -7635,6 +7807,13 @@ msgstr ""
 #. Text displayed on the button on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
 msgctxt "Onboarding terms screen button text"
 msgid "I Agree"
+msgstr ""
+
+#. Text for the button that takes the user to the external DuckDuckGo login subscription page.
+msgctxt ""
+"Text for the I already have a subscription button in the Duck.ai settings "
+"page"
+msgid "I Already Have a Subscription"
 msgstr ""
 
 #. Text for the button that takes the user to the login subscription page.
@@ -8094,6 +8273,11 @@ msgctxt "Sidemenu browser promo"
 msgid "Install Mac Browser"
 msgstr ""
 
+#. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
+msgctxt "settings"
+msgid "Install Now"
+msgstr ""
+
 #. Text of a button to install the DuckDuckGo app
 msgctxt "Serp footer content"
 msgid "Install Our App"
@@ -8173,9 +8357,36 @@ msgctxt "cloudsave"
 msgid "Is deleted data really deleted?"
 msgstr "Ma sguabas mi às dàta, an dèid a sguabadh às an da-rìreabh?"
 
+#. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is it worth taking?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this place any good?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"Is this place any good? Summarize its reputation based on reviews and "
+"ratings."
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "Is this video helpful?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this worth watching?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Is this worth watching? Give me a spoiler-free take."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -8672,6 +8883,11 @@ msgstr "Cruth-clò nan ceangal:"
 msgid "Links:"
 msgstr "Ceanglaichean:"
 
+#. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "List the tools, materials, or prerequisites I need for this."
+msgstr ""
+
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
 msgid "Listen"
 msgstr "Èist ris"
@@ -9006,6 +9222,11 @@ msgstr ""
 #. Label for linke navigating to site exclusion feature on Settings page
 msgctxt "Exclusion message manage sites button"
 msgid "Manage blocked sites"
+msgstr ""
+
+#. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
+msgctxt "setting"
+msgid "Manage in Browser Settings"
 msgstr ""
 
 #. Link to the site exclusion settings page
@@ -11311,6 +11532,11 @@ msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
+msgid "Please describe why the chat response is harmful or illegal. (optional)"
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
+msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
 msgstr ""
 
@@ -11329,6 +11555,13 @@ msgctxt "Modal disclaimer text"
 msgid ""
 "Please note: starting a new chat with any model will delete your current "
 "chat session."
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
+msgctxt "Feedback prompt"
+msgid ""
+"Please paste your prompt and the problematic output (with any personal "
+"information removed) and describe why the content is harmful or illegal."
 msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -11713,6 +11946,11 @@ msgctxt "settings"
 msgid "Privacy"
 msgstr "Prìobhaideachd"
 
+#. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
+msgctxt "Section heading on the Duck.ai settings page"
+msgid "Privacy & Terms"
+msgstr ""
+
 msgid "Privacy Blog"
 msgstr ""
 
@@ -11766,6 +12004,11 @@ msgstr ""
 
 #. Text used in other strings to link to the Privacy Policy and Terms of Service content.
 msgctxt "Copy used to compose link in sentences"
+msgid "Privacy Policy and Terms of Service"
+msgstr ""
+
+#. Text for a button that links to the terms of use and privacy policy page.
+msgctxt "Secondary button text in active privacy modal"
 msgid "Privacy Policy and Terms of Service"
 msgstr ""
 
@@ -12174,6 +12417,26 @@ msgctxt "Brief for recommending a book"
 msgid "Recommend a book"
 msgstr ""
 
+#. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar books"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar books."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar movies or shows."
+msgstr ""
+
+#. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar titles"
+msgstr ""
+
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
 msgid "Recording failed. Please try again."
 msgstr ""
@@ -12494,6 +12757,14 @@ msgstr ""
 msgid "Republic of Moldova"
 msgstr ""
 
+#. Note indicating that sharing the conversation is mandatory when reporting harmful or illegal content. Rendered alongside the standard share label (DUCKCHAT_RESPONSE_FEEDBACK_SHARE_PROMPT_RESPONSE_LABEL), not replacing it.
+msgctxt ""
+"Note shown under the share-content switch label on the Duck.ai response "
+"feedback form when the user has selected Harmful or Illegal as the feedback "
+"reason"
+msgid "Required for harmful or illegal reports"
+msgstr ""
+
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
 msgctxt "Description for extended reasoning mode in Duck.ai"
 msgid "Researches before responding"
@@ -12679,6 +12950,11 @@ msgstr "Lèirmheasan"
 #. Label above a list of customer reviews of a business.
 msgctxt "maps_places"
 msgid "Reviews"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Rewrite this recipe scaled for a different number of servings."
 msgstr ""
 
 msgid "Romania"
@@ -13727,6 +14003,11 @@ msgctxt "Setup button for native sync flow"
 msgid "Set Up Now"
 msgstr ""
 
+#. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
+msgctxt "Encrypted storage setup button shown in native browsers"
+msgid "Set Up Sync & Backup"
+msgstr ""
+
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
 msgctxt "Title for the Sync & Backup intro screen"
 msgid "Set Up Sync & Backup"
@@ -13871,6 +14152,12 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
+msgctxt ""
+"Label beside the share-content switch on the Duck.ai response feedback form"
+msgid "Share this conversation with DuckDuckGo"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -14887,6 +15174,21 @@ msgctxt "Brief for suggesting a blog post title"
 msgid "Suggest a title for a blog post"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest related articles or topics worth exploring next."
+msgstr ""
+
+#. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Suggest related articles to explore"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest some alternatives to this product."
+msgstr ""
+
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
 msgctxt "directions"
 msgid "Suggestions:"
@@ -14896,9 +15198,84 @@ msgctxt "noresults"
 msgid "Suggestions:"
 msgstr ""
 
+#. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Sum up the reviews"
+msgstr ""
+
 #. A short title for the a message asking the AI to summarize a text.
 msgctxt "Title for the summarize message"
 msgid "Summarize"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize the Q&As"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the background and notable work of this person."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the key details of this event."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the questions and answers on this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize their background"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this book"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this book."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this discussion"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this discussion thread."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this video"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this video."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize what the reviews say."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -15153,6 +15530,11 @@ msgstr ""
 msgid "Syria"
 msgstr ""
 
+#. Text for a button that enables the theme to follow the operating system's color scheme preference.
+msgctxt "System theme button for theme selector"
+msgid "System"
+msgstr ""
+
 #. Abbreviation indicating this is the total score for a game
 msgctxt "Sports module"
 msgid "T"
@@ -15176,6 +15558,11 @@ msgctxt "language_name"
 msgid "Tahitian"
 msgstr ""
 
+#. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Tailor my resume"
+msgstr ""
+
 msgid "Taiwan"
 msgstr "Taidh-Bhàn"
 
@@ -15197,6 +15584,12 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "Take control of your personal data!"
+msgstr ""
+
+#. Description for the Feedback section of the Duck.ai settings page, asking the user to take an anonymous survey to let us know how we can make Duck.ai better.
+msgctxt "Feedback section description on the Duck.ai settings page"
+msgid ""
+"Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
 
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -15441,6 +15834,11 @@ msgstr ""
 #. https://duck.co/media/files/theme.png
 msgid "Theme"
 msgstr "Ùrlar"
+
+#. Text for the theme selector label that allows users to switch between Light and dark theme.
+msgctxt "Label for the theme selector feature"
+msgid "Theme"
+msgstr ""
 
 #. http://i.imgur.com/LpFhb1e.png
 msgctxt "settings"
@@ -16095,6 +16493,16 @@ msgid ""
 "movie theatre?”"
 msgstr ""
 
+#. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Translate this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
+msgctxt "Page suggestion prompt"
+msgid "Translate this page into %s."
+msgstr ""
+
 #. Placeholder text for a region that will display translated text.
 msgctxt "translations_module"
 msgid "Translation"
@@ -16209,6 +16617,11 @@ msgstr ""
 #. Call-to-action button for the subscription promo in the SERP sidemenu.
 msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
+msgstr ""
+
+#. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
+msgctxt "settings"
+msgid "Try It Now"
 msgstr ""
 
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -16404,6 +16817,20 @@ msgstr "Feuch: %s"
 msgctxt "new user poll"
 msgid "Trying DuckDuckGo again"
 msgstr "A’ feuchainn DuckDuckGo a-rithist"
+
+#. Message shown in a modal after supported third-party browser users disable AI features in Settings. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+#. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
 
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
 msgctxt "Assistant response placeholder"
@@ -17010,6 +17437,11 @@ msgstr ""
 msgid "Uruguay"
 msgstr ""
 
+#. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
+msgctxt "Navigation label on the Duck.ai settings page"
+msgid "Usage"
+msgstr ""
+
 #. A feedback suggestion
 msgctxt "Feedback prompt"
 msgid "Usage limit"
@@ -17360,6 +17792,11 @@ msgstr ""
 msgid "Wales"
 msgstr ""
 
+#. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Walk me through the steps"
+msgstr ""
+
 #. Label for walking directions on a map.
 msgctxt "directions"
 msgid "Walking"
@@ -17450,6 +17887,16 @@ msgstr ""
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
+msgstr ""
+
+#. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
+msgctxt ""
+"Inline warning shown below the share-content toggle when the user selects "
+"Harmful or Illegal but has not enabled sharing"
+msgid ""
+"We can only fix what we can see. To report a harmful or illegal response, "
+"please share this conversation with DuckDuckGo so we can investigate and "
+"address the issue."
 msgstr ""
 
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -17878,6 +18325,87 @@ msgid ""
 "experience."
 msgstr ""
 
+#. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the counterarguments?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the hours & location?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key contributions of this paper?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key contributions?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key details?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key points covered in this video?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key points?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key takeaways from this article?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key takeaways?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key things I will learn from this course?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main counterarguments or criticisms of this?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main questions this page answers?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the must-try dishes here?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"What are the opening hours, location, and contact details for this place?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the pros and cons of this product?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the pros and cons?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
 msgctxt "feedback form"
 msgid "What bothered you most?"
@@ -17961,6 +18489,11 @@ msgctxt "Full sentence for defining a term"
 msgid "What does atria mean in the context of a medical article?"
 msgstr ""
 
+#. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What does this answer?"
+msgstr ""
+
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
@@ -17970,6 +18503,11 @@ msgstr ""
 msgctxt "cloudsave"
 msgid "What information gets saved?"
 msgstr "Dè am fiosrachadh a thèid a shàbhaladh?"
+
+#. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What interview questions might come up for this role?"
+msgstr ""
 
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
@@ -17981,6 +18519,11 @@ msgstr ""
 #. Text for a prompt suggestion for looking up the capital city of Albania.
 msgctxt "Full sentence for looking up basic facts"
 msgid "What is the capital city of Albania?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What is the overall verdict and rating for this?"
 msgstr ""
 
 #. Link to a page with additional information.
@@ -18001,6 +18544,11 @@ msgctxt "maps_places"
 msgid "What people say:"
 msgstr ""
 
+#. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What should I order?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
 msgctxt "feedback form"
 msgid "What stood out?"
@@ -18009,6 +18557,16 @@ msgstr ""
 #. Question on a feedback form for a negative feedback response.
 msgctxt "feedback form"
 msgid "What was wrong with the response? (optional)"
+msgstr ""
+
+#. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I learn?"
+msgstr ""
+
+#. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I need?"
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -18023,6 +18581,11 @@ msgstr ""
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
 msgctxt "SERP footer content"
 msgid "What's New"
+msgstr ""
+
+#. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What's the verdict?"
 msgstr ""
 
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -18066,6 +18629,11 @@ msgctxt "Feedback prompt"
 msgid "Which features are missing? (Optional)"
 msgstr ""
 
+#. An invitation for users to leave feedback
+msgctxt "Feedback prompt"
+msgid "Which features are missing? (optional)"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
 msgid "White"
 msgstr "Geal"
@@ -18077,6 +18645,16 @@ msgstr "Geal"
 
 #. Link to an about us page.
 msgid "Who We Are"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Who are the main cast and crew, and what else are they known for?"
+msgstr ""
+
+#. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Who is this person?"
 msgstr ""
 
 #. Header above a collection of privacy-related links.

--- a/locales/gl_ES/LC_MESSAGES/duckduckgo.po
+++ b/locales/gl_ES/LC_MESSAGES/duckduckgo.po
@@ -1168,6 +1168,11 @@ msgctxt "feedback form"
 msgid "Address is incorrect"
 msgstr ""
 
+#. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Adjust the servings"
+msgstr ""
+
 #. as in multiple advertisements
 msgid "Ads"
 msgstr ""
@@ -1341,6 +1346,13 @@ msgstr ""
 #. Heading shown on the empty chat screen. The text between the two %s markers is displayed inside a clickable privacy button. First %s renders a shield icon, second %s is an invisible end marker. Keep the word 'private' between both %s markers.
 msgctxt "Empty state heading in Duck.ai chat mode"
 msgid "All chats are %sprivate%s"
+msgstr ""
+
+#. Paragraph in the Privacy & Terms section of the About & Legal page in Duck.ai settings, summarizing how chats are anonymized and are not stored or used to train chat models.
+msgctxt "Privacy & Terms section description on the Duck.ai settings page"
+msgid ""
+"All chats are anonymized by DuckDuckGo, and your conversations are not used "
+"to train chat models by DuckDuckGo or the model providers"
 msgstr ""
 
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1553,6 +1565,12 @@ msgstr ""
 #. Confirmation message after location service is enabled.
 msgctxt "precise_user_location"
 msgid "Anonymous location enabled"
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Anonymously generates answers for search queries based on web content. "
+"Choose how often you want it to appear, or disable it completely."
 msgstr ""
 
 #. Instant Answer tab name
@@ -1778,6 +1796,11 @@ msgstr ""
 
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse
 msgid "Ask a follow-up with Duck.ai"
+msgstr ""
+
+#. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
+msgctxt "Page suggestion chip label"
+msgid "Ask about this page"
 msgstr ""
 
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2102,6 +2125,11 @@ msgstr ""
 msgid "Barcode"
 msgstr "Código de barras"
 
+#. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Based on this page, is this course worth taking?"
+msgstr ""
+
 msgctxt "settings"
 msgid "Basic"
 msgstr "Básico"
@@ -2133,6 +2161,13 @@ msgstr ""
 #. Placeholder text displayed while the assistant waits for the user to choose an action.
 msgctxt "Assistant response placeholder"
 msgid "Before continuing..."
+msgstr ""
+
+#. Explains that before storing the report, DuckDuckGo will anonymize the conversation by removing PII like names, email addresses, and identifying metadata.
+msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
+msgid ""
+"Before storing this report, DuckDuckGo will anonymize your conversation by "
+"removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
 #. Label that's displayed next to a past start date below a web search result.
@@ -2391,6 +2426,11 @@ msgstr "Brazil"
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Break Points Won"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Break this down into clear, numbered steps."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -2759,6 +2799,11 @@ msgstr "Carreiras"
 #. Text of a button that performs a search for the cast of a particular movie or tv show
 msgctxt "Movie/TV Show Title instant answer"
 msgid "Cast"
+msgstr ""
+
+#. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Cast & Crew"
 msgstr ""
 
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -4118,6 +4163,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Create a shopping list with quantities from this recipe."
+msgstr ""
+
 #. Placeholder text displayed in the input field when starting a new image generation session.
 msgctxt "Placeholder text for the image generation input field"
 msgid "Create an image of a cute duck..."
@@ -4644,6 +4694,10 @@ msgstr ""
 msgid "Dictation limit reached"
 msgstr ""
 
+#. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
+msgid "Dictation temporarily unavailable"
+msgstr ""
+
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
@@ -4888,6 +4942,20 @@ msgctxt "precise_user_location"
 msgid "Done"
 msgstr ""
 
+#. Message shown in a modal after DuckDuckGo browser users disable AI features in Settings. The first two placeholders bold noai.duckduckgo.com. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
+"filtered out. %sLearn More%s"
+msgstr ""
+
+#. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
+"and AI images filtered out. %sLearn more%s"
+msgstr ""
+
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Double Faults"
@@ -4978,6 +5046,16 @@ msgctxt "Full sentence for writing an email"
 msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
+msgstr ""
+
+#. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Draft a cover letter"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Draft a cover letter for this job."
 msgstr ""
 
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -5117,6 +5195,14 @@ msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
 msgstr ""
 
+#. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
+msgctxt "About section description on the Duck.ai settings page"
+msgid ""
+"Duck.ai is created by DuckDuckGo. We're an independent online protection "
+"company for anyone who wants to take back control of their personal "
+"information."
+msgstr ""
+
 #. Title shown when an update is required before proceeding.
 msgctxt "duckai_migration"
 msgid "Duck.ai is moving domains"
@@ -5150,6 +5236,12 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Duck.ai lets you chat privately with popular AI models. Disabling it hides "
+"Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
 
 msgctxt "settings"
@@ -5916,6 +6008,16 @@ msgstr ""
 msgid "Eritrea"
 msgstr ""
 
+#. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Estimate the nutrition"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Estimate the nutritional information for this recipe."
+msgstr ""
+
 msgid "Estonia"
 msgstr "Estonia"
 
@@ -5960,10 +6062,50 @@ msgctxt "merchant promotion product ad extension"
 msgid "Expires in 1 day"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain the accepted answer in simple terms."
+msgstr ""
+
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
+msgstr ""
+
+#. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain the top answer"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this in simple, plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this paper"
+msgstr ""
+
+#. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this repo"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this research paper in plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this simply"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain what this repository does and how to use it."
 msgstr ""
 
 #. Label to show if song lyrics contain explicit content
@@ -6194,6 +6336,11 @@ msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
 msgstr ""
 
+msgctxt "settings"
+msgid ""
+"Filters out known AI spam sites from image search results. %sLearn More%s"
+msgstr ""
+
 #. Label for the final score of a sporting event.
 msgid "Final"
 msgstr "Final"
@@ -6235,6 +6382,11 @@ msgstr ""
 #. Short description shown below the 'Web Search' label in the Tools dropdown.
 msgctxt "Subtitle for the Web Search tool entry in the Tools dropdown menu"
 msgid "Find current information"
+msgstr ""
+
+#. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Find me alternatives"
 msgstr ""
 
 #. Button that searches for results closer to the user's current location.
@@ -6625,6 +6777,11 @@ msgstr ""
 msgid "Generate More"
 msgstr ""
 
+#. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Generate a shopping list"
+msgstr ""
+
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
 msgid "Generate a short answer from the web"
 msgstr ""
@@ -6861,6 +7018,11 @@ msgstr ""
 #. Text for a button inviting users to give it a try for the Duck.ai product. On click, they're taken to the Duck.ai page.
 msgctxt "Onboarding welcome screen button text"
 msgid "Give it a Try"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Give me a quick background on this person."
 msgstr ""
 
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -7224,6 +7386,16 @@ msgstr ""
 #. Link to a page with information about sharing DuckDuckGo with friends.
 msgid "Help Spread Privacy"
 msgstr "Axude a espallar a privacidade"
+
+#. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Help me prep for the interview"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Help me tailor my resume for this job."
+msgstr ""
 
 #. Title of a SERP popup that invites users to take a survey (desktop only)
 msgctxt "User survey popup"
@@ -7645,6 +7817,13 @@ msgstr ""
 #. Text displayed on the button on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
 msgctxt "Onboarding terms screen button text"
 msgid "I Agree"
+msgstr ""
+
+#. Text for the button that takes the user to the external DuckDuckGo login subscription page.
+msgctxt ""
+"Text for the I already have a subscription button in the Duck.ai settings "
+"page"
+msgid "I Already Have a Subscription"
 msgstr ""
 
 #. Text for the button that takes the user to the login subscription page.
@@ -8101,6 +8280,11 @@ msgctxt "Sidemenu browser promo"
 msgid "Install Mac Browser"
 msgstr ""
 
+#. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
+msgctxt "settings"
+msgid "Install Now"
+msgstr ""
+
 #. Text of a button to install the DuckDuckGo app
 msgctxt "Serp footer content"
 msgid "Install Our App"
@@ -8180,9 +8364,36 @@ msgctxt "cloudsave"
 msgid "Is deleted data really deleted?"
 msgstr "Elimínanse realmente os datos eliminados?"
 
+#. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is it worth taking?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this place any good?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"Is this place any good? Summarize its reputation based on reviews and "
+"ratings."
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "Is this video helpful?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this worth watching?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Is this worth watching? Give me a spoiler-free take."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -8682,6 +8893,11 @@ msgstr "Tipo de letra da ligazón:"
 msgid "Links:"
 msgstr "Ligazóns:"
 
+#. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "List the tools, materials, or prerequisites I need for this."
+msgstr ""
+
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
 msgid "Listen"
 msgstr "Escoitar"
@@ -9014,6 +9230,11 @@ msgstr ""
 #. Label for linke navigating to site exclusion feature on Settings page
 msgctxt "Exclusion message manage sites button"
 msgid "Manage blocked sites"
+msgstr ""
+
+#. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
+msgctxt "setting"
+msgid "Manage in Browser Settings"
 msgstr ""
 
 #. Link to the site exclusion settings page
@@ -11322,6 +11543,11 @@ msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
+msgid "Please describe why the chat response is harmful or illegal. (optional)"
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
+msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
 msgstr ""
 
@@ -11340,6 +11566,13 @@ msgctxt "Modal disclaimer text"
 msgid ""
 "Please note: starting a new chat with any model will delete your current "
 "chat session."
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
+msgctxt "Feedback prompt"
+msgid ""
+"Please paste your prompt and the problematic output (with any personal "
+"information removed) and describe why the content is harmful or illegal."
 msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -11724,6 +11957,11 @@ msgctxt "settings"
 msgid "Privacy"
 msgstr "Privacidade"
 
+#. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
+msgctxt "Section heading on the Duck.ai settings page"
+msgid "Privacy & Terms"
+msgstr ""
+
 msgid "Privacy Blog"
 msgstr "Blog sobre privacidade"
 
@@ -11777,6 +12015,11 @@ msgstr ""
 
 #. Text used in other strings to link to the Privacy Policy and Terms of Service content.
 msgctxt "Copy used to compose link in sentences"
+msgid "Privacy Policy and Terms of Service"
+msgstr ""
+
+#. Text for a button that links to the terms of use and privacy policy page.
+msgctxt "Secondary button text in active privacy modal"
 msgid "Privacy Policy and Terms of Service"
 msgstr ""
 
@@ -12185,6 +12428,26 @@ msgctxt "Brief for recommending a book"
 msgid "Recommend a book"
 msgstr ""
 
+#. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar books"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar books."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar movies or shows."
+msgstr ""
+
+#. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar titles"
+msgstr ""
+
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
 msgid "Recording failed. Please try again."
 msgstr ""
@@ -12504,6 +12767,14 @@ msgstr ""
 msgid "Republic of Moldova"
 msgstr ""
 
+#. Note indicating that sharing the conversation is mandatory when reporting harmful or illegal content. Rendered alongside the standard share label (DUCKCHAT_RESPONSE_FEEDBACK_SHARE_PROMPT_RESPONSE_LABEL), not replacing it.
+msgctxt ""
+"Note shown under the share-content switch label on the Duck.ai response "
+"feedback form when the user has selected Harmful or Illegal as the feedback "
+"reason"
+msgid "Required for harmful or illegal reports"
+msgstr ""
+
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
 msgctxt "Description for extended reasoning mode in Duck.ai"
 msgid "Researches before responding"
@@ -12689,6 +12960,11 @@ msgstr "Revisións"
 #. Label above a list of customer reviews of a business.
 msgctxt "maps_places"
 msgid "Reviews"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Rewrite this recipe scaled for a different number of servings."
 msgstr ""
 
 msgid "Romania"
@@ -13741,6 +14017,11 @@ msgctxt "Setup button for native sync flow"
 msgid "Set Up Now"
 msgstr ""
 
+#. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
+msgctxt "Encrypted storage setup button shown in native browsers"
+msgid "Set Up Sync & Backup"
+msgstr ""
+
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
 msgctxt "Title for the Sync & Backup intro screen"
 msgid "Set Up Sync & Backup"
@@ -13884,6 +14165,12 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
+msgctxt ""
+"Label beside the share-content switch on the Duck.ai response feedback form"
+msgid "Share this conversation with DuckDuckGo"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -14898,6 +15185,21 @@ msgctxt "Brief for suggesting a blog post title"
 msgid "Suggest a title for a blog post"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest related articles or topics worth exploring next."
+msgstr ""
+
+#. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Suggest related articles to explore"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest some alternatives to this product."
+msgstr ""
+
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
 msgctxt "directions"
 msgid "Suggestions:"
@@ -14907,9 +15209,84 @@ msgctxt "noresults"
 msgid "Suggestions:"
 msgstr "Suxestións:"
 
+#. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Sum up the reviews"
+msgstr ""
+
 #. A short title for the a message asking the AI to summarize a text.
 msgctxt "Title for the summarize message"
 msgid "Summarize"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize the Q&As"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the background and notable work of this person."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the key details of this event."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the questions and answers on this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize their background"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this book"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this book."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this discussion"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this discussion thread."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this video"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this video."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize what the reviews say."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -15164,6 +15541,11 @@ msgstr ""
 msgid "Syria"
 msgstr ""
 
+#. Text for a button that enables the theme to follow the operating system's color scheme preference.
+msgctxt "System theme button for theme selector"
+msgid "System"
+msgstr ""
+
 #. Abbreviation indicating this is the total score for a game
 msgctxt "Sports module"
 msgid "T"
@@ -15187,6 +15569,11 @@ msgctxt "language_name"
 msgid "Tahitian"
 msgstr ""
 
+#. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Tailor my resume"
+msgstr ""
+
 msgid "Taiwan"
 msgstr "Taiwan"
 
@@ -15208,6 +15595,12 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "Take control of your personal data!"
+msgstr ""
+
+#. Description for the Feedback section of the Duck.ai settings page, asking the user to take an anonymous survey to let us know how we can make Duck.ai better.
+msgctxt "Feedback section description on the Duck.ai settings page"
+msgid ""
+"Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
 
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -15455,6 +15848,11 @@ msgstr ""
 #. https://duck.co/media/files/theme.png
 msgid "Theme"
 msgstr "Tema"
+
+#. Text for the theme selector label that allows users to switch between Light and dark theme.
+msgctxt "Label for the theme selector feature"
+msgid "Theme"
+msgstr ""
 
 #. http://i.imgur.com/LpFhb1e.png
 msgctxt "settings"
@@ -16111,6 +16509,16 @@ msgid ""
 "movie theatre?”"
 msgstr ""
 
+#. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Translate this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
+msgctxt "Page suggestion prompt"
+msgid "Translate this page into %s."
+msgstr ""
+
 #. Placeholder text for a region that will display translated text.
 msgctxt "translations_module"
 msgid "Translation"
@@ -16225,6 +16633,11 @@ msgstr ""
 #. Call-to-action button for the subscription promo in the SERP sidemenu.
 msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
+msgstr ""
+
+#. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
+msgctxt "settings"
+msgid "Try It Now"
 msgstr ""
 
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -16419,6 +16832,20 @@ msgstr "Tente: %s"
 msgctxt "new user poll"
 msgid "Trying DuckDuckGo again"
 msgstr "Probando o DuckDuckGo de novo"
+
+#. Message shown in a modal after supported third-party browser users disable AI features in Settings. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+#. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
 
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
 msgctxt "Assistant response placeholder"
@@ -17023,6 +17450,11 @@ msgstr ""
 msgid "Uruguay"
 msgstr ""
 
+#. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
+msgctxt "Navigation label on the Duck.ai settings page"
+msgid "Usage"
+msgstr ""
+
 #. A feedback suggestion
 msgctxt "Feedback prompt"
 msgid "Usage limit"
@@ -17373,6 +17805,11 @@ msgstr ""
 msgid "Wales"
 msgstr ""
 
+#. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Walk me through the steps"
+msgstr ""
+
 #. Label for walking directions on a map.
 msgctxt "directions"
 msgid "Walking"
@@ -17463,6 +17900,16 @@ msgstr ""
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
+msgstr ""
+
+#. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
+msgctxt ""
+"Inline warning shown below the share-content toggle when the user selects "
+"Harmful or Illegal but has not enabled sharing"
+msgid ""
+"We can only fix what we can see. To report a harmful or illegal response, "
+"please share this conversation with DuckDuckGo so we can investigate and "
+"address the issue."
 msgstr ""
 
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -17890,6 +18337,87 @@ msgid ""
 "experience."
 msgstr ""
 
+#. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the counterarguments?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the hours & location?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key contributions of this paper?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key contributions?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key details?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key points covered in this video?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key points?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key takeaways from this article?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key takeaways?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key things I will learn from this course?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main counterarguments or criticisms of this?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main questions this page answers?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the must-try dishes here?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"What are the opening hours, location, and contact details for this place?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the pros and cons of this product?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the pros and cons?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
 msgctxt "feedback form"
 msgid "What bothered you most?"
@@ -17973,6 +18501,11 @@ msgctxt "Full sentence for defining a term"
 msgid "What does atria mean in the context of a medical article?"
 msgstr ""
 
+#. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What does this answer?"
+msgstr ""
+
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
@@ -17982,6 +18515,11 @@ msgstr ""
 msgctxt "cloudsave"
 msgid "What information gets saved?"
 msgstr "Que información se garda?"
+
+#. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What interview questions might come up for this role?"
+msgstr ""
 
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
@@ -17993,6 +18531,11 @@ msgstr ""
 #. Text for a prompt suggestion for looking up the capital city of Albania.
 msgctxt "Full sentence for looking up basic facts"
 msgid "What is the capital city of Albania?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What is the overall verdict and rating for this?"
 msgstr ""
 
 #. Link to a page with additional information.
@@ -18013,6 +18556,11 @@ msgctxt "maps_places"
 msgid "What people say:"
 msgstr ""
 
+#. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What should I order?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
 msgctxt "feedback form"
 msgid "What stood out?"
@@ -18021,6 +18569,16 @@ msgstr ""
 #. Question on a feedback form for a negative feedback response.
 msgctxt "feedback form"
 msgid "What was wrong with the response? (optional)"
+msgstr ""
+
+#. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I learn?"
+msgstr ""
+
+#. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I need?"
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -18035,6 +18593,11 @@ msgstr ""
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
 msgctxt "SERP footer content"
 msgid "What's New"
+msgstr ""
+
+#. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What's the verdict?"
 msgstr ""
 
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -18076,6 +18639,11 @@ msgctxt "Feedback prompt"
 msgid "Which features are missing? (Optional)"
 msgstr ""
 
+#. An invitation for users to leave feedback
+msgctxt "Feedback prompt"
+msgid "Which features are missing? (optional)"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
 msgid "White"
 msgstr "Branco"
@@ -18088,6 +18656,16 @@ msgstr "Branco"
 #. Link to an about us page.
 msgid "Who We Are"
 msgstr "Quen somos"
+
+#. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Who are the main cast and crew, and what else are they known for?"
+msgstr ""
+
+#. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Who is this person?"
+msgstr ""
 
 #. Header above a collection of privacy-related links.
 msgid "Why Privacy"

--- a/locales/gu_IN/LC_MESSAGES/duckduckgo.po
+++ b/locales/gu_IN/LC_MESSAGES/duckduckgo.po
@@ -1161,6 +1161,11 @@ msgctxt "feedback form"
 msgid "Address is incorrect"
 msgstr ""
 
+#. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Adjust the servings"
+msgstr ""
+
 #. as in multiple advertisements
 msgid "Ads"
 msgstr ""
@@ -1332,6 +1337,13 @@ msgstr ""
 #. Heading shown on the empty chat screen. The text between the two %s markers is displayed inside a clickable privacy button. First %s renders a shield icon, second %s is an invisible end marker. Keep the word 'private' between both %s markers.
 msgctxt "Empty state heading in Duck.ai chat mode"
 msgid "All chats are %sprivate%s"
+msgstr ""
+
+#. Paragraph in the Privacy & Terms section of the About & Legal page in Duck.ai settings, summarizing how chats are anonymized and are not stored or used to train chat models.
+msgctxt "Privacy & Terms section description on the Duck.ai settings page"
+msgid ""
+"All chats are anonymized by DuckDuckGo, and your conversations are not used "
+"to train chat models by DuckDuckGo or the model providers"
 msgstr ""
 
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1544,6 +1556,12 @@ msgstr ""
 #. Confirmation message after location service is enabled.
 msgctxt "precise_user_location"
 msgid "Anonymous location enabled"
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Anonymously generates answers for search queries based on web content. "
+"Choose how often you want it to appear, or disable it completely."
 msgstr ""
 
 #. Instant Answer tab name
@@ -1766,6 +1784,11 @@ msgstr ""
 
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse
 msgid "Ask a follow-up with Duck.ai"
+msgstr ""
+
+#. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
+msgctxt "Page suggestion chip label"
+msgid "Ask about this page"
 msgstr ""
 
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2090,6 +2113,11 @@ msgstr ""
 msgid "Barcode"
 msgstr "બારકોડ"
 
+#. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Based on this page, is this course worth taking?"
+msgstr ""
+
 msgctxt "settings"
 msgid "Basic"
 msgstr ""
@@ -2121,6 +2149,13 @@ msgstr ""
 #. Placeholder text displayed while the assistant waits for the user to choose an action.
 msgctxt "Assistant response placeholder"
 msgid "Before continuing..."
+msgstr ""
+
+#. Explains that before storing the report, DuckDuckGo will anonymize the conversation by removing PII like names, email addresses, and identifying metadata.
+msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
+msgid ""
+"Before storing this report, DuckDuckGo will anonymize your conversation by "
+"removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
 #. Label that's displayed next to a past start date below a web search result.
@@ -2379,6 +2414,11 @@ msgstr "બ્રાઝિલ"
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Break Points Won"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Break this down into clear, numbered steps."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -2738,6 +2778,11 @@ msgstr ""
 #. Text of a button that performs a search for the cast of a particular movie or tv show
 msgctxt "Movie/TV Show Title instant answer"
 msgid "Cast"
+msgstr ""
+
+#. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Cast & Crew"
 msgstr ""
 
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -4087,6 +4132,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Create a shopping list with quantities from this recipe."
+msgstr ""
+
 #. Placeholder text displayed in the input field when starting a new image generation session.
 msgctxt "Placeholder text for the image generation input field"
 msgid "Create an image of a cute duck..."
@@ -4613,6 +4663,10 @@ msgstr ""
 msgid "Dictation limit reached"
 msgstr ""
 
+#. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
+msgid "Dictation temporarily unavailable"
+msgstr ""
+
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
@@ -4857,6 +4911,20 @@ msgctxt "precise_user_location"
 msgid "Done"
 msgstr ""
 
+#. Message shown in a modal after DuckDuckGo browser users disable AI features in Settings. The first two placeholders bold noai.duckduckgo.com. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
+"filtered out. %sLearn More%s"
+msgstr ""
+
+#. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
+"and AI images filtered out. %sLearn more%s"
+msgstr ""
+
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Double Faults"
@@ -4947,6 +5015,16 @@ msgctxt "Full sentence for writing an email"
 msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
+msgstr ""
+
+#. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Draft a cover letter"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Draft a cover letter for this job."
 msgstr ""
 
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -5086,6 +5164,14 @@ msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
 msgstr ""
 
+#. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
+msgctxt "About section description on the Duck.ai settings page"
+msgid ""
+"Duck.ai is created by DuckDuckGo. We're an independent online protection "
+"company for anyone who wants to take back control of their personal "
+"information."
+msgstr ""
+
 #. Title shown when an update is required before proceeding.
 msgctxt "duckai_migration"
 msgid "Duck.ai is moving domains"
@@ -5119,6 +5205,12 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Duck.ai lets you chat privately with popular AI models. Disabling it hides "
+"Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
 
 msgctxt "settings"
@@ -5892,6 +5984,16 @@ msgstr ""
 msgid "Eritrea"
 msgstr ""
 
+#. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Estimate the nutrition"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Estimate the nutritional information for this recipe."
+msgstr ""
+
 msgid "Estonia"
 msgstr ""
 
@@ -5936,10 +6038,50 @@ msgctxt "merchant promotion product ad extension"
 msgid "Expires in 1 day"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain the accepted answer in simple terms."
+msgstr ""
+
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
+msgstr ""
+
+#. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain the top answer"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this in simple, plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this paper"
+msgstr ""
+
+#. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this repo"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this research paper in plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this simply"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain what this repository does and how to use it."
 msgstr ""
 
 #. Label to show if song lyrics contain explicit content
@@ -6168,6 +6310,11 @@ msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
 msgstr ""
 
+msgctxt "settings"
+msgid ""
+"Filters out known AI spam sites from image search results. %sLearn More%s"
+msgstr ""
+
 #. Label for the final score of a sporting event.
 msgid "Final"
 msgstr ""
@@ -6207,6 +6354,11 @@ msgstr ""
 #. Short description shown below the 'Web Search' label in the Tools dropdown.
 msgctxt "Subtitle for the Web Search tool entry in the Tools dropdown menu"
 msgid "Find current information"
+msgstr ""
+
+#. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Find me alternatives"
 msgstr ""
 
 #. Button that searches for results closer to the user's current location.
@@ -6597,6 +6749,11 @@ msgstr ""
 msgid "Generate More"
 msgstr ""
 
+#. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Generate a shopping list"
+msgstr ""
+
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
 msgid "Generate a short answer from the web"
 msgstr ""
@@ -6831,6 +6988,11 @@ msgstr ""
 #. Text for a button inviting users to give it a try for the Duck.ai product. On click, they're taken to the Duck.ai page.
 msgctxt "Onboarding welcome screen button text"
 msgid "Give it a Try"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Give me a quick background on this person."
 msgstr ""
 
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -7193,6 +7355,16 @@ msgstr ""
 
 #. Link to a page with information about sharing DuckDuckGo with friends.
 msgid "Help Spread Privacy"
+msgstr ""
+
+#. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Help me prep for the interview"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Help me tailor my resume for this job."
 msgstr ""
 
 #. Title of a SERP popup that invites users to take a survey (desktop only)
@@ -7612,6 +7784,13 @@ msgstr ""
 #. Text displayed on the button on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
 msgctxt "Onboarding terms screen button text"
 msgid "I Agree"
+msgstr ""
+
+#. Text for the button that takes the user to the external DuckDuckGo login subscription page.
+msgctxt ""
+"Text for the I already have a subscription button in the Duck.ai settings "
+"page"
+msgid "I Already Have a Subscription"
 msgstr ""
 
 #. Text for the button that takes the user to the login subscription page.
@@ -8062,6 +8241,11 @@ msgctxt "Sidemenu browser promo"
 msgid "Install Mac Browser"
 msgstr ""
 
+#. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
+msgctxt "settings"
+msgid "Install Now"
+msgstr ""
+
 #. Text of a button to install the DuckDuckGo app
 msgctxt "Serp footer content"
 msgid "Install Our App"
@@ -8141,9 +8325,36 @@ msgctxt "cloudsave"
 msgid "Is deleted data really deleted?"
 msgstr "કાધીનાખેલ માહિતી ખરેખર કાઢી નાખવામાં આવે છે? "
 
+#. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is it worth taking?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this place any good?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"Is this place any good? Summarize its reputation based on reviews and "
+"ratings."
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "Is this video helpful?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this worth watching?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Is this worth watching? Give me a spoiler-free take."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -8640,6 +8851,11 @@ msgstr "કડી અક્ષર:"
 msgid "Links:"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "List the tools, materials, or prerequisites I need for this."
+msgstr ""
+
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
 msgid "Listen"
 msgstr "સાંભળો"
@@ -8972,6 +9188,11 @@ msgstr ""
 #. Label for linke navigating to site exclusion feature on Settings page
 msgctxt "Exclusion message manage sites button"
 msgid "Manage blocked sites"
+msgstr ""
+
+#. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
+msgctxt "setting"
+msgid "Manage in Browser Settings"
 msgstr ""
 
 #. Link to the site exclusion settings page
@@ -11269,6 +11490,11 @@ msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
+msgid "Please describe why the chat response is harmful or illegal. (optional)"
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
+msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
 msgstr ""
 
@@ -11287,6 +11513,13 @@ msgctxt "Modal disclaimer text"
 msgid ""
 "Please note: starting a new chat with any model will delete your current "
 "chat session."
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
+msgctxt "Feedback prompt"
+msgid ""
+"Please paste your prompt and the problematic output (with any personal "
+"information removed) and describe why the content is harmful or illegal."
 msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -11671,6 +11904,11 @@ msgctxt "settings"
 msgid "Privacy"
 msgstr ""
 
+#. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
+msgctxt "Section heading on the Duck.ai settings page"
+msgid "Privacy & Terms"
+msgstr ""
+
 msgid "Privacy Blog"
 msgstr ""
 
@@ -11724,6 +11962,11 @@ msgstr ""
 
 #. Text used in other strings to link to the Privacy Policy and Terms of Service content.
 msgctxt "Copy used to compose link in sentences"
+msgid "Privacy Policy and Terms of Service"
+msgstr ""
+
+#. Text for a button that links to the terms of use and privacy policy page.
+msgctxt "Secondary button text in active privacy modal"
 msgid "Privacy Policy and Terms of Service"
 msgstr ""
 
@@ -12132,6 +12375,26 @@ msgctxt "Brief for recommending a book"
 msgid "Recommend a book"
 msgstr ""
 
+#. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar books"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar books."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar movies or shows."
+msgstr ""
+
+#. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar titles"
+msgstr ""
+
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
 msgid "Recording failed. Please try again."
 msgstr ""
@@ -12451,6 +12714,14 @@ msgstr ""
 msgid "Republic of Moldova"
 msgstr ""
 
+#. Note indicating that sharing the conversation is mandatory when reporting harmful or illegal content. Rendered alongside the standard share label (DUCKCHAT_RESPONSE_FEEDBACK_SHARE_PROMPT_RESPONSE_LABEL), not replacing it.
+msgctxt ""
+"Note shown under the share-content switch label on the Duck.ai response "
+"feedback form when the user has selected Harmful or Illegal as the feedback "
+"reason"
+msgid "Required for harmful or illegal reports"
+msgstr ""
+
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
 msgctxt "Description for extended reasoning mode in Duck.ai"
 msgid "Researches before responding"
@@ -12636,6 +12907,11 @@ msgstr "ટીપ્પણીઓ"
 #. Label above a list of customer reviews of a business.
 msgctxt "maps_places"
 msgid "Reviews"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Rewrite this recipe scaled for a different number of servings."
 msgstr ""
 
 msgid "Romania"
@@ -13673,6 +13949,11 @@ msgctxt "Setup button for native sync flow"
 msgid "Set Up Now"
 msgstr ""
 
+#. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
+msgctxt "Encrypted storage setup button shown in native browsers"
+msgid "Set Up Sync & Backup"
+msgstr ""
+
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
 msgctxt "Title for the Sync & Backup intro screen"
 msgid "Set Up Sync & Backup"
@@ -13815,6 +14096,12 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
+msgctxt ""
+"Label beside the share-content switch on the Duck.ai response feedback form"
+msgid "Share this conversation with DuckDuckGo"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -14829,6 +15116,21 @@ msgctxt "Brief for suggesting a blog post title"
 msgid "Suggest a title for a blog post"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest related articles or topics worth exploring next."
+msgstr ""
+
+#. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Suggest related articles to explore"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest some alternatives to this product."
+msgstr ""
+
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
 msgctxt "directions"
 msgid "Suggestions:"
@@ -14838,9 +15140,84 @@ msgctxt "noresults"
 msgid "Suggestions:"
 msgstr ""
 
+#. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Sum up the reviews"
+msgstr ""
+
 #. A short title for the a message asking the AI to summarize a text.
 msgctxt "Title for the summarize message"
 msgid "Summarize"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize the Q&As"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the background and notable work of this person."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the key details of this event."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the questions and answers on this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize their background"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this book"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this book."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this discussion"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this discussion thread."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this video"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this video."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize what the reviews say."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -15095,6 +15472,11 @@ msgstr ""
 msgid "Syria"
 msgstr ""
 
+#. Text for a button that enables the theme to follow the operating system's color scheme preference.
+msgctxt "System theme button for theme selector"
+msgid "System"
+msgstr ""
+
 #. Abbreviation indicating this is the total score for a game
 msgctxt "Sports module"
 msgid "T"
@@ -15118,6 +15500,11 @@ msgctxt "language_name"
 msgid "Tahitian"
 msgstr ""
 
+#. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Tailor my resume"
+msgstr ""
+
 msgid "Taiwan"
 msgstr ""
 
@@ -15139,6 +15526,12 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "Take control of your personal data!"
+msgstr ""
+
+#. Description for the Feedback section of the Duck.ai settings page, asking the user to take an anonymous survey to let us know how we can make Duck.ai better.
+msgctxt "Feedback section description on the Duck.ai settings page"
+msgid ""
+"Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
 
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -15381,6 +15774,11 @@ msgstr ""
 
 #. Title for the theme menu:
 #. https://duck.co/media/files/theme.png
+msgid "Theme"
+msgstr ""
+
+#. Text for the theme selector label that allows users to switch between Light and dark theme.
+msgctxt "Label for the theme selector feature"
 msgid "Theme"
 msgstr ""
 
@@ -16034,6 +16432,16 @@ msgid ""
 "movie theatre?”"
 msgstr ""
 
+#. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Translate this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
+msgctxt "Page suggestion prompt"
+msgid "Translate this page into %s."
+msgstr ""
+
 #. Placeholder text for a region that will display translated text.
 msgctxt "translations_module"
 msgid "Translation"
@@ -16148,6 +16556,11 @@ msgstr ""
 #. Call-to-action button for the subscription promo in the SERP sidemenu.
 msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
+msgstr ""
+
+#. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
+msgctxt "settings"
+msgid "Try It Now"
 msgstr ""
 
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -16341,6 +16754,20 @@ msgstr "પ્રયત્ન કરો: %s"
 #. Response a user can select in a feedback form, indicating that they're trying DuckDuckGo again.
 msgctxt "new user poll"
 msgid "Trying DuckDuckGo again"
+msgstr ""
+
+#. Message shown in a modal after supported third-party browser users disable AI features in Settings. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+#. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
 msgstr ""
 
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -16941,6 +17368,11 @@ msgstr ""
 msgid "Uruguay"
 msgstr ""
 
+#. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
+msgctxt "Navigation label on the Duck.ai settings page"
+msgid "Usage"
+msgstr ""
+
 #. A feedback suggestion
 msgctxt "Feedback prompt"
 msgid "Usage limit"
@@ -17289,6 +17721,11 @@ msgstr ""
 msgid "Wales"
 msgstr ""
 
+#. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Walk me through the steps"
+msgstr ""
+
 #. Label for walking directions on a map.
 msgctxt "directions"
 msgid "Walking"
@@ -17379,6 +17816,16 @@ msgstr ""
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
+msgstr ""
+
+#. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
+msgctxt ""
+"Inline warning shown below the share-content toggle when the user selects "
+"Harmful or Illegal but has not enabled sharing"
+msgid ""
+"We can only fix what we can see. To report a harmful or illegal response, "
+"please share this conversation with DuckDuckGo so we can investigate and "
+"address the issue."
 msgstr ""
 
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -17798,6 +18245,87 @@ msgid ""
 "experience."
 msgstr ""
 
+#. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the counterarguments?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the hours & location?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key contributions of this paper?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key contributions?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key details?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key points covered in this video?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key points?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key takeaways from this article?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key takeaways?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key things I will learn from this course?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main counterarguments or criticisms of this?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main questions this page answers?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the must-try dishes here?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"What are the opening hours, location, and contact details for this place?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the pros and cons of this product?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the pros and cons?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
 msgctxt "feedback form"
 msgid "What bothered you most?"
@@ -17881,6 +18409,11 @@ msgctxt "Full sentence for defining a term"
 msgid "What does atria mean in the context of a medical article?"
 msgstr ""
 
+#. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What does this answer?"
+msgstr ""
+
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
@@ -17890,6 +18423,11 @@ msgstr ""
 msgctxt "cloudsave"
 msgid "What information gets saved?"
 msgstr "કઈ માહિતી સંગ્રહાય છે?"
+
+#. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What interview questions might come up for this role?"
+msgstr ""
 
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
@@ -17901,6 +18439,11 @@ msgstr ""
 #. Text for a prompt suggestion for looking up the capital city of Albania.
 msgctxt "Full sentence for looking up basic facts"
 msgid "What is the capital city of Albania?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What is the overall verdict and rating for this?"
 msgstr ""
 
 #. Link to a page with additional information.
@@ -17921,6 +18464,11 @@ msgctxt "maps_places"
 msgid "What people say:"
 msgstr ""
 
+#. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What should I order?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
 msgctxt "feedback form"
 msgid "What stood out?"
@@ -17929,6 +18477,16 @@ msgstr ""
 #. Question on a feedback form for a negative feedback response.
 msgctxt "feedback form"
 msgid "What was wrong with the response? (optional)"
+msgstr ""
+
+#. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I learn?"
+msgstr ""
+
+#. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I need?"
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -17943,6 +18501,11 @@ msgstr ""
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
 msgctxt "SERP footer content"
 msgid "What's New"
+msgstr ""
+
+#. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What's the verdict?"
 msgstr ""
 
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -17984,6 +18547,11 @@ msgctxt "Feedback prompt"
 msgid "Which features are missing? (Optional)"
 msgstr ""
 
+#. An invitation for users to leave feedback
+msgctxt "Feedback prompt"
+msgid "Which features are missing? (optional)"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
 msgid "White"
 msgstr ""
@@ -17995,6 +18563,16 @@ msgstr ""
 
 #. Link to an about us page.
 msgid "Who We Are"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Who are the main cast and crew, and what else are they known for?"
+msgstr ""
+
+#. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Who is this person?"
 msgstr ""
 
 #. Header above a collection of privacy-related links.

--- a/locales/he_IL/LC_MESSAGES/duckduckgo.po
+++ b/locales/he_IL/LC_MESSAGES/duckduckgo.po
@@ -1161,6 +1161,11 @@ msgctxt "feedback form"
 msgid "Address is incorrect"
 msgstr "כתובת לא נכונה"
 
+#. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Adjust the servings"
+msgstr ""
+
 #. as in multiple advertisements
 msgid "Ads"
 msgstr "פרסומות"
@@ -1332,6 +1337,13 @@ msgstr ""
 #. Heading shown on the empty chat screen. The text between the two %s markers is displayed inside a clickable privacy button. First %s renders a shield icon, second %s is an invisible end marker. Keep the word 'private' between both %s markers.
 msgctxt "Empty state heading in Duck.ai chat mode"
 msgid "All chats are %sprivate%s"
+msgstr ""
+
+#. Paragraph in the Privacy & Terms section of the About & Legal page in Duck.ai settings, summarizing how chats are anonymized and are not stored or used to train chat models.
+msgctxt "Privacy & Terms section description on the Duck.ai settings page"
+msgid ""
+"All chats are anonymized by DuckDuckGo, and your conversations are not used "
+"to train chat models by DuckDuckGo or the model providers"
 msgstr ""
 
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1546,6 +1558,12 @@ msgstr ""
 msgctxt "precise_user_location"
 msgid "Anonymous location enabled"
 msgstr "מיקום אנונימי מאופשר"
+
+msgctxt "settings"
+msgid ""
+"Anonymously generates answers for search queries based on web content. "
+"Choose how often you want it to appear, or disable it completely."
+msgstr ""
 
 #. Instant Answer tab name
 msgid "Answer"
@@ -1769,6 +1787,11 @@ msgstr ""
 
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse
 msgid "Ask a follow-up with Duck.ai"
+msgstr ""
+
+#. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
+msgctxt "Page suggestion chip label"
+msgid "Ask about this page"
 msgstr ""
 
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2093,6 +2116,11 @@ msgstr ""
 msgid "Barcode"
 msgstr "ברקוד"
 
+#. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Based on this page, is this course worth taking?"
+msgstr ""
+
 msgctxt "settings"
 msgid "Basic"
 msgstr "בסיסי"
@@ -2124,6 +2152,13 @@ msgstr ""
 #. Placeholder text displayed while the assistant waits for the user to choose an action.
 msgctxt "Assistant response placeholder"
 msgid "Before continuing..."
+msgstr ""
+
+#. Explains that before storing the report, DuckDuckGo will anonymize the conversation by removing PII like names, email addresses, and identifying metadata.
+msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
+msgid ""
+"Before storing this report, DuckDuckGo will anonymize your conversation by "
+"removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
 #. Label that's displayed next to a past start date below a web search result.
@@ -2382,6 +2417,11 @@ msgstr "ברזיל"
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Break Points Won"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Break this down into clear, numbered steps."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -2741,6 +2781,11 @@ msgstr "מקצועות"
 #. Text of a button that performs a search for the cast of a particular movie or tv show
 msgctxt "Movie/TV Show Title instant answer"
 msgid "Cast"
+msgstr ""
+
+#. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Cast & Crew"
 msgstr ""
 
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -4097,6 +4142,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Create a shopping list with quantities from this recipe."
+msgstr ""
+
 #. Placeholder text displayed in the input field when starting a new image generation session.
 msgctxt "Placeholder text for the image generation input field"
 msgid "Create an image of a cute duck..."
@@ -4623,6 +4673,10 @@ msgstr ""
 msgid "Dictation limit reached"
 msgstr ""
 
+#. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
+msgid "Dictation temporarily unavailable"
+msgstr ""
+
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
@@ -4867,6 +4921,20 @@ msgctxt "precise_user_location"
 msgid "Done"
 msgstr "בוצע"
 
+#. Message shown in a modal after DuckDuckGo browser users disable AI features in Settings. The first two placeholders bold noai.duckduckgo.com. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
+"filtered out. %sLearn More%s"
+msgstr ""
+
+#. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
+"and AI images filtered out. %sLearn more%s"
+msgstr ""
+
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Double Faults"
@@ -4957,6 +5025,16 @@ msgctxt "Full sentence for writing an email"
 msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
+msgstr ""
+
+#. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Draft a cover letter"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Draft a cover letter for this job."
 msgstr ""
 
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -5096,6 +5174,14 @@ msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
 msgstr ""
 
+#. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
+msgctxt "About section description on the Duck.ai settings page"
+msgid ""
+"Duck.ai is created by DuckDuckGo. We're an independent online protection "
+"company for anyone who wants to take back control of their personal "
+"information."
+msgstr ""
+
 #. Title shown when an update is required before proceeding.
 msgctxt "duckai_migration"
 msgid "Duck.ai is moving domains"
@@ -5129,6 +5215,12 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Duck.ai lets you chat privately with popular AI models. Disabling it hides "
+"Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
 
 msgctxt "settings"
@@ -5894,6 +5986,16 @@ msgstr ""
 msgid "Eritrea"
 msgstr ""
 
+#. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Estimate the nutrition"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Estimate the nutritional information for this recipe."
+msgstr ""
+
 msgid "Estonia"
 msgstr ""
 
@@ -5938,10 +6040,50 @@ msgctxt "merchant promotion product ad extension"
 msgid "Expires in 1 day"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain the accepted answer in simple terms."
+msgstr ""
+
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
+msgstr ""
+
+#. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain the top answer"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this in simple, plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this paper"
+msgstr ""
+
+#. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this repo"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this research paper in plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this simply"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain what this repository does and how to use it."
 msgstr ""
 
 #. Label to show if song lyrics contain explicit content
@@ -6171,6 +6313,11 @@ msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
 msgstr ""
 
+msgctxt "settings"
+msgid ""
+"Filters out known AI spam sites from image search results. %sLearn More%s"
+msgstr ""
+
 #. Label for the final score of a sporting event.
 msgid "Final"
 msgstr "סופי"
@@ -6210,6 +6357,11 @@ msgstr ""
 #. Short description shown below the 'Web Search' label in the Tools dropdown.
 msgctxt "Subtitle for the Web Search tool entry in the Tools dropdown menu"
 msgid "Find current information"
+msgstr ""
+
+#. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Find me alternatives"
 msgstr ""
 
 #. Button that searches for results closer to the user's current location.
@@ -6600,6 +6752,11 @@ msgstr ""
 msgid "Generate More"
 msgstr ""
 
+#. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Generate a shopping list"
+msgstr ""
+
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
 msgid "Generate a short answer from the web"
 msgstr ""
@@ -6834,6 +6991,11 @@ msgstr ""
 #. Text for a button inviting users to give it a try for the Duck.ai product. On click, they're taken to the Duck.ai page.
 msgctxt "Onboarding welcome screen button text"
 msgid "Give it a Try"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Give me a quick background on this person."
 msgstr ""
 
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -7196,6 +7358,16 @@ msgstr ""
 
 #. Link to a page with information about sharing DuckDuckGo with friends.
 msgid "Help Spread Privacy"
+msgstr ""
+
+#. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Help me prep for the interview"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Help me tailor my resume for this job."
 msgstr ""
 
 #. Title of a SERP popup that invites users to take a survey (desktop only)
@@ -7615,6 +7787,13 @@ msgstr ""
 #. Text displayed on the button on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
 msgctxt "Onboarding terms screen button text"
 msgid "I Agree"
+msgstr ""
+
+#. Text for the button that takes the user to the external DuckDuckGo login subscription page.
+msgctxt ""
+"Text for the I already have a subscription button in the Duck.ai settings "
+"page"
+msgid "I Already Have a Subscription"
 msgstr ""
 
 #. Text for the button that takes the user to the login subscription page.
@@ -8069,6 +8248,11 @@ msgctxt "Sidemenu browser promo"
 msgid "Install Mac Browser"
 msgstr ""
 
+#. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
+msgctxt "settings"
+msgid "Install Now"
+msgstr ""
+
 #. Text of a button to install the DuckDuckGo app
 msgctxt "Serp footer content"
 msgid "Install Our App"
@@ -8148,9 +8332,36 @@ msgctxt "cloudsave"
 msgid "Is deleted data really deleted?"
 msgstr "האם מידע מחוק הוא באמת מחוק?"
 
+#. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is it worth taking?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this place any good?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"Is this place any good? Summarize its reputation based on reviews and "
+"ratings."
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "Is this video helpful?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this worth watching?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Is this worth watching? Give me a spoiler-free take."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -8647,6 +8858,11 @@ msgstr "גופן לינקים:"
 msgid "Links:"
 msgstr "קישורים:"
 
+#. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "List the tools, materials, or prerequisites I need for this."
+msgstr ""
+
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
 msgid "Listen"
 msgstr "האזן/י"
@@ -8979,6 +9195,11 @@ msgstr ""
 #. Label for linke navigating to site exclusion feature on Settings page
 msgctxt "Exclusion message manage sites button"
 msgid "Manage blocked sites"
+msgstr ""
+
+#. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
+msgctxt "setting"
+msgid "Manage in Browser Settings"
 msgstr ""
 
 #. Link to the site exclusion settings page
@@ -11282,6 +11503,11 @@ msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
+msgid "Please describe why the chat response is harmful or illegal. (optional)"
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
+msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
 msgstr ""
 
@@ -11300,6 +11526,13 @@ msgctxt "Modal disclaimer text"
 msgid ""
 "Please note: starting a new chat with any model will delete your current "
 "chat session."
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
+msgctxt "Feedback prompt"
+msgid ""
+"Please paste your prompt and the problematic output (with any personal "
+"information removed) and describe why the content is harmful or illegal."
 msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -11684,6 +11917,11 @@ msgctxt "settings"
 msgid "Privacy"
 msgstr "פרטיות"
 
+#. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
+msgctxt "Section heading on the Duck.ai settings page"
+msgid "Privacy & Terms"
+msgstr ""
+
 msgid "Privacy Blog"
 msgstr "בלוג פרטיות"
 
@@ -11737,6 +11975,11 @@ msgstr ""
 
 #. Text used in other strings to link to the Privacy Policy and Terms of Service content.
 msgctxt "Copy used to compose link in sentences"
+msgid "Privacy Policy and Terms of Service"
+msgstr ""
+
+#. Text for a button that links to the terms of use and privacy policy page.
+msgctxt "Secondary button text in active privacy modal"
 msgid "Privacy Policy and Terms of Service"
 msgstr ""
 
@@ -12145,6 +12388,26 @@ msgctxt "Brief for recommending a book"
 msgid "Recommend a book"
 msgstr ""
 
+#. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar books"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar books."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar movies or shows."
+msgstr ""
+
+#. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar titles"
+msgstr ""
+
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
 msgid "Recording failed. Please try again."
 msgstr ""
@@ -12464,6 +12727,14 @@ msgstr ""
 msgid "Republic of Moldova"
 msgstr ""
 
+#. Note indicating that sharing the conversation is mandatory when reporting harmful or illegal content. Rendered alongside the standard share label (DUCKCHAT_RESPONSE_FEEDBACK_SHARE_PROMPT_RESPONSE_LABEL), not replacing it.
+msgctxt ""
+"Note shown under the share-content switch label on the Duck.ai response "
+"feedback form when the user has selected Harmful or Illegal as the feedback "
+"reason"
+msgid "Required for harmful or illegal reports"
+msgstr ""
+
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
 msgctxt "Description for extended reasoning mode in Duck.ai"
 msgid "Researches before responding"
@@ -12650,6 +12921,11 @@ msgstr "ביקורות"
 msgctxt "maps_places"
 msgid "Reviews"
 msgstr "סקירות"
+
+#. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Rewrite this recipe scaled for a different number of servings."
+msgstr ""
 
 msgid "Romania"
 msgstr "רומניה"
@@ -13689,6 +13965,11 @@ msgctxt "Setup button for native sync flow"
 msgid "Set Up Now"
 msgstr ""
 
+#. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
+msgctxt "Encrypted storage setup button shown in native browsers"
+msgid "Set Up Sync & Backup"
+msgstr ""
+
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
 msgctxt "Title for the Sync & Backup intro screen"
 msgid "Set Up Sync & Backup"
@@ -13831,6 +14112,12 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
+msgctxt ""
+"Label beside the share-content switch on the Duck.ai response feedback form"
+msgid "Share this conversation with DuckDuckGo"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -14845,6 +15132,21 @@ msgctxt "Brief for suggesting a blog post title"
 msgid "Suggest a title for a blog post"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest related articles or topics worth exploring next."
+msgstr ""
+
+#. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Suggest related articles to explore"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest some alternatives to this product."
+msgstr ""
+
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
 msgctxt "directions"
 msgid "Suggestions:"
@@ -14854,9 +15156,84 @@ msgctxt "noresults"
 msgid "Suggestions:"
 msgstr "הצעות:"
 
+#. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Sum up the reviews"
+msgstr ""
+
 #. A short title for the a message asking the AI to summarize a text.
 msgctxt "Title for the summarize message"
 msgid "Summarize"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize the Q&As"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the background and notable work of this person."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the key details of this event."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the questions and answers on this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize their background"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this book"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this book."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this discussion"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this discussion thread."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this video"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this video."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize what the reviews say."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -15111,6 +15488,11 @@ msgstr ""
 msgid "Syria"
 msgstr ""
 
+#. Text for a button that enables the theme to follow the operating system's color scheme preference.
+msgctxt "System theme button for theme selector"
+msgid "System"
+msgstr ""
+
 #. Abbreviation indicating this is the total score for a game
 msgctxt "Sports module"
 msgid "T"
@@ -15134,6 +15516,11 @@ msgctxt "language_name"
 msgid "Tahitian"
 msgstr ""
 
+#. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Tailor my resume"
+msgstr ""
+
 msgid "Taiwan"
 msgstr "טאיוואן"
 
@@ -15155,6 +15542,12 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "Take control of your personal data!"
+msgstr ""
+
+#. Description for the Feedback section of the Duck.ai settings page, asking the user to take an anonymous survey to let us know how we can make Duck.ai better.
+msgctxt "Feedback section description on the Duck.ai settings page"
+msgid ""
+"Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
 
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -15399,6 +15792,11 @@ msgstr ""
 #. https://duck.co/media/files/theme.png
 msgid "Theme"
 msgstr "מוטיב"
+
+#. Text for the theme selector label that allows users to switch between Light and dark theme.
+msgctxt "Label for the theme selector feature"
+msgid "Theme"
+msgstr ""
 
 #. http://i.imgur.com/LpFhb1e.png
 msgctxt "settings"
@@ -16050,6 +16448,16 @@ msgid ""
 "movie theatre?”"
 msgstr ""
 
+#. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Translate this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
+msgctxt "Page suggestion prompt"
+msgid "Translate this page into %s."
+msgstr ""
+
 #. Placeholder text for a region that will display translated text.
 msgctxt "translations_module"
 msgid "Translation"
@@ -16164,6 +16572,11 @@ msgstr ""
 #. Call-to-action button for the subscription promo in the SERP sidemenu.
 msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
+msgstr ""
+
+#. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
+msgctxt "settings"
+msgid "Try It Now"
 msgstr ""
 
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -16358,6 +16771,20 @@ msgstr "נסו: %s"
 msgctxt "new user poll"
 msgid "Trying DuckDuckGo again"
 msgstr "נסה את DuckDuckGo שוב"
+
+#. Message shown in a modal after supported third-party browser users disable AI features in Settings. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+#. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
 
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
 msgctxt "Assistant response placeholder"
@@ -16960,6 +17387,11 @@ msgstr ""
 msgid "Uruguay"
 msgstr ""
 
+#. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
+msgctxt "Navigation label on the Duck.ai settings page"
+msgid "Usage"
+msgstr ""
+
 #. A feedback suggestion
 msgctxt "Feedback prompt"
 msgid "Usage limit"
@@ -17308,6 +17740,11 @@ msgstr ""
 msgid "Wales"
 msgstr ""
 
+#. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Walk me through the steps"
+msgstr ""
+
 #. Label for walking directions on a map.
 msgctxt "directions"
 msgid "Walking"
@@ -17398,6 +17835,16 @@ msgstr ""
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
+msgstr ""
+
+#. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
+msgctxt ""
+"Inline warning shown below the share-content toggle when the user selects "
+"Harmful or Illegal but has not enabled sharing"
+msgid ""
+"We can only fix what we can see. To report a harmful or illegal response, "
+"please share this conversation with DuckDuckGo so we can investigate and "
+"address the issue."
 msgstr ""
 
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -17819,6 +18266,87 @@ msgid ""
 "experience."
 msgstr ""
 
+#. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the counterarguments?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the hours & location?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key contributions of this paper?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key contributions?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key details?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key points covered in this video?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key points?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key takeaways from this article?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key takeaways?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key things I will learn from this course?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main counterarguments or criticisms of this?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main questions this page answers?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the must-try dishes here?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"What are the opening hours, location, and contact details for this place?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the pros and cons of this product?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the pros and cons?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
 msgctxt "feedback form"
 msgid "What bothered you most?"
@@ -17902,6 +18430,11 @@ msgctxt "Full sentence for defining a term"
 msgid "What does atria mean in the context of a medical article?"
 msgstr ""
 
+#. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What does this answer?"
+msgstr ""
+
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
@@ -17911,6 +18444,11 @@ msgstr ""
 msgctxt "cloudsave"
 msgid "What information gets saved?"
 msgstr "איזה מידע נשמר?"
+
+#. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What interview questions might come up for this role?"
+msgstr ""
 
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
@@ -17922,6 +18460,11 @@ msgstr ""
 #. Text for a prompt suggestion for looking up the capital city of Albania.
 msgctxt "Full sentence for looking up basic facts"
 msgid "What is the capital city of Albania?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What is the overall verdict and rating for this?"
 msgstr ""
 
 #. Link to a page with additional information.
@@ -17942,6 +18485,11 @@ msgctxt "maps_places"
 msgid "What people say:"
 msgstr ""
 
+#. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What should I order?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
 msgctxt "feedback form"
 msgid "What stood out?"
@@ -17950,6 +18498,16 @@ msgstr ""
 #. Question on a feedback form for a negative feedback response.
 msgctxt "feedback form"
 msgid "What was wrong with the response? (optional)"
+msgstr ""
+
+#. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I learn?"
+msgstr ""
+
+#. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I need?"
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -17964,6 +18522,11 @@ msgstr ""
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
 msgctxt "SERP footer content"
 msgid "What's New"
+msgstr ""
+
+#. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What's the verdict?"
 msgstr ""
 
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -18005,6 +18568,11 @@ msgctxt "Feedback prompt"
 msgid "Which features are missing? (Optional)"
 msgstr ""
 
+#. An invitation for users to leave feedback
+msgctxt "Feedback prompt"
+msgid "Which features are missing? (optional)"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
 msgid "White"
 msgstr "לבן"
@@ -18017,6 +18585,16 @@ msgstr "לבן"
 #. Link to an about us page.
 msgid "Who We Are"
 msgstr "מי אנחנו"
+
+#. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Who are the main cast and crew, and what else are they known for?"
+msgstr ""
+
+#. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Who is this person?"
+msgstr ""
 
 #. Header above a collection of privacy-related links.
 msgid "Why Privacy"

--- a/locales/hi_IN/LC_MESSAGES/duckduckgo.po
+++ b/locales/hi_IN/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: hi_IN\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -176,8 +176,9 @@ msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
 msgstr ""
-"%1$s सिर्फ़ Pro प्लान में उपलब्ध है। चैट जारी रखने के लिए इस ब्राउज़र में अपना DuckDuckGo "
-"सब्सक्रिप्शन फिर से अपग्रेड करें, या Plus या मुफ़्त मॉडल पर स्विच करें।"
+"%1$s सिर्फ़ Pro प्लान में उपलब्ध है। चैट जारी रखने के लिए इस ब्राउज़र में "
+"अपना DuckDuckGo सब्सक्रिप्शन फिर से अपग्रेड करें, या Plus या मुफ़्त मॉडल पर "
+"स्विच करें।"
 
 # smartling.placeholder_format=C
 #. Text for the disclaimer message that appears when a Plus subscriber tries to use a Pro-only model. %s is replaced with the model name. Example: Claude Opus 4.6 is only available with Pro. Upgrade your DuckDuckGo subscription in this browser again to continue the chat, or switch to a Plus or free model.
@@ -187,8 +188,9 @@ msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
 msgstr ""
-"%1$s सिर्फ़ Pro प्लान में उपलब्ध है। चैट जारी रखने के लिए इस ब्राउज़र में अपना DuckDuckGo "
-"सब्सक्रिप्शन फिर से अपग्रेड करें, या Plus या मुफ़्त मॉडल पर स्विच करें।"
+"%1$s सिर्फ़ Pro प्लान में उपलब्ध है। चैट जारी रखने के लिए इस ब्राउज़र में "
+"अपना DuckDuckGo सब्सक्रिप्शन फिर से अपग्रेड करें, या Plus या मुफ़्त मॉडल पर "
+"स्विच करें।"
 
 # smartling.placeholder_format=C
 #. Displayed when an AI (Artificial Intelligence) chat model is temporarily unavailable. Example: 'GPT 4o is only available with a DuckDuckGo subscription.'
@@ -204,8 +206,9 @@ msgid ""
 "subscription in this browser again to continue the chat, or switch to a free "
 "model."
 msgstr ""
-"%1$s केवल DuckDuckGo सब्सक्रिप्शन के साथ उपलब्ध है। चैट जारी रखने के लिए इस ब्राउज़र में "
-"अपने सब्सक्रिप्शन को फिर से एक्टिवेट करें, या किसी मुफ़्त मॉडल पर स्विच करें।"
+"%1$s केवल DuckDuckGo सब्सक्रिप्शन के साथ उपलब्ध है। चैट जारी रखने के लिए इस "
+"ब्राउज़र में अपने सब्सक्रिप्शन को फिर से एक्टिवेट करें, या किसी मुफ़्त मॉडल "
+"पर स्विच करें।"
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is temporarily unavailable. Example: 'GPT 3.5 Turbo is temporarily unavailable. Please switch to a different model or try again later.'
@@ -214,8 +217,8 @@ msgid ""
 "%s is temporarily unavailable. Please switch to a different model or try "
 "again later."
 msgstr ""
-"%1$s फिलहाल उपलब्ध नहीं है। कृपया किसी अन्य मॉडल पर स्विच करें या बाद में फिर से कोशिश "
-"करें।"
+"%1$s फिलहाल उपलब्ध नहीं है। कृपया किसी अन्य मॉडल पर स्विच करें या बाद में "
+"फिर से कोशिश करें।"
 
 # smartling.placeholder_format=C
 #. Reddit's "fake internet points". https://support.reddithelp.com/hc/en-us/articles/204511829-What-is-karma
@@ -306,9 +309,9 @@ msgid ""
 "provider can see your prompts or the model’s responses, or save this chat on "
 "their servers."
 msgstr ""
-"%1$s एक भरोसेमंद एक्ज़ीक्यूशन एनवायरमेंट में चलता है। इसका मतलब है कि मॉडल प्रोवाइडर भी "
-"आपके प्रॉम्प्ट्स या मॉडल के जवाबों को नहीं देख सकता, और न ही इस चैट को अपने सर्वर पर सेव "
-"कर सकता है।"
+"%1$s एक भरोसेमंद एक्ज़ीक्यूशन एनवायरमेंट में चलता है। इसका मतलब है कि मॉडल "
+"प्रोवाइडर भी आपके प्रॉम्प्ट्स या मॉडल के जवाबों को नहीं देख सकता, और न ही इस "
+"चैट को अपने सर्वर पर सेव कर सकता है।"
 
 # smartling.placeholder_format=C
 #. Label shown in the batch selection toolbar when exactly one chat is selected. %s is replaced with 1. Use singular agreement where the language requires it.
@@ -388,8 +391,8 @@ msgid ""
 "%s will be leaving Duck.ai in %s days (%s). After that, you can switch "
 "models to continue this chat."
 msgstr ""
-"%1$s %2$s दिन में (%3$s को) Duck.ai से हट जाएगा। उसके बाद, आप इस चैट को जारी रखने "
-"के लिए मॉडल बदल सकते हैं।"
+"%1$s %2$s दिन में (%3$s को) Duck.ai से हट जाएगा। उसके बाद, आप इस चैट को जारी "
+"रखने के लिए मॉडल बदल सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Displayed in a saved chat when its AI model is about to be retired tomorrow. First placeholder is the friendly model name, second placeholder is the removal date formatted in the user's browser locale (e.g., 'June 15, 2026' in en-US). Singular-day form.
@@ -400,8 +403,8 @@ msgid ""
 "%s will be leaving Duck.ai in 1 day (%s). After that, you can switch models "
 "to continue this chat."
 msgstr ""
-"%1$s 1 दिन में (%2$s को) Duck.ai से हटने वाला है। उसके बाद, आप इस चैट को जारी रखने के "
-"लिए मॉडल बदल सकते हैं।"
+"%1$s 1 दिन में (%2$s को) Duck.ai से हटने वाला है। उसके बाद, आप इस चैट को "
+"जारी रखने के लिए मॉडल बदल सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Shown in a text selection chip when the selection contains multiple words. %s is replaced with the number of words, e.g. '142 words'.
@@ -414,8 +417,8 @@ msgstr "%1$s शब्द"
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
 msgstr ""
-"%1$sजोड़ें%2$sपर%3$s क्लिक करें %4$sअनुमति दें%5$s पर सही का निशान लगाएं, फिर %6$sठीक "
-"हैं%7$s पर क्लिक करें"
+"%1$sजोड़ें%2$sपर%3$s क्लिक करें %4$sअनुमति दें%5$s पर सही का निशान लगाएं, "
+"फिर %6$sठीक हैं%7$s पर क्लिक करें"
 
 # Firefox, obsolete
 # smartling.placeholder_format=C
@@ -423,8 +426,8 @@ msgstr ""
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAllow%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
 msgstr ""
-"%1$sअनुमति दें%2$s %3$sपर क्लिक करें %4$sजोड़ें%5$s पर क्लिक करें %6$sअनुमति दें%7$s पर "
-"निशान लगाएं, फिर %8$sओके%9$s पर क्लिक करें"
+"%1$sअनुमति दें%2$s %3$sपर क्लिक करें %4$sजोड़ें%5$s पर क्लिक करें %6$sअनुमति "
+"दें%7$s पर निशान लगाएं, फिर %8$sओके%9$s पर क्लिक करें"
 
 # Firefox
 # smartling.placeholder_format=C
@@ -434,8 +437,8 @@ msgid ""
 "%sClick %sContinue To Installation%sClick %sAdd%sCheck %sAllow%s, then click "
 "%sOkay%s"
 msgstr ""
-"%1$s%2$sइंस्टॉलेशन जारी रखें%3$s पर क्लिक करें %4$sजोड़ें%5$s पर क्लिक करें %6$sअनुमति "
-"दें%7$s पर निशान लगाएं, फिर %8$sओके%9$s पर क्लिक करें"
+"%1$s%2$sइंस्टॉलेशन जारी रखें%3$s पर क्लिक करें %4$sजोड़ें%5$s पर क्लिक करें "
+"%6$sअनुमति दें%7$s पर निशान लगाएं, फिर %8$sओके%9$s पर क्लिक करें"
 
 # smartling.placeholder_format=C
 #. A button that reloads search results when an error occurs.
@@ -469,14 +472,16 @@ msgctxt "Footer text for About Sync modal"
 msgid ""
 "%sLearn more%s about how chats are stored privately on DuckDuckGo's server."
 msgstr ""
-"%1$sऔर जानें%2$s कि चैट को DuckDuckGo के सर्वर पर गोपनीय ढंग से कैसे स्टोर किया जाता है।"
+"%1$sऔर जानें%2$s कि चैट को DuckDuckGo के सर्वर पर गोपनीय ढंग से कैसे स्टोर "
+"किया जाता है।"
 
 # smartling.placeholder_format=C
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "%sLearn more%s about how chats are stored privately on your device."
 msgstr ""
-"आपके डिवाइस पर चैट निजी तौर पर कैसे स्टोर किए जाते हैं, इस बारे में %1$sऔर जानें।%2$s"
+"आपके डिवाइस पर चैट निजी तौर पर कैसे स्टोर किए जाते हैं, इस बारे में %1$sऔर "
+"जानें।%2$s"
 
 # smartling.placeholder_format=C
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
@@ -488,7 +493,9 @@ msgstr "होम स्क्रीन पर DuckDuckGo ऐप आइकन �
 #. A message displayed when there is an error loading content or no results on requery
 msgctxt "Error or no results message"
 msgid "%sOops!%s%sSomething went wrong. Please %srefresh%s and try again."
-msgstr "%1$sउफ़!%2$s%3$sकुछ गड़बड़ हुई है। कृपया %4$sरीफ्रेश%5$s करें और फिर से कोशिश करें।"
+msgstr ""
+"%1$sउफ़!%2$s%3$sकुछ गड़बड़ हुई है। कृपया %4$sरीफ्रेश%5$s करें और फिर से "
+"कोशिश करें।"
 
 # smartling.placeholder_format=C
 #. Tagline in a popover encouraging the user to download the DuckDuckGo browser
@@ -805,7 +812,9 @@ msgstr "6 घंटे की उपयोग सीमा पूरी हो �
 #. Displayed when the user has reached a fixed 6-hour Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "6-hour usage limit reached. You can continue this chat after %s."
-msgstr "6 घंटे की उपयोग सीमा पूरी हो गई है। आप %1$s के बाद इस चैट को जारी रख सकते हैं।"
+msgstr ""
+"6 घंटे की उपयोग सीमा पूरी हो गई है। आप %1$s के बाद इस चैट को जारी रख सकते "
+"हैं।"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable 6-hour Duck.ai usage limit and can opt in to continue using the daily limit.
@@ -813,8 +822,8 @@ msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "6-hour usage limit reached. You can keep chatting by using your daily limit."
 msgstr ""
-"6 घंटे की उपयोग सीमा पूरी हो गई है। आप अपनी दैनिक सीमा का इस्तेमाल करके चैटिंग जारी रख "
-"सकते हैं।"
+"6 घंटे की उपयोग सीमा पूरी हो गई है। आप अपनी दैनिक सीमा का इस्तेमाल करके "
+"चैटिंग जारी रख सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes abbreviation
@@ -868,22 +877,26 @@ msgid ""
 "A network issue is preventing Search Assist from generating an answer. "
 "Please check your connection and try again."
 msgstr ""
-"नेटवर्क की समस्या की वजह से Search Assist जवाब नहीं दे पा रहा है। कृपया अपना कनेक्शन "
-"जांचें और फिर से कोशिश करें।"
+"नेटवर्क की समस्या की वजह से Search Assist जवाब नहीं दे पा रहा है। कृपया अपना "
+"कनेक्शन जांचें और फिर से कोशिश करें।"
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of AI Chat is available and they need to refresh the page.
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of AI Chat is available! Please refresh this page to continue."
-msgstr "AI Chat का नया वर्ज़न उपलब्ध है! कृपया जारी रखने के लिए इस पेज को रीफ्रेश करें।"
+msgstr ""
+"AI Chat का नया वर्ज़न उपलब्ध है! कृपया जारी रखने के लिए इस पेज को रीफ्रेश "
+"करें।"
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of Duck.ai is available and they need to refresh the page.
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of Duck.ai is available! Please refresh this page to continue."
-msgstr "Duck.ai का नया वर्ज़न उपलब्ध है! कृपया जारी रखने के लिए इस पेज को रीफ्रेश करें।"
+msgstr ""
+"Duck.ai का नया वर्ज़न उपलब्ध है! कृपया जारी रखने के लिए इस पेज को रीफ्रेश "
+"करें।"
 
 # smartling.placeholder_format=C
 #. Shown when the Duck.ai desktop app has been open a long time and a newer version exists.
@@ -921,9 +934,10 @@ msgid ""
 "still access AI Chat when this setting is off by visiting %sduckduckgo.com/"
 "aichat%s."
 msgstr ""
-"AI Chat आपको थर्ड-पार्टी AI चैट मॉडल के साथ गुमनाम ढंग से बातचीत करने की सुविधा देता "
-"है। इसे बंद करने से DuckDuckGo Search पर AI Chat फ़ीचर छिप जाएगा। जब यह सेटिंग बंद हो "
-"तब भी आप %1$sduckduckgo.com/aichat%2$s पर जाकर AI Chat का उपयोग कर सकते हैं।"
+"AI Chat आपको थर्ड-पार्टी AI चैट मॉडल के साथ गुमनाम ढंग से बातचीत करने की "
+"सुविधा देता है। इसे बंद करने से DuckDuckGo Search पर AI Chat फ़ीचर छिप "
+"जाएगा। जब यह सेटिंग बंद हो तब भी आप %1$sduckduckgo.com/aichat%2$s पर जाकर AI "
+"Chat का उपयोग कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -984,10 +998,10 @@ msgid ""
 "questions, which is our private AI-powered chat service that supports chat "
 "models from OpenAI, and Anthropic, and more."
 msgstr ""
-"AI की सहायता से दिए गए जवाब फिलहाल फ़ॉलोअप सवालों को सीधे सपोर्ट नहीं करते हैं। "
-"हालांकि, हम फ़ॉलोअप सवालों के लिए %1$sDuck.ai%2$s भी ऑफ़र करते हैं और अक्सर उससे लिंक "
-"करते हैं, जो हमारी निजी AI-संचालित चैट सेवा है जो OpenAI, और Anthropic, और अन्य के चैट "
-"मॉडलों को सपोर्ट करती है।"
+"AI की सहायता से दिए गए जवाब फिलहाल फ़ॉलोअप सवालों को सीधे सपोर्ट नहीं करते "
+"हैं। हालांकि, हम फ़ॉलोअप सवालों के लिए %1$sDuck.ai%2$s भी ऑफ़र करते हैं और "
+"अक्सर उससे लिंक करते हैं, जो हमारी निजी AI-संचालित चैट सेवा है जो OpenAI, और "
+"Anthropic, और अन्य के चैट मॉडलों को सपोर्ट करती है।"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has turned off AI features and will no longer see AI-assisted answers.
@@ -1172,8 +1186,8 @@ msgid ""
 "Activate your %s in this browser again to continue the chat, or switch to a "
 "free model."
 msgstr ""
-"चैट जारी रखने के लिए इस ब्राउज़र में अपने %1$s को फिर से एक्टिवेट करें, या किसी मुफ़्त मॉडल "
-"पर स्विच करें।"
+"चैट जारी रखने के लिए इस ब्राउज़र में अपने %1$s को फिर से एक्टिवेट करें, या "
+"किसी मुफ़्त मॉडल पर स्विच करें।"
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an active DuckDuckGo subscription.
@@ -1209,8 +1223,8 @@ msgstr "विज्ञापन"
 msgid ""
 "Ad clicks are managed by %s’s ad network and are not used to profile you."
 msgstr ""
-"%1$s के विज्ञापन नेटवर्क द्वारा विज्ञापन क्लिक प्रबंधित किए जाते हैं और इनका उपयोग आपकी "
-"व्यक्तिगत जानकारी जुटाने के लिए नहीं किया जाता।"
+"%1$s के विज्ञापन नेटवर्क द्वारा विज्ञापन क्लिक प्रबंधित किए जाते हैं और इनका "
+"उपयोग आपकी व्यक्तिगत जानकारी जुटाने के लिए नहीं किया जाता।"
 
 # smartling.placeholder_format=C
 #. Information that ad clicks are managed by Microsoft.
@@ -1218,8 +1232,8 @@ msgid ""
 "Ad clicks are managed by Microsoft’s ad network and are not used to profile "
 "you."
 msgstr ""
-"Microsoft के विज्ञापन नेटवर्क द्वारा विज्ञापन क्लिक प्रबंधित किए जाते हैं और इनका उपयोग "
-"आपकी व्यक्तिगत जानकारी जुटाने के लिए नहीं किया जाता।"
+"Microsoft के विज्ञापन नेटवर्क द्वारा विज्ञापन क्लिक प्रबंधित किए जाते हैं और "
+"इनका उपयोग आपकी व्यक्तिगत जानकारी जुटाने के लिए नहीं किया जाता।"
 
 # smartling.placeholder_format=C
 #. An item in the ads tooltip that explains that ad clicks aren’t used to profile you.
@@ -1270,7 +1284,8 @@ msgstr "DuckDuckGo एक्सटेंशन जोड़ें"
 msgid ""
 "Add DuckDuckGo Privacy Essentials to your browser for free with one download:"
 msgstr ""
-"एक डाउनलोड के साथ अपने ब्राउज़र पर मुफ़्त में DuckDuckGo Privacy Essentials जोड़ें:"
+"एक डाउनलोड के साथ अपने ब्राउज़र पर मुफ़्त में DuckDuckGo Privacy Essentials "
+"जोड़ें:"
 
 #  IE default search engine instruction
 # smartling.placeholder_format=C
@@ -1428,7 +1443,7 @@ msgstr "पता गलत है"
 #. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Adjust the servings"
-msgstr ""
+msgstr "सर्विंग एडजस्ट करें"
 
 # smartling.placeholder_format=C
 #. as in multiple advertisements
@@ -1512,7 +1527,9 @@ msgstr "जैसे ही वह डाउनलोड होकर खुल�
 #. Instructions on how to install the DuckDuckGo browser extension after it downloads.
 msgid ""
 "After it downloads, locate the extension file and double-click it to install"
-msgstr "डाइनलोड होने के बाद, ऐक्सटेंशन फ़ाइल को ढूंढें और इंस्टॉल करने के लिए डबल क्लिक करें"
+msgstr ""
+"डाइनलोड होने के बाद, ऐक्सटेंशन फ़ाइल को ढूंढें और इंस्टॉल करने के लिए डबल "
+"क्लिक करें"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an age below a web search result.
@@ -1648,6 +1665,9 @@ msgid ""
 "All chats are anonymized by DuckDuckGo, and your conversations are not used "
 "to train chat models by DuckDuckGo or the model providers"
 msgstr ""
+"सभी चैट DuckDuckGo द्वारा अनाम कर दी जाती हैं, और आपकी बातचीत का इस्तेमाल "
+"DuckDuckGo या मॉडल प्रोवाइडर द्वारा चैट मॉडल को प्रशिक्षित करने के लिए नहीं "
+"किया जाता है"
 
 # smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1680,8 +1700,8 @@ msgid ""
 "All model providers are prevented from training their AI on your "
 "conversations."
 msgstr ""
-"सभी मॉडल प्रदाताओं को आपकी बातचीत के आधार पर अपने AI को प्रशिक्षित करने से रोका गया "
-"है।"
+"सभी मॉडल प्रदाताओं को आपकी बातचीत के आधार पर अपने AI को प्रशिक्षित करने से "
+"रोका गया है।"
 
 # smartling.placeholder_format=C
 #. Text displayed in the subheader of the modal that allows the user to pick an AI chat model.
@@ -1696,8 +1716,8 @@ msgid ""
 "All personal metadata (for example, your IP address) is removed before "
 "sending a chat to the AI provider."
 msgstr ""
-"AI प्रोवाइडर को चैट भेजने से पहले सभी पर्सनल मेटाडेटा (जैसे, आपका IP एड्रेस) हटा दिया "
-"जाता है।"
+"AI प्रोवाइडर को चैट भेजने से पहले सभी पर्सनल मेटाडेटा (जैसे, आपका IP एड्रेस) "
+"हटा दिया जाता है।"
 
 # smartling.placeholder_format=C
 #. A filter that shows search results from all countries.
@@ -1723,8 +1743,8 @@ msgctxt "voice chat"
 msgid ""
 "Allow DuckDuckGo microphone access in System Settings to use voice chat."
 msgstr ""
-"वॉयस चैट का इस्तेमाल करने के लिए सिस्टम सेटिंग में DuckDuckGo माइक्रोफ़ोन एक्सेस की अनुमति "
-"दें।"
+"वॉयस चैट का इस्तेमाल करने के लिए सिस्टम सेटिंग में DuckDuckGo माइक्रोफ़ोन "
+"एक्सेस की अनुमति दें।"
 
 # smartling.placeholder_format=C
 #. Tells users which icon to press in their browser. Part of a list of instructions on how to enable location service.
@@ -1741,7 +1761,8 @@ msgstr "गोपनीयता का सम्मान करने वा�
 #. Title in a dialog informing the user how to disable their ad blocker for DuckDuckGo
 msgid "Allow privacy-respecting ads on DuckDuckGo Private Search"
 msgstr ""
-"DuckDuckGo Private Search पर गोपनीयता का सम्मान करने वाले विज्ञापनों को अनुमति दें"
+"DuckDuckGo Private Search पर गोपनीयता का सम्मान करने वाले विज्ञापनों को "
+"अनुमति दें"
 
 # smartling.placeholder_format=C
 #. Description explaining privacy implications of enabling web search on encrypted models. The first two placeholders are the full model name (e.g. 'gpt-oss 120B'). The third and fourth placeholders wrap a clickable link reading 'zero provider visibility' that opens the privacy modal, please keep those around the link text in your translation. An example full sentence would be: Allows gpt-oss 120B to search the web to improve responses to relevant prompts. Only sends AI-generated queries to a search engine with limited data retention. Prompts and responses with gpt-oss 120B still have zero provider visibility.
@@ -1751,10 +1772,10 @@ msgid ""
 "sends AI-generated queries to a search engine with limited data retention. "
 "Prompts and responses with %s still have %szero provider visibility%s."
 msgstr ""
-"यह %1$s को वेब पर सर्च करने की सुविधा देता है, ताकि वह संबंधित प्रॉम्प्ट्स के जवाबों को "
-"बेहतर बना सके। यह सर्च इंजन पर केवल AI-जनरेटेड क्वेरीज़ ही भेजता है, जिनमें डेटा रिटेंशन की "
-"लिमिट सीमित होती है। %2$s वाले प्रॉम्प्ट्स और जवाबों पर अभी भी %3$sप्रोवाइडर की "
-"विज़िबिलिटी शून्य%4$s रहती है।"
+"यह %1$s को वेब पर सर्च करने की सुविधा देता है, ताकि वह संबंधित प्रॉम्प्ट्स "
+"के जवाबों को बेहतर बना सके। यह सर्च इंजन पर केवल AI-जनरेटेड क्वेरीज़ ही "
+"भेजता है, जिनमें डेटा रिटेंशन की लिमिट सीमित होती है। %2$s वाले प्रॉम्प्ट्स "
+"और जवाबों पर अभी भी %3$sप्रोवाइडर की विज़िबिलिटी शून्य%4$s रहती है।"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -1762,8 +1783,8 @@ msgid ""
 "Allows Cloud Save key to be stored locally on device (required to use Cloud "
 "Save)"
 msgstr ""
-"डिवाइस पर स्थानीय रूप से संग्रहित की जाने वाली Cloud Save की को अनुमति देता है (Cloud "
-"Save का उपयोग करने के लिए आवश्यक है)"
+"डिवाइस पर स्थानीय रूप से संग्रहित की जाने वाली Cloud Save की को अनुमति देता "
+"है (Cloud Save का उपयोग करने के लिए आवश्यक है)"
 
 # smartling.placeholder_format=C
 #. Pending title indicating near completion.
@@ -1901,8 +1922,8 @@ msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
 msgstr ""
-"लोकप्रिय AI मॉडलों तक अनाम ढंग से पहुंच, जिसमें %1$s, %2$sऔर मुक्त स्रोत %3$s और %4$s "
-"शामिल हैं।"
+"लोकप्रिय AI मॉडलों तक अनाम ढंग से पहुंच, जिसमें %1$s, %2$sऔर मुक्त स्रोत "
+"%3$s और %4$s शामिल हैं।"
 
 # smartling.placeholder_format=C
 #. Text with information about Duck.ai and supported AI models, the placeholders list AI models. Example: 'Anonymous access to popular AI models, including GPT, Claude, and open-source Llama and Mistral.'
@@ -1911,8 +1932,8 @@ msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
 msgstr ""
-"लोकप्रिय AI मॉडलों तक अनाम ढंग से पहुंच, जिसमें %1$s, %2$sऔर मुक्त स्रोत %3$s और %4$s "
-"शामिल हैं।"
+"लोकप्रिय AI मॉडलों तक अनाम ढंग से पहुंच, जिसमें %1$s, %2$sऔर मुक्त स्रोत "
+"%3$s और %4$s शामिल हैं।"
 
 # smartling.placeholder_format=C
 #. Confirmation message after location service is enabled.
@@ -1926,6 +1947,8 @@ msgid ""
 "Anonymously generates answers for search queries based on web content. "
 "Choose how often you want it to appear, or disable it completely."
 msgstr ""
+"वेब कंटेंट के आधार पर सर्च क्वेरी के लिए गुमनाम रूप से जवाब तैयार करता है। "
+"चुनें कि इसे कितनी बार दिखाया जाए, या इसे पूरी तरह से बंद कर दें।"
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -1972,8 +1995,8 @@ msgid ""
 "Any additional instructions you want Duck.ai to follow. e.g. Always tell me "
 "facts about ducks"
 msgstr ""
-"कोई अतिरिक्त निर्देश जो आप चाहते हैं कि Duck.ai पालन करे। जैसे कि हमेशा मुझे बतख संबंधी "
-"तथ्य बताएं"
+"कोई अतिरिक्त निर्देश जो आप चाहते हैं कि Duck.ai पालन करे। जैसे कि हमेशा मुझे "
+"बतख संबंधी तथ्य बताएं"
 
 # smartling.placeholder_format=C
 #. Shown in video filtering. https://duckduckgo.com/?q=videos+of+cats&iax=videos&ia=videos
@@ -2073,8 +2096,8 @@ msgctxt "Body text for clear all chats confirmation modal"
 msgid ""
 "Are you sure you want to clear all of your chats? This cannot be undone."
 msgstr ""
-"क्या आपको पक्का पता है कि आप अपनी सभी चैट साफ़ करना चाहते हैं? इसे पहले जैसा नहीं किया "
-"जा सकता।"
+"क्या आपको पक्का पता है कि आप अपनी सभी चैट साफ़ करना चाहते हैं? इसे पहले जैसा "
+"नहीं किया जा सकता।"
 
 # smartling.placeholder_format=C
 #. Body text of the modal that asks the user if they want to clear the conversation.
@@ -2095,8 +2118,8 @@ msgid ""
 "Are you sure you want to disable history? This will delete all chats, "
 "including pinned chats."
 msgstr ""
-"क्या आप वाकई हिस्ट्री को बंद करना चाहते हैं? इससे सभी चैट्स डिलीट हो जाएंगी, जिनमें पिन "
-"की गई चैट्स भी शामिल हैं।"
+"क्या आप वाकई हिस्ट्री को बंद करना चाहते हैं? इससे सभी चैट्स डिलीट हो जाएंगी, "
+"जिनमें पिन की गई चैट्स भी शामिल हैं।"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to disable recent chats, with a warning that it will also delete currently saved chats.
@@ -2105,8 +2128,8 @@ msgid ""
 "Are you sure you want to disable recent chats? This will also delete any "
 "recent chats that are currently saved."
 msgstr ""
-"क्या आप वाकई हालिया चैट को बंद करना चाहते हैं? यह हाल ही में सेव की गई सभी चैट को भी "
-"डिलीट कर देगा।"
+"क्या आप वाकई हालिया चैट को बंद करना चाहते हैं? यह हाल ही में सेव की गई सभी "
+"चैट को भी डिलीट कर देगा।"
 
 # smartling.placeholder_format=C
 #. Question asking user if they want to share the URL of the page they were on when giving feedback
@@ -2144,8 +2167,8 @@ msgid ""
 "As per our privacy policy, we do not collect or share any personal "
 "information ourselves. All of this privacy protection happens on your device."
 msgstr ""
-"हमारी गोपनीयता नीति के अनुसार, हम खुद से कोई निजी जानकारी एकत्रित या साझा नहीं करते "
-"हैं। यह सभी गोपनीयता संरक्षण आपके डिवाइस पर होती है।"
+"हमारी गोपनीयता नीति के अनुसार, हम खुद से कोई निजी जानकारी एकत्रित या साझा "
+"नहीं करते हैं। यह सभी गोपनीयता संरक्षण आपके डिवाइस पर होती है।"
 
 # smartling.placeholder_format=C
 #. A button to ask Duck.ai a question
@@ -2211,7 +2234,7 @@ msgstr "Duck.ai से फ़ॉलोअप सवाल पूछें"
 #. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
 msgctxt "Page suggestion chip label"
 msgid "Ask about this page"
-msgstr ""
+msgstr "इस पेज के बारे में पूछें"
 
 # smartling.placeholder_format=C
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2275,12 +2298,13 @@ msgid ""
 "(shows more frequently on a wider range of searches). For now, AI-assisted "
 "answers are only available in the U.S. (English) region."
 msgstr ""
-"Assist प्रासंगिक वेब सामग्री को संक्षेप में प्रस्तुत करने के आधार पर कुछ खोजों के लिए गुमनाम "
-"रूप से AI की सहायता से जवाब जनरेट कर सकता है। आप चुन सकते हैं कि Assist को कितनी बार "
-"दिखाना है: कभी नहीं (यह खोज परिणामों से Assist के UI को पूरी तरह हटा देता है), ऑन-"
-"डिमांड (सिर्फ़ तभी दिखाता है जब आप 'सहायता' बटन पर क्लिक करते हैं), कभी-कभी (सिर्फ़ "
-"तभी दिखाता है, जब नतीजे बहुत काम के हों), या अक्सर (कई तरह की खोजों पर अक्सर दिखाता "
-"है)। फिलहाल, AI की सहायता से दिए गए जवाब केवल अमेरिका (अंग्रेज़ी) क्षेत्र में उपलब्ध हैं।"
+"Assist प्रासंगिक वेब सामग्री को संक्षेप में प्रस्तुत करने के आधार पर कुछ "
+"खोजों के लिए गुमनाम रूप से AI की सहायता से जवाब जनरेट कर सकता है। आप चुन "
+"सकते हैं कि Assist को कितनी बार दिखाना है: कभी नहीं (यह खोज परिणामों से "
+"Assist के UI को पूरी तरह हटा देता है), ऑन-डिमांड (सिर्फ़ तभी दिखाता है जब आप "
+"'सहायता' बटन पर क्लिक करते हैं), कभी-कभी (सिर्फ़ तभी दिखाता है, जब नतीजे "
+"बहुत काम के हों), या अक्सर (कई तरह की खोजों पर अक्सर दिखाता है)। फिलहाल, AI "
+"की सहायता से दिए गए जवाब केवल अमेरिका (अंग्रेज़ी) क्षेत्र में उपलब्ध हैं।"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2292,11 +2316,12 @@ msgid ""
 "to remember that responses are auto-generated from cited sources and based "
 "on %scrawling the web%s."
 msgstr ""
-"Assist, खोज परिणाम दिखाने से जुड़ा एक नया वैकल्पिक फ़ीचर है। यह गुमनाम रहकर, खोज संबंधी "
-"क्वेरी के जवाब AI की सहायता से जनरेट कर सकता है। ऐसा करने के लिए, यह वेब को स्कैन करके "
-"क्वेरी से जुड़ी सामग्री जुटाता है। इसके बाद, उस सामग्री से जुड़ी जानकारी के आधार पर कम "
-"शब्दों में जवाब देने के लिए, AI-संचालित नेचुरल लैंग्वेज टेक्नोलॉजी का इस्तेमाल करता है। यह याद "
-"रखना ज़रूरी है कि जवाब, दूसरे स्रोतों से अपने-आप जनरेट होते हैं और %1$sवेब क्रॉलिंग%2$s पर "
+"Assist, खोज परिणाम दिखाने से जुड़ा एक नया वैकल्पिक फ़ीचर है। यह गुमनाम रहकर, "
+"खोज संबंधी क्वेरी के जवाब AI की सहायता से जनरेट कर सकता है। ऐसा करने के लिए, "
+"यह वेब को स्कैन करके क्वेरी से जुड़ी सामग्री जुटाता है। इसके बाद, उस सामग्री "
+"से जुड़ी जानकारी के आधार पर कम शब्दों में जवाब देने के लिए, AI-संचालित "
+"नेचुरल लैंग्वेज टेक्नोलॉजी का इस्तेमाल करता है। यह याद रखना ज़रूरी है कि "
+"जवाब, दूसरे स्रोतों से अपने-आप जनरेट होते हैं और %1$sवेब क्रॉलिंग%2$s पर "
 "आधारित होते हैं।"
 
 # smartling.placeholder_format=C
@@ -2389,8 +2414,8 @@ msgstr "चैट खत्म होने के बाद ऑडियो ह
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat is transcribed."
 msgstr ""
-"चैट ट्रांसक्रिप्ट होने के बाद, ऑडियो हमारे द्वारा या OpenAI द्वारा स्टोर नहीं किया जाता "
-"है।"
+"चैट ट्रांसक्रिप्ट होने के बाद, ऑडियो हमारे द्वारा या OpenAI द्वारा स्टोर "
+"नहीं किया जाता है।"
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when MediaRecorder API is unavailable.
@@ -2432,14 +2457,16 @@ msgstr "स्वत: उत्तर"
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid "Auto-generated based on listed sources. May contain inaccuracies."
 msgstr ""
-"सूचीबद्ध स्रोतों के आधार पर स्वचालित ढंग से जनरेट किया गया। इसमें अशुद्धियां हो सकती हैं।"
+"सूचीबद्ध स्रोतों के आधार पर स्वचालित ढंग से जनरेट किया गया। इसमें अशुद्धियां "
+"हो सकती हैं।"
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid ""
 "Auto-generated based on listed sources. Responses may contain inaccuracies."
 msgstr ""
-"सूचीबद्ध स्रोतों के आधार पर स्वचालित ढंग से जनरेट किया गया। जवाबों में अशुद्धियां हो सकती हैं।"
+"सूचीबद्ध स्रोतों के आधार पर स्वचालित ढंग से जनरेट किया गया। जवाबों में "
+"अशुद्धियां हो सकती हैं।"
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI) on mobile
@@ -2464,9 +2491,9 @@ msgid ""
 "look up and summarize information in response to some searches. For now, "
 "Assist is only available in English regions."
 msgstr ""
-"प्रासंगिक खोजों के लिए Assist स्वतः ही दिखाता है। कुछ खोजों के लिए Assist, जानकारी को "
-"गुमनाम रूप से खोज सकता है और उसके बारे में खास जानकारी दे सकता है। फिलहाल, Assist केवल "
-"अंग्रेज़ी क्षेत्रों में उपलब्ध है।"
+"प्रासंगिक खोजों के लिए Assist स्वतः ही दिखाता है। कुछ खोजों के लिए Assist, "
+"जानकारी को गुमनाम रूप से खोज सकता है और उसके बारे में खास जानकारी दे सकता "
+"है। फिलहाल, Assist केवल अंग्रेज़ी क्षेत्रों में उपलब्ध है।"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2475,15 +2502,17 @@ msgid ""
 "anonymously look up and summarize information in response to some searches. "
 "For now, DuckAssist is only available in English regions."
 msgstr ""
-"प्रासंगिक खोजों के लिए DuckAssist स्वतः ही दिखाता है। कुछ खोजों के लिए DuckAssist "
-"जानकारी को गुमनाम रूप से खोज और संक्षिप्त कर सकता है। फिलहाल DuckAssist केवल अंग्रेज़ी "
-"क्षेत्रों में उपलब्ध है।"
+"प्रासंगिक खोजों के लिए DuckAssist स्वतः ही दिखाता है। कुछ खोजों के लिए "
+"DuckAssist जानकारी को गुमनाम रूप से खोज और संक्षिप्त कर सकता है। फिलहाल "
+"DuckAssist केवल अंग्रेज़ी क्षेत्रों में उपलब्ध है।"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Autoplay short, silent video previews when you hover over video results."
-msgstr "वीडियो परिणामों पर कर्सर ले जाने पर, छोटे और म्यूट वाले वीडियो प्रीव्यू ऑटोप्ले करें।"
+msgstr ""
+"वीडियो परिणामों पर कर्सर ले जाने पर, छोटे और म्यूट वाले वीडियो प्रीव्यू "
+"ऑटोप्ले करें।"
 
 # smartling.placeholder_format=C
 #. Screen-reader label for the radiogroup of tool options inside the Tools dropdown. Announced when assistive technology enters the group of menuitemradio items.
@@ -2628,7 +2657,7 @@ msgstr "बारकोड"
 #. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Based on this page, is this course worth taking?"
-msgstr ""
+msgstr "इस पेज के आधार पर, क्या यह कोर्स करना फ़ायदेमंद है?"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2677,6 +2706,9 @@ msgid ""
 "Before storing this report, DuckDuckGo will anonymize your conversation by "
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
+"इस रिपोर्ट को स्टोर करने से पहले, DuckDuckGo आपकी बातचीत से नाम, ईमेल एड्रेस "
+"और पहचान बताने वाले मेटाडेटा जैसी PII (व्यक्तिगत पहचान योग्य जानकारी) हटाकर "
+"उसे अनाम बना देगा।"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -2998,7 +3030,7 @@ msgstr "जीते गए ब्रेक पॉइंट"
 #. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Break this down into clear, numbered steps."
-msgstr ""
+msgstr "इसे स्पष्ट, नंबर वाले स्टेप्स में बांटें।"
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -3057,16 +3089,18 @@ msgid ""
 "Browse as usual while we add privacy protection. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
 msgstr ""
-"जब हम गोपनीयता संरक्षण जोड़ते हैं तब सामान्य रूप से ब्राउज़ करें। हमने अपने खोज इंजन, ट्रैकर "
-"ब्लॉकर और एन्क्रिप्शन एनफोर्सर को एक ही %1$s%2$s एक्सटेंशन%3$s में बंडल किया है।"
+"जब हम गोपनीयता संरक्षण जोड़ते हैं तब सामान्य रूप से ब्राउज़ करें। हमने अपने "
+"खोज इंजन, ट्रैकर ब्लॉकर और एन्क्रिप्शन एनफोर्सर को एक ही %1$s%2$s "
+"एक्सटेंशन%3$s में बंडल किया है।"
 
 # smartling.placeholder_format=C
 msgid ""
 "Browse as usual, and we'll take care of the rest. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
 msgstr ""
-"सामान्य तौर पर ब्राउज़ करें, और बाकी सबका ध्यान हम रखेंगे। हमने अपने खोज इंजन, ट्रैकर "
-"ब्लॉकर और एनक्रिप्शन एनफोर्सर को एक ही %1$s%2$s एक्सटेंशन%3$s में बंडल कर दिया है।"
+"सामान्य तौर पर ब्राउज़ करें, और बाकी सबका ध्यान हम रखेंगे। हमने अपने खोज "
+"इंजन, ट्रैकर ब्लॉकर और एनक्रिप्शन एनफोर्सर को एक ही %1$s%2$s एक्सटेंशन%3$s "
+"में बंडल कर दिया है।"
 
 # smartling.placeholder_format=C
 msgid ""
@@ -3074,8 +3108,9 @@ msgid ""
 "search, tracker blocking, and site encryption, all in one download, for "
 "%smajor browsers%s."
 msgstr ""
-"सामान्य तौर पर ब्राउज़ करें, और बाकी सबका ध्यान हम रखेंगे। %1$sप्रमुख ब्राउज़र्स%2$s के लिए "
-"गोपनीय खोज, ट्रैकर ब्लॉकिंग और साइट एनक्रिप्शन पाएं, सब कुछ एक ही डाउनलोड में।"
+"सामान्य तौर पर ब्राउज़ करें, और बाकी सबका ध्यान हम रखेंगे। %1$sप्रमुख "
+"ब्राउज़र्स%2$s के लिए गोपनीय खोज, ट्रैकर ब्लॉकिंग और साइट एनक्रिप्शन पाएं, "
+"सब कुछ एक ही डाउनलोड में।"
 
 # smartling.placeholder_format=C
 #. Header for a call to action to browse with the DuckDuckGo browser
@@ -3182,11 +3217,11 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"डिफ़ॉल्ट रूप से, सेटिंग्स को गैर-व्यक्तिगत ब्राउज़र कुकीज़ (आपके ब्राउज़र में) में संग्रहित किया "
-"जाता है। आप अपनी सेटिंग्स को अधिक स्थायी तरीके से (क्लाउड में रिमोट सर्वर पर) संग्रहित "
-"करने के लिए अनाम क्लाउड सेव का उपयोग कर सकते हैं। व्यक्तिगत रूप से पहचान योग्य कोई भी "
-"जानकारी क्लाउड में संग्रहित नहीं की जाएगी और आपका पासफ़्रेज़ आपके ब्राउज़र से कभी अलग नहीं "
-"होगा।"
+"डिफ़ॉल्ट रूप से, सेटिंग्स को गैर-व्यक्तिगत ब्राउज़र कुकीज़ (आपके ब्राउज़र "
+"में) में संग्रहित किया जाता है। आप अपनी सेटिंग्स को अधिक स्थायी तरीके से "
+"(क्लाउड में रिमोट सर्वर पर) संग्रहित करने के लिए अनाम क्लाउड सेव का उपयोग कर "
+"सकते हैं। व्यक्तिगत रूप से पहचान योग्य कोई भी जानकारी क्लाउड में संग्रहित "
+"नहीं की जाएगी और आपका पासफ़्रेज़ आपके ब्राउज़र से कभी अलग नहीं होगा।"
 
 # smartling.placeholder_format=C
 #. Description for the consent highlight in the dictation consent modal. %s is replaced with a link to the help page.
@@ -3194,8 +3229,8 @@ msgid ""
 "By enabling dictation, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
 msgstr ""
-"डिक्टेशन चालू करके, आप इस फ़ीचर के इस्तेमाल के लिए अपना वॉयस डेटा OpenAI को भेजने की "
-"सहमति देते हैं। शुरू करने से पहले हमारे %1$s को देखें।"
+"डिक्टेशन चालू करके, आप इस फ़ीचर के इस्तेमाल के लिए अपना वॉयस डेटा OpenAI को "
+"भेजने की सहमति देते हैं। शुरू करने से पहले हमारे %1$s को देखें।"
 
 # smartling.placeholder_format=C
 #. Description for the 'enable voice chat' section of the voice chat consent modal. Placeholder for the voice chat help page link and text. Example: 'By enabling voice chat, you consent to your voice data being sent to OpenAI for the use of this feature. See our voice chat help page before getting started.'
@@ -3204,8 +3239,8 @@ msgid ""
 "By enabling voice chat, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
 msgstr ""
-"वॉयस चैट चालू करके, आप इस फ़ीचर के इस्तेमाल के लिए अपना वॉयस डेटा OpenAI को भेजने की "
-"सहमति देते हैं। शुरू करने से पहले हमारे %1$s को देखें।"
+"वॉयस चैट चालू करके, आप इस फ़ीचर के इस्तेमाल के लिए अपना वॉयस डेटा OpenAI को "
+"भेजने की सहमति देते हैं। शुरू करने से पहले हमारे %1$s को देखें।"
 
 # smartling.placeholder_format=C
 #. Golf leaderboard: player missed the cut
@@ -3454,7 +3489,7 @@ msgstr "कास्ट"
 #. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Cast & Crew"
-msgstr ""
+msgstr "कास्ट एवं क्रू"
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -3541,7 +3576,9 @@ msgstr "यूआरएल के दिखाई देने का तरी�
 #. This is the description of a user setting
 msgctxt "settings"
 msgid "Changes how the header is displayed and its behavior as you scroll"
-msgstr "जब आप स्क्रॉल करते हैं तो हेडर कैसे प्रदर्शित होने और उसका ढंग परिवर्तित कर देता है"
+msgstr ""
+"जब आप स्क्रॉल करते हैं तो हेडर कैसे प्रदर्शित होने और उसका ढंग परिवर्तित कर "
+"देता है"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/mcZdcaF.png
@@ -3689,11 +3726,11 @@ msgid ""
 "DuckDuckGo Search. However, you can still access Chat when this setting is "
 "off by visiting %shttps://duck.ai%s directly."
 msgstr ""
-"Chat से (हमारी Duck.ai सेवा के माध्यम से) आपको थर्ड-पार्टी AI चैट मॉडल के साथ गुमनाम "
-"ढंग से बातचीत करने की सुविधा मिलती है, जो OpenAI, Anthropic आदि मॉडलों को सपोर्ट "
-"करती है। इस सेटिंग को बंद करने से DuckDuckGo Search पर Chat बटन और लिंक छिप जाएंगे। "
-"हालांकि, यह सेटिंग बंद होने पर भी आप %1$shttps://duck.ai%2$s पर जाकर, सीधे तौर पर "
-"Chat का इस्तेमाल कर सकते हैं।"
+"Chat से (हमारी Duck.ai सेवा के माध्यम से) आपको थर्ड-पार्टी AI चैट मॉडल के "
+"साथ गुमनाम ढंग से बातचीत करने की सुविधा मिलती है, जो OpenAI, Anthropic आदि "
+"मॉडलों को सपोर्ट करती है। इस सेटिंग को बंद करने से DuckDuckGo Search पर Chat "
+"बटन और लिंक छिप जाएंगे। हालांकि, यह सेटिंग बंद होने पर भी आप "
+"%1$shttps://duck.ai%2$s पर जाकर, सीधे तौर पर Chat का इस्तेमाल कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -3749,7 +3786,8 @@ msgstr "गोपनीय ढंग से चैट करें"
 msgctxt "Promotional text (mobile)"
 msgid "Chat privately on any website with Duck.ai built into our free browser."
 msgstr ""
-"हमारे मुफ़्त ब्राउज़र में मौजूद Duck.ai के ज़रिए किसी भी वेबसाइट पर गोपनीय ढंग से चैट करें।"
+"हमारे मुफ़्त ब्राउज़र में मौजूद Duck.ai के ज़रिए किसी भी वेबसाइट पर गोपनीय "
+"ढंग से चैट करें।"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card encouraging third-party browser users to download the DuckDuckGo browser. Not shown in the DuckDuckGo browser or on Linux.
@@ -3757,7 +3795,8 @@ msgctxt "Promotional text"
 msgid ""
 "Chat privately on any website with the Duck.ai sidebar in our free browser."
 msgstr ""
-"हमारे मुफ़्त ब्राउज़र में Duck.ai साइडबार के ज़रिए किसी भी वेबसाइट पर गोपनीय ढंग से चैट करें।"
+"हमारे मुफ़्त ब्राउज़र में Duck.ai साइडबार के ज़रिए किसी भी वेबसाइट पर गोपनीय "
+"ढंग से चैट करें।"
 
 # smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
@@ -3820,8 +3859,8 @@ msgid ""
 "Chats are stored locally on your device instead of on DuckDuckGo servers or "
 "remote servers. Disabling chat history will delete pinned chats."
 msgstr ""
-"चैट DuckDuckGo सर्वर या रिमोट सर्वर के बजाय आपके डिवाइस पर स्थानीय स्तर पर स्टोर की "
-"जाती हैं। चैट हिस्ट्री बंद करने से पिन की गई चैट्स डिलीट हो जाएंगी।"
+"चैट DuckDuckGo सर्वर या रिमोट सर्वर के बजाय आपके डिवाइस पर स्थानीय स्तर पर "
+"स्टोर की जाती हैं। चैट हिस्ट्री बंद करने से पिन की गई चैट्स डिलीट हो जाएंगी।"
 
 # smartling.placeholder_format=C
 #. Text explaining how the Chat History feature stores the user's chats locally to their device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection. Also explains that disabling chat history will delete pinned chats.
@@ -3833,10 +3872,11 @@ msgid ""
 "history will delete pinned chats, and disable the temporary storage of new "
 "prompts and responses."
 msgstr ""
-"चैट्स आपके डिवाइस में स्टोर होते हैं। नए प्रॉम्प्ट और रिस्पॉन्स भेजे जाने के बाद एन्क्रिप्ट किए "
-"जाते हैं और अस्थायी रूप से DuckDuckGo सर्वर पर स्टोर रहते हैं, ताकि यदि आपका इंटरनेट "
-"कनेक्शन खो जाए तो चैट को रिकवर किया जा सके। चैट हिस्ट्री को डिसेबल करने से पिन की गई "
-"चैट डिलीट हो जाएंगी, और नए प्रॉम्प्ट और रिस्पॉन्स का टेम्पररी स्टोरेज भी बंद हो जाएगा।"
+"चैट्स आपके डिवाइस में स्टोर होते हैं। नए प्रॉम्प्ट और रिस्पॉन्स भेजे जाने के "
+"बाद एन्क्रिप्ट किए जाते हैं और अस्थायी रूप से DuckDuckGo सर्वर पर स्टोर रहते "
+"हैं, ताकि यदि आपका इंटरनेट कनेक्शन खो जाए तो चैट को रिकवर किया जा सके। चैट "
+"हिस्ट्री को डिसेबल करने से पिन की गई चैट डिलीट हो जाएंगी, और नए प्रॉम्प्ट और "
+"रिस्पॉन्स का टेम्पररी स्टोरेज भी बंद हो जाएगा।"
 
 # smartling.placeholder_format=C
 #. Title shown above the body copy in the Duck.ai recent chats IndexedDB unavailable notice.
@@ -3858,7 +3898,8 @@ msgctxt "Sync file storage inline disclaimer body"
 msgid ""
 "Chats with attachments have stopped syncing. Free up storage to resume Sync."
 msgstr ""
-"अटैचमेंट वाली चैट्स सिंक होना बंद हो गई हैं। सिंक फिर से शुरू करने के लिए स्टोरेज खाली करें।"
+"अटैचमेंट वाली चैट्स सिंक होना बंद हो गई हैं। सिंक फिर से शुरू करने के लिए "
+"स्टोरेज खाली करें।"
 
 # smartling.placeholder_format=C
 #. Message shown when we have no data from upstream to display
@@ -4011,8 +4052,8 @@ msgctxt "settings"
 msgid ""
 "Choose which app to use when you need directions for a location search result"
 msgstr ""
-"किसी स्थान खोज परिणाम के लिए आपको डायरेक्शन की ज़रूरत होने पर चुनें कि किस ऐप का "
-"इस्तेमाल करना है"
+"किसी स्थान खोज परिणाम के लिए आपको डायरेक्शन की ज़रूरत होने पर चुनें कि किस "
+"ऐप का इस्तेमाल करना है"
 
 # smartling.placeholder_format=C
 #. Accessible label for the citations popover dialog in Duck.ai chat responses.
@@ -4193,8 +4234,9 @@ msgid ""
 "Clearing browser data deletes chats. Some browsers may keep recent chats "
 "indefinitely or auto-delete them after 7+ days of no AI Chat use."
 msgstr ""
-"ब्राउज़र डेटा साफ़ करने से चैट डिलीट हो जाती हैं। कुछ ब्राउज़र हालिया चैट को लंबे समय तक रख "
-"सकते हैं या 7 से ज़्यादा दिनों तक AI Chat का उपयोग न करने पर उन्हें ऑटो-डिलीट कर सकते हैं।"
+"ब्राउज़र डेटा साफ़ करने से चैट डिलीट हो जाती हैं। कुछ ब्राउज़र हालिया चैट को "
+"लंबे समय तक रख सकते हैं या 7 से ज़्यादा दिनों तक AI Chat का उपयोग न करने पर "
+"उन्हें ऑटो-डिलीट कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Text explaining what happens to recent chats when browser data is cleared.
@@ -4204,9 +4246,9 @@ msgid ""
 "indefinitely or auto-deleted after 7 days without using Duck.ai, depending "
 "on your browser."
 msgstr ""
-"ब्राउज़र डेटा साफ़ करने से हाल की चैट हट जाती हैं। Duck.ai का इस्तेमाल किए बिना, हाल की "
-"चैट को अनिश्चित काल के लिए सेव किया जा सकता है या 7 दिनों के बाद अपने-आप हटाया जा "
-"सकता है। यह आपके ब्राउज़र पर निर्भर करता है।"
+"ब्राउज़र डेटा साफ़ करने से हाल की चैट हट जाती हैं। Duck.ai का इस्तेमाल किए "
+"बिना, हाल की चैट को अनिश्चित काल के लिए सेव किया जा सकता है या 7 दिनों के "
+"बाद अपने-आप हटाया जा सकता है। यह आपके ब्राउज़र पर निर्भर करता है।"
 
 # smartling.placeholder_format=C
 #. Warning message shown on the Block domain success modal. Blocked sites are stored in localStorage which is cleared alongside cookies when users clear browser data. Followed by a linked 'our free browser' text.
@@ -4215,8 +4257,8 @@ msgid ""
 "Clearing browser data will reset your blocked sites. Save your block list "
 "permanently in"
 msgstr ""
-"ब्राउज़र डेटा क्लियर करने से आपकी ब्लॉक की गई साइटें रीसेट हो जाएंगी। अपनी ब्लॉक लिस्ट को "
-"हमेशा के लिए सेव करें"
+"ब्राउज़र डेटा क्लियर करने से आपकी ब्लॉक की गई साइटें रीसेट हो जाएंगी। अपनी "
+"ब्लॉक लिस्ट को हमेशा के लिए सेव करें"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -4225,9 +4267,9 @@ msgid ""
 "%sDuck.ai%s, our private AI chat service that supports chat models from "
 "OpenAI, Anthropic, and more."
 msgstr ""
-"किसी विषय पर और गहराई से जानने के लिए \"अधिक\" पर क्लिक करें, और फ़ॉलोअप प्रश्न "
-"%1$sDuck.ai%2$s के ज़रिए पूछें, यह हमारी प्राइवेट AI चैट सेवा है जो OpenAI, Anthropic "
-"और अन्य के चैट मॉडलों को सपोर्ट करती है।"
+"किसी विषय पर और गहराई से जानने के लिए \"अधिक\" पर क्लिक करें, और फ़ॉलोअप "
+"प्रश्न %1$sDuck.ai%2$s के ज़रिए पूछें, यह हमारी प्राइवेट AI चैट सेवा है जो "
+"OpenAI, Anthropic और अन्य के चैट मॉडलों को सपोर्ट करती है।"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4269,8 +4311,8 @@ msgid ""
 "Click %sEdit > Preferences%s (on Windows) %sSeaMonkey > Preferences%s (on "
 "Mac)"
 msgstr ""
-"%1$sसंपादित करें > प्राथमिकताएं%2$s (Windows पर) %3$sSeaMonkey > प्राथमिकताएं%4$s "
-"(Mac पर) क्लिक करें"
+"%1$sसंपादित करें > प्राथमिकताएं%2$s (Windows पर) %3$sSeaMonkey > "
+"प्राथमिकताएं%4$s (Mac पर) क्लिक करें"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -4286,7 +4328,9 @@ msgstr "DuckDuckGo एकस्टेंशन को डाउनलोड क�
 # smartling.placeholder_format=C
 #. Link to download the DuckDuckGo browser extension.
 msgid "Click %sOpen%s to download and open the DuckDuckGo Safari extension"
-msgstr "DuckDuckGo Safari एकस्टेंशन को डाउनलोड करके खोलने के लिए %1$sखोलें%2$s क्लिक करें"
+msgstr ""
+"DuckDuckGo Safari एकस्टेंशन को डाउनलोड करके खोलने के लिए %1$sखोलें%2$s क्लिक "
+"करें"
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -4301,8 +4345,8 @@ msgid ""
 "Click %sSafari%s in the top menu (On Windows, click the %sgears icon%s in "
 "the top right)"
 msgstr ""
-"शीर्ष मेनू में %1$sSafari%2$s पर क्लिक करें (Windows पर, शीर्ष दाईं ओर %3$sगियर "
-"आइकन%4$s पर क्लिक करें)"
+"शीर्ष मेनू में %1$sSafari%2$s पर क्लिक करें (Windows पर, शीर्ष दाईं ओर "
+"%3$sगियर आइकन%4$s पर क्लिक करें)"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4319,7 +4363,9 @@ msgstr "ड्रॉपडाउन में %1$sसेटिंग्स%2$s �
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
-msgstr "%1$sमौजूदा पेज इस्तेमाल करें%2$s पर क्लिक करें, फिर %3$sओके पर क्लिक%4$s करें।"
+msgstr ""
+"%1$sमौजूदा पेज इस्तेमाल करें%2$s पर क्लिक करें, फिर %3$sओके पर क्लिक%4$s "
+"करें।"
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -4332,7 +4378,8 @@ msgstr "%1$sहां%2$s पर क्लिक करें"
 #. Tells the user where to click to open their browser's settings menu.
 msgid "Click %ssettings/hamburger icon %s on the Chrome toolbar (top right)."
 msgstr ""
-"Chrome टूलबार (ऊपर से दाहिने) पर %1$ssettings/hamburger आइकन%2$s पर क्लिक करें"
+"Chrome टूलबार (ऊपर से दाहिने) पर %1$ssettings/hamburger आइकन%2$s पर क्लिक "
+"करें"
 
 #  Maxthon default search engine instruction
 # smartling.placeholder_format=C
@@ -4394,9 +4441,9 @@ msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Search Settings%s."
 msgstr ""
-"%1$sमेरा डेटा डिलीट करें%2$s पर क्लिक करें या टैप करें। यह क्लाउड से डेटा हटा देता है, लेकिन "
-"यह आपके ब्राउज़र में तब तक बना रहता है जब तक आप %3$sसभी खोज सेटिंग रीसेट करें%4$s पर "
-"क्लिक/टैप नहीं कर देते।"
+"%1$sमेरा डेटा डिलीट करें%2$s पर क्लिक करें या टैप करें। यह क्लाउड से डेटा "
+"हटा देता है, लेकिन यह आपके ब्राउज़र में तब तक बना रहता है जब तक आप %3$sसभी "
+"खोज सेटिंग रीसेट करें%4$s पर क्लिक/टैप नहीं कर देते।"
 
 # smartling.placeholder_format=C
 #. Tells users where to click in order to disable the cloud save feature and delete any data backed-up to the cloud.
@@ -4407,8 +4454,9 @@ msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Settings%s."
 msgstr ""
-"%1$sमेरा डेटा हटाएं%2$s पर क्लिक करें या टैप करें। यह क्लाउड से डेटा हटाता है, लेकिन यह "
-"आपके ब्राउज़र में तब तक रहता है जब तक आप %3$sसभी सेटिंग्स रीसेट%4$s पर क्लिक/टैप नहीं करते।"
+"%1$sमेरा डेटा हटाएं%2$s पर क्लिक करें या टैप करें। यह क्लाउड से डेटा हटाता "
+"है, लेकिन यह आपके ब्राउज़र में तब तक रहता है जब तक आप %3$sसभी सेटिंग्स "
+"रीसेट%4$s पर क्लिक/टैप नहीं करते।"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -4477,8 +4525,8 @@ msgid ""
 "Click the dropdown menu beside %sSearch engine used in the address bar%s and "
 "select %sDuckDuckGo%s."
 msgstr ""
-"%1$sएड्रेस बार में उपयोग किए गए खोज इंजन%2$s के पास वाले ड्रॉपडाउन मेनू पर क्लिक करें और "
-"%3$sDuckDuckGo%4$s चुनें।"
+"%1$sएड्रेस बार में उपयोग किए गए खोज इंजन%2$s के पास वाले ड्रॉपडाउन मेनू पर "
+"क्लिक करें और %3$sDuckDuckGo%4$s चुनें।"
 
 # smartling.placeholder_format=C
 #. First step in a list of steps to take to disable the user's ad blocker
@@ -4486,8 +4534,8 @@ msgid ""
 "Click the icon of the ad blocker extension. It's usually in the upper right "
 "hand corner of your browser."
 msgstr ""
-"विज्ञापन ब्लॉकर एक्सटेंशन के आइकॉन पर क्लिक करें। यह आम तौर पर आपके ब्राउज़र के ऊपरी दाएं "
-"कोने में होता है।"
+"विज्ञापन ब्लॉकर एक्सटेंशन के आइकॉन पर क्लिक करें। यह आम तौर पर आपके ब्राउज़र "
+"के ऊपरी दाएं कोने में होता है।"
 
 #  Safari default search engine instruction
 # smartling.placeholder_format=C
@@ -4676,8 +4724,8 @@ msgid ""
 "Cloud Save lets you save your settings more permanently by entering a "
 "passphrase. It is entirely optional."
 msgstr ""
-"Cloud Save से आप अपनी चुनी हुई सेटिंग्स एक पासवर्ड द्वारा सर्वर पर ज़्यादा सुरक्षित रख "
-"सकते हैं। यह पूर्ण तरह से वैकल्पिक है।"
+"Cloud Save से आप अपनी चुनी हुई सेटिंग्स एक पासवर्ड द्वारा सर्वर पर ज़्यादा "
+"सुरक्षित रख सकते हैं। यह पूर्ण तरह से वैकल्पिक है।"
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -5155,7 +5203,7 @@ msgstr "इमेज बनाएं"
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
-msgstr ""
+msgstr "इस रेसिपी वाली मात्राओं के साथ एक शॉपिंग लिस्ट बनाएं।"
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed in the input field when starting a new image generation session.
@@ -5420,8 +5468,8 @@ msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "Daily usage limit reached. You can keep chatting by using your weekly limit."
 msgstr ""
-"दैनिक उपयोग सीमा पूरी हो गई है। आप अपनी साप्ताहिक सीमा का इस्तेमाल करके चैट करना "
-"जारी रख सकते हैं।"
+"दैनिक उपयोग सीमा पूरी हो गई है। आप अपनी साप्ताहिक सीमा का इस्तेमाल करके चैट "
+"करना जारी रख सकते हैं।"
 
 # smartling.placeholder_format=C
 #. The name of the Danish language
@@ -5789,8 +5837,8 @@ msgstr "Duck.ai में डिक्टेशन"
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
 msgstr ""
-"हम डिक्टेशन को गुमनाम रखते हैं और इसका उपयोग कभी भी AI मॉडल प्रशिक्षित करने के लिए नहीं "
-"किया जाता है।"
+"हम डिक्टेशन को गुमनाम रखते हैं और इसका उपयोग कभी भी AI मॉडल प्रशिक्षित करने "
+"के लिए नहीं किया जाता है।"
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
@@ -5800,7 +5848,7 @@ msgstr "डिक्टेशन सीमा पूरी हो गई है"
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
 msgid "Dictation temporarily unavailable"
-msgstr ""
+msgstr "डिक्टेशन फिलहाल उपलब्ध नहीं है"
 
 # smartling.placeholder_format=C
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
@@ -5808,8 +5856,8 @@ msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
 "chat in Duck.ai without having to type."
 msgstr ""
-"डिक्टेशन आपकी स्पीच को टेक्स्ट में बदलने के लिए OpenAI मॉडल का इस्तेमाल करता है, ताकि आप "
-"बिना टाइप किए भी Duck.ai में चैट कर सकें।"
+"डिक्टेशन आपकी स्पीच को टेक्स्ट में बदलने के लिए OpenAI मॉडल का इस्तेमाल करता "
+"है, ताकि आप बिना टाइप किए भी Duck.ai में चैट कर सकें।"
 
 # smartling.placeholder_format=C
 #. In 0-click box -- link to definition.
@@ -6109,6 +6157,8 @@ msgid ""
 "Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
 "filtered out. %sLearn More%s"
 msgstr ""
+"क्या आपको AI नहीं चाहिए? %1$snoai.duckduckgo.com%2$s इसमें कोई AI सुविधा "
+"नहीं है और AI इमेज फ़िल्टर कर दी गई हैं। %3$sऔर जानें%4$s"
 
 # smartling.placeholder_format=C
 #. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
@@ -6117,6 +6167,8 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
+"क्या आपको AI नहीं चाहिए? %1$snoai.duckduckgo.com%2$s पर जाएं ताकि बिना AI "
+"फ़ीचर्स और बिना AI इमेज फ़िल्टर के साथ खोज सकें। %3$sऔर जानें%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6219,8 +6271,8 @@ msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for "
 "ceiling fan repair services."
 msgstr ""
-"छत वाले पंखे की मरम्मत सेवा के लिए कोटेशन का अनुरोध करते हुए, वेंडर को कम शब्दों में ज़रूरी "
-"जानकारी के साथ ईमेल लिखें।"
+"छत वाले पंखे की मरम्मत सेवा के लिए कोटेशन का अनुरोध करते हुए, वेंडर को कम "
+"शब्दों में ज़रूरी जानकारी के साथ ईमेल लिखें।"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion asking for an email draft to a vendor requesting a quote for home refrigerator repair services.
@@ -6229,20 +6281,20 @@ msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
 msgstr ""
-"घर के रेफ़्रिजरेरट की मरम्मत के लिए कोटेशन का अनुरोध करते हुए, वेंडर को कम शब्दों में ज़रूरी "
-"जानकारी के साथ ईमेल लिखें।"
+"घर के रेफ़्रिजरेरट की मरम्मत के लिए कोटेशन का अनुरोध करते हुए, वेंडर को कम "
+"शब्दों में ज़रूरी जानकारी के साथ ईमेल लिखें।"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Draft a cover letter"
-msgstr ""
+msgstr "कवर लेटर ड्राफ़्ट करें"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Draft a cover letter for this job."
-msgstr ""
+msgstr "इस ज़ॉब के लिए कवर लेटर ड्राफ़्ट करें।"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -6251,8 +6303,8 @@ msgid ""
 "Draft a few options for a social media post inviting people to my upcoming "
 "party."
 msgstr ""
-"ऐसी एक सोशल मीडिया पोस्ट हेतु कुछ ऑप्शन ड्राफ्ट करें जो मेरी आगामी पार्टी में लोगों को "
-"आमंत्रित करने के लिए है।"
+"ऐसी एक सोशल मीडिया पोस्ट हेतु कुछ ऑप्शन ड्राफ्ट करें जो मेरी आगामी पार्टी "
+"में लोगों को आमंत्रित करने के लिए है।"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a few options for a blog post title about strategies to increase team collaboration.
@@ -6261,8 +6313,8 @@ msgid ""
 "Draft a few options for a title of a post I’m writing about strategies to "
 "increase team collaboration."
 msgstr ""
-"ऐसी एक पोस्ट के शीर्षक के लिए कुछ ऑप्शन ड्राफ्ट करें जिसमें मुझे टीम सहयोग बढ़ाने की मेरी "
-"रणनीतियों के बारे में लिखना है।"
+"ऐसी एक पोस्ट के शीर्षक के लिए कुछ ऑप्शन ड्राफ्ट करें जिसमें मुझे टीम सहयोग "
+"बढ़ाने की मेरी रणनीतियों के बारे में लिखना है।"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for drafting a social media post.
@@ -6388,9 +6440,9 @@ msgid ""
 "content is only included when you attach it, unless you choose to attach "
 "pages automatically in Settings."
 msgstr ""
-"अब Duck.ai आपके द्वारा देखे जा रहे पेज से संबंधित सवालों के जवाब दे सकता है। पेज का कंटेंट "
-"तभी शामिल होता है जब आप उसे अटैच करते हैं, बशर्ते आपने सेटिंग में पेजों को ऑटोमैटिकली अटैच "
-"करने का विकल्प न चुना हो।"
+"अब Duck.ai आपके द्वारा देखे जा रहे पेज से संबंधित सवालों के जवाब दे सकता है। "
+"पेज का कंटेंट तभी शामिल होता है जब आप उसे अटैच करते हैं, बशर्ते आपने सेटिंग "
+"में पेजों को ऑटोमैटिकली अटैच करने का विकल्प न चुना हो।"
 
 # smartling.placeholder_format=C
 #. Shown in the Duck.ai recent chats list on standalone when the browser API needed to store chats locally is missing or unavailable.
@@ -6400,8 +6452,9 @@ msgid ""
 "Duck.ai can’t access local storage to save your chats. Please check your "
 "browser settings or disable any extensions and try again."
 msgstr ""
-"Duck.ai आपकी चैट्स को सेव करने के लिए लोकल स्टोरेज एक्सेस नहीं कर सकता। कृपया अपनी "
-"ब्राउज़र सेटिंग्स चेक करें या कोई भी एक्सटेंशन डिसेबल (अक्षम) करें और फिर से कोशिश करें।"
+"Duck.ai आपकी चैट्स को सेव करने के लिए लोकल स्टोरेज एक्सेस नहीं कर सकता। "
+"कृपया अपनी ब्राउज़र सेटिंग्स चेक करें या कोई भी एक्सटेंशन डिसेबल (अक्षम) "
+"करें और फिर से कोशिश करें।"
 
 # smartling.placeholder_format=C
 #. Displayed when the chat service has reached the maximum number of messages for one day.
@@ -6410,8 +6463,8 @@ msgid ""
 "Duck.ai has reached the maximum number of messages for one day. Please "
 "continue this chat tomorrow."
 msgstr ""
-"Duck.ai एक दिन के लिए तय संदेशों की अधिकतम संख्या तक पहुंच गया है। कृपया इस चैट को अब "
-"कल जारी रखें।"
+"Duck.ai एक दिन के लिए तय संदेशों की अधिकतम संख्या तक पहुंच गया है। कृपया इस "
+"चैट को अब कल जारी रखें।"
 
 # smartling.placeholder_format=C
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
@@ -6427,6 +6480,9 @@ msgid ""
 "company for anyone who wants to take back control of their personal "
 "information."
 msgstr ""
+"Duck.ai को DuckDuckGo द्वारा बनाया गया है। हम एक स्वतंत्र ऑनलाइन प्रोटेक्शन "
+"कंपनी हैं, जो उन सभी के लिए है जो अपनी पर्सनल जानकारी का कंट्रोल वापस अपने "
+"हाथ में लेना चाहते हैं।"
 
 # smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
@@ -6441,8 +6497,8 @@ msgid ""
 "Duck.ai is still a DuckDuckGo product, but will now have an easier to "
 "remember home on the web: https://duck.ai"
 msgstr ""
-"Duck.ai अभी भी DuckDuckGo का प्रोडक्ट है, लेकिन अब वेब पर इसे याद रखना और भी आसान "
-"होगा: https://duck.ai"
+"Duck.ai अभी भी DuckDuckGo का प्रोडक्ट है, लेकिन अब वेब पर इसे याद रखना और भी "
+"आसान होगा: https://duck.ai"
 
 # smartling.placeholder_format=C
 #. Headline for domain change notice.
@@ -6457,8 +6513,8 @@ msgid ""
 "Duck.ai is temporarily unavailable. If this persists, please email this "
 "anonymous code %s to %s"
 msgstr ""
-"Duck.ai फिलहाल उपलब्ध नहीं है। अगर यह समस्या बनी रहती है, तो कृपया इस अनाम कोड "
-"%1$s को %2$s पर ईमेल करें"
+"Duck.ai फिलहाल उपलब्ध नहीं है। अगर यह समस्या बनी रहती है, तो कृपया इस अनाम "
+"कोड %1$s को %2$s पर ईमेल करें"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -6479,6 +6535,9 @@ msgid ""
 "Duck.ai lets you chat privately with popular AI models. Disabling it hides "
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
+"Duck.ai आपको पॉपुलर AI मॉडल्स के साथ गोपनीय ढंग से प्राइवेट चैट करने देता "
+"है। इसे बंद करने से Duck.ai बटन और लिंक छिप जाते हैं, लेकिन आप अभी भी "
+"%1$sduck.ai%2$s पर जा सकते हैं सीधे ही।"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6489,10 +6548,11 @@ msgid ""
 "can still access Duck.ai when this setting is off by visiting %shttps://duck."
 "ai%s directly."
 msgstr ""
-"Duck.ai से आपको थर्ड-पार्टी AI चैट मॉडल के साथ गुमनाम ढंग से बातचीत करने की सुविधा "
-"मिलती है, जिसमें OpenAI, Anthropic और अन्य मॉडल शामिल हैं। इस सेटिंग को बंद करने से "
-"DuckDuckGo Search पर Duck.ai बटन और लिंक छिप जाएंगे। हालांकि, यह सेटिंग बंद होने पर "
-"भी आप %1$shttps://duck.ai%2$s पर जाकर, सीधे तौर पर Duck.ai का इस्तेमाल कर सकते हैं।"
+"Duck.ai से आपको थर्ड-पार्टी AI चैट मॉडल के साथ गुमनाम ढंग से बातचीत करने की "
+"सुविधा मिलती है, जिसमें OpenAI, Anthropic और अन्य मॉडल शामिल हैं। इस सेटिंग "
+"को बंद करने से DuckDuckGo Search पर Duck.ai बटन और लिंक छिप जाएंगे। हालांकि, "
+"यह सेटिंग बंद होने पर भी आप %1$shttps://duck.ai%2$s पर जाकर, सीधे तौर पर "
+"Duck.ai का इस्तेमाल कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
@@ -6507,8 +6567,8 @@ msgid ""
 "Duck.ai might have lost your recent chats. You can still use Duck.ai as "
 "usual."
 msgstr ""
-"हो सकता है कि Duck.ai ने आपकी पिछली चैट हटा दी हों। आप Duck.ai का उपयोग जारी रख "
-"सकते हैं।"
+"हो सकता है कि Duck.ai ने आपकी पिछली चैट हटा दी हों। आप Duck.ai का उपयोग जारी "
+"रख सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
@@ -6522,8 +6582,8 @@ msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
 msgstr ""
-"Duck.ai के जवाब कुछ खास स्रोतों पर आधारित नहीं होते हैं और इनकी सटीकता संबंधी कोई जांच "
-"नहीं होती है।"
+"Duck.ai के जवाब कुछ खास स्रोतों पर आधारित नहीं होते हैं और इनकी सटीकता "
+"संबंधी कोई जांच नहीं होती है।"
 
 # smartling.placeholder_format=C
 #. Title shown when native app needs to reload for service update.
@@ -6551,9 +6611,9 @@ msgid ""
 "AI chat no sign up, OpenAI, Anthropic, Llama, Mistral, open source AI "
 "models, privacy focused AI, no account AI chat"
 msgstr ""
-"Duck.ai, DuckDuckGo AI, प्राइवेट AI चैटबॉट, मुफ़्त AI चैट, गुमनाम AI चैट, बिना साइन "
-"अप AI चैट, OpenAI, Anthropic, Llama, Mistral, ओपन सोर्स AI मॉडल, गोपनीयता "
-"केंद्रित AI, बिना खाता AI चैट"
+"Duck.ai, DuckDuckGo AI, प्राइवेट AI चैटबॉट, मुफ़्त AI चैट, गुमनाम AI चैट, "
+"बिना साइन अप AI चैट, OpenAI, Anthropic, Llama, Mistral, ओपन सोर्स AI मॉडल, "
+"गोपनीयता केंद्रित AI, बिना खाता AI चैट"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -6581,12 +6641,13 @@ msgid ""
 "relevant), or Often (shows more frequently on a wider range of searches). "
 "For now, DuckAssist is only available in the U.S. (English) region."
 msgstr ""
-"कुछ खोजों के लिए DuckAssist, जानकारी को गुमनाम रूप से खोज सकता है और उसके बारे में खास "
-"जानकारी दे सकता है। आप चुन सकते हैं कि DuckAssist को कितनी बार दिखाना है: कभी नहीं "
-"(यह खोज परिणामों से DuckAssist के यूआई को पूरी तरह हटा देता है), ऑन-डिमांड (सिर्फ़ तभी "
-"दिखाता है जब आप 'सहायता' बटन पर क्लिक करते हैं), कभी-कभी (सिर्फ़ तभी दिखाता है, जब "
-"नतीजे बहुत काम के हों), या अक्सर (कई तरह की खोजों पर अक्सर दिखाता है)। फ़िलहाल, "
-"DuckAssist सिर्फ़ अमेरिका (अंग्रेज़ी) में उपलब्ध है।"
+"कुछ खोजों के लिए DuckAssist, जानकारी को गुमनाम रूप से खोज सकता है और उसके "
+"बारे में खास जानकारी दे सकता है। आप चुन सकते हैं कि DuckAssist को कितनी बार "
+"दिखाना है: कभी नहीं (यह खोज परिणामों से DuckAssist के यूआई को पूरी तरह हटा "
+"देता है), ऑन-डिमांड (सिर्फ़ तभी दिखाता है जब आप 'सहायता' बटन पर क्लिक करते "
+"हैं), कभी-कभी (सिर्फ़ तभी दिखाता है, जब नतीजे बहुत काम के हों), या अक्सर (कई "
+"तरह की खोजों पर अक्सर दिखाता है)। फ़िलहाल, DuckAssist सिर्फ़ अमेरिका "
+"(अंग्रेज़ी) में उपलब्ध है।"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6596,8 +6657,8 @@ msgid ""
 "supports chat models from OpenAI, and Anthropic, and more."
 msgstr ""
 "DuckAssist से फ़ॉलोअप सवालों के जवाब नहीं दिए जा सकते। हालांकि, हमारी ओर से "
-"%1$sDuckDuckGo AI Chat%2$s भी उपलब्ध है, जो एक प्राइवेट AI-संचालित चैट सेवा है जो "
-"OpenAI के चैट मॉडलों को, और Anthropic को और अन्य को सपोर्ट करती है।"
+"%1$sDuckDuckGo AI Chat%2$s भी उपलब्ध है, जो एक प्राइवेट AI-संचालित चैट सेवा "
+"है जो OpenAI के चैट मॉडलों को, और Anthropic को और अन्य को सपोर्ट करती है।"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6607,8 +6668,8 @@ msgid ""
 "supports chat models from OpenAI and Anthropic."
 msgstr ""
 "DuckAssist से फ़ॉलोअप सवालों के जवाब नहीं दिए जा सकते। हालांकि, हमारी ओर से "
-"DuckDuckGo %1$sAI Chat%2$s भी उपलब्ध है। यह एक प्राइवेट AI-संचालित चैट सेवा है जो "
-"OpenAI और Anthropic के चैट मॉडलों को सपोर्ट करती है।"
+"DuckDuckGo %1$sAI Chat%2$s भी उपलब्ध है। यह एक प्राइवेट AI-संचालित चैट सेवा "
+"है जो OpenAI और Anthropic के चैट मॉडलों को सपोर्ट करती है।"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6620,12 +6681,12 @@ msgid ""
 "responses are currently based on Wikipedia and related content and are not "
 "checked for accuracy."
 msgstr ""
-"DuckAssist, खोज परिणाम दिखाने से जुड़ा एक नया फ़ीचर है। यह गुमनाम रहकर, खोज संबंधी "
-"क्वेरी के जवाब जनरेट कर सकता है। ऐसा करने के लिए, यह Wikipedia और संबंधित साइटों को "
-"स्कैन करके उनसे काम की जानकारी जुटाता है। इसके बाद, उससे जुड़ी खास जानकारी को जनरेट करने "
-"के लिए AI-संचालित नेचुरल लैंग्वेज टेक्नोलॉजी का इस्तेमाल करता है। कृपया ध्यान दें कि फ़िलहाल "
-"इसके जवाब Wikipedia और संबंधित कॉन्टेंट पर आधारित होते हैं और इसकी सटीकता की जांच नहीं "
-"की जाती है।"
+"DuckAssist, खोज परिणाम दिखाने से जुड़ा एक नया फ़ीचर है। यह गुमनाम रहकर, खोज "
+"संबंधी क्वेरी के जवाब जनरेट कर सकता है। ऐसा करने के लिए, यह Wikipedia और "
+"संबंधित साइटों को स्कैन करके उनसे काम की जानकारी जुटाता है। इसके बाद, उससे "
+"जुड़ी खास जानकारी को जनरेट करने के लिए AI-संचालित नेचुरल लैंग्वेज टेक्नोलॉजी "
+"का इस्तेमाल करता है। कृपया ध्यान दें कि फ़िलहाल इसके जवाब Wikipedia और "
+"संबंधित कॉन्टेंट पर आधारित होते हैं और इसकी सटीकता की जांच नहीं की जाती है।"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6639,13 +6700,15 @@ msgid ""
 "It’s important to remember that responses are auto-generated from cited "
 "sources and based on %scrawling the web%s."
 msgstr ""
-"DuckAssist, खोज परिणाम दिखाने से जुड़ा एक नया वैकल्पिक फ़ीचर है। यह गुमनाम रहकर, खोज "
-"संबंधी क्वेरी के जवाब जनरेट कर सकता है। ऐसा करने के लिए, यह वेब को स्कैन करके क्वेरी से जुड़ी "
-"सामग्री जुटाता है। इसके बाद, उस सामग्री से जुड़ी जानकारी के आधार पर कम शब्दों में जवाब देने "
-"के लिए, AI-संचालित नेचुरल लैंग्वेज टेक्नोलॉजी का इस्तेमाल करता है। DuckAssist के जवाब हमेशा "
-"एक या दो स्रोतों से सीधे लिंक होते हैं, जिसमें बताया जाता है कि जवाब कहां से आया है, ताकि "
-"आपको आसानी से वहां जाकर ज़्यादा जानकारी मिल सके। यह याद रखना ज़रूरी है कि जवाब, दूसरे "
-"स्रोतों से अपने-आप जनरेट होते हैं और %1$sवेब क्रॉलिंग%2$s पर आधारित होते हैं।"
+"DuckAssist, खोज परिणाम दिखाने से जुड़ा एक नया वैकल्पिक फ़ीचर है। यह गुमनाम "
+"रहकर, खोज संबंधी क्वेरी के जवाब जनरेट कर सकता है। ऐसा करने के लिए, यह वेब को "
+"स्कैन करके क्वेरी से जुड़ी सामग्री जुटाता है। इसके बाद, उस सामग्री से जुड़ी "
+"जानकारी के आधार पर कम शब्दों में जवाब देने के लिए, AI-संचालित नेचुरल "
+"लैंग्वेज टेक्नोलॉजी का इस्तेमाल करता है। DuckAssist के जवाब हमेशा एक या दो "
+"स्रोतों से सीधे लिंक होते हैं, जिसमें बताया जाता है कि जवाब कहां से आया है, "
+"ताकि आपको आसानी से वहां जाकर ज़्यादा जानकारी मिल सके। यह याद रखना ज़रूरी है "
+"कि जवाब, दूसरे स्रोतों से अपने-आप जनरेट होते हैं और %1$sवेब क्रॉलिंग%2$s पर "
+"आधारित होते हैं।"
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
@@ -6653,8 +6716,8 @@ msgid ""
 "DuckAssist responses are auto-generated based on listed sources and not "
 "checked for accuracy."
 msgstr ""
-"DuckAssist वाले जवाब सूचीबद्ध स्रोतों के आधार पर स्वचालित ढंग से जनरेट होते हैं और इनकी "
-"सटीकता की जांच नहीं की जाती है।"
+"DuckAssist वाले जवाब सूचीबद्ध स्रोतों के आधार पर स्वचालित ढंग से जनरेट होते "
+"हैं और इनकी सटीकता की जांच नहीं की जाती है।"
 
 # smartling.placeholder_format=C
 #. Displayed when the chat service has reached the maximum number of messages for one day.
@@ -6663,8 +6726,8 @@ msgid ""
 "DuckDuckGo AI Chat has reached the maximum number of messages for one day. "
 "Please continue this chat tomorrow."
 msgstr ""
-"DuckDuckGo AI Chat में एक दिन के संदेशों की अधिकतम संख्या पूरी हो गई है। कृपया इस चैट को "
-"अब कल जारी रखें।"
+"DuckDuckGo AI Chat में एक दिन के संदेशों की अधिकतम संख्या पूरी हो गई है। "
+"कृपया इस चैट को अब कल जारी रखें।"
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the AI chat service and supported AI models. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -6673,8 +6736,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"DuckDuckGo AI Chat एक प्राइवेट AI-संचालित चैट सेवा है जो वर्तमान में %1$s के %2$s और "
-"%3$s के %4$s चैट मॉडल को सपोर्ट करती है।"
+"DuckDuckGo AI Chat एक प्राइवेट AI-संचालित चैट सेवा है जो वर्तमान में %1$s के "
+"%2$s और %3$s के %4$s चैट मॉडल को सपोर्ट करती है।"
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the welcome screen of the onboarding. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -6683,8 +6746,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"DuckDuckGo AI Chat एक प्राइवेट AI-संचालित चैट सेवा है जो वर्तमान में %1$s के %2$s और "
-"%3$s के %4$s चैट मॉडल को सपोर्ट करती है।"
+"DuckDuckGo AI Chat एक प्राइवेट AI-संचालित चैट सेवा है जो वर्तमान में %1$s के "
+"%2$s और %3$s के %4$s चैट मॉडल को सपोर्ट करती है।"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding DuckDuckGo AI Chat.
@@ -6693,7 +6756,8 @@ msgid ""
 "DuckDuckGo AI Chat is in Beta, it may display inaccurate or offensive "
 "information."
 msgstr ""
-"DuckDuckGo AI Chat बीटा में है, इसमें गलत या आपत्तिजनक जानकारी भी दिखाई दे सकती है।"
+"DuckDuckGo AI Chat बीटा में है, इसमें गलत या आपत्तिजनक जानकारी भी दिखाई दे "
+"सकती है।"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat making it unavailable, and asking the user to send an email with a specific code if the error persists. E.g. 'DuckDuckGo AI Chat is temporarily unavailable. If this persists, please email this anonymous code abcdefg12345 to aichat-error@duckduckgo.com'
@@ -6702,8 +6766,8 @@ msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. If this persists, please "
 "email this anonymous code %s to %s"
 msgstr ""
-"DuckDuckGo AI Chat फिलहाल उपलब्ध नहीं है। अगर यह समस्या बनी रहती है, तो कृपया इस "
-"अनाम कोड %1$s को %2$s पर ईमेल करें"
+"DuckDuckGo AI Chat फिलहाल उपलब्ध नहीं है। अगर यह समस्या बनी रहती है, तो "
+"कृपया इस अनाम कोड %1$s को %2$s पर ईमेल करें"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -6712,7 +6776,8 @@ msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. Please refresh the page and "
 "try again."
 msgstr ""
-"DuckDuckGo AI Chat फिलहाल उपलब्ध नहीं है। पेज को रीफ्रेश करें और फिर से कोशिश करें।"
+"DuckDuckGo AI Chat फिलहाल उपलब्ध नहीं है। पेज को रीफ्रेश करें और फिर से "
+"कोशिश करें।"
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -6837,8 +6902,9 @@ msgid ""
 "DuckDuckGo anonymizes these reports by automatically removing PII like "
 "names, email addresses, phone numbers, and identifying metadata."
 msgstr ""
-"DuckDuckGo सुरक्षा की दृष्टि से नाम, ईमेल पते, फ़ोन नंबर और पहचान संबंधी मेटाडेटा जैसी "
-"व्यक्तिगत जानकारी (PII) को ऑटोमैटिकली हटाकर इन रिपोर्टों को एनोनिमाइज़ कर देता है।"
+"DuckDuckGo सुरक्षा की दृष्टि से नाम, ईमेल पते, फ़ोन नंबर और पहचान संबंधी "
+"मेटाडेटा जैसी व्यक्तिगत जानकारी (PII) को ऑटोमैटिकली हटाकर इन रिपोर्टों को "
+"एनोनिमाइज़ कर देता है।"
 
 # smartling.placeholder_format=C
 #. The first %s is the agree button label ('Agree'). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. The leading sentence mirrors the drawer-style inline disclaimer (DUCKCHAT_TOS_INLINE_DISCLAIMER).
@@ -6846,8 +6912,8 @@ msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid ""
 "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to Duck.ai's %s."
 msgstr ""
-"DuckDuckGo आपकी चैट को अनाम बनाता है। '%1$s' पर क्लिक करके आप Duck.ai की %2$s से "
-"सहमत होते हैं।"
+"DuckDuckGo आपकी चैट को अनाम बनाता है। '%1$s' पर क्लिक करके आप Duck.ai की "
+"%2$s से सहमत होते हैं।"
 
 # smartling.placeholder_format=C
 #. Shown below the input on the empty state when the user has not yet accepted the terms of service. The first %s is the action button label ('Ask' for chat, 'Create' for image generation). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. Clicking the action button both accepts the terms and submits the prompt.
@@ -6856,8 +6922,8 @@ msgctxt ""
 "users"
 msgid "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to our %s."
 msgstr ""
-"DuckDuckGo आपकी चैट को अनाम बनाता है। '%1$s' पर क्लिक करके आप हमारी %2$s से सहमत "
-"होते हैं।"
+"DuckDuckGo आपकी चैट को अनाम बनाता है। '%1$s' पर क्लिक करके आप हमारी %2$s से "
+"सहमत होते हैं।"
 
 # smartling.placeholder_format=C
 #. An information popup explaining that we block trackers
@@ -6866,9 +6932,9 @@ msgid ""
 "companies like Google and Facebook, who often try to track you on other "
 "websites."
 msgstr ""
-"DuckDuckGo आपके द्वारा देखी जाने वाली वेबसाइटों पर ट्रैकरों को ब्लॉक करता है, जिसमें "
-"Google और Facebook जैसी कंपनियों के ट्रैकर शामिल हैं, जो अक्सर आपको अन्य वेबसाइटों पर "
-"ट्रैक करने की कोशिश करते हैं।"
+"DuckDuckGo आपके द्वारा देखी जाने वाली वेबसाइटों पर ट्रैकरों को ब्लॉक करता "
+"है, जिसमें Google और Facebook जैसी कंपनियों के ट्रैकर शामिल हैं, जो अक्सर "
+"आपको अन्य वेबसाइटों पर ट्रैक करने की कोशिश करते हैं।"
 
 # smartling.placeholder_format=C
 #. Description of how DuckDuckGo keeps a user's location anonymous while the user searches on a map of their area.
@@ -6880,11 +6946,12 @@ msgid ""
 "away, such that you remain anonymous. %sLearn more about how we designed "
 "this technology to protect your privacy%s."
 msgstr ""
-"DuckDuckGo को गोपनीयता के लिए बनाया गया है। जब आप स्‍थान सक्षम करते हैं, तो यह केवल "
-"आपके स्थानीय डिवाइस में स्टोर हो जाता है। जब आप खोज करते हैं, तो आपकी डिवाइस उसे हमें "
-"भेजता है, हम उसका उपयोग उस खोज के परिणामों को बेहतर बनाने के लिए करते हैं और फिर हम "
-"तुरंत इसे फेंक देते हैं, जिससे आप गुमनाम ही रहते हैं। %1$sआपकी गोपनीयता की सुरक्षा के लिए हमने "
-"इस तकनीक को कैसे डिज़ाइन किया है, इसके बारे में और जानें%2$s।"
+"DuckDuckGo को गोपनीयता के लिए बनाया गया है। जब आप स्‍थान सक्षम करते हैं, तो "
+"यह केवल आपके स्थानीय डिवाइस में स्टोर हो जाता है। जब आप खोज करते हैं, तो "
+"आपकी डिवाइस उसे हमें भेजता है, हम उसका उपयोग उस खोज के परिणामों को बेहतर "
+"बनाने के लिए करते हैं और फिर हम तुरंत इसे फेंक देते हैं, जिससे आप गुमनाम ही "
+"रहते हैं। %1$sआपकी गोपनीयता की सुरक्षा के लिए हमने इस तकनीक को कैसे डिज़ाइन "
+"किया है, इसके बारे में और जानें%2$s।"
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
@@ -6904,8 +6971,8 @@ msgid ""
 "DuckDuckGo only uses your approximate location. That's all we need to "
 "deliver better results, closer to you. %sLearn more%s."
 msgstr ""
-"DuckDuckGo केवल आपके अनुमानित स्‍थान का उपयोग करता है। हम सभी को आपके नज़दीक के बेहतर "
-"परिणाम देने की जरूरत है। %1$sऔर जानें%2$s।"
+"DuckDuckGo केवल आपके अनुमानित स्‍थान का उपयोग करता है। हम सभी को आपके नज़दीक "
+"के बेहतर परिणाम देने की जरूरत है। %1$sऔर जानें%2$s।"
 
 # smartling.placeholder_format=C
 msgid "DuckDuckGo search"
@@ -6991,9 +7058,10 @@ msgid ""
 "random words from that list, ensuring that the passphrase is at least 18-20 "
 "characters long."
 msgstr ""
-"हर बार जब आप पासफ्रेज़ सुझाव मांगते हैं, तो हमें DuckDuckGo सर्वर से आकस्मिक शब्दों की लंबी "
-"सूची मिलती है। ब्राउज़र में, हम उस सूची से 4-5 आकस्मिक शब्दों का चयन करते हैं, यह सुनिश्चित "
-"करते हुए कि पासफ्रेज़ कम से कम 18-20 अक्षर लंबा है।"
+"हर बार जब आप पासफ्रेज़ सुझाव मांगते हैं, तो हमें DuckDuckGo सर्वर से आकस्मिक "
+"शब्दों की लंबी सूची मिलती है। ब्राउज़र में, हम उस सूची से 4-5 आकस्मिक शब्दों "
+"का चयन करते हैं, यह सुनिश्चित करते हुए कि पासफ्रेज़ कम से कम 18-20 अक्षर "
+"लंबा है।"
 
 # smartling.placeholder_format=C
 msgctxt "Sports module"
@@ -7058,8 +7126,8 @@ msgctxt "Info text for the editing message feature"
 msgid ""
 "Editing your message will remove the response below and generate a new one."
 msgstr ""
-"आपके संदेश को एडिट करने से नीचे दिया गया जवाब हट जाएगा और उसकी जगह नया जवाब तैयार "
-"होगा।"
+"आपके संदेश को एडिट करने से नीचे दिया गया जवाब हट जाएगा और उसकी जगह नया जवाब "
+"तैयार होगा।"
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of an editor in its responses.
@@ -7191,8 +7259,8 @@ msgid ""
 "Enable anonymous location for more accurate results. You can always change "
 "your mind later."
 msgstr ""
-"अधिक सटीक परिणामों के लिए अनाम स्थान सक्षम करें। आप अक्‍सर बाद में अपना विचार बदल सकते "
-"हैं।"
+"अधिक सटीक परिणामों के लिए अनाम स्थान सक्षम करें। आप अक्‍सर बाद में अपना "
+"विचार बदल सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Title of the dictation privacy consent modal shown on first use.
@@ -7235,8 +7303,9 @@ msgid ""
 "Enabling anonymous location gives more accurate results but still keeps your "
 "searches and exact location private to DuckDuckGo."
 msgstr ""
-"जगह की जानकारी गुप्त रखने की सुविध चालू करने से ज़्यादा सटीक परिणाम मिलते हैं, लेकिन फिर "
-"भी DuckDuckGo के लिए आपकी खोजें और सटीक स्थान गोपनीय बने रहते हैं।"
+"जगह की जानकारी गुप्त रखने की सुविध चालू करने से ज़्यादा सटीक परिणाम मिलते "
+"हैं, लेकिन फिर भी DuckDuckGo के लिए आपकी खोजें और सटीक स्थान गोपनीय बने रहते "
+"हैं।"
 
 # smartling.placeholder_format=C
 msgid "Encrypt Connections"
@@ -7398,8 +7467,8 @@ msgid ""
 "Enter a new passphrase and click/tap %sSave Settings%s. This will save your "
 "data under your new passphrase."
 msgstr ""
-"एक नया पासफ्रेज़ दर्ज करें और %1$sसेटिंग सहेजें%2$s पर टैप/क्लिक करें। यह आपके नए पासफ्रेज़ के "
-"तहत आपके डेटा को बचाएगा।"
+"एक नया पासफ्रेज़ दर्ज करें और %1$sसेटिंग सहेजें%2$s पर टैप/क्लिक करें। यह "
+"आपके नए पासफ्रेज़ के तहत आपके डेटा को बचाएगा।"
 
 # smartling.placeholder_format=C
 #. Label for the field where a user enters their passphrase.
@@ -7425,8 +7494,8 @@ msgstr "टेक्स्ट डालें"
 msgid ""
 "Enter the following details: %sName%s: DuckDuckGo%s URL%s: %s Alias%s: d%s"
 msgstr ""
-"निम्नलिखित विवरण दर्ज करें: %1$sनाम%2$s: DuckDuckGo%3$s यूआरएल%4$s: %5$s उपनाम "
-"%6$s: d%7$s"
+"निम्नलिखित विवरण दर्ज करें: %1$sनाम%2$s: DuckDuckGo%3$s यूआरएल%4$s: %5$s "
+"उपनाम %6$s: d%7$s"
 
 # smartling.placeholder_format=C
 #. Prompt to enter a destination for driving directions.
@@ -7470,13 +7539,13 @@ msgstr "इरिट्रिया"
 #. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Estimate the nutrition"
-msgstr ""
+msgstr "न्यूट्रीशन का अनुमान लगाएं"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Estimate the nutritional information for this recipe."
-msgstr ""
+msgstr "इस रेसिपी के लिए न्यूट्रीशन संबंधी जानकारी का अनुमान लगाएं।"
 
 # smartling.placeholder_format=C
 msgid "Estonia"
@@ -7513,8 +7582,8 @@ msgstr "मैप का विस्तार करें"
 msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
 msgstr ""
-"उन लोगों के लिए बेहतरीन ढंग से तैयार किए गए प्रोडक्ट, जिन्हें अपनी प्राइवेसी की सचमुच "
-"परवाह है।"
+"उन लोगों के लिए बेहतरीन ढंग से तैयार किए गए प्रोडक्ट, जिन्हें अपनी प्राइवेसी "
+"की सचमुच परवाह है।"
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
@@ -7538,7 +7607,7 @@ msgstr "1 दिन में समाप्ति"
 #. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain the accepted answer in simple terms."
-msgstr ""
+msgstr "स्वीकार किए गए जवाब को आसान शब्दों में समझाएं।"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
@@ -7551,43 +7620,43 @@ msgstr "मुझे ब्लैक होल की मूलभूत अव�
 #. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain the top answer"
-msgstr ""
+msgstr "सबसे अच्छे जवाब की व्याख्या करें"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain this in simple, plain language."
-msgstr ""
+msgstr "इसे सरल और स्पष्ट भाषा में समझाएं।"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain this paper"
-msgstr ""
+msgstr "इस पेपर को समझाएं"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain this repo"
-msgstr ""
+msgstr "इस रिपॉज़िटरी को समझाएं"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain this research paper in plain language."
-msgstr ""
+msgstr "इस रिसर्च पेपर को सरल भाषा में समझाएं।"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain this simply"
-msgstr ""
+msgstr "इसे सरल शब्दों में समझाएं"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain what this repository does and how to use it."
-msgstr ""
+msgstr "बताएं कि यह रिपॉज़िटरी क्या करती है और इसे कैसे इस्तेमाल करें।"
 
 # smartling.placeholder_format=C
 #. Label to show if song lyrics contain explicit content
@@ -7765,8 +7834,8 @@ msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and improvements."
 msgstr ""
-"आप लोगों से जो फीडबैक मिलती है उससे हमें हमारे प्रोडक्ट अपडेट और सुधार संंबंधी कार्यों में मदद "
-"मिलती है।"
+"आप लोगों से जो फीडबैक मिलती है उससे हमें हमारे प्रोडक्ट अपडेट और सुधार "
+"संंबंधी कार्यों में मदद मिलती है।"
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -7775,8 +7844,9 @@ msgid ""
 "Feedback like yours directly influences our product updates and "
 "improvements. Hopefully we can address the issue you shared too."
 msgstr ""
-"आप लोगों से जो फ़ीडबैक मिलता है उससे हमारे प्रॉडक्ट अपडेट और बेहतर बनाने की कोशिश में मदद "
-"मिलती है। उम्मीद है हम जल्द ही वह समस्या भी हल कर पाएंगे जिसे आपने शेयर किया है।"
+"आप लोगों से जो फ़ीडबैक मिलता है उससे हमारे प्रॉडक्ट अपडेट और बेहतर बनाने की "
+"कोशिश में मदद मिलती है। उम्मीद है हम जल्द ही वह समस्या भी हल कर पाएंगे जिसे "
+"आपने शेयर किया है।"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box
@@ -7784,8 +7854,8 @@ msgid ""
 "Feel free to adjust the settings below. Then, just copy and paste the code "
 "into your website."
 msgstr ""
-"नीचे दी गई सेटिंग को निस्संकोच होकर एडजस्ट करें। उसके बाद, कोड को अपनी वेबसाइट में कॉपी "
-"पेस्ट करें।"
+"नीचे दी गई सेटिंग को निस्संकोच होकर एडजस्ट करें। उसके बाद, कोड को अपनी "
+"वेबसाइट में कॉपी पेस्ट करें।"
 
 # smartling.placeholder_format=C
 msgid "Fiji"
@@ -7875,6 +7945,8 @@ msgctxt "settings"
 msgid ""
 "Filters out known AI spam sites from image search results. %sLearn More%s"
 msgstr ""
+"इमेज खोज परिणामों से ज्ञात AI स्पैम साइटों को फ़िल्टर कर देता है। %1$sऔर "
+"जानें%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the final score of a sporting event.
@@ -7933,7 +8005,7 @@ msgstr "मौजूदा जानकारी प्राप्त करे
 #. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Find me alternatives"
-msgstr ""
+msgstr "मेरे लिए विकल्प ढूंढें"
 
 # smartling.placeholder_format=C
 #. Button that searches for results closer to the user's current location.
@@ -7952,7 +8024,9 @@ msgstr "अपने नज़दीक के परिणामों को �
 msgctxt "Precise user location overlay"
 msgid ""
 "Find results near you. %sYour location stays private, secure, and anonymous."
-msgstr "अपने आस-पास के परिणाम खोजें। %1$sआपकी लोकेशन निजी, सुरक्षित और गुमनाम रहती है।"
+msgstr ""
+"अपने आस-पास के परिणाम खोजें। %1$sआपकी लोकेशन निजी, सुरक्षित और गुमनाम रहती "
+"है।"
 
 # smartling.placeholder_format=C
 #. Loading message shown while generating explore more follow-up questions
@@ -8016,8 +8090,8 @@ msgid ""
 "Follow the instructions for turning off the ad blocker for DuckDuckGo. You "
 "may have to select a menu option or click a button."
 msgstr ""
-"DuckDuckGo के लिए विज्ञापन ब्लॉकर बंद करने के निर्देशों का पालन करें। कोई मेन्यू विकल्प चुनें "
-"या कोई बटन क्लिक करें।"
+"DuckDuckGo के लिए विज्ञापन ब्लॉकर बंद करने के निर्देशों का पालन करें। कोई "
+"मेन्यू विकल्प चुनें या कोई बटन क्लिक करें।"
 
 # smartling.placeholder_format=C
 #. Privacy reassurance and instructions intro.
@@ -8159,8 +8233,8 @@ msgstr "व्यावसायिक रूप से शेयर और उ�
 msgctxt "Sync limit modal description"
 msgid "Free up space by deleting your chats. Pinned chats will not be deleted."
 msgstr ""
-"जो चैट काम की नहीं हैं, उन्हें डिलीट कर स्पेस खाली करें। पिन की गई चैट डिलीट नहीं की "
-"जाएंगी।"
+"जो चैट काम की नहीं हैं, उन्हें डिलीट कर स्पेस खाली करें। पिन की गई चैट डिलीट "
+"नहीं की जाएंगी।"
 
 # smartling.placeholder_format=C
 #. Indicates that this streaming service is free to watch but shows ads
@@ -8241,8 +8315,8 @@ msgid ""
 "<strong>Check for Updates...</strong>, then select <strong>Install Update</"
 "strong>."
 msgstr ""
-"Mac पर ऐप के मेनू बार से, <strong>DuckDuckGo</strong> &gt; <strong>अपडेट देखें...</"
-"strong> चुनें, फिर <strong>अपडेट इंस्टॉल करें</strong> को चुनें।"
+"Mac पर ऐप के मेनू बार से, <strong>DuckDuckGo</strong> &gt; <strong>अपडेट "
+"देखें...</strong> चुनें, फिर <strong>अपडेट इंस्टॉल करें</strong> को चुनें।"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -8413,7 +8487,7 @@ msgstr "और जनरेट करें"
 #. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Generate a shopping list"
-msgstr ""
+msgstr "शॉपिंग लिस्ट जनरेट करें"
 
 # smartling.placeholder_format=C
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
@@ -8593,8 +8667,9 @@ msgid ""
 "Get access to advanced AI models in Duck.ai by subscribing to DuckDuckGo, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"DuckDuckGo को सब्सक्राइब करके Duck.ai में एडवांस्ड AI मॉडल्स का एक्सेस प्राप्त करें, जिसमें "
-"हमारा VPN और अन्य प्रीमियम गोपनीयता संरक्षण भी शामिल हैं।"
+"DuckDuckGo को सब्सक्राइब करके Duck.ai में एडवांस्ड AI मॉडल्स का एक्सेस "
+"प्राप्त करें, जिसमें हमारा VPN और अन्य प्रीमियम गोपनीयता संरक्षण भी शामिल "
+"हैं।"
 
 # smartling.placeholder_format=C
 #. Description for the subscription setting where users can subscribe to DuckDuckGo.
@@ -8605,8 +8680,9 @@ msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"Duck.ai में एडवांस्ड AI मॉडल मॉडल्स का एक्सेस प्राप्त करें DuckDuckGo सब्सक्रिप्शन के साथ, "
-"जिसमें हमारा VPN और अन्य प्रीमियम गोपनीयता संरक्षण भी शामिल हैं।"
+"Duck.ai में एडवांस्ड AI मॉडल मॉडल्स का एक्सेस प्राप्त करें DuckDuckGo "
+"सब्सक्रिप्शन के साथ, जिसमें हमारा VPN और अन्य प्रीमियम गोपनीयता संरक्षण भी "
+"शामिल हैं।"
 
 # smartling.placeholder_format=C
 #. A button for users to generate an AI generated answer from their query on the duckassist module
@@ -8686,7 +8762,9 @@ msgstr "यह गाना यहां पाएंः"
 # smartling.placeholder_format=C
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
-msgstr "आपके दोस्तों को स्विच करने के लिए प्रेरित करें और हमें विकसित होने में मदद करें!"
+msgstr ""
+"आपके दोस्तों को स्विच करने के लिए प्रेरित करें और हमें विकसित होने में मदद "
+"करें!"
 
 # smartling.placeholder_format=C
 msgid "Ghana"
@@ -8708,7 +8786,7 @@ msgstr "इसे आज़माएं"
 #. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Give me a quick background on this person."
-msgstr ""
+msgstr "मुझे इस व्यक्ति के बारे में एक क्विक बैकग्राउंड दें।"
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -8723,8 +8801,8 @@ msgid ""
 "Go to %sSettings > Privacy & Security > Location Services%s, and make sure "
 "“Location Services” is turned on."
 msgstr ""
-"%1$sसेटिंग > गोपनीयता और सुरक्षा > स्थान सेवाएं%2$s पर जाएं और पक्का करें कि \"स्थान "
-"सेवाएं\" चालू है।"
+"%1$sसेटिंग > गोपनीयता और सुरक्षा > स्थान सेवाएं%2$s पर जाएं और पक्का करें कि "
+"\"स्थान सेवाएं\" चालू है।"
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -8733,8 +8811,8 @@ msgid ""
 "Go to %sSettings > Privacy > Permission manager > Location%s and scroll down "
 "to %sDuckDuckGo%s."
 msgstr ""
-"यहां जाएं: %1$sसेटिंग > गोपनीयता > अनुमति प्रबंधक > स्थान%2$s, और फिर नीचे स्क्रॉल करके "
-"%3$sDuckDuckGo%4$s पर जाएं।"
+"यहां जाएं: %1$sसेटिंग > गोपनीयता > अनुमति प्रबंधक > स्थान%2$s, और फिर नीचे "
+"स्क्रॉल करके %3$sDuckDuckGo%4$s पर जाएं।"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9160,13 +9238,13 @@ msgstr "गोपनीयता को विस्तारित करने
 #. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Help me prep for the interview"
-msgstr ""
+msgstr "इंटरव्यू की तैयारी में मेरी मदद करें"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Help me tailor my resume for this job."
-msgstr ""
+msgstr "इस ज़ॉब के लिए मेरा रिज़्यूमे तैयार करने में मेरी मदद करें।"
 
 # smartling.placeholder_format=C
 #. Title of a SERP popup that invites users to take a survey (desktop only)
@@ -9405,8 +9483,8 @@ msgid ""
 "Highlights key facts in Search Assist answers to help you find important "
 "information faster."
 msgstr ""
-"महत्वपूर्ण जानकारी तेज़ी से ढूंढने में आपकी सहायता करने के लिए Search Assist उत्तरों में मुख्य "
-"तथ्यों को हाइलाइट करता है।"
+"महत्वपूर्ण जानकारी तेज़ी से ढूंढने में आपकी सहायता करने के लिए Search Assist "
+"उत्तरों में मुख्य तथ्यों को हाइलाइट करता है।"
 
 # smartling.placeholder_format=C
 #. The name of the Hindi language
@@ -9433,8 +9511,8 @@ msgid ""
 "Hit %sReturn%s on your keyboard to %ssave DuckDuckGo to the list. %sThen "
 "click %sMake Default%s"
 msgstr ""
-"सूची में DuckDuckGo को सहेजने के लिए अपने कीबोर्ड पर %1$sरिटर्न%2$s दबाएं%3$s। %4$sफिर "
-"%5$sडिफ़ॉल्ट बनाएं%6$s क्लिक करें"
+"सूची में DuckDuckGo को सहेजने के लिए अपने कीबोर्ड पर %1$sरिटर्न%2$s "
+"दबाएं%3$s। %4$sफिर %5$sडिफ़ॉल्ट बनाएं%6$s क्लिक करें"
 
 # smartling.placeholder_format=C
 #. The name of the Hmong Daw language
@@ -9448,8 +9526,8 @@ msgid ""
 "Hold on! Changing it back will disable the DuckDuckGo extension and you'll "
 "lose our privacy protection."
 msgstr ""
-"रुके रहें! इसे वापस बदलने पर DuckDuckGo एक्सटेंशन अक्षम हो जाएगा और आप हमारा गोपनीयता "
-"संरक्षण खो देंगे।"
+"रुके रहें! इसे वापस बदलने पर DuckDuckGo एक्सटेंशन अक्षम हो जाएगा और आप हमारा "
+"गोपनीयता संरक्षण खो देंगे।"
 
 # smartling.placeholder_format=C
 #. Heading shown above warning messages in the AI chat, for non-critical issues like unsupported file formats or file size limits. Analogous to 'Oops...' for error messages.
@@ -9499,8 +9577,8 @@ msgid ""
 "Hotel ad clicks are managed by Tripadvisor’s ad network and are not used to "
 "profile you."
 msgstr ""
-"होटल विज्ञापन क्लिक TripAdvisor के विज्ञापन नेटवर्क द्वारा प्रबंधित किए जाते हैं और इनका "
-"उपयोग आपकी व्यक्तिगत जानकारी जुटाने के लिए नहीं किया जाता।"
+"होटल विज्ञापन क्लिक TripAdvisor के विज्ञापन नेटवर्क द्वारा प्रबंधित किए जाते "
+"हैं और इनका उपयोग आपकी व्यक्तिगत जानकारी जुटाने के लिए नहीं किया जाता।"
 
 # smartling.placeholder_format=C
 #. Refers to hours of operation for a business.
@@ -9642,8 +9720,8 @@ msgid ""
 "How should I tactfully approach a colleague about their constant pencil "
 "tapping and what should I say?"
 msgstr ""
-"मुझे अपने सहकर्मी से उनकी लगातार पेंसिल से खट-खट करने के बारे में किस तरह व्यवहारकुशलता से "
-"बात करनी चाहिए और क्या कहना चाहिए?"
+"मुझे अपने सहकर्मी से उनकी लगातार पेंसिल से खट-खट करने के बारे में किस तरह "
+"व्यवहारकुशलता से बात करनी चाहिए और क्या कहना चाहिए?"
 
 # smartling.placeholder_format=C
 #. The title for a feedback prompt that includes thumbs up and thumbs down buttons
@@ -9689,7 +9767,7 @@ msgctxt ""
 "Text for the I already have a subscription button in the Duck.ai settings "
 "page"
 msgid "I Already Have a Subscription"
-msgstr ""
+msgstr "मेरे पास पहले से ही सब्सक्रिप्शन है"
 
 # smartling.placeholder_format=C
 #. Text for the button that takes the user to the login subscription page.
@@ -9765,8 +9843,8 @@ msgid ""
 "I like the book Name of the Wind. What are some other good books/series most "
 "like it and why?"
 msgstr ""
-"मुझे 'नेम ऑफ द विंड' पुस्तक पसंद है। इस तरह की कुछ और अच्छी किताबें/सीरीज़ कौन-सी हैं और "
-"क्यों?"
+"मुझे 'नेम ऑफ द विंड' पुस्तक पसंद है। इस तरह की कुछ और अच्छी किताबें/सीरीज़ "
+"कौन-सी हैं और क्यों?"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the user needs more help or information on how to use the chat.
@@ -9801,8 +9879,8 @@ msgid ""
 "If the browser location remains unavailable, then go to %sSettings > General "
 "> Reset > 'Reset Location & Privacy'%s."
 msgstr ""
-"यदि ब्राउज़र स्थान अभी भी मौजूद नहीं है, तो %1$sसेटिंग्‍स > सामान्य > रीसेट > 'स्थान और "
-"गोपनीयता रीसेट करें' पर जाएं%2$s।"
+"यदि ब्राउज़र स्थान अभी भी मौजूद नहीं है, तो %1$sसेटिंग्‍स > सामान्य > रीसेट "
+"> 'स्थान और गोपनीयता रीसेट करें' पर जाएं%2$s।"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -9812,8 +9890,9 @@ msgid ""
 "> Menu > Settings > Site settings > Location%s, and ensure DuckDuckGo is "
 "allowed location access."
 msgstr ""
-"यदि ब्राउज़र स्थान मौजूद नहीं है, तो अपने ब्राउज़र में %1$s⋮ > मेनू > सेटिंग्‍स > साइट सेटिंग्स "
-"> स्थान%2$s पर जाएं, और सुनिश्चित करें कि DuckDuckGo को स्थान एक्सेस की अनुमति है।"
+"यदि ब्राउज़र स्थान मौजूद नहीं है, तो अपने ब्राउज़र में %1$s⋮ > मेनू > "
+"सेटिंग्‍स > साइट सेटिंग्स > स्थान%2$s पर जाएं, और सुनिश्चित करें कि "
+"DuckDuckGo को स्थान एक्सेस की अनुमति है।"
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -9828,8 +9907,8 @@ msgid ""
 "If you don't see %sDuckDuckGo,%s you will need to add it to the list of "
 "%sOther Search Engines%s"
 msgstr ""
-"अगर आपको %1$sDuckDuckGo%2$s दिखाई नहीं दे रहा है तो आपको उसे %3$sअन्य खोज इंजन%4$s "
-"की सूची में जोड़ना होगा"
+"अगर आपको %1$sDuckDuckGo%2$s दिखाई नहीं दे रहा है तो आपको उसे %3$sअन्य खोज "
+"इंजन%4$s की सूची में जोड़ना होगा"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding the AI model providers and links to their support pages. Example: 'If you have concerns about our chat providers or any particular chat response, you can also reach out directly to OpenAI and Anthropic support pages.'
@@ -9838,8 +9917,8 @@ msgid ""
 "If you have concerns about our chat providers or any particular chat "
 "response, you can also reach out directly to %s and %s support pages."
 msgstr ""
-"अगर आपको हमारे चैट प्रदाताओं या किसी खास चैट जवाब के बारे में कोई समस्या है, तो आप सीधे "
-"%1$s और %2$s सपोर्ट पेज पर भी जा सकते हैं।"
+"अगर आपको हमारे चैट प्रदाताओं या किसी खास चैट जवाब के बारे में कोई समस्या है, "
+"तो आप सीधे %1$s और %2$s सपोर्ट पेज पर भी जा सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Body copy explaining what the recovery code is for and how it can be saved.
@@ -9848,15 +9927,17 @@ msgid ""
 "If you lose access to your devices, you will need this code to recover your "
 "saved chats. You can save this code to your device as a text file."
 msgstr ""
-"अगर आप अपने डिवाइस का एक्सेस खो देते हैं, तो अपनी सेव की गई चैट्स को रिकवर करने के लिए "
-"आपको इस कोड की ज़रूरत पड़ेगी। आप इस कोड को एक टेक्स्ट फ़ाइल के रूप में अपने डिवाइस पर सेव "
-"कर सकते हैं।"
+"अगर आप अपने डिवाइस का एक्सेस खो देते हैं, तो अपनी सेव की गई चैट्स को रिकवर "
+"करने के लिए आपको इस कोड की ज़रूरत पड़ेगी। आप इस कोड को एक टेक्स्ट फ़ाइल के "
+"रूप में अपने डिवाइस पर सेव कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
-msgstr "अगर आप और सहायता करना चाहते हैं तो, %1$s DuckDuckGo को फेलाने में मदद करें %2$s"
+msgstr ""
+"अगर आप और सहायता करना चाहते हैं तो, %1$s DuckDuckGo को फेलाने में मदद करें "
+"%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -9866,15 +9947,17 @@ msgid ""
 "If you want to use DuckDuckGo without JavaScript, please use our %s or %s "
 "versions."
 msgstr ""
-"अगर​ आप जावास्क्रिप्ट के बिना DuckDuckGo का उपयोग करना चाहते, तो कृपया हमारे %1$s या "
-"%2$s संस्करणों का उपयोग करें।"
+"अगर​ आप जावास्क्रिप्ट के बिना DuckDuckGo का उपयोग करना चाहते, तो कृपया हमारे "
+"%1$s या %2$s संस्करणों का उपयोग करें।"
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "If you want, select Home Page next to New windows and New tabs (open with)."
-msgstr "अगर आप चाहते हैं, तो नई विंडो और नए टैब के सामने होम पेज चुनें (इसके साथ खोलें)"
+msgstr ""
+"अगर आप चाहते हैं, तो नई विंडो और नए टैब के सामने होम पेज चुनें (इसके साथ "
+"खोलें)"
 
 # smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that adds an image to the AI chat message being composed.
@@ -10003,7 +10086,8 @@ msgctxt "settings"
 msgid ""
 "Improves result legibility with updated URL format, placement, and color"
 msgstr ""
-"अपडेट किए गए URL फ़ॉर्मैट, प्लेसमेंट और रंग के साथ नतीजे के बेहतर दिखने में सुधार करता है"
+"अपडेट किए गए URL फ़ॉर्मैट, प्लेसमेंट और रंग के साथ नतीजे के बेहतर दिखने में "
+"सुधार करता है"
 
 # smartling.placeholder_format=C
 #. A label that appears in front of the name of a company that DuckDuckGo has partnered with. For example, 'In partnership with Wikipedia'
@@ -10016,8 +10100,8 @@ msgid ""
 "In some older browsers, it's necessary to redirect your clicks through our "
 "server to prevent search leakage. %sLearn more%s."
 msgstr ""
-"कुछ पुराने ब्राउज़रों में हमारे सर्वर से खोज लीकेज रोकने के लिए आपके क्लिकों को रीडायरेक्ट करना "
-"आवश्यक है। %1$sऔर जानें%2$s।"
+"कुछ पुराने ब्राउज़रों में हमारे सर्वर से खोज लीकेज रोकने के लिए आपके क्लिकों "
+"को रीडायरेक्ट करना आवश्यक है। %1$sऔर जानें%2$s।"
 
 # smartling.placeholder_format=C
 #. Instructions accompanying DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE; tells the user where to use the code on a DuckDuckGo browser.
@@ -10028,8 +10112,8 @@ msgid ""
 "In the DuckDuckGo browser, go to Settings › Sync & Backup, and then “Sync "
 "with another device”."
 msgstr ""
-"DuckDuckGo ब्राउज़र में, सेटिंग › Sync & Backup पर जाएं और फिर “किसी अन्य डिवाइस के "
-"साथ सिंक करें” चुनें।"
+"DuckDuckGo ब्राउज़र में, सेटिंग › Sync & Backup पर जाएं और फिर “किसी अन्य "
+"डिवाइस के साथ सिंक करें” चुनें।"
 
 #  SeaMonkey default search engine instruction
 # smartling.placeholder_format=C
@@ -10044,8 +10128,8 @@ msgid ""
 "In the interest of transparency, this data is not encrypted: You can see "
 "exactly what information we store."
 msgstr ""
-"पारदर्शिता के हित में यह डेटा एन्क्रिप्ट नहीं किया गया है: आप वाकई देख सकते हैं कि हम क्या "
-"जानकारी संग्रहित करते हैं।"
+"पारदर्शिता के हित में यह डेटा एन्क्रिप्ट नहीं किया गया है: आप वाकई देख सकते "
+"हैं कि हम क्या जानकारी संग्रहित करते हैं।"
 
 # smartling.placeholder_format=C
 msgid "In the menu at the top select %sTools%s > %sSettings%s"
@@ -10264,7 +10348,7 @@ msgstr "Mac ब्राउज़र इंस्टॉल करें"
 #. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
 msgctxt "settings"
 msgid "Install Now"
-msgstr ""
+msgstr "अभी इंस्टॉल करें"
 
 # smartling.placeholder_format=C
 #. Text of a button to install the DuckDuckGo app
@@ -10367,13 +10451,13 @@ msgstr "क्या डिलीट किए गए डेटा वाकई 
 #. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Is it worth taking?"
-msgstr ""
+msgstr "क्या इसे लेना सही है?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Is this place any good?"
-msgstr ""
+msgstr "क्या यह जगह अच्छी है?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
@@ -10382,6 +10466,8 @@ msgid ""
 "Is this place any good? Summarize its reputation based on reviews and "
 "ratings."
 msgstr ""
+"क्या यह जगह अच्छी है? रिव्यू और रेटिंग के आधार पर इसकी रेपुटेशन का सारांश "
+"बताएं।"
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -10393,13 +10479,13 @@ msgstr "क्या यह वीडियो मददगार रहा?"
 #. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Is this worth watching?"
-msgstr ""
+msgstr "क्या यह देखने लायक है?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Is this worth watching? Give me a spoiler-free take."
-msgstr ""
+msgstr "क्या यह देखने लायक है? बिना सस्पेंस बताए अपनी राय दें।"
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -10432,7 +10518,8 @@ msgctxt "settings"
 msgid ""
 "It's okay to (very infrequently) ask me about my experience using DuckDuckGo"
 msgstr ""
-"मुझसे मेरे DuckDuckGo को उपयोग करने के अनुभव के बारे में पूछना (बहुत ज़्यादा बार) ठीक है"
+"मुझसे मेरे DuckDuckGo को उपयोग करने के अनुभव के बारे में पूछना (बहुत ज़्यादा "
+"बार) ठीक है"
 
 # smartling.placeholder_format=C
 #. The name of the Italian language
@@ -10451,9 +10538,10 @@ msgid ""
 "through Microsoft's Ad Network. Clicks lead directly to merchant landing "
 "pages and unlike ads, DuckDuckGo is not compensated for these results."
 msgstr ""
-"आइटम आपके खोज शब्दों की प्रासंगिकता के आधार पर रैंक किए जाते हैं और Microsoft के विज्ञापन "
-"नेटवर्क के माध्यम से डिलीवर किए जाते हैं। क्लिक सीधे मर्चेंट लैंडिंग पेज पर ले जाते हैं और "
-"विज्ञापनों के विपरीत, DuckDuckGo को इन परिणामों के लिए प्रतिफल नहीं दिया जाता है।"
+"आइटम आपके खोज शब्दों की प्रासंगिकता के आधार पर रैंक किए जाते हैं और "
+"Microsoft के विज्ञापन नेटवर्क के माध्यम से डिलीवर किए जाते हैं। क्लिक सीधे "
+"मर्चेंट लैंडिंग पेज पर ले जाते हैं और विज्ञापनों के विपरीत, DuckDuckGo को इन "
+"परिणामों के लिए प्रतिफल नहीं दिया जाता है।"
 
 # smartling.placeholder_format=C
 #. Text explaining why passphrases use a series of words instead of random numbers and letters.
@@ -10462,8 +10550,8 @@ msgid ""
 "It’s easier to remember 4-5 words than 10 random letters and numbers, and "
 "far more secure."
 msgstr ""
-"10 आकस्मिक अक्षरों और संख्याओं की तुलना में 4-5 शब्दों को याद रखना आसान और अधिक सुरक्षित "
-"भी है।"
+"10 आकस्मिक अक्षरों और संख्याओं की तुलना में 4-5 शब्दों को याद रखना आसान और "
+"अधिक सुरक्षित भी है।"
 
 # smartling.placeholder_format=C
 msgid "Ivory Coast"
@@ -11014,6 +11102,8 @@ msgstr "लिंक्स:"
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
 msgstr ""
+"इसके लिए मुझे जिन टूल्स, सामग्रियों या ज़रूरी चीज़ों की ज़रूरत होगी, उनकी "
+"लिस्ट दें।"
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -11425,7 +11515,7 @@ msgstr "ब्लॉक की गई साइटें मैनेज कर�
 #. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
 msgctxt "setting"
 msgid "Manage in Browser Settings"
-msgstr ""
+msgstr "ब्राउज़र सेटिंग में मैनेज करें"
 
 # smartling.placeholder_format=C
 #. Link to the site exclusion settings page
@@ -11651,8 +11741,8 @@ msgstr "माइक्रोनेशिया"
 msgid ""
 "Microphone access was denied. Please allow microphone access and try again."
 msgstr ""
-"माइक्रोफ़ोन एक्सेस की अनुमति नहीं दी गई। कृपया माइक्रोफ़ोन एक्सेस करने की अनुमति दें और फिर "
-"से प्रयास करें।"
+"माइक्रोफ़ोन एक्सेस की अनुमति नहीं दी गई। कृपया माइक्रोफ़ोन एक्सेस करने की "
+"अनुमति दें और फिर से प्रयास करें।"
 
 # smartling.placeholder_format=C
 #. The Microsoft brand name.
@@ -12400,10 +12490,11 @@ msgid ""
 "internet connection. Disabling chat history will delete pinned chats, and "
 "disable the temporary storage of new prompts and responses."
 msgstr ""
-"नए प्रॉम्प्ट और रिस्पॉन्स भेजे जाने के बाद एन्क्रिप्ट किए जाते हैं और अस्थायी रूप से "
-"DuckDuckGo सर्वर पर स्टोर रहते हैं, ताकि यदि आपका इंटरनेट कनेक्शन खो जाए तो चैट को "
-"रिकवर किया जा सके। चैट हिस्ट्री को डिसेबल करने से पिन की गई चैट डिलीट हो जाएंगी, और "
-"नए प्रॉम्प्ट और रिस्पॉन्स का टेम्पररी स्टोरेज भी बंद हो जाएगा।"
+"नए प्रॉम्प्ट और रिस्पॉन्स भेजे जाने के बाद एन्क्रिप्ट किए जाते हैं और "
+"अस्थायी रूप से DuckDuckGo सर्वर पर स्टोर रहते हैं, ताकि यदि आपका इंटरनेट "
+"कनेक्शन खो जाए तो चैट को रिकवर किया जा सके। चैट हिस्ट्री को डिसेबल करने से "
+"पिन की गई चैट डिलीट हो जाएंगी, और नए प्रॉम्प्ट और रिस्पॉन्स का टेम्पररी "
+"स्टोरेज भी बंद हो जाएगा।"
 
 # smartling.placeholder_format=C
 #. Question in a feedback form.
@@ -13219,8 +13310,8 @@ msgid ""
 "On Mac, %sClick Maxthon > Preferences%s, On Windows, %sClick the %s icon > "
 "Settings%s"
 msgstr ""
-"Mac पर, %1$sMaxthon > प्राथमिकताएं पर क्लिक करें%2$s, Windows पर, %3$s %4$s आइकन "
-"> सेटिंग्स%5$s पर क्लिक करें"
+"Mac पर, %1$sMaxthon > प्राथमिकताएं पर क्लिक करें%2$s, Windows पर, %3$s %4$s "
+"आइकन > सेटिंग्स%5$s पर क्लिक करें"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
@@ -13242,8 +13333,8 @@ msgid ""
 "One of the files attached has more pages than we support. Please upload "
 "files with %s pages or fewer."
 msgstr ""
-"अटैच की गई फ़ाइलों में से एक में हमारी सपोर्ट सीमा से ज़्यादा पेज हैं। कृपया %1$s पेज या उससे "
-"कम वाली फ़ाइलें अपलोड करें।"
+"अटैच की गई फ़ाइलों में से एक में हमारी सपोर्ट सीमा से ज़्यादा पेज हैं। कृपया "
+"%1$s पेज या उससे कम वाली फ़ाइलें अपलोड करें।"
 
 # smartling.placeholder_format=C
 #. Response a user can select in a feedback form, indicating that they heard about DuckDuckGo in an online article.
@@ -13270,8 +13361,8 @@ msgid ""
 "Only the settings that you have changed. They are detailed on the %sURL "
 "Parameters%s page."
 msgstr ""
-"केवल वो सेटिंग्स जिन्हें आपने बदला है। उनकी पूरी जानकारी इस %1$sयूआरएल पैरामीटर%2$s पेज "
-"पर है।"
+"केवल वो सेटिंग्स जिन्हें आपने बदला है। उनकी पूरी जानकारी इस %1$sयूआरएल "
+"पैरामीटर%2$s पेज पर है।"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers only when the user clicks the Assist button.
@@ -13286,7 +13377,8 @@ msgid ""
 "Oops! An unexpected error occurred while translating this text. Please try "
 "again later."
 msgstr ""
-"उफ़! इस टेक्स्ट का अनुवाद करते समय एक अनपेक्षित त्रुटि हुई है। कृपया बाद में फिर से प्रयास करें।"
+"उफ़! इस टेक्स्ट का अनुवाद करते समय एक अनपेक्षित त्रुटि हुई है। कृपया बाद में "
+"फिर से प्रयास करें।"
 
 # smartling.placeholder_format=C
 #. Title shown in a fatal error modal when Duck.ai fails to load.
@@ -13603,8 +13695,8 @@ msgid ""
 "Other search engines track your searches even when you’re in private "
 "browsing mode. We don’t track you &mdash; period."
 msgstr ""
-"अन्य खोज इंजन आपकी खोजों को ट्रैक करता है भले ही आप गुप्त ब्राउज़िंग मोड में हो। हम आपको — "
-"अवधि में ट्रैक नहीं करते हैं।"
+"अन्य खोज इंजन आपकी खोजों को ट्रैक करता है भले ही आप गुप्त ब्राउज़िंग मोड में "
+"हो। हम आपको — अवधि में ट्रैक नहीं करते हैं।"
 
 # smartling.placeholder_format=C
 msgctxt "SERP footer content"
@@ -13617,8 +13709,8 @@ msgid ""
 "Our privacy policy is simple: we don’t collect or share any of your personal "
 "information."
 msgstr ""
-"हमारी गोपनीयता नीति सरल है: हम आपकी किसी भी निजी जानकारी को एकत्रित या शेयर नहीं "
-"करते हैं।"
+"हमारी गोपनीयता नीति सरल है: हम आपकी किसी भी निजी जानकारी को एकत्रित या शेयर "
+"नहीं करते हैं।"
 
 # smartling.placeholder_format=C
 msgid ""
@@ -13626,8 +13718,8 @@ msgid ""
 "tracker blocker, encryption enforcer, and more. Available on %siOS & "
 "Android%s."
 msgstr ""
-"मोबाइल के लिए हमारे गोपनीय ब्राउज़र में हमारा खोज इंजन, ट्रैकर ब्लॉकर, एनक्रिप्शन "
-"एनफोर्सर और बहुत कुछ शामिल है। %1$siOS और Android%2$s पर उपलब्ध।"
+"मोबाइल के लिए हमारे गोपनीय ब्राउज़र में हमारा खोज इंजन, ट्रैकर ब्लॉकर, "
+"एनक्रिप्शन एनफोर्सर और बहुत कुछ शामिल है। %1$siOS और Android%2$s पर उपलब्ध।"
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the information was out of date.
@@ -13880,8 +13972,8 @@ msgid ""
 "Passphrases cannot be recovered as we don't associate your IP address, "
 "browser fingerprint, or any other information with the file."
 msgstr ""
-"पासफ्रेज़ को दोबारा प्राप्त नहीं किया जा सकता है, क्योंकि हम आपके आईपी पते, ब्राउज़र "
-"फ़िंगरप्रिंट या किसी अन्य जानकारी को फ़ाइल के साथ नहीं जोड़ते हैं।"
+"पासफ्रेज़ को दोबारा प्राप्त नहीं किया जा सकता है, क्योंकि हम आपके आईपी पते, "
+"ब्राउज़र फ़िंगरप्रिंट या किसी अन्य जानकारी को फ़ाइल के साथ नहीं जोड़ते हैं।"
 
 # smartling.placeholder_format=C
 #. Label for the section of recent chats that were edited in the past 7 days.
@@ -14075,9 +14167,10 @@ msgid ""
 "answers. To turn them off and hide the Assist button visit %sSearch "
 "Settings%s."
 msgstr ""
-"जब आप अपनी खोज क्वेरी को एक सवाल के रूप में और एक पूरे वाक्य में डालते हैं, तो AI की मदद से "
-"दिए गए जवाब अपने-आप दिखने की संभावना बढ़ जाती है और बेहतर जवाब अक्सर मिलते हैं। उन्हें बंद "
-"करने और Assist बटन छिपाने के लिए %1$sखोज सेटिंग%2$s पर जाएं।"
+"जब आप अपनी खोज क्वेरी को एक सवाल के रूप में और एक पूरे वाक्य में डालते हैं, "
+"तो AI की मदद से दिए गए जवाब अपने-आप दिखने की संभावना बढ़ जाती है और बेहतर "
+"जवाब अक्सर मिलते हैं। उन्हें बंद करने और Assist बटन छिपाने के लिए %1$sखोज "
+"सेटिंग%2$s पर जाएं।"
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -14086,9 +14179,10 @@ msgid ""
 "DuckAssist more likely to appear and often yields better answers. To adjust "
 "how this feature works, or to turn it off, visit %sDuckAssist Settings%s."
 msgstr ""
-"जब आप अपनी खोज क्वेरी को एक सवाल के रूप में और एक पूरे वाक्य में डालते हैं, तो DuckAssist "
-"के दिखने की संभावना बढ़ जाती है और बेहतर जवाब अक्सर मिलते हैं। इस फ़ीचर के काम करने के "
-"तरीके को एडजस्ट करने के लिए या इसे बंद करने के लिए, %1$sDuckAssist सेटिंग%2$s पर जाएं।"
+"जब आप अपनी खोज क्वेरी को एक सवाल के रूप में और एक पूरे वाक्य में डालते हैं, "
+"तो DuckAssist के दिखने की संभावना बढ़ जाती है और बेहतर जवाब अक्सर मिलते हैं। "
+"इस फ़ीचर के काम करने के तरीके को एडजस्ट करने के लिए या इसे बंद करने के लिए, "
+"%1$sDuckAssist सेटिंग%2$s पर जाएं।"
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -14098,9 +14192,10 @@ msgid ""
 "answers. To turn it off and hide the Assist button visit %sDuckAssist "
 "Settings%s."
 msgstr ""
-"जब आप अपनी खोज क्वेरी को एक सवाल के रूप में और एक पूरे वाक्य में डालते हैं, तो DuckAssist "
-"अपने-आप दिखने की संभावना बढ़ जाती है और बेहतर जवाब अक्सर मिलते हैं। इसे बंद करने और "
-"Assist यानी सहायता बटन छिपाने के लिए %1$sDuckAssist Settings%2$s पर जाएं।"
+"जब आप अपनी खोज क्वेरी को एक सवाल के रूप में और एक पूरे वाक्य में डालते हैं, "
+"तो DuckAssist अपने-आप दिखने की संभावना बढ़ जाती है और बेहतर जवाब अक्सर मिलते "
+"हैं। इसे बंद करने और Assist यानी सहायता बटन छिपाने के लिए %1$sDuckAssist "
+"Settings%2$s पर जाएं।"
 
 # smartling.placeholder_format=C
 #. Button that allows users to manually select a location on a map.
@@ -14133,8 +14228,8 @@ msgid ""
 "Pick a popular AI to chat with, like GPT-5 mini, Claude Haiku 4.5, Mistral, "
 "etc."
 msgstr ""
-"चैट करने के लिए कोई लोकप्रिय AI चुनें, जैसे GPT-5 mini, Claude Haiku 4.5, Mistral, "
-"वगैरह।"
+"चैट करने के लिए कोई लोकप्रिय AI चुनें, जैसे GPT-5 mini, Claude Haiku 4.5, "
+"Mistral, वगैरह।"
 
 # smartling.placeholder_format=C
 #. Describes the ability to choose from popular AI models. Pairs with a chat-bubble pictogram.
@@ -14153,7 +14248,8 @@ msgid ""
 "Pick a service to navigate to your destination. External apps won’t come "
 "with DuckDuckGo protections."
 msgstr ""
-"अपने गंतव्य तक जाने के लिए एक सेवा चुनें। बाहरी ऐप्स में DuckDuckGo सुरक्षा उपलब्ध नहीं होगी।"
+"अपने गंतव्य तक जाने के लिए एक सेवा चुनें। बाहरी ऐप्स में DuckDuckGo सुरक्षा "
+"उपलब्ध नहीं होगी।"
 
 # smartling.placeholder_format=C
 #. Label for a list of problems on a feedback form.
@@ -14166,8 +14262,8 @@ msgstr "कोई विशिष्ट समस्या चुनें"
 msgid ""
 "Pick your ad blocker and follow the instructions to allow ads on DuckDuckGo."
 msgstr ""
-"अपना विज्ञापन ब्लॉकर चुनें और DuckDuckGo पर विज्ञापनों की अनुमति देने के लिए निर्देशों का "
-"पालन करें।"
+"अपना विज्ञापन ब्लॉकर चुनें और DuckDuckGo पर विज्ञापनों की अनुमति देने के लिए "
+"निर्देशों का पालन करें।"
 
 # smartling.placeholder_format=C
 #. Text for a button that pins a chat, as in it will it will add the chat to the pinned chats list.
@@ -14238,8 +14334,8 @@ msgid ""
 "Please complete the following challenge to confirm this prompt was made by a "
 "human."
 msgstr ""
-"यह पुष्टि करने के लिए कि यह प्रॉम्प्ट किसी मनुष्य द्वारा बनाया गया था, कृपया निम्नलिखित "
-"चुनौती को पूरा करें।"
+"यह पुष्टि करने के लिए कि यह प्रॉम्प्ट किसी मनुष्य द्वारा बनाया गया था, कृपया "
+"निम्नलिखित चुनौती को पूरा करें।"
 
 # smartling.placeholder_format=C
 #. Bot challenge explanation
@@ -14248,14 +14344,14 @@ msgid ""
 "Please complete the following challenge to confirm this search was made by a "
 "human."
 msgstr ""
-"यह पुष्टि करने के लिए कि यह खोज किसी मनुष्य द्वारा की गई थी, कृपया निम्नलिखित चुनौती "
-"को पूरा करें।"
+"यह पुष्टि करने के लिए कि यह खोज किसी मनुष्य द्वारा की गई थी, कृपया "
+"निम्नलिखित चुनौती को पूरा करें।"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is harmful or illegal. (optional)"
-msgstr ""
+msgstr "कृपया बताएं कि चैट का जवाब हानिकारक या गैरकानूनी क्यों है। (वैकल्पिक)"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
@@ -14282,8 +14378,8 @@ msgid ""
 "Please note: starting a new chat with any model will delete your current "
 "chat session."
 msgstr ""
-"कृपया ध्यान दें: किसी भी मॉडल के जरिए नई चैट शुरू करने से आपका मौजूदा चैट सेशन डिलीट हो "
-"जाएगा।"
+"कृपया ध्यान दें: किसी भी मॉडल के जरिए नई चैट शुरू करने से आपका मौजूदा चैट "
+"सेशन डिलीट हो जाएगा।"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -14292,6 +14388,9 @@ msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is harmful or illegal."
 msgstr ""
+"अपना सवाल और जो गलत या आपत्तिजनक जवाब मिला है, यहां पेस्ट करें (अपनी कोई भी "
+"निजी जानकारी शामिल न करें), साथ में बताएं कि यह सामग्री क्यों हानिकारक या "
+"गैरकानूनी है।"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -14300,8 +14399,9 @@ msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is illegal or harmful."
 msgstr ""
-"अपना सवाल और जो गलत या आपत्तिजनक जवाब मिला है, यहां पेस्ट करें (अपनी कोई भी निजी "
-"जानकारी शामिल न करें), साथ में बताएं कि यह सामग्री क्यों गैरकानूनी या नुकसानदेह है।"
+"अपना सवाल और जो गलत या आपत्तिजनक जवाब मिला है, यहां पेस्ट करें (अपनी कोई भी "
+"निजी जानकारी शामिल न करें), साथ में बताएं कि यह सामग्री क्यों गैरकानूनी या "
+"नुकसानदेह है।"
 
 # smartling.placeholder_format=C
 #. Title on a feedback form.
@@ -14454,8 +14554,8 @@ msgid ""
 "Plus, what you watch in Duck Player won’t influence your recommendations on "
 "YouTube."
 msgstr ""
-"साथ ही, Duck Player में आप जो देखते हैं, वह YouTube पर आपके रिकमंडेशन या सुझावों को "
-"प्रभावित नहीं करेगा।"
+"साथ ही, Duck Player में आप जो देखते हैं, वह YouTube पर आपके रिकमंडेशन या "
+"सुझावों को प्रभावित नहीं करेगा।"
 
 # smartling.placeholder_format=C
 #. A link to the Substack page (https://insideduckduckgo.substack.com/?showWelcome=true)
@@ -14764,7 +14864,7 @@ msgstr "गोपनीयता"
 #. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
 msgctxt "Section heading on the Duck.ai settings page"
 msgid "Privacy & Terms"
-msgstr ""
+msgstr "गोपनीयता और शर्तें"
 
 # smartling.placeholder_format=C
 msgid "Privacy Blog"
@@ -14840,7 +14940,7 @@ msgstr "गोपनीयता नीति और सेवा की शर�
 #. Text for a button that links to the terms of use and privacy policy page.
 msgctxt "Secondary button text in active privacy modal"
 msgid "Privacy Policy and Terms of Service"
-msgstr ""
+msgstr "गोपनीयता नीति और सेवा की शर्तें"
 
 # smartling.placeholder_format=C
 #. Title displayed on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
@@ -15015,8 +15115,8 @@ msgstr "मुझे प्रॉम्प्ट करें"
 msgctxt "settings"
 msgid "Prompt me to use my approximate location to get nearby results."
 msgstr ""
-"नज़दीकी परिणाम प्राप्त करने के लिए मुझे अपने अनुमानित स्थान का उपयोग करने के लिए प्रेरित "
-"करें।"
+"नज़दीकी परिणाम प्राप्त करने के लिए मुझे अपने अनुमानित स्थान का उपयोग करने के "
+"लिए प्रेरित करें।"
 
 # smartling.placeholder_format=C
 #. DuckDuckGo Email Protection removes trackers from emails
@@ -15035,7 +15135,8 @@ msgstr "खोजते और ब्राउज़ करते समय अ�
 msgctxt "SERP footer content"
 msgid "Protect your data as you search, browse, and use AI."
 msgstr ""
-"सर्च करते समय, ब्राउज़ करते समय, और AI का इस्तेमाल करते हुए अपने डेटा को सुरक्षित रखें।"
+"सर्च करते समय, ब्राउज़ करते समय, और AI का इस्तेमाल करते हुए अपने डेटा को "
+"सुरक्षित रखें।"
 
 # smartling.placeholder_format=C
 #. A title above links to download the DuckDuckGo apps.
@@ -15060,7 +15161,8 @@ msgid ""
 "Provide a few suggestions to make the following text more concise. [Insert "
 "your own text here.]"
 msgstr ""
-"नीचे दिए गए टेक्स्ट को और संक्षिप्त बनाने के लिए कुछ सुझाव दें। [अपना खुद का टेक्स्ट यहां डालें।]"
+"नीचे दिए गए टेक्स्ट को और संक्षिप्त बनाने के लिए कुछ सुझाव दें। [अपना खुद का "
+"टेक्स्ट यहां डालें।]"
 
 # smartling.placeholder_format=C
 #. In the context of a standings table for NHL (hockey), column title that abbreviates 'Total Points' (the total points of this team)
@@ -15297,8 +15399,8 @@ msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
 msgstr ""
-"हालिया चैट DuckDuckGo सर्वर या दूसरे रिमोट सर्वर के बजाय आपके डिवाइस पर स्थानीय स्तर "
-"पर स्टोर की जाती हैं।"
+"हालिया चैट DuckDuckGo सर्वर या दूसरे रिमोट सर्वर के बजाय आपके डिवाइस पर "
+"स्थानीय स्तर पर स्टोर की जाती हैं।"
 
 # smartling.placeholder_format=C
 #. Text explaining that recent chats are stored locally on the user's device.
@@ -15307,8 +15409,8 @@ msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
 msgstr ""
-"हालिया चैट DuckDuckGo सर्वर या दूसरे रिमोट सर्वर के बजाय आपके डिवाइस पर स्थानीय स्तर "
-"पर स्टोर की जाती हैं।"
+"हालिया चैट DuckDuckGo सर्वर या दूसरे रिमोट सर्वर के बजाय आपके डिवाइस पर "
+"स्थानीय स्तर पर स्टोर की जाती हैं।"
 
 # smartling.placeholder_format=C
 #. Text explaining how recent chats are stored locally on the user's device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection.
@@ -15318,9 +15420,10 @@ msgid ""
 "are encrypted and temporarily stored on a DuckDuckGo server after being "
 "sent, to help recover a chat if you lose your internet connection."
 msgstr ""
-"हाल की चैट्स आपके डिवाइस पर लोकली स्टोर होती हैं। नए प्रॉम्प्ट और रिस्पॉन्स भेजे जाने के "
-"बाद एन्क्रिप्ट किए जाते हैं और अस्थायी रूप से DuckDuckGo सर्वर पर स्टोर रहते हैं, ताकि यदि "
-"आपका इंटरनेट कनेक्शन खो जाए तो चैट को रिकवर किया जा सके।"
+"हाल की चैट्स आपके डिवाइस पर लोकली स्टोर होती हैं। नए प्रॉम्प्ट और रिस्पॉन्स "
+"भेजे जाने के बाद एन्क्रिप्ट किए जाते हैं और अस्थायी रूप से DuckDuckGo सर्वर "
+"पर स्टोर रहते हैं, ताकि यदि आपका इंटरनेट कनेक्शन खो जाए तो चैट को रिकवर किया "
+"जा सके।"
 
 # smartling.placeholder_format=C
 msgctxt "region filter"
@@ -15347,25 +15450,25 @@ msgstr "कोई किताब सुझाएं"
 #. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Recommend similar books"
-msgstr ""
+msgstr "समान किताबें सुझाएं"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Recommend similar books."
-msgstr ""
+msgstr "समान किताबें सुझाएं।"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Recommend similar movies or shows."
-msgstr ""
+msgstr "समान फ़िल्में या शो सुझाएं।"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Recommend similar titles"
-msgstr ""
+msgstr "समान टाइटल सुझाएं"
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
@@ -15438,8 +15541,8 @@ msgid ""
 "Reduces extra space in and around results and reduces size of result title "
 "text"
 msgstr ""
-"परिणामों के अंदर और आसपास के अतिरिक्त स्पेस हटाता है और परिणाम टाइटल टेक्स्ट के आकार को "
-"घटाता है"
+"परिणामों के अंदर और आसपास के अतिरिक्त स्पेस हटाता है और परिणाम टाइटल टेक्स्ट "
+"के आकार को घटाता है"
 
 # smartling.placeholder_format=C
 #. Label for the input field where users specify how they want to be referred to. Example: 'Refer to me as John'
@@ -15580,8 +15683,8 @@ msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
 msgstr ""
-"DuckDuckGo को फिर से लोड करें, इसके लिए निर्देशों का पालन करें या अपने ब्राउज़र के &quot;"
-"रीफ्रेश&quot; या &quot;रीलोड&quot; बटन पर क्लिक करें।"
+"DuckDuckGo को फिर से लोड करें, इसके लिए निर्देशों का पालन करें या अपने "
+"ब्राउज़र के &quot;रीफ्रेश&quot; या &quot;रीलोड&quot; बटन पर क्लिक करें।"
 
 # smartling.placeholder_format=C
 #. checkbox label that allows the user to save the setting
@@ -15671,8 +15774,8 @@ msgid ""
 "Removes the \"Ask\" button so answers appear automatically in response to "
 "relevant searches. Cached answers always display automatically."
 msgstr ""
-"\"पूछें\" बटन को हटा देता है जिससे प्रासंगिक खोजों के लिए उत्तर स्वचालित रूप से दिखाई देते "
-"हैं। कैश्ड उत्तर हमेशा स्वचालित रूप से प्रदर्शित होते हैं।"
+"\"पूछें\" बटन को हटा देता है जिससे प्रासंगिक खोजों के लिए उत्तर स्वचालित रूप "
+"से दिखाई देते हैं। कैश्ड उत्तर हमेशा स्वचालित रूप से प्रदर्शित होते हैं।"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -15680,8 +15783,9 @@ msgid ""
 "Removes the \"Generate\" button so answers appear automatically in response "
 "to relevant searches. Cached answers always display automatically."
 msgstr ""
-"\"जनरेट करें\" बटन को हटा देता है जिससे प्रासंगिक खोजों के लिए उत्तर स्वचालित रूप से दिखाई "
-"देते हैं। कैश्ड उत्तर हमेशा स्वचालित रूप से प्रदर्शित होते हैं।"
+"\"जनरेट करें\" बटन को हटा देता है जिससे प्रासंगिक खोजों के लिए उत्तर "
+"स्वचालित रूप से दिखाई देते हैं। कैश्ड उत्तर हमेशा स्वचालित रूप से प्रदर्शित "
+"होते हैं।"
 
 # smartling.placeholder_format=C
 #. Text for a button to rename a chat, as in it will allow the user to change the title of the chat.
@@ -15739,9 +15843,9 @@ msgid ""
 "service. Your anonymous feedback is also shared with %s to help improve "
 "their services."
 msgstr ""
-"रिपोर्ट गुमनाम हैं और हमारी खोज सेवा को बेहतर बनाने में मदद करने के लिए DuckDuckGo को "
-"भेजी जाती हैं। उनकी सेवाओं को बेहतर बनाने में सहायता के लिए आपकी अनाम प्रतिक्रिया भी "
-"%1$s के साथ शेयर की जाती है।"
+"रिपोर्ट गुमनाम हैं और हमारी खोज सेवा को बेहतर बनाने में मदद करने के लिए "
+"DuckDuckGo को भेजी जाती हैं। उनकी सेवाओं को बेहतर बनाने में सहायता के लिए "
+"आपकी अनाम प्रतिक्रिया भी %1$s के साथ शेयर की जाती है।"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -15749,8 +15853,8 @@ msgid ""
 "Reports sent to DuckDuckGo are anonymous. Please do not include any personal "
 "or identifying information in your feedback."
 msgstr ""
-"DuckDuckGo को भेजी गई रिपोर्टें गुमनाम रहती हैं। कृपया अपने फ़ीडबैक में कोई भी व्यक्तिगत या "
-"पहचान योग्य जानकारी शामिल न करें।"
+"DuckDuckGo को भेजी गई रिपोर्टें गुमनाम रहती हैं। कृपया अपने फ़ीडबैक में कोई "
+"भी व्यक्तिगत या पहचान योग्य जानकारी शामिल न करें।"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -15759,9 +15863,9 @@ msgid ""
 "translate during this page load, and are anonymous. Please do not include "
 "any personal or identifying information in your feedback."
 msgstr ""
-"DuckDuckGo को भेजी गई रिपोर्ट में वे सभी टेक्स्ट शामिल होते हैं, जिन्हें आपने इस पेज लोड के "
-"दौरान अनुवाद के लिए कहा था, और वे गुमनाम हैं। कृपया अपने फ़ीडबैक में कोई भी व्यक्तिगत या "
-"पहचान योग्य जानकारी शामिल न करें।"
+"DuckDuckGo को भेजी गई रिपोर्ट में वे सभी टेक्स्ट शामिल होते हैं, जिन्हें "
+"आपने इस पेज लोड के दौरान अनुवाद के लिए कहा था, और वे गुमनाम हैं। कृपया अपने "
+"फ़ीडबैक में कोई भी व्यक्तिगत या पहचान योग्य जानकारी शामिल न करें।"
 
 # smartling.placeholder_format=C
 msgid "Republic of Moldova"
@@ -15774,7 +15878,7 @@ msgctxt ""
 "feedback form when the user has selected Harmful or Illegal as the feedback "
 "reason"
 msgid "Required for harmful or illegal reports"
-msgstr ""
+msgstr "हानिकारक या गैरकानूनी रिपोर्ट के लिए आवश्यक"
 
 # smartling.placeholder_format=C
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
@@ -15841,9 +15945,10 @@ msgid ""
 "legal, financial, investment, or other professional advice. AI-assisted "
 "answers are subject to our %sTerms of Service%s."
 msgstr ""
-"सारे रिस्पॉन्स या जवाब केवल शिक्षात्मक उद्देश्यों के लिए हैं और इन्हें चिकित्सा, कानूनी, "
-"वित्तीय, निवेश या अन्य पेशेवर सलाह के रूप में नहीं माना जाना चाहिए। AI की मदद से दिए गए "
-"जवाब हमारी %1$sसेवा की शर्तों%2$s के अधीन हैं।"
+"सारे रिस्पॉन्स या जवाब केवल शिक्षात्मक उद्देश्यों के लिए हैं और इन्हें "
+"चिकित्सा, कानूनी, वित्तीय, निवेश या अन्य पेशेवर सलाह के रूप में नहीं माना "
+"जाना चाहिए। AI की मदद से दिए गए जवाब हमारी %1$sसेवा की शर्तों%2$s के अधीन "
+"हैं।"
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -15852,9 +15957,9 @@ msgid ""
 "legal, financial, investment, or other professional advice. DuckAssist is "
 "subject to our %sTerms of Service%s."
 msgstr ""
-"सारे रिस्पॉन्स या जवाब केवल शिक्षात्मक उद्देश्यों के लिए हैं और इन्हें चिकित्सा, कानूनी, "
-"वित्तीय, निवेश या अन्य पेशेवर सलाह के रूप में नहीं माना जाना चाहिए। DuckAssist हमारी "
-"%1$sसेवा की शर्तों%2$s के अधीन है।"
+"सारे रिस्पॉन्स या जवाब केवल शिक्षात्मक उद्देश्यों के लिए हैं और इन्हें "
+"चिकित्सा, कानूनी, वित्तीय, निवेश या अन्य पेशेवर सलाह के रूप में नहीं माना "
+"जाना चाहिए। DuckAssist हमारी %1$sसेवा की शर्तों%2$s के अधीन है।"
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -15864,10 +15969,11 @@ msgid ""
 "generated based on web content and may contain inaccuracies. Search Assist "
 "is subject to our %sTerms of Service%s."
 msgstr ""
-"सारे रिस्पॉन्स या जवाब केवल शिक्षात्मक उद्देश्यों के लिए हैं और इन्हें चिकित्सा, कानूनी, "
-"वित्तीय, निवेश या अन्य पेशेवर सलाह के रूप में नहीं माना जाना चाहिए। ये वेब सामग्री के आधार "
-"पर तैयार किए जाते हैं और इनमें कुछ गलतियां भी हो सकती हैं। Search Assist हमारी %1$sसेवा "
-"की शर्तों%2$s के अधीन है।"
+"सारे रिस्पॉन्स या जवाब केवल शिक्षात्मक उद्देश्यों के लिए हैं और इन्हें "
+"चिकित्सा, कानूनी, वित्तीय, निवेश या अन्य पेशेवर सलाह के रूप में नहीं माना "
+"जाना चाहिए। ये वेब सामग्री के आधार पर तैयार किए जाते हैं और इनमें कुछ "
+"गलतियां भी हो सकती हैं। Search Assist हमारी %1$sसेवा की शर्तों%2$s के अधीन "
+"है।"
 
 # smartling.placeholder_format=C
 #. Label on the button for restoring all previous website data.
@@ -15944,7 +16050,8 @@ msgstr "परिणामों में ब्लॉक की गई सा�
 msgctxt "Blocked sites filter disclaimer"
 msgid "Results exclude your blocked sites, which you can manage in your %s."
 msgstr ""
-"परिणामों में ब्लॉक की गई साइटें नहीं दिखाई जातीं, आप उन्हें अपने %1$s में मैनेज कर सकते हैं।"
+"परिणामों में ब्लॉक की गई साइटें नहीं दिखाई जातीं, आप उन्हें अपने %1$s में "
+"मैनेज कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. A label showing the source of the results, e.g. "Results from Reddit"
@@ -16015,7 +16122,7 @@ msgstr "समीक्षा"
 #. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Rewrite this recipe scaled for a different number of servings."
-msgstr ""
+msgstr "इस रेसिपी को अलग संख्या में सर्विंग्स के हिसाब से दोबारा लिखें।"
 
 # smartling.placeholder_format=C
 msgid "Romania"
@@ -16287,8 +16394,8 @@ msgid ""
 "Save up to 30 of your most recent chats locally on your device, with the "
 "option for more with Encrypted Storage."
 msgstr ""
-"अपने डिवाइस पर अपनी सबसे नई 30 चैट तक स्थानीय रूप से सेव करें, और एन्क्रिप्टेड स्टोरेज के "
-"साथ इससे अधिक चैट सहेजने का विकल्प भी उपलब्ध है।"
+"अपने डिवाइस पर अपनी सबसे नई 30 चैट तक स्थानीय रूप से सेव करें, और "
+"एन्क्रिप्टेड स्टोरेज के साथ इससे अधिक चैट सहेजने का विकल्प भी उपलब्ध है।"
 
 # smartling.placeholder_format=C
 #. Short text for native DDG browser users explaining how Chat History stores up to 30 of their most recent chats locally on their device.
@@ -16301,7 +16408,9 @@ msgstr "अपनी सबसे हाल की 30 चैट तक को �
 msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
-msgstr "एंड-टू-एंड एनक्रिप्शन के साथ अपने Duck.ai चैट्स को अपने डिवाइसों के बीच सुरक्षित रखें।"
+msgstr ""
+"एंड-टू-एंड एनक्रिप्शन के साथ अपने Duck.ai चैट्स को अपने डिवाइसों के बीच "
+"सुरक्षित रखें।"
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -16431,8 +16540,8 @@ msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)"
 msgstr ""
-"नीचे स्क्रॉल करें और %1$sपता बार में खोजें%2$s ढूंढें। %3$sबदलें%4$s (या %5$sनया जोड़ें%6$s) "
-"क्लिक करें"
+"नीचे स्क्रॉल करें और %1$sपता बार में खोजें%2$s ढूंढें। %3$sबदलें%4$s (या "
+"%5$sनया जोड़ें%6$s) क्लिक करें"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
@@ -16441,8 +16550,8 @@ msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)."
 msgstr ""
-"नीचे स्क्रॉल करें और %1$sपता बार में खोजें%2$s ढूंढें। %3$sबदलें%4$s पर क्लिक करें (या %5$sनया "
-"जोड़ें%6$s)।"
+"नीचे स्क्रॉल करें और %1$sपता बार में खोजें%2$s ढूंढें। %3$sबदलें%4$s पर "
+"क्लिक करें (या %5$sनया जोड़ें%6$s)।"
 
 # smartling.placeholder_format=C
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -16461,8 +16570,8 @@ msgstr "नीचे स्क्रॉल करें और सूची म�
 msgctxt "precise_user_location"
 msgid "Scroll down to %sDuckDuckGo%s and allow it to use your location."
 msgstr ""
-"नीचे स्क्रॉल करते हुए %1$sDuckDuckGo%2$s पर जाएं और इसे अनुमति दें कि यह आपकी लोकेशन "
-"यानी स्थान का इस्तेमाल कर सके।"
+"नीचे स्क्रॉल करते हुए %1$sDuckDuckGo%2$s पर जाएं और इसे अनुमति दें कि यह "
+"आपकी लोकेशन यानी स्थान का इस्तेमाल कर सके।"
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -16516,11 +16625,12 @@ msgid ""
 "(on a wide range of searches). For now, Search Assist is only available in a "
 "subset of English speaking regions."
 msgstr ""
-"Search Assist आपके खोज प्रश्नों के जवाब गुमनाम तरीके से तैयार करता है। ऐसा करने के लिए "
-"यह वेब पर संबंधित सामग्री खोजता है और फिर AI की मदद से एक संक्षिप्त जवाब तैयार करता है। "
-"आप चुन सकते हैं कि यह कितनी बार दिखाई दे: कभी नहीं, केवल मांग पर (जब आप 'Assist' पर "
-"क्लिक करें), कभी-कभी (जब यह बहुत प्रासंगिक हो), या अक्सर (जब कई तरह की खोज पर लागू "
-"हो)। फिलहाल, Search Assist केवल कुछ अंग्रेज़ी भाषी क्षेत्रों में ही उपलब्ध है।"
+"Search Assist आपके खोज प्रश्नों के जवाब गुमनाम तरीके से तैयार करता है। ऐसा "
+"करने के लिए यह वेब पर संबंधित सामग्री खोजता है और फिर AI की मदद से एक "
+"संक्षिप्त जवाब तैयार करता है। आप चुन सकते हैं कि यह कितनी बार दिखाई दे: कभी "
+"नहीं, केवल मांग पर (जब आप 'Assist' पर क्लिक करें), कभी-कभी (जब यह बहुत "
+"प्रासंगिक हो), या अक्सर (जब कई तरह की खोज पर लागू हो)। फिलहाल, Search Assist "
+"केवल कुछ अंग्रेज़ी भाषी क्षेत्रों में ही उपलब्ध है।"
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI) when the answer is not found and the answer is unsourced or with no sources
@@ -16528,8 +16638,8 @@ msgid ""
 "Search Assist couldn't find enough reliable information to generate an "
 "answer for this question. Try another search."
 msgstr ""
-"Search Assist को इस प्रश्न का उत्तर जनरेट करने के लिए पर्याप्त विश्वसनीय जानकारी नहीं "
-"मिली। कुछ और सर्च करके देखें।"
+"Search Assist को इस प्रश्न का उत्तर जनरेट करने के लिए पर्याप्त विश्वसनीय "
+"जानकारी नहीं मिली। कुछ और सर्च करके देखें।"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -16538,9 +16648,10 @@ msgid ""
 "search queries. To do this, it %sscans the web%s for relevant content and "
 "then uses AI to generate a brief answer based on information found."
 msgstr ""
-"Search Assist एक वैकल्पिक फ़ीचर है जो खोज प्रश्नों के लिए गुमनाम रूप से जवाब तैयार करता "
-"है। ऐसा करने के लिए, यह %1$sवेब पर खोजबीन करता है%2$s ताकि संबंधित सामग्री मिल सके, "
-"और फिर मिली जानकारी के आधार पर AI की मदद से एक संक्षिप्त उत्तर तैयार करता है।"
+"Search Assist एक वैकल्पिक फ़ीचर है जो खोज प्रश्नों के लिए गुमनाम रूप से जवाब "
+"तैयार करता है। ऐसा करने के लिए, यह %1$sवेब पर खोजबीन करता है%2$s ताकि "
+"संबंधित सामग्री मिल सके, और फिर मिली जानकारी के आधार पर AI की मदद से एक "
+"संक्षिप्त उत्तर तैयार करता है।"
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/search_box. top header
@@ -16661,8 +16772,8 @@ msgid ""
 "Search other sites with %s shortcuts: a search for ”!w ducks” will search "
 "for “ducks” directly on Wikipedia."
 msgstr ""
-"%1$s शॉर्टकट के ज़रिए अन्य साइटों को खोजें: \"!w ducks” खोजने पर सीधे Wikipedia पर "
-"“ducks” को खोजा जाएगा।"
+"%1$s शॉर्टकट के ज़रिए अन्य साइटों को खोजें: \"!w ducks” खोजने पर सीधे "
+"Wikipedia पर “ducks” को खोजा जाएगा।"
 
 # smartling.placeholder_format=C
 #. Placeholder text for the search form when no text has been entered
@@ -16681,8 +16792,8 @@ msgid ""
 "Search privately with our app or extension, add private web search to your "
 "favorite browser, or search directly at %sduckduckgo.com%s."
 msgstr ""
-"हमारे ऐप या एक्सटेंशन के साथ गुप्त रूप से खोज करें, अपने पसंदीदा ब्राउज़र में गोपनीय वेब खोज "
-"जोड़ें या सीधा %1$sduckduckgo.com%2$s पर खोजें।"
+"हमारे ऐप या एक्सटेंशन के साथ गुप्त रूप से खोज करें, अपने पसंदीदा ब्राउज़र "
+"में गोपनीय वेब खोज जोड़ें या सीधा %1$sduckduckgo.com%2$s पर खोजें।"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/6LZAoqH.png
@@ -16690,8 +16801,8 @@ msgctxt "settings"
 msgid ""
 "Search queries are included in URL (if off, searches will use POST requests)"
 msgstr ""
-"खोज के प्रश्न यूआरएल में शामिल हैं (अगर ऑफ़ किया गया तब खोज द्वारा पोस्ट अनुरोध का उपयोग "
-"होगा)"
+"खोज के प्रश्न यूआरएल में शामिल हैं (अगर ऑफ़ किया गया तब खोज द्वारा पोस्ट "
+"अनुरोध का उपयोग होगा)"
 
 # smartling.placeholder_format=C
 #. Describes how cookies are used to store user settings privately and securely.
@@ -16703,11 +16814,11 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"खोज सेटिंग को आपके ब्राउज़र में गैर-व्यक्तिगत ब्राउज़र की कुकीज़ और लोकल स्टोरेज में रखा जाता "
-"है. हालांकि, आप चाहें तो Cloud Save का इस्तेमाल करके अपनी सेटिंग को क्लाउड में किसी "
-"रिमोट सर्वर पर गुमनाम रूप से भी सेव कर सकते हैं। क्लाउड में कोई भी व्यक्तिगत रूप से पहचान "
-"योग्य जानकारी स्टोर नहीं की जाएगी, और आपका पासफ्रेज़ कभी भी आपके ब्राउज़र से बाहर नहीं "
-"जाएगा।"
+"खोज सेटिंग को आपके ब्राउज़र में गैर-व्यक्तिगत ब्राउज़र की कुकीज़ और लोकल "
+"स्टोरेज में रखा जाता है. हालांकि, आप चाहें तो Cloud Save का इस्तेमाल करके "
+"अपनी सेटिंग को क्लाउड में किसी रिमोट सर्वर पर गुमनाम रूप से भी सेव कर सकते "
+"हैं। क्लाउड में कोई भी व्यक्तिगत रूप से पहचान योग्य जानकारी स्टोर नहीं की "
+"जाएगी, और आपका पासफ्रेज़ कभी भी आपके ब्राउज़र से बाहर नहीं जाएगा।"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -16804,8 +16915,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
 msgstr ""
-"हमारे सर्वर पर एंड-टू-एंड एनक्रिप्शन का उपयोग करके ढेर सारी चैट्स सुरक्षित रूप से स्टोर करें, "
-"और उन्हें अपने सभी डिवाइस से एक्सेस करें।"
+"हमारे सर्वर पर एंड-टू-एंड एनक्रिप्शन का उपयोग करके ढेर सारी चैट्स सुरक्षित "
+"रूप से स्टोर करें, और उन्हें अपने सभी डिवाइस से एक्सेस करें।"
 
 # smartling.placeholder_format=C
 #. Text explaining that the Encrypted Storage feature stores the user's chats encrypted on their device.
@@ -16814,8 +16925,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
 msgstr ""
-"हमारे सर्वर पर एंड-टू-एंड एनक्रिप्शन का उपयोग करके ढेर सारी चैट्स सुरक्षित रूप से स्टोर करें, "
-"और उन्हें अपने सभी डिवाइस से एक्सेस करें।"
+"हमारे सर्वर पर एंड-टू-एंड एनक्रिप्शन का उपयोग करके ढेर सारी चैट्स सुरक्षित "
+"रूप से स्टोर करें, और उन्हें अपने सभी डिवाइस से एक्सेस करें।"
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -16824,8 +16935,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your synced devices."
 msgstr ""
-"हमारे सर्वर पर एंड-टू-एंड एनक्रिप्शन का उपयोग करके ढेर सारी चैट्स सुरक्षित रूप से स्टोर करें, "
-"और उन्हें अपने सभी सिंक किए गए डिवाइसों से एक्सेस करें।"
+"हमारे सर्वर पर एंड-टू-एंड एनक्रिप्शन का उपयोग करके ढेर सारी चैट्स सुरक्षित "
+"रूप से स्टोर करें, और उन्हें अपने सभी सिंक किए गए डिवाइसों से एक्सेस करें।"
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -16834,8 +16945,8 @@ msgid ""
 "Securely store your chats on our server using end-to-end encryption, and "
 "access them from all your devices."
 msgstr ""
-"हमारे सर्वर पर एंड-टू-एंड एनक्रिप्शन का उपयोग करके अपनी चैट्स सुरक्षित रूप से स्टोर करें, और "
-"उन्हें अपने सभी डिवाइसों से एक्सेस करें।"
+"हमारे सर्वर पर एंड-टू-एंड एनक्रिप्शन का उपयोग करके अपनी चैट्स सुरक्षित रूप "
+"से स्टोर करें, और उन्हें अपने सभी डिवाइसों से एक्सेस करें।"
 
 # smartling.placeholder_format=C
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
@@ -16850,8 +16961,8 @@ msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
 msgstr ""
-"एंड-टू-एंड एनक्रिप्शन के साथ DuckDuckGo के सर्वर पर सुरक्षित रूप से स्टोर किया गया। आपके "
-"अलावा कोई भी आपका डेटा नहीं देख सकता, हम भी नहीं।"
+"एंड-टू-एंड एनक्रिप्शन के साथ DuckDuckGo के सर्वर पर सुरक्षित रूप से स्टोर "
+"किया गया। आपके अलावा कोई भी आपका डेटा नहीं देख सकता, हम भी नहीं।"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -16995,7 +17106,9 @@ msgstr "Safari मेनू से %1$s'इस वेबसाइट के ल�
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
-msgstr "%1$sकस्टम%2$s चुनें और इनपुट फ़ील्ड में %3$shttps://duckduckgo.com%4$s दर्ज करें"
+msgstr ""
+"%1$sकस्टम%2$s चुनें और इनपुट फ़ील्ड में %3$shttps://duckduckgo.com%4$s दर्ज "
+"करें"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
@@ -17005,13 +17118,17 @@ msgstr "%1$sDuckDuckGo%2$s चुनें और %3$sडिफ़ॉल्ट �
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s"
-msgstr "%1$sDuckDuckGo%2$s चुनें और %3$sडिफ़ॉल्ट के रूप में सेट करें%4$s पर क्लिक करें"
+msgstr ""
+"%1$sDuckDuckGo%2$s चुनें और %3$sडिफ़ॉल्ट के रूप में सेट करें%4$s पर क्लिक "
+"करें"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s."
-msgstr "%1$sDuckDuckGo%2$s चुनें और %3$sडिफ़ॉल्ट के रूप में सेट करें%4$s पर क्लिक करें।"
+msgstr ""
+"%1$sDuckDuckGo%2$s चुनें और %3$sडिफ़ॉल्ट के रूप में सेट करें%4$s पर क्लिक "
+"करें।"
 
 #  Firefox 33
 # smartling.placeholder_format=C
@@ -17060,7 +17177,8 @@ msgstr "ड्रॉपडाउन मेनू से %1$sएड-ऑन प्
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sMenu > Settings%s (on Windows)"
 msgstr ""
-"%1$sOpera > प्राथमिकताएं%2$s (Mac पर) या %3$sमेनू > सेटिंग%4$s (Windows पर) चुनें"
+"%1$sOpera > प्राथमिकताएं%2$s (Mac पर) या %3$sमेनू > सेटिंग%4$s (Windows पर) "
+"चुनें"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -17068,7 +17186,8 @@ msgstr ""
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sOpera > Options%s (on Windows)"
 msgstr ""
-"%1$sOpera > प्राथमिकताएं%2$s (Mac पर) या %3$sOpera > विकल्प%4$s (Windows पर) चुनें"
+"%1$sOpera > प्राथमिकताएं%2$s (Mac पर) या %3$sOpera > विकल्प%4$s (Windows पर) "
+"चुनें"
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -17133,8 +17252,8 @@ msgid ""
 "Select %sUse this webpage as your only home page%s (or one of the other "
 "options if you prefer)"
 msgstr ""
-"%1$sइस वेबपेज को अपना एकमात्र होमपेज बनाएं%2$s (या अन्य विकल्पों में से अपनी पसंद का कोई "
-"एक विकल्प) चुनें"
+"%1$sइस वेबपेज को अपना एकमात्र होमपेज बनाएं%2$s (या अन्य विकल्पों में से अपनी "
+"पसंद का कोई एक विकल्प) चुनें"
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
@@ -17256,8 +17375,8 @@ msgid ""
 "respond. These instructions will apply to all of your conversations going "
 "forward."
 msgstr ""
-"यह आपके संदेशों के साथ AI मॉडलों को निर्देश भेजता है कि उन्हें कैसे जवाब देना है। ये निर्देश आगे "
-"चलकर आपके सभी वार्तालापों पर लागू होंगे।"
+"यह आपके संदेशों के साथ AI मॉडलों को निर्देश भेजता है कि उन्हें कैसे जवाब "
+"देना है। ये निर्देश आगे चलकर आपके सभी वार्तालापों पर लागू होंगे।"
 
 # smartling.placeholder_format=C
 msgid "Senegal"
@@ -17336,7 +17455,7 @@ msgstr "अभी सेटअप करें"
 #. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
 msgctxt "Encrypted storage setup button shown in native browsers"
 msgid "Set Up Sync & Backup"
-msgstr ""
+msgstr "Sync & Backup सेटअप करें"
 
 # smartling.placeholder_format=C
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
@@ -17367,8 +17486,8 @@ msgid ""
 "Set up Sync & Backup after turning on Chat History to keep your chats synced "
 "across devices."
 msgstr ""
-"चैट हिस्ट्री चालू करने के बाद Sync & Backup सेट करें ताकि अपनी चैट को सभी डिवाइसों पर "
-"सिंक रख सकें।"
+"चैट हिस्ट्री चालू करने के बाद Sync & Backup सेट करें ताकि अपनी चैट को सभी "
+"डिवाइसों पर सिंक रख सकें।"
 
 # smartling.placeholder_format=C
 #. Prompt for the user to indicate their location on a map, to enable more relevant search results.
@@ -17455,8 +17574,9 @@ msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
 msgstr ""
-"AI मॉडलों के साथ शहर वाली आसपास की लोकेशन शेयर करें ताकि उनके जवाबों की सटीकता बेहतर "
-"हो। Duck.ai कभी भी आपकी सटीक लोकेशन हमें या AI मॉडल को नहीं बताता है।"
+"AI मॉडलों के साथ शहर वाली आसपास की लोकेशन शेयर करें ताकि उनके जवाबों की "
+"सटीकता बेहतर हो। Duck.ai कभी भी आपकी सटीक लोकेशन हमें या AI मॉडल को नहीं "
+"बताता है।"
 
 # smartling.placeholder_format=C
 #. Menu option to share feedback about a result
@@ -17521,7 +17641,7 @@ msgstr "सकारात्मक फ़ीडबैक शेयर करे
 msgctxt ""
 "Label beside the share-content switch on the Duck.ai response feedback form"
 msgid "Share this conversation with DuckDuckGo"
-msgstr ""
+msgstr "इस बातचीत को DuckDuckGo के साथ शेयर करें"
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -17539,8 +17659,8 @@ msgid ""
 "Share your prompt and chat response with DuckDuckGo (required for illegal "
 "and harmful report)"
 msgstr ""
-"DuckDuckGo के साथ अपना प्रॉम्प्ट और चैट रिस्पॉन्स शेयर करें (गैरकानूनी और हानिकारक "
-"रिपोर्ट के लिए आवश्यक है)"
+"DuckDuckGo के साथ अपना प्रॉम्प्ट और चैट रिस्पॉन्स शेयर करें (गैरकानूनी और "
+"हानिकारक रिपोर्ट के लिए आवश्यक है)"
 
 # smartling.placeholder_format=C
 #. An invitation for users to leave feedback
@@ -17661,7 +17781,8 @@ msgstr "DuckAssist <sup>बीटा</sup> दिखाएं"
 msgctxt "duckassist_optin"
 msgid "Show DuckAssist more often. (You can also completely %sturn it off%s.)"
 msgstr ""
-"DuckAssist को अक्सर दिखाएं। (आप चाहें तो इसे पूरी तरह से %1$sबंद%2$s भी कर सकते हैं।)"
+"DuckAssist को अक्सर दिखाएं। (आप चाहें तो इसे पूरी तरह से %1$sबंद%2$s भी कर "
+"सकते हैं।)"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
@@ -17887,9 +18008,9 @@ msgid ""
 "Shows a reminder that searches on DuckDuckGo are always private. Turning "
 "this off hides the reminder and never affects search privacy."
 msgstr ""
-"यह याद दिलाने के लिए एक रिमाइंडर दिखाता है कि DuckDuckGo पर हरेक सर्च यानी खोज "
-"गोपनीय रहती है। इसे बंद करने से रिमाइंडर छिप जाता है, मगर इससे खोज की गोपनीयता "
-"प्रभावित नहीं होती है।"
+"यह याद दिलाने के लिए एक रिमाइंडर दिखाता है कि DuckDuckGo पर हरेक सर्च यानी "
+"खोज गोपनीय रहती है। इसे बंद करने से रिमाइंडर छिप जाता है, मगर इससे खोज की "
+"गोपनीयता प्रभावित नहीं होती है।"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -17897,9 +18018,9 @@ msgid ""
 "Shows a reminder that searches on DuckDuckGo are always protected. Turning "
 "this off hides the reminder and never affects search protection."
 msgstr ""
-"यह याद दिलाने के लिए एक रिमाइंडर दिखाता है कि DuckDuckGo पर हरेक सर्च यानी खोज "
-"हमेशा सुरक्षित रहती है। इसे बंद करने से रिमाइंडर छिप जाता है, मगर इससे खोज सुरक्षा "
-"प्रभावित नहीं होती है।"
+"यह याद दिलाने के लिए एक रिमाइंडर दिखाता है कि DuckDuckGo पर हरेक सर्च यानी "
+"खोज हमेशा सुरक्षित रहती है। इसे बंद करने से रिमाइंडर छिप जाता है, मगर इससे "
+"खोज सुरक्षा प्रभावित नहीं होती है।"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -17937,7 +18058,8 @@ msgctxt "settings"
 msgid ""
 "Shows occasional reminders to sign up for the DuckDuckGo privacy newsletters"
 msgstr ""
-"DuckDuckGo गोपनीयता न्यूज़लेटर के लिए साइन अप करने के लिए सामयिक रिमांडर दिखाता है"
+"DuckDuckGo गोपनीयता न्यूज़लेटर के लिए साइन अप करने के लिए सामयिक रिमांडर "
+"दिखाता है"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18219,7 +18341,9 @@ msgstr "कभी-कभी"
 #. Generic error message shown when the image generation model cannot process the user's request.
 msgctxt "Error message from the image generation model"
 msgid "Sorry I can't help, please describe your image in a different way."
-msgstr "माफ़ करें, मैं मदद करने में असमर्थ हूं। कृपया अपनी इमेज का आइडिया अलग शब्दों में बताएं।"
+msgstr ""
+"माफ़ करें, मैं मदद करने में असमर्थ हूं। कृपया अपनी इमेज का आइडिया अलग शब्दों "
+"में बताएं।"
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -18258,8 +18382,8 @@ msgid ""
 "Sorry, the uploaded image couldn't be processed. Please try a different "
 "image or format."
 msgstr ""
-"माफ़ करें, अपलोड की गई इमेज को प्रोसेस नहीं किया जा सका। कृपया कोई दूसरी इमेज या फ़ॉर्मेट "
-"आज़माएं।"
+"माफ़ करें, अपलोड की गई इमेज को प्रोसेस नहीं किया जा सका। कृपया कोई दूसरी "
+"इमेज या फ़ॉर्मेट आज़माएं।"
 
 # smartling.placeholder_format=C
 #. Body copy shown when a scanned or pasted pairing payload fails schema validation.
@@ -18268,7 +18392,8 @@ msgid ""
 "Sorry, this code is invalid. Please make sure the correct code was entered "
 "or scanned."
 msgstr ""
-"माफ़ करें, यह कोड गलत है। कृपया सुनिश्चित करें कि सही कोड को दर्ज या स्कैन किया गया है।"
+"माफ़ करें, यह कोड गलत है। कृपया सुनिश्चित करें कि सही कोड को दर्ज या स्कैन "
+"किया गया है।"
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -18283,14 +18408,16 @@ msgid ""
 "Sorry, we ran into an error displaying these results. %sClick here%s to try "
 "again."
 msgstr ""
-"क्षमा करें, इन परिणामों को प्रदर्शित करने में त्रुटि हुई। फिर से प्रयास करने के लिए, %1$sयहाँ "
-"क्लिक करें%2$s।"
+"क्षमा करें, इन परिणामों को प्रदर्शित करने में त्रुटि हुई। फिर से प्रयास करने "
+"के लिए, %1$sयहाँ क्लिक करें%2$s।"
 
 # smartling.placeholder_format=C
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr "क्षमा करें, हम आपका फ़ीडबैक सबमिट नहीं कर सके। कृपया बाद में फिर से प्रयास करें।"
+msgstr ""
+"क्षमा करें, हम आपका फ़ीडबैक सबमिट नहीं कर सके। कृपया बाद में फिर से प्रयास "
+"करें।"
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -18345,8 +18472,8 @@ msgctxt "Error message for summary selection input limit"
 msgid ""
 "Source text is too long to summarize. Try again with a shorter selection."
 msgstr ""
-"सोर्स टेक्स्ट बहुत लंबा है, इसे संक्षेप में बताना संभव नहीं है। थोड़ा छोटा हिस्सा चुनकर फिर से "
-"प्रयास करें।"
+"सोर्स टेक्स्ट बहुत लंबा है, इसे संक्षेप में बताना संभव नहीं है। थोड़ा छोटा "
+"हिस्सा चुनकर फिर से प्रयास करें।"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under Interface Settings.in the end. It is a header
@@ -18690,8 +18817,8 @@ msgid ""
 "Subscribe to DuckDuckGo to unlock higher limits in Duck.ai, or come back "
 "later to create more images."
 msgstr ""
-"Duck.ai में ज़्यादा लिमिट पाने के लिए DuckDuckGo को सब्सक्राइब करें, या अधिक इमेज बनाने "
-"के लिए बाद में वापस आएं।"
+"Duck.ai में ज़्यादा लिमिट पाने के लिए DuckDuckGo को सब्सक्राइब करें, या अधिक "
+"इमेज बनाने के लिए बाद में वापस आएं।"
 
 # smartling.placeholder_format=C
 #. Description shown to free users who have reached their image generation limit, encouraging them to subscribe.
@@ -18760,8 +18887,8 @@ msgid ""
 "Suggest a phrase to write on a get-well card for someone recovering from a "
 "surgery?"
 msgstr ""
-"सर्जरी करवाकर ठीक हो रहे किसी व्यक्ति को देने लायक 'स्वास्थ्य शुभकामनाएं' वाले कार्ड पर "
-"लिखने के लिए वाक्य सुझाएं?"
+"सर्जरी करवाकर ठीक हो रहे किसी व्यक्ति को देने लायक 'स्वास्थ्य शुभकामनाएं' "
+"वाले कार्ड पर लिखने के लिए वाक्य सुझाएं?"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for asking for a suggestion of a blog post title.
@@ -18773,19 +18900,19 @@ msgstr "ब्लॉग पोस्ट के लिए शीर्षक स�
 #. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Suggest related articles or topics worth exploring next."
-msgstr ""
+msgstr "आगे एक्सप्लोर करने लायक संबंधित लेख या विषय सुझाएं।"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Suggest related articles to explore"
-msgstr ""
+msgstr "एक्सप्लोर करने के लिए संबंधित लेख सुझाएं"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Suggest some alternatives to this product."
-msgstr ""
+msgstr "इस प्रोडक्ट के कुछ विकल्प सुझाएं।"
 
 # smartling.placeholder_format=C
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
@@ -18802,7 +18929,7 @@ msgstr "सुझाव:"
 #. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Sum up the reviews"
-msgstr ""
+msgstr "रिव्यूज़ का सारांश दें"
 
 # smartling.placeholder_format=C
 #. A short title for the a message asking the AI to summarize a text.
@@ -18814,85 +18941,85 @@ msgstr "संक्षेप में बताएं"
 #. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize the Q&As"
-msgstr ""
+msgstr "प्रश्नोत्तर का सारांश दें"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the background and notable work of this person."
-msgstr ""
+msgstr "इस व्यक्ति की पृष्ठभूमि और उल्लेखनीय कार्यों का सारांश दें।"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the key details of this event."
-msgstr ""
+msgstr "इस घटना की अहम जानकारी संक्षेप में बताएं।"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the questions and answers on this page."
-msgstr ""
+msgstr "इस पेज पर मौजूद सवालों और जवाबों का सारांश दें।"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize their background"
-msgstr ""
+msgstr "उनकी पृष्ठभूमि संक्षेप में बताएं"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this book"
-msgstr ""
+msgstr "इस किताब का सारांश बताएं"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this book."
-msgstr ""
+msgstr "इस किताब का सारांश बताएं।"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this discussion"
-msgstr ""
+msgstr "इस चर्चा का सारांश बताएं"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this discussion thread."
-msgstr ""
+msgstr "इस चर्चा थ्रेड का सारांश बताएं।"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this page"
-msgstr ""
+msgstr "इस पेज का सारांश बताएं"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this page."
-msgstr ""
+msgstr "इस पेज का सारांश बताएं।"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this video"
-msgstr ""
+msgstr "इस वीडियो का सारांश बताएं"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this video."
-msgstr ""
+msgstr "इस वीडियो का सारांश बताएं।"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize what the reviews say."
-msgstr ""
+msgstr "रिव्यूज़ में क्या कहा गया है, उसका सारांश दें।"
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -19054,8 +19181,8 @@ msgctxt "AI Chat warning when switching from an encrypted model"
 msgid ""
 "Switching will send your chat to a model without zero provider visibility"
 msgstr ""
-"स्विच करने पर आपकी चैट एक ऐसे मॉडल को भेज दी जाएगी, जिसमें प्रोवाइडर विज़िबिलिटी ज़ीरो "
-"होगी"
+"स्विच करने पर आपकी चैट एक ऐसे मॉडल को भेज दी जाएगी, जिसमें प्रोवाइडर "
+"विज़िबिलिटी ज़ीरो होगी"
 
 # smartling.placeholder_format=C
 msgid "Switzerland"
@@ -19110,7 +19237,8 @@ msgstr "Sync & Backup चालू है!"
 msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
-"18 महीने तक निष्क्रिय रहने के बाद, Sync & Backup डेटा को रिकवर नहीं किया जा सकता।"
+"18 महीने तक निष्क्रिय रहने के बाद, Sync & Backup डेटा को रिकवर नहीं किया जा "
+"सकता।"
 
 # smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
@@ -19159,25 +19287,26 @@ msgid ""
 msgstr ""
 "सिंक रिकवरी कोड\n"
 "\n"
-" रिकवरी कोड की मदद से आप कई डिवाइस पर अपने पासवर्ड, ऑटोफ़िल डेटा और Duck.ai चैट को "
-"सिंक कर सकते हैं, और अगर किसी डिवाइस का एक्सेस खो जाए, तो अपना सिंक किया हुआ डेटा "
-"रिकवर कर सकते हैं।\n"
+" रिकवरी कोड की मदद से आप कई डिवाइस पर अपने पासवर्ड, ऑटोफ़िल डेटा और Duck.ai "
+"चैट को सिंक कर सकते हैं, और अगर किसी डिवाइस का एक्सेस खो जाए, तो अपना सिंक "
+"किया हुआ डेटा रिकवर कर सकते हैं।\n"
 "\n"
 "इस जानकारी को सुरक्षित और गोपनीय रखें।\n"
-"जिस किसी के पास भी इस कोड का एक्सेस होगा, वह आपके सिंक किए गए डेटा को एक्सेस कर सकता "
-"है।\n"
+"जिस किसी के पास भी इस कोड का एक्सेस होगा, वह आपके सिंक किए गए डेटा को एक्सेस "
+"कर सकता है।\n"
 "\n"
 "%1$s\n"
 "\n"
 "यह कोड कैसे काम करता है?\n"
 "1. अपने ब्राउज़र में Duck.ai पर जाएं और Duck.ai सेटिंग खोलें।\n"
-"2. \"Sync & Backup चालू करें\" चुनें, फिर \"सिंक किया गया डेटा रिकवर करें\" चुनें\n"
-"3. ऊपर दिए गए रिकवरी कोड को कॉपी करें और उसे वहां पेस्ट करें जहां \"अपना कोड यहां पेस्ट "
-"करें\" कहा गया है\n"
+"2. \"Sync & Backup चालू करें\" चुनें, फिर \"सिंक किया गया डेटा रिकवर करें\" "
+"चुनें\n"
+"3. ऊपर दिए गए रिकवरी कोड को कॉपी करें और उसे वहां पेस्ट करें जहां \"अपना कोड "
+"यहां पेस्ट करें\" कहा गया है\n"
 "\n"
-"अगर आप Sync & Backup चालू होने के बाद भी 18 महीने से ज़्यादा समय तक DuckDuckGo "
-"ब्राउज़र का इस्तेमाल नहीं करते हैं, तो आपका डेटा सर्वर से डिलीट कर दिया जाएगा और उसे "
-"रीस्टोर नहीं किया जा सकेगा।"
+"अगर आप Sync & Backup चालू होने के बाद भी 18 महीने से ज़्यादा समय तक "
+"DuckDuckGo ब्राउज़र का इस्तेमाल नहीं करते हैं, तो आपका डेटा सर्वर से डिलीट "
+"कर दिया जाएगा और उसे रीस्टोर नहीं किया जा सकेगा।"
 
 # smartling.placeholder_format=C
 #. Secondary button label on the Sync & Backup intro screen that takes the user to the camera scan screen to pair with another device.
@@ -19223,7 +19352,7 @@ msgstr "सीरिया"
 #. Text for a button that enables the theme to follow the operating system's color scheme preference.
 msgctxt "System theme button for theme selector"
 msgid "System"
-msgstr ""
+msgstr "सिस्टम"
 
 # smartling.placeholder_format=C
 #. Abbreviation indicating this is the total score for a game
@@ -19257,7 +19386,7 @@ msgstr "ताहितियन"
 #. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Tailor my resume"
-msgstr ""
+msgstr "मेरा रिज़्यूमे मेरा मुताबिक तैयार करें"
 
 # smartling.placeholder_format=C
 msgid "Taiwan"
@@ -19293,7 +19422,7 @@ msgstr "अपने व्यक्तिगत डेटा को निय�
 msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
-msgstr ""
+msgstr "यह गुमनाम सर्वे करें और हमें बताएं कि हम Duck.ai को कैसे बेहतर बना सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -19508,9 +19637,9 @@ msgid ""
 "link is at increased risk of being intercepted by a third party. In rare "
 "cases this includes passwords, or payment details."
 msgstr ""
-"इसका मतलब हैं कि आपके डिवाइस और इस लिंक के पीछे के वेबपेज के बीच भेजी गई जानकारी को "
-"किसी तीसरे पक्ष द्वारा इंटरसेप्ट किए जाने का जोखिम बढ़ रहा है। कम मामलों में इसमें पासवर्ड, "
-"या भुगतान विवरण शामिल होते हैं।"
+"इसका मतलब हैं कि आपके डिवाइस और इस लिंक के पीछे के वेबपेज के बीच भेजी गई "
+"जानकारी को किसी तीसरे पक्ष द्वारा इंटरसेप्ट किए जाने का जोखिम बढ़ रहा है। कम "
+"मामलों में इसमें पासवर्ड, या भुगतान विवरण शामिल होते हैं।"
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -19519,8 +19648,8 @@ msgid ""
 "The Cloud Save bookmarklet allows any changes you make to your settings to "
 "automatically save in the cloud."
 msgstr ""
-"Cloud Save बुकमार्कलेट आपको क्लाउड में ऑटोमैटिकली सेव करने के लिए अपनी सेटिंग्स में कोई भी "
-"बदलाव करने की अनुमति देता है।"
+"Cloud Save बुकमार्कलेट आपको क्लाउड में ऑटोमैटिकली सेव करने के लिए अपनी "
+"सेटिंग्स में कोई भी बदलाव करने की अनुमति देता है।"
 
 # smartling.placeholder_format=C
 msgid "The Gambia"
@@ -19550,8 +19679,8 @@ msgid ""
 "The encryption key is only saved in your browser's local storage, and only "
 "you can access it."
 msgstr ""
-"'एनक्रिप्शन की' केवल आपके ब्राउज़र के लोकल स्टोरेज में सेव रहती है, और सिर्फ़ आप ही इसे एक्सेस "
-"कर सकते हैं।"
+"'एनक्रिप्शन की' केवल आपके ब्राउज़र के लोकल स्टोरेज में सेव रहती है, और "
+"सिर्फ़ आप ही इसे एक्सेस कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider deletes all chat data within 30 days.
@@ -19600,7 +19729,7 @@ msgstr "थीम"
 #. Text for the theme selector label that allows users to switch between Light and dark theme.
 msgctxt "Label for the theme selector feature"
 msgid "Theme"
-msgstr ""
+msgstr "थीम"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/LpFhb1e.png
@@ -19631,8 +19760,8 @@ msgid ""
 "There was an error saving this chat locally. Please check your browser "
 "settings to make sure local data storage is enabled."
 msgstr ""
-"इस चैट को लोकल स्टोरेज में सेव करने के दौरान कोई गड़बड़ी हुई। कृपया अपनी ब्राउज़र सेटिंग जांचें "
-"और सुनिश्चित करें कि लोकल डेटा स्टोरेज चालू है।"
+"इस चैट को लोकल स्टोरेज में सेव करने के दौरान कोई गड़बड़ी हुई। कृपया अपनी "
+"ब्राउज़र सेटिंग जांचें और सुनिश्चित करें कि लोकल डेटा स्टोरेज चालू है।"
 
 # smartling.placeholder_format=C
 #. Error modal body line 1.
@@ -19647,8 +19776,8 @@ msgid ""
 "There was still an error displaying the search results. Please wait a few "
 "minutes before you try again."
 msgstr ""
-"खोज परिणाम दिखाने में अभी भी गड़बड़ी हो रही है। कृपया दोबारा कोशिश करने से पहले कुछ "
-"मिनट इंतज़ार करें।"
+"खोज परिणाम दिखाने में अभी भी गड़बड़ी हो रही है। कृपया दोबारा कोशिश करने से "
+"पहले कुछ मिनट इंतज़ार करें।"
 
 # smartling.placeholder_format=C
 #. Error message for explore more questions when a retryable error occurs (timeout, network)
@@ -19667,9 +19796,9 @@ msgid ""
 "visit by blocking hidden trackers, encrypting connections where possible, "
 "and by making DuckDuckGo your default search engine."
 msgstr ""
-"इन ब्राउज़र अनुमतियों को आपके द्वारा देखी जाने वाली वेबसाइटों पर छिपे ट्रैकर ब्लॉक करके, "
-"संभव होने पर कनेक्शन एन्क्रिप्ट करके और DuckDuckGo को आपका डिफ़ॉल्ट खोज इंजन बनाकर "
-"गोपनीयता सुरक्षा जोड़ने के लिए उपयोग किया जाता है।"
+"इन ब्राउज़र अनुमतियों को आपके द्वारा देखी जाने वाली वेबसाइटों पर छिपे ट्रैकर "
+"ब्लॉक करके, संभव होने पर कनेक्शन एन्क्रिप्ट करके और DuckDuckGo को आपका "
+"डिफ़ॉल्ट खोज इंजन बनाकर गोपनीयता सुरक्षा जोड़ने के लिए उपयोग किया जाता है।"
 
 # smartling.placeholder_format=C
 #. Secondary line under DUCKCHAT_SYNC_PAIRING_ALREADY_SYNCED_TITLE.
@@ -19707,7 +19836,8 @@ msgid ""
 "This AI model is no longer available. Try starting a new chat with a "
 "different model."
 msgstr ""
-"यह AI मॉडल अब उपलब्ध नहीं है। किसी दूसरे मॉडल के साथ नई चैट शुरू करने की कोशिश करें।"
+"यह AI मॉडल अब उपलब्ध नहीं है। किसी दूसरे मॉडल के साथ नई चैट शुरू करने की "
+"कोशिश करें।"
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is no longer supported because it has been upgraded to a newest version.
@@ -19716,8 +19846,8 @@ msgid ""
 "This AI model version is no longer supported. Try starting a new chat with "
 "the latest version of this model."
 msgstr ""
-"AI मॉडल के इस वर्ज़न के लिए अब सपोर्ट उपलब्ध नहीं है। इस मॉडल के सबसे नए वर्ज़न के साथ नई "
-"चैट शुरू करें।"
+"AI मॉडल के इस वर्ज़न के लिए अब सपोर्ट उपलब्ध नहीं है। इस मॉडल के सबसे नए "
+"वर्ज़न के साथ नई चैट शुरू करें।"
 
 # smartling.placeholder_format=C
 #. Appears below a type of search results called 'Instant Answers'
@@ -19744,8 +19874,9 @@ msgid ""
 "This conversation was generated with Duck.ai (%s) using %s's %s Model. AI "
 "chats may display inaccurate or offensive information (see %s for more info)."
 msgstr ""
-"यह बातचीत Duck.ai (%1$s) के जरिए %2$s के %3$s मॉडल का इस्तेमाल करके जनरेट की गई। "
-"AI चैट में गलत या आपत्तिजनक जानकारी दिखाई दे सकती है (ज़्यादा जानकारी के लिए %4$s देखें)।"
+"यह बातचीत Duck.ai (%1$s) के जरिए %2$s के %3$s मॉडल का इस्तेमाल करके जनरेट की "
+"गई। AI चैट में गलत या आपत्तिजनक जानकारी दिखाई दे सकती है (ज़्यादा जानकारी के "
+"लिए %4$s देखें)।"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with multiple AI models in the same chat, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using multiple chat models. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -19755,8 +19886,9 @@ msgid ""
 "models. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
 msgstr ""
-"यह बातचीत Duck.ai (%1$s) में कई चैट मॉडल इस्तेमाल करके तैयार की गई थी. एआई चैट में गलत "
-"या आपत्तिजनक जानकारी दिखाई दे सकती है (ज़्यादा जानकारी के लिए %2$s देखें)."
+"यह बातचीत Duck.ai (%1$s) में कई चैट मॉडल इस्तेमाल करके तैयार की गई थी. एआई "
+"चैट में गलत या आपत्तिजनक जानकारी दिखाई दे सकती है (ज़्यादा जानकारी के लिए "
+"%2$s देखें)."
 
 # smartling.placeholder_format=C
 #. When a user exports a transcript of a voice chat they had with the AI. This text goes at the very top of the downloaded file as a header. Placeholders are for links. Example: 'This conversation was generated with Duck.ai voice chat (https://duck.ai). AI may provide inaccurate or offensive information. (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -19765,8 +19897,8 @@ msgid ""
 "This conversation was generated with Duck.ai voice chat (%s). AI may provide "
 "inaccurate or offensive information. (see %s for more info)."
 msgstr ""
-"यह बातचीत Duck.ai वॉयस चैट (%1$s) से जनरेट हुई थी। AI गलत या आपत्तिजनक जानकारी भी "
-"प्रदान कर सकता है। (ज़्यादा जानकारी के लिए %2$s देखें।)"
+"यह बातचीत Duck.ai वॉयस चैट (%1$s) से जनरेट हुई थी। AI गलत या आपत्तिजनक "
+"जानकारी भी प्रदान कर सकता है। (ज़्यादा जानकारी के लिए %2$s देखें।)"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with DuckDuckGo AI Chat (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/aichat/privacy-terms for more info).'
@@ -19776,9 +19908,9 @@ msgid ""
 "Model. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
 msgstr ""
-"यह बातचीत %2$s के %3$s मॉडल का इस्तेमाल करके DuckDuckGo AI Chat (%1$s) के जरिए "
-"जनरेट की गई। AI चैट में गलत या आपत्तिजनक जानकारी दिखाई दे सकती है (ज़्यादा जानकारी के "
-"लिए %4$s देखें)।"
+"यह बातचीत %2$s के %3$s मॉडल का इस्तेमाल करके DuckDuckGo AI Chat (%1$s) के "
+"जरिए जनरेट की गई। AI चैट में गलत या आपत्तिजनक जानकारी दिखाई दे सकती है "
+"(ज़्यादा जानकारी के लिए %4$s देखें)।"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
@@ -19850,7 +19982,8 @@ msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF"
 msgstr ""
-"इस इमेज प्रकार को सपोर्ट हासिल नहीं है, कृपया कोई JPG, PNG, WebP या GIF अटैच करें"
+"इस इमेज प्रकार को सपोर्ट हासिल नहीं है, कृपया कोई JPG, PNG, WebP या GIF अटैच "
+"करें"
 
 # smartling.placeholder_format=C
 #. Error message displayed when a file that the user tried to upload is not of a supported format
@@ -19858,7 +19991,8 @@ msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF."
 msgstr ""
-"इस इमेज प्रकार को सपोर्ट हासिल नहीं है, कृपया कोई JPG, PNG, WebP या GIF अटैच करें।"
+"इस इमेज प्रकार को सपोर्ट हासिल नहीं है, कृपया कोई JPG, PNG, WebP या GIF अटैच "
+"करें।"
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
@@ -19884,8 +20018,8 @@ msgid ""
 "This model provider deletes data associated with this chat within 30 days. "
 "Other model providers follow a zero data retention model."
 msgstr ""
-"यह मॉडल प्रदाता इस चैट से जुड़ा डेटा 30 दिनों के अंदर डिलीट कर देता है। अन्य मॉडल प्रदाता "
-"'ज़ीरो डेटा रिटेंशन' मॉडल का पालन करते हैं।"
+"यह मॉडल प्रदाता इस चैट से जुड़ा डेटा 30 दिनों के अंदर डिलीट कर देता है। अन्य "
+"मॉडल प्रदाता 'ज़ीरो डेटा रिटेंशन' मॉडल का पालन करते हैं।"
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers, and that other providers may retain chat data for a limited time instead.
@@ -19894,8 +20028,8 @@ msgid ""
 "This model provider does not store any data associated with this chat. Other "
 "model providers follow a limited data retention model."
 msgstr ""
-"यह मॉडल प्रदाता इस चैट से जुड़ा कोई भी डेटा स्टोर नहीं करता है। अन्य मॉडल प्रदाता "
-"'सीमित डेटा रिटेंशन' मॉडल का पालन करते हैं।"
+"यह मॉडल प्रदाता इस चैट से जुड़ा कोई भी डेटा स्टोर नहीं करता है। अन्य मॉडल "
+"प्रदाता 'सीमित डेटा रिटेंशन' मॉडल का पालन करते हैं।"
 
 # smartling.placeholder_format=C
 #. Info that page may refresh during update.
@@ -19932,8 +20066,8 @@ msgid ""
 "This saves your chats with end-to-end encryption on DuckDuckGo's secure "
 "server, which later can be accessed from any browser."
 msgstr ""
-"यह आपकी चैट्स को DuckDuckGo के सुरक्षित सर्वर पर एंड-टू-एंड एनक्रिप्शन के साथ सेव करता है, "
-"जिसे बाद में किसी भी ब्राउज़र से एक्सेस किया जा सकता है।"
+"यह आपकी चैट्स को DuckDuckGo के सुरक्षित सर्वर पर एंड-टू-एंड एनक्रिप्शन के "
+"साथ सेव करता है, जिसे बाद में किसी भी ब्राउज़र से एक्सेस किया जा सकता है।"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -19942,8 +20076,9 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again."
 msgstr ""
-"यह सेटिंग आपके ब्राउज़र में स्टोर रहती है, जिसका मतलब है कि अगर आप duckduckgo.com "
-"ब्राउज़र डेटा मिटाते हैं, तो आपको AI से मिले जवाब फिर से दिख सकते हैं।"
+"यह सेटिंग आपके ब्राउज़र में स्टोर रहती है, जिसका मतलब है कि अगर आप "
+"duckduckgo.com ब्राउज़र डेटा मिटाते हैं, तो आपको AI से मिले जवाब फिर से दिख "
+"सकते हैं।"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -19953,9 +20088,10 @@ msgid ""
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
 msgstr ""
-"यह सेटिंग आपके ब्राउज़र में स्टोर रहती है, जिसका मतलब है कि अगर आप duckduckgo.com "
-"ब्राउज़र डेटा मिटाते हैं, तो आपको AI से मिले जवाब फिर से दिख सकते हैं। हालांकि, %1$s पर "
-"हमारे पास ऐसा स्टार्ट पेज भी है जो AI से मिलने वाले जवाब कभी नहीं दिखाता।"
+"यह सेटिंग आपके ब्राउज़र में स्टोर रहती है, जिसका मतलब है कि अगर आप "
+"duckduckgo.com ब्राउज़र डेटा मिटाते हैं, तो आपको AI से मिले जवाब फिर से दिख "
+"सकते हैं। हालांकि, %1$s पर हमारे पास ऐसा स्टार्ट पेज भी है जो AI से मिलने "
+"वाले जवाब कभी नहीं दिखाता।"
 
 # smartling.placeholder_format=C
 #. User feedback indicating that a translation is helpful
@@ -19984,7 +20120,9 @@ msgstr "यह वीडियो अब तक यहां देखे जा
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr "यह वेबपेज एक सुरक्षित, एन्क्रिप्ट किए गए, कनेक्शन (HTTPS) का उपयोग नहीं करता है।"
+msgstr ""
+"यह वेबपेज एक सुरक्षित, एन्क्रिप्ट किए गए, कनेक्शन (HTTPS) का उपयोग नहीं करता "
+"है।"
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -19994,8 +20132,9 @@ msgid ""
 "Sync & Backup. You'll still be able to access your chats in other browsers "
 "connected to Sync & Backup."
 msgstr ""
-"इससे इस ब्राउज़र से आपकी सभी Duck.ai चैट डिलीट हो जाएंगी, और Sync & Backup डिस्कनेक्ट "
-"हो जाएगा। आप Sync & Backup से जुड़े दूसरे ब्राउज़र में भी अपनी चैट एक्सेस कर पाएंगे।"
+"इससे इस ब्राउज़र से आपकी सभी Duck.ai चैट डिलीट हो जाएंगी, और Sync & Backup "
+"डिस्कनेक्ट हो जाएगा। आप Sync & Backup से जुड़े दूसरे ब्राउज़र में भी अपनी "
+"चैट एक्सेस कर पाएंगे।"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to clear all recentchats, with a warning that this action cannot be undone.
@@ -20004,15 +20143,16 @@ msgid ""
 "This will delete all your recent chats, unless they're pinned. This cannot "
 "be undone."
 msgstr ""
-"यह आपकी सभी हालिया चैट्स को डिलीट कर देगा, सिवाय उनके जो पिन की गई हैं। इसे पहले जैसा "
-"नहीं किया जा सकता है।"
+"यह आपकी सभी हालिया चैट्स को डिलीट कर देगा, सिवाय उनके जो पिन की गई हैं। इसे "
+"पहले जैसा नहीं किया जा सकता है।"
 
 # smartling.placeholder_format=C
 #. Message explaining what will happen when the user deletes an image.
 msgctxt "Confirmation message in delete image modal"
 msgid "This will delete your selected image. This cannot be undone."
 msgstr ""
-"यह आपके द्वारा चुनी गई इमेज को डिलीट कर देगा। इसे पहले जैसा नहीं किया जा सकता है।"
+"यह आपके द्वारा चुनी गई इमेज को डिलीट कर देगा। इसे पहले जैसा नहीं किया जा "
+"सकता है।"
 
 # smartling.placeholder_format=C
 #. Confirmation message asking if the user is sure they want to reset all of their settings.
@@ -20135,8 +20275,7 @@ msgstr "जारी रखने के लिए, आपको Duck.ai की 
 msgctxt ""
 "Copy stating agreement to AI Chat Privacy Policy and Terms of Service."
 msgid "To continue, you must agree to DuckDuckGo AI Chat’s %s and %s"
-msgstr ""
-"जारी रखने के लिए, आपको DuckDuckGo AI Chat की %1$s और %2$s से सहमत होना होगा"
+msgstr "जारी रखने के लिए, आपको DuckDuckGo AI Chat की %1$s और %2$s से सहमत होना होगा"
 
 # smartling.placeholder_format=C
 #. Instructions for how to print driving directions.
@@ -20145,8 +20284,8 @@ msgid ""
 "To print directions:%sGo back to the map.%sSelect the route you want to "
 "print.%sClick the print icon.%s"
 msgstr ""
-"निर्देश प्रिंट करने के लिए:%1$sमैप पर वापस जाएं।%2$sउस रूट को चुनें जिसे आप प्रिंट करना "
-"चाहते हैं।%3$sप्रिंट आइकन पर क्लिक करें।%4$s"
+"निर्देश प्रिंट करने के लिए:%1$sमैप पर वापस जाएं।%2$sउस रूट को चुनें जिसे आप "
+"प्रिंट करना चाहते हैं।%3$sप्रिंट आइकन पर क्लिक करें।%4$s"
 
 # smartling.placeholder_format=C
 #. Explains where the user can find their recovery code. Figma frame 3703-44420.
@@ -20156,9 +20295,10 @@ msgid ""
 "you first set up Sync. This code may have been saved as a PDF on the device "
 "you originally used to set up Sync."
 msgstr ""
-"अपने सिंक किए गए डेटा को रीस्टोर करने के लिए, आपको उस रिकवरी कोड की ज़रूरत होगी जिसे "
-"आपने पहली बार Sync सेटअप करते समय सेव किया था। यह कोड उस डिवाइस पर PDF के रूप में सेव "
-"किया गया हो सकता है, जिसका इस्तेमाल आपने मूल रूप से Sync सेटअप करने के लिए किया था।"
+"अपने सिंक किए गए डेटा को रीस्टोर करने के लिए, आपको उस रिकवरी कोड की ज़रूरत "
+"होगी जिसे आपने पहली बार Sync सेटअप करते समय सेव किया था। यह कोड उस डिवाइस पर "
+"PDF के रूप में सेव किया गया हो सकता है, जिसका इस्तेमाल आपने मूल रूप से Sync "
+"सेटअप करने के लिए किया था।"
 
 # smartling.placeholder_format=C
 #. Body text explaining that the user needs to update their DDG browser before migration can proceed.
@@ -20167,8 +20307,8 @@ msgid ""
 "To transfer your chat history to Duck.ai, please update your DuckDuckGo "
 "browser to the latest version and try again."
 msgstr ""
-"अपनी चैट हिस्ट्री को Duck.ai पर ट्रांसफ़र करने के लिए, कृपया अपने DuckDuckGo ब्राउज़र को "
-"नवीनतम वर्ज़न में अपडेट करें और दोबारा प्रयास करें।"
+"अपनी चैट हिस्ट्री को Duck.ai पर ट्रांसफ़र करने के लिए, कृपया अपने DuckDuckGo "
+"ब्राउज़र को नवीनतम वर्ज़न में अपडेट करें और दोबारा प्रयास करें।"
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
@@ -20176,8 +20316,8 @@ msgid ""
 "To use dictation, allow your browser to access the microphone in your system "
 "settings."
 msgstr ""
-"डिक्टेशन का इस्तेमाल करने के लिए, अपने सिस्टम सेटिंग में जाकर ब्राउज़र को माइक्रोफ़ोन का "
-"एक्सेस दें।"
+"डिक्टेशन का इस्तेमाल करने के लिए, अपने सिस्टम सेटिंग में जाकर ब्राउज़र को "
+"माइक्रोफ़ोन का एक्सेस दें।"
 
 # smartling.placeholder_format=C
 msgid "Today"
@@ -20367,8 +20507,8 @@ msgid ""
 "Tracking attempts blocked by DuckDuckGo appear here. Keep browsing to see "
 "how many we block."
 msgstr ""
-"DuckDuckGo द्वारा ब्लॉक की गई ट्रैकिंग की कोशिशें यहां दिखाई देंगी। ब्राउज़ करते रहें और देखें "
-"हम कितनों को ब्लॉक करते हैं।"
+"DuckDuckGo द्वारा ब्लॉक की गई ट्रैकिंग की कोशिशें यहां दिखाई देंगी। ब्राउज़ "
+"करते रहें और देखें हम कितनों को ब्लॉक करते हैं।"
 
 # smartling.placeholder_format=C
 #. Placeholder for when we cannot report any blocked trackers yet
@@ -20415,7 +20555,9 @@ msgctxt "Full sentence for translating text"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr "फ्रेंच में इस अंग्रेजी वाक्य का अनुवाद करें: \"मैं निकटतम मूवी थियेटर में कैसे पहुंचूं?\""
+msgstr ""
+"फ्रेंच में इस अंग्रेजी वाक्य का अनुवाद करें: \"मैं निकटतम मूवी थियेटर में "
+"कैसे पहुंचूं?\""
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for translating a sentence into another language. Translate the whole sentence and please use target language instead of 'English' and modify the sentence to translate into 'English' instead of 'French'. Example: 'Translate this {target language} sentence into English: “How do I get to the nearest movie theatre?”'
@@ -20424,19 +20566,20 @@ msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
 msgstr ""
-"हिन्दी में दिए गए इस वाक्य का अंग्रेज़ी में अनुवाद करें: \"मैं नज़दीकी सिनेमा हॉल तक कैसे पहुंचूं?\""
+"हिन्दी में दिए गए इस वाक्य का अंग्रेज़ी में अनुवाद करें: \"मैं नज़दीकी "
+"सिनेमा हॉल तक कैसे पहुंचूं?\""
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Translate this page"
-msgstr ""
+msgstr "इस पेज का अनुवाद करें"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
 msgctxt "Page suggestion prompt"
 msgid "Translate this page into %s."
-msgstr ""
+msgstr "इस पेज का %1$s में अनुवाद करें।"
 
 # smartling.placeholder_format=C
 #. Placeholder text for a region that will display translated text.
@@ -20583,7 +20726,7 @@ msgstr "मुफ़्त में आज़माएं"
 #. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
 msgctxt "settings"
 msgid "Try It Now"
-msgstr ""
+msgstr "इसे अभी आज़माएं"
 
 # smartling.placeholder_format=C
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -20642,7 +20785,8 @@ msgstr "अलग कीवर्ड आज़माएं।"
 #. Prompt encouraging the user to turn off their ad blocker to see more results for their query.
 msgid "Try disabling your ad blocker on DuckDuckGo to see more results."
 msgstr ""
-"DuckDuckGo पर अधिक परिणाम देखने के लिए अपने विज्ञापन ब्लॉकर को डिसेबल यानी अक्षम करें।"
+"DuckDuckGo पर अधिक परिणाम देखने के लिए अपने विज्ञापन ब्लॉकर को डिसेबल यानी "
+"अक्षम करें।"
 
 # smartling.placeholder_format=C
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
@@ -20786,7 +20930,8 @@ msgstr "हाल ही में जोड़े गए ओपन-सोर्
 msgctxt "Promotional text for new AI models"
 msgid "Try the recently added open-source Llama 3.1 and Mixtral"
 msgstr ""
-"हाल ही में जोड़े गए ओपन-सोर्स यानी मुक्त स्रोत वाले Llama 3.1 और Mixtral को आजमाएं"
+"हाल ही में जोड़े गए ओपन-सोर्स यानी मुक्त स्रोत वाले Llama 3.1 और Mixtral को "
+"आजमाएं"
 
 # smartling.placeholder_format=C
 #. Message displayed to suggest the user to try the provided prompts or enter their own.
@@ -20826,6 +20971,8 @@ msgid ""
 "Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
+"क्या आप AI फ़ीचर्स को बंद करने की कोशिश कर रहे हैं? अपनी सेटिंग याद रखने के "
+"लिए %1$sDuckDuckGo No AI%2$s सर्च एक्सटेंशन इंस्टॉल करें। %3$sऔर जानें%4$s"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -20834,6 +20981,8 @@ msgid ""
 "Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
+"क्या आप AI फ़ीचर्स को बंद करने की कोशिश कर रहे हैं? अपनी सेटिंग याद रखने के "
+"लिए %1$sDuckDuckGo No AI%2$s सर्च एक्सटेंशन पर स्विच करें। %3$sऔर जानें%4$s"
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -21004,8 +21153,8 @@ msgid ""
 "Types out DuckAssist answers as they're generated. Turning this off may "
 "result in a short delay between a search and the answer being displayed."
 msgstr ""
-"जनरेट होते ही DuckAssist के उत्तर टाइप हो जाते हैं। इसे बंद करने से खोज और दिखाई देने वाले "
-"उत्तर के बीच थोड़ा समय लग सकता है।"
+"जनरेट होते ही DuckAssist के उत्तर टाइप हो जाते हैं। इसे बंद करने से खोज और "
+"दिखाई देने वाले उत्तर के बीच थोड़ा समय लग सकता है।"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -21135,8 +21284,8 @@ msgid ""
 "Under %sOn startup%s, click %sOpen a specific page%s then click %sSet "
 "Pages%s."
 msgstr ""
-"%1$sस्टार्टअप पर%2$s के नीचे, %3$sकोई खास पेज खोलें%4$s पर क्लिक करें, फिर %5$sसेट "
-"पेज%6$s पर क्लिक करें।"
+"%1$sस्टार्टअप पर%2$s के नीचे, %3$sकोई खास पेज खोलें%4$s पर क्लिक करें, फिर "
+"%5$sसेट पेज%6$s पर क्लिक करें।"
 
 #  Maxthon homepage instruction
 # smartling.placeholder_format=C
@@ -21144,8 +21293,8 @@ msgstr ""
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
 msgstr ""
-"%1$sस्टार्टअप पर%2$s के अंतर्गत, %3$sहोमपेज%4$s चुनें और यह डालें: https://duckduckgo."
-"com"
+"%1$sस्टार्टअप पर%2$s के अंतर्गत, %3$sहोमपेज%4$s चुनें और यह डालें: "
+"https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -21177,7 +21326,9 @@ msgstr "%1$sसर्च%2$s सेक्शन के नीचे, %3$sसर�
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under On startup select %sOpen a specific page or set of pages%s"
-msgstr "स्टार्टअप चालू करें के अंतर्गत %1$sएक विशिष्ट पेज या कई पेज के सेट खोलें%2$s चुनें"
+msgstr ""
+"स्टार्टअप चालू करें के अंतर्गत %1$sएक विशिष्ट पेज या कई पेज के सेट खोलें%2$s "
+"चुनें"
 
 #  Opera default search engine instruction
 # smartling.placeholder_format=C
@@ -21261,8 +21412,8 @@ msgid ""
 "Unlock %s, higher AI reasoning, and 2x higher usage limits than the Plus "
 "plan by upgrading to Pro."
 msgstr ""
-"Pro में अपग्रेड करके %1$s, बेहतर AI रीज़निंग, और Plus प्लान की तुलना में 2 गुना ज़्यादा "
-"उपयोग सीमाएं अनलॉक करें।"
+"Pro में अपग्रेड करके %1$s, बेहतर AI रीज़निंग, और Plus प्लान की तुलना में 2 "
+"गुना ज़्यादा उपयोग सीमाएं अनलॉक करें।"
 
 # smartling.placeholder_format=C
 #. Title for the subscription promo shown in the SERP sidemenu.
@@ -21396,8 +21547,8 @@ msgid ""
 "Update the DuckDuckGo browser to activate your subscription in Duck.ai and "
 "access advanced models"
 msgstr ""
-"Duck.ai में अपने सब्सक्रिप्शन को एक्टिव करने और एडवांस्ड मॉडल्स एक्सेस करने के लिए "
-"DuckDuckGo ब्राउज़र को अपडेट करें"
+"Duck.ai में अपने सब्सक्रिप्शन को एक्टिव करने और एडवांस्ड मॉडल्स एक्सेस करने "
+"के लिए DuckDuckGo ब्राउज़र को अपडेट करें"
 
 # smartling.placeholder_format=C
 #. The placeholder indicates a formatted date (e.g., 'Updated 2 days ago')
@@ -21522,14 +21673,16 @@ msgid ""
 "Upgrade to Pro to unlock 2x higher limits than Plus, or come back later to "
 "create more images."
 msgstr ""
-"Plus से 2 गुना ज़्यादा लिमिट पाने के लिए Pro में अपग्रेड करें, या अधिक इमेज बनाने के लिए "
-"बाद में वापस आएं।"
+"Plus से 2 गुना ज़्यादा लिमिट पाने के लिए Pro में अपग्रेड करें, या अधिक इमेज "
+"बनाने के लिए बाद में वापस आएं।"
 
 # smartling.placeholder_format=C
 #. Upsell message shown in the voice chat limit and duration limit modals for Plus subscribers, encouraging them to upgrade to Pro.
 msgctxt "voice chat limit modal"
 msgid "Upgrade to Pro to unlock 2x higher usage limits than Plus"
-msgstr "Plus की तुलना में 2 गुना ज़्यादा उपयोग सीमाएं अनलॉक करने के लिए Pro में अपग्रेड करें"
+msgstr ""
+"Plus की तुलना में 2 गुना ज़्यादा उपयोग सीमाएं अनलॉक करने के लिए Pro में "
+"अपग्रेड करें"
 
 # smartling.placeholder_format=C
 #. Heading in a promotion for a desktop web browser
@@ -21581,7 +21734,7 @@ msgstr "उरुग्वे"
 #. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
 msgctxt "Navigation label on the Duck.ai settings page"
 msgid "Usage"
-msgstr ""
+msgstr "उपयोग"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -21625,9 +21778,9 @@ msgid ""
 "Use ChatGPT, Claude, and other AIs, privately. Protect chats from hackers, "
 "scammers, and companies. Keep info confidential. Free. No account required."
 msgstr ""
-"ChatGPT, Claude और अन्य AI का उपयोग गोपनीय ढंग से निजी तौर पर करें। चैट्स को हैकर्स, "
-"स्कैमर्स और कंपनियों से सुरक्षित रखें। जानकारी गोपनीय बनाए रखें। मुफ़्त। किसी खाते की ज़रूरत "
-"नहीं है।"
+"ChatGPT, Claude और अन्य AI का उपयोग गोपनीय ढंग से निजी तौर पर करें। चैट्स को "
+"हैकर्स, स्कैमर्स और कंपनियों से सुरक्षित रखें। जानकारी गोपनीय बनाए रखें। "
+"मुफ़्त। किसी खाते की ज़रूरत नहीं है।"
 
 # smartling.placeholder_format=C
 #. Header above instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -21669,8 +21822,8 @@ msgctxt "Description for the recovery section inside Manage"
 msgid ""
 "Use this code to restore your saved chats if you lose access to your devices."
 msgstr ""
-"अगर आप अपने डिवाइस का एक्सेस खो देते हैं, तो अपनी सेव की गई चैट्स वापस पाने के लिए इस "
-"कोड का इस्तेमाल करें।"
+"अगर आप अपने डिवाइस का एक्सेस खो देते हैं, तो अपनी सेव की गई चैट्स वापस पाने "
+"के लिए इस कोड का इस्तेमाल करें।"
 
 # smartling.placeholder_format=C
 #. Prompt to ask the user if they want to use their approximate location for more accurate results
@@ -21820,8 +21973,8 @@ msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Microsoft's ad network"
 msgstr ""
-"विज्ञापन देखना DuckDuckGo द्वारा गोपनीयता संरक्षित है। विज्ञापन क्लिक को Microsoft के "
-"विज्ञापन नेटवर्क द्वारा प्रबंधित किया जाता है"
+"विज्ञापन देखना DuckDuckGo द्वारा गोपनीयता संरक्षित है। विज्ञापन क्लिक को "
+"Microsoft के विज्ञापन नेटवर्क द्वारा प्रबंधित किया जाता है"
 
 # smartling.placeholder_format=C
 #. Information about TripAdvisor ads for DuckDuckGo's users. This appears in a tooltip.
@@ -21830,8 +21983,8 @@ msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "TripAdvisor's ad network."
 msgstr ""
-"विज्ञापन देखना DuckDuckGo द्वारा गोपनीयता संरक्षित है। विज्ञापन क्लिक TripAdvisor के "
-"विज्ञापन नेटवर्क द्वारा प्रबंधित किए जाते हैं।"
+"विज्ञापन देखना DuckDuckGo द्वारा गोपनीयता संरक्षित है। विज्ञापन क्लिक "
+"TripAdvisor के विज्ञापन नेटवर्क द्वारा प्रबंधित किए जाते हैं।"
 
 # smartling.placeholder_format=C
 msgid "Virgin Islands"
@@ -21843,8 +21996,8 @@ msgctxt "duckassist"
 msgid ""
 "Visit %sAssist Settings%s to adjust how this feature works or turn it off."
 msgstr ""
-"इस फ़ीचर के काम करने का तरीका एडजस्ट करने या इसे बंद करने के लिए %1$sAssist सेटिंग%2$s "
-"पर जाएं।"
+"इस फ़ीचर के काम करने का तरीका एडजस्ट करने या इसे बंद करने के लिए %1$sAssist "
+"सेटिंग%2$s पर जाएं।"
 
 # smartling.placeholder_format=C
 #. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
@@ -21853,8 +22006,8 @@ msgid ""
 "Visit %sDuckAssist Settings%s to adjust how this feature works or turn it "
 "off."
 msgstr ""
-"इस फ़ीचर के काम करने का तरीका एडजस्ट करने या इसे बंद करने के लिए %1$sDuckAssist "
-"सेटिंग%2$s पर जाएं।"
+"इस फ़ीचर के काम करने का तरीका एडजस्ट करने या इसे बंद करने के लिए "
+"%1$sDuckAssist सेटिंग%2$s पर जाएं।"
 
 # smartling.placeholder_format=C
 #. Prompt to visit DuckDuckGo on another device.
@@ -21863,7 +22016,8 @@ msgid ""
 "Visit %sDuckDuckGo.com%s on your tablet or phone and follow the provided "
 "instructions."
 msgstr ""
-"अपने टैबलेट या फ़ोन पर %1$sDuckDuckGo.com%2$s पर जाएं और दिए गए निर्देशों का पालन करें।"
+"अपने टैबलेट या फ़ोन पर %1$sDuckDuckGo.com%2$s पर जाएं और दिए गए निर्देशों का "
+"पालन करें।"
 
 # smartling.placeholder_format=C
 #. Primary button to visit Duck.ai.
@@ -21879,8 +22033,8 @@ msgid ""
 "& Backup%s > %sManage%s then select %sSync With Another Device%s."
 msgstr ""
 "अपने दूसरे ब्राउज़र में Duck.ai पर जाकर %1$sDuck.ai सेटिंग%2$s > %3$sSync & "
-"Backup%4$s > %5$sमैनेज करें%6$s पर जाएं और उसके बाद %7$sकिसी दूसरे डिवाइस के साथ सिंक "
-"करें%8$s को चुनें।"
+"Backup%4$s > %5$sमैनेज करें%6$s पर जाएं और उसके बाद %7$sकिसी दूसरे डिवाइस के "
+"साथ सिंक करें%8$s को चुनें।"
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -21890,9 +22044,9 @@ msgid ""
 "On” under Sync & Backup and select “Sync With Another Device”. Or scan the "
 "QR on your Recovery PDF."
 msgstr ""
-"अपने दूसरे ब्राउज़र में Duck.ai पर जाएं और Duck.ai की सेटिंग खोलें। Sync & Backup के "
-"अंतर्गत \"चालू करें\" को चुनें और \"किसी दूसरे डिवाइस के साथ सिंक करें\" को चुनें। या अपनी "
-"रिकवरी PDF पर मौजूद QR कोड स्कैन करें।"
+"अपने दूसरे ब्राउज़र में Duck.ai पर जाएं और Duck.ai की सेटिंग खोलें। Sync & "
+"Backup के अंतर्गत \"चालू करें\" को चुनें और \"किसी दूसरे डिवाइस के साथ सिंक "
+"करें\" को चुनें। या अपनी रिकवरी PDF पर मौजूद QR कोड स्कैन करें।"
 
 # smartling.placeholder_format=C
 #. Shared body copy for every screen in the Sync Another Device flow (QR display, camera scan, camera-unavailable fallback, manual entry). Bold tags wrap navigation breadcrumbs. Render with <Translate /> so the HTML is interpreted; plain `translate()` will trip the html-string warning.
@@ -21902,9 +22056,9 @@ msgid ""
 "ai Settings%s > %sSync & Backup%s > %sManage%s then select %sSync With "
 "Another Device%s."
 msgstr ""
-"अपने दूसरे ब्राउज़र या DuckDuckGo ऐप में Duck.ai पर जाकर %1$sDuck.ai सेटिंग%2$s > "
-"%3$sSync & Backup%4$s > %5$sमैनेज करें%6$s पर जाएं और उसके बाद %7$sकिसी दूसरे डिवाइस "
-"के साथ सिंक करें%8$s को चुनें।"
+"अपने दूसरे ब्राउज़र या DuckDuckGo ऐप में Duck.ai पर जाकर %1$sDuck.ai "
+"सेटिंग%2$s > %3$sSync & Backup%4$s > %5$sमैनेज करें%6$s पर जाएं और उसके बाद "
+"%7$sकिसी दूसरे डिवाइस के साथ सिंक करें%8$s को चुनें।"
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -21914,9 +22068,10 @@ msgid ""
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
 msgstr ""
-"अपने दूसरे ब्राउज़र या DuckDuckGo ऐप में Duck.ai पर जाएं और Duck.ai की सेटिंग खोलें। "
-"Sync & Backup के अंतर्गत \"चालू करें\" को चुनें और \"किसी दूसरे डिवाइस के साथ सिंक करें\" "
-"को चुनें। या अपनी रिकवरी PDF पर मौजूद QR कोड स्कैन करें।"
+"अपने दूसरे ब्राउज़र या DuckDuckGo ऐप में Duck.ai पर जाएं और Duck.ai की "
+"सेटिंग खोलें। Sync & Backup के अंतर्गत \"चालू करें\" को चुनें और \"किसी "
+"दूसरे डिवाइस के साथ सिंक करें\" को चुनें। या अपनी रिकवरी PDF पर मौजूद QR कोड "
+"स्कैन करें।"
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -21969,8 +22124,8 @@ msgstr "वॉयस चैट समाप्त हो गई"
 msgctxt "voice chat"
 msgid "Voice chat is anonymized by us, and never used to train AI models."
 msgstr ""
-"हम वॉयस चैट को गुमनाम रखते हैं और इसका उपयोग कभी भी AI मॉडल प्रशिक्षित करने के लिए "
-"नहीं किया जाता है।"
+"हम वॉयस चैट को गुमनाम रखते हैं और इसका उपयोग कभी भी AI मॉडल प्रशिक्षित करने "
+"के लिए नहीं किया जाता है।"
 
 # smartling.placeholder_format=C
 #. Title of the modal shown when the user has reached their daily voice chat limit.
@@ -22034,7 +22189,7 @@ msgstr "वेल्स"
 #. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Walk me through the steps"
-msgstr ""
+msgstr "मुझे एक-एक करके सारे स्टेप बताएं"
 
 # smartling.placeholder_format=C
 #. Label for walking directions on a map.
@@ -22114,8 +22269,8 @@ msgid ""
 "Watch in Duck Player to block personalized ads on YouTube and prevent your "
 "viewing activity from influencing YouTube recommendations."
 msgstr ""
-"YouTube पर वैयक्तिकृत विज्ञापनों को ब्लॉक करने और अपनी देखने की गतिविधि को YouTube "
-"अनुशंसाओं को प्रभावित करने से रोकने के लिए Duck प्लेयर में देखें।"
+"YouTube पर वैयक्तिकृत विज्ञापनों को ब्लॉक करने और अपनी देखने की गतिविधि को "
+"YouTube अनुशंसाओं को प्रभावित करने से रोकने के लिए Duck प्लेयर में देखें।"
 
 # smartling.placeholder_format=C
 #. A button that takes a user to another site in order to watch a video. The placeholder is the name of the video site. For example: 'Watch on Vimeo'
@@ -22135,9 +22290,10 @@ msgid ""
 "independent company and has no relationship with YouTube, where most videos "
 "are hosted."
 msgstr ""
-"यहाँ वीडियो देखने का अर्थ है कि होस्ट की गई वेबसाइट आपको ट्रैक कर सकती है क्योंकि हमें वहाँ "
-"से कॉन्टेंट स्ट्रीम करना होगा। DuckDuckGo एक स्वतंत्र कंपनी है और इसका YouTube से कोई "
-"संबंध नहीं है, जहाँ अधिकांश वीडियो होस्ट किए जाते हैं।"
+"यहाँ वीडियो देखने का अर्थ है कि होस्ट की गई वेबसाइट आपको ट्रैक कर सकती है "
+"क्योंकि हमें वहाँ से कॉन्टेंट स्ट्रीम करना होगा। DuckDuckGo एक स्वतंत्र "
+"कंपनी है और इसका YouTube से कोई संबंध नहीं है, जहाँ अधिकांश वीडियो होस्ट किए "
+"जाते हैं।"
 
 # smartling.placeholder_format=C
 #. Heading for the highlight card explaining anonymized prompt delivery.
@@ -22150,8 +22306,8 @@ msgstr "हम गुमनाम करते हैं"
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
 msgstr ""
-"आपको अधिक सटीक नतीजे दिखाने के लिए हम%1$s आपके स्थान%2$s की जानकारी को गुमनाम रख "
-"सकते हैं।"
+"आपको अधिक सटीक नतीजे दिखाने के लिए हम%1$s आपके स्थान%2$s की जानकारी को "
+"गुमनाम रख सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
@@ -22163,6 +22319,9 @@ msgid ""
 "please share this conversation with DuckDuckGo so we can investigate and "
 "address the issue."
 msgstr ""
+"सुधार तभी मुमकिन है, जब कमी नज़र आए। किसी हानिकारक या गैरकानूनी जवाब की "
+"रिपोर्ट करने के लिए, कृपया इस बातचीत को DuckDuckGo के साथ शेयर करें ताकि हम "
+"जांच कर सकें और समस्या का समाधान कर सकें।"
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -22174,16 +22333,17 @@ msgid ""
 "please share your prompt and response so we can investigate and address the "
 "issue."
 msgstr ""
-"सुधार तभी मुमकिन है, जब कमी नज़र आए। किसी हानिकारक या गैर-कानूनी जवाब की रिपोर्ट "
-"करने के लिए, कृपया अपना प्रॉम्प्ट और जवाब शेयर करें, ताकि हम उस मामले की जांच करके उसे "
-"ठीक कर सकें।"
+"सुधार तभी मुमकिन है, जब कमी नज़र आए। किसी हानिकारक या गैर-कानूनी जवाब की "
+"रिपोर्ट करने के लिए, कृपया अपना प्रॉम्प्ट और जवाब शेयर करें, ताकि हम उस "
+"मामले की जांच करके उसे ठीक कर सकें।"
 
 # smartling.placeholder_format=C
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can use your anonymous%s location%s to show you nearby results."
 msgstr ""
-"आपको आस-पास के परिणाम दिखाने के लिए हम आपके अनाम%1$s स्थान%2$s का इस्‍तेमाल कर सकते हैं।"
+"आपको आस-पास के परिणाम दिखाने के लिए हम आपके अनाम%1$s स्थान%2$s का इस्‍तेमाल "
+"कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Error message displayed when one or more attached files are encrypted and cannot be read.
@@ -22191,7 +22351,8 @@ msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
 msgstr ""
-"हम अटैच की गई फ़ाइलों को पढ़ नहीं पा रहे हैं, क्योंकि उनमें से कम से कम एक एन्क्रिप्टेड है।"
+"हम अटैच की गई फ़ाइलों को पढ़ नहीं पा रहे हैं, क्योंकि उनमें से कम से कम एक "
+"एन्क्रिप्टेड है।"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -22203,7 +22364,8 @@ msgstr "हम विज्ञापनों के साथ आपको फ�
 msgctxt "cloudsave"
 msgid "We don't store usernames or any personally identifiable information."
 msgstr ""
-"हम यूज़रनेम या किसी भी व्यक्तिगत रूप से पहचान योग्य जानकारी को संग्रहित नहीं करते हैं।"
+"हम यूज़रनेम या किसी भी व्यक्तिगत रूप से पहचान योग्य जानकारी को संग्रहित नहीं "
+"करते हैं।"
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -22220,8 +22382,8 @@ msgid ""
 "We don't store your personal info. We don't follow you around with ads. We "
 "don't track you. Ever."
 msgstr ""
-"हम आपकी गोपनीय जानकारी स्टोर नहीं करते। हम विज्ञापनों के साथ आपको फ़ॉलो नहीं करते हैं। "
-"हम आपको ट्रैक नहीं करते हैं। कभी भी।"
+"हम आपकी गोपनीय जानकारी स्टोर नहीं करते। हम विज्ञापनों के साथ आपको फ़ॉलो नहीं "
+"करते हैं। हम आपको ट्रैक नहीं करते हैं। कभी भी।"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -22235,8 +22397,8 @@ msgid ""
 "We don't track you, so we could use your help telling us what brought you "
 "back today:"
 msgstr ""
-"हम आपको ट्रैक नहीं करते हैं, ताकि यह बताने में आपकी मदद ले सके कि आप आज यहां वापस क्यों आए "
-"हैं:"
+"हम आपको ट्रैक नहीं करते हैं, ताकि यह बताने में आपकी मदद ले सके कि आप आज यहां "
+"वापस क्यों आए हैं:"
 
 # smartling.placeholder_format=C
 #. Message prompting users to fill out a feedback form.
@@ -22245,8 +22407,8 @@ msgid ""
 "We don't track you, so we could use your help telling us what convinced you "
 "to try us out today:"
 msgstr ""
-"हम आपको ट्रैक नहीं करते हैं, ताकि यह जानने में आपकी मदद ली जा सके कि आप किस वजह से हमें "
-"आज़माना चाहते हैं:"
+"हम आपको ट्रैक नहीं करते हैं, ताकि यह जानने में आपकी मदद ली जा सके कि आप किस "
+"वजह से हमें आज़माना चाहते हैं:"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -22286,8 +22448,9 @@ msgid ""
 "We don’t store your search history. We therefore have nothing to sell to "
 "advertisers that track you across the Internet."
 msgstr ""
-"हम आपकी खोज का इतिहास स्टोर नहीं करते हैं। इसलिए हमारे पास ऐसे विज्ञापनकर्ताओं को बेचने "
-"के लिए कुछ भी नहीं है जो आपको इंटरनेट पर ट्रैक करते हैं।"
+"हम आपकी खोज का इतिहास स्टोर नहीं करते हैं। इसलिए हमारे पास ऐसे "
+"विज्ञापनकर्ताओं को बेचने के लिए कुछ भी नहीं है जो आपको इंटरनेट पर ट्रैक करते "
+"हैं।"
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -22313,8 +22476,8 @@ msgid ""
 "We have agreements with all AI providers to ensure your chats aren't used to "
 "train AIs."
 msgstr ""
-"हमने सभी AI प्रोवाइडर्स के साथ एग्रीमेंट किए हैं ताकि यह पक्का किया जा सके कि आपकी चैट्स "
-"का इस्तेमाल AI को ट्रेन करने के लिए न हो।"
+"हमने सभी AI प्रोवाइडर्स के साथ एग्रीमेंट किए हैं ताकि यह पक्का किया जा सके "
+"कि आपकी चैट्स का इस्तेमाल AI को ट्रेन करने के लिए न हो।"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -22339,8 +22502,8 @@ msgid ""
 "We make money from %sprivacy-respecting search ads%s, not by exploiting your "
 "data."
 msgstr ""
-"हम %1$sगोपनीयता का सम्मान करने वाले खोज विज्ञापनों%2$s से पैसा कमाते हैं, आपके डेटा का "
-"फायदा उठाकर नहीं।"
+"हम %1$sगोपनीयता का सम्मान करने वाले खोज विज्ञापनों%2$s से पैसा कमाते हैं, "
+"आपके डेटा का फायदा उठाकर नहीं।"
 
 # smartling.placeholder_format=C
 #. Message describing how DuckDuckGo users location access anonymously to provide better search results.
@@ -22349,19 +22512,23 @@ msgid ""
 "We only use your anonymous location to deliver better results, closer to "
 "you. You can always change your mind later."
 msgstr ""
-"हम आपके करीब आपके अनाम स्थान का इस्‍तेमाल केवल बेहतर परिणाम देने के लिए करते हैं। आप अक्‍सर "
-"बाद में अपना विचार बदल सकते हैं।"
+"हम आपके करीब आपके अनाम स्थान का इस्‍तेमाल केवल बेहतर परिणाम देने के लिए करते "
+"हैं। आप अक्‍सर बाद में अपना विचार बदल सकते हैं।"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
-msgstr "हम DuckDuckGo को सबके लिए बेहतर बनाने हेतु आपकी गुमनाम फीडबैक पर निर्भर करते हैं।"
+msgstr ""
+"हम DuckDuckGo को सबके लिए बेहतर बनाने हेतु आपकी गुमनाम फीडबैक पर निर्भर करते "
+"हैं।"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We stop anyone from getting your search history, including us."
-msgstr "हम सभी को आपका खोज का इतिहास प्राप्त करने से रोकते हैं, जिनमें हम भी शामिल हैं।"
+msgstr ""
+"हम सभी को आपका खोज का इतिहास प्राप्त करने से रोकते हैं, जिनमें हम भी शामिल "
+"हैं।"
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -22377,15 +22544,16 @@ msgid ""
 "incorporated at the discretion of %s. Corrections may not show up in results "
 "right away."
 msgstr ""
-"हम इस तरह की प्रतिक्रिया का उपयोग करते हैं ताकि DuckDuckGo को बेहतर बनाया जा सके। "
-"%1$s के विवेकानुसार सुझावों को शामिल किया जाएगा। हो सकता है कि सुधार तुरंत परिणामों में "
-"दिखाई ना दें।"
+"हम इस तरह की प्रतिक्रिया का उपयोग करते हैं ताकि DuckDuckGo को बेहतर बनाया जा "
+"सके। %1$s के विवेकानुसार सुझावों को शामिल किया जाएगा। हो सकता है कि सुधार "
+"तुरंत परिणामों में दिखाई ना दें।"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
 msgstr ""
-"जैसे ही आप ब्राउज़ करेंगे, हम आपके डेटा एकत्र करने का प्रयास करने वाले ट्रैकर्स को ब्लॉक कर देंगे।"
+"जैसे ही आप ब्राउज़ करेंगे, हम आपके डेटा एकत्र करने का प्रयास करने वाले "
+"ट्रैकर्स को ब्लॉक कर देंगे।"
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -22394,8 +22562,9 @@ msgid ""
 "We're aware of this issue and are currently working to resolve it. If you "
 "continue to see this error, please reach out to %s."
 msgstr ""
-"हमें इस समस्या की जानकारी है और फ़िलहाल हम इसे हल करने के लिए काम कर रहे हैं। अगर आपको "
-"यह गड़बड़ी लगातार दिखाई दे रही है, तो कृपया %1$s से संपर्क करें।"
+"हमें इस समस्या की जानकारी है और फ़िलहाल हम इसे हल करने के लिए काम कर रहे "
+"हैं। अगर आपको यह गड़बड़ी लगातार दिखाई दे रही है, तो कृपया %1$s से संपर्क "
+"करें।"
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -22404,8 +22573,8 @@ msgid ""
 "We're aware of this issue and are currently working to resolve it. Sometimes "
 "clearing your browser's cache can help."
 msgstr ""
-"हमें इस समस्या की जानकारी है और फ़िलहाल हम इसे हल करने के लिए काम कर रहे हैं। कभी-कभी "
-"अपने ब्राउज़र का कैशे मिटाने से समस्या हल हो जाती है।"
+"हमें इस समस्या की जानकारी है और फ़िलहाल हम इसे हल करने के लिए काम कर रहे "
+"हैं। कभी-कभी अपने ब्राउज़र का कैशे मिटाने से समस्या हल हो जाती है।"
 
 # smartling.placeholder_format=C
 #. Header for a feedback form for new users.
@@ -22420,7 +22589,8 @@ msgid ""
 "We're sorry for this inconvenience. We’re working hard to make your "
 "experience better."
 msgstr ""
-"इस असुविधा के लिए हमें खेद है। हम आपके अनुभव को बेहतर बनाने के लिए लगातार मेहनत कर रहे हैं।"
+"इस असुविधा के लिए हमें खेद है। हम आपके अनुभव को बेहतर बनाने के लिए लगातार "
+"मेहनत कर रहे हैं।"
 
 # smartling.placeholder_format=C
 #. Body text explaining the service update requires a page reload.
@@ -22429,8 +22599,8 @@ msgid ""
 "We've updated the Duck.ai service. For the change to take effect, we need to "
 "reload the page."
 msgstr ""
-"हमने Duck.ai सेवा को अपडेट कर दिया है। बदलाव प्रभावी होने के लिए, हमें पेज फिर से लोड "
-"करना होगा।"
+"हमने Duck.ai सेवा को अपडेट कर दिया है। बदलाव प्रभावी होने के लिए, हमें पेज "
+"फिर से लोड करना होगा।"
 
 # smartling.placeholder_format=C
 #. Instant Answer Tab Name
@@ -22524,7 +22694,9 @@ msgstr "साप्ताहिक सीमा पूरी हो गई"
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Weekly usage limit reached. You can continue this chat after %s."
-msgstr "साप्ताहिक उपयोग सीमा पूरी हो गई है। आप %1$s के बाद इस चैट को जारी रख सकते हैं।"
+msgstr ""
+"साप्ताहिक उपयोग सीमा पूरी हो गई है। आप %1$s के बाद इस चैट को जारी रख सकते "
+"हैं।"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable weekly Duck.ai usage limit and can opt in to continue using the monthly limit.
@@ -22533,8 +22705,8 @@ msgid ""
 "Weekly usage limit reached. You can keep chatting by using your monthly "
 "limit."
 msgstr ""
-"साप्ताहिक उपयोग सीमा पूरी हो गई है। आप अपनी मासिक सीमा का उपयोग करके चैट करना "
-"जारी रख सकते हैं।"
+"साप्ताहिक उपयोग सीमा पूरी हो गई है। आप अपनी मासिक सीमा का उपयोग करके चैट "
+"करना जारी रख सकते हैं।"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -22548,8 +22720,9 @@ msgid ""
 "Welcome to Duck.ai! All of your chats here are private, anonymized by us and "
 "not used to train AI models."
 msgstr ""
-"Duck.ai में आपका स्वागत है! यहां आपकी सभी चैट गोपनीय रहती हैं, हम उन्हें अनाम कर देते हैं "
-"और उनका इस्तेमाल AI मॉडलों को प्रशिक्षित करने के लिए नहीं किया जाता।"
+"Duck.ai में आपका स्वागत है! यहां आपकी सभी चैट गोपनीय रहती हैं, हम उन्हें "
+"अनाम कर देते हैं और उनका इस्तेमाल AI मॉडलों को प्रशिक्षित करने के लिए नहीं "
+"किया जाता।"
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened.
@@ -22558,8 +22731,9 @@ msgid ""
 "Welcome to DuckDuckGo AI Chat! All of your chats here are private, "
 "anonymized by us and not used to train AI models."
 msgstr ""
-"DuckDuckGo AI Chat में आपका स्वागत है! यहां आपकी सभी चैट गोपनीय रहती हैं, हम उन्हें "
-"अनाम कर देते हैं और उनका इस्तेमाल AI मॉडलों को प्रशिक्षित करने के लिए नहीं किया जाता।"
+"DuckDuckGo AI Chat में आपका स्वागत है! यहां आपकी सभी चैट गोपनीय रहती हैं, हम "
+"उन्हें अनाम कर देते हैं और उनका इस्तेमाल AI मॉडलों को प्रशिक्षित करने के लिए "
+"नहीं किया जाता।"
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened. Example: 'Welcome to DuckDuckGo AI Chat! This chat session is powered by OpenAI’s GPT-3. All of your chats here are private, and are never stored by DuckDuckGo or used to train AI models.'
@@ -22569,16 +22743,17 @@ msgid ""
 "of your chats here are private, and are never stored by DuckDuckGo or used "
 "to train AI models."
 msgstr ""
-"DuckDuckGo AI Chat में आपका स्वागत है! इस चैट सेशन को %1$s का %2$s संचालित करता है। "
-"यहां आपकी सभी चैट निजी हैं और उन्हें DuckDuckGo कभी भी स्टोर नहीं करता है या उनका "
-"उपयोग AI मॉडल को प्रशिक्षित करने में नहीं किया जाता है।"
+"DuckDuckGo AI Chat में आपका स्वागत है! इस चैट सेशन को %1$s का %2$s संचालित "
+"करता है। यहां आपकी सभी चैट निजी हैं और उन्हें DuckDuckGo कभी भी स्टोर नहीं "
+"करता है या उनका उपयोग AI मॉडल को प्रशिक्षित करने में नहीं किया जाता है।"
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai! You can now import your downloaded chats."
 msgstr ""
-"नए Duck.ai में आपका स्वागत है! अब आप अपनी डाउनलोड की गई चैट्स को इंपोर्ट कर सकते हैं।"
+"नए Duck.ai में आपका स्वागत है! अब आप अपनी डाउनलोड की गई चैट्स को इंपोर्ट कर "
+"सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -22646,8 +22821,8 @@ msgid ""
 "We’re really sorry, but it seems there was a problem loading Duck.ai. Try "
 "reloading the page."
 msgstr ""
-"हमें वाकई खेद है, लेकिन ऐसा लगता है कि Duck.ai को लोड करने में कोई समस्या आई है। पेज को "
-"रीलोड करने की कोशिश करें।"
+"हमें वाकई खेद है, लेकिन ऐसा लगता है कि Duck.ai को लोड करने में कोई समस्या आई "
+"है। पेज को रीलोड करने की कोशिश करें।"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to suggest an AI (Artificial Intelligence) model to be added to the product, and this field is optional.
@@ -22682,7 +22857,8 @@ msgid ""
 "What are some options for the word ‘better’ in the context of “We really "
 "need to do better.”"
 msgstr ""
-"\"हमें वास्तव में बेहतर काम करना होगा\" के संदर्भ में 'बेहतर' शब्द के लिए कुछ विकल्प बताएं।"
+"\"हमें वास्तव में बेहतर काम करना होगा\" के संदर्भ में 'बेहतर' शब्द के लिए "
+"कुछ विकल्प बताएं।"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
@@ -22701,108 +22877,109 @@ msgid ""
 "easy to understand for people with or without much AI, or technical, "
 "experience."
 msgstr ""
-"Duck.ai इस्तेमाल करने में रुचि रखने वाले लोगों के लिए, DuckDuckGo ब्राउज़र डाउनलोड करने के "
-"क्या फ़ायदे हैं? केवल आधिकारिक DuckDuckGo स्रोतों का ही संदर्भ लें। जवाब को स्पष्ट हिस्सों में "
-"बांटें और हर हिस्से के लिए शीर्षक दें, जिसमें Duck.ai इंटीग्रेशन और प्राइवेसी की रक्षा पर "
-"विशेष ध्यान दिया गया हो। इसे संक्षिप्त, सरल और समझने में आसान रखें, ताकि AI या तकनीकी "
-"अनुभव रखने वाले या न रखने वाले लोग भी इसे आसानी से समझ सकें।"
+"Duck.ai इस्तेमाल करने में रुचि रखने वाले लोगों के लिए, DuckDuckGo ब्राउज़र "
+"डाउनलोड करने के क्या फ़ायदे हैं? केवल आधिकारिक DuckDuckGo स्रोतों का ही "
+"संदर्भ लें। जवाब को स्पष्ट हिस्सों में बांटें और हर हिस्से के लिए शीर्षक "
+"दें, जिसमें Duck.ai इंटीग्रेशन और प्राइवेसी की रक्षा पर विशेष ध्यान दिया गया "
+"हो। इसे संक्षिप्त, सरल और समझने में आसान रखें, ताकि AI या तकनीकी अनुभव रखने "
+"वाले या न रखने वाले लोग भी इसे आसानी से समझ सकें।"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the counterarguments?"
-msgstr ""
+msgstr "इसके विरोध में क्या तर्क हैं?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the hours & location?"
-msgstr ""
+msgstr "समय और जगह क्या है?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key contributions of this paper?"
-msgstr ""
+msgstr "इस पेपर के मुख्य योगदान क्या हैं?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key contributions?"
-msgstr ""
+msgstr "मुख्य योगदान क्या हैं?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key details?"
-msgstr ""
+msgstr "प्रमुख विवरण क्या हैं?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key points covered in this video?"
-msgstr ""
+msgstr "इस वीडियो में कवर किए गए मुख्य बिंदु क्या हैं?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key points?"
-msgstr ""
+msgstr "मुख्य बिंदु क्या हैं?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key takeaways from this article?"
-msgstr ""
+msgstr "इस लेख के प्रमुख निष्कर्ष क्या हैं?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key takeaways?"
-msgstr ""
+msgstr "प्रमुख निष्कर्ष क्या हैं?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key things I will learn from this course?"
-msgstr ""
+msgstr "इस कोर्स से मुझे कौन-सी मुख्य बातें सीखने को मिलेंगी?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the main counterarguments or criticisms of this?"
-msgstr ""
+msgstr "इसके मुख्य विरोधी तर्क या आलोचनाएं क्या हैं?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the main questions this page answers?"
-msgstr ""
+msgstr "यह पेज मुख्य रूप से किन सवालों के जवाब देता है?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the must-try dishes here?"
-msgstr ""
+msgstr "यहां कौन-सी डिशेज़ अवश्य ट्राई करनी चाहिए?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid ""
 "What are the opening hours, location, and contact details for this place?"
-msgstr ""
+msgstr "इस जगह के खुलने का समय, स्थान और संपर्क विवरण क्या हैं?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the pros and cons of this product?"
-msgstr ""
+msgstr "इस प्रोडक्ट के फ़ायदे और नुकसान क्या हैं?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the pros and cons?"
-msgstr ""
+msgstr "फ़ायदे और नुकसान क्या हैं?"
 
 # smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
@@ -22908,7 +23085,7 @@ msgstr "चिकित्सा संबंधी लेख के संद�
 #. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What does this answer?"
-msgstr ""
+msgstr "यह किस बात का जवाब देता है?"
 
 # smartling.placeholder_format=C
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
@@ -22926,7 +23103,7 @@ msgstr "कौन सी जानकारी सेव होती है?"
 #. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What interview questions might come up for this role?"
-msgstr ""
+msgstr "इस रोल के लिए इंटरव्यू में कौन-से सवाल पूछे जा सकते हैं?"
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -22935,7 +23112,8 @@ msgid ""
 "What is the Cloud Save bookmarklet and how does it differ from the URL "
 "parameter bookmarklet?"
 msgstr ""
-"Cloud Save बुकमार्कलेट क्या है और यह यूआरएल पैरामीटर बुकमार्कलेट से कैसे अलग होता है?"
+"Cloud Save बुकमार्कलेट क्या है और यह यूआरएल पैरामीटर बुकमार्कलेट से कैसे अलग "
+"होता है?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for looking up the capital city of Albania.
@@ -22947,7 +23125,7 @@ msgstr "अल्बानिया की राजधानी क्या �
 #. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What is the overall verdict and rating for this?"
-msgstr ""
+msgstr "इसके लिए कुल मिलाकर क्या राय है और क्या रेटिंग है?"
 
 # smartling.placeholder_format=C
 #. Link to a page with additional information.
@@ -22975,7 +23153,7 @@ msgstr "लोग क्या कहते हैं:"
 #. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What should I order?"
-msgstr ""
+msgstr "मैं क्या ऑर्डर करूं?"
 
 # smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
@@ -22993,13 +23171,13 @@ msgstr "जवाब में क्या गलत था? (वैकल्�
 #. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What will I learn?"
-msgstr ""
+msgstr "मुझे क्या सीखने को मिलेगा?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What will I need?"
-msgstr ""
+msgstr "मुझे क्या चाहिए होगा?"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -23011,8 +23189,8 @@ msgstr "आप किस पर फीडबैक देना चाहें�
 msgid ""
 "What you watch in DuckDuckGo won't influence your recommendations on YouTube."
 msgstr ""
-"आप DuckDuckGo में जो देखते हैं, वह YouTube पर आपके रिकमंडेशन या सुझावों को प्रभावित नहीं "
-"करेगा।"
+"आप DuckDuckGo में जो देखते हैं, वह YouTube पर आपके रिकमंडेशन या सुझावों को "
+"प्रभावित नहीं करेगा।"
 
 # smartling.placeholder_format=C
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
@@ -23024,7 +23202,7 @@ msgstr "क्या नया है"
 #. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What's the verdict?"
-msgstr ""
+msgstr "क्या फ़ाइनल राय है?"
 
 # smartling.placeholder_format=C
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -23038,8 +23216,8 @@ msgid ""
 "When buying an electric guitar for a beginner, what are the top product "
 "brands I should consider?"
 msgstr ""
-"एक नौसिखिए के तौर पर, इलेक्ट्रिक गिटार खरीदते समय मुझे किन प्रमुख उत्पाद ब्रांडों पर "
-"विचार करना चाहिए?"
+"एक नौसिखिए के तौर पर, इलेक्ट्रिक गिटार खरीदते समय मुझे किन प्रमुख उत्पाद "
+"ब्रांडों पर विचार करना चाहिए?"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -23080,7 +23258,7 @@ msgstr "कौन-से फीचर मौजूद नहीं हैं? (�
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Which features are missing? (optional)"
-msgstr ""
+msgstr "कौन-से फ़ीचर मौजूद नहीं हैं? (वैकल्पिक)"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
@@ -23102,13 +23280,13 @@ msgstr "हम कौन हैं"
 #. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Who are the main cast and crew, and what else are they known for?"
-msgstr ""
+msgstr "मुख्य कास्ट और क्रू कौन हैं, वे और किस काम के लिए जाने जाते हैं?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Who is this person?"
-msgstr ""
+msgstr "यह व्यक्ति कौन है?"
 
 # smartling.placeholder_format=C
 #. Header above a collection of privacy-related links.
@@ -23480,8 +23658,8 @@ msgctxt "cloudsave"
 msgid ""
 "Yes, we throw away data when you’re done with it, and it cannot be recovered."
 msgstr ""
-"हां, जब आप इसके साथ काम करते हैं, तो हम डेटा का निस्तारण कर देते हैं और इसे दोबारा प्राप्त "
-"नहीं किया जा सकता है।"
+"हां, जब आप इसके साथ काम करते हैं, तो हम डेटा का निस्तारण कर देते हैं और इसे "
+"दोबारा प्राप्त नहीं किया जा सकता है।"
 
 # smartling.placeholder_format=C
 #. Option for the filter-by-date search.
@@ -23501,7 +23679,8 @@ msgid ""
 "You are chatting with %s. AI chats may display inaccurate or offensive "
 "information."
 msgstr ""
-"आप %1$s से चैट कर रहे हैं। AI चैट में गलत या आपत्तिजनक जानकारी भी दिखाई दे सकती है।"
+"आप %1$s से चैट कर रहे हैं। AI चैट में गलत या आपत्तिजनक जानकारी भी दिखाई दे "
+"सकती है।"
 
 # smartling.placeholder_format=C
 #. Provide users with the ability to retry their search on a different search engine. First placeholder will be a link with the text "try your search again" OR "try your search later". Second is a URL to the !bangs page: https://duckduckgo.com/bangs.
@@ -23510,8 +23689,8 @@ msgid ""
 "You can %s or search directly on other search engines from DuckDuckGo using "
 "%s search shortcuts."
 msgstr ""
-"आप चाहें तो यह कर सकते हैं: %1$s या फिर %2$s खोज शॉर्टकट का इस्तेमाल करके DuckDuckGo "
-"से सीधे अन्य खोज इंजनों पर खोज सकते हैं।"
+"आप चाहें तो यह कर सकते हैं: %1$s या फिर %2$s खोज शॉर्टकट का इस्तेमाल करके "
+"DuckDuckGo से सीधे अन्य खोज इंजनों पर खोज सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Text informing the user that they can access DuckDuckGo AI Chat directly at a specific URL. The placeholder %s will be replaced with the link. Example: 'You can access DuckDuckGo AI Chat directly at duck.ai.'
@@ -23525,8 +23704,8 @@ msgctxt "duckassist"
 msgid ""
 "You can adjust how %s works or turn it off anytime in %sSearch Settings%s."
 msgstr ""
-"आप %1$s के काम करने के तरीके को %2$sखोज सेटिंग%3$s में एडजस्ट कर सकते हैं या इसे कभी भी "
-"बंद कर सकते हैं।"
+"आप %1$s के काम करने के तरीके को %2$sखोज सेटिंग%3$s में एडजस्ट कर सकते हैं या "
+"इसे कभी भी बंद कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Assist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate Assist.
@@ -23535,22 +23714,22 @@ msgid ""
 "You can adjust how Assist works or turn it off anytime in %sSearch "
 "Settings%s."
 msgstr ""
-"आप %1$sखोज सेटिंग%2$s में जाकर Assist के काम करने के तरीके को एडजस्ट कर सकते हैं या इसे "
-"कभी भी बंद कर सकते हैं।"
+"आप %1$sखोज सेटिंग%2$s में जाकर Assist के काम करने के तरीके को एडजस्ट कर सकते "
+"हैं या इसे कभी भी बंद कर सकते हैं।"
 
 # smartling.placeholder_format=C
 msgid "You can also use %sDuck.ai%s to answer questions or summarize text."
 msgstr ""
-"आप सवालों के जवाब देने या टेक्स्ट को सारांशित करने के लिए %1$sDuck.ai%2$s का भी इस्तेमाल "
-"कर सकते हैं।"
+"आप सवालों के जवाब देने या टेक्स्ट को सारांशित करने के लिए %1$sDuck.ai%2$s का "
+"भी इस्तेमाल कर सकते हैं।"
 
 # smartling.placeholder_format=C
 msgid ""
 "You can also use %sDuckDuckGo AI Chat%s to answer questions or summarize "
 "text."
 msgstr ""
-"आप सवालों के जवाब देने या टेक्स्ट को सारांशित करने के लिए %1$sDuckDuckGo AI Chat%2$s "
-"का भी इस्तेमाल कर सकते हैं।"
+"आप सवालों के जवाब देने या टेक्स्ट को सारांशित करने के लिए %1$sDuckDuckGo AI "
+"Chat%2$s का भी इस्तेमाल कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach more text selections than are allowed. Placeholder is the maximum number of text selections. E.g. You can attach up to 5 text selections.
@@ -23564,8 +23743,8 @@ msgid ""
 "You can change how frequently you see Search Assist, or turn it off "
 "entirely, in %sSearch Settings%s."
 msgstr ""
-"आपको Search Assist कितनी बार देखना है, इसे %1$sखोज Assist सेटिंग%2$s में जाकर बदल "
-"सकते हैं या इसे पूरी तरह से बंद कर सकते हैं।"
+"आपको Search Assist कितनी बार देखना है, इसे %1$sखोज Assist सेटिंग%2$s में "
+"जाकर बदल सकते हैं या इसे पूरी तरह से बंद कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
@@ -23580,8 +23759,8 @@ msgid ""
 "You can do this by saving your settings under a different passphrase, "
 "optionally deleting the first set."
 msgstr ""
-"आप ऐसा अपनी सेटिंग्स को दूसरे पासफ्रेज़ के अंतर्गत सेव करते हुए कर सकते है और चाहे तो पहली "
-"सेटिंग को डिलीट भी कर सकते हैं।"
+"आप ऐसा अपनी सेटिंग्स को दूसरे पासफ्रेज़ के अंतर्गत सेव करते हुए कर सकते है "
+"और चाहे तो पहली सेटिंग को डिलीट भी कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Prefix for filename location sentence.
@@ -23661,8 +23840,8 @@ msgid ""
 "You can only block up to %s sites. To block %s, you'll need to unblock "
 "another site first."
 msgstr ""
-"आप अधिकतम %1$s साइटें ही ब्लॉक कर सकते हैं। %2$s को ब्लॉक करने के लिए, आपको पहले किसी "
-"अन्य साइट को अनब्लॉक करना होगा।"
+"आप अधिकतम %1$s साइटें ही ब्लॉक कर सकते हैं। %2$s को ब्लॉक करने के लिए, आपको "
+"पहले किसी अन्य साइट को अनब्लॉक करना होगा।"
 
 # smartling.placeholder_format=C
 #. Text explaining the benefits of the cloud save feature.
@@ -23719,8 +23898,8 @@ msgid ""
 "You now have access to %s, higher AI reasoning, and 2x higher usage limits "
 "than Plus."
 msgstr ""
-"अब आपको %1$s का एक्सेस हासिल है, बेहतर AI तर्क-क्षमता, और Plus की तुलना में 2 गुना "
-"ज़्यादा उपयोग सीमाएं।"
+"अब आपको %1$s का एक्सेस हासिल है, बेहतर AI तर्क-क्षमता, और Plus की तुलना में "
+"2 गुना ज़्यादा उपयोग सीमाएं।"
 
 # smartling.placeholder_format=C
 #. Description text for the welcome modal displayed after the user subscribes to DuckDuckGo.
@@ -23729,8 +23908,8 @@ msgid ""
 "You now have access to advanced AI models. You can access the VPN and other "
 "DuckDuckGo subscription protections in the DuckDuckGo browser."
 msgstr ""
-"अब आपके पास एडवांस्ड AI मॉडल्स का एक्सेस है। आप DuckDuckGo ब्राउज़र में VPN और अन्य "
-"DuckDuckGo सब्सक्रिप्शन सुरक्षा सुविधाओं का उपयोग कर सकते हैं।"
+"अब आपके पास एडवांस्ड AI मॉडल्स का एक्सेस है। आप DuckDuckGo ब्राउज़र में VPN "
+"और अन्य DuckDuckGo सब्सक्रिप्शन सुरक्षा सुविधाओं का उपयोग कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Welcome message that appears after the DuckDuckGo extension is installed.
@@ -23752,8 +23931,9 @@ msgid ""
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
 msgstr ""
-"अब आप इस ब्राउज़र से अपनी सेव की गई चैट्स एक्सेस नहीं कर पाएंगे। पिछली 30 चैट अभी भी "
-"लोकल स्टोरेज में उपलब्ध रहेंगी। इससे एन्क्रिप्टेड सर्वर से आपकी चैट डिलीट नहीं होंगी।"
+"अब आप इस ब्राउज़र से अपनी सेव की गई चैट्स एक्सेस नहीं कर पाएंगे। पिछली 30 "
+"चैट अभी भी लोकल स्टोरेज में उपलब्ध रहेंगी। इससे एन्क्रिप्टेड सर्वर से आपकी "
+"चैट डिलीट नहीं होंगी।"
 
 # smartling.placeholder_format=C
 #. Explains that turning off disconnects this browser only; the last 30 chats stay in local storage and the encrypted server backup is not deleted.
@@ -23763,8 +23943,9 @@ msgid ""
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
 msgstr ""
-"अब आप इस ब्राउज़र से अपनी सेव की गई चैट्स एक्सेस नहीं कर पाएंगे। पिछली 30 चैट अभी भी "
-"लोकल स्टोरेज में उपलब्ध रहेंगी। इससे एन्क्रिप्टेड सर्वर से आपकी चैट डिलीट नहीं होंगी।"
+"अब आप इस ब्राउज़र से अपनी सेव की गई चैट्स एक्सेस नहीं कर पाएंगे। पिछली 30 "
+"चैट अभी भी लोकल स्टोरेज में उपलब्ध रहेंगी। इससे एन्क्रिप्टेड सर्वर से आपकी "
+"चैट डिलीट नहीं होंगी।"
 
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
@@ -23786,8 +23967,9 @@ msgid ""
 "You're now searching privately in Chrome. Use our app instead of Chrome to "
 "browse privately too. It’s already installed and can:"
 msgstr ""
-"अभी आप Chrome में गुप्त रूप से खोज रहे हैं। गुप्त रूप से ब्राउज़ करने के लिए भी Chrome की "
-"बजाय हमारे ऐप का उपयोग करेंगे। यह पहले से ही इंस्टॉल हैं और यह कर सकता है:"
+"अभी आप Chrome में गुप्त रूप से खोज रहे हैं। गुप्त रूप से ब्राउज़ करने के लिए "
+"भी Chrome की बजाय हमारे ऐप का उपयोग करेंगे। यह पहले से ही इंस्टॉल हैं और यह "
+"कर सकता है:"
 
 # smartling.placeholder_format=C
 #. Confirmation message that appears after the DuckDuckGo browser extension is installed.
@@ -23800,8 +23982,8 @@ msgid ""
 "You're now searching with privacy. %sGet tips to reduce your footprint even "
 "more."
 msgstr ""
-"अब आप गोपनीयता के साथ खोज कर रहे हैं। %1$sअपने फुटप्रिंट को और भी अधिक कम करने के लिए "
-"सुझाव पाएं।"
+"अब आप गोपनीयता के साथ खोज कर रहे हैं। %1$sअपने फुटप्रिंट को और भी अधिक कम "
+"करने के लिए सुझाव पाएं।"
 
 # smartling.placeholder_format=C
 #. Title of a notice thanking the user for turning off their adblocker
@@ -23844,7 +24026,9 @@ msgctxt "Error message for user limit"
 msgid ""
 "You've reached the maximum number of messages for the moment. Please try "
 "again later."
-msgstr "आप फिलहाल संदेशों की अधिकतम संख्या तक पहुंच गए हैं। कृपया बाद में फिर से कोशिश करें।"
+msgstr ""
+"आप फिलहाल संदेशों की अधिकतम संख्या तक पहुंच गए हैं। कृपया बाद में फिर से "
+"कोशिश करें।"
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -23863,7 +24047,8 @@ msgstr "आज की वॉयस चैट सीमा पूरी हो �
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
 msgid "You've reached your dictation usage limit. Try again later."
 msgstr ""
-"आपने अपनी डिक्टेशन इस्तेमाल करने की सीमा पूरी कर ली है। कृपया बाद में फिर से कोशिश करें।"
+"आपने अपनी डिक्टेशन इस्तेमाल करने की सीमा पूरी कर ली है। कृपया बाद में फिर से "
+"कोशिश करें।"
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -23872,9 +24057,9 @@ msgid ""
 "You've run out of Sync & Backup storage for Duck.ai chats with attachments. "
 "Delete the %s oldest chats to resume Sync. Pinned chats will not be deleted."
 msgstr ""
-"अटैचमेंट वाली Duck.ai चैट्स के लिए आपके Sync & Backup स्टोरेज की सीमा समाप्त हो गई है। "
-"सिंक फिर से शुरू करने के लिए %1$s सबसे पुरानी चैट डिलीट करें। पिन की गई चैट डिलीट नहीं की "
-"जाएंगी।"
+"अटैचमेंट वाली Duck.ai चैट्स के लिए आपके Sync & Backup स्टोरेज की सीमा समाप्त "
+"हो गई है। सिंक फिर से शुरू करने के लिए %1$s सबसे पुरानी चैट डिलीट करें। पिन "
+"की गई चैट डिलीट नहीं की जाएंगी।"
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -23884,9 +24069,9 @@ msgid ""
 "oldest chats with attachments to resume Sync. Pinned chats will not be "
 "deleted."
 msgstr ""
-"आपके Duck.ai चैट्स के लिए आपके Sync & Backup स्टोरेज की सीमा समाप्त हो गई है। सिंक फिर "
-"से शुरू करने के लिए, अटैचमेंट वाली %1$s सबसे पुरानी चैट डिलीट कर दें। पिन की गई चैट डिलीट "
-"नहीं की जाएंगी।"
+"आपके Duck.ai चैट्स के लिए आपके Sync & Backup स्टोरेज की सीमा समाप्त हो गई "
+"है। सिंक फिर से शुरू करने के लिए, अटैचमेंट वाली %1$s सबसे पुरानी चैट डिलीट "
+"कर दें। पिन की गई चैट डिलीट नहीं की जाएंगी।"
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the sync storage limit.
@@ -23900,8 +24085,8 @@ msgid ""
 "YouTube (owned by Google) does not let you watch videos anonymously. As "
 "such, watching YouTube videos here will be tracked by YouTube/Google."
 msgstr ""
-"YouTube (Google के अधीन) आपको गुमनाम रूप से वीडियो नहीं देखने देता है । इस वजह से "
-"YouTube के वीडियो यहां देखने पर YouTube/Google को पता लग जाएगा |"
+"YouTube (Google के अधीन) आपको गुमनाम रूप से वीडियो नहीं देखने देता है । इस "
+"वजह से YouTube के वीडियो यहां देखने पर YouTube/Google को पता लग जाएगा |"
 
 # smartling.placeholder_format=C
 #. Label for a privacy disclaimer related to YouTube videos
@@ -23945,8 +24130,9 @@ msgid ""
 "disconnected from sync. Your %s most recent chats will be available in local "
 "storage on these browsers:"
 msgstr ""
-"आपका बैकअप DuckDuckGo के सर्वर से हटा दिया जाएगा। सभी डिवाइस सिंक से डिस्कनेक्ट हो "
-"जाएंगे। आपकी सबसे हाल की %1$s चैट इन ब्राउज़रों के लोकल स्टोरेज में उपलब्ध होंगी:"
+"आपका बैकअप DuckDuckGo के सर्वर से हटा दिया जाएगा। सभी डिवाइस सिंक से "
+"डिस्कनेक्ट हो जाएंगे। आपकी सबसे हाल की %1$s चैट इन ब्राउज़रों के लोकल "
+"स्टोरेज में उपलब्ध होंगी:"
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list.
@@ -23956,8 +24142,9 @@ msgid ""
 "disconnected from sync. Your 100 most recent chats will be available in "
 "local storage on these browsers:"
 msgstr ""
-"आपका बैकअप DuckDuckGo के सर्वर से हटा दिया जाएगा। सभी डिवाइस सिंक से डिस्कनेक्ट हो "
-"जाएंगे। आपकी सबसे हाल की 100 चैट इन ब्राउज़रों के लोकल स्टोरेज में उपलब्ध होंगी:"
+"आपका बैकअप DuckDuckGo के सर्वर से हटा दिया जाएगा। सभी डिवाइस सिंक से "
+"डिस्कनेक्ट हो जाएंगे। आपकी सबसे हाल की 100 चैट इन ब्राउज़रों के लोकल स्टोरेज "
+"में उपलब्ध होंगी:"
 
 # smartling.placeholder_format=C
 #. List item indicating that a site exclusion filter is currently active for the search
@@ -23982,8 +24169,8 @@ msgid ""
 "Your browser provides a list of your most-visited sites. DuckDuckGo never "
 "has access to this data."
 msgstr ""
-"आपका ब्राउज़र, आपकी सबसे ज़्यादा देखी गई साइटों की एक सूची प्रदान करता है।DuckDuckGo के "
-"पास कभी भी इस डेटा का एक्सेस नहीं रहता है।"
+"आपका ब्राउज़र, आपकी सबसे ज़्यादा देखी गई साइटों की एक सूची प्रदान करता "
+"है।DuckDuckGo के पास कभी भी इस डेटा का एक्सेस नहीं रहता है।"
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
@@ -23991,8 +24178,8 @@ msgid ""
 "Your browser provides the list of most-visited sites. DuckDuckGo never has "
 "access to this data."
 msgstr ""
-"आपका ब्राउज़र सबसे ज़्यादा देखी गई साइटों की सूची प्रदान करता है। DuckDuckGo के पास इस "
-"डेटा का कभी भी एक्सेस नहीं रहा है।"
+"आपका ब्राउज़र सबसे ज़्यादा देखी गई साइटों की सूची प्रदान करता है। DuckDuckGo "
+"के पास इस डेटा का कभी भी एक्सेस नहीं रहा है।"
 
 # smartling.placeholder_format=C
 #. Disclaimer text shown bellow chat input. Example: 'You are chatting with GPT-3. AI chats may display inaccurate or offensive information.'
@@ -24001,8 +24188,8 @@ msgid ""
 "Your chat with %s is private. AI chats may display inaccurate or offensive "
 "information."
 msgstr ""
-"%1$s के साथ आपकी चैट गोपनीय रहती है। AI चैट में गलत या आपत्तिजनक जानकारी भी दिखाई दे "
-"सकती है।"
+"%1$s के साथ आपकी चैट गोपनीय रहती है। AI चैट में गलत या आपत्तिजनक जानकारी भी "
+"दिखाई दे सकती है।"
 
 # smartling.placeholder_format=C
 #. Body copy shown after Sync & Backup is enabled, confirming chats are now syncing.
@@ -24015,8 +24202,8 @@ msgstr "आपकी चैट अब सेव की जा रही है�
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never saved or used to train AI models"
 msgstr ""
-"आपकी चैट निजी रहती हैं, कभी भी इन्हें सेव नहीं किया जाता या इनका इस्तेमाल AI मॉडलों को "
-"प्रशिक्षित करने के लिए नहीं किया जाता"
+"आपकी चैट निजी रहती हैं, कभी भी इन्हें सेव नहीं किया जाता या इनका इस्तेमाल AI "
+"मॉडलों को प्रशिक्षित करने के लिए नहीं किया जाता"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
@@ -24030,8 +24217,8 @@ msgctxt "Active Privacy protection description"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
 msgstr ""
-"आपकी चैट गोपनीय रहती हैं, हम उन्हें अनाम कर देते हैं, और उनका इस्तेमाल AI मॉडलों को "
-"प्रशिक्षित करने के लिए नहीं किया जाता।"
+"आपकी चैट गोपनीय रहती हैं, हम उन्हें अनाम कर देते हैं, और उनका इस्तेमाल AI "
+"मॉडलों को प्रशिक्षित करने के लिए नहीं किया जाता।"
 
 # smartling.placeholder_format=C
 #. Text explaining that user chats are private and not used for AI (Artificial Intelligence) training.
@@ -24039,8 +24226,8 @@ msgctxt "Body text for privacy protection modal"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
 msgstr ""
-"आपकी चैट गोपनीय रहती हैं, हम उन्हें अनाम कर देते हैं, और उनका इस्तेमाल AI मॉडलों को "
-"प्रशिक्षित करने के लिए नहीं किया जाता।"
+"आपकी चैट गोपनीय रहती हैं, हम उन्हें अनाम कर देते हैं, और उनका इस्तेमाल AI "
+"मॉडलों को प्रशिक्षित करने के लिए नहीं किया जाता।"
 
 # smartling.placeholder_format=C
 #. Text for a menu item that describes the privacy protection feature.
@@ -24048,8 +24235,8 @@ msgctxt "Menu item description"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
 msgstr ""
-"आपकी चैट निजी रहती हैं, हमारे द्वारा कभी सेव नहीं की जाती हैं, और इनका इस्तेमाल AI "
-"मॉडलों को प्रशिक्षित करने के लिए नहीं किया जाता।"
+"आपकी चैट निजी रहती हैं, हमारे द्वारा कभी सेव नहीं की जाती हैं, और इनका "
+"इस्तेमाल AI मॉडलों को प्रशिक्षित करने के लिए नहीं किया जाता।"
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the active privacy protection.
@@ -24057,8 +24244,8 @@ msgctxt "Modal body for privacy"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
 msgstr ""
-"आपकी चैट निजी रहती हैं, हमारे द्वारा कभी सेव नहीं की जाती हैं, और इनका इस्तेमाल AI "
-"मॉडलों को प्रशिक्षित करने के लिए नहीं किया जाता।"
+"आपकी चैट निजी रहती हैं, हमारे द्वारा कभी सेव नहीं की जाती हैं, और इनका "
+"इस्तेमाल AI मॉडलों को प्रशिक्षित करने के लिए नहीं किया जाता।"
 
 # smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that chats are stored locally on the user's device.
@@ -24073,9 +24260,9 @@ msgid ""
 "Your chats are still private, anonymized by us, and not used to train AI "
 "models. Follow these steps to keep your chat history."
 msgstr ""
-"आपकी चैट अभी भी गोपनीय हैं, जिन्हें हम अनाम कर देते हैं, और इनका उपयोग AI मॉडल्स को "
-"प्रशिक्षित करने के लिए नहीं किया जाता है। अपनी चैट हिस्ट्री सुरक्षित रखने के लिए इन चरणों "
-"का पालन करें।"
+"आपकी चैट अभी भी गोपनीय हैं, जिन्हें हम अनाम कर देते हैं, और इनका उपयोग AI "
+"मॉडल्स को प्रशिक्षित करने के लिए नहीं किया जाता है। अपनी चैट हिस्ट्री "
+"सुरक्षित रखने के लिए इन चरणों का पालन करें।"
 
 # smartling.placeholder_format=C
 #. Body shown after import completes.
@@ -24084,7 +24271,8 @@ msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
 msgstr ""
-"आपकी चैट्स इंपोर्ट कर दी गई हैं। आगे बढ़ें और Duck.ai में वहीं से जारी रखें जहां आपने छोड़ा था।"
+"आपकी चैट्स इंपोर्ट कर दी गई हैं। आगे बढ़ें और Duck.ai में वहीं से जारी रखें "
+"जहां आपने छोड़ा था।"
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.
@@ -24116,8 +24304,8 @@ msgid ""
 "Your email address will not be shared, %sor associated with anonymous "
 "searches. [%sExample message%s]"
 msgstr ""
-"आपका ईमेल पता शेयर नहीं किया जाएगा, %1$sया किन्हीं अनाम खोजों के साथ संबद्ध नहीं है। "
-"[%2$sउदाहरण संदेश%3$s]"
+"आपका ईमेल पता शेयर नहीं किया जाएगा, %1$sया किन्हीं अनाम खोजों के साथ संबद्ध "
+"नहीं है। [%2$sउदाहरण संदेश%3$s]"
 
 # smartling.placeholder_format=C
 #. A prompt for the user to provide feedback on the third party map app directions experience
@@ -24132,8 +24320,8 @@ msgctxt ""
 "an AI response"
 msgid "Your feedback is anonymized and not used to train AI."
 msgstr ""
-"आपकी फ़ीडबैक को अनाम रखा जाता है और इसका इस्तेमाल AI को ट्रेनिंग देने के लिए नहीं किया "
-"जाता।"
+"आपकी फ़ीडबैक को अनाम रखा जाता है और इसका इस्तेमाल AI को ट्रेनिंग देने के लिए "
+"नहीं किया जाता।"
 
 # smartling.placeholder_format=C
 #. Explains that the User's Location is always private to DuckDuckGo.
@@ -24162,10 +24350,10 @@ msgid ""
 "browser. We save the settings file using the key as the name. DuckDuckGo "
 "never knows your passphrase."
 msgstr ""
-"आपके पासफ़्रेज़ ने %1$sSHA-2%2$s के रूप में ज्ञात सुरक्षित हैश एल्गोरिथम का उपयोग करके '512-"
-"बिट की' जनरेट किया है। केवल 'की' और संबंधित सेटिंग्स फ़ाइल आपके ब्राउज़र को छोड़ देती है। "
-"हम नाम के रूप में 'की' का उपयोग करके सेटिंग्स फ़ाइल को सेव करते हैं। DuckDuckGo कभी भी "
-"आपके पासफ़्रेज़ को नहीं जानता है।"
+"आपके पासफ़्रेज़ ने %1$sSHA-2%2$s के रूप में ज्ञात सुरक्षित हैश एल्गोरिथम का "
+"उपयोग करके '512-बिट की' जनरेट किया है। केवल 'की' और संबंधित सेटिंग्स फ़ाइल "
+"आपके ब्राउज़र को छोड़ देती है। हम नाम के रूप में 'की' का उपयोग करके सेटिंग्स "
+"फ़ाइल को सेव करते हैं। DuckDuckGo कभी भी आपके पासफ़्रेज़ को नहीं जानता है।"
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -24180,8 +24368,9 @@ msgid ""
 "personally identifiable metadata, so model providers can't tie your "
 "conversations back to you."
 msgstr ""
-"आपके प्रॉम्प्ट DuckDuckGo सर्वर के ज़रिए भेजे जाते हैं और उनसे आपकी पहचान बताने वाला "
-"मेटाडेटा हटा दिया जाता है, ताकि मॉडल प्रदाता आपकी बातचीत को आपसे जोड़ न सकें।"
+"आपके प्रॉम्प्ट DuckDuckGo सर्वर के ज़रिए भेजे जाते हैं और उनसे आपकी पहचान "
+"बताने वाला मेटाडेटा हटा दिया जाता है, ताकि मॉडल प्रदाता आपकी बातचीत को आपसे "
+"जोड़ न सकें।"
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -24195,7 +24384,8 @@ msgid ""
 "Your recent chats live here! You can refer to your chats or clear them "
 "anytime."
 msgstr ""
-"आपकी हालिया चैट यहां रहती हैं! आप कभी भी अपनी चैट देख सकते हैं या उन्हें हटा सकते हैं।"
+"आपकी हालिया चैट यहां रहती हैं! आप कभी भी अपनी चैट देख सकते हैं या उन्हें हटा "
+"सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Message on a feedback form.
@@ -24238,8 +24428,9 @@ msgid ""
 "You’re now searching privately in Chrome. Use our browser instead of Chrome "
 "for more protection. It’s already installed and can:"
 msgstr ""
-"फ़िलहाल, आप Chrome में गोपनीय रूप से सर्च कर रहे हैं। ज़्यादा सुरक्षा के लिए Chrome के बजाय "
-"हमारे ब्राउज़र का इस्तेमाल करें। यह पहले से ही इंस्टॉल है और यहां दिए गए काम कर सकता है:"
+"फ़िलहाल, आप Chrome में गोपनीय रूप से सर्च कर रहे हैं। ज़्यादा सुरक्षा के लिए "
+"Chrome के बजाय हमारे ब्राउज़र का इस्तेमाल करें। यह पहले से ही इंस्टॉल है और "
+"यहां दिए गए काम कर सकता है:"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has exceeded the maximum message size.
@@ -24248,8 +24439,8 @@ msgid ""
 "You’ve exceeded the maximum message size. Please shorten your message and "
 "try again."
 msgstr ""
-"आपने संदेश की अधिकतम आकार सीमा पार कर ली है। कृपया अपने संदेश को छोटा करके फिर से "
-"कोशिश करें।"
+"आपने संदेश की अधिकतम आकार सीमा पार कर ली है। कृपया अपने संदेश को छोटा करके "
+"फिर से कोशिश करें।"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -24258,8 +24449,8 @@ msgid ""
 "You’ve reached the maximum chat length in this conversation. Clear this "
 "conversation with the Fire Button to continue."
 msgstr ""
-"आप इस बातचीत में अधिकतम चैट अवधि तक पहुंच गए हैं। आगे बढ़ने के लिए, Fire Button की मदद "
-"से इस बातचीत को मिटाएं।"
+"आप इस बातचीत में अधिकतम चैट अवधि तक पहुंच गए हैं। आगे बढ़ने के लिए, Fire "
+"Button की मदद से इस बातचीत को मिटाएं।"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -24268,7 +24459,8 @@ msgid ""
 "You’ve reached the maximum chat length in this conversation. Start a new "
 "chat to continue."
 msgstr ""
-"आप इस बातचीत में अधिकतम चैट अवधि तक पहुंच गए हैं। जारी रखने के लिए एक नई चैट शुरू करें।"
+"आप इस बातचीत में अधिकतम चैट अवधि तक पहुंच गए हैं। जारी रखने के लिए एक नई चैट "
+"शुरू करें।"
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -24283,8 +24475,8 @@ msgid ""
 "You’ve reached the maximum number of messages for one day. Please continue "
 "this chat tomorrow."
 msgstr ""
-"आप एक दिन में भेजे जाने वाले संदेशों की अधिकतम संख्या तक पहुंच गए हैं। कृपया इस चैट को अब कल "
-"जारी रखें।"
+"आप एक दिन में भेजे जाने वाले संदेशों की अधिकतम संख्या तक पहुंच गए हैं। कृपया "
+"इस चैट को अब कल जारी रखें।"
 
 # smartling.placeholder_format=C
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
@@ -24587,7 +24779,8 @@ msgstr "ऑफ़िशियल वेबसाइट"
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
 msgstr ""
-"या जो रंग आप चाहते है उसका कलर कोड लिखे, जैसे %1$s (%2$s एक एनकोडेड %3$s अक्षर है)"
+"या जो रंग आप चाहते है उसका कलर कोड लिखे, जैसे %1$s (%2$s एक एनकोडेड %3$s "
+"अक्षर है)"
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "

--- a/locales/hi_IN/LC_MESSAGES/duckduckgo.po
+++ b/locales/hi_IN/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: hi_IN\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -176,9 +176,8 @@ msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
 msgstr ""
-"%1$s सिर्फ़ Pro प्लान में उपलब्ध है। चैट जारी रखने के लिए इस ब्राउज़र में "
-"अपना DuckDuckGo सब्सक्रिप्शन फिर से अपग्रेड करें, या Plus या मुफ़्त मॉडल पर "
-"स्विच करें।"
+"%1$s सिर्फ़ Pro प्लान में उपलब्ध है। चैट जारी रखने के लिए इस ब्राउज़र में अपना DuckDuckGo "
+"सब्सक्रिप्शन फिर से अपग्रेड करें, या Plus या मुफ़्त मॉडल पर स्विच करें।"
 
 # smartling.placeholder_format=C
 #. Text for the disclaimer message that appears when a Plus subscriber tries to use a Pro-only model. %s is replaced with the model name. Example: Claude Opus 4.6 is only available with Pro. Upgrade your DuckDuckGo subscription in this browser again to continue the chat, or switch to a Plus or free model.
@@ -188,9 +187,8 @@ msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
 msgstr ""
-"%1$s सिर्फ़ Pro प्लान में उपलब्ध है। चैट जारी रखने के लिए इस ब्राउज़र में "
-"अपना DuckDuckGo सब्सक्रिप्शन फिर से अपग्रेड करें, या Plus या मुफ़्त मॉडल पर "
-"स्विच करें।"
+"%1$s सिर्फ़ Pro प्लान में उपलब्ध है। चैट जारी रखने के लिए इस ब्राउज़र में अपना DuckDuckGo "
+"सब्सक्रिप्शन फिर से अपग्रेड करें, या Plus या मुफ़्त मॉडल पर स्विच करें।"
 
 # smartling.placeholder_format=C
 #. Displayed when an AI (Artificial Intelligence) chat model is temporarily unavailable. Example: 'GPT 4o is only available with a DuckDuckGo subscription.'
@@ -206,9 +204,8 @@ msgid ""
 "subscription in this browser again to continue the chat, or switch to a free "
 "model."
 msgstr ""
-"%1$s केवल DuckDuckGo सब्सक्रिप्शन के साथ उपलब्ध है। चैट जारी रखने के लिए इस "
-"ब्राउज़र में अपने सब्सक्रिप्शन को फिर से एक्टिवेट करें, या किसी मुफ़्त मॉडल "
-"पर स्विच करें।"
+"%1$s केवल DuckDuckGo सब्सक्रिप्शन के साथ उपलब्ध है। चैट जारी रखने के लिए इस ब्राउज़र में "
+"अपने सब्सक्रिप्शन को फिर से एक्टिवेट करें, या किसी मुफ़्त मॉडल पर स्विच करें।"
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is temporarily unavailable. Example: 'GPT 3.5 Turbo is temporarily unavailable. Please switch to a different model or try again later.'
@@ -217,8 +214,8 @@ msgid ""
 "%s is temporarily unavailable. Please switch to a different model or try "
 "again later."
 msgstr ""
-"%1$s फिलहाल उपलब्ध नहीं है। कृपया किसी अन्य मॉडल पर स्विच करें या बाद में "
-"फिर से कोशिश करें।"
+"%1$s फिलहाल उपलब्ध नहीं है। कृपया किसी अन्य मॉडल पर स्विच करें या बाद में फिर से कोशिश "
+"करें।"
 
 # smartling.placeholder_format=C
 #. Reddit's "fake internet points". https://support.reddithelp.com/hc/en-us/articles/204511829-What-is-karma
@@ -309,9 +306,9 @@ msgid ""
 "provider can see your prompts or the model’s responses, or save this chat on "
 "their servers."
 msgstr ""
-"%1$s एक भरोसेमंद एक्ज़ीक्यूशन एनवायरमेंट में चलता है। इसका मतलब है कि मॉडल "
-"प्रोवाइडर भी आपके प्रॉम्प्ट्स या मॉडल के जवाबों को नहीं देख सकता, और न ही इस "
-"चैट को अपने सर्वर पर सेव कर सकता है।"
+"%1$s एक भरोसेमंद एक्ज़ीक्यूशन एनवायरमेंट में चलता है। इसका मतलब है कि मॉडल प्रोवाइडर भी "
+"आपके प्रॉम्प्ट्स या मॉडल के जवाबों को नहीं देख सकता, और न ही इस चैट को अपने सर्वर पर सेव "
+"कर सकता है।"
 
 # smartling.placeholder_format=C
 #. Label shown in the batch selection toolbar when exactly one chat is selected. %s is replaced with 1. Use singular agreement where the language requires it.
@@ -391,8 +388,8 @@ msgid ""
 "%s will be leaving Duck.ai in %s days (%s). After that, you can switch "
 "models to continue this chat."
 msgstr ""
-"%1$s %2$s दिन में (%3$s को) Duck.ai से हट जाएगा। उसके बाद, आप इस चैट को जारी "
-"रखने के लिए मॉडल बदल सकते हैं।"
+"%1$s %2$s दिन में (%3$s को) Duck.ai से हट जाएगा। उसके बाद, आप इस चैट को जारी रखने "
+"के लिए मॉडल बदल सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Displayed in a saved chat when its AI model is about to be retired tomorrow. First placeholder is the friendly model name, second placeholder is the removal date formatted in the user's browser locale (e.g., 'June 15, 2026' in en-US). Singular-day form.
@@ -403,8 +400,8 @@ msgid ""
 "%s will be leaving Duck.ai in 1 day (%s). After that, you can switch models "
 "to continue this chat."
 msgstr ""
-"%1$s 1 दिन में (%2$s को) Duck.ai से हटने वाला है। उसके बाद, आप इस चैट को "
-"जारी रखने के लिए मॉडल बदल सकते हैं।"
+"%1$s 1 दिन में (%2$s को) Duck.ai से हटने वाला है। उसके बाद, आप इस चैट को जारी रखने के "
+"लिए मॉडल बदल सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Shown in a text selection chip when the selection contains multiple words. %s is replaced with the number of words, e.g. '142 words'.
@@ -417,8 +414,8 @@ msgstr "%1$s शब्द"
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
 msgstr ""
-"%1$sजोड़ें%2$sपर%3$s क्लिक करें %4$sअनुमति दें%5$s पर सही का निशान लगाएं, "
-"फिर %6$sठीक हैं%7$s पर क्लिक करें"
+"%1$sजोड़ें%2$sपर%3$s क्लिक करें %4$sअनुमति दें%5$s पर सही का निशान लगाएं, फिर %6$sठीक "
+"हैं%7$s पर क्लिक करें"
 
 # Firefox, obsolete
 # smartling.placeholder_format=C
@@ -426,8 +423,8 @@ msgstr ""
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAllow%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
 msgstr ""
-"%1$sअनुमति दें%2$s %3$sपर क्लिक करें %4$sजोड़ें%5$s पर क्लिक करें %6$sअनुमति "
-"दें%7$s पर निशान लगाएं, फिर %8$sओके%9$s पर क्लिक करें"
+"%1$sअनुमति दें%2$s %3$sपर क्लिक करें %4$sजोड़ें%5$s पर क्लिक करें %6$sअनुमति दें%7$s पर "
+"निशान लगाएं, फिर %8$sओके%9$s पर क्लिक करें"
 
 # Firefox
 # smartling.placeholder_format=C
@@ -437,8 +434,8 @@ msgid ""
 "%sClick %sContinue To Installation%sClick %sAdd%sCheck %sAllow%s, then click "
 "%sOkay%s"
 msgstr ""
-"%1$s%2$sइंस्टॉलेशन जारी रखें%3$s पर क्लिक करें %4$sजोड़ें%5$s पर क्लिक करें "
-"%6$sअनुमति दें%7$s पर निशान लगाएं, फिर %8$sओके%9$s पर क्लिक करें"
+"%1$s%2$sइंस्टॉलेशन जारी रखें%3$s पर क्लिक करें %4$sजोड़ें%5$s पर क्लिक करें %6$sअनुमति "
+"दें%7$s पर निशान लगाएं, फिर %8$sओके%9$s पर क्लिक करें"
 
 # smartling.placeholder_format=C
 #. A button that reloads search results when an error occurs.
@@ -472,16 +469,14 @@ msgctxt "Footer text for About Sync modal"
 msgid ""
 "%sLearn more%s about how chats are stored privately on DuckDuckGo's server."
 msgstr ""
-"%1$sऔर जानें%2$s कि चैट को DuckDuckGo के सर्वर पर गोपनीय ढंग से कैसे स्टोर "
-"किया जाता है।"
+"%1$sऔर जानें%2$s कि चैट को DuckDuckGo के सर्वर पर गोपनीय ढंग से कैसे स्टोर किया जाता है।"
 
 # smartling.placeholder_format=C
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "%sLearn more%s about how chats are stored privately on your device."
 msgstr ""
-"आपके डिवाइस पर चैट निजी तौर पर कैसे स्टोर किए जाते हैं, इस बारे में %1$sऔर "
-"जानें।%2$s"
+"आपके डिवाइस पर चैट निजी तौर पर कैसे स्टोर किए जाते हैं, इस बारे में %1$sऔर जानें।%2$s"
 
 # smartling.placeholder_format=C
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
@@ -493,9 +488,7 @@ msgstr "होम स्क्रीन पर DuckDuckGo ऐप आइकन �
 #. A message displayed when there is an error loading content or no results on requery
 msgctxt "Error or no results message"
 msgid "%sOops!%s%sSomething went wrong. Please %srefresh%s and try again."
-msgstr ""
-"%1$sउफ़!%2$s%3$sकुछ गड़बड़ हुई है। कृपया %4$sरीफ्रेश%5$s करें और फिर से "
-"कोशिश करें।"
+msgstr "%1$sउफ़!%2$s%3$sकुछ गड़बड़ हुई है। कृपया %4$sरीफ्रेश%5$s करें और फिर से कोशिश करें।"
 
 # smartling.placeholder_format=C
 #. Tagline in a popover encouraging the user to download the DuckDuckGo browser
@@ -812,9 +805,7 @@ msgstr "6 घंटे की उपयोग सीमा पूरी हो �
 #. Displayed when the user has reached a fixed 6-hour Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "6-hour usage limit reached. You can continue this chat after %s."
-msgstr ""
-"6 घंटे की उपयोग सीमा पूरी हो गई है। आप %1$s के बाद इस चैट को जारी रख सकते "
-"हैं।"
+msgstr "6 घंटे की उपयोग सीमा पूरी हो गई है। आप %1$s के बाद इस चैट को जारी रख सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable 6-hour Duck.ai usage limit and can opt in to continue using the daily limit.
@@ -822,8 +813,8 @@ msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "6-hour usage limit reached. You can keep chatting by using your daily limit."
 msgstr ""
-"6 घंटे की उपयोग सीमा पूरी हो गई है। आप अपनी दैनिक सीमा का इस्तेमाल करके "
-"चैटिंग जारी रख सकते हैं।"
+"6 घंटे की उपयोग सीमा पूरी हो गई है। आप अपनी दैनिक सीमा का इस्तेमाल करके चैटिंग जारी रख "
+"सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes abbreviation
@@ -877,26 +868,22 @@ msgid ""
 "A network issue is preventing Search Assist from generating an answer. "
 "Please check your connection and try again."
 msgstr ""
-"नेटवर्क की समस्या की वजह से Search Assist जवाब नहीं दे पा रहा है। कृपया अपना "
-"कनेक्शन जांचें और फिर से कोशिश करें।"
+"नेटवर्क की समस्या की वजह से Search Assist जवाब नहीं दे पा रहा है। कृपया अपना कनेक्शन "
+"जांचें और फिर से कोशिश करें।"
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of AI Chat is available and they need to refresh the page.
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of AI Chat is available! Please refresh this page to continue."
-msgstr ""
-"AI Chat का नया वर्ज़न उपलब्ध है! कृपया जारी रखने के लिए इस पेज को रीफ्रेश "
-"करें।"
+msgstr "AI Chat का नया वर्ज़न उपलब्ध है! कृपया जारी रखने के लिए इस पेज को रीफ्रेश करें।"
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of Duck.ai is available and they need to refresh the page.
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of Duck.ai is available! Please refresh this page to continue."
-msgstr ""
-"Duck.ai का नया वर्ज़न उपलब्ध है! कृपया जारी रखने के लिए इस पेज को रीफ्रेश "
-"करें।"
+msgstr "Duck.ai का नया वर्ज़न उपलब्ध है! कृपया जारी रखने के लिए इस पेज को रीफ्रेश करें।"
 
 # smartling.placeholder_format=C
 #. Shown when the Duck.ai desktop app has been open a long time and a newer version exists.
@@ -934,10 +921,9 @@ msgid ""
 "still access AI Chat when this setting is off by visiting %sduckduckgo.com/"
 "aichat%s."
 msgstr ""
-"AI Chat आपको थर्ड-पार्टी AI चैट मॉडल के साथ गुमनाम ढंग से बातचीत करने की "
-"सुविधा देता है। इसे बंद करने से DuckDuckGo Search पर AI Chat फ़ीचर छिप "
-"जाएगा। जब यह सेटिंग बंद हो तब भी आप %1$sduckduckgo.com/aichat%2$s पर जाकर AI "
-"Chat का उपयोग कर सकते हैं।"
+"AI Chat आपको थर्ड-पार्टी AI चैट मॉडल के साथ गुमनाम ढंग से बातचीत करने की सुविधा देता "
+"है। इसे बंद करने से DuckDuckGo Search पर AI Chat फ़ीचर छिप जाएगा। जब यह सेटिंग बंद हो "
+"तब भी आप %1$sduckduckgo.com/aichat%2$s पर जाकर AI Chat का उपयोग कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -998,10 +984,10 @@ msgid ""
 "questions, which is our private AI-powered chat service that supports chat "
 "models from OpenAI, and Anthropic, and more."
 msgstr ""
-"AI की सहायता से दिए गए जवाब फिलहाल फ़ॉलोअप सवालों को सीधे सपोर्ट नहीं करते "
-"हैं। हालांकि, हम फ़ॉलोअप सवालों के लिए %1$sDuck.ai%2$s भी ऑफ़र करते हैं और "
-"अक्सर उससे लिंक करते हैं, जो हमारी निजी AI-संचालित चैट सेवा है जो OpenAI, और "
-"Anthropic, और अन्य के चैट मॉडलों को सपोर्ट करती है।"
+"AI की सहायता से दिए गए जवाब फिलहाल फ़ॉलोअप सवालों को सीधे सपोर्ट नहीं करते हैं। "
+"हालांकि, हम फ़ॉलोअप सवालों के लिए %1$sDuck.ai%2$s भी ऑफ़र करते हैं और अक्सर उससे लिंक "
+"करते हैं, जो हमारी निजी AI-संचालित चैट सेवा है जो OpenAI, और Anthropic, और अन्य के चैट "
+"मॉडलों को सपोर्ट करती है।"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has turned off AI features and will no longer see AI-assisted answers.
@@ -1186,8 +1172,8 @@ msgid ""
 "Activate your %s in this browser again to continue the chat, or switch to a "
 "free model."
 msgstr ""
-"चैट जारी रखने के लिए इस ब्राउज़र में अपने %1$s को फिर से एक्टिवेट करें, या "
-"किसी मुफ़्त मॉडल पर स्विच करें।"
+"चैट जारी रखने के लिए इस ब्राउज़र में अपने %1$s को फिर से एक्टिवेट करें, या किसी मुफ़्त मॉडल "
+"पर स्विच करें।"
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an active DuckDuckGo subscription.
@@ -1223,8 +1209,8 @@ msgstr "विज्ञापन"
 msgid ""
 "Ad clicks are managed by %s’s ad network and are not used to profile you."
 msgstr ""
-"%1$s के विज्ञापन नेटवर्क द्वारा विज्ञापन क्लिक प्रबंधित किए जाते हैं और इनका "
-"उपयोग आपकी व्यक्तिगत जानकारी जुटाने के लिए नहीं किया जाता।"
+"%1$s के विज्ञापन नेटवर्क द्वारा विज्ञापन क्लिक प्रबंधित किए जाते हैं और इनका उपयोग आपकी "
+"व्यक्तिगत जानकारी जुटाने के लिए नहीं किया जाता।"
 
 # smartling.placeholder_format=C
 #. Information that ad clicks are managed by Microsoft.
@@ -1232,8 +1218,8 @@ msgid ""
 "Ad clicks are managed by Microsoft’s ad network and are not used to profile "
 "you."
 msgstr ""
-"Microsoft के विज्ञापन नेटवर्क द्वारा विज्ञापन क्लिक प्रबंधित किए जाते हैं और "
-"इनका उपयोग आपकी व्यक्तिगत जानकारी जुटाने के लिए नहीं किया जाता।"
+"Microsoft के विज्ञापन नेटवर्क द्वारा विज्ञापन क्लिक प्रबंधित किए जाते हैं और इनका उपयोग "
+"आपकी व्यक्तिगत जानकारी जुटाने के लिए नहीं किया जाता।"
 
 # smartling.placeholder_format=C
 #. An item in the ads tooltip that explains that ad clicks aren’t used to profile you.
@@ -1284,8 +1270,7 @@ msgstr "DuckDuckGo एक्सटेंशन जोड़ें"
 msgid ""
 "Add DuckDuckGo Privacy Essentials to your browser for free with one download:"
 msgstr ""
-"एक डाउनलोड के साथ अपने ब्राउज़र पर मुफ़्त में DuckDuckGo Privacy Essentials "
-"जोड़ें:"
+"एक डाउनलोड के साथ अपने ब्राउज़र पर मुफ़्त में DuckDuckGo Privacy Essentials जोड़ें:"
 
 #  IE default search engine instruction
 # smartling.placeholder_format=C
@@ -1440,6 +1425,12 @@ msgid "Address is incorrect"
 msgstr "पता गलत है"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Adjust the servings"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. as in multiple advertisements
 msgid "Ads"
 msgstr "विज्ञापन"
@@ -1521,9 +1512,7 @@ msgstr "जैसे ही वह डाउनलोड होकर खुल�
 #. Instructions on how to install the DuckDuckGo browser extension after it downloads.
 msgid ""
 "After it downloads, locate the extension file and double-click it to install"
-msgstr ""
-"डाइनलोड होने के बाद, ऐक्सटेंशन फ़ाइल को ढूंढें और इंस्टॉल करने के लिए डबल "
-"क्लिक करें"
+msgstr "डाइनलोड होने के बाद, ऐक्सटेंशन फ़ाइल को ढूंढें और इंस्टॉल करने के लिए डबल क्लिक करें"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an age below a web search result.
@@ -1653,6 +1642,14 @@ msgid "All chats are %sprivate%s"
 msgstr "सभी चैट %1$sगोपनीय%2$s हैं"
 
 # smartling.placeholder_format=C
+#. Paragraph in the Privacy & Terms section of the About & Legal page in Duck.ai settings, summarizing how chats are anonymized and are not stored or used to train chat models.
+msgctxt "Privacy & Terms section description on the Duck.ai settings page"
+msgid ""
+"All chats are anonymized by DuckDuckGo, and your conversations are not used "
+"to train chat models by DuckDuckGo or the model providers"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
 msgctxt "Privacy modal header in Duck.ai chat"
 msgid "All chats are private"
@@ -1683,8 +1680,8 @@ msgid ""
 "All model providers are prevented from training their AI on your "
 "conversations."
 msgstr ""
-"सभी मॉडल प्रदाताओं को आपकी बातचीत के आधार पर अपने AI को प्रशिक्षित करने से "
-"रोका गया है।"
+"सभी मॉडल प्रदाताओं को आपकी बातचीत के आधार पर अपने AI को प्रशिक्षित करने से रोका गया "
+"है।"
 
 # smartling.placeholder_format=C
 #. Text displayed in the subheader of the modal that allows the user to pick an AI chat model.
@@ -1699,8 +1696,8 @@ msgid ""
 "All personal metadata (for example, your IP address) is removed before "
 "sending a chat to the AI provider."
 msgstr ""
-"AI प्रोवाइडर को चैट भेजने से पहले सभी पर्सनल मेटाडेटा (जैसे, आपका IP एड्रेस) "
-"हटा दिया जाता है।"
+"AI प्रोवाइडर को चैट भेजने से पहले सभी पर्सनल मेटाडेटा (जैसे, आपका IP एड्रेस) हटा दिया "
+"जाता है।"
 
 # smartling.placeholder_format=C
 #. A filter that shows search results from all countries.
@@ -1726,8 +1723,8 @@ msgctxt "voice chat"
 msgid ""
 "Allow DuckDuckGo microphone access in System Settings to use voice chat."
 msgstr ""
-"वॉयस चैट का इस्तेमाल करने के लिए सिस्टम सेटिंग में DuckDuckGo माइक्रोफ़ोन "
-"एक्सेस की अनुमति दें।"
+"वॉयस चैट का इस्तेमाल करने के लिए सिस्टम सेटिंग में DuckDuckGo माइक्रोफ़ोन एक्सेस की अनुमति "
+"दें।"
 
 # smartling.placeholder_format=C
 #. Tells users which icon to press in their browser. Part of a list of instructions on how to enable location service.
@@ -1744,8 +1741,7 @@ msgstr "गोपनीयता का सम्मान करने वा�
 #. Title in a dialog informing the user how to disable their ad blocker for DuckDuckGo
 msgid "Allow privacy-respecting ads on DuckDuckGo Private Search"
 msgstr ""
-"DuckDuckGo Private Search पर गोपनीयता का सम्मान करने वाले विज्ञापनों को "
-"अनुमति दें"
+"DuckDuckGo Private Search पर गोपनीयता का सम्मान करने वाले विज्ञापनों को अनुमति दें"
 
 # smartling.placeholder_format=C
 #. Description explaining privacy implications of enabling web search on encrypted models. The first two placeholders are the full model name (e.g. 'gpt-oss 120B'). The third and fourth placeholders wrap a clickable link reading 'zero provider visibility' that opens the privacy modal, please keep those around the link text in your translation. An example full sentence would be: Allows gpt-oss 120B to search the web to improve responses to relevant prompts. Only sends AI-generated queries to a search engine with limited data retention. Prompts and responses with gpt-oss 120B still have zero provider visibility.
@@ -1755,10 +1751,10 @@ msgid ""
 "sends AI-generated queries to a search engine with limited data retention. "
 "Prompts and responses with %s still have %szero provider visibility%s."
 msgstr ""
-"यह %1$s को वेब पर सर्च करने की सुविधा देता है, ताकि वह संबंधित प्रॉम्प्ट्स "
-"के जवाबों को बेहतर बना सके। यह सर्च इंजन पर केवल AI-जनरेटेड क्वेरीज़ ही "
-"भेजता है, जिनमें डेटा रिटेंशन की लिमिट सीमित होती है। %2$s वाले प्रॉम्प्ट्स "
-"और जवाबों पर अभी भी %3$sप्रोवाइडर की विज़िबिलिटी शून्य%4$s रहती है।"
+"यह %1$s को वेब पर सर्च करने की सुविधा देता है, ताकि वह संबंधित प्रॉम्प्ट्स के जवाबों को "
+"बेहतर बना सके। यह सर्च इंजन पर केवल AI-जनरेटेड क्वेरीज़ ही भेजता है, जिनमें डेटा रिटेंशन की "
+"लिमिट सीमित होती है। %2$s वाले प्रॉम्प्ट्स और जवाबों पर अभी भी %3$sप्रोवाइडर की "
+"विज़िबिलिटी शून्य%4$s रहती है।"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -1766,8 +1762,8 @@ msgid ""
 "Allows Cloud Save key to be stored locally on device (required to use Cloud "
 "Save)"
 msgstr ""
-"डिवाइस पर स्थानीय रूप से संग्रहित की जाने वाली Cloud Save की को अनुमति देता "
-"है (Cloud Save का उपयोग करने के लिए आवश्यक है)"
+"डिवाइस पर स्थानीय रूप से संग्रहित की जाने वाली Cloud Save की को अनुमति देता है (Cloud "
+"Save का उपयोग करने के लिए आवश्यक है)"
 
 # smartling.placeholder_format=C
 #. Pending title indicating near completion.
@@ -1905,8 +1901,8 @@ msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
 msgstr ""
-"लोकप्रिय AI मॉडलों तक अनाम ढंग से पहुंच, जिसमें %1$s, %2$sऔर मुक्त स्रोत "
-"%3$s और %4$s शामिल हैं।"
+"लोकप्रिय AI मॉडलों तक अनाम ढंग से पहुंच, जिसमें %1$s, %2$sऔर मुक्त स्रोत %3$s और %4$s "
+"शामिल हैं।"
 
 # smartling.placeholder_format=C
 #. Text with information about Duck.ai and supported AI models, the placeholders list AI models. Example: 'Anonymous access to popular AI models, including GPT, Claude, and open-source Llama and Mistral.'
@@ -1915,14 +1911,21 @@ msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
 msgstr ""
-"लोकप्रिय AI मॉडलों तक अनाम ढंग से पहुंच, जिसमें %1$s, %2$sऔर मुक्त स्रोत "
-"%3$s और %4$s शामिल हैं।"
+"लोकप्रिय AI मॉडलों तक अनाम ढंग से पहुंच, जिसमें %1$s, %2$sऔर मुक्त स्रोत %3$s और %4$s "
+"शामिल हैं।"
 
 # smartling.placeholder_format=C
 #. Confirmation message after location service is enabled.
 msgctxt "precise_user_location"
 msgid "Anonymous location enabled"
 msgstr "अनाम स्‍थान सक्षम किया गया"
+
+# smartling.placeholder_format=C
+msgctxt "settings"
+msgid ""
+"Anonymously generates answers for search queries based on web content. "
+"Choose how often you want it to appear, or disable it completely."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -1969,8 +1972,8 @@ msgid ""
 "Any additional instructions you want Duck.ai to follow. e.g. Always tell me "
 "facts about ducks"
 msgstr ""
-"कोई अतिरिक्त निर्देश जो आप चाहते हैं कि Duck.ai पालन करे। जैसे कि हमेशा मुझे "
-"बतख संबंधी तथ्य बताएं"
+"कोई अतिरिक्त निर्देश जो आप चाहते हैं कि Duck.ai पालन करे। जैसे कि हमेशा मुझे बतख संबंधी "
+"तथ्य बताएं"
 
 # smartling.placeholder_format=C
 #. Shown in video filtering. https://duckduckgo.com/?q=videos+of+cats&iax=videos&ia=videos
@@ -2070,8 +2073,8 @@ msgctxt "Body text for clear all chats confirmation modal"
 msgid ""
 "Are you sure you want to clear all of your chats? This cannot be undone."
 msgstr ""
-"क्या आपको पक्का पता है कि आप अपनी सभी चैट साफ़ करना चाहते हैं? इसे पहले जैसा "
-"नहीं किया जा सकता।"
+"क्या आपको पक्का पता है कि आप अपनी सभी चैट साफ़ करना चाहते हैं? इसे पहले जैसा नहीं किया "
+"जा सकता।"
 
 # smartling.placeholder_format=C
 #. Body text of the modal that asks the user if they want to clear the conversation.
@@ -2092,8 +2095,8 @@ msgid ""
 "Are you sure you want to disable history? This will delete all chats, "
 "including pinned chats."
 msgstr ""
-"क्या आप वाकई हिस्ट्री को बंद करना चाहते हैं? इससे सभी चैट्स डिलीट हो जाएंगी, "
-"जिनमें पिन की गई चैट्स भी शामिल हैं।"
+"क्या आप वाकई हिस्ट्री को बंद करना चाहते हैं? इससे सभी चैट्स डिलीट हो जाएंगी, जिनमें पिन "
+"की गई चैट्स भी शामिल हैं।"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to disable recent chats, with a warning that it will also delete currently saved chats.
@@ -2102,8 +2105,8 @@ msgid ""
 "Are you sure you want to disable recent chats? This will also delete any "
 "recent chats that are currently saved."
 msgstr ""
-"क्या आप वाकई हालिया चैट को बंद करना चाहते हैं? यह हाल ही में सेव की गई सभी "
-"चैट को भी डिलीट कर देगा।"
+"क्या आप वाकई हालिया चैट को बंद करना चाहते हैं? यह हाल ही में सेव की गई सभी चैट को भी "
+"डिलीट कर देगा।"
 
 # smartling.placeholder_format=C
 #. Question asking user if they want to share the URL of the page they were on when giving feedback
@@ -2141,8 +2144,8 @@ msgid ""
 "As per our privacy policy, we do not collect or share any personal "
 "information ourselves. All of this privacy protection happens on your device."
 msgstr ""
-"हमारी गोपनीयता नीति के अनुसार, हम खुद से कोई निजी जानकारी एकत्रित या साझा "
-"नहीं करते हैं। यह सभी गोपनीयता संरक्षण आपके डिवाइस पर होती है।"
+"हमारी गोपनीयता नीति के अनुसार, हम खुद से कोई निजी जानकारी एकत्रित या साझा नहीं करते "
+"हैं। यह सभी गोपनीयता संरक्षण आपके डिवाइस पर होती है।"
 
 # smartling.placeholder_format=C
 #. A button to ask Duck.ai a question
@@ -2203,6 +2206,12 @@ msgstr "फ़ॉलोअप सवाल पूछें"
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse
 msgid "Ask a follow-up with Duck.ai"
 msgstr "Duck.ai से फ़ॉलोअप सवाल पूछें"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
+msgctxt "Page suggestion chip label"
+msgid "Ask about this page"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2266,13 +2275,12 @@ msgid ""
 "(shows more frequently on a wider range of searches). For now, AI-assisted "
 "answers are only available in the U.S. (English) region."
 msgstr ""
-"Assist प्रासंगिक वेब सामग्री को संक्षेप में प्रस्तुत करने के आधार पर कुछ "
-"खोजों के लिए गुमनाम रूप से AI की सहायता से जवाब जनरेट कर सकता है। आप चुन "
-"सकते हैं कि Assist को कितनी बार दिखाना है: कभी नहीं (यह खोज परिणामों से "
-"Assist के UI को पूरी तरह हटा देता है), ऑन-डिमांड (सिर्फ़ तभी दिखाता है जब आप "
-"'सहायता' बटन पर क्लिक करते हैं), कभी-कभी (सिर्फ़ तभी दिखाता है, जब नतीजे "
-"बहुत काम के हों), या अक्सर (कई तरह की खोजों पर अक्सर दिखाता है)। फिलहाल, AI "
-"की सहायता से दिए गए जवाब केवल अमेरिका (अंग्रेज़ी) क्षेत्र में उपलब्ध हैं।"
+"Assist प्रासंगिक वेब सामग्री को संक्षेप में प्रस्तुत करने के आधार पर कुछ खोजों के लिए गुमनाम "
+"रूप से AI की सहायता से जवाब जनरेट कर सकता है। आप चुन सकते हैं कि Assist को कितनी बार "
+"दिखाना है: कभी नहीं (यह खोज परिणामों से Assist के UI को पूरी तरह हटा देता है), ऑन-"
+"डिमांड (सिर्फ़ तभी दिखाता है जब आप 'सहायता' बटन पर क्लिक करते हैं), कभी-कभी (सिर्फ़ "
+"तभी दिखाता है, जब नतीजे बहुत काम के हों), या अक्सर (कई तरह की खोजों पर अक्सर दिखाता "
+"है)। फिलहाल, AI की सहायता से दिए गए जवाब केवल अमेरिका (अंग्रेज़ी) क्षेत्र में उपलब्ध हैं।"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2284,12 +2292,11 @@ msgid ""
 "to remember that responses are auto-generated from cited sources and based "
 "on %scrawling the web%s."
 msgstr ""
-"Assist, खोज परिणाम दिखाने से जुड़ा एक नया वैकल्पिक फ़ीचर है। यह गुमनाम रहकर, "
-"खोज संबंधी क्वेरी के जवाब AI की सहायता से जनरेट कर सकता है। ऐसा करने के लिए, "
-"यह वेब को स्कैन करके क्वेरी से जुड़ी सामग्री जुटाता है। इसके बाद, उस सामग्री "
-"से जुड़ी जानकारी के आधार पर कम शब्दों में जवाब देने के लिए, AI-संचालित "
-"नेचुरल लैंग्वेज टेक्नोलॉजी का इस्तेमाल करता है। यह याद रखना ज़रूरी है कि "
-"जवाब, दूसरे स्रोतों से अपने-आप जनरेट होते हैं और %1$sवेब क्रॉलिंग%2$s पर "
+"Assist, खोज परिणाम दिखाने से जुड़ा एक नया वैकल्पिक फ़ीचर है। यह गुमनाम रहकर, खोज संबंधी "
+"क्वेरी के जवाब AI की सहायता से जनरेट कर सकता है। ऐसा करने के लिए, यह वेब को स्कैन करके "
+"क्वेरी से जुड़ी सामग्री जुटाता है। इसके बाद, उस सामग्री से जुड़ी जानकारी के आधार पर कम "
+"शब्दों में जवाब देने के लिए, AI-संचालित नेचुरल लैंग्वेज टेक्नोलॉजी का इस्तेमाल करता है। यह याद "
+"रखना ज़रूरी है कि जवाब, दूसरे स्रोतों से अपने-आप जनरेट होते हैं और %1$sवेब क्रॉलिंग%2$s पर "
 "आधारित होते हैं।"
 
 # smartling.placeholder_format=C
@@ -2382,8 +2389,8 @@ msgstr "चैट खत्म होने के बाद ऑडियो ह
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat is transcribed."
 msgstr ""
-"चैट ट्रांसक्रिप्ट होने के बाद, ऑडियो हमारे द्वारा या OpenAI द्वारा स्टोर "
-"नहीं किया जाता है।"
+"चैट ट्रांसक्रिप्ट होने के बाद, ऑडियो हमारे द्वारा या OpenAI द्वारा स्टोर नहीं किया जाता "
+"है।"
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when MediaRecorder API is unavailable.
@@ -2425,16 +2432,14 @@ msgstr "स्वत: उत्तर"
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid "Auto-generated based on listed sources. May contain inaccuracies."
 msgstr ""
-"सूचीबद्ध स्रोतों के आधार पर स्वचालित ढंग से जनरेट किया गया। इसमें अशुद्धियां "
-"हो सकती हैं।"
+"सूचीबद्ध स्रोतों के आधार पर स्वचालित ढंग से जनरेट किया गया। इसमें अशुद्धियां हो सकती हैं।"
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid ""
 "Auto-generated based on listed sources. Responses may contain inaccuracies."
 msgstr ""
-"सूचीबद्ध स्रोतों के आधार पर स्वचालित ढंग से जनरेट किया गया। जवाबों में "
-"अशुद्धियां हो सकती हैं।"
+"सूचीबद्ध स्रोतों के आधार पर स्वचालित ढंग से जनरेट किया गया। जवाबों में अशुद्धियां हो सकती हैं।"
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI) on mobile
@@ -2459,9 +2464,9 @@ msgid ""
 "look up and summarize information in response to some searches. For now, "
 "Assist is only available in English regions."
 msgstr ""
-"प्रासंगिक खोजों के लिए Assist स्वतः ही दिखाता है। कुछ खोजों के लिए Assist, "
-"जानकारी को गुमनाम रूप से खोज सकता है और उसके बारे में खास जानकारी दे सकता "
-"है। फिलहाल, Assist केवल अंग्रेज़ी क्षेत्रों में उपलब्ध है।"
+"प्रासंगिक खोजों के लिए Assist स्वतः ही दिखाता है। कुछ खोजों के लिए Assist, जानकारी को "
+"गुमनाम रूप से खोज सकता है और उसके बारे में खास जानकारी दे सकता है। फिलहाल, Assist केवल "
+"अंग्रेज़ी क्षेत्रों में उपलब्ध है।"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2470,17 +2475,15 @@ msgid ""
 "anonymously look up and summarize information in response to some searches. "
 "For now, DuckAssist is only available in English regions."
 msgstr ""
-"प्रासंगिक खोजों के लिए DuckAssist स्वतः ही दिखाता है। कुछ खोजों के लिए "
-"DuckAssist जानकारी को गुमनाम रूप से खोज और संक्षिप्त कर सकता है। फिलहाल "
-"DuckAssist केवल अंग्रेज़ी क्षेत्रों में उपलब्ध है।"
+"प्रासंगिक खोजों के लिए DuckAssist स्वतः ही दिखाता है। कुछ खोजों के लिए DuckAssist "
+"जानकारी को गुमनाम रूप से खोज और संक्षिप्त कर सकता है। फिलहाल DuckAssist केवल अंग्रेज़ी "
+"क्षेत्रों में उपलब्ध है।"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Autoplay short, silent video previews when you hover over video results."
-msgstr ""
-"वीडियो परिणामों पर कर्सर ले जाने पर, छोटे और म्यूट वाले वीडियो प्रीव्यू "
-"ऑटोप्ले करें।"
+msgstr "वीडियो परिणामों पर कर्सर ले जाने पर, छोटे और म्यूट वाले वीडियो प्रीव्यू ऑटोप्ले करें।"
 
 # smartling.placeholder_format=C
 #. Screen-reader label for the radiogroup of tool options inside the Tools dropdown. Announced when assistive technology enters the group of menuitemradio items.
@@ -2622,6 +2625,12 @@ msgid "Barcode"
 msgstr "बारकोड"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Based on this page, is this course worth taking?"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Basic"
 msgstr "बेसिक"
@@ -2660,6 +2669,14 @@ msgstr "बैटर"
 msgctxt "Assistant response placeholder"
 msgid "Before continuing..."
 msgstr "जारी रखने से पहले..."
+
+# smartling.placeholder_format=C
+#. Explains that before storing the report, DuckDuckGo will anonymize the conversation by removing PII like names, email addresses, and identifying metadata.
+msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
+msgid ""
+"Before storing this report, DuckDuckGo will anonymize your conversation by "
+"removing PII like names, email addresses, and identifying metadata."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -2978,6 +2995,12 @@ msgid "Break Points Won"
 msgstr "जीते गए ब्रेक पॉइंट"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Break this down into clear, numbered steps."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
 msgctxt "Weather IA"
 msgid "Breezy"
@@ -3034,18 +3057,16 @@ msgid ""
 "Browse as usual while we add privacy protection. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
 msgstr ""
-"जब हम गोपनीयता संरक्षण जोड़ते हैं तब सामान्य रूप से ब्राउज़ करें। हमने अपने "
-"खोज इंजन, ट्रैकर ब्लॉकर और एन्क्रिप्शन एनफोर्सर को एक ही %1$s%2$s "
-"एक्सटेंशन%3$s में बंडल किया है।"
+"जब हम गोपनीयता संरक्षण जोड़ते हैं तब सामान्य रूप से ब्राउज़ करें। हमने अपने खोज इंजन, ट्रैकर "
+"ब्लॉकर और एन्क्रिप्शन एनफोर्सर को एक ही %1$s%2$s एक्सटेंशन%3$s में बंडल किया है।"
 
 # smartling.placeholder_format=C
 msgid ""
 "Browse as usual, and we'll take care of the rest. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
 msgstr ""
-"सामान्य तौर पर ब्राउज़ करें, और बाकी सबका ध्यान हम रखेंगे। हमने अपने खोज "
-"इंजन, ट्रैकर ब्लॉकर और एनक्रिप्शन एनफोर्सर को एक ही %1$s%2$s एक्सटेंशन%3$s "
-"में बंडल कर दिया है।"
+"सामान्य तौर पर ब्राउज़ करें, और बाकी सबका ध्यान हम रखेंगे। हमने अपने खोज इंजन, ट्रैकर "
+"ब्लॉकर और एनक्रिप्शन एनफोर्सर को एक ही %1$s%2$s एक्सटेंशन%3$s में बंडल कर दिया है।"
 
 # smartling.placeholder_format=C
 msgid ""
@@ -3053,9 +3074,8 @@ msgid ""
 "search, tracker blocking, and site encryption, all in one download, for "
 "%smajor browsers%s."
 msgstr ""
-"सामान्य तौर पर ब्राउज़ करें, और बाकी सबका ध्यान हम रखेंगे। %1$sप्रमुख "
-"ब्राउज़र्स%2$s के लिए गोपनीय खोज, ट्रैकर ब्लॉकिंग और साइट एनक्रिप्शन पाएं, "
-"सब कुछ एक ही डाउनलोड में।"
+"सामान्य तौर पर ब्राउज़ करें, और बाकी सबका ध्यान हम रखेंगे। %1$sप्रमुख ब्राउज़र्स%2$s के लिए "
+"गोपनीय खोज, ट्रैकर ब्लॉकिंग और साइट एनक्रिप्शन पाएं, सब कुछ एक ही डाउनलोड में।"
 
 # smartling.placeholder_format=C
 #. Header for a call to action to browse with the DuckDuckGo browser
@@ -3162,11 +3182,11 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"डिफ़ॉल्ट रूप से, सेटिंग्स को गैर-व्यक्तिगत ब्राउज़र कुकीज़ (आपके ब्राउज़र "
-"में) में संग्रहित किया जाता है। आप अपनी सेटिंग्स को अधिक स्थायी तरीके से "
-"(क्लाउड में रिमोट सर्वर पर) संग्रहित करने के लिए अनाम क्लाउड सेव का उपयोग कर "
-"सकते हैं। व्यक्तिगत रूप से पहचान योग्य कोई भी जानकारी क्लाउड में संग्रहित "
-"नहीं की जाएगी और आपका पासफ़्रेज़ आपके ब्राउज़र से कभी अलग नहीं होगा।"
+"डिफ़ॉल्ट रूप से, सेटिंग्स को गैर-व्यक्तिगत ब्राउज़र कुकीज़ (आपके ब्राउज़र में) में संग्रहित किया "
+"जाता है। आप अपनी सेटिंग्स को अधिक स्थायी तरीके से (क्लाउड में रिमोट सर्वर पर) संग्रहित "
+"करने के लिए अनाम क्लाउड सेव का उपयोग कर सकते हैं। व्यक्तिगत रूप से पहचान योग्य कोई भी "
+"जानकारी क्लाउड में संग्रहित नहीं की जाएगी और आपका पासफ़्रेज़ आपके ब्राउज़र से कभी अलग नहीं "
+"होगा।"
 
 # smartling.placeholder_format=C
 #. Description for the consent highlight in the dictation consent modal. %s is replaced with a link to the help page.
@@ -3174,8 +3194,8 @@ msgid ""
 "By enabling dictation, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
 msgstr ""
-"डिक्टेशन चालू करके, आप इस फ़ीचर के इस्तेमाल के लिए अपना वॉयस डेटा OpenAI को "
-"भेजने की सहमति देते हैं। शुरू करने से पहले हमारे %1$s को देखें।"
+"डिक्टेशन चालू करके, आप इस फ़ीचर के इस्तेमाल के लिए अपना वॉयस डेटा OpenAI को भेजने की "
+"सहमति देते हैं। शुरू करने से पहले हमारे %1$s को देखें।"
 
 # smartling.placeholder_format=C
 #. Description for the 'enable voice chat' section of the voice chat consent modal. Placeholder for the voice chat help page link and text. Example: 'By enabling voice chat, you consent to your voice data being sent to OpenAI for the use of this feature. See our voice chat help page before getting started.'
@@ -3184,8 +3204,8 @@ msgid ""
 "By enabling voice chat, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
 msgstr ""
-"वॉयस चैट चालू करके, आप इस फ़ीचर के इस्तेमाल के लिए अपना वॉयस डेटा OpenAI को "
-"भेजने की सहमति देते हैं। शुरू करने से पहले हमारे %1$s को देखें।"
+"वॉयस चैट चालू करके, आप इस फ़ीचर के इस्तेमाल के लिए अपना वॉयस डेटा OpenAI को भेजने की "
+"सहमति देते हैं। शुरू करने से पहले हमारे %1$s को देखें।"
 
 # smartling.placeholder_format=C
 #. Golf leaderboard: player missed the cut
@@ -3431,6 +3451,12 @@ msgid "Cast"
 msgstr "कास्ट"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Cast & Crew"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
 msgctxt "Tone option label for Casual"
 msgid "Casual"
@@ -3515,9 +3541,7 @@ msgstr "यूआरएल के दिखाई देने का तरी�
 #. This is the description of a user setting
 msgctxt "settings"
 msgid "Changes how the header is displayed and its behavior as you scroll"
-msgstr ""
-"जब आप स्क्रॉल करते हैं तो हेडर कैसे प्रदर्शित होने और उसका ढंग परिवर्तित कर "
-"देता है"
+msgstr "जब आप स्क्रॉल करते हैं तो हेडर कैसे प्रदर्शित होने और उसका ढंग परिवर्तित कर देता है"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/mcZdcaF.png
@@ -3665,11 +3689,11 @@ msgid ""
 "DuckDuckGo Search. However, you can still access Chat when this setting is "
 "off by visiting %shttps://duck.ai%s directly."
 msgstr ""
-"Chat से (हमारी Duck.ai सेवा के माध्यम से) आपको थर्ड-पार्टी AI चैट मॉडल के "
-"साथ गुमनाम ढंग से बातचीत करने की सुविधा मिलती है, जो OpenAI, Anthropic आदि "
-"मॉडलों को सपोर्ट करती है। इस सेटिंग को बंद करने से DuckDuckGo Search पर Chat "
-"बटन और लिंक छिप जाएंगे। हालांकि, यह सेटिंग बंद होने पर भी आप "
-"%1$shttps://duck.ai%2$s पर जाकर, सीधे तौर पर Chat का इस्तेमाल कर सकते हैं।"
+"Chat से (हमारी Duck.ai सेवा के माध्यम से) आपको थर्ड-पार्टी AI चैट मॉडल के साथ गुमनाम "
+"ढंग से बातचीत करने की सुविधा मिलती है, जो OpenAI, Anthropic आदि मॉडलों को सपोर्ट "
+"करती है। इस सेटिंग को बंद करने से DuckDuckGo Search पर Chat बटन और लिंक छिप जाएंगे। "
+"हालांकि, यह सेटिंग बंद होने पर भी आप %1$shttps://duck.ai%2$s पर जाकर, सीधे तौर पर "
+"Chat का इस्तेमाल कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -3725,8 +3749,7 @@ msgstr "गोपनीय ढंग से चैट करें"
 msgctxt "Promotional text (mobile)"
 msgid "Chat privately on any website with Duck.ai built into our free browser."
 msgstr ""
-"हमारे मुफ़्त ब्राउज़र में मौजूद Duck.ai के ज़रिए किसी भी वेबसाइट पर गोपनीय "
-"ढंग से चैट करें।"
+"हमारे मुफ़्त ब्राउज़र में मौजूद Duck.ai के ज़रिए किसी भी वेबसाइट पर गोपनीय ढंग से चैट करें।"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card encouraging third-party browser users to download the DuckDuckGo browser. Not shown in the DuckDuckGo browser or on Linux.
@@ -3734,8 +3757,7 @@ msgctxt "Promotional text"
 msgid ""
 "Chat privately on any website with the Duck.ai sidebar in our free browser."
 msgstr ""
-"हमारे मुफ़्त ब्राउज़र में Duck.ai साइडबार के ज़रिए किसी भी वेबसाइट पर गोपनीय "
-"ढंग से चैट करें।"
+"हमारे मुफ़्त ब्राउज़र में Duck.ai साइडबार के ज़रिए किसी भी वेबसाइट पर गोपनीय ढंग से चैट करें।"
 
 # smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
@@ -3798,8 +3820,8 @@ msgid ""
 "Chats are stored locally on your device instead of on DuckDuckGo servers or "
 "remote servers. Disabling chat history will delete pinned chats."
 msgstr ""
-"चैट DuckDuckGo सर्वर या रिमोट सर्वर के बजाय आपके डिवाइस पर स्थानीय स्तर पर "
-"स्टोर की जाती हैं। चैट हिस्ट्री बंद करने से पिन की गई चैट्स डिलीट हो जाएंगी।"
+"चैट DuckDuckGo सर्वर या रिमोट सर्वर के बजाय आपके डिवाइस पर स्थानीय स्तर पर स्टोर की "
+"जाती हैं। चैट हिस्ट्री बंद करने से पिन की गई चैट्स डिलीट हो जाएंगी।"
 
 # smartling.placeholder_format=C
 #. Text explaining how the Chat History feature stores the user's chats locally to their device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection. Also explains that disabling chat history will delete pinned chats.
@@ -3811,11 +3833,10 @@ msgid ""
 "history will delete pinned chats, and disable the temporary storage of new "
 "prompts and responses."
 msgstr ""
-"चैट्स आपके डिवाइस में स्टोर होते हैं। नए प्रॉम्प्ट और रिस्पॉन्स भेजे जाने के "
-"बाद एन्क्रिप्ट किए जाते हैं और अस्थायी रूप से DuckDuckGo सर्वर पर स्टोर रहते "
-"हैं, ताकि यदि आपका इंटरनेट कनेक्शन खो जाए तो चैट को रिकवर किया जा सके। चैट "
-"हिस्ट्री को डिसेबल करने से पिन की गई चैट डिलीट हो जाएंगी, और नए प्रॉम्प्ट और "
-"रिस्पॉन्स का टेम्पररी स्टोरेज भी बंद हो जाएगा।"
+"चैट्स आपके डिवाइस में स्टोर होते हैं। नए प्रॉम्प्ट और रिस्पॉन्स भेजे जाने के बाद एन्क्रिप्ट किए "
+"जाते हैं और अस्थायी रूप से DuckDuckGo सर्वर पर स्टोर रहते हैं, ताकि यदि आपका इंटरनेट "
+"कनेक्शन खो जाए तो चैट को रिकवर किया जा सके। चैट हिस्ट्री को डिसेबल करने से पिन की गई "
+"चैट डिलीट हो जाएंगी, और नए प्रॉम्प्ट और रिस्पॉन्स का टेम्पररी स्टोरेज भी बंद हो जाएगा।"
 
 # smartling.placeholder_format=C
 #. Title shown above the body copy in the Duck.ai recent chats IndexedDB unavailable notice.
@@ -3837,8 +3858,7 @@ msgctxt "Sync file storage inline disclaimer body"
 msgid ""
 "Chats with attachments have stopped syncing. Free up storage to resume Sync."
 msgstr ""
-"अटैचमेंट वाली चैट्स सिंक होना बंद हो गई हैं। सिंक फिर से शुरू करने के लिए "
-"स्टोरेज खाली करें।"
+"अटैचमेंट वाली चैट्स सिंक होना बंद हो गई हैं। सिंक फिर से शुरू करने के लिए स्टोरेज खाली करें।"
 
 # smartling.placeholder_format=C
 #. Message shown when we have no data from upstream to display
@@ -3991,8 +4011,8 @@ msgctxt "settings"
 msgid ""
 "Choose which app to use when you need directions for a location search result"
 msgstr ""
-"किसी स्थान खोज परिणाम के लिए आपको डायरेक्शन की ज़रूरत होने पर चुनें कि किस "
-"ऐप का इस्तेमाल करना है"
+"किसी स्थान खोज परिणाम के लिए आपको डायरेक्शन की ज़रूरत होने पर चुनें कि किस ऐप का "
+"इस्तेमाल करना है"
 
 # smartling.placeholder_format=C
 #. Accessible label for the citations popover dialog in Duck.ai chat responses.
@@ -4173,9 +4193,8 @@ msgid ""
 "Clearing browser data deletes chats. Some browsers may keep recent chats "
 "indefinitely or auto-delete them after 7+ days of no AI Chat use."
 msgstr ""
-"ब्राउज़र डेटा साफ़ करने से चैट डिलीट हो जाती हैं। कुछ ब्राउज़र हालिया चैट को "
-"लंबे समय तक रख सकते हैं या 7 से ज़्यादा दिनों तक AI Chat का उपयोग न करने पर "
-"उन्हें ऑटो-डिलीट कर सकते हैं।"
+"ब्राउज़र डेटा साफ़ करने से चैट डिलीट हो जाती हैं। कुछ ब्राउज़र हालिया चैट को लंबे समय तक रख "
+"सकते हैं या 7 से ज़्यादा दिनों तक AI Chat का उपयोग न करने पर उन्हें ऑटो-डिलीट कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Text explaining what happens to recent chats when browser data is cleared.
@@ -4185,9 +4204,9 @@ msgid ""
 "indefinitely or auto-deleted after 7 days without using Duck.ai, depending "
 "on your browser."
 msgstr ""
-"ब्राउज़र डेटा साफ़ करने से हाल की चैट हट जाती हैं। Duck.ai का इस्तेमाल किए "
-"बिना, हाल की चैट को अनिश्चित काल के लिए सेव किया जा सकता है या 7 दिनों के "
-"बाद अपने-आप हटाया जा सकता है। यह आपके ब्राउज़र पर निर्भर करता है।"
+"ब्राउज़र डेटा साफ़ करने से हाल की चैट हट जाती हैं। Duck.ai का इस्तेमाल किए बिना, हाल की "
+"चैट को अनिश्चित काल के लिए सेव किया जा सकता है या 7 दिनों के बाद अपने-आप हटाया जा "
+"सकता है। यह आपके ब्राउज़र पर निर्भर करता है।"
 
 # smartling.placeholder_format=C
 #. Warning message shown on the Block domain success modal. Blocked sites are stored in localStorage which is cleared alongside cookies when users clear browser data. Followed by a linked 'our free browser' text.
@@ -4196,8 +4215,8 @@ msgid ""
 "Clearing browser data will reset your blocked sites. Save your block list "
 "permanently in"
 msgstr ""
-"ब्राउज़र डेटा क्लियर करने से आपकी ब्लॉक की गई साइटें रीसेट हो जाएंगी। अपनी "
-"ब्लॉक लिस्ट को हमेशा के लिए सेव करें"
+"ब्राउज़र डेटा क्लियर करने से आपकी ब्लॉक की गई साइटें रीसेट हो जाएंगी। अपनी ब्लॉक लिस्ट को "
+"हमेशा के लिए सेव करें"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -4206,9 +4225,9 @@ msgid ""
 "%sDuck.ai%s, our private AI chat service that supports chat models from "
 "OpenAI, Anthropic, and more."
 msgstr ""
-"किसी विषय पर और गहराई से जानने के लिए \"अधिक\" पर क्लिक करें, और फ़ॉलोअप "
-"प्रश्न %1$sDuck.ai%2$s के ज़रिए पूछें, यह हमारी प्राइवेट AI चैट सेवा है जो "
-"OpenAI, Anthropic और अन्य के चैट मॉडलों को सपोर्ट करती है।"
+"किसी विषय पर और गहराई से जानने के लिए \"अधिक\" पर क्लिक करें, और फ़ॉलोअप प्रश्न "
+"%1$sDuck.ai%2$s के ज़रिए पूछें, यह हमारी प्राइवेट AI चैट सेवा है जो OpenAI, Anthropic "
+"और अन्य के चैट मॉडलों को सपोर्ट करती है।"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4250,8 +4269,8 @@ msgid ""
 "Click %sEdit > Preferences%s (on Windows) %sSeaMonkey > Preferences%s (on "
 "Mac)"
 msgstr ""
-"%1$sसंपादित करें > प्राथमिकताएं%2$s (Windows पर) %3$sSeaMonkey > "
-"प्राथमिकताएं%4$s (Mac पर) क्लिक करें"
+"%1$sसंपादित करें > प्राथमिकताएं%2$s (Windows पर) %3$sSeaMonkey > प्राथमिकताएं%4$s "
+"(Mac पर) क्लिक करें"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -4267,9 +4286,7 @@ msgstr "DuckDuckGo एकस्टेंशन को डाउनलोड क�
 # smartling.placeholder_format=C
 #. Link to download the DuckDuckGo browser extension.
 msgid "Click %sOpen%s to download and open the DuckDuckGo Safari extension"
-msgstr ""
-"DuckDuckGo Safari एकस्टेंशन को डाउनलोड करके खोलने के लिए %1$sखोलें%2$s क्लिक "
-"करें"
+msgstr "DuckDuckGo Safari एकस्टेंशन को डाउनलोड करके खोलने के लिए %1$sखोलें%2$s क्लिक करें"
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -4284,8 +4301,8 @@ msgid ""
 "Click %sSafari%s in the top menu (On Windows, click the %sgears icon%s in "
 "the top right)"
 msgstr ""
-"शीर्ष मेनू में %1$sSafari%2$s पर क्लिक करें (Windows पर, शीर्ष दाईं ओर "
-"%3$sगियर आइकन%4$s पर क्लिक करें)"
+"शीर्ष मेनू में %1$sSafari%2$s पर क्लिक करें (Windows पर, शीर्ष दाईं ओर %3$sगियर "
+"आइकन%4$s पर क्लिक करें)"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4302,9 +4319,7 @@ msgstr "ड्रॉपडाउन में %1$sसेटिंग्स%2$s �
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
-msgstr ""
-"%1$sमौजूदा पेज इस्तेमाल करें%2$s पर क्लिक करें, फिर %3$sओके पर क्लिक%4$s "
-"करें।"
+msgstr "%1$sमौजूदा पेज इस्तेमाल करें%2$s पर क्लिक करें, फिर %3$sओके पर क्लिक%4$s करें।"
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -4317,8 +4332,7 @@ msgstr "%1$sहां%2$s पर क्लिक करें"
 #. Tells the user where to click to open their browser's settings menu.
 msgid "Click %ssettings/hamburger icon %s on the Chrome toolbar (top right)."
 msgstr ""
-"Chrome टूलबार (ऊपर से दाहिने) पर %1$ssettings/hamburger आइकन%2$s पर क्लिक "
-"करें"
+"Chrome टूलबार (ऊपर से दाहिने) पर %1$ssettings/hamburger आइकन%2$s पर क्लिक करें"
 
 #  Maxthon default search engine instruction
 # smartling.placeholder_format=C
@@ -4380,9 +4394,9 @@ msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Search Settings%s."
 msgstr ""
-"%1$sमेरा डेटा डिलीट करें%2$s पर क्लिक करें या टैप करें। यह क्लाउड से डेटा "
-"हटा देता है, लेकिन यह आपके ब्राउज़र में तब तक बना रहता है जब तक आप %3$sसभी "
-"खोज सेटिंग रीसेट करें%4$s पर क्लिक/टैप नहीं कर देते।"
+"%1$sमेरा डेटा डिलीट करें%2$s पर क्लिक करें या टैप करें। यह क्लाउड से डेटा हटा देता है, लेकिन "
+"यह आपके ब्राउज़र में तब तक बना रहता है जब तक आप %3$sसभी खोज सेटिंग रीसेट करें%4$s पर "
+"क्लिक/टैप नहीं कर देते।"
 
 # smartling.placeholder_format=C
 #. Tells users where to click in order to disable the cloud save feature and delete any data backed-up to the cloud.
@@ -4393,9 +4407,8 @@ msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Settings%s."
 msgstr ""
-"%1$sमेरा डेटा हटाएं%2$s पर क्लिक करें या टैप करें। यह क्लाउड से डेटा हटाता "
-"है, लेकिन यह आपके ब्राउज़र में तब तक रहता है जब तक आप %3$sसभी सेटिंग्स "
-"रीसेट%4$s पर क्लिक/टैप नहीं करते।"
+"%1$sमेरा डेटा हटाएं%2$s पर क्लिक करें या टैप करें। यह क्लाउड से डेटा हटाता है, लेकिन यह "
+"आपके ब्राउज़र में तब तक रहता है जब तक आप %3$sसभी सेटिंग्स रीसेट%4$s पर क्लिक/टैप नहीं करते।"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -4464,8 +4477,8 @@ msgid ""
 "Click the dropdown menu beside %sSearch engine used in the address bar%s and "
 "select %sDuckDuckGo%s."
 msgstr ""
-"%1$sएड्रेस बार में उपयोग किए गए खोज इंजन%2$s के पास वाले ड्रॉपडाउन मेनू पर "
-"क्लिक करें और %3$sDuckDuckGo%4$s चुनें।"
+"%1$sएड्रेस बार में उपयोग किए गए खोज इंजन%2$s के पास वाले ड्रॉपडाउन मेनू पर क्लिक करें और "
+"%3$sDuckDuckGo%4$s चुनें।"
 
 # smartling.placeholder_format=C
 #. First step in a list of steps to take to disable the user's ad blocker
@@ -4473,8 +4486,8 @@ msgid ""
 "Click the icon of the ad blocker extension. It's usually in the upper right "
 "hand corner of your browser."
 msgstr ""
-"विज्ञापन ब्लॉकर एक्सटेंशन के आइकॉन पर क्लिक करें। यह आम तौर पर आपके ब्राउज़र "
-"के ऊपरी दाएं कोने में होता है।"
+"विज्ञापन ब्लॉकर एक्सटेंशन के आइकॉन पर क्लिक करें। यह आम तौर पर आपके ब्राउज़र के ऊपरी दाएं "
+"कोने में होता है।"
 
 #  Safari default search engine instruction
 # smartling.placeholder_format=C
@@ -4663,8 +4676,8 @@ msgid ""
 "Cloud Save lets you save your settings more permanently by entering a "
 "passphrase. It is entirely optional."
 msgstr ""
-"Cloud Save से आप अपनी चुनी हुई सेटिंग्स एक पासवर्ड द्वारा सर्वर पर ज़्यादा "
-"सुरक्षित रख सकते हैं। यह पूर्ण तरह से वैकल्पिक है।"
+"Cloud Save से आप अपनी चुनी हुई सेटिंग्स एक पासवर्ड द्वारा सर्वर पर ज़्यादा सुरक्षित रख "
+"सकते हैं। यह पूर्ण तरह से वैकल्पिक है।"
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -5139,6 +5152,12 @@ msgid "Create Image"
 msgstr "इमेज बनाएं"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Create a shopping list with quantities from this recipe."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text displayed in the input field when starting a new image generation session.
 msgctxt "Placeholder text for the image generation input field"
 msgid "Create an image of a cute duck..."
@@ -5401,8 +5420,8 @@ msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "Daily usage limit reached. You can keep chatting by using your weekly limit."
 msgstr ""
-"दैनिक उपयोग सीमा पूरी हो गई है। आप अपनी साप्ताहिक सीमा का इस्तेमाल करके चैट "
-"करना जारी रख सकते हैं।"
+"दैनिक उपयोग सीमा पूरी हो गई है। आप अपनी साप्ताहिक सीमा का इस्तेमाल करके चैट करना "
+"जारी रख सकते हैं।"
 
 # smartling.placeholder_format=C
 #. The name of the Danish language
@@ -5770,8 +5789,8 @@ msgstr "Duck.ai में डिक्टेशन"
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
 msgstr ""
-"हम डिक्टेशन को गुमनाम रखते हैं और इसका उपयोग कभी भी AI मॉडल प्रशिक्षित करने "
-"के लिए नहीं किया जाता है।"
+"हम डिक्टेशन को गुमनाम रखते हैं और इसका उपयोग कभी भी AI मॉडल प्रशिक्षित करने के लिए नहीं "
+"किया जाता है।"
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
@@ -5779,13 +5798,18 @@ msgid "Dictation limit reached"
 msgstr "डिक्टेशन सीमा पूरी हो गई है"
 
 # smartling.placeholder_format=C
+#. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
+msgid "Dictation temporarily unavailable"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
 "chat in Duck.ai without having to type."
 msgstr ""
-"डिक्टेशन आपकी स्पीच को टेक्स्ट में बदलने के लिए OpenAI मॉडल का इस्तेमाल करता "
-"है, ताकि आप बिना टाइप किए भी Duck.ai में चैट कर सकें।"
+"डिक्टेशन आपकी स्पीच को टेक्स्ट में बदलने के लिए OpenAI मॉडल का इस्तेमाल करता है, ताकि आप "
+"बिना टाइप किए भी Duck.ai में चैट कर सकें।"
 
 # smartling.placeholder_format=C
 #. In 0-click box -- link to definition.
@@ -6079,6 +6103,22 @@ msgid "Done"
 msgstr "हो गया"
 
 # smartling.placeholder_format=C
+#. Message shown in a modal after DuckDuckGo browser users disable AI features in Settings. The first two placeholders bold noai.duckduckgo.com. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
+"filtered out. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
+"and AI images filtered out. %sLearn more%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Double Faults"
@@ -6179,8 +6219,8 @@ msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for "
 "ceiling fan repair services."
 msgstr ""
-"छत वाले पंखे की मरम्मत सेवा के लिए कोटेशन का अनुरोध करते हुए, वेंडर को कम "
-"शब्दों में ज़रूरी जानकारी के साथ ईमेल लिखें।"
+"छत वाले पंखे की मरम्मत सेवा के लिए कोटेशन का अनुरोध करते हुए, वेंडर को कम शब्दों में ज़रूरी "
+"जानकारी के साथ ईमेल लिखें।"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion asking for an email draft to a vendor requesting a quote for home refrigerator repair services.
@@ -6189,8 +6229,20 @@ msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
 msgstr ""
-"घर के रेफ़्रिजरेरट की मरम्मत के लिए कोटेशन का अनुरोध करते हुए, वेंडर को कम "
-"शब्दों में ज़रूरी जानकारी के साथ ईमेल लिखें।"
+"घर के रेफ़्रिजरेरट की मरम्मत के लिए कोटेशन का अनुरोध करते हुए, वेंडर को कम शब्दों में ज़रूरी "
+"जानकारी के साथ ईमेल लिखें।"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Draft a cover letter"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Draft a cover letter for this job."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -6199,8 +6251,8 @@ msgid ""
 "Draft a few options for a social media post inviting people to my upcoming "
 "party."
 msgstr ""
-"ऐसी एक सोशल मीडिया पोस्ट हेतु कुछ ऑप्शन ड्राफ्ट करें जो मेरी आगामी पार्टी "
-"में लोगों को आमंत्रित करने के लिए है।"
+"ऐसी एक सोशल मीडिया पोस्ट हेतु कुछ ऑप्शन ड्राफ्ट करें जो मेरी आगामी पार्टी में लोगों को "
+"आमंत्रित करने के लिए है।"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a few options for a blog post title about strategies to increase team collaboration.
@@ -6209,8 +6261,8 @@ msgid ""
 "Draft a few options for a title of a post I’m writing about strategies to "
 "increase team collaboration."
 msgstr ""
-"ऐसी एक पोस्ट के शीर्षक के लिए कुछ ऑप्शन ड्राफ्ट करें जिसमें मुझे टीम सहयोग "
-"बढ़ाने की मेरी रणनीतियों के बारे में लिखना है।"
+"ऐसी एक पोस्ट के शीर्षक के लिए कुछ ऑप्शन ड्राफ्ट करें जिसमें मुझे टीम सहयोग बढ़ाने की मेरी "
+"रणनीतियों के बारे में लिखना है।"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for drafting a social media post.
@@ -6336,9 +6388,9 @@ msgid ""
 "content is only included when you attach it, unless you choose to attach "
 "pages automatically in Settings."
 msgstr ""
-"अब Duck.ai आपके द्वारा देखे जा रहे पेज से संबंधित सवालों के जवाब दे सकता है। "
-"पेज का कंटेंट तभी शामिल होता है जब आप उसे अटैच करते हैं, बशर्ते आपने सेटिंग "
-"में पेजों को ऑटोमैटिकली अटैच करने का विकल्प न चुना हो।"
+"अब Duck.ai आपके द्वारा देखे जा रहे पेज से संबंधित सवालों के जवाब दे सकता है। पेज का कंटेंट "
+"तभी शामिल होता है जब आप उसे अटैच करते हैं, बशर्ते आपने सेटिंग में पेजों को ऑटोमैटिकली अटैच "
+"करने का विकल्प न चुना हो।"
 
 # smartling.placeholder_format=C
 #. Shown in the Duck.ai recent chats list on standalone when the browser API needed to store chats locally is missing or unavailable.
@@ -6348,9 +6400,8 @@ msgid ""
 "Duck.ai can’t access local storage to save your chats. Please check your "
 "browser settings or disable any extensions and try again."
 msgstr ""
-"Duck.ai आपकी चैट्स को सेव करने के लिए लोकल स्टोरेज एक्सेस नहीं कर सकता। "
-"कृपया अपनी ब्राउज़र सेटिंग्स चेक करें या कोई भी एक्सटेंशन डिसेबल (अक्षम) "
-"करें और फिर से कोशिश करें।"
+"Duck.ai आपकी चैट्स को सेव करने के लिए लोकल स्टोरेज एक्सेस नहीं कर सकता। कृपया अपनी "
+"ब्राउज़र सेटिंग्स चेक करें या कोई भी एक्सटेंशन डिसेबल (अक्षम) करें और फिर से कोशिश करें।"
 
 # smartling.placeholder_format=C
 #. Displayed when the chat service has reached the maximum number of messages for one day.
@@ -6359,14 +6410,23 @@ msgid ""
 "Duck.ai has reached the maximum number of messages for one day. Please "
 "continue this chat tomorrow."
 msgstr ""
-"Duck.ai एक दिन के लिए तय संदेशों की अधिकतम संख्या तक पहुंच गया है। कृपया इस "
-"चैट को अब कल जारी रखें।"
+"Duck.ai एक दिन के लिए तय संदेशों की अधिकतम संख्या तक पहुंच गया है। कृपया इस चैट को अब "
+"कल जारी रखें।"
 
 # smartling.placeholder_format=C
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
 msgstr "Duck.ai हमारे प्राइवेट और फ्री DuckDuckGo ब्राउज़र में सबसे बढ़िया है!"
+
+# smartling.placeholder_format=C
+#. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
+msgctxt "About section description on the Duck.ai settings page"
+msgid ""
+"Duck.ai is created by DuckDuckGo. We're an independent online protection "
+"company for anyone who wants to take back control of their personal "
+"information."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
@@ -6381,8 +6441,8 @@ msgid ""
 "Duck.ai is still a DuckDuckGo product, but will now have an easier to "
 "remember home on the web: https://duck.ai"
 msgstr ""
-"Duck.ai अभी भी DuckDuckGo का प्रोडक्ट है, लेकिन अब वेब पर इसे याद रखना और भी "
-"आसान होगा: https://duck.ai"
+"Duck.ai अभी भी DuckDuckGo का प्रोडक्ट है, लेकिन अब वेब पर इसे याद रखना और भी आसान "
+"होगा: https://duck.ai"
 
 # smartling.placeholder_format=C
 #. Headline for domain change notice.
@@ -6397,8 +6457,8 @@ msgid ""
 "Duck.ai is temporarily unavailable. If this persists, please email this "
 "anonymous code %s to %s"
 msgstr ""
-"Duck.ai फिलहाल उपलब्ध नहीं है। अगर यह समस्या बनी रहती है, तो कृपया इस अनाम "
-"कोड %1$s को %2$s पर ईमेल करें"
+"Duck.ai फिलहाल उपलब्ध नहीं है। अगर यह समस्या बनी रहती है, तो कृपया इस अनाम कोड "
+"%1$s को %2$s पर ईमेल करें"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -6416,17 +6476,23 @@ msgstr "Duck.ai फिलहाल उपलब्ध नहीं है। क
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
+"Duck.ai lets you chat privately with popular AI models. Disabling it hides "
+"Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
+msgstr ""
+
+# smartling.placeholder_format=C
+msgctxt "settings"
+msgid ""
 "Duck.ai lets you have anonymous conversations with 3rd-party AI chat models, "
 "including models from OpenAI, Anthropic, and others. Turning this setting "
 "off will hide Duck.ai buttons and links on DuckDuckGo Search. However, you "
 "can still access Duck.ai when this setting is off by visiting %shttps://duck."
 "ai%s directly."
 msgstr ""
-"Duck.ai से आपको थर्ड-पार्टी AI चैट मॉडल के साथ गुमनाम ढंग से बातचीत करने की "
-"सुविधा मिलती है, जिसमें OpenAI, Anthropic और अन्य मॉडल शामिल हैं। इस सेटिंग "
-"को बंद करने से DuckDuckGo Search पर Duck.ai बटन और लिंक छिप जाएंगे। हालांकि, "
-"यह सेटिंग बंद होने पर भी आप %1$shttps://duck.ai%2$s पर जाकर, सीधे तौर पर "
-"Duck.ai का इस्तेमाल कर सकते हैं।"
+"Duck.ai से आपको थर्ड-पार्टी AI चैट मॉडल के साथ गुमनाम ढंग से बातचीत करने की सुविधा "
+"मिलती है, जिसमें OpenAI, Anthropic और अन्य मॉडल शामिल हैं। इस सेटिंग को बंद करने से "
+"DuckDuckGo Search पर Duck.ai बटन और लिंक छिप जाएंगे। हालांकि, यह सेटिंग बंद होने पर "
+"भी आप %1$shttps://duck.ai%2$s पर जाकर, सीधे तौर पर Duck.ai का इस्तेमाल कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
@@ -6441,8 +6507,8 @@ msgid ""
 "Duck.ai might have lost your recent chats. You can still use Duck.ai as "
 "usual."
 msgstr ""
-"हो सकता है कि Duck.ai ने आपकी पिछली चैट हटा दी हों। आप Duck.ai का उपयोग जारी "
-"रख सकते हैं।"
+"हो सकता है कि Duck.ai ने आपकी पिछली चैट हटा दी हों। आप Duck.ai का उपयोग जारी रख "
+"सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
@@ -6456,8 +6522,8 @@ msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
 msgstr ""
-"Duck.ai के जवाब कुछ खास स्रोतों पर आधारित नहीं होते हैं और इनकी सटीकता "
-"संबंधी कोई जांच नहीं होती है।"
+"Duck.ai के जवाब कुछ खास स्रोतों पर आधारित नहीं होते हैं और इनकी सटीकता संबंधी कोई जांच "
+"नहीं होती है।"
 
 # smartling.placeholder_format=C
 #. Title shown when native app needs to reload for service update.
@@ -6485,9 +6551,9 @@ msgid ""
 "AI chat no sign up, OpenAI, Anthropic, Llama, Mistral, open source AI "
 "models, privacy focused AI, no account AI chat"
 msgstr ""
-"Duck.ai, DuckDuckGo AI, प्राइवेट AI चैटबॉट, मुफ़्त AI चैट, गुमनाम AI चैट, "
-"बिना साइन अप AI चैट, OpenAI, Anthropic, Llama, Mistral, ओपन सोर्स AI मॉडल, "
-"गोपनीयता केंद्रित AI, बिना खाता AI चैट"
+"Duck.ai, DuckDuckGo AI, प्राइवेट AI चैटबॉट, मुफ़्त AI चैट, गुमनाम AI चैट, बिना साइन "
+"अप AI चैट, OpenAI, Anthropic, Llama, Mistral, ओपन सोर्स AI मॉडल, गोपनीयता "
+"केंद्रित AI, बिना खाता AI चैट"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -6515,13 +6581,12 @@ msgid ""
 "relevant), or Often (shows more frequently on a wider range of searches). "
 "For now, DuckAssist is only available in the U.S. (English) region."
 msgstr ""
-"कुछ खोजों के लिए DuckAssist, जानकारी को गुमनाम रूप से खोज सकता है और उसके "
-"बारे में खास जानकारी दे सकता है। आप चुन सकते हैं कि DuckAssist को कितनी बार "
-"दिखाना है: कभी नहीं (यह खोज परिणामों से DuckAssist के यूआई को पूरी तरह हटा "
-"देता है), ऑन-डिमांड (सिर्फ़ तभी दिखाता है जब आप 'सहायता' बटन पर क्लिक करते "
-"हैं), कभी-कभी (सिर्फ़ तभी दिखाता है, जब नतीजे बहुत काम के हों), या अक्सर (कई "
-"तरह की खोजों पर अक्सर दिखाता है)। फ़िलहाल, DuckAssist सिर्फ़ अमेरिका "
-"(अंग्रेज़ी) में उपलब्ध है।"
+"कुछ खोजों के लिए DuckAssist, जानकारी को गुमनाम रूप से खोज सकता है और उसके बारे में खास "
+"जानकारी दे सकता है। आप चुन सकते हैं कि DuckAssist को कितनी बार दिखाना है: कभी नहीं "
+"(यह खोज परिणामों से DuckAssist के यूआई को पूरी तरह हटा देता है), ऑन-डिमांड (सिर्फ़ तभी "
+"दिखाता है जब आप 'सहायता' बटन पर क्लिक करते हैं), कभी-कभी (सिर्फ़ तभी दिखाता है, जब "
+"नतीजे बहुत काम के हों), या अक्सर (कई तरह की खोजों पर अक्सर दिखाता है)। फ़िलहाल, "
+"DuckAssist सिर्फ़ अमेरिका (अंग्रेज़ी) में उपलब्ध है।"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6531,8 +6596,8 @@ msgid ""
 "supports chat models from OpenAI, and Anthropic, and more."
 msgstr ""
 "DuckAssist से फ़ॉलोअप सवालों के जवाब नहीं दिए जा सकते। हालांकि, हमारी ओर से "
-"%1$sDuckDuckGo AI Chat%2$s भी उपलब्ध है, जो एक प्राइवेट AI-संचालित चैट सेवा "
-"है जो OpenAI के चैट मॉडलों को, और Anthropic को और अन्य को सपोर्ट करती है।"
+"%1$sDuckDuckGo AI Chat%2$s भी उपलब्ध है, जो एक प्राइवेट AI-संचालित चैट सेवा है जो "
+"OpenAI के चैट मॉडलों को, और Anthropic को और अन्य को सपोर्ट करती है।"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6542,8 +6607,8 @@ msgid ""
 "supports chat models from OpenAI and Anthropic."
 msgstr ""
 "DuckAssist से फ़ॉलोअप सवालों के जवाब नहीं दिए जा सकते। हालांकि, हमारी ओर से "
-"DuckDuckGo %1$sAI Chat%2$s भी उपलब्ध है। यह एक प्राइवेट AI-संचालित चैट सेवा "
-"है जो OpenAI और Anthropic के चैट मॉडलों को सपोर्ट करती है।"
+"DuckDuckGo %1$sAI Chat%2$s भी उपलब्ध है। यह एक प्राइवेट AI-संचालित चैट सेवा है जो "
+"OpenAI और Anthropic के चैट मॉडलों को सपोर्ट करती है।"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6555,12 +6620,12 @@ msgid ""
 "responses are currently based on Wikipedia and related content and are not "
 "checked for accuracy."
 msgstr ""
-"DuckAssist, खोज परिणाम दिखाने से जुड़ा एक नया फ़ीचर है। यह गुमनाम रहकर, खोज "
-"संबंधी क्वेरी के जवाब जनरेट कर सकता है। ऐसा करने के लिए, यह Wikipedia और "
-"संबंधित साइटों को स्कैन करके उनसे काम की जानकारी जुटाता है। इसके बाद, उससे "
-"जुड़ी खास जानकारी को जनरेट करने के लिए AI-संचालित नेचुरल लैंग्वेज टेक्नोलॉजी "
-"का इस्तेमाल करता है। कृपया ध्यान दें कि फ़िलहाल इसके जवाब Wikipedia और "
-"संबंधित कॉन्टेंट पर आधारित होते हैं और इसकी सटीकता की जांच नहीं की जाती है।"
+"DuckAssist, खोज परिणाम दिखाने से जुड़ा एक नया फ़ीचर है। यह गुमनाम रहकर, खोज संबंधी "
+"क्वेरी के जवाब जनरेट कर सकता है। ऐसा करने के लिए, यह Wikipedia और संबंधित साइटों को "
+"स्कैन करके उनसे काम की जानकारी जुटाता है। इसके बाद, उससे जुड़ी खास जानकारी को जनरेट करने "
+"के लिए AI-संचालित नेचुरल लैंग्वेज टेक्नोलॉजी का इस्तेमाल करता है। कृपया ध्यान दें कि फ़िलहाल "
+"इसके जवाब Wikipedia और संबंधित कॉन्टेंट पर आधारित होते हैं और इसकी सटीकता की जांच नहीं "
+"की जाती है।"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6574,15 +6639,13 @@ msgid ""
 "It’s important to remember that responses are auto-generated from cited "
 "sources and based on %scrawling the web%s."
 msgstr ""
-"DuckAssist, खोज परिणाम दिखाने से जुड़ा एक नया वैकल्पिक फ़ीचर है। यह गुमनाम "
-"रहकर, खोज संबंधी क्वेरी के जवाब जनरेट कर सकता है। ऐसा करने के लिए, यह वेब को "
-"स्कैन करके क्वेरी से जुड़ी सामग्री जुटाता है। इसके बाद, उस सामग्री से जुड़ी "
-"जानकारी के आधार पर कम शब्दों में जवाब देने के लिए, AI-संचालित नेचुरल "
-"लैंग्वेज टेक्नोलॉजी का इस्तेमाल करता है। DuckAssist के जवाब हमेशा एक या दो "
-"स्रोतों से सीधे लिंक होते हैं, जिसमें बताया जाता है कि जवाब कहां से आया है, "
-"ताकि आपको आसानी से वहां जाकर ज़्यादा जानकारी मिल सके। यह याद रखना ज़रूरी है "
-"कि जवाब, दूसरे स्रोतों से अपने-आप जनरेट होते हैं और %1$sवेब क्रॉलिंग%2$s पर "
-"आधारित होते हैं।"
+"DuckAssist, खोज परिणाम दिखाने से जुड़ा एक नया वैकल्पिक फ़ीचर है। यह गुमनाम रहकर, खोज "
+"संबंधी क्वेरी के जवाब जनरेट कर सकता है। ऐसा करने के लिए, यह वेब को स्कैन करके क्वेरी से जुड़ी "
+"सामग्री जुटाता है। इसके बाद, उस सामग्री से जुड़ी जानकारी के आधार पर कम शब्दों में जवाब देने "
+"के लिए, AI-संचालित नेचुरल लैंग्वेज टेक्नोलॉजी का इस्तेमाल करता है। DuckAssist के जवाब हमेशा "
+"एक या दो स्रोतों से सीधे लिंक होते हैं, जिसमें बताया जाता है कि जवाब कहां से आया है, ताकि "
+"आपको आसानी से वहां जाकर ज़्यादा जानकारी मिल सके। यह याद रखना ज़रूरी है कि जवाब, दूसरे "
+"स्रोतों से अपने-आप जनरेट होते हैं और %1$sवेब क्रॉलिंग%2$s पर आधारित होते हैं।"
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
@@ -6590,8 +6653,8 @@ msgid ""
 "DuckAssist responses are auto-generated based on listed sources and not "
 "checked for accuracy."
 msgstr ""
-"DuckAssist वाले जवाब सूचीबद्ध स्रोतों के आधार पर स्वचालित ढंग से जनरेट होते "
-"हैं और इनकी सटीकता की जांच नहीं की जाती है।"
+"DuckAssist वाले जवाब सूचीबद्ध स्रोतों के आधार पर स्वचालित ढंग से जनरेट होते हैं और इनकी "
+"सटीकता की जांच नहीं की जाती है।"
 
 # smartling.placeholder_format=C
 #. Displayed when the chat service has reached the maximum number of messages for one day.
@@ -6600,8 +6663,8 @@ msgid ""
 "DuckDuckGo AI Chat has reached the maximum number of messages for one day. "
 "Please continue this chat tomorrow."
 msgstr ""
-"DuckDuckGo AI Chat में एक दिन के संदेशों की अधिकतम संख्या पूरी हो गई है। "
-"कृपया इस चैट को अब कल जारी रखें।"
+"DuckDuckGo AI Chat में एक दिन के संदेशों की अधिकतम संख्या पूरी हो गई है। कृपया इस चैट को "
+"अब कल जारी रखें।"
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the AI chat service and supported AI models. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -6610,8 +6673,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"DuckDuckGo AI Chat एक प्राइवेट AI-संचालित चैट सेवा है जो वर्तमान में %1$s के "
-"%2$s और %3$s के %4$s चैट मॉडल को सपोर्ट करती है।"
+"DuckDuckGo AI Chat एक प्राइवेट AI-संचालित चैट सेवा है जो वर्तमान में %1$s के %2$s और "
+"%3$s के %4$s चैट मॉडल को सपोर्ट करती है।"
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the welcome screen of the onboarding. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -6620,8 +6683,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"DuckDuckGo AI Chat एक प्राइवेट AI-संचालित चैट सेवा है जो वर्तमान में %1$s के "
-"%2$s और %3$s के %4$s चैट मॉडल को सपोर्ट करती है।"
+"DuckDuckGo AI Chat एक प्राइवेट AI-संचालित चैट सेवा है जो वर्तमान में %1$s के %2$s और "
+"%3$s के %4$s चैट मॉडल को सपोर्ट करती है।"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding DuckDuckGo AI Chat.
@@ -6630,8 +6693,7 @@ msgid ""
 "DuckDuckGo AI Chat is in Beta, it may display inaccurate or offensive "
 "information."
 msgstr ""
-"DuckDuckGo AI Chat बीटा में है, इसमें गलत या आपत्तिजनक जानकारी भी दिखाई दे "
-"सकती है।"
+"DuckDuckGo AI Chat बीटा में है, इसमें गलत या आपत्तिजनक जानकारी भी दिखाई दे सकती है।"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat making it unavailable, and asking the user to send an email with a specific code if the error persists. E.g. 'DuckDuckGo AI Chat is temporarily unavailable. If this persists, please email this anonymous code abcdefg12345 to aichat-error@duckduckgo.com'
@@ -6640,8 +6702,8 @@ msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. If this persists, please "
 "email this anonymous code %s to %s"
 msgstr ""
-"DuckDuckGo AI Chat फिलहाल उपलब्ध नहीं है। अगर यह समस्या बनी रहती है, तो "
-"कृपया इस अनाम कोड %1$s को %2$s पर ईमेल करें"
+"DuckDuckGo AI Chat फिलहाल उपलब्ध नहीं है। अगर यह समस्या बनी रहती है, तो कृपया इस "
+"अनाम कोड %1$s को %2$s पर ईमेल करें"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -6650,8 +6712,7 @@ msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. Please refresh the page and "
 "try again."
 msgstr ""
-"DuckDuckGo AI Chat फिलहाल उपलब्ध नहीं है। पेज को रीफ्रेश करें और फिर से "
-"कोशिश करें।"
+"DuckDuckGo AI Chat फिलहाल उपलब्ध नहीं है। पेज को रीफ्रेश करें और फिर से कोशिश करें।"
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -6776,9 +6837,8 @@ msgid ""
 "DuckDuckGo anonymizes these reports by automatically removing PII like "
 "names, email addresses, phone numbers, and identifying metadata."
 msgstr ""
-"DuckDuckGo सुरक्षा की दृष्टि से नाम, ईमेल पते, फ़ोन नंबर और पहचान संबंधी "
-"मेटाडेटा जैसी व्यक्तिगत जानकारी (PII) को ऑटोमैटिकली हटाकर इन रिपोर्टों को "
-"एनोनिमाइज़ कर देता है।"
+"DuckDuckGo सुरक्षा की दृष्टि से नाम, ईमेल पते, फ़ोन नंबर और पहचान संबंधी मेटाडेटा जैसी "
+"व्यक्तिगत जानकारी (PII) को ऑटोमैटिकली हटाकर इन रिपोर्टों को एनोनिमाइज़ कर देता है।"
 
 # smartling.placeholder_format=C
 #. The first %s is the agree button label ('Agree'). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. The leading sentence mirrors the drawer-style inline disclaimer (DUCKCHAT_TOS_INLINE_DISCLAIMER).
@@ -6786,8 +6846,8 @@ msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid ""
 "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to Duck.ai's %s."
 msgstr ""
-"DuckDuckGo आपकी चैट को अनाम बनाता है। '%1$s' पर क्लिक करके आप Duck.ai की "
-"%2$s से सहमत होते हैं।"
+"DuckDuckGo आपकी चैट को अनाम बनाता है। '%1$s' पर क्लिक करके आप Duck.ai की %2$s से "
+"सहमत होते हैं।"
 
 # smartling.placeholder_format=C
 #. Shown below the input on the empty state when the user has not yet accepted the terms of service. The first %s is the action button label ('Ask' for chat, 'Create' for image generation). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. Clicking the action button both accepts the terms and submits the prompt.
@@ -6796,8 +6856,8 @@ msgctxt ""
 "users"
 msgid "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to our %s."
 msgstr ""
-"DuckDuckGo आपकी चैट को अनाम बनाता है। '%1$s' पर क्लिक करके आप हमारी %2$s से "
-"सहमत होते हैं।"
+"DuckDuckGo आपकी चैट को अनाम बनाता है। '%1$s' पर क्लिक करके आप हमारी %2$s से सहमत "
+"होते हैं।"
 
 # smartling.placeholder_format=C
 #. An information popup explaining that we block trackers
@@ -6806,9 +6866,9 @@ msgid ""
 "companies like Google and Facebook, who often try to track you on other "
 "websites."
 msgstr ""
-"DuckDuckGo आपके द्वारा देखी जाने वाली वेबसाइटों पर ट्रैकरों को ब्लॉक करता "
-"है, जिसमें Google और Facebook जैसी कंपनियों के ट्रैकर शामिल हैं, जो अक्सर "
-"आपको अन्य वेबसाइटों पर ट्रैक करने की कोशिश करते हैं।"
+"DuckDuckGo आपके द्वारा देखी जाने वाली वेबसाइटों पर ट्रैकरों को ब्लॉक करता है, जिसमें "
+"Google और Facebook जैसी कंपनियों के ट्रैकर शामिल हैं, जो अक्सर आपको अन्य वेबसाइटों पर "
+"ट्रैक करने की कोशिश करते हैं।"
 
 # smartling.placeholder_format=C
 #. Description of how DuckDuckGo keeps a user's location anonymous while the user searches on a map of their area.
@@ -6820,12 +6880,11 @@ msgid ""
 "away, such that you remain anonymous. %sLearn more about how we designed "
 "this technology to protect your privacy%s."
 msgstr ""
-"DuckDuckGo को गोपनीयता के लिए बनाया गया है। जब आप स्‍थान सक्षम करते हैं, तो "
-"यह केवल आपके स्थानीय डिवाइस में स्टोर हो जाता है। जब आप खोज करते हैं, तो "
-"आपकी डिवाइस उसे हमें भेजता है, हम उसका उपयोग उस खोज के परिणामों को बेहतर "
-"बनाने के लिए करते हैं और फिर हम तुरंत इसे फेंक देते हैं, जिससे आप गुमनाम ही "
-"रहते हैं। %1$sआपकी गोपनीयता की सुरक्षा के लिए हमने इस तकनीक को कैसे डिज़ाइन "
-"किया है, इसके बारे में और जानें%2$s।"
+"DuckDuckGo को गोपनीयता के लिए बनाया गया है। जब आप स्‍थान सक्षम करते हैं, तो यह केवल "
+"आपके स्थानीय डिवाइस में स्टोर हो जाता है। जब आप खोज करते हैं, तो आपकी डिवाइस उसे हमें "
+"भेजता है, हम उसका उपयोग उस खोज के परिणामों को बेहतर बनाने के लिए करते हैं और फिर हम "
+"तुरंत इसे फेंक देते हैं, जिससे आप गुमनाम ही रहते हैं। %1$sआपकी गोपनीयता की सुरक्षा के लिए हमने "
+"इस तकनीक को कैसे डिज़ाइन किया है, इसके बारे में और जानें%2$s।"
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
@@ -6845,8 +6904,8 @@ msgid ""
 "DuckDuckGo only uses your approximate location. That's all we need to "
 "deliver better results, closer to you. %sLearn more%s."
 msgstr ""
-"DuckDuckGo केवल आपके अनुमानित स्‍थान का उपयोग करता है। हम सभी को आपके नज़दीक "
-"के बेहतर परिणाम देने की जरूरत है। %1$sऔर जानें%2$s।"
+"DuckDuckGo केवल आपके अनुमानित स्‍थान का उपयोग करता है। हम सभी को आपके नज़दीक के बेहतर "
+"परिणाम देने की जरूरत है। %1$sऔर जानें%2$s।"
 
 # smartling.placeholder_format=C
 msgid "DuckDuckGo search"
@@ -6932,10 +6991,9 @@ msgid ""
 "random words from that list, ensuring that the passphrase is at least 18-20 "
 "characters long."
 msgstr ""
-"हर बार जब आप पासफ्रेज़ सुझाव मांगते हैं, तो हमें DuckDuckGo सर्वर से आकस्मिक "
-"शब्दों की लंबी सूची मिलती है। ब्राउज़र में, हम उस सूची से 4-5 आकस्मिक शब्दों "
-"का चयन करते हैं, यह सुनिश्चित करते हुए कि पासफ्रेज़ कम से कम 18-20 अक्षर "
-"लंबा है।"
+"हर बार जब आप पासफ्रेज़ सुझाव मांगते हैं, तो हमें DuckDuckGo सर्वर से आकस्मिक शब्दों की लंबी "
+"सूची मिलती है। ब्राउज़र में, हम उस सूची से 4-5 आकस्मिक शब्दों का चयन करते हैं, यह सुनिश्चित "
+"करते हुए कि पासफ्रेज़ कम से कम 18-20 अक्षर लंबा है।"
 
 # smartling.placeholder_format=C
 msgctxt "Sports module"
@@ -7000,8 +7058,8 @@ msgctxt "Info text for the editing message feature"
 msgid ""
 "Editing your message will remove the response below and generate a new one."
 msgstr ""
-"आपके संदेश को एडिट करने से नीचे दिया गया जवाब हट जाएगा और उसकी जगह नया जवाब "
-"तैयार होगा।"
+"आपके संदेश को एडिट करने से नीचे दिया गया जवाब हट जाएगा और उसकी जगह नया जवाब तैयार "
+"होगा।"
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of an editor in its responses.
@@ -7133,8 +7191,8 @@ msgid ""
 "Enable anonymous location for more accurate results. You can always change "
 "your mind later."
 msgstr ""
-"अधिक सटीक परिणामों के लिए अनाम स्थान सक्षम करें। आप अक्‍सर बाद में अपना "
-"विचार बदल सकते हैं।"
+"अधिक सटीक परिणामों के लिए अनाम स्थान सक्षम करें। आप अक्‍सर बाद में अपना विचार बदल सकते "
+"हैं।"
 
 # smartling.placeholder_format=C
 #. Title of the dictation privacy consent modal shown on first use.
@@ -7177,9 +7235,8 @@ msgid ""
 "Enabling anonymous location gives more accurate results but still keeps your "
 "searches and exact location private to DuckDuckGo."
 msgstr ""
-"जगह की जानकारी गुप्त रखने की सुविध चालू करने से ज़्यादा सटीक परिणाम मिलते "
-"हैं, लेकिन फिर भी DuckDuckGo के लिए आपकी खोजें और सटीक स्थान गोपनीय बने रहते "
-"हैं।"
+"जगह की जानकारी गुप्त रखने की सुविध चालू करने से ज़्यादा सटीक परिणाम मिलते हैं, लेकिन फिर "
+"भी DuckDuckGo के लिए आपकी खोजें और सटीक स्थान गोपनीय बने रहते हैं।"
 
 # smartling.placeholder_format=C
 msgid "Encrypt Connections"
@@ -7341,8 +7398,8 @@ msgid ""
 "Enter a new passphrase and click/tap %sSave Settings%s. This will save your "
 "data under your new passphrase."
 msgstr ""
-"एक नया पासफ्रेज़ दर्ज करें और %1$sसेटिंग सहेजें%2$s पर टैप/क्लिक करें। यह "
-"आपके नए पासफ्रेज़ के तहत आपके डेटा को बचाएगा।"
+"एक नया पासफ्रेज़ दर्ज करें और %1$sसेटिंग सहेजें%2$s पर टैप/क्लिक करें। यह आपके नए पासफ्रेज़ के "
+"तहत आपके डेटा को बचाएगा।"
 
 # smartling.placeholder_format=C
 #. Label for the field where a user enters their passphrase.
@@ -7368,8 +7425,8 @@ msgstr "टेक्स्ट डालें"
 msgid ""
 "Enter the following details: %sName%s: DuckDuckGo%s URL%s: %s Alias%s: d%s"
 msgstr ""
-"निम्नलिखित विवरण दर्ज करें: %1$sनाम%2$s: DuckDuckGo%3$s यूआरएल%4$s: %5$s "
-"उपनाम %6$s: d%7$s"
+"निम्नलिखित विवरण दर्ज करें: %1$sनाम%2$s: DuckDuckGo%3$s यूआरएल%4$s: %5$s उपनाम "
+"%6$s: d%7$s"
 
 # smartling.placeholder_format=C
 #. Prompt to enter a destination for driving directions.
@@ -7410,6 +7467,18 @@ msgid "Eritrea"
 msgstr "इरिट्रिया"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Estimate the nutrition"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Estimate the nutritional information for this recipe."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Estonia"
 msgstr "इस्टोनिया"
 
@@ -7444,8 +7513,8 @@ msgstr "मैप का विस्तार करें"
 msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
 msgstr ""
-"उन लोगों के लिए बेहतरीन ढंग से तैयार किए गए प्रोडक्ट, जिन्हें अपनी प्राइवेसी "
-"की सचमुच परवाह है।"
+"उन लोगों के लिए बेहतरीन ढंग से तैयार किए गए प्रोडक्ट, जिन्हें अपनी प्राइवेसी की सचमुच "
+"परवाह है।"
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
@@ -7466,11 +7535,59 @@ msgid "Expires in 1 day"
 msgstr "1 दिन में समाप्ति"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain the accepted answer in simple terms."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
 msgstr "मुझे ब्लैक होल की मूलभूत अवधारणाएं बताएं जो हाई-स्कूल स्तर की हों।"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain the top answer"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this in simple, plain language."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this paper"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this repo"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this research paper in plain language."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this simply"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain what this repository does and how to use it."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label to show if song lyrics contain explicit content
@@ -7648,8 +7765,8 @@ msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and improvements."
 msgstr ""
-"आप लोगों से जो फीडबैक मिलती है उससे हमें हमारे प्रोडक्ट अपडेट और सुधार "
-"संंबंधी कार्यों में मदद मिलती है।"
+"आप लोगों से जो फीडबैक मिलती है उससे हमें हमारे प्रोडक्ट अपडेट और सुधार संंबंधी कार्यों में मदद "
+"मिलती है।"
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -7658,9 +7775,8 @@ msgid ""
 "Feedback like yours directly influences our product updates and "
 "improvements. Hopefully we can address the issue you shared too."
 msgstr ""
-"आप लोगों से जो फ़ीडबैक मिलता है उससे हमारे प्रॉडक्ट अपडेट और बेहतर बनाने की "
-"कोशिश में मदद मिलती है। उम्मीद है हम जल्द ही वह समस्या भी हल कर पाएंगे जिसे "
-"आपने शेयर किया है।"
+"आप लोगों से जो फ़ीडबैक मिलता है उससे हमारे प्रॉडक्ट अपडेट और बेहतर बनाने की कोशिश में मदद "
+"मिलती है। उम्मीद है हम जल्द ही वह समस्या भी हल कर पाएंगे जिसे आपने शेयर किया है।"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box
@@ -7668,8 +7784,8 @@ msgid ""
 "Feel free to adjust the settings below. Then, just copy and paste the code "
 "into your website."
 msgstr ""
-"नीचे दी गई सेटिंग को निस्संकोच होकर एडजस्ट करें। उसके बाद, कोड को अपनी "
-"वेबसाइट में कॉपी पेस्ट करें।"
+"नीचे दी गई सेटिंग को निस्संकोच होकर एडजस्ट करें। उसके बाद, कोड को अपनी वेबसाइट में कॉपी "
+"पेस्ट करें।"
 
 # smartling.placeholder_format=C
 msgid "Fiji"
@@ -7755,6 +7871,12 @@ msgid ""
 msgstr "इमेज खोज परिणामों से AI-जनरेटेड इमेज फ़िल्टर कर देता है। %1$sऔर जानें%2$s"
 
 # smartling.placeholder_format=C
+msgctxt "settings"
+msgid ""
+"Filters out known AI spam sites from image search results. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the final score of a sporting event.
 msgid "Final"
 msgstr "अंतिम"
@@ -7808,6 +7930,12 @@ msgid "Find current information"
 msgstr "मौजूदा जानकारी प्राप्त करें"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Find me alternatives"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Button that searches for results closer to the user's current location.
 msgctxt "precise_user_location"
 msgid "Find results closer to you"
@@ -7824,9 +7952,7 @@ msgstr "अपने नज़दीक के परिणामों को �
 msgctxt "Precise user location overlay"
 msgid ""
 "Find results near you. %sYour location stays private, secure, and anonymous."
-msgstr ""
-"अपने आस-पास के परिणाम खोजें। %1$sआपकी लोकेशन निजी, सुरक्षित और गुमनाम रहती "
-"है।"
+msgstr "अपने आस-पास के परिणाम खोजें। %1$sआपकी लोकेशन निजी, सुरक्षित और गुमनाम रहती है।"
 
 # smartling.placeholder_format=C
 #. Loading message shown while generating explore more follow-up questions
@@ -7890,8 +8016,8 @@ msgid ""
 "Follow the instructions for turning off the ad blocker for DuckDuckGo. You "
 "may have to select a menu option or click a button."
 msgstr ""
-"DuckDuckGo के लिए विज्ञापन ब्लॉकर बंद करने के निर्देशों का पालन करें। कोई "
-"मेन्यू विकल्प चुनें या कोई बटन क्लिक करें।"
+"DuckDuckGo के लिए विज्ञापन ब्लॉकर बंद करने के निर्देशों का पालन करें। कोई मेन्यू विकल्प चुनें "
+"या कोई बटन क्लिक करें।"
 
 # smartling.placeholder_format=C
 #. Privacy reassurance and instructions intro.
@@ -8033,8 +8159,8 @@ msgstr "व्यावसायिक रूप से शेयर और उ�
 msgctxt "Sync limit modal description"
 msgid "Free up space by deleting your chats. Pinned chats will not be deleted."
 msgstr ""
-"जो चैट काम की नहीं हैं, उन्हें डिलीट कर स्पेस खाली करें। पिन की गई चैट डिलीट "
-"नहीं की जाएंगी।"
+"जो चैट काम की नहीं हैं, उन्हें डिलीट कर स्पेस खाली करें। पिन की गई चैट डिलीट नहीं की "
+"जाएंगी।"
 
 # smartling.placeholder_format=C
 #. Indicates that this streaming service is free to watch but shows ads
@@ -8115,8 +8241,8 @@ msgid ""
 "<strong>Check for Updates...</strong>, then select <strong>Install Update</"
 "strong>."
 msgstr ""
-"Mac पर ऐप के मेनू बार से, <strong>DuckDuckGo</strong> &gt; <strong>अपडेट "
-"देखें...</strong> चुनें, फिर <strong>अपडेट इंस्टॉल करें</strong> को चुनें।"
+"Mac पर ऐप के मेनू बार से, <strong>DuckDuckGo</strong> &gt; <strong>अपडेट देखें...</"
+"strong> चुनें, फिर <strong>अपडेट इंस्टॉल करें</strong> को चुनें।"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -8282,6 +8408,12 @@ msgstr "इमेज जनरेट करें"
 #. Text for the button that generates more of an answer from duckassist when the answer has come from a collapsed state
 msgid "Generate More"
 msgstr "और जनरेट करें"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Generate a shopping list"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
@@ -8461,9 +8593,8 @@ msgid ""
 "Get access to advanced AI models in Duck.ai by subscribing to DuckDuckGo, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"DuckDuckGo को सब्सक्राइब करके Duck.ai में एडवांस्ड AI मॉडल्स का एक्सेस "
-"प्राप्त करें, जिसमें हमारा VPN और अन्य प्रीमियम गोपनीयता संरक्षण भी शामिल "
-"हैं।"
+"DuckDuckGo को सब्सक्राइब करके Duck.ai में एडवांस्ड AI मॉडल्स का एक्सेस प्राप्त करें, जिसमें "
+"हमारा VPN और अन्य प्रीमियम गोपनीयता संरक्षण भी शामिल हैं।"
 
 # smartling.placeholder_format=C
 #. Description for the subscription setting where users can subscribe to DuckDuckGo.
@@ -8474,9 +8605,8 @@ msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"Duck.ai में एडवांस्ड AI मॉडल मॉडल्स का एक्सेस प्राप्त करें DuckDuckGo "
-"सब्सक्रिप्शन के साथ, जिसमें हमारा VPN और अन्य प्रीमियम गोपनीयता संरक्षण भी "
-"शामिल हैं।"
+"Duck.ai में एडवांस्ड AI मॉडल मॉडल्स का एक्सेस प्राप्त करें DuckDuckGo सब्सक्रिप्शन के साथ, "
+"जिसमें हमारा VPN और अन्य प्रीमियम गोपनीयता संरक्षण भी शामिल हैं।"
 
 # smartling.placeholder_format=C
 #. A button for users to generate an AI generated answer from their query on the duckassist module
@@ -8556,9 +8686,7 @@ msgstr "यह गाना यहां पाएंः"
 # smartling.placeholder_format=C
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
-msgstr ""
-"आपके दोस्तों को स्विच करने के लिए प्रेरित करें और हमें विकसित होने में मदद "
-"करें!"
+msgstr "आपके दोस्तों को स्विच करने के लिए प्रेरित करें और हमें विकसित होने में मदद करें!"
 
 # smartling.placeholder_format=C
 msgid "Ghana"
@@ -8577,6 +8705,12 @@ msgid "Give it a Try"
 msgstr "इसे आज़माएं"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Give me a quick background on this person."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
@@ -8589,8 +8723,8 @@ msgid ""
 "Go to %sSettings > Privacy & Security > Location Services%s, and make sure "
 "“Location Services” is turned on."
 msgstr ""
-"%1$sसेटिंग > गोपनीयता और सुरक्षा > स्थान सेवाएं%2$s पर जाएं और पक्का करें कि "
-"\"स्थान सेवाएं\" चालू है।"
+"%1$sसेटिंग > गोपनीयता और सुरक्षा > स्थान सेवाएं%2$s पर जाएं और पक्का करें कि \"स्थान "
+"सेवाएं\" चालू है।"
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -8599,8 +8733,8 @@ msgid ""
 "Go to %sSettings > Privacy > Permission manager > Location%s and scroll down "
 "to %sDuckDuckGo%s."
 msgstr ""
-"यहां जाएं: %1$sसेटिंग > गोपनीयता > अनुमति प्रबंधक > स्थान%2$s, और फिर नीचे "
-"स्क्रॉल करके %3$sDuckDuckGo%4$s पर जाएं।"
+"यहां जाएं: %1$sसेटिंग > गोपनीयता > अनुमति प्रबंधक > स्थान%2$s, और फिर नीचे स्क्रॉल करके "
+"%3$sDuckDuckGo%4$s पर जाएं।"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9023,6 +9157,18 @@ msgid "Help Spread Privacy"
 msgstr "गोपनीयता को विस्तारित करने में मदद करें"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Help me prep for the interview"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Help me tailor my resume for this job."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title of a SERP popup that invites users to take a survey (desktop only)
 msgctxt "User survey popup"
 msgid "Help us improve DuckDuckGo"
@@ -9259,8 +9405,8 @@ msgid ""
 "Highlights key facts in Search Assist answers to help you find important "
 "information faster."
 msgstr ""
-"महत्वपूर्ण जानकारी तेज़ी से ढूंढने में आपकी सहायता करने के लिए Search Assist "
-"उत्तरों में मुख्य तथ्यों को हाइलाइट करता है।"
+"महत्वपूर्ण जानकारी तेज़ी से ढूंढने में आपकी सहायता करने के लिए Search Assist उत्तरों में मुख्य "
+"तथ्यों को हाइलाइट करता है।"
 
 # smartling.placeholder_format=C
 #. The name of the Hindi language
@@ -9287,8 +9433,8 @@ msgid ""
 "Hit %sReturn%s on your keyboard to %ssave DuckDuckGo to the list. %sThen "
 "click %sMake Default%s"
 msgstr ""
-"सूची में DuckDuckGo को सहेजने के लिए अपने कीबोर्ड पर %1$sरिटर्न%2$s "
-"दबाएं%3$s। %4$sफिर %5$sडिफ़ॉल्ट बनाएं%6$s क्लिक करें"
+"सूची में DuckDuckGo को सहेजने के लिए अपने कीबोर्ड पर %1$sरिटर्न%2$s दबाएं%3$s। %4$sफिर "
+"%5$sडिफ़ॉल्ट बनाएं%6$s क्लिक करें"
 
 # smartling.placeholder_format=C
 #. The name of the Hmong Daw language
@@ -9302,8 +9448,8 @@ msgid ""
 "Hold on! Changing it back will disable the DuckDuckGo extension and you'll "
 "lose our privacy protection."
 msgstr ""
-"रुके रहें! इसे वापस बदलने पर DuckDuckGo एक्सटेंशन अक्षम हो जाएगा और आप हमारा "
-"गोपनीयता संरक्षण खो देंगे।"
+"रुके रहें! इसे वापस बदलने पर DuckDuckGo एक्सटेंशन अक्षम हो जाएगा और आप हमारा गोपनीयता "
+"संरक्षण खो देंगे।"
 
 # smartling.placeholder_format=C
 #. Heading shown above warning messages in the AI chat, for non-critical issues like unsupported file formats or file size limits. Analogous to 'Oops...' for error messages.
@@ -9353,8 +9499,8 @@ msgid ""
 "Hotel ad clicks are managed by Tripadvisor’s ad network and are not used to "
 "profile you."
 msgstr ""
-"होटल विज्ञापन क्लिक TripAdvisor के विज्ञापन नेटवर्क द्वारा प्रबंधित किए जाते "
-"हैं और इनका उपयोग आपकी व्यक्तिगत जानकारी जुटाने के लिए नहीं किया जाता।"
+"होटल विज्ञापन क्लिक TripAdvisor के विज्ञापन नेटवर्क द्वारा प्रबंधित किए जाते हैं और इनका "
+"उपयोग आपकी व्यक्तिगत जानकारी जुटाने के लिए नहीं किया जाता।"
 
 # smartling.placeholder_format=C
 #. Refers to hours of operation for a business.
@@ -9496,8 +9642,8 @@ msgid ""
 "How should I tactfully approach a colleague about their constant pencil "
 "tapping and what should I say?"
 msgstr ""
-"मुझे अपने सहकर्मी से उनकी लगातार पेंसिल से खट-खट करने के बारे में किस तरह "
-"व्यवहारकुशलता से बात करनी चाहिए और क्या कहना चाहिए?"
+"मुझे अपने सहकर्मी से उनकी लगातार पेंसिल से खट-खट करने के बारे में किस तरह व्यवहारकुशलता से "
+"बात करनी चाहिए और क्या कहना चाहिए?"
 
 # smartling.placeholder_format=C
 #. The title for a feedback prompt that includes thumbs up and thumbs down buttons
@@ -9536,6 +9682,14 @@ msgstr "तूफ़ान"
 msgctxt "Onboarding terms screen button text"
 msgid "I Agree"
 msgstr "मैं सहमत हूं"
+
+# smartling.placeholder_format=C
+#. Text for the button that takes the user to the external DuckDuckGo login subscription page.
+msgctxt ""
+"Text for the I already have a subscription button in the Duck.ai settings "
+"page"
+msgid "I Already Have a Subscription"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the button that takes the user to the login subscription page.
@@ -9611,8 +9765,8 @@ msgid ""
 "I like the book Name of the Wind. What are some other good books/series most "
 "like it and why?"
 msgstr ""
-"मुझे 'नेम ऑफ द विंड' पुस्तक पसंद है। इस तरह की कुछ और अच्छी किताबें/सीरीज़ "
-"कौन-सी हैं और क्यों?"
+"मुझे 'नेम ऑफ द विंड' पुस्तक पसंद है। इस तरह की कुछ और अच्छी किताबें/सीरीज़ कौन-सी हैं और "
+"क्यों?"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the user needs more help or information on how to use the chat.
@@ -9647,8 +9801,8 @@ msgid ""
 "If the browser location remains unavailable, then go to %sSettings > General "
 "> Reset > 'Reset Location & Privacy'%s."
 msgstr ""
-"यदि ब्राउज़र स्थान अभी भी मौजूद नहीं है, तो %1$sसेटिंग्‍स > सामान्य > रीसेट "
-"> 'स्थान और गोपनीयता रीसेट करें' पर जाएं%2$s।"
+"यदि ब्राउज़र स्थान अभी भी मौजूद नहीं है, तो %1$sसेटिंग्‍स > सामान्य > रीसेट > 'स्थान और "
+"गोपनीयता रीसेट करें' पर जाएं%2$s।"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -9658,9 +9812,8 @@ msgid ""
 "> Menu > Settings > Site settings > Location%s, and ensure DuckDuckGo is "
 "allowed location access."
 msgstr ""
-"यदि ब्राउज़र स्थान मौजूद नहीं है, तो अपने ब्राउज़र में %1$s⋮ > मेनू > "
-"सेटिंग्‍स > साइट सेटिंग्स > स्थान%2$s पर जाएं, और सुनिश्चित करें कि "
-"DuckDuckGo को स्थान एक्सेस की अनुमति है।"
+"यदि ब्राउज़र स्थान मौजूद नहीं है, तो अपने ब्राउज़र में %1$s⋮ > मेनू > सेटिंग्‍स > साइट सेटिंग्स "
+"> स्थान%2$s पर जाएं, और सुनिश्चित करें कि DuckDuckGo को स्थान एक्सेस की अनुमति है।"
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -9675,8 +9828,8 @@ msgid ""
 "If you don't see %sDuckDuckGo,%s you will need to add it to the list of "
 "%sOther Search Engines%s"
 msgstr ""
-"अगर आपको %1$sDuckDuckGo%2$s दिखाई नहीं दे रहा है तो आपको उसे %3$sअन्य खोज "
-"इंजन%4$s की सूची में जोड़ना होगा"
+"अगर आपको %1$sDuckDuckGo%2$s दिखाई नहीं दे रहा है तो आपको उसे %3$sअन्य खोज इंजन%4$s "
+"की सूची में जोड़ना होगा"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding the AI model providers and links to their support pages. Example: 'If you have concerns about our chat providers or any particular chat response, you can also reach out directly to OpenAI and Anthropic support pages.'
@@ -9685,8 +9838,8 @@ msgid ""
 "If you have concerns about our chat providers or any particular chat "
 "response, you can also reach out directly to %s and %s support pages."
 msgstr ""
-"अगर आपको हमारे चैट प्रदाताओं या किसी खास चैट जवाब के बारे में कोई समस्या है, "
-"तो आप सीधे %1$s और %2$s सपोर्ट पेज पर भी जा सकते हैं।"
+"अगर आपको हमारे चैट प्रदाताओं या किसी खास चैट जवाब के बारे में कोई समस्या है, तो आप सीधे "
+"%1$s और %2$s सपोर्ट पेज पर भी जा सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Body copy explaining what the recovery code is for and how it can be saved.
@@ -9695,17 +9848,15 @@ msgid ""
 "If you lose access to your devices, you will need this code to recover your "
 "saved chats. You can save this code to your device as a text file."
 msgstr ""
-"अगर आप अपने डिवाइस का एक्सेस खो देते हैं, तो अपनी सेव की गई चैट्स को रिकवर "
-"करने के लिए आपको इस कोड की ज़रूरत पड़ेगी। आप इस कोड को एक टेक्स्ट फ़ाइल के "
-"रूप में अपने डिवाइस पर सेव कर सकते हैं।"
+"अगर आप अपने डिवाइस का एक्सेस खो देते हैं, तो अपनी सेव की गई चैट्स को रिकवर करने के लिए "
+"आपको इस कोड की ज़रूरत पड़ेगी। आप इस कोड को एक टेक्स्ट फ़ाइल के रूप में अपने डिवाइस पर सेव "
+"कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
-msgstr ""
-"अगर आप और सहायता करना चाहते हैं तो, %1$s DuckDuckGo को फेलाने में मदद करें "
-"%2$s"
+msgstr "अगर आप और सहायता करना चाहते हैं तो, %1$s DuckDuckGo को फेलाने में मदद करें %2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -9715,17 +9866,15 @@ msgid ""
 "If you want to use DuckDuckGo without JavaScript, please use our %s or %s "
 "versions."
 msgstr ""
-"अगर​ आप जावास्क्रिप्ट के बिना DuckDuckGo का उपयोग करना चाहते, तो कृपया हमारे "
-"%1$s या %2$s संस्करणों का उपयोग करें।"
+"अगर​ आप जावास्क्रिप्ट के बिना DuckDuckGo का उपयोग करना चाहते, तो कृपया हमारे %1$s या "
+"%2$s संस्करणों का उपयोग करें।"
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "If you want, select Home Page next to New windows and New tabs (open with)."
-msgstr ""
-"अगर आप चाहते हैं, तो नई विंडो और नए टैब के सामने होम पेज चुनें (इसके साथ "
-"खोलें)"
+msgstr "अगर आप चाहते हैं, तो नई विंडो और नए टैब के सामने होम पेज चुनें (इसके साथ खोलें)"
 
 # smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that adds an image to the AI chat message being composed.
@@ -9854,8 +10003,7 @@ msgctxt "settings"
 msgid ""
 "Improves result legibility with updated URL format, placement, and color"
 msgstr ""
-"अपडेट किए गए URL फ़ॉर्मैट, प्लेसमेंट और रंग के साथ नतीजे के बेहतर दिखने में "
-"सुधार करता है"
+"अपडेट किए गए URL फ़ॉर्मैट, प्लेसमेंट और रंग के साथ नतीजे के बेहतर दिखने में सुधार करता है"
 
 # smartling.placeholder_format=C
 #. A label that appears in front of the name of a company that DuckDuckGo has partnered with. For example, 'In partnership with Wikipedia'
@@ -9868,8 +10016,8 @@ msgid ""
 "In some older browsers, it's necessary to redirect your clicks through our "
 "server to prevent search leakage. %sLearn more%s."
 msgstr ""
-"कुछ पुराने ब्राउज़रों में हमारे सर्वर से खोज लीकेज रोकने के लिए आपके क्लिकों "
-"को रीडायरेक्ट करना आवश्यक है। %1$sऔर जानें%2$s।"
+"कुछ पुराने ब्राउज़रों में हमारे सर्वर से खोज लीकेज रोकने के लिए आपके क्लिकों को रीडायरेक्ट करना "
+"आवश्यक है। %1$sऔर जानें%2$s।"
 
 # smartling.placeholder_format=C
 #. Instructions accompanying DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE; tells the user where to use the code on a DuckDuckGo browser.
@@ -9880,8 +10028,8 @@ msgid ""
 "In the DuckDuckGo browser, go to Settings › Sync & Backup, and then “Sync "
 "with another device”."
 msgstr ""
-"DuckDuckGo ब्राउज़र में, सेटिंग › Sync & Backup पर जाएं और फिर “किसी अन्य "
-"डिवाइस के साथ सिंक करें” चुनें।"
+"DuckDuckGo ब्राउज़र में, सेटिंग › Sync & Backup पर जाएं और फिर “किसी अन्य डिवाइस के "
+"साथ सिंक करें” चुनें।"
 
 #  SeaMonkey default search engine instruction
 # smartling.placeholder_format=C
@@ -9896,8 +10044,8 @@ msgid ""
 "In the interest of transparency, this data is not encrypted: You can see "
 "exactly what information we store."
 msgstr ""
-"पारदर्शिता के हित में यह डेटा एन्क्रिप्ट नहीं किया गया है: आप वाकई देख सकते "
-"हैं कि हम क्या जानकारी संग्रहित करते हैं।"
+"पारदर्शिता के हित में यह डेटा एन्क्रिप्ट नहीं किया गया है: आप वाकई देख सकते हैं कि हम क्या "
+"जानकारी संग्रहित करते हैं।"
 
 # smartling.placeholder_format=C
 msgid "In the menu at the top select %sTools%s > %sSettings%s"
@@ -10113,6 +10261,12 @@ msgid "Install Mac Browser"
 msgstr "Mac ब्राउज़र इंस्टॉल करें"
 
 # smartling.placeholder_format=C
+#. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
+msgctxt "settings"
+msgid "Install Now"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of a button to install the DuckDuckGo app
 msgctxt "Serp footer content"
 msgid "Install Our App"
@@ -10210,10 +10364,42 @@ msgid "Is deleted data really deleted?"
 msgstr "क्या डिलीट किए गए डेटा वाकई डिलीट किए जाते हैं?"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is it worth taking?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this place any good?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"Is this place any good? Summarize its reputation based on reviews and "
+"ratings."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "Is this video helpful?"
 msgstr "क्या यह वीडियो मददगार रहा?"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this worth watching?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Is this worth watching? Give me a spoiler-free take."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -10246,8 +10432,7 @@ msgctxt "settings"
 msgid ""
 "It's okay to (very infrequently) ask me about my experience using DuckDuckGo"
 msgstr ""
-"मुझसे मेरे DuckDuckGo को उपयोग करने के अनुभव के बारे में पूछना (बहुत ज़्यादा "
-"बार) ठीक है"
+"मुझसे मेरे DuckDuckGo को उपयोग करने के अनुभव के बारे में पूछना (बहुत ज़्यादा बार) ठीक है"
 
 # smartling.placeholder_format=C
 #. The name of the Italian language
@@ -10266,10 +10451,9 @@ msgid ""
 "through Microsoft's Ad Network. Clicks lead directly to merchant landing "
 "pages and unlike ads, DuckDuckGo is not compensated for these results."
 msgstr ""
-"आइटम आपके खोज शब्दों की प्रासंगिकता के आधार पर रैंक किए जाते हैं और "
-"Microsoft के विज्ञापन नेटवर्क के माध्यम से डिलीवर किए जाते हैं। क्लिक सीधे "
-"मर्चेंट लैंडिंग पेज पर ले जाते हैं और विज्ञापनों के विपरीत, DuckDuckGo को इन "
-"परिणामों के लिए प्रतिफल नहीं दिया जाता है।"
+"आइटम आपके खोज शब्दों की प्रासंगिकता के आधार पर रैंक किए जाते हैं और Microsoft के विज्ञापन "
+"नेटवर्क के माध्यम से डिलीवर किए जाते हैं। क्लिक सीधे मर्चेंट लैंडिंग पेज पर ले जाते हैं और "
+"विज्ञापनों के विपरीत, DuckDuckGo को इन परिणामों के लिए प्रतिफल नहीं दिया जाता है।"
 
 # smartling.placeholder_format=C
 #. Text explaining why passphrases use a series of words instead of random numbers and letters.
@@ -10278,8 +10462,8 @@ msgid ""
 "It’s easier to remember 4-5 words than 10 random letters and numbers, and "
 "far more secure."
 msgstr ""
-"10 आकस्मिक अक्षरों और संख्याओं की तुलना में 4-5 शब्दों को याद रखना आसान और "
-"अधिक सुरक्षित भी है।"
+"10 आकस्मिक अक्षरों और संख्याओं की तुलना में 4-5 शब्दों को याद रखना आसान और अधिक सुरक्षित "
+"भी है।"
 
 # smartling.placeholder_format=C
 msgid "Ivory Coast"
@@ -10826,6 +11010,12 @@ msgid "Links:"
 msgstr "लिंक्स:"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "List the tools, materials, or prerequisites I need for this."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
 msgid "Listen"
 msgstr "सुनें"
@@ -11232,6 +11422,12 @@ msgid "Manage blocked sites"
 msgstr "ब्लॉक की गई साइटें मैनेज करें"
 
 # smartling.placeholder_format=C
+#. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
+msgctxt "setting"
+msgid "Manage in Browser Settings"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to the site exclusion settings page
 msgctxt "Organic result context menu"
 msgid "Manage sites you've blocked"
@@ -11455,8 +11651,8 @@ msgstr "माइक्रोनेशिया"
 msgid ""
 "Microphone access was denied. Please allow microphone access and try again."
 msgstr ""
-"माइक्रोफ़ोन एक्सेस की अनुमति नहीं दी गई। कृपया माइक्रोफ़ोन एक्सेस करने की "
-"अनुमति दें और फिर से प्रयास करें।"
+"माइक्रोफ़ोन एक्सेस की अनुमति नहीं दी गई। कृपया माइक्रोफ़ोन एक्सेस करने की अनुमति दें और फिर "
+"से प्रयास करें।"
 
 # smartling.placeholder_format=C
 #. The Microsoft brand name.
@@ -12204,11 +12400,10 @@ msgid ""
 "internet connection. Disabling chat history will delete pinned chats, and "
 "disable the temporary storage of new prompts and responses."
 msgstr ""
-"नए प्रॉम्प्ट और रिस्पॉन्स भेजे जाने के बाद एन्क्रिप्ट किए जाते हैं और "
-"अस्थायी रूप से DuckDuckGo सर्वर पर स्टोर रहते हैं, ताकि यदि आपका इंटरनेट "
-"कनेक्शन खो जाए तो चैट को रिकवर किया जा सके। चैट हिस्ट्री को डिसेबल करने से "
-"पिन की गई चैट डिलीट हो जाएंगी, और नए प्रॉम्प्ट और रिस्पॉन्स का टेम्पररी "
-"स्टोरेज भी बंद हो जाएगा।"
+"नए प्रॉम्प्ट और रिस्पॉन्स भेजे जाने के बाद एन्क्रिप्ट किए जाते हैं और अस्थायी रूप से "
+"DuckDuckGo सर्वर पर स्टोर रहते हैं, ताकि यदि आपका इंटरनेट कनेक्शन खो जाए तो चैट को "
+"रिकवर किया जा सके। चैट हिस्ट्री को डिसेबल करने से पिन की गई चैट डिलीट हो जाएंगी, और "
+"नए प्रॉम्प्ट और रिस्पॉन्स का टेम्पररी स्टोरेज भी बंद हो जाएगा।"
 
 # smartling.placeholder_format=C
 #. Question in a feedback form.
@@ -13024,8 +13219,8 @@ msgid ""
 "On Mac, %sClick Maxthon > Preferences%s, On Windows, %sClick the %s icon > "
 "Settings%s"
 msgstr ""
-"Mac पर, %1$sMaxthon > प्राथमिकताएं पर क्लिक करें%2$s, Windows पर, %3$s %4$s "
-"आइकन > सेटिंग्स%5$s पर क्लिक करें"
+"Mac पर, %1$sMaxthon > प्राथमिकताएं पर क्लिक करें%2$s, Windows पर, %3$s %4$s आइकन "
+"> सेटिंग्स%5$s पर क्लिक करें"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
@@ -13047,8 +13242,8 @@ msgid ""
 "One of the files attached has more pages than we support. Please upload "
 "files with %s pages or fewer."
 msgstr ""
-"अटैच की गई फ़ाइलों में से एक में हमारी सपोर्ट सीमा से ज़्यादा पेज हैं। कृपया "
-"%1$s पेज या उससे कम वाली फ़ाइलें अपलोड करें।"
+"अटैच की गई फ़ाइलों में से एक में हमारी सपोर्ट सीमा से ज़्यादा पेज हैं। कृपया %1$s पेज या उससे "
+"कम वाली फ़ाइलें अपलोड करें।"
 
 # smartling.placeholder_format=C
 #. Response a user can select in a feedback form, indicating that they heard about DuckDuckGo in an online article.
@@ -13075,8 +13270,8 @@ msgid ""
 "Only the settings that you have changed. They are detailed on the %sURL "
 "Parameters%s page."
 msgstr ""
-"केवल वो सेटिंग्स जिन्हें आपने बदला है। उनकी पूरी जानकारी इस %1$sयूआरएल "
-"पैरामीटर%2$s पेज पर है।"
+"केवल वो सेटिंग्स जिन्हें आपने बदला है। उनकी पूरी जानकारी इस %1$sयूआरएल पैरामीटर%2$s पेज "
+"पर है।"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers only when the user clicks the Assist button.
@@ -13091,8 +13286,7 @@ msgid ""
 "Oops! An unexpected error occurred while translating this text. Please try "
 "again later."
 msgstr ""
-"उफ़! इस टेक्स्ट का अनुवाद करते समय एक अनपेक्षित त्रुटि हुई है। कृपया बाद में "
-"फिर से प्रयास करें।"
+"उफ़! इस टेक्स्ट का अनुवाद करते समय एक अनपेक्षित त्रुटि हुई है। कृपया बाद में फिर से प्रयास करें।"
 
 # smartling.placeholder_format=C
 #. Title shown in a fatal error modal when Duck.ai fails to load.
@@ -13409,8 +13603,8 @@ msgid ""
 "Other search engines track your searches even when you’re in private "
 "browsing mode. We don’t track you &mdash; period."
 msgstr ""
-"अन्य खोज इंजन आपकी खोजों को ट्रैक करता है भले ही आप गुप्त ब्राउज़िंग मोड में "
-"हो। हम आपको — अवधि में ट्रैक नहीं करते हैं।"
+"अन्य खोज इंजन आपकी खोजों को ट्रैक करता है भले ही आप गुप्त ब्राउज़िंग मोड में हो। हम आपको — "
+"अवधि में ट्रैक नहीं करते हैं।"
 
 # smartling.placeholder_format=C
 msgctxt "SERP footer content"
@@ -13423,8 +13617,8 @@ msgid ""
 "Our privacy policy is simple: we don’t collect or share any of your personal "
 "information."
 msgstr ""
-"हमारी गोपनीयता नीति सरल है: हम आपकी किसी भी निजी जानकारी को एकत्रित या शेयर "
-"नहीं करते हैं।"
+"हमारी गोपनीयता नीति सरल है: हम आपकी किसी भी निजी जानकारी को एकत्रित या शेयर नहीं "
+"करते हैं।"
 
 # smartling.placeholder_format=C
 msgid ""
@@ -13432,8 +13626,8 @@ msgid ""
 "tracker blocker, encryption enforcer, and more. Available on %siOS & "
 "Android%s."
 msgstr ""
-"मोबाइल के लिए हमारे गोपनीय ब्राउज़र में हमारा खोज इंजन, ट्रैकर ब्लॉकर, "
-"एनक्रिप्शन एनफोर्सर और बहुत कुछ शामिल है। %1$siOS और Android%2$s पर उपलब्ध।"
+"मोबाइल के लिए हमारे गोपनीय ब्राउज़र में हमारा खोज इंजन, ट्रैकर ब्लॉकर, एनक्रिप्शन "
+"एनफोर्सर और बहुत कुछ शामिल है। %1$siOS और Android%2$s पर उपलब्ध।"
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the information was out of date.
@@ -13686,8 +13880,8 @@ msgid ""
 "Passphrases cannot be recovered as we don't associate your IP address, "
 "browser fingerprint, or any other information with the file."
 msgstr ""
-"पासफ्रेज़ को दोबारा प्राप्त नहीं किया जा सकता है, क्योंकि हम आपके आईपी पते, "
-"ब्राउज़र फ़िंगरप्रिंट या किसी अन्य जानकारी को फ़ाइल के साथ नहीं जोड़ते हैं।"
+"पासफ्रेज़ को दोबारा प्राप्त नहीं किया जा सकता है, क्योंकि हम आपके आईपी पते, ब्राउज़र "
+"फ़िंगरप्रिंट या किसी अन्य जानकारी को फ़ाइल के साथ नहीं जोड़ते हैं।"
 
 # smartling.placeholder_format=C
 #. Label for the section of recent chats that were edited in the past 7 days.
@@ -13881,10 +14075,9 @@ msgid ""
 "answers. To turn them off and hide the Assist button visit %sSearch "
 "Settings%s."
 msgstr ""
-"जब आप अपनी खोज क्वेरी को एक सवाल के रूप में और एक पूरे वाक्य में डालते हैं, "
-"तो AI की मदद से दिए गए जवाब अपने-आप दिखने की संभावना बढ़ जाती है और बेहतर "
-"जवाब अक्सर मिलते हैं। उन्हें बंद करने और Assist बटन छिपाने के लिए %1$sखोज "
-"सेटिंग%2$s पर जाएं।"
+"जब आप अपनी खोज क्वेरी को एक सवाल के रूप में और एक पूरे वाक्य में डालते हैं, तो AI की मदद से "
+"दिए गए जवाब अपने-आप दिखने की संभावना बढ़ जाती है और बेहतर जवाब अक्सर मिलते हैं। उन्हें बंद "
+"करने और Assist बटन छिपाने के लिए %1$sखोज सेटिंग%2$s पर जाएं।"
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -13893,10 +14086,9 @@ msgid ""
 "DuckAssist more likely to appear and often yields better answers. To adjust "
 "how this feature works, or to turn it off, visit %sDuckAssist Settings%s."
 msgstr ""
-"जब आप अपनी खोज क्वेरी को एक सवाल के रूप में और एक पूरे वाक्य में डालते हैं, "
-"तो DuckAssist के दिखने की संभावना बढ़ जाती है और बेहतर जवाब अक्सर मिलते हैं। "
-"इस फ़ीचर के काम करने के तरीके को एडजस्ट करने के लिए या इसे बंद करने के लिए, "
-"%1$sDuckAssist सेटिंग%2$s पर जाएं।"
+"जब आप अपनी खोज क्वेरी को एक सवाल के रूप में और एक पूरे वाक्य में डालते हैं, तो DuckAssist "
+"के दिखने की संभावना बढ़ जाती है और बेहतर जवाब अक्सर मिलते हैं। इस फ़ीचर के काम करने के "
+"तरीके को एडजस्ट करने के लिए या इसे बंद करने के लिए, %1$sDuckAssist सेटिंग%2$s पर जाएं।"
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -13906,10 +14098,9 @@ msgid ""
 "answers. To turn it off and hide the Assist button visit %sDuckAssist "
 "Settings%s."
 msgstr ""
-"जब आप अपनी खोज क्वेरी को एक सवाल के रूप में और एक पूरे वाक्य में डालते हैं, "
-"तो DuckAssist अपने-आप दिखने की संभावना बढ़ जाती है और बेहतर जवाब अक्सर मिलते "
-"हैं। इसे बंद करने और Assist यानी सहायता बटन छिपाने के लिए %1$sDuckAssist "
-"Settings%2$s पर जाएं।"
+"जब आप अपनी खोज क्वेरी को एक सवाल के रूप में और एक पूरे वाक्य में डालते हैं, तो DuckAssist "
+"अपने-आप दिखने की संभावना बढ़ जाती है और बेहतर जवाब अक्सर मिलते हैं। इसे बंद करने और "
+"Assist यानी सहायता बटन छिपाने के लिए %1$sDuckAssist Settings%2$s पर जाएं।"
 
 # smartling.placeholder_format=C
 #. Button that allows users to manually select a location on a map.
@@ -13942,8 +14133,8 @@ msgid ""
 "Pick a popular AI to chat with, like GPT-5 mini, Claude Haiku 4.5, Mistral, "
 "etc."
 msgstr ""
-"चैट करने के लिए कोई लोकप्रिय AI चुनें, जैसे GPT-5 mini, Claude Haiku 4.5, "
-"Mistral, वगैरह।"
+"चैट करने के लिए कोई लोकप्रिय AI चुनें, जैसे GPT-5 mini, Claude Haiku 4.5, Mistral, "
+"वगैरह।"
 
 # smartling.placeholder_format=C
 #. Describes the ability to choose from popular AI models. Pairs with a chat-bubble pictogram.
@@ -13962,8 +14153,7 @@ msgid ""
 "Pick a service to navigate to your destination. External apps won’t come "
 "with DuckDuckGo protections."
 msgstr ""
-"अपने गंतव्य तक जाने के लिए एक सेवा चुनें। बाहरी ऐप्स में DuckDuckGo सुरक्षा "
-"उपलब्ध नहीं होगी।"
+"अपने गंतव्य तक जाने के लिए एक सेवा चुनें। बाहरी ऐप्स में DuckDuckGo सुरक्षा उपलब्ध नहीं होगी।"
 
 # smartling.placeholder_format=C
 #. Label for a list of problems on a feedback form.
@@ -13976,8 +14166,8 @@ msgstr "कोई विशिष्ट समस्या चुनें"
 msgid ""
 "Pick your ad blocker and follow the instructions to allow ads on DuckDuckGo."
 msgstr ""
-"अपना विज्ञापन ब्लॉकर चुनें और DuckDuckGo पर विज्ञापनों की अनुमति देने के लिए "
-"निर्देशों का पालन करें।"
+"अपना विज्ञापन ब्लॉकर चुनें और DuckDuckGo पर विज्ञापनों की अनुमति देने के लिए निर्देशों का "
+"पालन करें।"
 
 # smartling.placeholder_format=C
 #. Text for a button that pins a chat, as in it will it will add the chat to the pinned chats list.
@@ -14048,8 +14238,8 @@ msgid ""
 "Please complete the following challenge to confirm this prompt was made by a "
 "human."
 msgstr ""
-"यह पुष्टि करने के लिए कि यह प्रॉम्प्ट किसी मनुष्य द्वारा बनाया गया था, कृपया "
-"निम्नलिखित चुनौती को पूरा करें।"
+"यह पुष्टि करने के लिए कि यह प्रॉम्प्ट किसी मनुष्य द्वारा बनाया गया था, कृपया निम्नलिखित "
+"चुनौती को पूरा करें।"
 
 # smartling.placeholder_format=C
 #. Bot challenge explanation
@@ -14058,8 +14248,14 @@ msgid ""
 "Please complete the following challenge to confirm this search was made by a "
 "human."
 msgstr ""
-"यह पुष्टि करने के लिए कि यह खोज किसी मनुष्य द्वारा की गई थी, कृपया "
-"निम्नलिखित चुनौती को पूरा करें।"
+"यह पुष्टि करने के लिए कि यह खोज किसी मनुष्य द्वारा की गई थी, कृपया निम्नलिखित चुनौती "
+"को पूरा करें।"
+
+# smartling.placeholder_format=C
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
+msgctxt "Feedback prompt"
+msgid "Please describe why the chat response is harmful or illegal. (optional)"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
@@ -14086,8 +14282,16 @@ msgid ""
 "Please note: starting a new chat with any model will delete your current "
 "chat session."
 msgstr ""
-"कृपया ध्यान दें: किसी भी मॉडल के जरिए नई चैट शुरू करने से आपका मौजूदा चैट "
-"सेशन डिलीट हो जाएगा।"
+"कृपया ध्यान दें: किसी भी मॉडल के जरिए नई चैट शुरू करने से आपका मौजूदा चैट सेशन डिलीट हो "
+"जाएगा।"
+
+# smartling.placeholder_format=C
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
+msgctxt "Feedback prompt"
+msgid ""
+"Please paste your prompt and the problematic output (with any personal "
+"information removed) and describe why the content is harmful or illegal."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -14096,9 +14300,8 @@ msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is illegal or harmful."
 msgstr ""
-"अपना सवाल और जो गलत या आपत्तिजनक जवाब मिला है, यहां पेस्ट करें (अपनी कोई भी "
-"निजी जानकारी शामिल न करें), साथ में बताएं कि यह सामग्री क्यों गैरकानूनी या "
-"नुकसानदेह है।"
+"अपना सवाल और जो गलत या आपत्तिजनक जवाब मिला है, यहां पेस्ट करें (अपनी कोई भी निजी "
+"जानकारी शामिल न करें), साथ में बताएं कि यह सामग्री क्यों गैरकानूनी या नुकसानदेह है।"
 
 # smartling.placeholder_format=C
 #. Title on a feedback form.
@@ -14251,8 +14454,8 @@ msgid ""
 "Plus, what you watch in Duck Player won’t influence your recommendations on "
 "YouTube."
 msgstr ""
-"साथ ही, Duck Player में आप जो देखते हैं, वह YouTube पर आपके रिकमंडेशन या "
-"सुझावों को प्रभावित नहीं करेगा।"
+"साथ ही, Duck Player में आप जो देखते हैं, वह YouTube पर आपके रिकमंडेशन या सुझावों को "
+"प्रभावित नहीं करेगा।"
 
 # smartling.placeholder_format=C
 #. A link to the Substack page (https://insideduckduckgo.substack.com/?showWelcome=true)
@@ -14558,6 +14761,12 @@ msgid "Privacy"
 msgstr "गोपनीयता"
 
 # smartling.placeholder_format=C
+#. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
+msgctxt "Section heading on the Duck.ai settings page"
+msgid "Privacy & Terms"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Privacy Blog"
 msgstr "गोपनीयता ब्लॉग"
 
@@ -14626,6 +14835,12 @@ msgstr "गोपनीयता नीति और उपयोग की श�
 msgctxt "Copy used to compose link in sentences"
 msgid "Privacy Policy and Terms of Service"
 msgstr "गोपनीयता नीति और सेवा की शर्तें"
+
+# smartling.placeholder_format=C
+#. Text for a button that links to the terms of use and privacy policy page.
+msgctxt "Secondary button text in active privacy modal"
+msgid "Privacy Policy and Terms of Service"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title displayed on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
@@ -14800,8 +15015,8 @@ msgstr "मुझे प्रॉम्प्ट करें"
 msgctxt "settings"
 msgid "Prompt me to use my approximate location to get nearby results."
 msgstr ""
-"नज़दीकी परिणाम प्राप्त करने के लिए मुझे अपने अनुमानित स्थान का उपयोग करने के "
-"लिए प्रेरित करें।"
+"नज़दीकी परिणाम प्राप्त करने के लिए मुझे अपने अनुमानित स्थान का उपयोग करने के लिए प्रेरित "
+"करें।"
 
 # smartling.placeholder_format=C
 #. DuckDuckGo Email Protection removes trackers from emails
@@ -14820,8 +15035,7 @@ msgstr "खोजते और ब्राउज़ करते समय अ�
 msgctxt "SERP footer content"
 msgid "Protect your data as you search, browse, and use AI."
 msgstr ""
-"सर्च करते समय, ब्राउज़ करते समय, और AI का इस्तेमाल करते हुए अपने डेटा को "
-"सुरक्षित रखें।"
+"सर्च करते समय, ब्राउज़ करते समय, और AI का इस्तेमाल करते हुए अपने डेटा को सुरक्षित रखें।"
 
 # smartling.placeholder_format=C
 #. A title above links to download the DuckDuckGo apps.
@@ -14846,8 +15060,7 @@ msgid ""
 "Provide a few suggestions to make the following text more concise. [Insert "
 "your own text here.]"
 msgstr ""
-"नीचे दिए गए टेक्स्ट को और संक्षिप्त बनाने के लिए कुछ सुझाव दें। [अपना खुद का "
-"टेक्स्ट यहां डालें।]"
+"नीचे दिए गए टेक्स्ट को और संक्षिप्त बनाने के लिए कुछ सुझाव दें। [अपना खुद का टेक्स्ट यहां डालें।]"
 
 # smartling.placeholder_format=C
 #. In the context of a standings table for NHL (hockey), column title that abbreviates 'Total Points' (the total points of this team)
@@ -15084,8 +15297,8 @@ msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
 msgstr ""
-"हालिया चैट DuckDuckGo सर्वर या दूसरे रिमोट सर्वर के बजाय आपके डिवाइस पर "
-"स्थानीय स्तर पर स्टोर की जाती हैं।"
+"हालिया चैट DuckDuckGo सर्वर या दूसरे रिमोट सर्वर के बजाय आपके डिवाइस पर स्थानीय स्तर "
+"पर स्टोर की जाती हैं।"
 
 # smartling.placeholder_format=C
 #. Text explaining that recent chats are stored locally on the user's device.
@@ -15094,8 +15307,8 @@ msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
 msgstr ""
-"हालिया चैट DuckDuckGo सर्वर या दूसरे रिमोट सर्वर के बजाय आपके डिवाइस पर "
-"स्थानीय स्तर पर स्टोर की जाती हैं।"
+"हालिया चैट DuckDuckGo सर्वर या दूसरे रिमोट सर्वर के बजाय आपके डिवाइस पर स्थानीय स्तर "
+"पर स्टोर की जाती हैं।"
 
 # smartling.placeholder_format=C
 #. Text explaining how recent chats are stored locally on the user's device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection.
@@ -15105,10 +15318,9 @@ msgid ""
 "are encrypted and temporarily stored on a DuckDuckGo server after being "
 "sent, to help recover a chat if you lose your internet connection."
 msgstr ""
-"हाल की चैट्स आपके डिवाइस पर लोकली स्टोर होती हैं। नए प्रॉम्प्ट और रिस्पॉन्स "
-"भेजे जाने के बाद एन्क्रिप्ट किए जाते हैं और अस्थायी रूप से DuckDuckGo सर्वर "
-"पर स्टोर रहते हैं, ताकि यदि आपका इंटरनेट कनेक्शन खो जाए तो चैट को रिकवर किया "
-"जा सके।"
+"हाल की चैट्स आपके डिवाइस पर लोकली स्टोर होती हैं। नए प्रॉम्प्ट और रिस्पॉन्स भेजे जाने के "
+"बाद एन्क्रिप्ट किए जाते हैं और अस्थायी रूप से DuckDuckGo सर्वर पर स्टोर रहते हैं, ताकि यदि "
+"आपका इंटरनेट कनेक्शन खो जाए तो चैट को रिकवर किया जा सके।"
 
 # smartling.placeholder_format=C
 msgctxt "region filter"
@@ -15130,6 +15342,30 @@ msgstr "%1$s%2$s%3$s वाली रेसिपी"
 msgctxt "Brief for recommending a book"
 msgid "Recommend a book"
 msgstr "कोई किताब सुझाएं"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar books"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar books."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar movies or shows."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar titles"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
@@ -15202,8 +15438,8 @@ msgid ""
 "Reduces extra space in and around results and reduces size of result title "
 "text"
 msgstr ""
-"परिणामों के अंदर और आसपास के अतिरिक्त स्पेस हटाता है और परिणाम टाइटल टेक्स्ट "
-"के आकार को घटाता है"
+"परिणामों के अंदर और आसपास के अतिरिक्त स्पेस हटाता है और परिणाम टाइटल टेक्स्ट के आकार को "
+"घटाता है"
 
 # smartling.placeholder_format=C
 #. Label for the input field where users specify how they want to be referred to. Example: 'Refer to me as John'
@@ -15344,8 +15580,8 @@ msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
 msgstr ""
-"DuckDuckGo को फिर से लोड करें, इसके लिए निर्देशों का पालन करें या अपने "
-"ब्राउज़र के &quot;रीफ्रेश&quot; या &quot;रीलोड&quot; बटन पर क्लिक करें।"
+"DuckDuckGo को फिर से लोड करें, इसके लिए निर्देशों का पालन करें या अपने ब्राउज़र के &quot;"
+"रीफ्रेश&quot; या &quot;रीलोड&quot; बटन पर क्लिक करें।"
 
 # smartling.placeholder_format=C
 #. checkbox label that allows the user to save the setting
@@ -15435,8 +15671,8 @@ msgid ""
 "Removes the \"Ask\" button so answers appear automatically in response to "
 "relevant searches. Cached answers always display automatically."
 msgstr ""
-"\"पूछें\" बटन को हटा देता है जिससे प्रासंगिक खोजों के लिए उत्तर स्वचालित रूप "
-"से दिखाई देते हैं। कैश्ड उत्तर हमेशा स्वचालित रूप से प्रदर्शित होते हैं।"
+"\"पूछें\" बटन को हटा देता है जिससे प्रासंगिक खोजों के लिए उत्तर स्वचालित रूप से दिखाई देते "
+"हैं। कैश्ड उत्तर हमेशा स्वचालित रूप से प्रदर्शित होते हैं।"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -15444,9 +15680,8 @@ msgid ""
 "Removes the \"Generate\" button so answers appear automatically in response "
 "to relevant searches. Cached answers always display automatically."
 msgstr ""
-"\"जनरेट करें\" बटन को हटा देता है जिससे प्रासंगिक खोजों के लिए उत्तर "
-"स्वचालित रूप से दिखाई देते हैं। कैश्ड उत्तर हमेशा स्वचालित रूप से प्रदर्शित "
-"होते हैं।"
+"\"जनरेट करें\" बटन को हटा देता है जिससे प्रासंगिक खोजों के लिए उत्तर स्वचालित रूप से दिखाई "
+"देते हैं। कैश्ड उत्तर हमेशा स्वचालित रूप से प्रदर्शित होते हैं।"
 
 # smartling.placeholder_format=C
 #. Text for a button to rename a chat, as in it will allow the user to change the title of the chat.
@@ -15504,9 +15739,9 @@ msgid ""
 "service. Your anonymous feedback is also shared with %s to help improve "
 "their services."
 msgstr ""
-"रिपोर्ट गुमनाम हैं और हमारी खोज सेवा को बेहतर बनाने में मदद करने के लिए "
-"DuckDuckGo को भेजी जाती हैं। उनकी सेवाओं को बेहतर बनाने में सहायता के लिए "
-"आपकी अनाम प्रतिक्रिया भी %1$s के साथ शेयर की जाती है।"
+"रिपोर्ट गुमनाम हैं और हमारी खोज सेवा को बेहतर बनाने में मदद करने के लिए DuckDuckGo को "
+"भेजी जाती हैं। उनकी सेवाओं को बेहतर बनाने में सहायता के लिए आपकी अनाम प्रतिक्रिया भी "
+"%1$s के साथ शेयर की जाती है।"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -15514,8 +15749,8 @@ msgid ""
 "Reports sent to DuckDuckGo are anonymous. Please do not include any personal "
 "or identifying information in your feedback."
 msgstr ""
-"DuckDuckGo को भेजी गई रिपोर्टें गुमनाम रहती हैं। कृपया अपने फ़ीडबैक में कोई "
-"भी व्यक्तिगत या पहचान योग्य जानकारी शामिल न करें।"
+"DuckDuckGo को भेजी गई रिपोर्टें गुमनाम रहती हैं। कृपया अपने फ़ीडबैक में कोई भी व्यक्तिगत या "
+"पहचान योग्य जानकारी शामिल न करें।"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -15524,13 +15759,22 @@ msgid ""
 "translate during this page load, and are anonymous. Please do not include "
 "any personal or identifying information in your feedback."
 msgstr ""
-"DuckDuckGo को भेजी गई रिपोर्ट में वे सभी टेक्स्ट शामिल होते हैं, जिन्हें "
-"आपने इस पेज लोड के दौरान अनुवाद के लिए कहा था, और वे गुमनाम हैं। कृपया अपने "
-"फ़ीडबैक में कोई भी व्यक्तिगत या पहचान योग्य जानकारी शामिल न करें।"
+"DuckDuckGo को भेजी गई रिपोर्ट में वे सभी टेक्स्ट शामिल होते हैं, जिन्हें आपने इस पेज लोड के "
+"दौरान अनुवाद के लिए कहा था, और वे गुमनाम हैं। कृपया अपने फ़ीडबैक में कोई भी व्यक्तिगत या "
+"पहचान योग्य जानकारी शामिल न करें।"
 
 # smartling.placeholder_format=C
 msgid "Republic of Moldova"
 msgstr "रिपब्लिक ऑफ़ मोल्डोवा"
+
+# smartling.placeholder_format=C
+#. Note indicating that sharing the conversation is mandatory when reporting harmful or illegal content. Rendered alongside the standard share label (DUCKCHAT_RESPONSE_FEEDBACK_SHARE_PROMPT_RESPONSE_LABEL), not replacing it.
+msgctxt ""
+"Note shown under the share-content switch label on the Duck.ai response "
+"feedback form when the user has selected Harmful or Illegal as the feedback "
+"reason"
+msgid "Required for harmful or illegal reports"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
@@ -15597,10 +15841,9 @@ msgid ""
 "legal, financial, investment, or other professional advice. AI-assisted "
 "answers are subject to our %sTerms of Service%s."
 msgstr ""
-"सारे रिस्पॉन्स या जवाब केवल शिक्षात्मक उद्देश्यों के लिए हैं और इन्हें "
-"चिकित्सा, कानूनी, वित्तीय, निवेश या अन्य पेशेवर सलाह के रूप में नहीं माना "
-"जाना चाहिए। AI की मदद से दिए गए जवाब हमारी %1$sसेवा की शर्तों%2$s के अधीन "
-"हैं।"
+"सारे रिस्पॉन्स या जवाब केवल शिक्षात्मक उद्देश्यों के लिए हैं और इन्हें चिकित्सा, कानूनी, "
+"वित्तीय, निवेश या अन्य पेशेवर सलाह के रूप में नहीं माना जाना चाहिए। AI की मदद से दिए गए "
+"जवाब हमारी %1$sसेवा की शर्तों%2$s के अधीन हैं।"
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -15609,9 +15852,9 @@ msgid ""
 "legal, financial, investment, or other professional advice. DuckAssist is "
 "subject to our %sTerms of Service%s."
 msgstr ""
-"सारे रिस्पॉन्स या जवाब केवल शिक्षात्मक उद्देश्यों के लिए हैं और इन्हें "
-"चिकित्सा, कानूनी, वित्तीय, निवेश या अन्य पेशेवर सलाह के रूप में नहीं माना "
-"जाना चाहिए। DuckAssist हमारी %1$sसेवा की शर्तों%2$s के अधीन है।"
+"सारे रिस्पॉन्स या जवाब केवल शिक्षात्मक उद्देश्यों के लिए हैं और इन्हें चिकित्सा, कानूनी, "
+"वित्तीय, निवेश या अन्य पेशेवर सलाह के रूप में नहीं माना जाना चाहिए। DuckAssist हमारी "
+"%1$sसेवा की शर्तों%2$s के अधीन है।"
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -15621,11 +15864,10 @@ msgid ""
 "generated based on web content and may contain inaccuracies. Search Assist "
 "is subject to our %sTerms of Service%s."
 msgstr ""
-"सारे रिस्पॉन्स या जवाब केवल शिक्षात्मक उद्देश्यों के लिए हैं और इन्हें "
-"चिकित्सा, कानूनी, वित्तीय, निवेश या अन्य पेशेवर सलाह के रूप में नहीं माना "
-"जाना चाहिए। ये वेब सामग्री के आधार पर तैयार किए जाते हैं और इनमें कुछ "
-"गलतियां भी हो सकती हैं। Search Assist हमारी %1$sसेवा की शर्तों%2$s के अधीन "
-"है।"
+"सारे रिस्पॉन्स या जवाब केवल शिक्षात्मक उद्देश्यों के लिए हैं और इन्हें चिकित्सा, कानूनी, "
+"वित्तीय, निवेश या अन्य पेशेवर सलाह के रूप में नहीं माना जाना चाहिए। ये वेब सामग्री के आधार "
+"पर तैयार किए जाते हैं और इनमें कुछ गलतियां भी हो सकती हैं। Search Assist हमारी %1$sसेवा "
+"की शर्तों%2$s के अधीन है।"
 
 # smartling.placeholder_format=C
 #. Label on the button for restoring all previous website data.
@@ -15702,8 +15944,7 @@ msgstr "परिणामों में ब्लॉक की गई सा�
 msgctxt "Blocked sites filter disclaimer"
 msgid "Results exclude your blocked sites, which you can manage in your %s."
 msgstr ""
-"परिणामों में ब्लॉक की गई साइटें नहीं दिखाई जातीं, आप उन्हें अपने %1$s में "
-"मैनेज कर सकते हैं।"
+"परिणामों में ब्लॉक की गई साइटें नहीं दिखाई जातीं, आप उन्हें अपने %1$s में मैनेज कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. A label showing the source of the results, e.g. "Results from Reddit"
@@ -15769,6 +16010,12 @@ msgstr "समीक्षा"
 msgctxt "maps_places"
 msgid "Reviews"
 msgstr "समीक्षा"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Rewrite this recipe scaled for a different number of servings."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Romania"
@@ -16040,8 +16287,8 @@ msgid ""
 "Save up to 30 of your most recent chats locally on your device, with the "
 "option for more with Encrypted Storage."
 msgstr ""
-"अपने डिवाइस पर अपनी सबसे नई 30 चैट तक स्थानीय रूप से सेव करें, और "
-"एन्क्रिप्टेड स्टोरेज के साथ इससे अधिक चैट सहेजने का विकल्प भी उपलब्ध है।"
+"अपने डिवाइस पर अपनी सबसे नई 30 चैट तक स्थानीय रूप से सेव करें, और एन्क्रिप्टेड स्टोरेज के "
+"साथ इससे अधिक चैट सहेजने का विकल्प भी उपलब्ध है।"
 
 # smartling.placeholder_format=C
 #. Short text for native DDG browser users explaining how Chat History stores up to 30 of their most recent chats locally on their device.
@@ -16054,9 +16301,7 @@ msgstr "अपनी सबसे हाल की 30 चैट तक को �
 msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
-msgstr ""
-"एंड-टू-एंड एनक्रिप्शन के साथ अपने Duck.ai चैट्स को अपने डिवाइसों के बीच "
-"सुरक्षित रखें।"
+msgstr "एंड-टू-एंड एनक्रिप्शन के साथ अपने Duck.ai चैट्स को अपने डिवाइसों के बीच सुरक्षित रखें।"
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -16186,8 +16431,8 @@ msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)"
 msgstr ""
-"नीचे स्क्रॉल करें और %1$sपता बार में खोजें%2$s ढूंढें। %3$sबदलें%4$s (या "
-"%5$sनया जोड़ें%6$s) क्लिक करें"
+"नीचे स्क्रॉल करें और %1$sपता बार में खोजें%2$s ढूंढें। %3$sबदलें%4$s (या %5$sनया जोड़ें%6$s) "
+"क्लिक करें"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
@@ -16196,8 +16441,8 @@ msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)."
 msgstr ""
-"नीचे स्क्रॉल करें और %1$sपता बार में खोजें%2$s ढूंढें। %3$sबदलें%4$s पर "
-"क्लिक करें (या %5$sनया जोड़ें%6$s)।"
+"नीचे स्क्रॉल करें और %1$sपता बार में खोजें%2$s ढूंढें। %3$sबदलें%4$s पर क्लिक करें (या %5$sनया "
+"जोड़ें%6$s)।"
 
 # smartling.placeholder_format=C
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -16216,8 +16461,8 @@ msgstr "नीचे स्क्रॉल करें और सूची म�
 msgctxt "precise_user_location"
 msgid "Scroll down to %sDuckDuckGo%s and allow it to use your location."
 msgstr ""
-"नीचे स्क्रॉल करते हुए %1$sDuckDuckGo%2$s पर जाएं और इसे अनुमति दें कि यह "
-"आपकी लोकेशन यानी स्थान का इस्तेमाल कर सके।"
+"नीचे स्क्रॉल करते हुए %1$sDuckDuckGo%2$s पर जाएं और इसे अनुमति दें कि यह आपकी लोकेशन "
+"यानी स्थान का इस्तेमाल कर सके।"
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -16271,12 +16516,11 @@ msgid ""
 "(on a wide range of searches). For now, Search Assist is only available in a "
 "subset of English speaking regions."
 msgstr ""
-"Search Assist आपके खोज प्रश्नों के जवाब गुमनाम तरीके से तैयार करता है। ऐसा "
-"करने के लिए यह वेब पर संबंधित सामग्री खोजता है और फिर AI की मदद से एक "
-"संक्षिप्त जवाब तैयार करता है। आप चुन सकते हैं कि यह कितनी बार दिखाई दे: कभी "
-"नहीं, केवल मांग पर (जब आप 'Assist' पर क्लिक करें), कभी-कभी (जब यह बहुत "
-"प्रासंगिक हो), या अक्सर (जब कई तरह की खोज पर लागू हो)। फिलहाल, Search Assist "
-"केवल कुछ अंग्रेज़ी भाषी क्षेत्रों में ही उपलब्ध है।"
+"Search Assist आपके खोज प्रश्नों के जवाब गुमनाम तरीके से तैयार करता है। ऐसा करने के लिए "
+"यह वेब पर संबंधित सामग्री खोजता है और फिर AI की मदद से एक संक्षिप्त जवाब तैयार करता है। "
+"आप चुन सकते हैं कि यह कितनी बार दिखाई दे: कभी नहीं, केवल मांग पर (जब आप 'Assist' पर "
+"क्लिक करें), कभी-कभी (जब यह बहुत प्रासंगिक हो), या अक्सर (जब कई तरह की खोज पर लागू "
+"हो)। फिलहाल, Search Assist केवल कुछ अंग्रेज़ी भाषी क्षेत्रों में ही उपलब्ध है।"
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI) when the answer is not found and the answer is unsourced or with no sources
@@ -16284,8 +16528,8 @@ msgid ""
 "Search Assist couldn't find enough reliable information to generate an "
 "answer for this question. Try another search."
 msgstr ""
-"Search Assist को इस प्रश्न का उत्तर जनरेट करने के लिए पर्याप्त विश्वसनीय "
-"जानकारी नहीं मिली। कुछ और सर्च करके देखें।"
+"Search Assist को इस प्रश्न का उत्तर जनरेट करने के लिए पर्याप्त विश्वसनीय जानकारी नहीं "
+"मिली। कुछ और सर्च करके देखें।"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -16294,10 +16538,9 @@ msgid ""
 "search queries. To do this, it %sscans the web%s for relevant content and "
 "then uses AI to generate a brief answer based on information found."
 msgstr ""
-"Search Assist एक वैकल्पिक फ़ीचर है जो खोज प्रश्नों के लिए गुमनाम रूप से जवाब "
-"तैयार करता है। ऐसा करने के लिए, यह %1$sवेब पर खोजबीन करता है%2$s ताकि "
-"संबंधित सामग्री मिल सके, और फिर मिली जानकारी के आधार पर AI की मदद से एक "
-"संक्षिप्त उत्तर तैयार करता है।"
+"Search Assist एक वैकल्पिक फ़ीचर है जो खोज प्रश्नों के लिए गुमनाम रूप से जवाब तैयार करता "
+"है। ऐसा करने के लिए, यह %1$sवेब पर खोजबीन करता है%2$s ताकि संबंधित सामग्री मिल सके, "
+"और फिर मिली जानकारी के आधार पर AI की मदद से एक संक्षिप्त उत्तर तैयार करता है।"
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/search_box. top header
@@ -16418,8 +16661,8 @@ msgid ""
 "Search other sites with %s shortcuts: a search for ”!w ducks” will search "
 "for “ducks” directly on Wikipedia."
 msgstr ""
-"%1$s शॉर्टकट के ज़रिए अन्य साइटों को खोजें: \"!w ducks” खोजने पर सीधे "
-"Wikipedia पर “ducks” को खोजा जाएगा।"
+"%1$s शॉर्टकट के ज़रिए अन्य साइटों को खोजें: \"!w ducks” खोजने पर सीधे Wikipedia पर "
+"“ducks” को खोजा जाएगा।"
 
 # smartling.placeholder_format=C
 #. Placeholder text for the search form when no text has been entered
@@ -16438,8 +16681,8 @@ msgid ""
 "Search privately with our app or extension, add private web search to your "
 "favorite browser, or search directly at %sduckduckgo.com%s."
 msgstr ""
-"हमारे ऐप या एक्सटेंशन के साथ गुप्त रूप से खोज करें, अपने पसंदीदा ब्राउज़र "
-"में गोपनीय वेब खोज जोड़ें या सीधा %1$sduckduckgo.com%2$s पर खोजें।"
+"हमारे ऐप या एक्सटेंशन के साथ गुप्त रूप से खोज करें, अपने पसंदीदा ब्राउज़र में गोपनीय वेब खोज "
+"जोड़ें या सीधा %1$sduckduckgo.com%2$s पर खोजें।"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/6LZAoqH.png
@@ -16447,8 +16690,8 @@ msgctxt "settings"
 msgid ""
 "Search queries are included in URL (if off, searches will use POST requests)"
 msgstr ""
-"खोज के प्रश्न यूआरएल में शामिल हैं (अगर ऑफ़ किया गया तब खोज द्वारा पोस्ट "
-"अनुरोध का उपयोग होगा)"
+"खोज के प्रश्न यूआरएल में शामिल हैं (अगर ऑफ़ किया गया तब खोज द्वारा पोस्ट अनुरोध का उपयोग "
+"होगा)"
 
 # smartling.placeholder_format=C
 #. Describes how cookies are used to store user settings privately and securely.
@@ -16460,11 +16703,11 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"खोज सेटिंग को आपके ब्राउज़र में गैर-व्यक्तिगत ब्राउज़र की कुकीज़ और लोकल "
-"स्टोरेज में रखा जाता है. हालांकि, आप चाहें तो Cloud Save का इस्तेमाल करके "
-"अपनी सेटिंग को क्लाउड में किसी रिमोट सर्वर पर गुमनाम रूप से भी सेव कर सकते "
-"हैं। क्लाउड में कोई भी व्यक्तिगत रूप से पहचान योग्य जानकारी स्टोर नहीं की "
-"जाएगी, और आपका पासफ्रेज़ कभी भी आपके ब्राउज़र से बाहर नहीं जाएगा।"
+"खोज सेटिंग को आपके ब्राउज़र में गैर-व्यक्तिगत ब्राउज़र की कुकीज़ और लोकल स्टोरेज में रखा जाता "
+"है. हालांकि, आप चाहें तो Cloud Save का इस्तेमाल करके अपनी सेटिंग को क्लाउड में किसी "
+"रिमोट सर्वर पर गुमनाम रूप से भी सेव कर सकते हैं। क्लाउड में कोई भी व्यक्तिगत रूप से पहचान "
+"योग्य जानकारी स्टोर नहीं की जाएगी, और आपका पासफ्रेज़ कभी भी आपके ब्राउज़र से बाहर नहीं "
+"जाएगा।"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -16561,8 +16804,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
 msgstr ""
-"हमारे सर्वर पर एंड-टू-एंड एनक्रिप्शन का उपयोग करके ढेर सारी चैट्स सुरक्षित "
-"रूप से स्टोर करें, और उन्हें अपने सभी डिवाइस से एक्सेस करें।"
+"हमारे सर्वर पर एंड-टू-एंड एनक्रिप्शन का उपयोग करके ढेर सारी चैट्स सुरक्षित रूप से स्टोर करें, "
+"और उन्हें अपने सभी डिवाइस से एक्सेस करें।"
 
 # smartling.placeholder_format=C
 #. Text explaining that the Encrypted Storage feature stores the user's chats encrypted on their device.
@@ -16571,8 +16814,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
 msgstr ""
-"हमारे सर्वर पर एंड-टू-एंड एनक्रिप्शन का उपयोग करके ढेर सारी चैट्स सुरक्षित "
-"रूप से स्टोर करें, और उन्हें अपने सभी डिवाइस से एक्सेस करें।"
+"हमारे सर्वर पर एंड-टू-एंड एनक्रिप्शन का उपयोग करके ढेर सारी चैट्स सुरक्षित रूप से स्टोर करें, "
+"और उन्हें अपने सभी डिवाइस से एक्सेस करें।"
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -16581,8 +16824,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your synced devices."
 msgstr ""
-"हमारे सर्वर पर एंड-टू-एंड एनक्रिप्शन का उपयोग करके ढेर सारी चैट्स सुरक्षित "
-"रूप से स्टोर करें, और उन्हें अपने सभी सिंक किए गए डिवाइसों से एक्सेस करें।"
+"हमारे सर्वर पर एंड-टू-एंड एनक्रिप्शन का उपयोग करके ढेर सारी चैट्स सुरक्षित रूप से स्टोर करें, "
+"और उन्हें अपने सभी सिंक किए गए डिवाइसों से एक्सेस करें।"
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -16591,8 +16834,8 @@ msgid ""
 "Securely store your chats on our server using end-to-end encryption, and "
 "access them from all your devices."
 msgstr ""
-"हमारे सर्वर पर एंड-टू-एंड एनक्रिप्शन का उपयोग करके अपनी चैट्स सुरक्षित रूप "
-"से स्टोर करें, और उन्हें अपने सभी डिवाइसों से एक्सेस करें।"
+"हमारे सर्वर पर एंड-टू-एंड एनक्रिप्शन का उपयोग करके अपनी चैट्स सुरक्षित रूप से स्टोर करें, और "
+"उन्हें अपने सभी डिवाइसों से एक्सेस करें।"
 
 # smartling.placeholder_format=C
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
@@ -16607,8 +16850,8 @@ msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
 msgstr ""
-"एंड-टू-एंड एनक्रिप्शन के साथ DuckDuckGo के सर्वर पर सुरक्षित रूप से स्टोर "
-"किया गया। आपके अलावा कोई भी आपका डेटा नहीं देख सकता, हम भी नहीं।"
+"एंड-टू-एंड एनक्रिप्शन के साथ DuckDuckGo के सर्वर पर सुरक्षित रूप से स्टोर किया गया। आपके "
+"अलावा कोई भी आपका डेटा नहीं देख सकता, हम भी नहीं।"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -16752,9 +16995,7 @@ msgstr "Safari मेनू से %1$s'इस वेबसाइट के ल�
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
-msgstr ""
-"%1$sकस्टम%2$s चुनें और इनपुट फ़ील्ड में %3$shttps://duckduckgo.com%4$s दर्ज "
-"करें"
+msgstr "%1$sकस्टम%2$s चुनें और इनपुट फ़ील्ड में %3$shttps://duckduckgo.com%4$s दर्ज करें"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
@@ -16764,17 +17005,13 @@ msgstr "%1$sDuckDuckGo%2$s चुनें और %3$sडिफ़ॉल्ट �
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s"
-msgstr ""
-"%1$sDuckDuckGo%2$s चुनें और %3$sडिफ़ॉल्ट के रूप में सेट करें%4$s पर क्लिक "
-"करें"
+msgstr "%1$sDuckDuckGo%2$s चुनें और %3$sडिफ़ॉल्ट के रूप में सेट करें%4$s पर क्लिक करें"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s."
-msgstr ""
-"%1$sDuckDuckGo%2$s चुनें और %3$sडिफ़ॉल्ट के रूप में सेट करें%4$s पर क्लिक "
-"करें।"
+msgstr "%1$sDuckDuckGo%2$s चुनें और %3$sडिफ़ॉल्ट के रूप में सेट करें%4$s पर क्लिक करें।"
 
 #  Firefox 33
 # smartling.placeholder_format=C
@@ -16823,8 +17060,7 @@ msgstr "ड्रॉपडाउन मेनू से %1$sएड-ऑन प्
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sMenu > Settings%s (on Windows)"
 msgstr ""
-"%1$sOpera > प्राथमिकताएं%2$s (Mac पर) या %3$sमेनू > सेटिंग%4$s (Windows पर) "
-"चुनें"
+"%1$sOpera > प्राथमिकताएं%2$s (Mac पर) या %3$sमेनू > सेटिंग%4$s (Windows पर) चुनें"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -16832,8 +17068,7 @@ msgstr ""
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sOpera > Options%s (on Windows)"
 msgstr ""
-"%1$sOpera > प्राथमिकताएं%2$s (Mac पर) या %3$sOpera > विकल्प%4$s (Windows पर) "
-"चुनें"
+"%1$sOpera > प्राथमिकताएं%2$s (Mac पर) या %3$sOpera > विकल्प%4$s (Windows पर) चुनें"
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -16898,8 +17133,8 @@ msgid ""
 "Select %sUse this webpage as your only home page%s (or one of the other "
 "options if you prefer)"
 msgstr ""
-"%1$sइस वेबपेज को अपना एकमात्र होमपेज बनाएं%2$s (या अन्य विकल्पों में से अपनी "
-"पसंद का कोई एक विकल्प) चुनें"
+"%1$sइस वेबपेज को अपना एकमात्र होमपेज बनाएं%2$s (या अन्य विकल्पों में से अपनी पसंद का कोई "
+"एक विकल्प) चुनें"
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
@@ -17021,8 +17256,8 @@ msgid ""
 "respond. These instructions will apply to all of your conversations going "
 "forward."
 msgstr ""
-"यह आपके संदेशों के साथ AI मॉडलों को निर्देश भेजता है कि उन्हें कैसे जवाब "
-"देना है। ये निर्देश आगे चलकर आपके सभी वार्तालापों पर लागू होंगे।"
+"यह आपके संदेशों के साथ AI मॉडलों को निर्देश भेजता है कि उन्हें कैसे जवाब देना है। ये निर्देश आगे "
+"चलकर आपके सभी वार्तालापों पर लागू होंगे।"
 
 # smartling.placeholder_format=C
 msgid "Senegal"
@@ -17098,6 +17333,12 @@ msgid "Set Up Now"
 msgstr "अभी सेटअप करें"
 
 # smartling.placeholder_format=C
+#. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
+msgctxt "Encrypted storage setup button shown in native browsers"
+msgid "Set Up Sync & Backup"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
 msgctxt "Title for the Sync & Backup intro screen"
 msgid "Set Up Sync & Backup"
@@ -17126,8 +17367,8 @@ msgid ""
 "Set up Sync & Backup after turning on Chat History to keep your chats synced "
 "across devices."
 msgstr ""
-"चैट हिस्ट्री चालू करने के बाद Sync & Backup सेट करें ताकि अपनी चैट को सभी "
-"डिवाइसों पर सिंक रख सकें।"
+"चैट हिस्ट्री चालू करने के बाद Sync & Backup सेट करें ताकि अपनी चैट को सभी डिवाइसों पर "
+"सिंक रख सकें।"
 
 # smartling.placeholder_format=C
 #. Prompt for the user to indicate their location on a map, to enable more relevant search results.
@@ -17214,9 +17455,8 @@ msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
 msgstr ""
-"AI मॉडलों के साथ शहर वाली आसपास की लोकेशन शेयर करें ताकि उनके जवाबों की "
-"सटीकता बेहतर हो। Duck.ai कभी भी आपकी सटीक लोकेशन हमें या AI मॉडल को नहीं "
-"बताता है।"
+"AI मॉडलों के साथ शहर वाली आसपास की लोकेशन शेयर करें ताकि उनके जवाबों की सटीकता बेहतर "
+"हो। Duck.ai कभी भी आपकी सटीक लोकेशन हमें या AI मॉडल को नहीं बताता है।"
 
 # smartling.placeholder_format=C
 #. Menu option to share feedback about a result
@@ -17277,6 +17517,13 @@ msgid "Share positive feedback"
 msgstr "सकारात्मक फ़ीडबैक शेयर करें"
 
 # smartling.placeholder_format=C
+#. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
+msgctxt ""
+"Label beside the share-content switch on the Duck.ai response feedback form"
+msgid "Share this conversation with DuckDuckGo"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
 msgctxt ""
 "Label beside the share-content switch on the Duck.ai response feedback form"
@@ -17292,8 +17539,8 @@ msgid ""
 "Share your prompt and chat response with DuckDuckGo (required for illegal "
 "and harmful report)"
 msgstr ""
-"DuckDuckGo के साथ अपना प्रॉम्प्ट और चैट रिस्पॉन्स शेयर करें (गैरकानूनी और "
-"हानिकारक रिपोर्ट के लिए आवश्यक है)"
+"DuckDuckGo के साथ अपना प्रॉम्प्ट और चैट रिस्पॉन्स शेयर करें (गैरकानूनी और हानिकारक "
+"रिपोर्ट के लिए आवश्यक है)"
 
 # smartling.placeholder_format=C
 #. An invitation for users to leave feedback
@@ -17414,8 +17661,7 @@ msgstr "DuckAssist <sup>बीटा</sup> दिखाएं"
 msgctxt "duckassist_optin"
 msgid "Show DuckAssist more often. (You can also completely %sturn it off%s.)"
 msgstr ""
-"DuckAssist को अक्सर दिखाएं। (आप चाहें तो इसे पूरी तरह से %1$sबंद%2$s भी कर "
-"सकते हैं।)"
+"DuckAssist को अक्सर दिखाएं। (आप चाहें तो इसे पूरी तरह से %1$sबंद%2$s भी कर सकते हैं।)"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
@@ -17641,9 +17887,9 @@ msgid ""
 "Shows a reminder that searches on DuckDuckGo are always private. Turning "
 "this off hides the reminder and never affects search privacy."
 msgstr ""
-"यह याद दिलाने के लिए एक रिमाइंडर दिखाता है कि DuckDuckGo पर हरेक सर्च यानी "
-"खोज गोपनीय रहती है। इसे बंद करने से रिमाइंडर छिप जाता है, मगर इससे खोज की "
-"गोपनीयता प्रभावित नहीं होती है।"
+"यह याद दिलाने के लिए एक रिमाइंडर दिखाता है कि DuckDuckGo पर हरेक सर्च यानी खोज "
+"गोपनीय रहती है। इसे बंद करने से रिमाइंडर छिप जाता है, मगर इससे खोज की गोपनीयता "
+"प्रभावित नहीं होती है।"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -17651,9 +17897,9 @@ msgid ""
 "Shows a reminder that searches on DuckDuckGo are always protected. Turning "
 "this off hides the reminder and never affects search protection."
 msgstr ""
-"यह याद दिलाने के लिए एक रिमाइंडर दिखाता है कि DuckDuckGo पर हरेक सर्च यानी "
-"खोज हमेशा सुरक्षित रहती है। इसे बंद करने से रिमाइंडर छिप जाता है, मगर इससे "
-"खोज सुरक्षा प्रभावित नहीं होती है।"
+"यह याद दिलाने के लिए एक रिमाइंडर दिखाता है कि DuckDuckGo पर हरेक सर्च यानी खोज "
+"हमेशा सुरक्षित रहती है। इसे बंद करने से रिमाइंडर छिप जाता है, मगर इससे खोज सुरक्षा "
+"प्रभावित नहीं होती है।"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -17691,8 +17937,7 @@ msgctxt "settings"
 msgid ""
 "Shows occasional reminders to sign up for the DuckDuckGo privacy newsletters"
 msgstr ""
-"DuckDuckGo गोपनीयता न्यूज़लेटर के लिए साइन अप करने के लिए सामयिक रिमांडर "
-"दिखाता है"
+"DuckDuckGo गोपनीयता न्यूज़लेटर के लिए साइन अप करने के लिए सामयिक रिमांडर दिखाता है"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -17974,9 +18219,7 @@ msgstr "कभी-कभी"
 #. Generic error message shown when the image generation model cannot process the user's request.
 msgctxt "Error message from the image generation model"
 msgid "Sorry I can't help, please describe your image in a different way."
-msgstr ""
-"माफ़ करें, मैं मदद करने में असमर्थ हूं। कृपया अपनी इमेज का आइडिया अलग शब्दों "
-"में बताएं।"
+msgstr "माफ़ करें, मैं मदद करने में असमर्थ हूं। कृपया अपनी इमेज का आइडिया अलग शब्दों में बताएं।"
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -18015,8 +18258,8 @@ msgid ""
 "Sorry, the uploaded image couldn't be processed. Please try a different "
 "image or format."
 msgstr ""
-"माफ़ करें, अपलोड की गई इमेज को प्रोसेस नहीं किया जा सका। कृपया कोई दूसरी "
-"इमेज या फ़ॉर्मेट आज़माएं।"
+"माफ़ करें, अपलोड की गई इमेज को प्रोसेस नहीं किया जा सका। कृपया कोई दूसरी इमेज या फ़ॉर्मेट "
+"आज़माएं।"
 
 # smartling.placeholder_format=C
 #. Body copy shown when a scanned or pasted pairing payload fails schema validation.
@@ -18025,8 +18268,7 @@ msgid ""
 "Sorry, this code is invalid. Please make sure the correct code was entered "
 "or scanned."
 msgstr ""
-"माफ़ करें, यह कोड गलत है। कृपया सुनिश्चित करें कि सही कोड को दर्ज या स्कैन "
-"किया गया है।"
+"माफ़ करें, यह कोड गलत है। कृपया सुनिश्चित करें कि सही कोड को दर्ज या स्कैन किया गया है।"
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -18041,16 +18283,14 @@ msgid ""
 "Sorry, we ran into an error displaying these results. %sClick here%s to try "
 "again."
 msgstr ""
-"क्षमा करें, इन परिणामों को प्रदर्शित करने में त्रुटि हुई। फिर से प्रयास करने "
-"के लिए, %1$sयहाँ क्लिक करें%2$s।"
+"क्षमा करें, इन परिणामों को प्रदर्शित करने में त्रुटि हुई। फिर से प्रयास करने के लिए, %1$sयहाँ "
+"क्लिक करें%2$s।"
 
 # smartling.placeholder_format=C
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr ""
-"क्षमा करें, हम आपका फ़ीडबैक सबमिट नहीं कर सके। कृपया बाद में फिर से प्रयास "
-"करें।"
+msgstr "क्षमा करें, हम आपका फ़ीडबैक सबमिट नहीं कर सके। कृपया बाद में फिर से प्रयास करें।"
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -18105,8 +18345,8 @@ msgctxt "Error message for summary selection input limit"
 msgid ""
 "Source text is too long to summarize. Try again with a shorter selection."
 msgstr ""
-"सोर्स टेक्स्ट बहुत लंबा है, इसे संक्षेप में बताना संभव नहीं है। थोड़ा छोटा "
-"हिस्सा चुनकर फिर से प्रयास करें।"
+"सोर्स टेक्स्ट बहुत लंबा है, इसे संक्षेप में बताना संभव नहीं है। थोड़ा छोटा हिस्सा चुनकर फिर से "
+"प्रयास करें।"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under Interface Settings.in the end. It is a header
@@ -18450,8 +18690,8 @@ msgid ""
 "Subscribe to DuckDuckGo to unlock higher limits in Duck.ai, or come back "
 "later to create more images."
 msgstr ""
-"Duck.ai में ज़्यादा लिमिट पाने के लिए DuckDuckGo को सब्सक्राइब करें, या अधिक "
-"इमेज बनाने के लिए बाद में वापस आएं।"
+"Duck.ai में ज़्यादा लिमिट पाने के लिए DuckDuckGo को सब्सक्राइब करें, या अधिक इमेज बनाने "
+"के लिए बाद में वापस आएं।"
 
 # smartling.placeholder_format=C
 #. Description shown to free users who have reached their image generation limit, encouraging them to subscribe.
@@ -18520,14 +18760,32 @@ msgid ""
 "Suggest a phrase to write on a get-well card for someone recovering from a "
 "surgery?"
 msgstr ""
-"सर्जरी करवाकर ठीक हो रहे किसी व्यक्ति को देने लायक 'स्वास्थ्य शुभकामनाएं' "
-"वाले कार्ड पर लिखने के लिए वाक्य सुझाएं?"
+"सर्जरी करवाकर ठीक हो रहे किसी व्यक्ति को देने लायक 'स्वास्थ्य शुभकामनाएं' वाले कार्ड पर "
+"लिखने के लिए वाक्य सुझाएं?"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for asking for a suggestion of a blog post title.
 msgctxt "Brief for suggesting a blog post title"
 msgid "Suggest a title for a blog post"
 msgstr "ब्लॉग पोस्ट के लिए शीर्षक सुझाएं"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest related articles or topics worth exploring next."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Suggest related articles to explore"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest some alternatives to this product."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
@@ -18541,10 +18799,100 @@ msgid "Suggestions:"
 msgstr "सुझाव:"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Sum up the reviews"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A short title for the a message asking the AI to summarize a text.
 msgctxt "Title for the summarize message"
 msgid "Summarize"
 msgstr "संक्षेप में बताएं"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize the Q&As"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the background and notable work of this person."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the key details of this event."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the questions and answers on this page."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize their background"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this book"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this book."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this discussion"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this discussion thread."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this page"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this page."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this video"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this video."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize what the reviews say."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -18706,8 +19054,8 @@ msgctxt "AI Chat warning when switching from an encrypted model"
 msgid ""
 "Switching will send your chat to a model without zero provider visibility"
 msgstr ""
-"स्विच करने पर आपकी चैट एक ऐसे मॉडल को भेज दी जाएगी, जिसमें प्रोवाइडर "
-"विज़िबिलिटी ज़ीरो होगी"
+"स्विच करने पर आपकी चैट एक ऐसे मॉडल को भेज दी जाएगी, जिसमें प्रोवाइडर विज़िबिलिटी ज़ीरो "
+"होगी"
 
 # smartling.placeholder_format=C
 msgid "Switzerland"
@@ -18762,8 +19110,7 @@ msgstr "Sync & Backup चालू है!"
 msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
-"18 महीने तक निष्क्रिय रहने के बाद, Sync & Backup डेटा को रिकवर नहीं किया जा "
-"सकता।"
+"18 महीने तक निष्क्रिय रहने के बाद, Sync & Backup डेटा को रिकवर नहीं किया जा सकता।"
 
 # smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
@@ -18812,26 +19159,25 @@ msgid ""
 msgstr ""
 "सिंक रिकवरी कोड\n"
 "\n"
-" रिकवरी कोड की मदद से आप कई डिवाइस पर अपने पासवर्ड, ऑटोफ़िल डेटा और Duck.ai "
-"चैट को सिंक कर सकते हैं, और अगर किसी डिवाइस का एक्सेस खो जाए, तो अपना सिंक "
-"किया हुआ डेटा रिकवर कर सकते हैं।\n"
+" रिकवरी कोड की मदद से आप कई डिवाइस पर अपने पासवर्ड, ऑटोफ़िल डेटा और Duck.ai चैट को "
+"सिंक कर सकते हैं, और अगर किसी डिवाइस का एक्सेस खो जाए, तो अपना सिंक किया हुआ डेटा "
+"रिकवर कर सकते हैं।\n"
 "\n"
 "इस जानकारी को सुरक्षित और गोपनीय रखें।\n"
-"जिस किसी के पास भी इस कोड का एक्सेस होगा, वह आपके सिंक किए गए डेटा को एक्सेस "
-"कर सकता है।\n"
+"जिस किसी के पास भी इस कोड का एक्सेस होगा, वह आपके सिंक किए गए डेटा को एक्सेस कर सकता "
+"है।\n"
 "\n"
 "%1$s\n"
 "\n"
 "यह कोड कैसे काम करता है?\n"
 "1. अपने ब्राउज़र में Duck.ai पर जाएं और Duck.ai सेटिंग खोलें।\n"
-"2. \"Sync & Backup चालू करें\" चुनें, फिर \"सिंक किया गया डेटा रिकवर करें\" "
-"चुनें\n"
-"3. ऊपर दिए गए रिकवरी कोड को कॉपी करें और उसे वहां पेस्ट करें जहां \"अपना कोड "
-"यहां पेस्ट करें\" कहा गया है\n"
+"2. \"Sync & Backup चालू करें\" चुनें, फिर \"सिंक किया गया डेटा रिकवर करें\" चुनें\n"
+"3. ऊपर दिए गए रिकवरी कोड को कॉपी करें और उसे वहां पेस्ट करें जहां \"अपना कोड यहां पेस्ट "
+"करें\" कहा गया है\n"
 "\n"
-"अगर आप Sync & Backup चालू होने के बाद भी 18 महीने से ज़्यादा समय तक "
-"DuckDuckGo ब्राउज़र का इस्तेमाल नहीं करते हैं, तो आपका डेटा सर्वर से डिलीट "
-"कर दिया जाएगा और उसे रीस्टोर नहीं किया जा सकेगा।"
+"अगर आप Sync & Backup चालू होने के बाद भी 18 महीने से ज़्यादा समय तक DuckDuckGo "
+"ब्राउज़र का इस्तेमाल नहीं करते हैं, तो आपका डेटा सर्वर से डिलीट कर दिया जाएगा और उसे "
+"रीस्टोर नहीं किया जा सकेगा।"
 
 # smartling.placeholder_format=C
 #. Secondary button label on the Sync & Backup intro screen that takes the user to the camera scan screen to pair with another device.
@@ -18874,6 +19220,12 @@ msgid "Syria"
 msgstr "सीरिया"
 
 # smartling.placeholder_format=C
+#. Text for a button that enables the theme to follow the operating system's color scheme preference.
+msgctxt "System theme button for theme selector"
+msgid "System"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Abbreviation indicating this is the total score for a game
 msgctxt "Sports module"
 msgid "T"
@@ -18900,6 +19252,12 @@ msgstr "टीवी"
 msgctxt "language_name"
 msgid "Tahitian"
 msgstr "ताहितियन"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Tailor my resume"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Taiwan"
@@ -18929,6 +19287,13 @@ msgstr "अपने निजी आंकड़ों का नियंत्�
 msgctxt "homepage ATB modal"
 msgid "Take control of your personal data!"
 msgstr "अपने व्यक्तिगत डेटा को नियंत्रित करें!"
+
+# smartling.placeholder_format=C
+#. Description for the Feedback section of the Duck.ai settings page, asking the user to take an anonymous survey to let us know how we can make Duck.ai better.
+msgctxt "Feedback section description on the Duck.ai settings page"
+msgid ""
+"Take this anonymous survey to let us know how we can make Duck.ai better."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -19143,9 +19508,9 @@ msgid ""
 "link is at increased risk of being intercepted by a third party. In rare "
 "cases this includes passwords, or payment details."
 msgstr ""
-"इसका मतलब हैं कि आपके डिवाइस और इस लिंक के पीछे के वेबपेज के बीच भेजी गई "
-"जानकारी को किसी तीसरे पक्ष द्वारा इंटरसेप्ट किए जाने का जोखिम बढ़ रहा है। कम "
-"मामलों में इसमें पासवर्ड, या भुगतान विवरण शामिल होते हैं।"
+"इसका मतलब हैं कि आपके डिवाइस और इस लिंक के पीछे के वेबपेज के बीच भेजी गई जानकारी को "
+"किसी तीसरे पक्ष द्वारा इंटरसेप्ट किए जाने का जोखिम बढ़ रहा है। कम मामलों में इसमें पासवर्ड, "
+"या भुगतान विवरण शामिल होते हैं।"
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -19154,8 +19519,8 @@ msgid ""
 "The Cloud Save bookmarklet allows any changes you make to your settings to "
 "automatically save in the cloud."
 msgstr ""
-"Cloud Save बुकमार्कलेट आपको क्लाउड में ऑटोमैटिकली सेव करने के लिए अपनी "
-"सेटिंग्स में कोई भी बदलाव करने की अनुमति देता है।"
+"Cloud Save बुकमार्कलेट आपको क्लाउड में ऑटोमैटिकली सेव करने के लिए अपनी सेटिंग्स में कोई भी "
+"बदलाव करने की अनुमति देता है।"
 
 # smartling.placeholder_format=C
 msgid "The Gambia"
@@ -19185,8 +19550,8 @@ msgid ""
 "The encryption key is only saved in your browser's local storage, and only "
 "you can access it."
 msgstr ""
-"'एनक्रिप्शन की' केवल आपके ब्राउज़र के लोकल स्टोरेज में सेव रहती है, और "
-"सिर्फ़ आप ही इसे एक्सेस कर सकते हैं।"
+"'एनक्रिप्शन की' केवल आपके ब्राउज़र के लोकल स्टोरेज में सेव रहती है, और सिर्फ़ आप ही इसे एक्सेस "
+"कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider deletes all chat data within 30 days.
@@ -19232,6 +19597,12 @@ msgid "Theme"
 msgstr "थीम"
 
 # smartling.placeholder_format=C
+#. Text for the theme selector label that allows users to switch between Light and dark theme.
+msgctxt "Label for the theme selector feature"
+msgid "Theme"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. http://i.imgur.com/LpFhb1e.png
 msgctxt "settings"
 msgid "Theme"
@@ -19260,8 +19631,8 @@ msgid ""
 "There was an error saving this chat locally. Please check your browser "
 "settings to make sure local data storage is enabled."
 msgstr ""
-"इस चैट को लोकल स्टोरेज में सेव करने के दौरान कोई गड़बड़ी हुई। कृपया अपनी "
-"ब्राउज़र सेटिंग जांचें और सुनिश्चित करें कि लोकल डेटा स्टोरेज चालू है।"
+"इस चैट को लोकल स्टोरेज में सेव करने के दौरान कोई गड़बड़ी हुई। कृपया अपनी ब्राउज़र सेटिंग जांचें "
+"और सुनिश्चित करें कि लोकल डेटा स्टोरेज चालू है।"
 
 # smartling.placeholder_format=C
 #. Error modal body line 1.
@@ -19276,8 +19647,8 @@ msgid ""
 "There was still an error displaying the search results. Please wait a few "
 "minutes before you try again."
 msgstr ""
-"खोज परिणाम दिखाने में अभी भी गड़बड़ी हो रही है। कृपया दोबारा कोशिश करने से "
-"पहले कुछ मिनट इंतज़ार करें।"
+"खोज परिणाम दिखाने में अभी भी गड़बड़ी हो रही है। कृपया दोबारा कोशिश करने से पहले कुछ "
+"मिनट इंतज़ार करें।"
 
 # smartling.placeholder_format=C
 #. Error message for explore more questions when a retryable error occurs (timeout, network)
@@ -19296,9 +19667,9 @@ msgid ""
 "visit by blocking hidden trackers, encrypting connections where possible, "
 "and by making DuckDuckGo your default search engine."
 msgstr ""
-"इन ब्राउज़र अनुमतियों को आपके द्वारा देखी जाने वाली वेबसाइटों पर छिपे ट्रैकर "
-"ब्लॉक करके, संभव होने पर कनेक्शन एन्क्रिप्ट करके और DuckDuckGo को आपका "
-"डिफ़ॉल्ट खोज इंजन बनाकर गोपनीयता सुरक्षा जोड़ने के लिए उपयोग किया जाता है।"
+"इन ब्राउज़र अनुमतियों को आपके द्वारा देखी जाने वाली वेबसाइटों पर छिपे ट्रैकर ब्लॉक करके, "
+"संभव होने पर कनेक्शन एन्क्रिप्ट करके और DuckDuckGo को आपका डिफ़ॉल्ट खोज इंजन बनाकर "
+"गोपनीयता सुरक्षा जोड़ने के लिए उपयोग किया जाता है।"
 
 # smartling.placeholder_format=C
 #. Secondary line under DUCKCHAT_SYNC_PAIRING_ALREADY_SYNCED_TITLE.
@@ -19336,8 +19707,7 @@ msgid ""
 "This AI model is no longer available. Try starting a new chat with a "
 "different model."
 msgstr ""
-"यह AI मॉडल अब उपलब्ध नहीं है। किसी दूसरे मॉडल के साथ नई चैट शुरू करने की "
-"कोशिश करें।"
+"यह AI मॉडल अब उपलब्ध नहीं है। किसी दूसरे मॉडल के साथ नई चैट शुरू करने की कोशिश करें।"
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is no longer supported because it has been upgraded to a newest version.
@@ -19346,8 +19716,8 @@ msgid ""
 "This AI model version is no longer supported. Try starting a new chat with "
 "the latest version of this model."
 msgstr ""
-"AI मॉडल के इस वर्ज़न के लिए अब सपोर्ट उपलब्ध नहीं है। इस मॉडल के सबसे नए "
-"वर्ज़न के साथ नई चैट शुरू करें।"
+"AI मॉडल के इस वर्ज़न के लिए अब सपोर्ट उपलब्ध नहीं है। इस मॉडल के सबसे नए वर्ज़न के साथ नई "
+"चैट शुरू करें।"
 
 # smartling.placeholder_format=C
 #. Appears below a type of search results called 'Instant Answers'
@@ -19374,9 +19744,8 @@ msgid ""
 "This conversation was generated with Duck.ai (%s) using %s's %s Model. AI "
 "chats may display inaccurate or offensive information (see %s for more info)."
 msgstr ""
-"यह बातचीत Duck.ai (%1$s) के जरिए %2$s के %3$s मॉडल का इस्तेमाल करके जनरेट की "
-"गई। AI चैट में गलत या आपत्तिजनक जानकारी दिखाई दे सकती है (ज़्यादा जानकारी के "
-"लिए %4$s देखें)।"
+"यह बातचीत Duck.ai (%1$s) के जरिए %2$s के %3$s मॉडल का इस्तेमाल करके जनरेट की गई। "
+"AI चैट में गलत या आपत्तिजनक जानकारी दिखाई दे सकती है (ज़्यादा जानकारी के लिए %4$s देखें)।"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with multiple AI models in the same chat, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using multiple chat models. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -19386,9 +19755,8 @@ msgid ""
 "models. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
 msgstr ""
-"यह बातचीत Duck.ai (%1$s) में कई चैट मॉडल इस्तेमाल करके तैयार की गई थी. एआई "
-"चैट में गलत या आपत्तिजनक जानकारी दिखाई दे सकती है (ज़्यादा जानकारी के लिए "
-"%2$s देखें)."
+"यह बातचीत Duck.ai (%1$s) में कई चैट मॉडल इस्तेमाल करके तैयार की गई थी. एआई चैट में गलत "
+"या आपत्तिजनक जानकारी दिखाई दे सकती है (ज़्यादा जानकारी के लिए %2$s देखें)."
 
 # smartling.placeholder_format=C
 #. When a user exports a transcript of a voice chat they had with the AI. This text goes at the very top of the downloaded file as a header. Placeholders are for links. Example: 'This conversation was generated with Duck.ai voice chat (https://duck.ai). AI may provide inaccurate or offensive information. (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -19397,8 +19765,8 @@ msgid ""
 "This conversation was generated with Duck.ai voice chat (%s). AI may provide "
 "inaccurate or offensive information. (see %s for more info)."
 msgstr ""
-"यह बातचीत Duck.ai वॉयस चैट (%1$s) से जनरेट हुई थी। AI गलत या आपत्तिजनक "
-"जानकारी भी प्रदान कर सकता है। (ज़्यादा जानकारी के लिए %2$s देखें।)"
+"यह बातचीत Duck.ai वॉयस चैट (%1$s) से जनरेट हुई थी। AI गलत या आपत्तिजनक जानकारी भी "
+"प्रदान कर सकता है। (ज़्यादा जानकारी के लिए %2$s देखें।)"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with DuckDuckGo AI Chat (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/aichat/privacy-terms for more info).'
@@ -19408,9 +19776,9 @@ msgid ""
 "Model. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
 msgstr ""
-"यह बातचीत %2$s के %3$s मॉडल का इस्तेमाल करके DuckDuckGo AI Chat (%1$s) के "
-"जरिए जनरेट की गई। AI चैट में गलत या आपत्तिजनक जानकारी दिखाई दे सकती है "
-"(ज़्यादा जानकारी के लिए %4$s देखें)।"
+"यह बातचीत %2$s के %3$s मॉडल का इस्तेमाल करके DuckDuckGo AI Chat (%1$s) के जरिए "
+"जनरेट की गई। AI चैट में गलत या आपत्तिजनक जानकारी दिखाई दे सकती है (ज़्यादा जानकारी के "
+"लिए %4$s देखें)।"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
@@ -19482,8 +19850,7 @@ msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF"
 msgstr ""
-"इस इमेज प्रकार को सपोर्ट हासिल नहीं है, कृपया कोई JPG, PNG, WebP या GIF अटैच "
-"करें"
+"इस इमेज प्रकार को सपोर्ट हासिल नहीं है, कृपया कोई JPG, PNG, WebP या GIF अटैच करें"
 
 # smartling.placeholder_format=C
 #. Error message displayed when a file that the user tried to upload is not of a supported format
@@ -19491,8 +19858,7 @@ msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF."
 msgstr ""
-"इस इमेज प्रकार को सपोर्ट हासिल नहीं है, कृपया कोई JPG, PNG, WebP या GIF अटैच "
-"करें।"
+"इस इमेज प्रकार को सपोर्ट हासिल नहीं है, कृपया कोई JPG, PNG, WebP या GIF अटैच करें।"
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
@@ -19518,8 +19884,8 @@ msgid ""
 "This model provider deletes data associated with this chat within 30 days. "
 "Other model providers follow a zero data retention model."
 msgstr ""
-"यह मॉडल प्रदाता इस चैट से जुड़ा डेटा 30 दिनों के अंदर डिलीट कर देता है। अन्य "
-"मॉडल प्रदाता 'ज़ीरो डेटा रिटेंशन' मॉडल का पालन करते हैं।"
+"यह मॉडल प्रदाता इस चैट से जुड़ा डेटा 30 दिनों के अंदर डिलीट कर देता है। अन्य मॉडल प्रदाता "
+"'ज़ीरो डेटा रिटेंशन' मॉडल का पालन करते हैं।"
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers, and that other providers may retain chat data for a limited time instead.
@@ -19528,8 +19894,8 @@ msgid ""
 "This model provider does not store any data associated with this chat. Other "
 "model providers follow a limited data retention model."
 msgstr ""
-"यह मॉडल प्रदाता इस चैट से जुड़ा कोई भी डेटा स्टोर नहीं करता है। अन्य मॉडल "
-"प्रदाता 'सीमित डेटा रिटेंशन' मॉडल का पालन करते हैं।"
+"यह मॉडल प्रदाता इस चैट से जुड़ा कोई भी डेटा स्टोर नहीं करता है। अन्य मॉडल प्रदाता "
+"'सीमित डेटा रिटेंशन' मॉडल का पालन करते हैं।"
 
 # smartling.placeholder_format=C
 #. Info that page may refresh during update.
@@ -19566,8 +19932,8 @@ msgid ""
 "This saves your chats with end-to-end encryption on DuckDuckGo's secure "
 "server, which later can be accessed from any browser."
 msgstr ""
-"यह आपकी चैट्स को DuckDuckGo के सुरक्षित सर्वर पर एंड-टू-एंड एनक्रिप्शन के "
-"साथ सेव करता है, जिसे बाद में किसी भी ब्राउज़र से एक्सेस किया जा सकता है।"
+"यह आपकी चैट्स को DuckDuckGo के सुरक्षित सर्वर पर एंड-टू-एंड एनक्रिप्शन के साथ सेव करता है, "
+"जिसे बाद में किसी भी ब्राउज़र से एक्सेस किया जा सकता है।"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -19576,9 +19942,8 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again."
 msgstr ""
-"यह सेटिंग आपके ब्राउज़र में स्टोर रहती है, जिसका मतलब है कि अगर आप "
-"duckduckgo.com ब्राउज़र डेटा मिटाते हैं, तो आपको AI से मिले जवाब फिर से दिख "
-"सकते हैं।"
+"यह सेटिंग आपके ब्राउज़र में स्टोर रहती है, जिसका मतलब है कि अगर आप duckduckgo.com "
+"ब्राउज़र डेटा मिटाते हैं, तो आपको AI से मिले जवाब फिर से दिख सकते हैं।"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -19588,10 +19953,9 @@ msgid ""
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
 msgstr ""
-"यह सेटिंग आपके ब्राउज़र में स्टोर रहती है, जिसका मतलब है कि अगर आप "
-"duckduckgo.com ब्राउज़र डेटा मिटाते हैं, तो आपको AI से मिले जवाब फिर से दिख "
-"सकते हैं। हालांकि, %1$s पर हमारे पास ऐसा स्टार्ट पेज भी है जो AI से मिलने "
-"वाले जवाब कभी नहीं दिखाता।"
+"यह सेटिंग आपके ब्राउज़र में स्टोर रहती है, जिसका मतलब है कि अगर आप duckduckgo.com "
+"ब्राउज़र डेटा मिटाते हैं, तो आपको AI से मिले जवाब फिर से दिख सकते हैं। हालांकि, %1$s पर "
+"हमारे पास ऐसा स्टार्ट पेज भी है जो AI से मिलने वाले जवाब कभी नहीं दिखाता।"
 
 # smartling.placeholder_format=C
 #. User feedback indicating that a translation is helpful
@@ -19620,9 +19984,7 @@ msgstr "यह वीडियो अब तक यहां देखे जा
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr ""
-"यह वेबपेज एक सुरक्षित, एन्क्रिप्ट किए गए, कनेक्शन (HTTPS) का उपयोग नहीं करता "
-"है।"
+msgstr "यह वेबपेज एक सुरक्षित, एन्क्रिप्ट किए गए, कनेक्शन (HTTPS) का उपयोग नहीं करता है।"
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -19632,9 +19994,8 @@ msgid ""
 "Sync & Backup. You'll still be able to access your chats in other browsers "
 "connected to Sync & Backup."
 msgstr ""
-"इससे इस ब्राउज़र से आपकी सभी Duck.ai चैट डिलीट हो जाएंगी, और Sync & Backup "
-"डिस्कनेक्ट हो जाएगा। आप Sync & Backup से जुड़े दूसरे ब्राउज़र में भी अपनी "
-"चैट एक्सेस कर पाएंगे।"
+"इससे इस ब्राउज़र से आपकी सभी Duck.ai चैट डिलीट हो जाएंगी, और Sync & Backup डिस्कनेक्ट "
+"हो जाएगा। आप Sync & Backup से जुड़े दूसरे ब्राउज़र में भी अपनी चैट एक्सेस कर पाएंगे।"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to clear all recentchats, with a warning that this action cannot be undone.
@@ -19643,16 +20004,15 @@ msgid ""
 "This will delete all your recent chats, unless they're pinned. This cannot "
 "be undone."
 msgstr ""
-"यह आपकी सभी हालिया चैट्स को डिलीट कर देगा, सिवाय उनके जो पिन की गई हैं। इसे "
-"पहले जैसा नहीं किया जा सकता है।"
+"यह आपकी सभी हालिया चैट्स को डिलीट कर देगा, सिवाय उनके जो पिन की गई हैं। इसे पहले जैसा "
+"नहीं किया जा सकता है।"
 
 # smartling.placeholder_format=C
 #. Message explaining what will happen when the user deletes an image.
 msgctxt "Confirmation message in delete image modal"
 msgid "This will delete your selected image. This cannot be undone."
 msgstr ""
-"यह आपके द्वारा चुनी गई इमेज को डिलीट कर देगा। इसे पहले जैसा नहीं किया जा "
-"सकता है।"
+"यह आपके द्वारा चुनी गई इमेज को डिलीट कर देगा। इसे पहले जैसा नहीं किया जा सकता है।"
 
 # smartling.placeholder_format=C
 #. Confirmation message asking if the user is sure they want to reset all of their settings.
@@ -19775,7 +20135,8 @@ msgstr "जारी रखने के लिए, आपको Duck.ai की 
 msgctxt ""
 "Copy stating agreement to AI Chat Privacy Policy and Terms of Service."
 msgid "To continue, you must agree to DuckDuckGo AI Chat’s %s and %s"
-msgstr "जारी रखने के लिए, आपको DuckDuckGo AI Chat की %1$s और %2$s से सहमत होना होगा"
+msgstr ""
+"जारी रखने के लिए, आपको DuckDuckGo AI Chat की %1$s और %2$s से सहमत होना होगा"
 
 # smartling.placeholder_format=C
 #. Instructions for how to print driving directions.
@@ -19784,8 +20145,8 @@ msgid ""
 "To print directions:%sGo back to the map.%sSelect the route you want to "
 "print.%sClick the print icon.%s"
 msgstr ""
-"निर्देश प्रिंट करने के लिए:%1$sमैप पर वापस जाएं।%2$sउस रूट को चुनें जिसे आप "
-"प्रिंट करना चाहते हैं।%3$sप्रिंट आइकन पर क्लिक करें।%4$s"
+"निर्देश प्रिंट करने के लिए:%1$sमैप पर वापस जाएं।%2$sउस रूट को चुनें जिसे आप प्रिंट करना "
+"चाहते हैं।%3$sप्रिंट आइकन पर क्लिक करें।%4$s"
 
 # smartling.placeholder_format=C
 #. Explains where the user can find their recovery code. Figma frame 3703-44420.
@@ -19795,10 +20156,9 @@ msgid ""
 "you first set up Sync. This code may have been saved as a PDF on the device "
 "you originally used to set up Sync."
 msgstr ""
-"अपने सिंक किए गए डेटा को रीस्टोर करने के लिए, आपको उस रिकवरी कोड की ज़रूरत "
-"होगी जिसे आपने पहली बार Sync सेटअप करते समय सेव किया था। यह कोड उस डिवाइस पर "
-"PDF के रूप में सेव किया गया हो सकता है, जिसका इस्तेमाल आपने मूल रूप से Sync "
-"सेटअप करने के लिए किया था।"
+"अपने सिंक किए गए डेटा को रीस्टोर करने के लिए, आपको उस रिकवरी कोड की ज़रूरत होगी जिसे "
+"आपने पहली बार Sync सेटअप करते समय सेव किया था। यह कोड उस डिवाइस पर PDF के रूप में सेव "
+"किया गया हो सकता है, जिसका इस्तेमाल आपने मूल रूप से Sync सेटअप करने के लिए किया था।"
 
 # smartling.placeholder_format=C
 #. Body text explaining that the user needs to update their DDG browser before migration can proceed.
@@ -19807,8 +20167,8 @@ msgid ""
 "To transfer your chat history to Duck.ai, please update your DuckDuckGo "
 "browser to the latest version and try again."
 msgstr ""
-"अपनी चैट हिस्ट्री को Duck.ai पर ट्रांसफ़र करने के लिए, कृपया अपने DuckDuckGo "
-"ब्राउज़र को नवीनतम वर्ज़न में अपडेट करें और दोबारा प्रयास करें।"
+"अपनी चैट हिस्ट्री को Duck.ai पर ट्रांसफ़र करने के लिए, कृपया अपने DuckDuckGo ब्राउज़र को "
+"नवीनतम वर्ज़न में अपडेट करें और दोबारा प्रयास करें।"
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
@@ -19816,8 +20176,8 @@ msgid ""
 "To use dictation, allow your browser to access the microphone in your system "
 "settings."
 msgstr ""
-"डिक्टेशन का इस्तेमाल करने के लिए, अपने सिस्टम सेटिंग में जाकर ब्राउज़र को "
-"माइक्रोफ़ोन का एक्सेस दें।"
+"डिक्टेशन का इस्तेमाल करने के लिए, अपने सिस्टम सेटिंग में जाकर ब्राउज़र को माइक्रोफ़ोन का "
+"एक्सेस दें।"
 
 # smartling.placeholder_format=C
 msgid "Today"
@@ -20007,8 +20367,8 @@ msgid ""
 "Tracking attempts blocked by DuckDuckGo appear here. Keep browsing to see "
 "how many we block."
 msgstr ""
-"DuckDuckGo द्वारा ब्लॉक की गई ट्रैकिंग की कोशिशें यहां दिखाई देंगी। ब्राउज़ "
-"करते रहें और देखें हम कितनों को ब्लॉक करते हैं।"
+"DuckDuckGo द्वारा ब्लॉक की गई ट्रैकिंग की कोशिशें यहां दिखाई देंगी। ब्राउज़ करते रहें और देखें "
+"हम कितनों को ब्लॉक करते हैं।"
 
 # smartling.placeholder_format=C
 #. Placeholder for when we cannot report any blocked trackers yet
@@ -20055,9 +20415,7 @@ msgctxt "Full sentence for translating text"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr ""
-"फ्रेंच में इस अंग्रेजी वाक्य का अनुवाद करें: \"मैं निकटतम मूवी थियेटर में "
-"कैसे पहुंचूं?\""
+msgstr "फ्रेंच में इस अंग्रेजी वाक्य का अनुवाद करें: \"मैं निकटतम मूवी थियेटर में कैसे पहुंचूं?\""
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for translating a sentence into another language. Translate the whole sentence and please use target language instead of 'English' and modify the sentence to translate into 'English' instead of 'French'. Example: 'Translate this {target language} sentence into English: “How do I get to the nearest movie theatre?”'
@@ -20066,8 +20424,19 @@ msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
 msgstr ""
-"हिन्दी में दिए गए इस वाक्य का अंग्रेज़ी में अनुवाद करें: \"मैं नज़दीकी "
-"सिनेमा हॉल तक कैसे पहुंचूं?\""
+"हिन्दी में दिए गए इस वाक्य का अंग्रेज़ी में अनुवाद करें: \"मैं नज़दीकी सिनेमा हॉल तक कैसे पहुंचूं?\""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Translate this page"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
+msgctxt "Page suggestion prompt"
+msgid "Translate this page into %s."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder text for a region that will display translated text.
@@ -20211,6 +20580,12 @@ msgid "Try Free"
 msgstr "मुफ़्त में आज़माएं"
 
 # smartling.placeholder_format=C
+#. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
+msgctxt "settings"
+msgid "Try It Now"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
 msgctxt "Promotional CTA for new AI models"
 msgid "Try Now"
@@ -20267,8 +20642,7 @@ msgstr "अलग कीवर्ड आज़माएं।"
 #. Prompt encouraging the user to turn off their ad blocker to see more results for their query.
 msgid "Try disabling your ad blocker on DuckDuckGo to see more results."
 msgstr ""
-"DuckDuckGo पर अधिक परिणाम देखने के लिए अपने विज्ञापन ब्लॉकर को डिसेबल यानी "
-"अक्षम करें।"
+"DuckDuckGo पर अधिक परिणाम देखने के लिए अपने विज्ञापन ब्लॉकर को डिसेबल यानी अक्षम करें।"
 
 # smartling.placeholder_format=C
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
@@ -20412,8 +20786,7 @@ msgstr "हाल ही में जोड़े गए ओपन-सोर्
 msgctxt "Promotional text for new AI models"
 msgid "Try the recently added open-source Llama 3.1 and Mixtral"
 msgstr ""
-"हाल ही में जोड़े गए ओपन-सोर्स यानी मुक्त स्रोत वाले Llama 3.1 और Mixtral को "
-"आजमाएं"
+"हाल ही में जोड़े गए ओपन-सोर्स यानी मुक्त स्रोत वाले Llama 3.1 और Mixtral को आजमाएं"
 
 # smartling.placeholder_format=C
 #. Message displayed to suggest the user to try the provided prompts or enter their own.
@@ -20445,6 +20818,22 @@ msgstr "प्रयास करें: %1$s"
 msgctxt "new user poll"
 msgid "Trying DuckDuckGo again"
 msgstr "DuckDuckGo फिर से आज़मा रहे हैं"
+
+# smartling.placeholder_format=C
+#. Message shown in a modal after supported third-party browser users disable AI features in Settings. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -20615,8 +21004,8 @@ msgid ""
 "Types out DuckAssist answers as they're generated. Turning this off may "
 "result in a short delay between a search and the answer being displayed."
 msgstr ""
-"जनरेट होते ही DuckAssist के उत्तर टाइप हो जाते हैं। इसे बंद करने से खोज और "
-"दिखाई देने वाले उत्तर के बीच थोड़ा समय लग सकता है।"
+"जनरेट होते ही DuckAssist के उत्तर टाइप हो जाते हैं। इसे बंद करने से खोज और दिखाई देने वाले "
+"उत्तर के बीच थोड़ा समय लग सकता है।"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -20746,8 +21135,8 @@ msgid ""
 "Under %sOn startup%s, click %sOpen a specific page%s then click %sSet "
 "Pages%s."
 msgstr ""
-"%1$sस्टार्टअप पर%2$s के नीचे, %3$sकोई खास पेज खोलें%4$s पर क्लिक करें, फिर "
-"%5$sसेट पेज%6$s पर क्लिक करें।"
+"%1$sस्टार्टअप पर%2$s के नीचे, %3$sकोई खास पेज खोलें%4$s पर क्लिक करें, फिर %5$sसेट "
+"पेज%6$s पर क्लिक करें।"
 
 #  Maxthon homepage instruction
 # smartling.placeholder_format=C
@@ -20755,8 +21144,8 @@ msgstr ""
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
 msgstr ""
-"%1$sस्टार्टअप पर%2$s के अंतर्गत, %3$sहोमपेज%4$s चुनें और यह डालें: "
-"https://duckduckgo.com"
+"%1$sस्टार्टअप पर%2$s के अंतर्गत, %3$sहोमपेज%4$s चुनें और यह डालें: https://duckduckgo."
+"com"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -20788,9 +21177,7 @@ msgstr "%1$sसर्च%2$s सेक्शन के नीचे, %3$sसर�
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under On startup select %sOpen a specific page or set of pages%s"
-msgstr ""
-"स्टार्टअप चालू करें के अंतर्गत %1$sएक विशिष्ट पेज या कई पेज के सेट खोलें%2$s "
-"चुनें"
+msgstr "स्टार्टअप चालू करें के अंतर्गत %1$sएक विशिष्ट पेज या कई पेज के सेट खोलें%2$s चुनें"
 
 #  Opera default search engine instruction
 # smartling.placeholder_format=C
@@ -20874,8 +21261,8 @@ msgid ""
 "Unlock %s, higher AI reasoning, and 2x higher usage limits than the Plus "
 "plan by upgrading to Pro."
 msgstr ""
-"Pro में अपग्रेड करके %1$s, बेहतर AI रीज़निंग, और Plus प्लान की तुलना में 2 "
-"गुना ज़्यादा उपयोग सीमाएं अनलॉक करें।"
+"Pro में अपग्रेड करके %1$s, बेहतर AI रीज़निंग, और Plus प्लान की तुलना में 2 गुना ज़्यादा "
+"उपयोग सीमाएं अनलॉक करें।"
 
 # smartling.placeholder_format=C
 #. Title for the subscription promo shown in the SERP sidemenu.
@@ -21009,8 +21396,8 @@ msgid ""
 "Update the DuckDuckGo browser to activate your subscription in Duck.ai and "
 "access advanced models"
 msgstr ""
-"Duck.ai में अपने सब्सक्रिप्शन को एक्टिव करने और एडवांस्ड मॉडल्स एक्सेस करने "
-"के लिए DuckDuckGo ब्राउज़र को अपडेट करें"
+"Duck.ai में अपने सब्सक्रिप्शन को एक्टिव करने और एडवांस्ड मॉडल्स एक्सेस करने के लिए "
+"DuckDuckGo ब्राउज़र को अपडेट करें"
 
 # smartling.placeholder_format=C
 #. The placeholder indicates a formatted date (e.g., 'Updated 2 days ago')
@@ -21135,16 +21522,14 @@ msgid ""
 "Upgrade to Pro to unlock 2x higher limits than Plus, or come back later to "
 "create more images."
 msgstr ""
-"Plus से 2 गुना ज़्यादा लिमिट पाने के लिए Pro में अपग्रेड करें, या अधिक इमेज "
-"बनाने के लिए बाद में वापस आएं।"
+"Plus से 2 गुना ज़्यादा लिमिट पाने के लिए Pro में अपग्रेड करें, या अधिक इमेज बनाने के लिए "
+"बाद में वापस आएं।"
 
 # smartling.placeholder_format=C
 #. Upsell message shown in the voice chat limit and duration limit modals for Plus subscribers, encouraging them to upgrade to Pro.
 msgctxt "voice chat limit modal"
 msgid "Upgrade to Pro to unlock 2x higher usage limits than Plus"
-msgstr ""
-"Plus की तुलना में 2 गुना ज़्यादा उपयोग सीमाएं अनलॉक करने के लिए Pro में "
-"अपग्रेड करें"
+msgstr "Plus की तुलना में 2 गुना ज़्यादा उपयोग सीमाएं अनलॉक करने के लिए Pro में अपग्रेड करें"
 
 # smartling.placeholder_format=C
 #. Heading in a promotion for a desktop web browser
@@ -21193,6 +21578,12 @@ msgid "Uruguay"
 msgstr "उरुग्वे"
 
 # smartling.placeholder_format=C
+#. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
+msgctxt "Navigation label on the Duck.ai settings page"
+msgid "Usage"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A feedback suggestion
 msgctxt "Feedback prompt"
 msgid "Usage limit"
@@ -21234,9 +21625,9 @@ msgid ""
 "Use ChatGPT, Claude, and other AIs, privately. Protect chats from hackers, "
 "scammers, and companies. Keep info confidential. Free. No account required."
 msgstr ""
-"ChatGPT, Claude और अन्य AI का उपयोग गोपनीय ढंग से निजी तौर पर करें। चैट्स को "
-"हैकर्स, स्कैमर्स और कंपनियों से सुरक्षित रखें। जानकारी गोपनीय बनाए रखें। "
-"मुफ़्त। किसी खाते की ज़रूरत नहीं है।"
+"ChatGPT, Claude और अन्य AI का उपयोग गोपनीय ढंग से निजी तौर पर करें। चैट्स को हैकर्स, "
+"स्कैमर्स और कंपनियों से सुरक्षित रखें। जानकारी गोपनीय बनाए रखें। मुफ़्त। किसी खाते की ज़रूरत "
+"नहीं है।"
 
 # smartling.placeholder_format=C
 #. Header above instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -21278,8 +21669,8 @@ msgctxt "Description for the recovery section inside Manage"
 msgid ""
 "Use this code to restore your saved chats if you lose access to your devices."
 msgstr ""
-"अगर आप अपने डिवाइस का एक्सेस खो देते हैं, तो अपनी सेव की गई चैट्स वापस पाने "
-"के लिए इस कोड का इस्तेमाल करें।"
+"अगर आप अपने डिवाइस का एक्सेस खो देते हैं, तो अपनी सेव की गई चैट्स वापस पाने के लिए इस "
+"कोड का इस्तेमाल करें।"
 
 # smartling.placeholder_format=C
 #. Prompt to ask the user if they want to use their approximate location for more accurate results
@@ -21429,8 +21820,8 @@ msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Microsoft's ad network"
 msgstr ""
-"विज्ञापन देखना DuckDuckGo द्वारा गोपनीयता संरक्षित है। विज्ञापन क्लिक को "
-"Microsoft के विज्ञापन नेटवर्क द्वारा प्रबंधित किया जाता है"
+"विज्ञापन देखना DuckDuckGo द्वारा गोपनीयता संरक्षित है। विज्ञापन क्लिक को Microsoft के "
+"विज्ञापन नेटवर्क द्वारा प्रबंधित किया जाता है"
 
 # smartling.placeholder_format=C
 #. Information about TripAdvisor ads for DuckDuckGo's users. This appears in a tooltip.
@@ -21439,8 +21830,8 @@ msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "TripAdvisor's ad network."
 msgstr ""
-"विज्ञापन देखना DuckDuckGo द्वारा गोपनीयता संरक्षित है। विज्ञापन क्लिक "
-"TripAdvisor के विज्ञापन नेटवर्क द्वारा प्रबंधित किए जाते हैं।"
+"विज्ञापन देखना DuckDuckGo द्वारा गोपनीयता संरक्षित है। विज्ञापन क्लिक TripAdvisor के "
+"विज्ञापन नेटवर्क द्वारा प्रबंधित किए जाते हैं।"
 
 # smartling.placeholder_format=C
 msgid "Virgin Islands"
@@ -21452,8 +21843,8 @@ msgctxt "duckassist"
 msgid ""
 "Visit %sAssist Settings%s to adjust how this feature works or turn it off."
 msgstr ""
-"इस फ़ीचर के काम करने का तरीका एडजस्ट करने या इसे बंद करने के लिए %1$sAssist "
-"सेटिंग%2$s पर जाएं।"
+"इस फ़ीचर के काम करने का तरीका एडजस्ट करने या इसे बंद करने के लिए %1$sAssist सेटिंग%2$s "
+"पर जाएं।"
 
 # smartling.placeholder_format=C
 #. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
@@ -21462,8 +21853,8 @@ msgid ""
 "Visit %sDuckAssist Settings%s to adjust how this feature works or turn it "
 "off."
 msgstr ""
-"इस फ़ीचर के काम करने का तरीका एडजस्ट करने या इसे बंद करने के लिए "
-"%1$sDuckAssist सेटिंग%2$s पर जाएं।"
+"इस फ़ीचर के काम करने का तरीका एडजस्ट करने या इसे बंद करने के लिए %1$sDuckAssist "
+"सेटिंग%2$s पर जाएं।"
 
 # smartling.placeholder_format=C
 #. Prompt to visit DuckDuckGo on another device.
@@ -21472,8 +21863,7 @@ msgid ""
 "Visit %sDuckDuckGo.com%s on your tablet or phone and follow the provided "
 "instructions."
 msgstr ""
-"अपने टैबलेट या फ़ोन पर %1$sDuckDuckGo.com%2$s पर जाएं और दिए गए निर्देशों का "
-"पालन करें।"
+"अपने टैबलेट या फ़ोन पर %1$sDuckDuckGo.com%2$s पर जाएं और दिए गए निर्देशों का पालन करें।"
 
 # smartling.placeholder_format=C
 #. Primary button to visit Duck.ai.
@@ -21489,8 +21879,8 @@ msgid ""
 "& Backup%s > %sManage%s then select %sSync With Another Device%s."
 msgstr ""
 "अपने दूसरे ब्राउज़र में Duck.ai पर जाकर %1$sDuck.ai सेटिंग%2$s > %3$sSync & "
-"Backup%4$s > %5$sमैनेज करें%6$s पर जाएं और उसके बाद %7$sकिसी दूसरे डिवाइस के "
-"साथ सिंक करें%8$s को चुनें।"
+"Backup%4$s > %5$sमैनेज करें%6$s पर जाएं और उसके बाद %7$sकिसी दूसरे डिवाइस के साथ सिंक "
+"करें%8$s को चुनें।"
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -21500,9 +21890,9 @@ msgid ""
 "On” under Sync & Backup and select “Sync With Another Device”. Or scan the "
 "QR on your Recovery PDF."
 msgstr ""
-"अपने दूसरे ब्राउज़र में Duck.ai पर जाएं और Duck.ai की सेटिंग खोलें। Sync & "
-"Backup के अंतर्गत \"चालू करें\" को चुनें और \"किसी दूसरे डिवाइस के साथ सिंक "
-"करें\" को चुनें। या अपनी रिकवरी PDF पर मौजूद QR कोड स्कैन करें।"
+"अपने दूसरे ब्राउज़र में Duck.ai पर जाएं और Duck.ai की सेटिंग खोलें। Sync & Backup के "
+"अंतर्गत \"चालू करें\" को चुनें और \"किसी दूसरे डिवाइस के साथ सिंक करें\" को चुनें। या अपनी "
+"रिकवरी PDF पर मौजूद QR कोड स्कैन करें।"
 
 # smartling.placeholder_format=C
 #. Shared body copy for every screen in the Sync Another Device flow (QR display, camera scan, camera-unavailable fallback, manual entry). Bold tags wrap navigation breadcrumbs. Render with <Translate /> so the HTML is interpreted; plain `translate()` will trip the html-string warning.
@@ -21512,9 +21902,9 @@ msgid ""
 "ai Settings%s > %sSync & Backup%s > %sManage%s then select %sSync With "
 "Another Device%s."
 msgstr ""
-"अपने दूसरे ब्राउज़र या DuckDuckGo ऐप में Duck.ai पर जाकर %1$sDuck.ai "
-"सेटिंग%2$s > %3$sSync & Backup%4$s > %5$sमैनेज करें%6$s पर जाएं और उसके बाद "
-"%7$sकिसी दूसरे डिवाइस के साथ सिंक करें%8$s को चुनें।"
+"अपने दूसरे ब्राउज़र या DuckDuckGo ऐप में Duck.ai पर जाकर %1$sDuck.ai सेटिंग%2$s > "
+"%3$sSync & Backup%4$s > %5$sमैनेज करें%6$s पर जाएं और उसके बाद %7$sकिसी दूसरे डिवाइस "
+"के साथ सिंक करें%8$s को चुनें।"
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -21524,10 +21914,9 @@ msgid ""
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
 msgstr ""
-"अपने दूसरे ब्राउज़र या DuckDuckGo ऐप में Duck.ai पर जाएं और Duck.ai की "
-"सेटिंग खोलें। Sync & Backup के अंतर्गत \"चालू करें\" को चुनें और \"किसी "
-"दूसरे डिवाइस के साथ सिंक करें\" को चुनें। या अपनी रिकवरी PDF पर मौजूद QR कोड "
-"स्कैन करें।"
+"अपने दूसरे ब्राउज़र या DuckDuckGo ऐप में Duck.ai पर जाएं और Duck.ai की सेटिंग खोलें। "
+"Sync & Backup के अंतर्गत \"चालू करें\" को चुनें और \"किसी दूसरे डिवाइस के साथ सिंक करें\" "
+"को चुनें। या अपनी रिकवरी PDF पर मौजूद QR कोड स्कैन करें।"
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -21580,8 +21969,8 @@ msgstr "वॉयस चैट समाप्त हो गई"
 msgctxt "voice chat"
 msgid "Voice chat is anonymized by us, and never used to train AI models."
 msgstr ""
-"हम वॉयस चैट को गुमनाम रखते हैं और इसका उपयोग कभी भी AI मॉडल प्रशिक्षित करने "
-"के लिए नहीं किया जाता है।"
+"हम वॉयस चैट को गुमनाम रखते हैं और इसका उपयोग कभी भी AI मॉडल प्रशिक्षित करने के लिए "
+"नहीं किया जाता है।"
 
 # smartling.placeholder_format=C
 #. Title of the modal shown when the user has reached their daily voice chat limit.
@@ -21640,6 +22029,12 @@ msgstr "लोकेशन की प्रतिक्षा जारी ह�
 # smartling.placeholder_format=C
 msgid "Wales"
 msgstr "वेल्स"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Walk me through the steps"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for walking directions on a map.
@@ -21719,8 +22114,8 @@ msgid ""
 "Watch in Duck Player to block personalized ads on YouTube and prevent your "
 "viewing activity from influencing YouTube recommendations."
 msgstr ""
-"YouTube पर वैयक्तिकृत विज्ञापनों को ब्लॉक करने और अपनी देखने की गतिविधि को "
-"YouTube अनुशंसाओं को प्रभावित करने से रोकने के लिए Duck प्लेयर में देखें।"
+"YouTube पर वैयक्तिकृत विज्ञापनों को ब्लॉक करने और अपनी देखने की गतिविधि को YouTube "
+"अनुशंसाओं को प्रभावित करने से रोकने के लिए Duck प्लेयर में देखें।"
 
 # smartling.placeholder_format=C
 #. A button that takes a user to another site in order to watch a video. The placeholder is the name of the video site. For example: 'Watch on Vimeo'
@@ -21740,10 +22135,9 @@ msgid ""
 "independent company and has no relationship with YouTube, where most videos "
 "are hosted."
 msgstr ""
-"यहाँ वीडियो देखने का अर्थ है कि होस्ट की गई वेबसाइट आपको ट्रैक कर सकती है "
-"क्योंकि हमें वहाँ से कॉन्टेंट स्ट्रीम करना होगा। DuckDuckGo एक स्वतंत्र "
-"कंपनी है और इसका YouTube से कोई संबंध नहीं है, जहाँ अधिकांश वीडियो होस्ट किए "
-"जाते हैं।"
+"यहाँ वीडियो देखने का अर्थ है कि होस्ट की गई वेबसाइट आपको ट्रैक कर सकती है क्योंकि हमें वहाँ "
+"से कॉन्टेंट स्ट्रीम करना होगा। DuckDuckGo एक स्वतंत्र कंपनी है और इसका YouTube से कोई "
+"संबंध नहीं है, जहाँ अधिकांश वीडियो होस्ट किए जाते हैं।"
 
 # smartling.placeholder_format=C
 #. Heading for the highlight card explaining anonymized prompt delivery.
@@ -21756,8 +22150,19 @@ msgstr "हम गुमनाम करते हैं"
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
 msgstr ""
-"आपको अधिक सटीक नतीजे दिखाने के लिए हम%1$s आपके स्थान%2$s की जानकारी को "
-"गुमनाम रख सकते हैं।"
+"आपको अधिक सटीक नतीजे दिखाने के लिए हम%1$s आपके स्थान%2$s की जानकारी को गुमनाम रख "
+"सकते हैं।"
+
+# smartling.placeholder_format=C
+#. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
+msgctxt ""
+"Inline warning shown below the share-content toggle when the user selects "
+"Harmful or Illegal but has not enabled sharing"
+msgid ""
+"We can only fix what we can see. To report a harmful or illegal response, "
+"please share this conversation with DuckDuckGo so we can investigate and "
+"address the issue."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -21769,17 +22174,16 @@ msgid ""
 "please share your prompt and response so we can investigate and address the "
 "issue."
 msgstr ""
-"सुधार तभी मुमकिन है, जब कमी नज़र आए। किसी हानिकारक या गैर-कानूनी जवाब की "
-"रिपोर्ट करने के लिए, कृपया अपना प्रॉम्प्ट और जवाब शेयर करें, ताकि हम उस "
-"मामले की जांच करके उसे ठीक कर सकें।"
+"सुधार तभी मुमकिन है, जब कमी नज़र आए। किसी हानिकारक या गैर-कानूनी जवाब की रिपोर्ट "
+"करने के लिए, कृपया अपना प्रॉम्प्ट और जवाब शेयर करें, ताकि हम उस मामले की जांच करके उसे "
+"ठीक कर सकें।"
 
 # smartling.placeholder_format=C
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can use your anonymous%s location%s to show you nearby results."
 msgstr ""
-"आपको आस-पास के परिणाम दिखाने के लिए हम आपके अनाम%1$s स्थान%2$s का इस्‍तेमाल "
-"कर सकते हैं।"
+"आपको आस-पास के परिणाम दिखाने के लिए हम आपके अनाम%1$s स्थान%2$s का इस्‍तेमाल कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Error message displayed when one or more attached files are encrypted and cannot be read.
@@ -21787,8 +22191,7 @@ msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
 msgstr ""
-"हम अटैच की गई फ़ाइलों को पढ़ नहीं पा रहे हैं, क्योंकि उनमें से कम से कम एक "
-"एन्क्रिप्टेड है।"
+"हम अटैच की गई फ़ाइलों को पढ़ नहीं पा रहे हैं, क्योंकि उनमें से कम से कम एक एन्क्रिप्टेड है।"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -21800,8 +22203,7 @@ msgstr "हम विज्ञापनों के साथ आपको फ�
 msgctxt "cloudsave"
 msgid "We don't store usernames or any personally identifiable information."
 msgstr ""
-"हम यूज़रनेम या किसी भी व्यक्तिगत रूप से पहचान योग्य जानकारी को संग्रहित नहीं "
-"करते हैं।"
+"हम यूज़रनेम या किसी भी व्यक्तिगत रूप से पहचान योग्य जानकारी को संग्रहित नहीं करते हैं।"
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -21818,8 +22220,8 @@ msgid ""
 "We don't store your personal info. We don't follow you around with ads. We "
 "don't track you. Ever."
 msgstr ""
-"हम आपकी गोपनीय जानकारी स्टोर नहीं करते। हम विज्ञापनों के साथ आपको फ़ॉलो नहीं "
-"करते हैं। हम आपको ट्रैक नहीं करते हैं। कभी भी।"
+"हम आपकी गोपनीय जानकारी स्टोर नहीं करते। हम विज्ञापनों के साथ आपको फ़ॉलो नहीं करते हैं। "
+"हम आपको ट्रैक नहीं करते हैं। कभी भी।"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -21833,8 +22235,8 @@ msgid ""
 "We don't track you, so we could use your help telling us what brought you "
 "back today:"
 msgstr ""
-"हम आपको ट्रैक नहीं करते हैं, ताकि यह बताने में आपकी मदद ले सके कि आप आज यहां "
-"वापस क्यों आए हैं:"
+"हम आपको ट्रैक नहीं करते हैं, ताकि यह बताने में आपकी मदद ले सके कि आप आज यहां वापस क्यों आए "
+"हैं:"
 
 # smartling.placeholder_format=C
 #. Message prompting users to fill out a feedback form.
@@ -21843,8 +22245,8 @@ msgid ""
 "We don't track you, so we could use your help telling us what convinced you "
 "to try us out today:"
 msgstr ""
-"हम आपको ट्रैक नहीं करते हैं, ताकि यह जानने में आपकी मदद ली जा सके कि आप किस "
-"वजह से हमें आज़माना चाहते हैं:"
+"हम आपको ट्रैक नहीं करते हैं, ताकि यह जानने में आपकी मदद ली जा सके कि आप किस वजह से हमें "
+"आज़माना चाहते हैं:"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -21884,9 +22286,8 @@ msgid ""
 "We don’t store your search history. We therefore have nothing to sell to "
 "advertisers that track you across the Internet."
 msgstr ""
-"हम आपकी खोज का इतिहास स्टोर नहीं करते हैं। इसलिए हमारे पास ऐसे "
-"विज्ञापनकर्ताओं को बेचने के लिए कुछ भी नहीं है जो आपको इंटरनेट पर ट्रैक करते "
-"हैं।"
+"हम आपकी खोज का इतिहास स्टोर नहीं करते हैं। इसलिए हमारे पास ऐसे विज्ञापनकर्ताओं को बेचने "
+"के लिए कुछ भी नहीं है जो आपको इंटरनेट पर ट्रैक करते हैं।"
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -21912,8 +22313,8 @@ msgid ""
 "We have agreements with all AI providers to ensure your chats aren't used to "
 "train AIs."
 msgstr ""
-"हमने सभी AI प्रोवाइडर्स के साथ एग्रीमेंट किए हैं ताकि यह पक्का किया जा सके "
-"कि आपकी चैट्स का इस्तेमाल AI को ट्रेन करने के लिए न हो।"
+"हमने सभी AI प्रोवाइडर्स के साथ एग्रीमेंट किए हैं ताकि यह पक्का किया जा सके कि आपकी चैट्स "
+"का इस्तेमाल AI को ट्रेन करने के लिए न हो।"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -21938,8 +22339,8 @@ msgid ""
 "We make money from %sprivacy-respecting search ads%s, not by exploiting your "
 "data."
 msgstr ""
-"हम %1$sगोपनीयता का सम्मान करने वाले खोज विज्ञापनों%2$s से पैसा कमाते हैं, "
-"आपके डेटा का फायदा उठाकर नहीं।"
+"हम %1$sगोपनीयता का सम्मान करने वाले खोज विज्ञापनों%2$s से पैसा कमाते हैं, आपके डेटा का "
+"फायदा उठाकर नहीं।"
 
 # smartling.placeholder_format=C
 #. Message describing how DuckDuckGo users location access anonymously to provide better search results.
@@ -21948,23 +22349,19 @@ msgid ""
 "We only use your anonymous location to deliver better results, closer to "
 "you. You can always change your mind later."
 msgstr ""
-"हम आपके करीब आपके अनाम स्थान का इस्‍तेमाल केवल बेहतर परिणाम देने के लिए करते "
-"हैं। आप अक्‍सर बाद में अपना विचार बदल सकते हैं।"
+"हम आपके करीब आपके अनाम स्थान का इस्‍तेमाल केवल बेहतर परिणाम देने के लिए करते हैं। आप अक्‍सर "
+"बाद में अपना विचार बदल सकते हैं।"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
-msgstr ""
-"हम DuckDuckGo को सबके लिए बेहतर बनाने हेतु आपकी गुमनाम फीडबैक पर निर्भर करते "
-"हैं।"
+msgstr "हम DuckDuckGo को सबके लिए बेहतर बनाने हेतु आपकी गुमनाम फीडबैक पर निर्भर करते हैं।"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We stop anyone from getting your search history, including us."
-msgstr ""
-"हम सभी को आपका खोज का इतिहास प्राप्त करने से रोकते हैं, जिनमें हम भी शामिल "
-"हैं।"
+msgstr "हम सभी को आपका खोज का इतिहास प्राप्त करने से रोकते हैं, जिनमें हम भी शामिल हैं।"
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -21980,16 +22377,15 @@ msgid ""
 "incorporated at the discretion of %s. Corrections may not show up in results "
 "right away."
 msgstr ""
-"हम इस तरह की प्रतिक्रिया का उपयोग करते हैं ताकि DuckDuckGo को बेहतर बनाया जा "
-"सके। %1$s के विवेकानुसार सुझावों को शामिल किया जाएगा। हो सकता है कि सुधार "
-"तुरंत परिणामों में दिखाई ना दें।"
+"हम इस तरह की प्रतिक्रिया का उपयोग करते हैं ताकि DuckDuckGo को बेहतर बनाया जा सके। "
+"%1$s के विवेकानुसार सुझावों को शामिल किया जाएगा। हो सकता है कि सुधार तुरंत परिणामों में "
+"दिखाई ना दें।"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
 msgstr ""
-"जैसे ही आप ब्राउज़ करेंगे, हम आपके डेटा एकत्र करने का प्रयास करने वाले "
-"ट्रैकर्स को ब्लॉक कर देंगे।"
+"जैसे ही आप ब्राउज़ करेंगे, हम आपके डेटा एकत्र करने का प्रयास करने वाले ट्रैकर्स को ब्लॉक कर देंगे।"
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -21998,9 +22394,8 @@ msgid ""
 "We're aware of this issue and are currently working to resolve it. If you "
 "continue to see this error, please reach out to %s."
 msgstr ""
-"हमें इस समस्या की जानकारी है और फ़िलहाल हम इसे हल करने के लिए काम कर रहे "
-"हैं। अगर आपको यह गड़बड़ी लगातार दिखाई दे रही है, तो कृपया %1$s से संपर्क "
-"करें।"
+"हमें इस समस्या की जानकारी है और फ़िलहाल हम इसे हल करने के लिए काम कर रहे हैं। अगर आपको "
+"यह गड़बड़ी लगातार दिखाई दे रही है, तो कृपया %1$s से संपर्क करें।"
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -22009,8 +22404,8 @@ msgid ""
 "We're aware of this issue and are currently working to resolve it. Sometimes "
 "clearing your browser's cache can help."
 msgstr ""
-"हमें इस समस्या की जानकारी है और फ़िलहाल हम इसे हल करने के लिए काम कर रहे "
-"हैं। कभी-कभी अपने ब्राउज़र का कैशे मिटाने से समस्या हल हो जाती है।"
+"हमें इस समस्या की जानकारी है और फ़िलहाल हम इसे हल करने के लिए काम कर रहे हैं। कभी-कभी "
+"अपने ब्राउज़र का कैशे मिटाने से समस्या हल हो जाती है।"
 
 # smartling.placeholder_format=C
 #. Header for a feedback form for new users.
@@ -22025,8 +22420,7 @@ msgid ""
 "We're sorry for this inconvenience. We’re working hard to make your "
 "experience better."
 msgstr ""
-"इस असुविधा के लिए हमें खेद है। हम आपके अनुभव को बेहतर बनाने के लिए लगातार "
-"मेहनत कर रहे हैं।"
+"इस असुविधा के लिए हमें खेद है। हम आपके अनुभव को बेहतर बनाने के लिए लगातार मेहनत कर रहे हैं।"
 
 # smartling.placeholder_format=C
 #. Body text explaining the service update requires a page reload.
@@ -22035,8 +22429,8 @@ msgid ""
 "We've updated the Duck.ai service. For the change to take effect, we need to "
 "reload the page."
 msgstr ""
-"हमने Duck.ai सेवा को अपडेट कर दिया है। बदलाव प्रभावी होने के लिए, हमें पेज "
-"फिर से लोड करना होगा।"
+"हमने Duck.ai सेवा को अपडेट कर दिया है। बदलाव प्रभावी होने के लिए, हमें पेज फिर से लोड "
+"करना होगा।"
 
 # smartling.placeholder_format=C
 #. Instant Answer Tab Name
@@ -22130,9 +22524,7 @@ msgstr "साप्ताहिक सीमा पूरी हो गई"
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Weekly usage limit reached. You can continue this chat after %s."
-msgstr ""
-"साप्ताहिक उपयोग सीमा पूरी हो गई है। आप %1$s के बाद इस चैट को जारी रख सकते "
-"हैं।"
+msgstr "साप्ताहिक उपयोग सीमा पूरी हो गई है। आप %1$s के बाद इस चैट को जारी रख सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable weekly Duck.ai usage limit and can opt in to continue using the monthly limit.
@@ -22141,8 +22533,8 @@ msgid ""
 "Weekly usage limit reached. You can keep chatting by using your monthly "
 "limit."
 msgstr ""
-"साप्ताहिक उपयोग सीमा पूरी हो गई है। आप अपनी मासिक सीमा का उपयोग करके चैट "
-"करना जारी रख सकते हैं।"
+"साप्ताहिक उपयोग सीमा पूरी हो गई है। आप अपनी मासिक सीमा का उपयोग करके चैट करना "
+"जारी रख सकते हैं।"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -22156,9 +22548,8 @@ msgid ""
 "Welcome to Duck.ai! All of your chats here are private, anonymized by us and "
 "not used to train AI models."
 msgstr ""
-"Duck.ai में आपका स्वागत है! यहां आपकी सभी चैट गोपनीय रहती हैं, हम उन्हें "
-"अनाम कर देते हैं और उनका इस्तेमाल AI मॉडलों को प्रशिक्षित करने के लिए नहीं "
-"किया जाता।"
+"Duck.ai में आपका स्वागत है! यहां आपकी सभी चैट गोपनीय रहती हैं, हम उन्हें अनाम कर देते हैं "
+"और उनका इस्तेमाल AI मॉडलों को प्रशिक्षित करने के लिए नहीं किया जाता।"
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened.
@@ -22167,9 +22558,8 @@ msgid ""
 "Welcome to DuckDuckGo AI Chat! All of your chats here are private, "
 "anonymized by us and not used to train AI models."
 msgstr ""
-"DuckDuckGo AI Chat में आपका स्वागत है! यहां आपकी सभी चैट गोपनीय रहती हैं, हम "
-"उन्हें अनाम कर देते हैं और उनका इस्तेमाल AI मॉडलों को प्रशिक्षित करने के लिए "
-"नहीं किया जाता।"
+"DuckDuckGo AI Chat में आपका स्वागत है! यहां आपकी सभी चैट गोपनीय रहती हैं, हम उन्हें "
+"अनाम कर देते हैं और उनका इस्तेमाल AI मॉडलों को प्रशिक्षित करने के लिए नहीं किया जाता।"
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened. Example: 'Welcome to DuckDuckGo AI Chat! This chat session is powered by OpenAI’s GPT-3. All of your chats here are private, and are never stored by DuckDuckGo or used to train AI models.'
@@ -22179,17 +22569,16 @@ msgid ""
 "of your chats here are private, and are never stored by DuckDuckGo or used "
 "to train AI models."
 msgstr ""
-"DuckDuckGo AI Chat में आपका स्वागत है! इस चैट सेशन को %1$s का %2$s संचालित "
-"करता है। यहां आपकी सभी चैट निजी हैं और उन्हें DuckDuckGo कभी भी स्टोर नहीं "
-"करता है या उनका उपयोग AI मॉडल को प्रशिक्षित करने में नहीं किया जाता है।"
+"DuckDuckGo AI Chat में आपका स्वागत है! इस चैट सेशन को %1$s का %2$s संचालित करता है। "
+"यहां आपकी सभी चैट निजी हैं और उन्हें DuckDuckGo कभी भी स्टोर नहीं करता है या उनका "
+"उपयोग AI मॉडल को प्रशिक्षित करने में नहीं किया जाता है।"
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai! You can now import your downloaded chats."
 msgstr ""
-"नए Duck.ai में आपका स्वागत है! अब आप अपनी डाउनलोड की गई चैट्स को इंपोर्ट कर "
-"सकते हैं।"
+"नए Duck.ai में आपका स्वागत है! अब आप अपनी डाउनलोड की गई चैट्स को इंपोर्ट कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -22257,8 +22646,8 @@ msgid ""
 "We’re really sorry, but it seems there was a problem loading Duck.ai. Try "
 "reloading the page."
 msgstr ""
-"हमें वाकई खेद है, लेकिन ऐसा लगता है कि Duck.ai को लोड करने में कोई समस्या आई "
-"है। पेज को रीलोड करने की कोशिश करें।"
+"हमें वाकई खेद है, लेकिन ऐसा लगता है कि Duck.ai को लोड करने में कोई समस्या आई है। पेज को "
+"रीलोड करने की कोशिश करें।"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to suggest an AI (Artificial Intelligence) model to be added to the product, and this field is optional.
@@ -22293,8 +22682,7 @@ msgid ""
 "What are some options for the word ‘better’ in the context of “We really "
 "need to do better.”"
 msgstr ""
-"\"हमें वास्तव में बेहतर काम करना होगा\" के संदर्भ में 'बेहतर' शब्द के लिए "
-"कुछ विकल्प बताएं।"
+"\"हमें वास्तव में बेहतर काम करना होगा\" के संदर्भ में 'बेहतर' शब्द के लिए कुछ विकल्प बताएं।"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
@@ -22313,12 +22701,108 @@ msgid ""
 "easy to understand for people with or without much AI, or technical, "
 "experience."
 msgstr ""
-"Duck.ai इस्तेमाल करने में रुचि रखने वाले लोगों के लिए, DuckDuckGo ब्राउज़र "
-"डाउनलोड करने के क्या फ़ायदे हैं? केवल आधिकारिक DuckDuckGo स्रोतों का ही "
-"संदर्भ लें। जवाब को स्पष्ट हिस्सों में बांटें और हर हिस्से के लिए शीर्षक "
-"दें, जिसमें Duck.ai इंटीग्रेशन और प्राइवेसी की रक्षा पर विशेष ध्यान दिया गया "
-"हो। इसे संक्षिप्त, सरल और समझने में आसान रखें, ताकि AI या तकनीकी अनुभव रखने "
-"वाले या न रखने वाले लोग भी इसे आसानी से समझ सकें।"
+"Duck.ai इस्तेमाल करने में रुचि रखने वाले लोगों के लिए, DuckDuckGo ब्राउज़र डाउनलोड करने के "
+"क्या फ़ायदे हैं? केवल आधिकारिक DuckDuckGo स्रोतों का ही संदर्भ लें। जवाब को स्पष्ट हिस्सों में "
+"बांटें और हर हिस्से के लिए शीर्षक दें, जिसमें Duck.ai इंटीग्रेशन और प्राइवेसी की रक्षा पर "
+"विशेष ध्यान दिया गया हो। इसे संक्षिप्त, सरल और समझने में आसान रखें, ताकि AI या तकनीकी "
+"अनुभव रखने वाले या न रखने वाले लोग भी इसे आसानी से समझ सकें।"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the counterarguments?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the hours & location?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key contributions of this paper?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key contributions?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key details?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key points covered in this video?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key points?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key takeaways from this article?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key takeaways?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key things I will learn from this course?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main counterarguments or criticisms of this?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main questions this page answers?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the must-try dishes here?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"What are the opening hours, location, and contact details for this place?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the pros and cons of this product?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the pros and cons?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
@@ -22421,6 +22905,12 @@ msgid "What does atria mean in the context of a medical article?"
 msgstr "चिकित्सा संबंधी लेख के संदर्भ में एट्रिया का अर्थ क्या है?"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What does this answer?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
@@ -22433,20 +22923,31 @@ msgid "What information gets saved?"
 msgstr "कौन सी जानकारी सेव होती है?"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What interview questions might come up for this role?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
 msgid ""
 "What is the Cloud Save bookmarklet and how does it differ from the URL "
 "parameter bookmarklet?"
 msgstr ""
-"Cloud Save बुकमार्कलेट क्या है और यह यूआरएल पैरामीटर बुकमार्कलेट से कैसे अलग "
-"होता है?"
+"Cloud Save बुकमार्कलेट क्या है और यह यूआरएल पैरामीटर बुकमार्कलेट से कैसे अलग होता है?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for looking up the capital city of Albania.
 msgctxt "Full sentence for looking up basic facts"
 msgid "What is the capital city of Albania?"
 msgstr "अल्बानिया की राजधानी क्या है?"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What is the overall verdict and rating for this?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to a page with additional information.
@@ -22471,6 +22972,12 @@ msgid "What people say:"
 msgstr "लोग क्या कहते हैं:"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What should I order?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
 msgctxt "feedback form"
 msgid "What stood out?"
@@ -22483,6 +22990,18 @@ msgid "What was wrong with the response? (optional)"
 msgstr "जवाब में क्या गलत था? (वैकल्पिक)"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I learn?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I need?"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid "What would you like to provide feedback on?"
 msgstr "आप किस पर फीडबैक देना चाहेंगे?"
@@ -22492,14 +23011,20 @@ msgstr "आप किस पर फीडबैक देना चाहें�
 msgid ""
 "What you watch in DuckDuckGo won't influence your recommendations on YouTube."
 msgstr ""
-"आप DuckDuckGo में जो देखते हैं, वह YouTube पर आपके रिकमंडेशन या सुझावों को "
-"प्रभावित नहीं करेगा।"
+"आप DuckDuckGo में जो देखते हैं, वह YouTube पर आपके रिकमंडेशन या सुझावों को प्रभावित नहीं "
+"करेगा।"
 
 # smartling.placeholder_format=C
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
 msgctxt "SERP footer content"
 msgid "What's New"
 msgstr "क्या नया है"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What's the verdict?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -22513,8 +23038,8 @@ msgid ""
 "When buying an electric guitar for a beginner, what are the top product "
 "brands I should consider?"
 msgstr ""
-"एक नौसिखिए के तौर पर, इलेक्ट्रिक गिटार खरीदते समय मुझे किन प्रमुख उत्पाद "
-"ब्रांडों पर विचार करना चाहिए?"
+"एक नौसिखिए के तौर पर, इलेक्ट्रिक गिटार खरीदते समय मुझे किन प्रमुख उत्पाद ब्रांडों पर "
+"विचार करना चाहिए?"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -22552,6 +23077,12 @@ msgid "Which features are missing? (Optional)"
 msgstr "कौन-से फीचर मौजूद नहीं हैं? (वैकल्पिक)"
 
 # smartling.placeholder_format=C
+#. An invitation for users to leave feedback
+msgctxt "Feedback prompt"
+msgid "Which features are missing? (optional)"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
 msgid "White"
 msgstr "सफ़ेद"
@@ -22566,6 +23097,18 @@ msgstr "सफ़ेद"
 #. Link to an about us page.
 msgid "Who We Are"
 msgstr "हम कौन हैं"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Who are the main cast and crew, and what else are they known for?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Who is this person?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Header above a collection of privacy-related links.
@@ -22937,8 +23480,8 @@ msgctxt "cloudsave"
 msgid ""
 "Yes, we throw away data when you’re done with it, and it cannot be recovered."
 msgstr ""
-"हां, जब आप इसके साथ काम करते हैं, तो हम डेटा का निस्तारण कर देते हैं और इसे "
-"दोबारा प्राप्त नहीं किया जा सकता है।"
+"हां, जब आप इसके साथ काम करते हैं, तो हम डेटा का निस्तारण कर देते हैं और इसे दोबारा प्राप्त "
+"नहीं किया जा सकता है।"
 
 # smartling.placeholder_format=C
 #. Option for the filter-by-date search.
@@ -22958,8 +23501,7 @@ msgid ""
 "You are chatting with %s. AI chats may display inaccurate or offensive "
 "information."
 msgstr ""
-"आप %1$s से चैट कर रहे हैं। AI चैट में गलत या आपत्तिजनक जानकारी भी दिखाई दे "
-"सकती है।"
+"आप %1$s से चैट कर रहे हैं। AI चैट में गलत या आपत्तिजनक जानकारी भी दिखाई दे सकती है।"
 
 # smartling.placeholder_format=C
 #. Provide users with the ability to retry their search on a different search engine. First placeholder will be a link with the text "try your search again" OR "try your search later". Second is a URL to the !bangs page: https://duckduckgo.com/bangs.
@@ -22968,8 +23510,8 @@ msgid ""
 "You can %s or search directly on other search engines from DuckDuckGo using "
 "%s search shortcuts."
 msgstr ""
-"आप चाहें तो यह कर सकते हैं: %1$s या फिर %2$s खोज शॉर्टकट का इस्तेमाल करके "
-"DuckDuckGo से सीधे अन्य खोज इंजनों पर खोज सकते हैं।"
+"आप चाहें तो यह कर सकते हैं: %1$s या फिर %2$s खोज शॉर्टकट का इस्तेमाल करके DuckDuckGo "
+"से सीधे अन्य खोज इंजनों पर खोज सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Text informing the user that they can access DuckDuckGo AI Chat directly at a specific URL. The placeholder %s will be replaced with the link. Example: 'You can access DuckDuckGo AI Chat directly at duck.ai.'
@@ -22983,8 +23525,8 @@ msgctxt "duckassist"
 msgid ""
 "You can adjust how %s works or turn it off anytime in %sSearch Settings%s."
 msgstr ""
-"आप %1$s के काम करने के तरीके को %2$sखोज सेटिंग%3$s में एडजस्ट कर सकते हैं या "
-"इसे कभी भी बंद कर सकते हैं।"
+"आप %1$s के काम करने के तरीके को %2$sखोज सेटिंग%3$s में एडजस्ट कर सकते हैं या इसे कभी भी "
+"बंद कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Assist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate Assist.
@@ -22993,22 +23535,22 @@ msgid ""
 "You can adjust how Assist works or turn it off anytime in %sSearch "
 "Settings%s."
 msgstr ""
-"आप %1$sखोज सेटिंग%2$s में जाकर Assist के काम करने के तरीके को एडजस्ट कर सकते "
-"हैं या इसे कभी भी बंद कर सकते हैं।"
+"आप %1$sखोज सेटिंग%2$s में जाकर Assist के काम करने के तरीके को एडजस्ट कर सकते हैं या इसे "
+"कभी भी बंद कर सकते हैं।"
 
 # smartling.placeholder_format=C
 msgid "You can also use %sDuck.ai%s to answer questions or summarize text."
 msgstr ""
-"आप सवालों के जवाब देने या टेक्स्ट को सारांशित करने के लिए %1$sDuck.ai%2$s का "
-"भी इस्तेमाल कर सकते हैं।"
+"आप सवालों के जवाब देने या टेक्स्ट को सारांशित करने के लिए %1$sDuck.ai%2$s का भी इस्तेमाल "
+"कर सकते हैं।"
 
 # smartling.placeholder_format=C
 msgid ""
 "You can also use %sDuckDuckGo AI Chat%s to answer questions or summarize "
 "text."
 msgstr ""
-"आप सवालों के जवाब देने या टेक्स्ट को सारांशित करने के लिए %1$sDuckDuckGo AI "
-"Chat%2$s का भी इस्तेमाल कर सकते हैं।"
+"आप सवालों के जवाब देने या टेक्स्ट को सारांशित करने के लिए %1$sDuckDuckGo AI Chat%2$s "
+"का भी इस्तेमाल कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach more text selections than are allowed. Placeholder is the maximum number of text selections. E.g. You can attach up to 5 text selections.
@@ -23022,8 +23564,8 @@ msgid ""
 "You can change how frequently you see Search Assist, or turn it off "
 "entirely, in %sSearch Settings%s."
 msgstr ""
-"आपको Search Assist कितनी बार देखना है, इसे %1$sखोज Assist सेटिंग%2$s में "
-"जाकर बदल सकते हैं या इसे पूरी तरह से बंद कर सकते हैं।"
+"आपको Search Assist कितनी बार देखना है, इसे %1$sखोज Assist सेटिंग%2$s में जाकर बदल "
+"सकते हैं या इसे पूरी तरह से बंद कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
@@ -23038,8 +23580,8 @@ msgid ""
 "You can do this by saving your settings under a different passphrase, "
 "optionally deleting the first set."
 msgstr ""
-"आप ऐसा अपनी सेटिंग्स को दूसरे पासफ्रेज़ के अंतर्गत सेव करते हुए कर सकते है "
-"और चाहे तो पहली सेटिंग को डिलीट भी कर सकते हैं।"
+"आप ऐसा अपनी सेटिंग्स को दूसरे पासफ्रेज़ के अंतर्गत सेव करते हुए कर सकते है और चाहे तो पहली "
+"सेटिंग को डिलीट भी कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Prefix for filename location sentence.
@@ -23119,8 +23661,8 @@ msgid ""
 "You can only block up to %s sites. To block %s, you'll need to unblock "
 "another site first."
 msgstr ""
-"आप अधिकतम %1$s साइटें ही ब्लॉक कर सकते हैं। %2$s को ब्लॉक करने के लिए, आपको "
-"पहले किसी अन्य साइट को अनब्लॉक करना होगा।"
+"आप अधिकतम %1$s साइटें ही ब्लॉक कर सकते हैं। %2$s को ब्लॉक करने के लिए, आपको पहले किसी "
+"अन्य साइट को अनब्लॉक करना होगा।"
 
 # smartling.placeholder_format=C
 #. Text explaining the benefits of the cloud save feature.
@@ -23177,8 +23719,8 @@ msgid ""
 "You now have access to %s, higher AI reasoning, and 2x higher usage limits "
 "than Plus."
 msgstr ""
-"अब आपको %1$s का एक्सेस हासिल है, बेहतर AI तर्क-क्षमता, और Plus की तुलना में "
-"2 गुना ज़्यादा उपयोग सीमाएं।"
+"अब आपको %1$s का एक्सेस हासिल है, बेहतर AI तर्क-क्षमता, और Plus की तुलना में 2 गुना "
+"ज़्यादा उपयोग सीमाएं।"
 
 # smartling.placeholder_format=C
 #. Description text for the welcome modal displayed after the user subscribes to DuckDuckGo.
@@ -23187,8 +23729,8 @@ msgid ""
 "You now have access to advanced AI models. You can access the VPN and other "
 "DuckDuckGo subscription protections in the DuckDuckGo browser."
 msgstr ""
-"अब आपके पास एडवांस्ड AI मॉडल्स का एक्सेस है। आप DuckDuckGo ब्राउज़र में VPN "
-"और अन्य DuckDuckGo सब्सक्रिप्शन सुरक्षा सुविधाओं का उपयोग कर सकते हैं।"
+"अब आपके पास एडवांस्ड AI मॉडल्स का एक्सेस है। आप DuckDuckGo ब्राउज़र में VPN और अन्य "
+"DuckDuckGo सब्सक्रिप्शन सुरक्षा सुविधाओं का उपयोग कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Welcome message that appears after the DuckDuckGo extension is installed.
@@ -23210,9 +23752,8 @@ msgid ""
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
 msgstr ""
-"अब आप इस ब्राउज़र से अपनी सेव की गई चैट्स एक्सेस नहीं कर पाएंगे। पिछली 30 "
-"चैट अभी भी लोकल स्टोरेज में उपलब्ध रहेंगी। इससे एन्क्रिप्टेड सर्वर से आपकी "
-"चैट डिलीट नहीं होंगी।"
+"अब आप इस ब्राउज़र से अपनी सेव की गई चैट्स एक्सेस नहीं कर पाएंगे। पिछली 30 चैट अभी भी "
+"लोकल स्टोरेज में उपलब्ध रहेंगी। इससे एन्क्रिप्टेड सर्वर से आपकी चैट डिलीट नहीं होंगी।"
 
 # smartling.placeholder_format=C
 #. Explains that turning off disconnects this browser only; the last 30 chats stay in local storage and the encrypted server backup is not deleted.
@@ -23222,9 +23763,8 @@ msgid ""
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
 msgstr ""
-"अब आप इस ब्राउज़र से अपनी सेव की गई चैट्स एक्सेस नहीं कर पाएंगे। पिछली 30 "
-"चैट अभी भी लोकल स्टोरेज में उपलब्ध रहेंगी। इससे एन्क्रिप्टेड सर्वर से आपकी "
-"चैट डिलीट नहीं होंगी।"
+"अब आप इस ब्राउज़र से अपनी सेव की गई चैट्स एक्सेस नहीं कर पाएंगे। पिछली 30 चैट अभी भी "
+"लोकल स्टोरेज में उपलब्ध रहेंगी। इससे एन्क्रिप्टेड सर्वर से आपकी चैट डिलीट नहीं होंगी।"
 
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
@@ -23246,9 +23786,8 @@ msgid ""
 "You're now searching privately in Chrome. Use our app instead of Chrome to "
 "browse privately too. It’s already installed and can:"
 msgstr ""
-"अभी आप Chrome में गुप्त रूप से खोज रहे हैं। गुप्त रूप से ब्राउज़ करने के लिए "
-"भी Chrome की बजाय हमारे ऐप का उपयोग करेंगे। यह पहले से ही इंस्टॉल हैं और यह "
-"कर सकता है:"
+"अभी आप Chrome में गुप्त रूप से खोज रहे हैं। गुप्त रूप से ब्राउज़ करने के लिए भी Chrome की "
+"बजाय हमारे ऐप का उपयोग करेंगे। यह पहले से ही इंस्टॉल हैं और यह कर सकता है:"
 
 # smartling.placeholder_format=C
 #. Confirmation message that appears after the DuckDuckGo browser extension is installed.
@@ -23261,8 +23800,8 @@ msgid ""
 "You're now searching with privacy. %sGet tips to reduce your footprint even "
 "more."
 msgstr ""
-"अब आप गोपनीयता के साथ खोज कर रहे हैं। %1$sअपने फुटप्रिंट को और भी अधिक कम "
-"करने के लिए सुझाव पाएं।"
+"अब आप गोपनीयता के साथ खोज कर रहे हैं। %1$sअपने फुटप्रिंट को और भी अधिक कम करने के लिए "
+"सुझाव पाएं।"
 
 # smartling.placeholder_format=C
 #. Title of a notice thanking the user for turning off their adblocker
@@ -23305,9 +23844,7 @@ msgctxt "Error message for user limit"
 msgid ""
 "You've reached the maximum number of messages for the moment. Please try "
 "again later."
-msgstr ""
-"आप फिलहाल संदेशों की अधिकतम संख्या तक पहुंच गए हैं। कृपया बाद में फिर से "
-"कोशिश करें।"
+msgstr "आप फिलहाल संदेशों की अधिकतम संख्या तक पहुंच गए हैं। कृपया बाद में फिर से कोशिश करें।"
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -23326,8 +23863,7 @@ msgstr "आज की वॉयस चैट सीमा पूरी हो �
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
 msgid "You've reached your dictation usage limit. Try again later."
 msgstr ""
-"आपने अपनी डिक्टेशन इस्तेमाल करने की सीमा पूरी कर ली है। कृपया बाद में फिर से "
-"कोशिश करें।"
+"आपने अपनी डिक्टेशन इस्तेमाल करने की सीमा पूरी कर ली है। कृपया बाद में फिर से कोशिश करें।"
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -23336,9 +23872,9 @@ msgid ""
 "You've run out of Sync & Backup storage for Duck.ai chats with attachments. "
 "Delete the %s oldest chats to resume Sync. Pinned chats will not be deleted."
 msgstr ""
-"अटैचमेंट वाली Duck.ai चैट्स के लिए आपके Sync & Backup स्टोरेज की सीमा समाप्त "
-"हो गई है। सिंक फिर से शुरू करने के लिए %1$s सबसे पुरानी चैट डिलीट करें। पिन "
-"की गई चैट डिलीट नहीं की जाएंगी।"
+"अटैचमेंट वाली Duck.ai चैट्स के लिए आपके Sync & Backup स्टोरेज की सीमा समाप्त हो गई है। "
+"सिंक फिर से शुरू करने के लिए %1$s सबसे पुरानी चैट डिलीट करें। पिन की गई चैट डिलीट नहीं की "
+"जाएंगी।"
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -23348,9 +23884,9 @@ msgid ""
 "oldest chats with attachments to resume Sync. Pinned chats will not be "
 "deleted."
 msgstr ""
-"आपके Duck.ai चैट्स के लिए आपके Sync & Backup स्टोरेज की सीमा समाप्त हो गई "
-"है। सिंक फिर से शुरू करने के लिए, अटैचमेंट वाली %1$s सबसे पुरानी चैट डिलीट "
-"कर दें। पिन की गई चैट डिलीट नहीं की जाएंगी।"
+"आपके Duck.ai चैट्स के लिए आपके Sync & Backup स्टोरेज की सीमा समाप्त हो गई है। सिंक फिर "
+"से शुरू करने के लिए, अटैचमेंट वाली %1$s सबसे पुरानी चैट डिलीट कर दें। पिन की गई चैट डिलीट "
+"नहीं की जाएंगी।"
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the sync storage limit.
@@ -23364,8 +23900,8 @@ msgid ""
 "YouTube (owned by Google) does not let you watch videos anonymously. As "
 "such, watching YouTube videos here will be tracked by YouTube/Google."
 msgstr ""
-"YouTube (Google के अधीन) आपको गुमनाम रूप से वीडियो नहीं देखने देता है । इस "
-"वजह से YouTube के वीडियो यहां देखने पर YouTube/Google को पता लग जाएगा |"
+"YouTube (Google के अधीन) आपको गुमनाम रूप से वीडियो नहीं देखने देता है । इस वजह से "
+"YouTube के वीडियो यहां देखने पर YouTube/Google को पता लग जाएगा |"
 
 # smartling.placeholder_format=C
 #. Label for a privacy disclaimer related to YouTube videos
@@ -23409,9 +23945,8 @@ msgid ""
 "disconnected from sync. Your %s most recent chats will be available in local "
 "storage on these browsers:"
 msgstr ""
-"आपका बैकअप DuckDuckGo के सर्वर से हटा दिया जाएगा। सभी डिवाइस सिंक से "
-"डिस्कनेक्ट हो जाएंगे। आपकी सबसे हाल की %1$s चैट इन ब्राउज़रों के लोकल "
-"स्टोरेज में उपलब्ध होंगी:"
+"आपका बैकअप DuckDuckGo के सर्वर से हटा दिया जाएगा। सभी डिवाइस सिंक से डिस्कनेक्ट हो "
+"जाएंगे। आपकी सबसे हाल की %1$s चैट इन ब्राउज़रों के लोकल स्टोरेज में उपलब्ध होंगी:"
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list.
@@ -23421,9 +23956,8 @@ msgid ""
 "disconnected from sync. Your 100 most recent chats will be available in "
 "local storage on these browsers:"
 msgstr ""
-"आपका बैकअप DuckDuckGo के सर्वर से हटा दिया जाएगा। सभी डिवाइस सिंक से "
-"डिस्कनेक्ट हो जाएंगे। आपकी सबसे हाल की 100 चैट इन ब्राउज़रों के लोकल स्टोरेज "
-"में उपलब्ध होंगी:"
+"आपका बैकअप DuckDuckGo के सर्वर से हटा दिया जाएगा। सभी डिवाइस सिंक से डिस्कनेक्ट हो "
+"जाएंगे। आपकी सबसे हाल की 100 चैट इन ब्राउज़रों के लोकल स्टोरेज में उपलब्ध होंगी:"
 
 # smartling.placeholder_format=C
 #. List item indicating that a site exclusion filter is currently active for the search
@@ -23448,8 +23982,8 @@ msgid ""
 "Your browser provides a list of your most-visited sites. DuckDuckGo never "
 "has access to this data."
 msgstr ""
-"आपका ब्राउज़र, आपकी सबसे ज़्यादा देखी गई साइटों की एक सूची प्रदान करता "
-"है।DuckDuckGo के पास कभी भी इस डेटा का एक्सेस नहीं रहता है।"
+"आपका ब्राउज़र, आपकी सबसे ज़्यादा देखी गई साइटों की एक सूची प्रदान करता है।DuckDuckGo के "
+"पास कभी भी इस डेटा का एक्सेस नहीं रहता है।"
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
@@ -23457,8 +23991,8 @@ msgid ""
 "Your browser provides the list of most-visited sites. DuckDuckGo never has "
 "access to this data."
 msgstr ""
-"आपका ब्राउज़र सबसे ज़्यादा देखी गई साइटों की सूची प्रदान करता है। DuckDuckGo "
-"के पास इस डेटा का कभी भी एक्सेस नहीं रहा है।"
+"आपका ब्राउज़र सबसे ज़्यादा देखी गई साइटों की सूची प्रदान करता है। DuckDuckGo के पास इस "
+"डेटा का कभी भी एक्सेस नहीं रहा है।"
 
 # smartling.placeholder_format=C
 #. Disclaimer text shown bellow chat input. Example: 'You are chatting with GPT-3. AI chats may display inaccurate or offensive information.'
@@ -23467,8 +24001,8 @@ msgid ""
 "Your chat with %s is private. AI chats may display inaccurate or offensive "
 "information."
 msgstr ""
-"%1$s के साथ आपकी चैट गोपनीय रहती है। AI चैट में गलत या आपत्तिजनक जानकारी भी "
-"दिखाई दे सकती है।"
+"%1$s के साथ आपकी चैट गोपनीय रहती है। AI चैट में गलत या आपत्तिजनक जानकारी भी दिखाई दे "
+"सकती है।"
 
 # smartling.placeholder_format=C
 #. Body copy shown after Sync & Backup is enabled, confirming chats are now syncing.
@@ -23481,8 +24015,8 @@ msgstr "आपकी चैट अब सेव की जा रही है�
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never saved or used to train AI models"
 msgstr ""
-"आपकी चैट निजी रहती हैं, कभी भी इन्हें सेव नहीं किया जाता या इनका इस्तेमाल AI "
-"मॉडलों को प्रशिक्षित करने के लिए नहीं किया जाता"
+"आपकी चैट निजी रहती हैं, कभी भी इन्हें सेव नहीं किया जाता या इनका इस्तेमाल AI मॉडलों को "
+"प्रशिक्षित करने के लिए नहीं किया जाता"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
@@ -23496,8 +24030,8 @@ msgctxt "Active Privacy protection description"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
 msgstr ""
-"आपकी चैट गोपनीय रहती हैं, हम उन्हें अनाम कर देते हैं, और उनका इस्तेमाल AI "
-"मॉडलों को प्रशिक्षित करने के लिए नहीं किया जाता।"
+"आपकी चैट गोपनीय रहती हैं, हम उन्हें अनाम कर देते हैं, और उनका इस्तेमाल AI मॉडलों को "
+"प्रशिक्षित करने के लिए नहीं किया जाता।"
 
 # smartling.placeholder_format=C
 #. Text explaining that user chats are private and not used for AI (Artificial Intelligence) training.
@@ -23505,8 +24039,8 @@ msgctxt "Body text for privacy protection modal"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
 msgstr ""
-"आपकी चैट गोपनीय रहती हैं, हम उन्हें अनाम कर देते हैं, और उनका इस्तेमाल AI "
-"मॉडलों को प्रशिक्षित करने के लिए नहीं किया जाता।"
+"आपकी चैट गोपनीय रहती हैं, हम उन्हें अनाम कर देते हैं, और उनका इस्तेमाल AI मॉडलों को "
+"प्रशिक्षित करने के लिए नहीं किया जाता।"
 
 # smartling.placeholder_format=C
 #. Text for a menu item that describes the privacy protection feature.
@@ -23514,8 +24048,8 @@ msgctxt "Menu item description"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
 msgstr ""
-"आपकी चैट निजी रहती हैं, हमारे द्वारा कभी सेव नहीं की जाती हैं, और इनका "
-"इस्तेमाल AI मॉडलों को प्रशिक्षित करने के लिए नहीं किया जाता।"
+"आपकी चैट निजी रहती हैं, हमारे द्वारा कभी सेव नहीं की जाती हैं, और इनका इस्तेमाल AI "
+"मॉडलों को प्रशिक्षित करने के लिए नहीं किया जाता।"
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the active privacy protection.
@@ -23523,8 +24057,8 @@ msgctxt "Modal body for privacy"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
 msgstr ""
-"आपकी चैट निजी रहती हैं, हमारे द्वारा कभी सेव नहीं की जाती हैं, और इनका "
-"इस्तेमाल AI मॉडलों को प्रशिक्षित करने के लिए नहीं किया जाता।"
+"आपकी चैट निजी रहती हैं, हमारे द्वारा कभी सेव नहीं की जाती हैं, और इनका इस्तेमाल AI "
+"मॉडलों को प्रशिक्षित करने के लिए नहीं किया जाता।"
 
 # smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that chats are stored locally on the user's device.
@@ -23539,9 +24073,9 @@ msgid ""
 "Your chats are still private, anonymized by us, and not used to train AI "
 "models. Follow these steps to keep your chat history."
 msgstr ""
-"आपकी चैट अभी भी गोपनीय हैं, जिन्हें हम अनाम कर देते हैं, और इनका उपयोग AI "
-"मॉडल्स को प्रशिक्षित करने के लिए नहीं किया जाता है। अपनी चैट हिस्ट्री "
-"सुरक्षित रखने के लिए इन चरणों का पालन करें।"
+"आपकी चैट अभी भी गोपनीय हैं, जिन्हें हम अनाम कर देते हैं, और इनका उपयोग AI मॉडल्स को "
+"प्रशिक्षित करने के लिए नहीं किया जाता है। अपनी चैट हिस्ट्री सुरक्षित रखने के लिए इन चरणों "
+"का पालन करें।"
 
 # smartling.placeholder_format=C
 #. Body shown after import completes.
@@ -23550,8 +24084,7 @@ msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
 msgstr ""
-"आपकी चैट्स इंपोर्ट कर दी गई हैं। आगे बढ़ें और Duck.ai में वहीं से जारी रखें "
-"जहां आपने छोड़ा था।"
+"आपकी चैट्स इंपोर्ट कर दी गई हैं। आगे बढ़ें और Duck.ai में वहीं से जारी रखें जहां आपने छोड़ा था।"
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.
@@ -23583,8 +24116,8 @@ msgid ""
 "Your email address will not be shared, %sor associated with anonymous "
 "searches. [%sExample message%s]"
 msgstr ""
-"आपका ईमेल पता शेयर नहीं किया जाएगा, %1$sया किन्हीं अनाम खोजों के साथ संबद्ध "
-"नहीं है। [%2$sउदाहरण संदेश%3$s]"
+"आपका ईमेल पता शेयर नहीं किया जाएगा, %1$sया किन्हीं अनाम खोजों के साथ संबद्ध नहीं है। "
+"[%2$sउदाहरण संदेश%3$s]"
 
 # smartling.placeholder_format=C
 #. A prompt for the user to provide feedback on the third party map app directions experience
@@ -23599,8 +24132,8 @@ msgctxt ""
 "an AI response"
 msgid "Your feedback is anonymized and not used to train AI."
 msgstr ""
-"आपकी फ़ीडबैक को अनाम रखा जाता है और इसका इस्तेमाल AI को ट्रेनिंग देने के लिए "
-"नहीं किया जाता।"
+"आपकी फ़ीडबैक को अनाम रखा जाता है और इसका इस्तेमाल AI को ट्रेनिंग देने के लिए नहीं किया "
+"जाता।"
 
 # smartling.placeholder_format=C
 #. Explains that the User's Location is always private to DuckDuckGo.
@@ -23629,10 +24162,10 @@ msgid ""
 "browser. We save the settings file using the key as the name. DuckDuckGo "
 "never knows your passphrase."
 msgstr ""
-"आपके पासफ़्रेज़ ने %1$sSHA-2%2$s के रूप में ज्ञात सुरक्षित हैश एल्गोरिथम का "
-"उपयोग करके '512-बिट की' जनरेट किया है। केवल 'की' और संबंधित सेटिंग्स फ़ाइल "
-"आपके ब्राउज़र को छोड़ देती है। हम नाम के रूप में 'की' का उपयोग करके सेटिंग्स "
-"फ़ाइल को सेव करते हैं। DuckDuckGo कभी भी आपके पासफ़्रेज़ को नहीं जानता है।"
+"आपके पासफ़्रेज़ ने %1$sSHA-2%2$s के रूप में ज्ञात सुरक्षित हैश एल्गोरिथम का उपयोग करके '512-"
+"बिट की' जनरेट किया है। केवल 'की' और संबंधित सेटिंग्स फ़ाइल आपके ब्राउज़र को छोड़ देती है। "
+"हम नाम के रूप में 'की' का उपयोग करके सेटिंग्स फ़ाइल को सेव करते हैं। DuckDuckGo कभी भी "
+"आपके पासफ़्रेज़ को नहीं जानता है।"
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -23647,9 +24180,8 @@ msgid ""
 "personally identifiable metadata, so model providers can't tie your "
 "conversations back to you."
 msgstr ""
-"आपके प्रॉम्प्ट DuckDuckGo सर्वर के ज़रिए भेजे जाते हैं और उनसे आपकी पहचान "
-"बताने वाला मेटाडेटा हटा दिया जाता है, ताकि मॉडल प्रदाता आपकी बातचीत को आपसे "
-"जोड़ न सकें।"
+"आपके प्रॉम्प्ट DuckDuckGo सर्वर के ज़रिए भेजे जाते हैं और उनसे आपकी पहचान बताने वाला "
+"मेटाडेटा हटा दिया जाता है, ताकि मॉडल प्रदाता आपकी बातचीत को आपसे जोड़ न सकें।"
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -23663,8 +24195,7 @@ msgid ""
 "Your recent chats live here! You can refer to your chats or clear them "
 "anytime."
 msgstr ""
-"आपकी हालिया चैट यहां रहती हैं! आप कभी भी अपनी चैट देख सकते हैं या उन्हें हटा "
-"सकते हैं।"
+"आपकी हालिया चैट यहां रहती हैं! आप कभी भी अपनी चैट देख सकते हैं या उन्हें हटा सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Message on a feedback form.
@@ -23707,9 +24238,8 @@ msgid ""
 "You’re now searching privately in Chrome. Use our browser instead of Chrome "
 "for more protection. It’s already installed and can:"
 msgstr ""
-"फ़िलहाल, आप Chrome में गोपनीय रूप से सर्च कर रहे हैं। ज़्यादा सुरक्षा के लिए "
-"Chrome के बजाय हमारे ब्राउज़र का इस्तेमाल करें। यह पहले से ही इंस्टॉल है और "
-"यहां दिए गए काम कर सकता है:"
+"फ़िलहाल, आप Chrome में गोपनीय रूप से सर्च कर रहे हैं। ज़्यादा सुरक्षा के लिए Chrome के बजाय "
+"हमारे ब्राउज़र का इस्तेमाल करें। यह पहले से ही इंस्टॉल है और यहां दिए गए काम कर सकता है:"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has exceeded the maximum message size.
@@ -23718,8 +24248,8 @@ msgid ""
 "You’ve exceeded the maximum message size. Please shorten your message and "
 "try again."
 msgstr ""
-"आपने संदेश की अधिकतम आकार सीमा पार कर ली है। कृपया अपने संदेश को छोटा करके "
-"फिर से कोशिश करें।"
+"आपने संदेश की अधिकतम आकार सीमा पार कर ली है। कृपया अपने संदेश को छोटा करके फिर से "
+"कोशिश करें।"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -23728,8 +24258,8 @@ msgid ""
 "You’ve reached the maximum chat length in this conversation. Clear this "
 "conversation with the Fire Button to continue."
 msgstr ""
-"आप इस बातचीत में अधिकतम चैट अवधि तक पहुंच गए हैं। आगे बढ़ने के लिए, Fire "
-"Button की मदद से इस बातचीत को मिटाएं।"
+"आप इस बातचीत में अधिकतम चैट अवधि तक पहुंच गए हैं। आगे बढ़ने के लिए, Fire Button की मदद "
+"से इस बातचीत को मिटाएं।"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -23738,8 +24268,7 @@ msgid ""
 "You’ve reached the maximum chat length in this conversation. Start a new "
 "chat to continue."
 msgstr ""
-"आप इस बातचीत में अधिकतम चैट अवधि तक पहुंच गए हैं। जारी रखने के लिए एक नई चैट "
-"शुरू करें।"
+"आप इस बातचीत में अधिकतम चैट अवधि तक पहुंच गए हैं। जारी रखने के लिए एक नई चैट शुरू करें।"
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -23754,8 +24283,8 @@ msgid ""
 "You’ve reached the maximum number of messages for one day. Please continue "
 "this chat tomorrow."
 msgstr ""
-"आप एक दिन में भेजे जाने वाले संदेशों की अधिकतम संख्या तक पहुंच गए हैं। कृपया "
-"इस चैट को अब कल जारी रखें।"
+"आप एक दिन में भेजे जाने वाले संदेशों की अधिकतम संख्या तक पहुंच गए हैं। कृपया इस चैट को अब कल "
+"जारी रखें।"
 
 # smartling.placeholder_format=C
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
@@ -24058,8 +24587,7 @@ msgstr "ऑफ़िशियल वेबसाइट"
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
 msgstr ""
-"या जो रंग आप चाहते है उसका कलर कोड लिखे, जैसे %1$s (%2$s एक एनकोडेड %3$s "
-"अक्षर है)"
+"या जो रंग आप चाहते है उसका कलर कोड लिखे, जैसे %1$s (%2$s एक एनकोडेड %3$s अक्षर है)"
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "

--- a/locales/hr_HR/LC_MESSAGES/duckduckgo.po
+++ b/locales/hr_HR/LC_MESSAGES/duckduckgo.po
@@ -2,15 +2,16 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: hr_HR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 
 # smartling.gettext_line_width = normalized : 79
 # smartling.placeholder_format=C
@@ -87,7 +88,8 @@ msgstr "AI modeli %1$s i %2$s"
 #. Message that appears above the search results encouraging them to filter results by domain. The placeholder string would include a the name of a website. E.g. 'Reddit appears in some of the top results for this search.'
 msgctxt "Site filter message"
 msgid "%s appears in some of the top results for this search."
-msgstr "%1$s se pojavljuje u nekim od najboljih rezultata za ovo pretraživanje."
+msgstr ""
+"%1$s se pojavljuje u nekim od najboljih rezultata za ovo pretraživanje."
 
 # smartling.placeholder_format=C
 #. Number of tracking attempts blocked, when there is more than 1. Eg: '2 attempts' or '302 attempts'
@@ -490,7 +492,8 @@ msgstr ""
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "%sLong-press%s the DuckDuckGo app icon on the home screen"
-msgstr "%1$sPritisni i drži%2$s ikonu aplikacije DuckDuckGo na početnom zaslonu"
+msgstr ""
+"%1$sPritisni i drži%2$s ikonu aplikacije DuckDuckGo na početnom zaslonu"
 
 # smartling.placeholder_format=C
 #. A message displayed when there is an error loading content or no results on requery
@@ -895,7 +898,8 @@ msgstr "Dostupna je nova verzija AI Chata! Osvježi ovu stranicu za nastavak."
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of Duck.ai is available! Please refresh this page to continue."
-msgstr "Dostupna je nova verzija usluge Duck.ai! Osvježi ovu stranicu za nastavak."
+msgstr ""
+"Dostupna je nova verzija usluge Duck.ai! Osvježi ovu stranicu za nastavak."
 
 # smartling.placeholder_format=C
 #. Shown when the Duck.ai desktop app has been open a long time and a newer version exists.
@@ -1440,6 +1444,12 @@ msgid "Address is incorrect"
 msgstr "Adresa je netočna"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Adjust the servings"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. as in multiple advertisements
 msgid "Ads"
 msgstr "Oglasi"
@@ -1651,6 +1661,14 @@ msgstr "Sva čavrljanja su %1$s. AI može griješiti."
 msgctxt "Empty state heading in Duck.ai chat mode"
 msgid "All chats are %sprivate%s"
 msgstr "Sva čavrljanja su %1$sprivatna%2$s"
+
+# smartling.placeholder_format=C
+#. Paragraph in the Privacy & Terms section of the About & Legal page in Duck.ai settings, summarizing how chats are anonymized and are not stored or used to train chat models.
+msgctxt "Privacy & Terms section description on the Duck.ai settings page"
+msgid ""
+"All chats are anonymized by DuckDuckGo, and your conversations are not used "
+"to train chat models by DuckDuckGo or the model providers"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1921,6 +1939,13 @@ msgstr ""
 msgctxt "precise_user_location"
 msgid "Anonymous location enabled"
 msgstr "Omogućena anonimna lokacija"
+
+# smartling.placeholder_format=C
+msgctxt "settings"
+msgid ""
+"Anonymously generates answers for search queries based on web content. "
+"Choose how often you want it to appear, or disable it completely."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -2201,6 +2226,12 @@ msgid "Ask a follow-up with Duck.ai"
 msgstr "Pitaj Duck.ai za daljnje informacije"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
+msgctxt "Page suggestion chip label"
+msgid "Ask about this page"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
 msgctxt "Title for the page context onboarding modal"
 msgid "Ask about this page"
@@ -2378,7 +2409,8 @@ msgstr "Nakon završetka čavrljanja, zvuk ne pohranjujemo ni mi ni OpenAI."
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat is transcribed."
-msgstr "Zvuk ne pohranjujemo ni mi ni OpenAI nakon što se čavrljanje transkribira."
+msgstr ""
+"Zvuk ne pohranjujemo ni mi ni OpenAI nakon što se čavrljanje transkribira."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when MediaRecorder API is unavailable.
@@ -2617,6 +2649,12 @@ msgid "Barcode"
 msgstr "Crtični kôd"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Based on this page, is this course worth taking?"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Basic"
 msgstr "Osnovna"
@@ -2655,6 +2693,14 @@ msgstr "Udarač"
 msgctxt "Assistant response placeholder"
 msgid "Before continuing..."
 msgstr "Prije nego nastaviš..."
+
+# smartling.placeholder_format=C
+#. Explains that before storing the report, DuckDuckGo will anonymize the conversation by removing PII like names, email addresses, and identifying metadata.
+msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
+msgid ""
+"Before storing this report, DuckDuckGo will anonymize your conversation by "
+"removing PII like names, email addresses, and identifying metadata."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -2796,7 +2842,8 @@ msgstr "Blokiraj ovu stranicu iz svih rezultata"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Block trackers and take control of your personal data"
-msgstr "Blokiraj alate za praćenje i preuzmi kontrolu nad svojim osobnim podacima"
+msgstr ""
+"Blokiraj alate za praćenje i preuzmi kontrolu nad svojim osobnim podacima"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -2971,6 +3018,12 @@ msgstr "Brazil"
 msgctxt "Sports module"
 msgid "Break Points Won"
 msgstr "Osvojeni breakovi"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Break this down into clear, numbered steps."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -3428,6 +3481,12 @@ msgid "Cast"
 msgstr "Glume"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Cast & Crew"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
 msgctxt "Tone option label for Casual"
 msgid "Casual"
@@ -3512,7 +3571,8 @@ msgstr "Promjena načina prikaza URL-ova rezultata"
 #. This is the description of a user setting
 msgctxt "settings"
 msgid "Changes how the header is displayed and its behavior as you scroll"
-msgstr "Promjena načina prikaza zaglavlja i njegova ponašanja tijekom pomicanja"
+msgstr ""
+"Promjena načina prikaza zaglavlja i njegova ponašanja tijekom pomicanja"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/mcZdcaF.png
@@ -4302,7 +4362,8 @@ msgstr "Klikni %1$sPostavke%2$s u padajućem izborniku."
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
-msgstr "Klikni %1$sUpotrijebi trenutačne stranice%2$s zatim %3$sklikni U redu%4$s."
+msgstr ""
+"Klikni %1$sUpotrijebi trenutačne stranice%2$s zatim %3$sklikni U redu%4$s."
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -5093,7 +5154,8 @@ msgstr "Kostarika"
 #. Inline error shown on the recovery code screen when exportSyncSettings rejects.
 msgctxt "Error message when the recovery code fails to generate"
 msgid "Couldn't load your recovery code. Please close this and try again."
-msgstr "Nije moguće učitati tvoj kôd za oporavak. Zatvori ovo i pokušaj ponovno."
+msgstr ""
+"Nije moguće učitati tvoj kôd za oporavak. Zatvori ovo i pokušaj ponovno."
 
 # smartling.placeholder_format=C
 #. Pairs with a Retry button. Shown after two consecutive failed attempts to load the device list.
@@ -5137,6 +5199,12 @@ msgstr "Izradi sliku"
 msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr "Izradi sliku"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Create a shopping list with quantities from this recipe."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed in the input field when starting a new image generation session.
@@ -5783,6 +5851,11 @@ msgid "Dictation limit reached"
 msgstr "Dosegnuto je ograničenje diktiranja"
 
 # smartling.placeholder_format=C
+#. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
+msgid "Dictation temporarily unavailable"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
@@ -5869,7 +5942,8 @@ msgstr "Onemogući i isključi"
 #. Title of a modal that asks the user if they want to turn off chat history and disconnect from Sync & Backup.
 msgctxt "Modal header for disabling chat history and disconnecting sync"
 msgid "Disable chat history and disconnect from Sync & Backup?"
-msgstr "Onemogućiti povijest čavrljanja i prekinuti vezu s uslugom Sync & Backup?"
+msgstr ""
+"Onemogućiti povijest čavrljanja i prekinuti vezu s uslugom Sync & Backup?"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to turn off the chat history feature.
@@ -6083,6 +6157,22 @@ msgid "Done"
 msgstr "Gotovo"
 
 # smartling.placeholder_format=C
+#. Message shown in a modal after DuckDuckGo browser users disable AI features in Settings. The first two placeholders bold noai.duckduckgo.com. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
+"filtered out. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
+"and AI images filtered out. %sLearn more%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Double Faults"
@@ -6195,6 +6285,18 @@ msgid ""
 msgstr ""
 "Sastavi sažetu i detaljnu e-poruku za dobavljača koji traži ponudu za usluge "
 "popravka kućnog hladnjaka."
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Draft a cover letter"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Draft a cover letter for this job."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -6369,7 +6471,17 @@ msgstr ""
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
-msgstr "Duck.ai je najbolji u našem privatnom i besplatnom DuckDuckGo pregledniku!"
+msgstr ""
+"Duck.ai je najbolji u našem privatnom i besplatnom DuckDuckGo pregledniku!"
+
+# smartling.placeholder_format=C
+#. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
+msgctxt "About section description on the Duck.ai settings page"
+msgid ""
+"Duck.ai is created by DuckDuckGo. We're an independent online protection "
+"company for anyone who wants to take back control of their personal "
+"information."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
@@ -6415,6 +6527,13 @@ msgstr "Duck.ai je privremeno nedostupan. Osvježi stranicu i pokušaj ponovno."
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
 msgstr "Duck.ai je privremeno nedostupan. Pokušaj ponovno nešto kasnije."
+
+# smartling.placeholder_format=C
+msgctxt "settings"
+msgid ""
+"Duck.ai lets you chat privately with popular AI models. Disabling it hides "
+"Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6665,7 +6784,8 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr "DuckDuckGo AI Chat trenutačno nije dostupan. Pokušaj ponovno nešto kasnije."
+msgstr ""
+"DuckDuckGo AI Chat trenutačno nije dostupan. Pokušaj ponovno nešto kasnije."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -6794,8 +6914,8 @@ msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid ""
 "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to Duck.ai's %s."
 msgstr ""
-"DuckDuckGo anonimizira tvoje razgovore. Klikom na '%1$s' prihvaćaš "
-"Duck.ai-jeve %2$s."
+"DuckDuckGo anonimizira tvoje razgovore. Klikom na '%1$s' prihvaćaš Duck.ai-"
+"jeve %2$s."
 
 # smartling.placeholder_format=C
 #. Shown below the input on the empty state when the user has not yet accepted the terms of service. The first %s is the action button label ('Ask' for chat, 'Create' for image generation). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. Clicking the action button both accepts the terms and submits the prompt.
@@ -6803,7 +6923,8 @@ msgctxt ""
 "Inline terms-of-service disclaimer below chat or image-gen input for new "
 "users"
 msgid "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to our %s."
-msgstr "DuckDuckGo anonimizira tvoje razgovore. Klikom na '%1$s' prihvaćaš naše %2$s."
+msgstr ""
+"DuckDuckGo anonimizira tvoje razgovore. Klikom na '%1$s' prihvaćaš naše %2$s."
 
 # smartling.placeholder_format=C
 #. An information popup explaining that we block trackers
@@ -7004,7 +7125,8 @@ msgstr "Slika se uređuje..."
 msgctxt "Info text for the editing message feature"
 msgid ""
 "Editing your message will remove the response below and generate a new one."
-msgstr "Uređivanjem tvoje poruke uklonit će se odgovor ispod nje i generirati novi."
+msgstr ""
+"Uređivanjem tvoje poruke uklonit će se odgovor ispod nje i generirati novi."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of an editor in its responses.
@@ -7405,11 +7527,24 @@ msgstr "Ekvatorska Gvineja"
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Erase your browsing data in a flash with our %sFire Button%s"
-msgstr "Brzo izbriši svoje podatke o pregledavanju koristeći naš %1$sFire Button%2$s"
+msgstr ""
+"Brzo izbriši svoje podatke o pregledavanju koristeći naš %1$sFire Button%2$s"
 
 # smartling.placeholder_format=C
 msgid "Eritrea"
 msgstr "Eritreja"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Estimate the nutrition"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Estimate the nutritional information for this recipe."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Estonia"
@@ -7468,11 +7603,59 @@ msgid "Expires in 1 day"
 msgstr "Istječe za 1 dan"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain the accepted answer in simple terms."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
 msgstr "Objasni mi temeljne koncepte crnih rupa na razini srednje škole."
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain the top answer"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this in simple, plain language."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this paper"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this repo"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this research paper in plain language."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this simply"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain what this repository does and how to use it."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label to show if song lyrics contain explicit content
@@ -7669,8 +7852,8 @@ msgid ""
 "Feel free to adjust the settings below. Then, just copy and paste the code "
 "into your website."
 msgstr ""
-"Prilagodi donje postavke, a zatim samo kopiraj i zalijepi kôd na svoje "
-"web-mjesto."
+"Prilagodi donje postavke, a zatim samo kopiraj i zalijepi kôd na svoje web-"
+"mjesto."
 
 # smartling.placeholder_format=C
 msgid "Fiji"
@@ -7760,6 +7943,12 @@ msgstr ""
 "slika. %1$sSaznaj više%2$s"
 
 # smartling.placeholder_format=C
+msgctxt "settings"
+msgid ""
+"Filters out known AI spam sites from image search results. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the final score of a sporting event.
 msgid "Final"
 msgstr "Završno"
@@ -7798,7 +7987,8 @@ msgstr "Pronađi <b>%1$s</b> u mapi za preuzimanje"
 # smartling.placeholder_format=C
 #. Tells users how to change their default search engine to DuckDuckGo.
 msgid "Find DuckDuckGo in the displayed list and click %sMake Default%s"
-msgstr "Pronađi DuckDuckGo u prikazanom popisu i klikni %1$sPostavi za zadano%2$s"
+msgstr ""
+"Pronađi DuckDuckGo u prikazanom popisu i klikni %1$sPostavi za zadano%2$s"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for finding a better word.
@@ -7811,6 +8001,12 @@ msgstr "Pronađi bolju riječ"
 msgctxt "Subtitle for the Web Search tool entry in the Tools dropdown menu"
 msgid "Find current information"
 msgstr "Pronađi aktualne informacije"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Find me alternatives"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button that searches for results closer to the user's current location.
@@ -8007,7 +8203,8 @@ msgstr "Besplatni i privatni razgovori, mi ih anonimiziramo"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr "Besplatni i privatni razgovori, mi ih anonimiziramo. Nije potreban račun."
+msgstr ""
+"Besplatni i privatni razgovori, mi ih anonimiziramo. Nije potreban račun."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -8288,6 +8485,12 @@ msgstr "Generiraj sliku"
 #. Text for the button that generates more of an answer from duckassist when the answer has come from a collapsed state
 msgid "Generate More"
 msgstr "Generiraj više"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Generate a shopping list"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
@@ -8579,6 +8782,12 @@ msgstr "Isprobaj ga"
 msgctxt "Onboarding welcome screen button text"
 msgid "Give it a Try"
 msgstr "Isprobaj ga"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Give me a quick background on this person."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9027,6 +9236,18 @@ msgid "Help Spread Privacy"
 msgstr "Pomozi nam širiti privatnost"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Help me prep for the interview"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Help me tailor my resume for this job."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title of a SERP popup that invites users to take a survey (desktop only)
 msgctxt "User survey popup"
 msgid "Help us improve DuckDuckGo"
@@ -9036,7 +9257,8 @@ msgstr "Pomozi nam poboljšati DuckDuckGo"
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Help us improve DuckDuckGo searches with your feedback"
-msgstr "Pomozi nam poboljšati DuckDuckGo pretraživanja svojim povratnim informacijama"
+msgstr ""
+"Pomozi nam poboljšati DuckDuckGo pretraživanja svojim povratnim informacijama"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -9467,7 +9689,8 @@ msgstr "Kako funkcionira"
 #. Header for the assist settings modal where the user can choose how often they want AI-assisted answers to appear.
 msgctxt "duckassist"
 msgid "How much do you want AI-assisted answers to appear?"
-msgstr "Koliko često želiš da se pojave odgovori uz pomoć umjetne inteligencije?"
+msgstr ""
+"Koliko često želiš da se pojave odgovori uz pomoć umjetne inteligencije?"
 
 # smartling.placeholder_format=C
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
@@ -9540,6 +9763,14 @@ msgstr "Uragan"
 msgctxt "Onboarding terms screen button text"
 msgid "I Agree"
 msgstr "Slažem se"
+
+# smartling.placeholder_format=C
+#. Text for the button that takes the user to the external DuckDuckGo login subscription page.
+msgctxt ""
+"Text for the I already have a subscription button in the Duck.ai settings "
+"page"
+msgid "I Already Have a Subscription"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the button that takes the user to the login subscription page.
@@ -9718,7 +9949,8 @@ msgstr "Ako nas ipak želiš podržati, %1$spomozi proširiti DuckDuckGo%2$s"
 msgid ""
 "If you want to use DuckDuckGo without JavaScript, please use our %s or %s "
 "versions."
-msgstr "Želiš li koristiti DuckDuckGo bez JavaScripta, koristi %1$s ili %2$s verziju."
+msgstr ""
+"Želiš li koristiti DuckDuckGo bez JavaScripta, koristi %1$s ili %2$s verziju."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -10026,7 +10258,8 @@ msgstr "Lako pregledavanje rezultata pretraživanja za slike i videozapise"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Infinite Scroll for Images, Videos, and Shopping"
-msgstr "Lako pregledavanje rezultata pretraživanja slika, videozapisa i kupovina"
+msgstr ""
+"Lako pregledavanje rezultata pretraživanja slika, videozapisa i kupovina"
 
 # smartling.placeholder_format=C
 #. Feedback option when AI response is accurate
@@ -10114,6 +10347,12 @@ msgstr "Instaliraj DuckDuckGo za Windows"
 msgctxt "Sidemenu browser promo"
 msgid "Install Mac Browser"
 msgstr "Instaliraj Mac preglednik"
+
+# smartling.placeholder_format=C
+#. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
+msgctxt "settings"
+msgid "Install Now"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text of a button to install the DuckDuckGo app
@@ -10213,10 +10452,42 @@ msgid "Is deleted data really deleted?"
 msgstr "Brišu li se podaci doista?"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is it worth taking?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this place any good?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"Is this place any good? Summarize its reputation based on reviews and "
+"ratings."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "Is this video helpful?"
 msgstr "Je li ovaj videozapis koristan?"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this worth watching?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Is this worth watching? Give me a spoiler-free take."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -10827,6 +11098,12 @@ msgid "Links:"
 msgstr "Poveznice:"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "List the tools, materials, or prerequisites I need for this."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
 msgid "Listen"
 msgstr "Slušaj"
@@ -11235,6 +11512,12 @@ msgid "Manage blocked sites"
 msgstr "Upravljanje blokiranim mrežnim lokacijama"
 
 # smartling.placeholder_format=C
+#. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
+msgctxt "setting"
+msgid "Manage in Browser Settings"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to the site exclusion settings page
 msgctxt "Organic result context menu"
 msgid "Manage sites you've blocked"
@@ -11457,7 +11740,8 @@ msgstr "Mikronezija"
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
 msgid ""
 "Microphone access was denied. Please allow microphone access and try again."
-msgstr "Pristup mikrofona je uskraćen. Dopusti pristup mikrofonu i pokušaj ponovno."
+msgstr ""
+"Pristup mikrofona je uskraćen. Dopusti pristup mikrofonu i pokušaj ponovno."
 
 # smartling.placeholder_format=C
 #. The Microsoft brand name.
@@ -14064,6 +14348,12 @@ msgstr "Ispuni sljedeći upit i potvrdi da je ovo pretraživanje izvršio čovje
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
+msgid "Please describe why the chat response is harmful or illegal. (optional)"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
+msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
 msgstr "Opiši zašto je odgovor u čavrljanju nezakonit ili štetan. (Neobavezno)"
 
@@ -14088,6 +14378,14 @@ msgid ""
 msgstr ""
 "Napomena: započinjanje novog chata s bilo kojim AI modelom izbrisat će tvoju "
 "aktualnu sesiju chata."
+
+# smartling.placeholder_format=C
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
+msgctxt "Feedback prompt"
+msgid ""
+"Please paste your prompt and the problematic output (with any personal "
+"information removed) and describe why the content is harmful or illegal."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -14557,6 +14855,12 @@ msgid "Privacy"
 msgstr "Privatnost"
 
 # smartling.placeholder_format=C
+#. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
+msgctxt "Section heading on the Duck.ai settings page"
+msgid "Privacy & Terms"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Privacy Blog"
 msgstr "Blog o privatnosti"
 
@@ -14625,6 +14929,12 @@ msgstr "Pravila privatnosti i Uvjeti korištenja"
 msgctxt "Copy used to compose link in sentences"
 msgid "Privacy Policy and Terms of Service"
 msgstr "Pravila privatnosti i Uvjeti pružanja usluge"
+
+# smartling.placeholder_format=C
+#. Text for a button that links to the terms of use and privacy policy page.
+msgctxt "Secondary button text in active privacy modal"
+msgid "Privacy Policy and Terms of Service"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title displayed on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
@@ -15131,6 +15441,30 @@ msgid "Recommend a book"
 msgstr "Preporuči knjigu"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar books"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar books."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar movies or shows."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar titles"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
 msgid "Recording failed. Please try again."
 msgstr "Snimanje nije uspjelo. Pokušaj ponovno."
@@ -15343,8 +15677,8 @@ msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
 msgstr ""
-"Ponovno učitaj DuckDuckGo slijedeći upute ili klikom na gumb "
-"&quot;Osvježi&quot; (Refresh) ili &quot;Ponovno učitaj&quot; (Reload) u "
+"Ponovno učitaj DuckDuckGo slijedeći upute ili klikom na gumb &quot;"
+"Osvježi&quot; (Refresh) ili &quot;Ponovno učitaj&quot; (Reload) u "
 "pregledniku."
 
 # smartling.placeholder_format=C
@@ -15355,7 +15689,8 @@ msgstr "Zapamti moj izbor"
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings
 msgid "Remember my choice (this can be changed in %s%s%sSettings%s)"
-msgstr "Zapamti moj odabir (ovo se može promijeniti u %1$s%2$s%3$sPostavkama%4$s)"
+msgstr ""
+"Zapamti moj odabir (ovo se može promijeniti u %1$s%2$s%3$sPostavkama%4$s)"
 
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
@@ -15532,6 +15867,15 @@ msgstr ""
 # smartling.placeholder_format=C
 msgid "Republic of Moldova"
 msgstr "Republika Moldavija"
+
+# smartling.placeholder_format=C
+#. Note indicating that sharing the conversation is mandatory when reporting harmful or illegal content. Rendered alongside the standard share label (DUCKCHAT_RESPONSE_FEEDBACK_SHARE_PROMPT_RESPONSE_LABEL), not replacing it.
+msgctxt ""
+"Note shown under the share-content switch label on the Duck.ai response "
+"feedback form when the user has selected Harmful or Illegal as the feedback "
+"reason"
+msgid "Required for harmful or illegal reports"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
@@ -15769,6 +16113,12 @@ msgstr "Recenzije"
 msgctxt "maps_places"
 msgid "Reviews"
 msgstr "Recenzije"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Rewrite this recipe scaled for a different number of servings."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Romania"
@@ -16054,7 +16404,8 @@ msgstr "Spremi do 30 svojih najnovijih čavrljanja lokalno na svom uređaju."
 msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
-msgstr "Spremi svoja Duck.ai čavrljanja između uređaja pomoću end-to-end šifriranja."
+msgstr ""
+"Spremi svoja Duck.ai čavrljanja između uređaja pomoću end-to-end šifriranja."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -16221,7 +16572,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down to the %sServices%s section and click %sAddress bar%s."
-msgstr "Listaj prema dolje do %1$sUsluga%2$s i klikni na %3$sAdresna traka%4$s."
+msgstr ""
+"Listaj prema dolje do %1$sUsluga%2$s i klikni na %3$sAdresna traka%4$s."
 
 # smartling.placeholder_format=C
 #. Rugby match stats
@@ -16508,7 +16860,8 @@ msgstr "Pretraži putem DuckDuckGoa"
 #. Text for a promotional card encouraging third-party browser users to download the DuckDuckGo browser. Not shown in the DuckDuckGo browser or on Linux.
 msgctxt "Promotional text"
 msgid "Search, browse, and chat privately in our free browser"
-msgstr "Pretražuj, pregledavaj i privatno razgovaraj u našem besplatnom pregledniku"
+msgstr ""
+"Pretražuj, pregledavaj i privatno razgovaraj u našem besplatnom pregledniku"
 
 # smartling.placeholder_format=C
 #. Message displayed sometimes at top of results (for bang syntax), e.g. <a href="https://duckduckgo.com/?q=twitter+test">https://duckduckgo.com/?q=twitter+test</a>
@@ -16552,7 +16905,8 @@ msgstr "Tjedni sezone"
 #. Description shown in the Sync & Backup settings section when sync is not yet enabled, explaining the feature.
 msgctxt "Description for sync and backup feature"
 msgid "Securely save and sync your chats across all your devices."
-msgstr "Sigurno spremi i sinkroniziraj svoja čavrljanja na svim svojim uređajima."
+msgstr ""
+"Sigurno spremi i sinkroniziraj svoja čavrljanja na svim svojim uređajima."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -16601,7 +16955,8 @@ msgstr ""
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
 msgctxt "Sync feature benefit description"
 msgid "Securely stored on DuckDuckGo's server with end-to-end encryption."
-msgstr "Sigurno pohranjeno na DuckDuckGo poslužitelju s end-to-end šifriranjem."
+msgstr ""
+"Sigurno pohranjeno na DuckDuckGo poslužitelju s end-to-end šifriranjem."
 
 # smartling.placeholder_format=C
 #. List item explaining that synced chats are stored with end-to-end encryption on DuckDuckGo's server and only the user can access them.
@@ -16787,7 +17142,8 @@ msgstr "Odaberi %1$sDuckDuckGo%2$s u padajućem izborniku zadanih tražilica"
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %sDuckDuckGo%s in the list and %sallow%s location access"
-msgstr "Odaberi %1$sDuckDuckGo%2$s na popisu i %3$sdopusti%4$s pristup lokaciji"
+msgstr ""
+"Odaberi %1$sDuckDuckGo%2$s na popisu i %3$sdopusti%4$s pristup lokaciji"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -16906,7 +17262,8 @@ msgstr ""
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %syour browser%s in the list and %sallow%s location access"
-msgstr "Odaberi %1$ssvoj preglednik%2$s na popisu i %3$sdopusti%4$s pristup lokaciji"
+msgstr ""
+"Odaberi %1$ssvoj preglednik%2$s na popisu i %3$sdopusti%4$s pristup lokaciji"
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the modal for deleting all recent chats, that allows the user to select the chats to delete.
@@ -17099,6 +17456,12 @@ msgid "Set Up Now"
 msgstr "Postavi odmah"
 
 # smartling.placeholder_format=C
+#. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
+msgctxt "Encrypted storage setup button shown in native browsers"
+msgid "Set Up Sync & Backup"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
 msgctxt "Title for the Sync & Backup intro screen"
 msgid "Set Up Sync & Backup"
@@ -17134,7 +17497,8 @@ msgstr ""
 #. Prompt for the user to indicate their location on a map, to enable more relevant search results.
 msgctxt "precise_user_location"
 msgid "Set your location manually, or ensure Location Services is enabled."
-msgstr "Ručno postavi lokaciju ili provjeri jesu li omogućene lokacijske usluge."
+msgstr ""
+"Ručno postavi lokaciju ili provjeri jesu li omogućene lokacijske usluge."
 
 # smartling.placeholder_format=C
 #. In the top dropdown menu  ("More" > "Settings")
@@ -17188,7 +17552,8 @@ msgstr "Podijeli"
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "Share DuckDuckGo and help friends take their privacy back!"
-msgstr "Podijeli DuckDuckGo i pomozi prijateljima u vraćanju njihove privatnosti!"
+msgstr ""
+"Podijeli DuckDuckGo i pomozi prijateljima u vraćanju njihove privatnosti!"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button that opens a feedback modal when clicked.
@@ -17276,6 +17641,13 @@ msgstr "Podijeli URL stranice"
 msgctxt "feedback form"
 msgid "Share positive feedback"
 msgstr "Podijeli pozitivne povratne informacije"
+
+# smartling.placeholder_format=C
+#. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
+msgctxt ""
+"Label beside the share-content switch on the Duck.ai response feedback form"
+msgid "Share this conversation with DuckDuckGo"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -17414,7 +17786,8 @@ msgstr "Prikaži DuckAssist <sup>BETA</sup>"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show DuckAssist more often. (You can also completely %sturn it off%s.)"
-msgstr "Češće prikazuj DuckAssist. (Također ga možeš potpuno %1$sisključiti%2$s.)"
+msgstr ""
+"Češće prikazuj DuckAssist. (Također ga možeš potpuno %1$sisključiti%2$s.)"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
@@ -17729,7 +18102,8 @@ msgstr "Prikazuje poruku dobrodošlice na vrhu stranice rezultata pretraživanja
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message to EU Android preference menu users"
-msgstr "Prikazuje poruku dobrodošlice korisnicima Androida u EU, u izborniku postavki"
+msgstr ""
+"Prikazuje poruku dobrodošlice korisnicima Androida u EU, u izborniku postavki"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers sometimes.
@@ -17801,12 +18175,14 @@ msgstr "Nazivi web-mjesta"
 #. A message saying that site filters are not currently working
 msgctxt "Site filter message"
 msgid "Site search is temporarily unavailable. We are working on a fix."
-msgstr "Pretraživanje web lokacija privremeno je nedostupno. Radimo na rješenju."
+msgstr ""
+"Pretraživanje web lokacija privremeno je nedostupno. Radimo na rješenju."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Sites you block will be hidden from all your search results"
-msgstr "Stranice koje blokiraš bit će skrivene iz svih tvojih rezultata pretraživanja"
+msgstr ""
+"Stranice koje blokiraš bit će skrivene iz svih tvojih rezultata pretraživanja"
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes full name (tooltip)
@@ -17977,7 +18353,8 @@ msgstr "Ponekad"
 #. Generic error message shown when the image generation model cannot process the user's request.
 msgctxt "Error message from the image generation model"
 msgid "Sorry I can't help, please describe your image in a different way."
-msgstr "Žao mi je što ne mogu pomoći, molim te opiši svoju sliku na drugačiji način."
+msgstr ""
+"Žao mi je što ne mogu pomoći, molim te opiši svoju sliku na drugačiji način."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -18025,7 +18402,8 @@ msgctxt "Description for the wrong code error screen"
 msgid ""
 "Sorry, this code is invalid. Please make sure the correct code was entered "
 "or scanned."
-msgstr "Nažalost, ovaj je kôd nevažeći. Provjeri je li unesen ili skeniran točan kôd."
+msgstr ""
+"Nažalost, ovaj je kôd nevažeći. Provjeri je li unesen ili skeniran točan kôd."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -18105,7 +18483,8 @@ msgstr "Izvorni tekst je izbrisan"
 msgctxt "Error message for summary selection input limit"
 msgid ""
 "Source text is too long to summarize. Try again with a shorter selection."
-msgstr "Izvorni tekst je predug za sažimanje. Pokušaj ponovno s kraćim odabirom."
+msgstr ""
+"Izvorni tekst je predug za sažimanje. Pokušaj ponovno s kraćim odabirom."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under Interface Settings.in the end. It is a header
@@ -18304,19 +18683,22 @@ msgstr "Ostani na DuckDuckGou"
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletter."
-msgstr "Ostani zaštićen i informiran putem naših e-novosti o zaštiti privatnosti."
+msgstr ""
+"Ostani zaštićen i informiran putem naših e-novosti o zaštiti privatnosti."
 
 # smartling.placeholder_format=C
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletters."
-msgstr "Ostani zaštićen i informiran putem naših biltena o zaštiti privatnosti."
+msgstr ""
+"Ostani zaštićen i informiran putem naših biltena o zaštiti privatnosti."
 
 # smartling.placeholder_format=C
 #. Text on the page where users can subscribe to DuckDuckGo's privacy newsletter
 msgctxt "showcase_newsletter"
 msgid "Stay protected and informed with our privacy newsletters."
-msgstr "Ostani zaštićen i informiran putem naših biltena o zaštiti privatnosti."
+msgstr ""
+"Ostani zaštićen i informiran putem naših biltena o zaštiti privatnosti."
 
 # smartling.placeholder_format=C
 #. Loading message shown when image generation is taking longer than usual.
@@ -18354,14 +18736,15 @@ msgstr "Zaustavi generiranje"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop hidden trackers lurking on other websites."
-msgstr "Onemogući skrivene alate za praćenje koji vrebaju na drugim web-mjestima."
+msgstr ""
+"Onemogući skrivene alate za praćenje koji vrebaju na drugim web-mjestima."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop most hidden trackers lurking on other websites."
 msgstr ""
-"Onemogući većinu skrivenih alata za praćenje koji vrebaju na drugim "
-"web-mjestima."
+"Onemogući većinu skrivenih alata za praćenje koji vrebaju na drugim web-"
+"mjestima."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18531,6 +18914,24 @@ msgid "Suggest a title for a blog post"
 msgstr "Predloži naslov za objavu na blogu"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest related articles or topics worth exploring next."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Suggest related articles to explore"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest some alternatives to this product."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
 msgctxt "directions"
 msgid "Suggestions:"
@@ -18542,10 +18943,100 @@ msgid "Suggestions:"
 msgstr "Prijedlozi:"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Sum up the reviews"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A short title for the a message asking the AI to summarize a text.
 msgctxt "Title for the summarize message"
 msgid "Summarize"
 msgstr "Sažmi"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize the Q&As"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the background and notable work of this person."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the key details of this event."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the questions and answers on this page."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize their background"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this book"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this book."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this discussion"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this discussion thread."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this page"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this page."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this video"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this video."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize what the reviews say."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -18873,6 +19364,12 @@ msgid "Syria"
 msgstr "Sirija"
 
 # smartling.placeholder_format=C
+#. Text for a button that enables the theme to follow the operating system's color scheme preference.
+msgctxt "System theme button for theme selector"
+msgid "System"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Abbreviation indicating this is the total score for a game
 msgctxt "Sports module"
 msgid "T"
@@ -18899,6 +19396,12 @@ msgstr "TV"
 msgctxt "language_name"
 msgid "Tahitian"
 msgstr "Tahićansko"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Tailor my resume"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Taiwan"
@@ -18928,6 +19431,13 @@ msgstr "Preuzmi nadzor nad svojim osobnim podacima"
 msgctxt "homepage ATB modal"
 msgid "Take control of your personal data!"
 msgstr "Preuzmi nadzor nad svojim osobnim podacima!"
+
+# smartling.placeholder_format=C
+#. Description for the Feedback section of the Duck.ai settings page, asking the user to take an anonymous survey to let us know how we can make Duck.ai better.
+msgctxt "Feedback section description on the Duck.ai settings page"
+msgid ""
+"Take this anonymous survey to let us know how we can make Duck.ai better."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -19175,7 +19685,8 @@ msgstr "Priložene datoteke prelaze ukupno ograničenje veličine od %1$s MB."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the server rejects corrupt or unrecognized audio.
 msgid "The audio could not be processed. Please try recording again."
-msgstr "Zvučni zapis nije moguće obraditi. Pokušaj ponovno snimiti zvučni zapis."
+msgstr ""
+"Zvučni zapis nije moguće obraditi. Pokušaj ponovno snimiti zvučni zapis."
 
 # smartling.placeholder_format=C
 #. Second paragraph explaining where the encryption key is stored on the entry screen.
@@ -19233,6 +19744,12 @@ msgstr "Poslužitelj je naišao na pogrešku i nije mogao dovršiti tvoj zahtjev
 #. https://duck.co/media/files/theme.png
 msgid "Theme"
 msgstr "Tema"
+
+# smartling.placeholder_format=C
+#. Text for the theme selector label that allows users to switch between Light and dark theme.
+msgctxt "Label for the theme selector feature"
+msgid "Theme"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/LpFhb1e.png
@@ -19548,7 +20065,8 @@ msgstr "Za pravilno funkcioniranje ove stranice potreban je Javascript."
 #. Information tooltip text explaining that the current page's content will be included with the chat message.
 msgctxt "Tooltip explaining that page content will be sent to Duck.ai"
 msgid "This page's content will be sent with your message to Duck.ai"
-msgstr "Sadržaj ove stranice bit će poslan alatu Duck.ai zajedno s tvojom porukom"
+msgstr ""
+"Sadržaj ove stranice bit će poslan alatu Duck.ai zajedno s tvojom porukom"
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -19619,7 +20137,8 @@ msgstr "Ovaj je prijevod pogrešan"
 # smartling.placeholder_format=C
 #. Label indicating that the video can't be played on the current page, and only on the website that owns the vide. The placeholder is the name of the website that owns the video.
 msgid "This video is not yet able to be watched here. You can watch it on %s."
-msgstr "Ovaj se videozapis ovdje još ne može gledati. Možeš ga pogledati na %1$s."
+msgstr ""
+"Ovaj se videozapis ovdje još ne može gledati. Možeš ga pogledati na %1$s."
 
 # smartling.placeholder_format=C
 #. Message indicating that a website is not using an encrypted connection and is not secure.
@@ -19789,8 +20308,8 @@ msgid ""
 "To print directions:%sGo back to the map.%sSelect the route you want to "
 "print.%sClick the print icon.%s"
 msgstr ""
-"Za ispis uputa:%1$svrati se na kartu.%2$sOdaberi rutu koju želiš "
-"ispisati.%3$sKlikni na ikonu za ispis.%4$s"
+"Za ispis uputa:%1$svrati se na kartu.%2$sOdaberi rutu koju želiš ispisati."
+"%3$sKlikni na ikonu za ispis.%4$s"
 
 # smartling.placeholder_format=C
 #. Explains where the user can find their recovery code. Figma frame 3703-44420.
@@ -19886,7 +20405,8 @@ msgstr "Previše oglasa"
 #. Displayed when the user has sent too many requests in a short period of time.
 msgctxt "Error message for rate limit"
 msgid "Too many requests. Please take a short break and try again."
-msgstr "Previše zahtjeva. Molimo te da napraviš kratku pauzu i pokušaš ponovno."
+msgstr ""
+"Previše zahtjeva. Molimo te da napraviš kratku pauzu i pokušaš ponovno."
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -20075,6 +20595,18 @@ msgstr ""
 "kina?\""
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Translate this page"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
+msgctxt "Page suggestion prompt"
+msgid "Translate this page into %s."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text for a region that will display translated text.
 msgctxt "translations_module"
 msgid "Translation"
@@ -20216,6 +20748,12 @@ msgid "Try Free"
 msgstr "Isprobaj besplatno"
 
 # smartling.placeholder_format=C
+#. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
+msgctxt "settings"
+msgid "Try It Now"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
 msgctxt "Promotional CTA for new AI models"
 msgid "Try Now"
@@ -20286,7 +20824,8 @@ msgstr "Pokušaj omogućiti anonimnu lokaciju za točnije rezultate."
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr "Pokušaj eksperimentirati sa svakim modelom - oni će dati različite odgovore."
+msgstr ""
+"Pokušaj eksperimentirati sa svakim modelom - oni će dati različite odgovore."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
@@ -20452,6 +20991,22 @@ msgid "Trying DuckDuckGo again"
 msgstr "Ponovno isprobavaš DuckDuckGo"
 
 # smartling.placeholder_format=C
+#. Message shown in a modal after supported third-party browser users disable AI features in Settings. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
 msgctxt "Assistant response placeholder"
 msgid "Trying with %s"
@@ -20556,7 +21111,8 @@ msgstr "Uključi %1$sPreciznu lokaciju%2$s za preciznije rezultate"
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
-msgstr "Uključi Duck Player za gledanje vidoezapisa na YouTubeu bez ciljanih oglasa"
+msgstr ""
+"Uključi Duck Player za gledanje vidoezapisa na YouTubeu bez ciljanih oglasa"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service.
@@ -20720,7 +21276,8 @@ msgstr "Nije moguće poslati povratne informacije"
 #. Message shown to the user when the voice chat failed to establish a connection, and they should try again later.
 msgctxt "voice chat"
 msgid "Unable to connect to voice chat, please try again later."
-msgstr "Nije moguće povezivanje s glasovnim čavrljanjem, pokušaj ponovno kasnije."
+msgstr ""
+"Nije moguće povezivanje s glasovnim čavrljanjem, pokušaj ponovno kasnije."
 
 # smartling.placeholder_format=C
 #. Message shown to the user when there was an issue connecting to their microphone.
@@ -20772,7 +21329,8 @@ msgstr "Pod %1$sOtvori s%2$s odaberi %3$sOdređenu stranicu ili stranice%4$s"
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
-msgstr "Pod %1$sPRI POKRETANJU > Početna stranica%2$s unesi: https://duckduckgo.com"
+msgstr ""
+"Pod %1$sPRI POKRETANJU > Početna stranica%2$s unesi: https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -20794,13 +21352,15 @@ msgstr "Pod %1$sTraži%2$s, klikni %3$sUpravljaj tražilicama...%4$s"
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under On startup select %sOpen a specific page or set of pages%s"
-msgstr "Pod Pri pokretanju odaberi %1$sOtvori određenu stranicu ili skup stranica%2$s"
+msgstr ""
+"Pod Pri pokretanju odaberi %1$sOtvori određenu stranicu ili skup stranica%2$s"
 
 #  Opera default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine
 msgid "Under Search click the drop down and select %sDuckDuckGo%s"
-msgstr "Pod Pretraživanje klikni padajući izbornik i odaberi %1$sDuckDuckGo%2$s"
+msgstr ""
+"Pod Pretraživanje klikni padajući izbornik i odaberi %1$sDuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings" header
@@ -20900,7 +21460,8 @@ msgstr "Otključaj uz pretplatu na DuckDuckGo"
 msgctxt "voice chat limit modal"
 msgid ""
 "Unlock advanced AI models and higher limits with a DuckDuckGo Subscription"
-msgstr "Otključaj napredne AI modele i viša ograničenja uz pretplatu na DuckDuckGo"
+msgstr ""
+"Otključaj napredne AI modele i viša ograničenja uz pretplatu na DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Text informing the user that advanced AI models can be unlocked with a subscription. The variable is used to insert a link that opens the subscription modal. Example: Unlock advanced AI models with a DuckDuckGo subscription.
@@ -21128,7 +21689,8 @@ msgctxt ""
 "Description prompting Plus subscribers to upgrade to Pro for higher image "
 "generation limits"
 msgid "Upgrade to Pro to unlock 2x higher limits"
-msgstr "Nadogradi na Pro verziju za otključavanje dva puta veće količine generiranja"
+msgstr ""
+"Nadogradi na Pro verziju za otključavanje dva puta veće količine generiranja"
 
 # smartling.placeholder_format=C
 #. Description shown to Plus subscribers who have reached their image generation limit, encouraging them to upgrade to Pro.
@@ -21195,6 +21757,12 @@ msgstr "Urdu"
 # smartling.placeholder_format=C
 msgid "Uruguay"
 msgstr "Urugvaj"
+
+# smartling.placeholder_format=C
+#. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
+msgctxt "Navigation label on the Duck.ai settings page"
+msgid "Usage"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -21532,8 +22100,8 @@ msgid ""
 msgstr ""
 "Posjeti Duck.ai u svom drugom pregledniku ili u aplikaciji DuckDuckGo i "
 "otvori Postavke Duck.ai. Odaberi „Uključi“ pod Sync & Backup i odaberi "
-"„Sinkronizacija s drugim uređajem“. Ili skeniraj QR kôd na svom Recovery "
-"PDF-u."
+"„Sinkronizacija s drugim uređajem“. Ili skeniraj QR kôd na svom Recovery PDF-"
+"u."
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -21646,6 +22214,12 @@ msgstr "Čeka se lokacija..."
 # smartling.placeholder_format=C
 msgid "Wales"
 msgstr "Wales"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Walk me through the steps"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for walking directions on a map.
@@ -21766,6 +22340,17 @@ msgstr ""
 "rezultate."
 
 # smartling.placeholder_format=C
+#. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
+msgctxt ""
+"Inline warning shown below the share-content toggle when the user selects "
+"Harmful or Illegal but has not enabled sharing"
+msgid ""
+"We can only fix what we can see. To report a harmful or illegal response, "
+"please share this conversation with DuckDuckGo so we can investigate and "
+"address the issue."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
 msgctxt ""
 "Inline warning shown below the share-content toggle when the user selects "
@@ -21792,7 +22377,8 @@ msgstr ""
 msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
-msgstr "Ne možemo pročitati priložene datoteke jer je barem jedna od njih šifrirana."
+msgstr ""
+"Ne možemo pročitati priložene datoteke jer je barem jedna od njih šifrirana."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -22253,8 +22839,8 @@ msgid ""
 "We’re really sorry, but it seems there was a problem loading Duck.ai. Try "
 "reloading the page."
 msgstr ""
-"Stvarno nam je žao, ali čini se da je došlo do problema s učitavanjem "
-"Duck.ai. Pokušaj ponovo učitati stranicu."
+"Stvarno nam je žao, ali čini se da je došlo do problema s učitavanjem Duck."
+"ai. Pokušaj ponovo učitati stranicu."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to suggest an AI (Artificial Intelligence) model to be added to the product, and this field is optional.
@@ -22268,7 +22854,8 @@ msgctxt "Full sentence for improving arguments"
 msgid ""
 "What are some arguments, counter-arguments, and rebuttals to the concept of "
 "a plant-based diet?"
-msgstr "Koji su neki argumenti, protuargumenti i pobijanja koncepta biljne prehrane?"
+msgstr ""
+"Koji su neki argumenti, protuargumenti i pobijanja koncepta biljne prehrane?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for considering factors when purchasing a computer monitor.
@@ -22317,6 +22904,103 @@ msgstr ""
 "naglaskom na Duck.ai integracije i zaštitu privatnosti. Neka to bude "
 "prilično kratko, jednostavno i lako razumljivo ljudima sa ili bez puno "
 "iskustva s umjetnom inteligencijom ili tehničkog iskustva."
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the counterarguments?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the hours & location?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key contributions of this paper?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key contributions?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key details?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key points covered in this video?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key points?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key takeaways from this article?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key takeaways?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key things I will learn from this course?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main counterarguments or criticisms of this?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main questions this page answers?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the must-try dishes here?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"What are the opening hours, location, and contact details for this place?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the pros and cons of this product?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the pros and cons?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
@@ -22419,6 +23103,12 @@ msgid "What does atria mean in the context of a medical article?"
 msgstr "Što znači atrija u kontekstu medicinskog članka?"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What does this answer?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
@@ -22431,20 +23121,32 @@ msgid "What information gets saved?"
 msgstr "Koje se informacije spremaju?"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What interview questions might come up for this role?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
 msgid ""
 "What is the Cloud Save bookmarklet and how does it differ from the URL "
 "parameter bookmarklet?"
 msgstr ""
-"Što je to označeni aplet za Cloud Save i kako se razlikuje od parametra "
-"URL-a označenog apleta?"
+"Što je to označeni aplet za Cloud Save i kako se razlikuje od parametra URL-"
+"a označenog apleta?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for looking up the capital city of Albania.
 msgctxt "Full sentence for looking up basic facts"
 msgid "What is the capital city of Albania?"
 msgstr "Koji je glavni grad Albanije?"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What is the overall verdict and rating for this?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to a page with additional information.
@@ -22469,6 +23171,12 @@ msgid "What people say:"
 msgstr "Što kažu ljudi:"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What should I order?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
 msgctxt "feedback form"
 msgid "What stood out?"
@@ -22481,6 +23189,18 @@ msgid "What was wrong with the response? (optional)"
 msgstr "Što je bilo pogrešno u odgovoru? (neobavezno)"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I learn?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I need?"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid "What would you like to provide feedback on?"
 msgstr "O čemu želiš pružiti povratne informacije?"
@@ -22489,13 +23209,20 @@ msgstr "O čemu želiš pružiti povratne informacije?"
 #. Explains the benefits of using our custom video player, the Duck Player
 msgid ""
 "What you watch in DuckDuckGo won't influence your recommendations on YouTube."
-msgstr "Ono što gledaš u DuckDuckGou neće utjecati na tvoje preporuke na YouTubeu."
+msgstr ""
+"Ono što gledaš u DuckDuckGou neće utjecati na tvoje preporuke na YouTubeu."
 
 # smartling.placeholder_format=C
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
 msgctxt "SERP footer content"
 msgid "What's New"
 msgstr "Što je novo"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What's the verdict?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -22515,7 +23242,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "When enabled, Duck.ai will show instant answers in the chat."
-msgstr "Kada je to omogućeno, Duck.ai će prikazivati izravne odgovore u čavrljanju."
+msgstr ""
+"Kada je to omogućeno, Duck.ai će prikazivati izravne odgovore u čavrljanju."
 
 # smartling.placeholder_format=C
 #. Text of a button that performs a search for the available streaming services that show a particular movie or tv show
@@ -22533,7 +23261,8 @@ msgstr "Gdje gledati <strong>%1$s</strong>"
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Where it says Homepage click %sSet to Current Page%s."
-msgstr "Tamo gdje piše Početna stranica, klikni %1$sPostavi na trenutnu stranicu%2$s."
+msgstr ""
+"Tamo gdje piše Početna stranica, klikni %1$sPostavi na trenutnu stranicu%2$s."
 
 # smartling.placeholder_format=C
 #. Heading of a module showing what streaming services are showing a movie or series, e.g. Where to Watch The Matrix
@@ -22546,6 +23275,12 @@ msgstr "Gdje gledati <strong>%1$s</strong>"
 msgctxt "Feedback prompt"
 msgid "Which features are missing? (Optional)"
 msgstr "Koje značajke nedostaju? (Neobavezno)"
+
+# smartling.placeholder_format=C
+#. An invitation for users to leave feedback
+msgctxt "Feedback prompt"
+msgid "Which features are missing? (optional)"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
@@ -22562,6 +23297,18 @@ msgstr "Bijela"
 #. Link to an about us page.
 msgid "Who We Are"
 msgstr "Tko smo"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Who are the main cast and crew, and what else are they known for?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Who is this person?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Header above a collection of privacy-related links.
@@ -22932,7 +23679,8 @@ msgstr "Da, novi korisnik!"
 msgctxt "cloudsave"
 msgid ""
 "Yes, we throw away data when you’re done with it, and it cannot be recovered."
-msgstr "Da, mi se rješavamo podataka kad ti više ne trebaju i nemoguće ih je vratiti."
+msgstr ""
+"Da, mi se rješavamo podataka kad ti više ne trebaju i nemoguće ih je vratiti."
 
 # smartling.placeholder_format=C
 #. Option for the filter-by-date search.
@@ -23023,7 +23771,8 @@ msgstr ""
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
 msgctxt "Third party map app picker feedback dialog"
 msgid "You can change this any time in %sSearch Settings%s"
-msgstr "Ovo možeš promijeniti u svakom trenutku u %1$sPostavke pretraživanja%2$s"
+msgstr ""
+"Ovo možeš promijeniti u svakom trenutku u %1$sPostavke pretraživanja%2$s"
 
 # smartling.placeholder_format=C
 #. Text explaning how to change a passphrase.
@@ -23056,7 +23805,8 @@ msgstr "Ovaj podsjetnik možeš sakriti kroz %1$sPostavke pretraživanja%2$s"
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
-msgstr "Sada možeš spremiti do 100 čavrljanja na ovom uređaju. Sretno čavrljanje!"
+msgstr ""
+"Sada možeš spremiti do 100 čavrljanja na ovom uređaju. Sretno čavrljanje!"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -23223,7 +23973,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
 msgid "You won't see this message again unless you clear your browser data."
-msgstr "Ovu poruku više nećeš vidjeti osim ako ne izbrišeš podatke svog preglednika."
+msgstr ""
+"Ovu poruku više nećeš vidjeti osim ako ne izbrišeš podatke svog preglednika."
 
 # smartling.placeholder_format=C
 #. The second paragraph of a pop up where we explain how to update the browser manually.
@@ -23316,12 +24067,14 @@ msgstr "Dosegao si maksimalno trajanje glasovnog čavrljanja za jednu sesiju."
 msgctxt "voice chat limit modal"
 msgid ""
 "You've reached the voice chat limit for today. Please try again tomorrow."
-msgstr "Dosegao si ograničenje glasovnog čavrljanja za danas. Pokušaj ponovno sutra."
+msgstr ""
+"Dosegao si ograničenje glasovnog čavrljanja za danas. Pokušaj ponovno sutra."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
 msgid "You've reached your dictation usage limit. Try again later."
-msgstr "Dosegnuto je tvoje ograničenje korištenja diktata. Pokušaj ponovno kasnije."
+msgstr ""
+"Dosegnuto je tvoje ograničenje korištenja diktata. Pokušaj ponovno kasnije."
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -23482,7 +24235,8 @@ msgstr ""
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never used to train AI models"
-msgstr "Tvoji su razgovori privatni i nikada se ne koriste za učenje AI modela."
+msgstr ""
+"Tvoji su razgovori privatni i nikada se ne koriste za učenje AI modela."
 
 # smartling.placeholder_format=C
 #. Text for a description of the active privacy protection for DuckDuckGo's AI Chat feature.
@@ -23543,8 +24297,8 @@ msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
 msgstr ""
-"Vaši su razgovori uvezeni. Samo naprijed i nastavi tamo gdje si stao u "
-"Duck.ai."
+"Vaši su razgovori uvezeni. Samo naprijed i nastavi tamo gdje si stao u Duck."
+"ai."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.
@@ -23709,7 +24463,8 @@ msgctxt "Error message for input limit"
 msgid ""
 "You’ve exceeded the maximum message size. Please shorten your message and "
 "try again."
-msgstr "Premašena je maksimalna duljina poruke. Skrati poruku i pokušaj ponovno."
+msgstr ""
+"Premašena je maksimalna duljina poruke. Skrati poruku i pokušaj ponovno."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -24049,7 +24804,8 @@ msgstr "službenu web lokaciju"
 #. <em>%s</em> is for a hexadecimal color code as <em>#395323</em>, but it has to be safe encoded, and as <em>#</em> seems not safe, <em>%23</em> must be used in place of the sharp symbol, but they are the same for your browser.
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
-msgstr "ili napiši šifru boje koju želiš, npr. %1$s (%2$s je kodirani znak %3$s)."
+msgstr ""
+"ili napiši šifru boje koju želiš, npr. %1$s (%2$s je kodirani znak %3$s)."
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "

--- a/locales/hr_HR/LC_MESSAGES/duckduckgo.po
+++ b/locales/hr_HR/LC_MESSAGES/duckduckgo.po
@@ -10521,7 +10521,7 @@ msgstr "Brz je, besplatan i pruža ti još veću online zaštitu."
 msgctxt "settings"
 msgid ""
 "It's okay to (very infrequently) ask me about my experience using DuckDuckGo"
-msgstr "U redu je ako me (vrlo rijetko) pitate o mojem iskustvu s DuckDuckGoom"
+msgstr "U redu je ako me (vrlo rijetko) pitate o mojem iskustvu s DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. The name of the Italian language
@@ -17640,14 +17640,14 @@ msgstr "Podijeli pozitivne povratne informacije"
 msgctxt ""
 "Label beside the share-content switch on the Duck.ai response feedback form"
 msgid "Share this conversation with DuckDuckGo"
-msgstr "Podijeli ovaj razgovor s DuckDuckGoom"
+msgstr "Podijeli ovaj razgovor s DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
 msgctxt ""
 "Label beside the share-content switch on the Duck.ai response feedback form"
 msgid "Share your prompt and chat response with DuckDuckGo"
-msgstr "Podijeli svoj upit i odgovor u čavrljanju s DuckDuckGoom"
+msgstr "Podijeli svoj upit i odgovor u čavrljanju s DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Variant of the share toggle label that makes sharing mandatory when reporting harmful or illegal content.
@@ -17658,7 +17658,7 @@ msgid ""
 "Share your prompt and chat response with DuckDuckGo (required for illegal "
 "and harmful report)"
 msgstr ""
-"Podijeli svoju poruku i odgovor u čavrljanju s DuckDuckGoom (obavezno za "
+"Podijeli svoju poruku i odgovor u čavrljanju s DuckDuckGo (obavezno za "
 "prijavu nezakonitih i štetnih sadržaja)"
 
 # smartling.placeholder_format=C
@@ -22326,7 +22326,7 @@ msgid ""
 "address the issue."
 msgstr ""
 "Možemo popraviti samo ono što vidimo. Za prijavu štetnog ili nezakonitog "
-"odgovora, podijeli ovaj razgovor s DuckDuckGoom kako bismo mogli istražiti i "
+"odgovora, podijeli ovaj razgovor s DuckDuckGo kako bismo mogli istražiti i "
 "riješiti problem."
 
 # smartling.placeholder_format=C

--- a/locales/hr_HR/LC_MESSAGES/duckduckgo.po
+++ b/locales/hr_HR/LC_MESSAGES/duckduckgo.po
@@ -2,16 +2,15 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: hr_HR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
-"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 
 # smartling.gettext_line_width = normalized : 79
 # smartling.placeholder_format=C
@@ -88,8 +87,7 @@ msgstr "AI modeli %1$s i %2$s"
 #. Message that appears above the search results encouraging them to filter results by domain. The placeholder string would include a the name of a website. E.g. 'Reddit appears in some of the top results for this search.'
 msgctxt "Site filter message"
 msgid "%s appears in some of the top results for this search."
-msgstr ""
-"%1$s se pojavljuje u nekim od najboljih rezultata za ovo pretraživanje."
+msgstr "%1$s se pojavljuje u nekim od najboljih rezultata za ovo pretraživanje."
 
 # smartling.placeholder_format=C
 #. Number of tracking attempts blocked, when there is more than 1. Eg: '2 attempts' or '302 attempts'
@@ -492,8 +490,7 @@ msgstr ""
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "%sLong-press%s the DuckDuckGo app icon on the home screen"
-msgstr ""
-"%1$sPritisni i drži%2$s ikonu aplikacije DuckDuckGo na početnom zaslonu"
+msgstr "%1$sPritisni i drži%2$s ikonu aplikacije DuckDuckGo na početnom zaslonu"
 
 # smartling.placeholder_format=C
 #. A message displayed when there is an error loading content or no results on requery
@@ -898,8 +895,7 @@ msgstr "Dostupna je nova verzija AI Chata! Osvježi ovu stranicu za nastavak."
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of Duck.ai is available! Please refresh this page to continue."
-msgstr ""
-"Dostupna je nova verzija usluge Duck.ai! Osvježi ovu stranicu za nastavak."
+msgstr "Dostupna je nova verzija usluge Duck.ai! Osvježi ovu stranicu za nastavak."
 
 # smartling.placeholder_format=C
 #. Shown when the Duck.ai desktop app has been open a long time and a newer version exists.
@@ -1447,7 +1443,7 @@ msgstr "Adresa je netočna"
 #. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Adjust the servings"
-msgstr ""
+msgstr "Prilagodi porcije"
 
 # smartling.placeholder_format=C
 #. as in multiple advertisements
@@ -1669,6 +1665,9 @@ msgid ""
 "All chats are anonymized by DuckDuckGo, and your conversations are not used "
 "to train chat models by DuckDuckGo or the model providers"
 msgstr ""
+"Svi su razgovori anonimizirani od strane DuckDuckGoa, a tvoji se razgovori "
+"ne koriste za obuku modela čavrljanja od strane DuckDuckGoa ili pružatelja "
+"modela"
 
 # smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1946,6 +1945,9 @@ msgid ""
 "Anonymously generates answers for search queries based on web content. "
 "Choose how often you want it to appear, or disable it completely."
 msgstr ""
+"Anonimno generira odgovore na upite za pretraživanje na temelju web "
+"sadržaja. Odaberi koliko često želiš da se prikazuje ili ga potpuno "
+"onemogući."
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -2229,7 +2231,7 @@ msgstr "Pitaj Duck.ai za daljnje informacije"
 #. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
 msgctxt "Page suggestion chip label"
 msgid "Ask about this page"
-msgstr ""
+msgstr "Pitaj o ovoj stranici"
 
 # smartling.placeholder_format=C
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2409,8 +2411,7 @@ msgstr "Nakon završetka čavrljanja, zvuk ne pohranjujemo ni mi ni OpenAI."
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat is transcribed."
-msgstr ""
-"Zvuk ne pohranjujemo ni mi ni OpenAI nakon što se čavrljanje transkribira."
+msgstr "Zvuk ne pohranjujemo ni mi ni OpenAI nakon što se čavrljanje transkribira."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when MediaRecorder API is unavailable.
@@ -2652,7 +2653,7 @@ msgstr "Crtični kôd"
 #. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Based on this page, is this course worth taking?"
-msgstr ""
+msgstr "Na temelju ove stranice, isplati li se pohađati ovaj tečaj?"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2701,6 +2702,9 @@ msgid ""
 "Before storing this report, DuckDuckGo will anonymize your conversation by "
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
+"Prije pohrane ovog izvješća DuckDuckGo će anonimizirati tvoj razgovor "
+"uklanjanjem osobnih podataka poput imena, adresa e-pošte i identifikacijskih "
+"metapodataka."
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -2842,8 +2846,7 @@ msgstr "Blokiraj ovu stranicu iz svih rezultata"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Block trackers and take control of your personal data"
-msgstr ""
-"Blokiraj alate za praćenje i preuzmi kontrolu nad svojim osobnim podacima"
+msgstr "Blokiraj alate za praćenje i preuzmi kontrolu nad svojim osobnim podacima"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -3023,7 +3026,7 @@ msgstr "Osvojeni breakovi"
 #. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Break this down into clear, numbered steps."
-msgstr ""
+msgstr "Raščlani to u jasne, numerirane korake."
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -3484,7 +3487,7 @@ msgstr "Glume"
 #. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Cast & Crew"
-msgstr ""
+msgstr "Glumačka postava i ekipa"
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -3571,8 +3574,7 @@ msgstr "Promjena načina prikaza URL-ova rezultata"
 #. This is the description of a user setting
 msgctxt "settings"
 msgid "Changes how the header is displayed and its behavior as you scroll"
-msgstr ""
-"Promjena načina prikaza zaglavlja i njegova ponašanja tijekom pomicanja"
+msgstr "Promjena načina prikaza zaglavlja i njegova ponašanja tijekom pomicanja"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/mcZdcaF.png
@@ -4362,8 +4364,7 @@ msgstr "Klikni %1$sPostavke%2$s u padajućem izborniku."
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
-msgstr ""
-"Klikni %1$sUpotrijebi trenutačne stranice%2$s zatim %3$sklikni U redu%4$s."
+msgstr "Klikni %1$sUpotrijebi trenutačne stranice%2$s zatim %3$sklikni U redu%4$s."
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -5154,8 +5155,7 @@ msgstr "Kostarika"
 #. Inline error shown on the recovery code screen when exportSyncSettings rejects.
 msgctxt "Error message when the recovery code fails to generate"
 msgid "Couldn't load your recovery code. Please close this and try again."
-msgstr ""
-"Nije moguće učitati tvoj kôd za oporavak. Zatvori ovo i pokušaj ponovno."
+msgstr "Nije moguće učitati tvoj kôd za oporavak. Zatvori ovo i pokušaj ponovno."
 
 # smartling.placeholder_format=C
 #. Pairs with a Retry button. Shown after two consecutive failed attempts to load the device list.
@@ -5204,7 +5204,7 @@ msgstr "Izradi sliku"
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
-msgstr ""
+msgstr "Kreiraj popis za kupnju s količinama iz ovog recepta."
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed in the input field when starting a new image generation session.
@@ -5853,7 +5853,7 @@ msgstr "Dosegnuto je ograničenje diktiranja"
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
 msgid "Dictation temporarily unavailable"
-msgstr ""
+msgstr "Diktiranje je privremeno nedostupno"
 
 # smartling.placeholder_format=C
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
@@ -5942,8 +5942,7 @@ msgstr "Onemogući i isključi"
 #. Title of a modal that asks the user if they want to turn off chat history and disconnect from Sync & Backup.
 msgctxt "Modal header for disabling chat history and disconnecting sync"
 msgid "Disable chat history and disconnect from Sync & Backup?"
-msgstr ""
-"Onemogućiti povijest čavrljanja i prekinuti vezu s uslugom Sync & Backup?"
+msgstr "Onemogućiti povijest čavrljanja i prekinuti vezu s uslugom Sync & Backup?"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to turn off the chat history feature.
@@ -6163,6 +6162,8 @@ msgid ""
 "Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
 "filtered out. %sLearn More%s"
 msgstr ""
+"Ne želiš AI? %1$snoai.duckduckgo.com%2$s ne nudi AI značajke i filtrira AI "
+"slike. %3$sSaznaj više%4$s"
 
 # smartling.placeholder_format=C
 #. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
@@ -6171,6 +6172,8 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
+"Ne želiš AI? Posjeti %1$snoai.duckduckgo.com%2$s za pretraživanje bez AI "
+"značajki i s filtriranim AI slikama. %3$sSaznaj više%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6290,13 +6293,13 @@ msgstr ""
 #. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Draft a cover letter"
-msgstr ""
+msgstr "Izradi popratno pismo"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Draft a cover letter for this job."
-msgstr ""
+msgstr "Izradi popratno pismo za ovaj posao."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -6471,8 +6474,7 @@ msgstr ""
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
-msgstr ""
-"Duck.ai je najbolji u našem privatnom i besplatnom DuckDuckGo pregledniku!"
+msgstr "Duck.ai je najbolji u našem privatnom i besplatnom DuckDuckGo pregledniku!"
 
 # smartling.placeholder_format=C
 #. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
@@ -6482,6 +6484,9 @@ msgid ""
 "company for anyone who wants to take back control of their personal "
 "information."
 msgstr ""
+"Duck.ai izrađuje DuckDuckGo. DuckDuckGo je neovisna tvrtka za zaštitu "
+"privatnosti na internetu za svakoga tko želi preuzeti kontrolu nad svojim "
+"osobnim podacima."
 
 # smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
@@ -6534,6 +6539,9 @@ msgid ""
 "Duck.ai lets you chat privately with popular AI models. Disabling it hides "
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
+"Duck.ai ti omogućuje privatno čavrljanje s popularnim AI modelima. "
+"Isključivanjem se skrivaju gumbi i poveznice za Duck.ai, ali %1$sduck.ai%2$s "
+"i dalje možeš posjetiti izravno."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6784,8 +6792,7 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr ""
-"DuckDuckGo AI Chat trenutačno nije dostupan. Pokušaj ponovno nešto kasnije."
+msgstr "DuckDuckGo AI Chat trenutačno nije dostupan. Pokušaj ponovno nešto kasnije."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -6914,8 +6921,8 @@ msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid ""
 "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to Duck.ai's %s."
 msgstr ""
-"DuckDuckGo anonimizira tvoje razgovore. Klikom na '%1$s' prihvaćaš Duck.ai-"
-"jeve %2$s."
+"DuckDuckGo anonimizira tvoje razgovore. Klikom na '%1$s' prihvaćaš "
+"Duck.ai-jeve %2$s."
 
 # smartling.placeholder_format=C
 #. Shown below the input on the empty state when the user has not yet accepted the terms of service. The first %s is the action button label ('Ask' for chat, 'Create' for image generation). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. Clicking the action button both accepts the terms and submits the prompt.
@@ -6923,8 +6930,7 @@ msgctxt ""
 "Inline terms-of-service disclaimer below chat or image-gen input for new "
 "users"
 msgid "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to our %s."
-msgstr ""
-"DuckDuckGo anonimizira tvoje razgovore. Klikom na '%1$s' prihvaćaš naše %2$s."
+msgstr "DuckDuckGo anonimizira tvoje razgovore. Klikom na '%1$s' prihvaćaš naše %2$s."
 
 # smartling.placeholder_format=C
 #. An information popup explaining that we block trackers
@@ -7125,8 +7131,7 @@ msgstr "Slika se uređuje..."
 msgctxt "Info text for the editing message feature"
 msgid ""
 "Editing your message will remove the response below and generate a new one."
-msgstr ""
-"Uređivanjem tvoje poruke uklonit će se odgovor ispod nje i generirati novi."
+msgstr "Uređivanjem tvoje poruke uklonit će se odgovor ispod nje i generirati novi."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of an editor in its responses.
@@ -7527,8 +7532,7 @@ msgstr "Ekvatorska Gvineja"
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Erase your browsing data in a flash with our %sFire Button%s"
-msgstr ""
-"Brzo izbriši svoje podatke o pregledavanju koristeći naš %1$sFire Button%2$s"
+msgstr "Brzo izbriši svoje podatke o pregledavanju koristeći naš %1$sFire Button%2$s"
 
 # smartling.placeholder_format=C
 msgid "Eritrea"
@@ -7538,13 +7542,13 @@ msgstr "Eritreja"
 #. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Estimate the nutrition"
-msgstr ""
+msgstr "Procijeni prehranu"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Estimate the nutritional information for this recipe."
-msgstr ""
+msgstr "Procijeni nutritivne vrijednosti za ovaj recept."
 
 # smartling.placeholder_format=C
 msgid "Estonia"
@@ -7606,7 +7610,7 @@ msgstr "Istječe za 1 dan"
 #. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain the accepted answer in simple terms."
-msgstr ""
+msgstr "Objasni prihvaćeni odgovor jednostavnim riječima."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
@@ -7619,43 +7623,43 @@ msgstr "Objasni mi temeljne koncepte crnih rupa na razini srednje škole."
 #. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain the top answer"
-msgstr ""
+msgstr "Objasni glavni odgovor"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain this in simple, plain language."
-msgstr ""
+msgstr "Objasni ovo jednostavnim, jasnim jezikom."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain this paper"
-msgstr ""
+msgstr "Objasni ovaj rad"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain this repo"
-msgstr ""
+msgstr "Objasni ovaj repozitorij"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain this research paper in plain language."
-msgstr ""
+msgstr "Objasni ovaj istraživački rad jednostavnim jezikom."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain this simply"
-msgstr ""
+msgstr "Objasni ovo na jednostavan način"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain what this repository does and how to use it."
-msgstr ""
+msgstr "Objasni što ovaj repozitorij radi i kako ga koristiti."
 
 # smartling.placeholder_format=C
 #. Label to show if song lyrics contain explicit content
@@ -7852,8 +7856,8 @@ msgid ""
 "Feel free to adjust the settings below. Then, just copy and paste the code "
 "into your website."
 msgstr ""
-"Prilagodi donje postavke, a zatim samo kopiraj i zalijepi kôd na svoje web-"
-"mjesto."
+"Prilagodi donje postavke, a zatim samo kopiraj i zalijepi kôd na svoje "
+"web-mjesto."
 
 # smartling.placeholder_format=C
 msgid "Fiji"
@@ -7947,6 +7951,8 @@ msgctxt "settings"
 msgid ""
 "Filters out known AI spam sites from image search results. %sLearn More%s"
 msgstr ""
+"Filtrira poznata neželjena web-mjesta s AI-jem iz rezultata pretraživanja "
+"slika. %1$sSaznaj više%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the final score of a sporting event.
@@ -7987,8 +7993,7 @@ msgstr "Pronađi <b>%1$s</b> u mapi za preuzimanje"
 # smartling.placeholder_format=C
 #. Tells users how to change their default search engine to DuckDuckGo.
 msgid "Find DuckDuckGo in the displayed list and click %sMake Default%s"
-msgstr ""
-"Pronađi DuckDuckGo u prikazanom popisu i klikni %1$sPostavi za zadano%2$s"
+msgstr "Pronađi DuckDuckGo u prikazanom popisu i klikni %1$sPostavi za zadano%2$s"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for finding a better word.
@@ -8006,7 +8011,7 @@ msgstr "Pronađi aktualne informacije"
 #. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Find me alternatives"
-msgstr ""
+msgstr "Pronađi mi druge mogućnosti"
 
 # smartling.placeholder_format=C
 #. Button that searches for results closer to the user's current location.
@@ -8203,8 +8208,7 @@ msgstr "Besplatni i privatni razgovori, mi ih anonimiziramo"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr ""
-"Besplatni i privatni razgovori, mi ih anonimiziramo. Nije potreban račun."
+msgstr "Besplatni i privatni razgovori, mi ih anonimiziramo. Nije potreban račun."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -8490,7 +8494,7 @@ msgstr "Generiraj više"
 #. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Generate a shopping list"
-msgstr ""
+msgstr "Generiraj popis za kupnju"
 
 # smartling.placeholder_format=C
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
@@ -8787,7 +8791,7 @@ msgstr "Isprobaj ga"
 #. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Give me a quick background on this person."
-msgstr ""
+msgstr "Daj mi kratke informacije o ovoj osobi."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9239,13 +9243,13 @@ msgstr "Pomozi nam širiti privatnost"
 #. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Help me prep for the interview"
-msgstr ""
+msgstr "Pomozi mi pripremiti se za intervju"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Help me tailor my resume for this job."
-msgstr ""
+msgstr "Pomozi mi prilagoditi životopis za ovaj posao."
 
 # smartling.placeholder_format=C
 #. Title of a SERP popup that invites users to take a survey (desktop only)
@@ -9257,8 +9261,7 @@ msgstr "Pomozi nam poboljšati DuckDuckGo"
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Help us improve DuckDuckGo searches with your feedback"
-msgstr ""
-"Pomozi nam poboljšati DuckDuckGo pretraživanja svojim povratnim informacijama"
+msgstr "Pomozi nam poboljšati DuckDuckGo pretraživanja svojim povratnim informacijama"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -9689,8 +9692,7 @@ msgstr "Kako funkcionira"
 #. Header for the assist settings modal where the user can choose how often they want AI-assisted answers to appear.
 msgctxt "duckassist"
 msgid "How much do you want AI-assisted answers to appear?"
-msgstr ""
-"Koliko često želiš da se pojave odgovori uz pomoć umjetne inteligencije?"
+msgstr "Koliko često želiš da se pojave odgovori uz pomoć umjetne inteligencije?"
 
 # smartling.placeholder_format=C
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
@@ -9770,7 +9772,7 @@ msgctxt ""
 "Text for the I already have a subscription button in the Duck.ai settings "
 "page"
 msgid "I Already Have a Subscription"
-msgstr ""
+msgstr "Već imam pretplatu"
 
 # smartling.placeholder_format=C
 #. Text for the button that takes the user to the login subscription page.
@@ -9949,8 +9951,7 @@ msgstr "Ako nas ipak želiš podržati, %1$spomozi proširiti DuckDuckGo%2$s"
 msgid ""
 "If you want to use DuckDuckGo without JavaScript, please use our %s or %s "
 "versions."
-msgstr ""
-"Želiš li koristiti DuckDuckGo bez JavaScripta, koristi %1$s ili %2$s verziju."
+msgstr "Želiš li koristiti DuckDuckGo bez JavaScripta, koristi %1$s ili %2$s verziju."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -10258,8 +10259,7 @@ msgstr "Lako pregledavanje rezultata pretraživanja za slike i videozapise"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Infinite Scroll for Images, Videos, and Shopping"
-msgstr ""
-"Lako pregledavanje rezultata pretraživanja slika, videozapisa i kupovina"
+msgstr "Lako pregledavanje rezultata pretraživanja slika, videozapisa i kupovina"
 
 # smartling.placeholder_format=C
 #. Feedback option when AI response is accurate
@@ -10352,7 +10352,7 @@ msgstr "Instaliraj Mac preglednik"
 #. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
 msgctxt "settings"
 msgid "Install Now"
-msgstr ""
+msgstr "Instaliraj"
 
 # smartling.placeholder_format=C
 #. Text of a button to install the DuckDuckGo app
@@ -10455,13 +10455,13 @@ msgstr "Brišu li se podaci doista?"
 #. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Is it worth taking?"
-msgstr ""
+msgstr "Isplati li se uzeti?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Is this place any good?"
-msgstr ""
+msgstr "Je li ovo mjesto dobro?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
@@ -10470,6 +10470,8 @@ msgid ""
 "Is this place any good? Summarize its reputation based on reviews and "
 "ratings."
 msgstr ""
+"Je li ovo mjesto dobro? Sažmi njegovu reputaciju na temelju recenzija i "
+"ocjena."
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -10481,13 +10483,13 @@ msgstr "Je li ovaj videozapis koristan?"
 #. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Is this worth watching?"
-msgstr ""
+msgstr "Isplati li se ovo gledati?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Is this worth watching? Give me a spoiler-free take."
-msgstr ""
+msgstr "Isplati li se ovo gledati? Daj mi mišljenje bez spoilera."
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -11101,7 +11103,7 @@ msgstr "Poveznice:"
 #. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
-msgstr ""
+msgstr "Navedi alate, materijale ili preduvjete koji su mi potrebni za ovo."
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -11515,7 +11517,7 @@ msgstr "Upravljanje blokiranim mrežnim lokacijama"
 #. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
 msgctxt "setting"
 msgid "Manage in Browser Settings"
-msgstr ""
+msgstr "Upravljaj u postavkama preglednika"
 
 # smartling.placeholder_format=C
 #. Link to the site exclusion settings page
@@ -11740,8 +11742,7 @@ msgstr "Mikronezija"
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
 msgid ""
 "Microphone access was denied. Please allow microphone access and try again."
-msgstr ""
-"Pristup mikrofona je uskraćen. Dopusti pristup mikrofonu i pokušaj ponovno."
+msgstr "Pristup mikrofona je uskraćen. Dopusti pristup mikrofonu i pokušaj ponovno."
 
 # smartling.placeholder_format=C
 #. The Microsoft brand name.
@@ -14349,7 +14350,7 @@ msgstr "Ispuni sljedeći upit i potvrdi da je ovo pretraživanje izvršio čovje
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is harmful or illegal. (optional)"
-msgstr ""
+msgstr "Opiši zašto je odgovor na čavrljanju štetan ili nezakonit. (neobavezno)"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
@@ -14386,6 +14387,8 @@ msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is harmful or illegal."
 msgstr ""
+"Zalijepi svoj upit i problematični odgovor (bez svih osobnih podataka) i "
+"opiši zašto je sadržaj štetan ili nezakonit."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -14858,7 +14861,7 @@ msgstr "Privatnost"
 #. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
 msgctxt "Section heading on the Duck.ai settings page"
 msgid "Privacy & Terms"
-msgstr ""
+msgstr "Privatnost i uvjeti"
 
 # smartling.placeholder_format=C
 msgid "Privacy Blog"
@@ -14934,7 +14937,7 @@ msgstr "Pravila privatnosti i Uvjeti pružanja usluge"
 #. Text for a button that links to the terms of use and privacy policy page.
 msgctxt "Secondary button text in active privacy modal"
 msgid "Privacy Policy and Terms of Service"
-msgstr ""
+msgstr "Pravila privatnosti i Uvjeti pružanja usluge"
 
 # smartling.placeholder_format=C
 #. Title displayed on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
@@ -15444,25 +15447,25 @@ msgstr "Preporuči knjigu"
 #. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Recommend similar books"
-msgstr ""
+msgstr "Preporuči slične knjige"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Recommend similar books."
-msgstr ""
+msgstr "Preporuči slične knjige."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Recommend similar movies or shows."
-msgstr ""
+msgstr "Preporuči slične filmove ili TV emisije."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Recommend similar titles"
-msgstr ""
+msgstr "Preporuči slične naslove"
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
@@ -15677,8 +15680,8 @@ msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
 msgstr ""
-"Ponovno učitaj DuckDuckGo slijedeći upute ili klikom na gumb &quot;"
-"Osvježi&quot; (Refresh) ili &quot;Ponovno učitaj&quot; (Reload) u "
+"Ponovno učitaj DuckDuckGo slijedeći upute ili klikom na gumb "
+"&quot;Osvježi&quot; (Refresh) ili &quot;Ponovno učitaj&quot; (Reload) u "
 "pregledniku."
 
 # smartling.placeholder_format=C
@@ -15689,8 +15692,7 @@ msgstr "Zapamti moj izbor"
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings
 msgid "Remember my choice (this can be changed in %s%s%sSettings%s)"
-msgstr ""
-"Zapamti moj odabir (ovo se može promijeniti u %1$s%2$s%3$sPostavkama%4$s)"
+msgstr "Zapamti moj odabir (ovo se može promijeniti u %1$s%2$s%3$sPostavkama%4$s)"
 
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
@@ -15875,7 +15877,7 @@ msgctxt ""
 "feedback form when the user has selected Harmful or Illegal as the feedback "
 "reason"
 msgid "Required for harmful or illegal reports"
-msgstr ""
+msgstr "Obavezno za prijave štetnog ili nezakonitog sadržaja"
 
 # smartling.placeholder_format=C
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
@@ -16118,7 +16120,7 @@ msgstr "Recenzije"
 #. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Rewrite this recipe scaled for a different number of servings."
-msgstr ""
+msgstr "Prepiši ovaj recept prilagođen za drugačiji broj porcija."
 
 # smartling.placeholder_format=C
 msgid "Romania"
@@ -16404,8 +16406,7 @@ msgstr "Spremi do 30 svojih najnovijih čavrljanja lokalno na svom uređaju."
 msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
-msgstr ""
-"Spremi svoja Duck.ai čavrljanja između uređaja pomoću end-to-end šifriranja."
+msgstr "Spremi svoja Duck.ai čavrljanja između uređaja pomoću end-to-end šifriranja."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -16572,8 +16573,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down to the %sServices%s section and click %sAddress bar%s."
-msgstr ""
-"Listaj prema dolje do %1$sUsluga%2$s i klikni na %3$sAdresna traka%4$s."
+msgstr "Listaj prema dolje do %1$sUsluga%2$s i klikni na %3$sAdresna traka%4$s."
 
 # smartling.placeholder_format=C
 #. Rugby match stats
@@ -16860,8 +16860,7 @@ msgstr "Pretraži putem DuckDuckGoa"
 #. Text for a promotional card encouraging third-party browser users to download the DuckDuckGo browser. Not shown in the DuckDuckGo browser or on Linux.
 msgctxt "Promotional text"
 msgid "Search, browse, and chat privately in our free browser"
-msgstr ""
-"Pretražuj, pregledavaj i privatno razgovaraj u našem besplatnom pregledniku"
+msgstr "Pretražuj, pregledavaj i privatno razgovaraj u našem besplatnom pregledniku"
 
 # smartling.placeholder_format=C
 #. Message displayed sometimes at top of results (for bang syntax), e.g. <a href="https://duckduckgo.com/?q=twitter+test">https://duckduckgo.com/?q=twitter+test</a>
@@ -16905,8 +16904,7 @@ msgstr "Tjedni sezone"
 #. Description shown in the Sync & Backup settings section when sync is not yet enabled, explaining the feature.
 msgctxt "Description for sync and backup feature"
 msgid "Securely save and sync your chats across all your devices."
-msgstr ""
-"Sigurno spremi i sinkroniziraj svoja čavrljanja na svim svojim uređajima."
+msgstr "Sigurno spremi i sinkroniziraj svoja čavrljanja na svim svojim uređajima."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -16955,8 +16953,7 @@ msgstr ""
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
 msgctxt "Sync feature benefit description"
 msgid "Securely stored on DuckDuckGo's server with end-to-end encryption."
-msgstr ""
-"Sigurno pohranjeno na DuckDuckGo poslužitelju s end-to-end šifriranjem."
+msgstr "Sigurno pohranjeno na DuckDuckGo poslužitelju s end-to-end šifriranjem."
 
 # smartling.placeholder_format=C
 #. List item explaining that synced chats are stored with end-to-end encryption on DuckDuckGo's server and only the user can access them.
@@ -17142,8 +17139,7 @@ msgstr "Odaberi %1$sDuckDuckGo%2$s u padajućem izborniku zadanih tražilica"
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %sDuckDuckGo%s in the list and %sallow%s location access"
-msgstr ""
-"Odaberi %1$sDuckDuckGo%2$s na popisu i %3$sdopusti%4$s pristup lokaciji"
+msgstr "Odaberi %1$sDuckDuckGo%2$s na popisu i %3$sdopusti%4$s pristup lokaciji"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -17262,8 +17258,7 @@ msgstr ""
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %syour browser%s in the list and %sallow%s location access"
-msgstr ""
-"Odaberi %1$ssvoj preglednik%2$s na popisu i %3$sdopusti%4$s pristup lokaciji"
+msgstr "Odaberi %1$ssvoj preglednik%2$s na popisu i %3$sdopusti%4$s pristup lokaciji"
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the modal for deleting all recent chats, that allows the user to select the chats to delete.
@@ -17459,7 +17454,7 @@ msgstr "Postavi odmah"
 #. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
 msgctxt "Encrypted storage setup button shown in native browsers"
 msgid "Set Up Sync & Backup"
-msgstr ""
+msgstr "Postavi Sync & Backup"
 
 # smartling.placeholder_format=C
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
@@ -17497,8 +17492,7 @@ msgstr ""
 #. Prompt for the user to indicate their location on a map, to enable more relevant search results.
 msgctxt "precise_user_location"
 msgid "Set your location manually, or ensure Location Services is enabled."
-msgstr ""
-"Ručno postavi lokaciju ili provjeri jesu li omogućene lokacijske usluge."
+msgstr "Ručno postavi lokaciju ili provjeri jesu li omogućene lokacijske usluge."
 
 # smartling.placeholder_format=C
 #. In the top dropdown menu  ("More" > "Settings")
@@ -17552,8 +17546,7 @@ msgstr "Podijeli"
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "Share DuckDuckGo and help friends take their privacy back!"
-msgstr ""
-"Podijeli DuckDuckGo i pomozi prijateljima u vraćanju njihove privatnosti!"
+msgstr "Podijeli DuckDuckGo i pomozi prijateljima u vraćanju njihove privatnosti!"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button that opens a feedback modal when clicked.
@@ -17647,7 +17640,7 @@ msgstr "Podijeli pozitivne povratne informacije"
 msgctxt ""
 "Label beside the share-content switch on the Duck.ai response feedback form"
 msgid "Share this conversation with DuckDuckGo"
-msgstr ""
+msgstr "Podijeli ovaj razgovor s DuckDuckGoom"
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -17786,8 +17779,7 @@ msgstr "Prikaži DuckAssist <sup>BETA</sup>"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show DuckAssist more often. (You can also completely %sturn it off%s.)"
-msgstr ""
-"Češće prikazuj DuckAssist. (Također ga možeš potpuno %1$sisključiti%2$s.)"
+msgstr "Češće prikazuj DuckAssist. (Također ga možeš potpuno %1$sisključiti%2$s.)"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
@@ -18102,8 +18094,7 @@ msgstr "Prikazuje poruku dobrodošlice na vrhu stranice rezultata pretraživanja
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message to EU Android preference menu users"
-msgstr ""
-"Prikazuje poruku dobrodošlice korisnicima Androida u EU, u izborniku postavki"
+msgstr "Prikazuje poruku dobrodošlice korisnicima Androida u EU, u izborniku postavki"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers sometimes.
@@ -18175,14 +18166,12 @@ msgstr "Nazivi web-mjesta"
 #. A message saying that site filters are not currently working
 msgctxt "Site filter message"
 msgid "Site search is temporarily unavailable. We are working on a fix."
-msgstr ""
-"Pretraživanje web lokacija privremeno je nedostupno. Radimo na rješenju."
+msgstr "Pretraživanje web lokacija privremeno je nedostupno. Radimo na rješenju."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Sites you block will be hidden from all your search results"
-msgstr ""
-"Stranice koje blokiraš bit će skrivene iz svih tvojih rezultata pretraživanja"
+msgstr "Stranice koje blokiraš bit će skrivene iz svih tvojih rezultata pretraživanja"
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes full name (tooltip)
@@ -18353,8 +18342,7 @@ msgstr "Ponekad"
 #. Generic error message shown when the image generation model cannot process the user's request.
 msgctxt "Error message from the image generation model"
 msgid "Sorry I can't help, please describe your image in a different way."
-msgstr ""
-"Žao mi je što ne mogu pomoći, molim te opiši svoju sliku na drugačiji način."
+msgstr "Žao mi je što ne mogu pomoći, molim te opiši svoju sliku na drugačiji način."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -18402,8 +18390,7 @@ msgctxt "Description for the wrong code error screen"
 msgid ""
 "Sorry, this code is invalid. Please make sure the correct code was entered "
 "or scanned."
-msgstr ""
-"Nažalost, ovaj je kôd nevažeći. Provjeri je li unesen ili skeniran točan kôd."
+msgstr "Nažalost, ovaj je kôd nevažeći. Provjeri je li unesen ili skeniran točan kôd."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -18483,8 +18470,7 @@ msgstr "Izvorni tekst je izbrisan"
 msgctxt "Error message for summary selection input limit"
 msgid ""
 "Source text is too long to summarize. Try again with a shorter selection."
-msgstr ""
-"Izvorni tekst je predug za sažimanje. Pokušaj ponovno s kraćim odabirom."
+msgstr "Izvorni tekst je predug za sažimanje. Pokušaj ponovno s kraćim odabirom."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under Interface Settings.in the end. It is a header
@@ -18683,22 +18669,19 @@ msgstr "Ostani na DuckDuckGou"
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletter."
-msgstr ""
-"Ostani zaštićen i informiran putem naših e-novosti o zaštiti privatnosti."
+msgstr "Ostani zaštićen i informiran putem naših e-novosti o zaštiti privatnosti."
 
 # smartling.placeholder_format=C
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletters."
-msgstr ""
-"Ostani zaštićen i informiran putem naših biltena o zaštiti privatnosti."
+msgstr "Ostani zaštićen i informiran putem naših biltena o zaštiti privatnosti."
 
 # smartling.placeholder_format=C
 #. Text on the page where users can subscribe to DuckDuckGo's privacy newsletter
 msgctxt "showcase_newsletter"
 msgid "Stay protected and informed with our privacy newsletters."
-msgstr ""
-"Ostani zaštićen i informiran putem naših biltena o zaštiti privatnosti."
+msgstr "Ostani zaštićen i informiran putem naših biltena o zaštiti privatnosti."
 
 # smartling.placeholder_format=C
 #. Loading message shown when image generation is taking longer than usual.
@@ -18736,15 +18719,14 @@ msgstr "Zaustavi generiranje"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop hidden trackers lurking on other websites."
-msgstr ""
-"Onemogući skrivene alate za praćenje koji vrebaju na drugim web-mjestima."
+msgstr "Onemogući skrivene alate za praćenje koji vrebaju na drugim web-mjestima."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop most hidden trackers lurking on other websites."
 msgstr ""
-"Onemogući većinu skrivenih alata za praćenje koji vrebaju na drugim web-"
-"mjestima."
+"Onemogući većinu skrivenih alata za praćenje koji vrebaju na drugim "
+"web-mjestima."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18917,19 +18899,19 @@ msgstr "Predloži naslov za objavu na blogu"
 #. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Suggest related articles or topics worth exploring next."
-msgstr ""
+msgstr "Predloži povezane članke ili teme koje vrijedi istražiti sljedeće."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Suggest related articles to explore"
-msgstr ""
+msgstr "Predloži povezane članke za istraživanje"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Suggest some alternatives to this product."
-msgstr ""
+msgstr "Predloži neke druge mogućnosti za ovaj proizvod."
 
 # smartling.placeholder_format=C
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
@@ -18946,7 +18928,7 @@ msgstr "Prijedlozi:"
 #. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Sum up the reviews"
-msgstr ""
+msgstr "Sažmi recenzije"
 
 # smartling.placeholder_format=C
 #. A short title for the a message asking the AI to summarize a text.
@@ -18958,85 +18940,85 @@ msgstr "Sažmi"
 #. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize the Q&As"
-msgstr ""
+msgstr "Sažmi pitanja i odgovore"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the background and notable work of this person."
-msgstr ""
+msgstr "Sažmi pozadinu i značajan rad ove osobe."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the key details of this event."
-msgstr ""
+msgstr "Sažmi ključne pojedinosti ovog događaja."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the questions and answers on this page."
-msgstr ""
+msgstr "Sažmi pitanja i odgovore na ovoj stranici."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize their background"
-msgstr ""
+msgstr "Sažmi njihovu pozadinu"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this book"
-msgstr ""
+msgstr "Sažmi ovu knjigu"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this book."
-msgstr ""
+msgstr "Sažmi ovu knjigu."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this discussion"
-msgstr ""
+msgstr "Sažmi ovu raspravu"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this discussion thread."
-msgstr ""
+msgstr "Sažmi ovu raspravu."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this page"
-msgstr ""
+msgstr "Sažmi ovu stranicu"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this page."
-msgstr ""
+msgstr "Sažmi ovu stranicu."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this video"
-msgstr ""
+msgstr "Sažmi ovaj video"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this video."
-msgstr ""
+msgstr "Sažmi ovaj video."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize what the reviews say."
-msgstr ""
+msgstr "Sažmi što kažu recenzije."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -19367,7 +19349,7 @@ msgstr "Sirija"
 #. Text for a button that enables the theme to follow the operating system's color scheme preference.
 msgctxt "System theme button for theme selector"
 msgid "System"
-msgstr ""
+msgstr "Zadano"
 
 # smartling.placeholder_format=C
 #. Abbreviation indicating this is the total score for a game
@@ -19401,7 +19383,7 @@ msgstr "Tahićansko"
 #. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Tailor my resume"
-msgstr ""
+msgstr "Prilagodi moj životopis"
 
 # smartling.placeholder_format=C
 msgid "Taiwan"
@@ -19437,7 +19419,7 @@ msgstr "Preuzmi nadzor nad svojim osobnim podacima!"
 msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
-msgstr ""
+msgstr "Ispuni ovu anonimnu anketu i javi nam kako možemo poboljšati Duck.ai."
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -19685,8 +19667,7 @@ msgstr "Priložene datoteke prelaze ukupno ograničenje veličine od %1$s MB."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the server rejects corrupt or unrecognized audio.
 msgid "The audio could not be processed. Please try recording again."
-msgstr ""
-"Zvučni zapis nije moguće obraditi. Pokušaj ponovno snimiti zvučni zapis."
+msgstr "Zvučni zapis nije moguće obraditi. Pokušaj ponovno snimiti zvučni zapis."
 
 # smartling.placeholder_format=C
 #. Second paragraph explaining where the encryption key is stored on the entry screen.
@@ -19749,7 +19730,7 @@ msgstr "Tema"
 #. Text for the theme selector label that allows users to switch between Light and dark theme.
 msgctxt "Label for the theme selector feature"
 msgid "Theme"
-msgstr ""
+msgstr "Tema"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/LpFhb1e.png
@@ -20065,8 +20046,7 @@ msgstr "Za pravilno funkcioniranje ove stranice potreban je Javascript."
 #. Information tooltip text explaining that the current page's content will be included with the chat message.
 msgctxt "Tooltip explaining that page content will be sent to Duck.ai"
 msgid "This page's content will be sent with your message to Duck.ai"
-msgstr ""
-"Sadržaj ove stranice bit će poslan alatu Duck.ai zajedno s tvojom porukom"
+msgstr "Sadržaj ove stranice bit će poslan alatu Duck.ai zajedno s tvojom porukom"
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -20137,8 +20117,7 @@ msgstr "Ovaj je prijevod pogrešan"
 # smartling.placeholder_format=C
 #. Label indicating that the video can't be played on the current page, and only on the website that owns the vide. The placeholder is the name of the website that owns the video.
 msgid "This video is not yet able to be watched here. You can watch it on %s."
-msgstr ""
-"Ovaj se videozapis ovdje još ne može gledati. Možeš ga pogledati na %1$s."
+msgstr "Ovaj se videozapis ovdje još ne može gledati. Možeš ga pogledati na %1$s."
 
 # smartling.placeholder_format=C
 #. Message indicating that a website is not using an encrypted connection and is not secure.
@@ -20308,8 +20287,8 @@ msgid ""
 "To print directions:%sGo back to the map.%sSelect the route you want to "
 "print.%sClick the print icon.%s"
 msgstr ""
-"Za ispis uputa:%1$svrati se na kartu.%2$sOdaberi rutu koju želiš ispisati."
-"%3$sKlikni na ikonu za ispis.%4$s"
+"Za ispis uputa:%1$svrati se na kartu.%2$sOdaberi rutu koju želiš "
+"ispisati.%3$sKlikni na ikonu za ispis.%4$s"
 
 # smartling.placeholder_format=C
 #. Explains where the user can find their recovery code. Figma frame 3703-44420.
@@ -20405,8 +20384,7 @@ msgstr "Previše oglasa"
 #. Displayed when the user has sent too many requests in a short period of time.
 msgctxt "Error message for rate limit"
 msgid "Too many requests. Please take a short break and try again."
-msgstr ""
-"Previše zahtjeva. Molimo te da napraviš kratku pauzu i pokušaš ponovno."
+msgstr "Previše zahtjeva. Molimo te da napraviš kratku pauzu i pokušaš ponovno."
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -20598,13 +20576,13 @@ msgstr ""
 #. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Translate this page"
-msgstr ""
+msgstr "Prevedi ovu stranicu"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
 msgctxt "Page suggestion prompt"
 msgid "Translate this page into %s."
-msgstr ""
+msgstr "Prevedi ovu stranicu na %1$s."
 
 # smartling.placeholder_format=C
 #. Placeholder text for a region that will display translated text.
@@ -20751,7 +20729,7 @@ msgstr "Isprobaj besplatno"
 #. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
 msgctxt "settings"
 msgid "Try It Now"
-msgstr ""
+msgstr "Isprobaj odmah"
 
 # smartling.placeholder_format=C
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -20824,8 +20802,7 @@ msgstr "Pokušaj omogućiti anonimnu lokaciju za točnije rezultate."
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr ""
-"Pokušaj eksperimentirati sa svakim modelom - oni će dati različite odgovore."
+msgstr "Pokušaj eksperimentirati sa svakim modelom - oni će dati različite odgovore."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
@@ -20997,6 +20974,9 @@ msgid ""
 "Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
+"Želiš onemogućiti AI značajke? Instaliraj %1$sDuckDuckGo No AI%2$s "
+"proširenje za pretraživanje kako bi zapamtio svoje postavke. %3$sSaznaj "
+"više%4$s"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -21005,6 +20985,9 @@ msgid ""
 "Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
+"Želiš onemogućiti AI značajke? Prebaci se na %1$sDuckDuckGo No AI%2$s "
+"proširenje za pretraživanje kako bi zapamtio svoje postavke. %3$sSaznaj "
+"više%4$s"
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -21111,8 +21094,7 @@ msgstr "Uključi %1$sPreciznu lokaciju%2$s za preciznije rezultate"
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
-msgstr ""
-"Uključi Duck Player za gledanje vidoezapisa na YouTubeu bez ciljanih oglasa"
+msgstr "Uključi Duck Player za gledanje vidoezapisa na YouTubeu bez ciljanih oglasa"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service.
@@ -21276,8 +21258,7 @@ msgstr "Nije moguće poslati povratne informacije"
 #. Message shown to the user when the voice chat failed to establish a connection, and they should try again later.
 msgctxt "voice chat"
 msgid "Unable to connect to voice chat, please try again later."
-msgstr ""
-"Nije moguće povezivanje s glasovnim čavrljanjem, pokušaj ponovno kasnije."
+msgstr "Nije moguće povezivanje s glasovnim čavrljanjem, pokušaj ponovno kasnije."
 
 # smartling.placeholder_format=C
 #. Message shown to the user when there was an issue connecting to their microphone.
@@ -21329,8 +21310,7 @@ msgstr "Pod %1$sOtvori s%2$s odaberi %3$sOdređenu stranicu ili stranice%4$s"
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
-msgstr ""
-"Pod %1$sPRI POKRETANJU > Početna stranica%2$s unesi: https://duckduckgo.com"
+msgstr "Pod %1$sPRI POKRETANJU > Početna stranica%2$s unesi: https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -21352,15 +21332,13 @@ msgstr "Pod %1$sTraži%2$s, klikni %3$sUpravljaj tražilicama...%4$s"
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under On startup select %sOpen a specific page or set of pages%s"
-msgstr ""
-"Pod Pri pokretanju odaberi %1$sOtvori određenu stranicu ili skup stranica%2$s"
+msgstr "Pod Pri pokretanju odaberi %1$sOtvori određenu stranicu ili skup stranica%2$s"
 
 #  Opera default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine
 msgid "Under Search click the drop down and select %sDuckDuckGo%s"
-msgstr ""
-"Pod Pretraživanje klikni padajući izbornik i odaberi %1$sDuckDuckGo%2$s"
+msgstr "Pod Pretraživanje klikni padajući izbornik i odaberi %1$sDuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings" header
@@ -21460,8 +21438,7 @@ msgstr "Otključaj uz pretplatu na DuckDuckGo"
 msgctxt "voice chat limit modal"
 msgid ""
 "Unlock advanced AI models and higher limits with a DuckDuckGo Subscription"
-msgstr ""
-"Otključaj napredne AI modele i viša ograničenja uz pretplatu na DuckDuckGo"
+msgstr "Otključaj napredne AI modele i viša ograničenja uz pretplatu na DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Text informing the user that advanced AI models can be unlocked with a subscription. The variable is used to insert a link that opens the subscription modal. Example: Unlock advanced AI models with a DuckDuckGo subscription.
@@ -21689,8 +21666,7 @@ msgctxt ""
 "Description prompting Plus subscribers to upgrade to Pro for higher image "
 "generation limits"
 msgid "Upgrade to Pro to unlock 2x higher limits"
-msgstr ""
-"Nadogradi na Pro verziju za otključavanje dva puta veće količine generiranja"
+msgstr "Nadogradi na Pro verziju za otključavanje dva puta veće količine generiranja"
 
 # smartling.placeholder_format=C
 #. Description shown to Plus subscribers who have reached their image generation limit, encouraging them to upgrade to Pro.
@@ -21762,7 +21738,7 @@ msgstr "Urugvaj"
 #. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
 msgctxt "Navigation label on the Duck.ai settings page"
 msgid "Usage"
-msgstr ""
+msgstr "Uporaba"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -22100,8 +22076,8 @@ msgid ""
 msgstr ""
 "Posjeti Duck.ai u svom drugom pregledniku ili u aplikaciji DuckDuckGo i "
 "otvori Postavke Duck.ai. Odaberi „Uključi“ pod Sync & Backup i odaberi "
-"„Sinkronizacija s drugim uređajem“. Ili skeniraj QR kôd na svom Recovery PDF-"
-"u."
+"„Sinkronizacija s drugim uređajem“. Ili skeniraj QR kôd na svom Recovery "
+"PDF-u."
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -22219,7 +22195,7 @@ msgstr "Wales"
 #. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Walk me through the steps"
-msgstr ""
+msgstr "Provedi me kroz korake"
 
 # smartling.placeholder_format=C
 #. Label for walking directions on a map.
@@ -22349,6 +22325,9 @@ msgid ""
 "please share this conversation with DuckDuckGo so we can investigate and "
 "address the issue."
 msgstr ""
+"Možemo popraviti samo ono što vidimo. Za prijavu štetnog ili nezakonitog "
+"odgovora, podijeli ovaj razgovor s DuckDuckGoom kako bismo mogli istražiti i "
+"riješiti problem."
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -22377,8 +22356,7 @@ msgstr ""
 msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
-msgstr ""
-"Ne možemo pročitati priložene datoteke jer je barem jedna od njih šifrirana."
+msgstr "Ne možemo pročitati priložene datoteke jer je barem jedna od njih šifrirana."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -22839,8 +22817,8 @@ msgid ""
 "We’re really sorry, but it seems there was a problem loading Duck.ai. Try "
 "reloading the page."
 msgstr ""
-"Stvarno nam je žao, ali čini se da je došlo do problema s učitavanjem Duck."
-"ai. Pokušaj ponovo učitati stranicu."
+"Stvarno nam je žao, ali čini se da je došlo do problema s učitavanjem "
+"Duck.ai. Pokušaj ponovo učitati stranicu."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to suggest an AI (Artificial Intelligence) model to be added to the product, and this field is optional.
@@ -22854,8 +22832,7 @@ msgctxt "Full sentence for improving arguments"
 msgid ""
 "What are some arguments, counter-arguments, and rebuttals to the concept of "
 "a plant-based diet?"
-msgstr ""
-"Koji su neki argumenti, protuargumenti i pobijanja koncepta biljne prehrane?"
+msgstr "Koji su neki argumenti, protuargumenti i pobijanja koncepta biljne prehrane?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for considering factors when purchasing a computer monitor.
@@ -22909,98 +22886,98 @@ msgstr ""
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the counterarguments?"
-msgstr ""
+msgstr "Koji su protuargumenti?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the hours & location?"
-msgstr ""
+msgstr "Koje je radno vrijeme i lokacija?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key contributions of this paper?"
-msgstr ""
+msgstr "Koji su glavni doprinosi ovog rada?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key contributions?"
-msgstr ""
+msgstr "Koji su ključni doprinosi?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key details?"
-msgstr ""
+msgstr "Koji su ključni detalji?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key points covered in this video?"
-msgstr ""
+msgstr "Koje su ključne točke obrađene u ovom videozapisu?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key points?"
-msgstr ""
+msgstr "Koje su ključne točke?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key takeaways from this article?"
-msgstr ""
+msgstr "Koje su ključne pouke iz ovog članka?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key takeaways?"
-msgstr ""
+msgstr "Koji su ključni zaključci?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key things I will learn from this course?"
-msgstr ""
+msgstr "Koje su ključne stvari koje ćeš naučiti iz ovog tečaja?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the main counterarguments or criticisms of this?"
-msgstr ""
+msgstr "Koji su glavni protuargumenti ili kritike navedenog?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the main questions this page answers?"
-msgstr ""
+msgstr "Na koja glavna pitanja ova stranica odgovara?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the must-try dishes here?"
-msgstr ""
+msgstr "Koja jela ovdje svakako moram probati?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid ""
 "What are the opening hours, location, and contact details for this place?"
-msgstr ""
+msgstr "Koje je radno vrijeme, lokacija i podaci za kontakt za ovo mjesto?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the pros and cons of this product?"
-msgstr ""
+msgstr "Koje su prednosti i mane ovog proizvoda?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the pros and cons?"
-msgstr ""
+msgstr "Koje su prednosti i mane?"
 
 # smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
@@ -23106,7 +23083,7 @@ msgstr "Što znači atrija u kontekstu medicinskog članka?"
 #. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What does this answer?"
-msgstr ""
+msgstr "Na što ovo odgovara?"
 
 # smartling.placeholder_format=C
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
@@ -23124,7 +23101,7 @@ msgstr "Koje se informacije spremaju?"
 #. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What interview questions might come up for this role?"
-msgstr ""
+msgstr "Koja bi se pitanja za intervju mogla pojaviti za ovu ulogu?"
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -23133,8 +23110,8 @@ msgid ""
 "What is the Cloud Save bookmarklet and how does it differ from the URL "
 "parameter bookmarklet?"
 msgstr ""
-"Što je to označeni aplet za Cloud Save i kako se razlikuje od parametra URL-"
-"a označenog apleta?"
+"Što je to označeni aplet za Cloud Save i kako se razlikuje od parametra "
+"URL-a označenog apleta?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for looking up the capital city of Albania.
@@ -23146,7 +23123,7 @@ msgstr "Koji je glavni grad Albanije?"
 #. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What is the overall verdict and rating for this?"
-msgstr ""
+msgstr "Kakav je ukupni dojam i ocjena za ovo?"
 
 # smartling.placeholder_format=C
 #. Link to a page with additional information.
@@ -23174,7 +23151,7 @@ msgstr "Što kažu ljudi:"
 #. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What should I order?"
-msgstr ""
+msgstr "Što da naručim?"
 
 # smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
@@ -23192,13 +23169,13 @@ msgstr "Što je bilo pogrešno u odgovoru? (neobavezno)"
 #. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What will I learn?"
-msgstr ""
+msgstr "Što ću naučiti?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What will I need?"
-msgstr ""
+msgstr "Što će mi trebati?"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -23209,8 +23186,7 @@ msgstr "O čemu želiš pružiti povratne informacije?"
 #. Explains the benefits of using our custom video player, the Duck Player
 msgid ""
 "What you watch in DuckDuckGo won't influence your recommendations on YouTube."
-msgstr ""
-"Ono što gledaš u DuckDuckGou neće utjecati na tvoje preporuke na YouTubeu."
+msgstr "Ono što gledaš u DuckDuckGou neće utjecati na tvoje preporuke na YouTubeu."
 
 # smartling.placeholder_format=C
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
@@ -23222,7 +23198,7 @@ msgstr "Što je novo"
 #. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What's the verdict?"
-msgstr ""
+msgstr "Kakav je zaključak?"
 
 # smartling.placeholder_format=C
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -23242,8 +23218,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "When enabled, Duck.ai will show instant answers in the chat."
-msgstr ""
-"Kada je to omogućeno, Duck.ai će prikazivati izravne odgovore u čavrljanju."
+msgstr "Kada je to omogućeno, Duck.ai će prikazivati izravne odgovore u čavrljanju."
 
 # smartling.placeholder_format=C
 #. Text of a button that performs a search for the available streaming services that show a particular movie or tv show
@@ -23261,8 +23236,7 @@ msgstr "Gdje gledati <strong>%1$s</strong>"
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Where it says Homepage click %sSet to Current Page%s."
-msgstr ""
-"Tamo gdje piše Početna stranica, klikni %1$sPostavi na trenutnu stranicu%2$s."
+msgstr "Tamo gdje piše Početna stranica, klikni %1$sPostavi na trenutnu stranicu%2$s."
 
 # smartling.placeholder_format=C
 #. Heading of a module showing what streaming services are showing a movie or series, e.g. Where to Watch The Matrix
@@ -23280,7 +23254,7 @@ msgstr "Koje značajke nedostaju? (Neobavezno)"
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Which features are missing? (optional)"
-msgstr ""
+msgstr "Koje značajke nedostaju? (neobavezno)"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
@@ -23302,13 +23276,13 @@ msgstr "Tko smo"
 #. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Who are the main cast and crew, and what else are they known for?"
-msgstr ""
+msgstr "Tko su glavni glumci i članovi ekipe i po čemu su još poznati?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Who is this person?"
-msgstr ""
+msgstr "Tko je ta osoba?"
 
 # smartling.placeholder_format=C
 #. Header above a collection of privacy-related links.
@@ -23679,8 +23653,7 @@ msgstr "Da, novi korisnik!"
 msgctxt "cloudsave"
 msgid ""
 "Yes, we throw away data when you’re done with it, and it cannot be recovered."
-msgstr ""
-"Da, mi se rješavamo podataka kad ti više ne trebaju i nemoguće ih je vratiti."
+msgstr "Da, mi se rješavamo podataka kad ti više ne trebaju i nemoguće ih je vratiti."
 
 # smartling.placeholder_format=C
 #. Option for the filter-by-date search.
@@ -23771,8 +23744,7 @@ msgstr ""
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
 msgctxt "Third party map app picker feedback dialog"
 msgid "You can change this any time in %sSearch Settings%s"
-msgstr ""
-"Ovo možeš promijeniti u svakom trenutku u %1$sPostavke pretraživanja%2$s"
+msgstr "Ovo možeš promijeniti u svakom trenutku u %1$sPostavke pretraživanja%2$s"
 
 # smartling.placeholder_format=C
 #. Text explaning how to change a passphrase.
@@ -23805,8 +23777,7 @@ msgstr "Ovaj podsjetnik možeš sakriti kroz %1$sPostavke pretraživanja%2$s"
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
-msgstr ""
-"Sada možeš spremiti do 100 čavrljanja na ovom uređaju. Sretno čavrljanje!"
+msgstr "Sada možeš spremiti do 100 čavrljanja na ovom uređaju. Sretno čavrljanje!"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -23973,8 +23944,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
 msgid "You won't see this message again unless you clear your browser data."
-msgstr ""
-"Ovu poruku više nećeš vidjeti osim ako ne izbrišeš podatke svog preglednika."
+msgstr "Ovu poruku više nećeš vidjeti osim ako ne izbrišeš podatke svog preglednika."
 
 # smartling.placeholder_format=C
 #. The second paragraph of a pop up where we explain how to update the browser manually.
@@ -24067,14 +24037,12 @@ msgstr "Dosegao si maksimalno trajanje glasovnog čavrljanja za jednu sesiju."
 msgctxt "voice chat limit modal"
 msgid ""
 "You've reached the voice chat limit for today. Please try again tomorrow."
-msgstr ""
-"Dosegao si ograničenje glasovnog čavrljanja za danas. Pokušaj ponovno sutra."
+msgstr "Dosegao si ograničenje glasovnog čavrljanja za danas. Pokušaj ponovno sutra."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
 msgid "You've reached your dictation usage limit. Try again later."
-msgstr ""
-"Dosegnuto je tvoje ograničenje korištenja diktata. Pokušaj ponovno kasnije."
+msgstr "Dosegnuto je tvoje ograničenje korištenja diktata. Pokušaj ponovno kasnije."
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -24235,8 +24203,7 @@ msgstr ""
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never used to train AI models"
-msgstr ""
-"Tvoji su razgovori privatni i nikada se ne koriste za učenje AI modela."
+msgstr "Tvoji su razgovori privatni i nikada se ne koriste za učenje AI modela."
 
 # smartling.placeholder_format=C
 #. Text for a description of the active privacy protection for DuckDuckGo's AI Chat feature.
@@ -24297,8 +24264,8 @@ msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
 msgstr ""
-"Vaši su razgovori uvezeni. Samo naprijed i nastavi tamo gdje si stao u Duck."
-"ai."
+"Vaši su razgovori uvezeni. Samo naprijed i nastavi tamo gdje si stao u "
+"Duck.ai."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.
@@ -24463,8 +24430,7 @@ msgctxt "Error message for input limit"
 msgid ""
 "You’ve exceeded the maximum message size. Please shorten your message and "
 "try again."
-msgstr ""
-"Premašena je maksimalna duljina poruke. Skrati poruku i pokušaj ponovno."
+msgstr "Premašena je maksimalna duljina poruke. Skrati poruku i pokušaj ponovno."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -24804,8 +24770,7 @@ msgstr "službenu web lokaciju"
 #. <em>%s</em> is for a hexadecimal color code as <em>#395323</em>, but it has to be safe encoded, and as <em>#</em> seems not safe, <em>%23</em> must be used in place of the sharp symbol, but they are the same for your browser.
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
-msgstr ""
-"ili napiši šifru boje koju želiš, npr. %1$s (%2$s je kodirani znak %3$s)."
+msgstr "ili napiši šifru boje koju želiš, npr. %1$s (%2$s je kodirani znak %3$s)."
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "

--- a/locales/hu_HU/LC_MESSAGES/duckduckgo.po
+++ b/locales/hu_HU/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: hu_HU\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -176,9 +176,9 @@ msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
 msgstr ""
-"A(z) %1$s csak a Pro verzióval érhető el. Frissítsd újra a DuckDuckGo-"
-"előfizetésedet ebben a böngészőben a csevegés folytatásához, vagy válts a "
-"Plus vagy az ingyenes modellre."
+"A(z) %1$s csak a Pro verzióval érhető el. Frissítsd újra a "
+"DuckDuckGo-előfizetésedet ebben a böngészőben a csevegés folytatásához, vagy "
+"válts a Plus vagy az ingyenes modellre."
 
 # smartling.placeholder_format=C
 #. Text for the disclaimer message that appears when a Plus subscriber tries to use a Pro-only model. %s is replaced with the model name. Example: Claude Opus 4.6 is only available with Pro. Upgrade your DuckDuckGo subscription in this browser again to continue the chat, or switch to a Plus or free model.
@@ -188,9 +188,9 @@ msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
 msgstr ""
-"A(z) %1$s csak a Pro verzióval érhető el. Frissítsd újra a DuckDuckGo-"
-"előfizetésedet ebben a böngészőben a csevegés folytatásához, vagy válts a "
-"Plus vagy az ingyenes modellre."
+"A(z) %1$s csak a Pro verzióval érhető el. Frissítsd újra a "
+"DuckDuckGo-előfizetésedet ebben a böngészőben a csevegés folytatásához, vagy "
+"válts a Plus vagy az ingyenes modellre."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI (Artificial Intelligence) chat model is temporarily unavailable. Example: 'GPT 4o is only available with a DuckDuckGo subscription.'
@@ -468,8 +468,7 @@ msgstr "%1$sTudj meg többet%2$s"
 #. Link to a page with more information about how anonymous location works.
 msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
-msgstr ""
-"%1$sTudd meg, hogyan őrizzük meg a tartózkodási helyed bizalmasságát%2$s."
+msgstr "%1$sTudd meg, hogyan őrizzük meg a tartózkodási helyed bizalmasságát%2$s."
 
 # smartling.placeholder_format=C
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
@@ -484,15 +483,13 @@ msgstr ""
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "%sLearn more%s about how chats are stored privately on your device."
-msgstr ""
-"%1$sTovábbi részletek%2$s a csevegések eszközön való privát tárolásáról."
+msgstr "%1$sTovábbi részletek%2$s a csevegések eszközön való privát tárolásáról."
 
 # smartling.placeholder_format=C
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "%sLong-press%s the DuckDuckGo app icon on the home screen"
-msgstr ""
-"%1$sNyomd meg hosszan%2$s a DuckDuckGo alkalmazás ikonját a kezdőképernyőn"
+msgstr "%1$sNyomd meg hosszan%2$s a DuckDuckGo alkalmazás ikonját a kezdőképernyőn"
 
 # smartling.placeholder_format=C
 #. A message displayed when there is an error loading content or no results on requery
@@ -815,8 +812,7 @@ msgstr "Elérted a 6 órás használati limitet."
 #. Displayed when the user has reached a fixed 6-hour Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "6-hour usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Elérted a 6 órás használati limitet. A csevegést %1$s után folytathatod."
+msgstr "Elérted a 6 órás használati limitet. A csevegést %1$s után folytathatod."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable 6-hour Duck.ai usage limit and can opt in to continue using the daily limit.
@@ -935,8 +931,9 @@ msgstr ""
 "Az AI Chat segítségével névtelen beszélgetéseket folytathatsz harmadik felek "
 "mesterséges intelligencián alapuló csevegési modelljeivel. Ennek "
 "kikapcsolása elrejti az AI Chat funkciót a DuckDuckGo Search "
-"szolgáltatásban. Ha a beállítás ki van kapcsolva, a %1$sduckduckgo.com/"
-"aichat%2$s oldalra látogatva továbbra is elérheted az AI Chatet."
+"szolgáltatásban. Ha a beállítás ki van kapcsolva, a "
+"%1$sduckduckgo.com/aichat%2$s oldalra látogatva továbbra is elérheted az AI "
+"Chatet."
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -1000,8 +997,9 @@ msgstr ""
 "Az AI-alapú válaszokra jelenleg nem tehetők fel közvetlenül további "
 "kérdések. Azonban ha újabb kérdést szeretnél feltenni, az OpenAI, az "
 "Anthropic, valamint más szolgáltatók csevegési modelljeit is támogató "
-"mesterségesintelligencia-alapú privát csevegési szolgáltatásunk, a %1$sDuck."
-"ai%2$s használatát is felajánljuk, és gyakran megjelenítjük annak linkjét."
+"mesterségesintelligencia-alapú privát csevegési szolgáltatásunk, a "
+"%1$sDuck.ai%2$s használatát is felajánljuk, és gyakran megjelenítjük annak "
+"linkjét."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has turned off AI features and will no longer see AI-assisted answers.
@@ -1447,7 +1445,7 @@ msgstr "A cím helytelen"
 #. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Adjust the servings"
-msgstr ""
+msgstr "Adagok módosítása"
 
 # smartling.placeholder_format=C
 #. as in multiple advertisements
@@ -1669,6 +1667,9 @@ msgid ""
 "All chats are anonymized by DuckDuckGo, and your conversations are not used "
 "to train chat models by DuckDuckGo or the model providers"
 msgstr ""
+"A DuckDuckGo anonimizál minden beszélgetést, és a beszélgetéseidet sem a "
+"DuckDuckGo, sem a modellszolgáltatók nem használják fel csevegőmodellek "
+"betanítására"
 
 # smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1949,6 +1950,8 @@ msgid ""
 "Anonymously generates answers for search queries based on web content. "
 "Choose how often you want it to appear, or disable it completely."
 msgstr ""
+"Névtelenül generál válaszokat a keresésekre webes tartalmak alapján. Válaszd "
+"ki, milyen gyakran jelenjen meg, vagy kapcsold ki teljesen."
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -2233,7 +2236,7 @@ msgstr "Tegyél fel kapcsolódó kérést a Duck.ai segítségével"
 #. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
 msgctxt "Page suggestion chip label"
 msgid "Ask about this page"
-msgstr ""
+msgstr "Kérdezz erről az oldalról"
 
 # smartling.placeholder_format=C
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2303,9 +2306,9 @@ msgstr ""
 "felhasználói felületét a keresési eredményekből), Igény szerint (csak az "
 "Asszisztens gombra kattintás esetén jelennek meg az AI-alapú válaszok), Néha "
 "(csak akkor jelenik meg AI-alapú válasz, ha nagyon releváns), illetve "
-"Gyakran (gyakrabban jelenik meg, szélesebb körű keresések esetén). Az AI-"
-"alapú válaszok egyelőre csak az Egyesült Államok (angol) régiójában érhetők "
-"el."
+"Gyakran (gyakrabban jelenik meg, szélesebb körű keresések esetén). Az "
+"AI-alapú válaszok egyelőre csak az Egyesült Államok (angol) régiójában "
+"érhetők el."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2402,21 +2405,18 @@ msgstr "Hang"
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat ends."
-msgstr ""
-"A hanganyagot a csevegés befejezése után mi nem tároljuk, és az OpenAI sem."
+msgstr "A hanganyagot a csevegés befejezése után mi nem tároljuk, és az OpenAI sem."
 
 # smartling.placeholder_format=C
 #. Description in consent disclaimer informing that audio from the voice chat session is not stored by us or by OpenAI after the voice chat ends.
 msgctxt "voice chat"
 msgid "Audio is not stored by us or by OpenAI after the chat ends."
-msgstr ""
-"A hanganyagot a csevegés befejezése után mi nem tároljuk, és az OpenAI sem."
+msgstr "A hanganyagot a csevegés befejezése után mi nem tároljuk, és az OpenAI sem."
 
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat is transcribed."
-msgstr ""
-"A hanganyagot a csevegés átírása után mi nem tároljuk, és az OpenAI sem."
+msgstr "A hanganyagot a csevegés átírása után mi nem tároljuk, és az OpenAI sem."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when MediaRecorder API is unavailable.
@@ -2659,7 +2659,7 @@ msgstr "Vonalkód"
 #. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Based on this page, is this course worth taking?"
-msgstr ""
+msgstr "Az oldalon szereplő információk alapján érdemes elvégezni ezt a tanfolyamot?"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2708,6 +2708,9 @@ msgid ""
 "Before storing this report, DuckDuckGo will anonymize your conversation by "
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
+"A jelentés tárolása előtt a DuckDuckGo anonimizálja a beszélgetésedet az "
+"olyan személyazonosításra alkalmas adatok eltávolításával, mint a nevek, az "
+"e-mail-címek és az azonosításra alkalmas metaadatok."
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -2849,8 +2852,7 @@ msgstr "Webhely blokkolása minden találatból"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Block trackers and take control of your personal data"
-msgstr ""
-"Blokkold a nyomkövetőket, és vedd át az irányítást a személyes adataid felett"
+msgstr "Blokkold a nyomkövetőket, és vedd át az irányítást a személyes adataid felett"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -3030,7 +3032,7 @@ msgstr "Megnyert bréklabdák"
 #. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Break this down into clear, numbered steps."
-msgstr ""
+msgstr "Bontsd le ezt világos, számozott lépésekre."
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -3497,7 +3499,7 @@ msgstr "Szereposztás"
 #. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Cast & Crew"
-msgstr ""
+msgstr "Szereplők és alkotók"
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -3584,8 +3586,7 @@ msgstr "Módosítja az eredmények URL-jeinek megjelenítési módját"
 #. This is the description of a user setting
 msgctxt "settings"
 msgid "Changes how the header is displayed and its behavior as you scroll"
-msgstr ""
-"Módosítja a fejléc megjelenítési módját és viselkedését görgetés közben."
+msgstr "Módosítja a fejléc megjelenítési módját és viselkedését görgetés közben."
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/mcZdcaF.png
@@ -3797,8 +3798,8 @@ msgstr "Privát csevegés"
 msgctxt "Promotional text (mobile)"
 msgid "Chat privately on any website with Duck.ai built into our free browser."
 msgstr ""
-"Csevegj privátban bármely webhelyen az ingyenes böngészőnkbe beépített Duck."
-"ai segítségével."
+"Csevegj privátban bármely webhelyen az ingyenes böngészőnkbe beépített "
+"Duck.ai segítségével."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card encouraging third-party browser users to download the DuckDuckGo browser. Not shown in the DuckDuckGo browser or on Linux.
@@ -4287,8 +4288,8 @@ msgid ""
 msgstr ""
 "Kattints a „Több” lehetőségre, ha többet meg szeretnél tudni egy témáról, és "
 "tegyél fel kapcsolódó kérdéseket az OpenAI, az Anthropic és további "
-"csevegési modelleket támogató privát AI-csevegőszolgáltatásunk, a %1$sDuck."
-"ai%2$s használatával."
+"csevegési modelleket támogató privát AI-csevegőszolgáltatásunk, a "
+"%1$sDuck.ai%2$s használatával."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4315,15 +4316,13 @@ msgstr "Kattints a %1$sHozzáadás%2$s lehetőségre"
 #. Instructions on which buttons the user has to click in order to add the DuckDuckGo extension to their browser.
 msgctxt "install-duckduckgo"
 msgid "Click %sAllow%s, then %sAdd%s."
-msgstr ""
-"Kattints az %1$sEngedélyezés%2$slehetőségre, majd a %3$sHozzáadás%4$s gombra."
+msgstr "Kattints az %1$sEngedélyezés%2$slehetőségre, majd a %3$sHozzáadás%4$s gombra."
 
 #  Firefox 33
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Click %sChange Search Settings%s in the drop down"
-msgstr ""
-"Kattints a %1$sKeresési beállítások módosítása%2$s sorra a lenyíló menüben"
+msgstr "Kattints a %1$sKeresési beállítások módosítása%2$s sorra a lenyíló menüben"
 
 #  SeaMonkey default search engine instruction
 # smartling.placeholder_format=C
@@ -4357,8 +4356,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click %sPrivacy and Services%s in the left sidebar."
-msgstr ""
-"Kattints a bal oldali sáv %1$sAdatvédelem és szolgáltatások%2$s elemére."
+msgstr "Kattints a bal oldali sáv %1$sAdatvédelem és szolgáltatások%2$s elemére."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -4439,8 +4437,7 @@ msgstr "Kattints a %1$sBeállítás alapértelmezettként%2$s lehetőségre lent
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click on the %sSearch Providers%s under Add-on Types"
-msgstr ""
-"Kattints a %1$sKeresőszolgáltatók%2$s lehetőségre a bővítménytípusoknál"
+msgstr "Kattints a %1$sKeresőszolgáltatók%2$s lehetőségre a bővítménytípusoknál"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -5111,8 +5108,7 @@ msgstr "Másolás"
 # smartling.placeholder_format=C
 #. Instructions on how to change the default search engine
 msgid "Copy &amp; paste %sabout:preferences#search%s into the address bar"
-msgstr ""
-"Másold ki és illeszd be az %1$sabout:preferences#search%2$s címet a címsorba"
+msgstr "Másold ki és illeszd be az %1$sabout:preferences#search%2$s címet a címsorba"
 
 # smartling.placeholder_format=C
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
@@ -5234,6 +5230,8 @@ msgstr "Kép létrehozása"
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
 msgstr ""
+"Készíts a receptből egy bevásárlólistát, amelyen a mennyiségek is "
+"szerepelnek."
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed in the input field when starting a new image generation session.
@@ -5880,7 +5878,7 @@ msgstr "Elérted a diktálási korlátot"
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
 msgid "Dictation temporarily unavailable"
-msgstr ""
+msgstr "A diktálás átmenetileg nem érhető el"
 
 # smartling.placeholder_format=C
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
@@ -6191,6 +6189,8 @@ msgid ""
 "Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
 "filtered out. %sLearn More%s"
 msgstr ""
+"Nem kérsz az MI-ből? %1$snoai.duckduckgo.com%2$s nem kínál MI-funkciókat, és "
+"kiszűri az MI-képeket. %3$sTovábbi információk%4$s"
 
 # smartling.placeholder_format=C
 #. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
@@ -6199,6 +6199,9 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
+"Nem kérsz az MI-ből? Látogass el a %1$snoai.duckduckgo.com%2$s oldalra ha "
+"MI-funkciók nélkül, és az MI-képek kiszűrésével szeretnél keresni! "
+"%3$sTovábbi információk%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6318,13 +6321,13 @@ msgstr ""
 #. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Draft a cover letter"
-msgstr ""
+msgstr "Motivációs levél írása"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Draft a cover letter for this job."
-msgstr ""
+msgstr "Írj egy motivációs levelet ehhez az álláshoz."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -6414,8 +6417,7 @@ msgstr "Dobd ide a fotókat vagy PDF-fájlokat"
 # smartling.placeholder_format=C
 #. A title explaining what Duck Player (DDG's feature to watch youtube videos more privately) does
 msgid "Duck Player lets you watch YouTube without targeted ads"
-msgstr ""
-"A Duck Player segítségével célzott hirdetések nélkül nézheted a YouTube-ot"
+msgstr "A Duck Player segítségével célzott hirdetések nélkül nézheted a YouTube-ot"
 
 # smartling.placeholder_format=C
 #. This is the DDG version of "Google it", meaning "search it".
@@ -6502,8 +6504,7 @@ msgstr ""
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
-msgstr ""
-"A Duck.ai a privát és ingyenes DuckDuckGo böngészőnkben működik a legjobban!"
+msgstr "A Duck.ai a privát és ingyenes DuckDuckGo böngészőnkben működik a legjobban!"
 
 # smartling.placeholder_format=C
 #. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
@@ -6513,6 +6514,9 @@ msgid ""
 "company for anyone who wants to take back control of their personal "
 "information."
 msgstr ""
+"A Duck.ai-t a DuckDuckGo alkotta meg. Független adatvédelmi cégként abban "
+"segítünk az embereknek, hogy visszavegyék az irányítást a személyes adataik "
+"felett."
 
 # smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
@@ -6543,8 +6547,8 @@ msgid ""
 "Duck.ai is temporarily unavailable. If this persists, please email this "
 "anonymous code %s to %s"
 msgstr ""
-"A Duck.ai átmenetileg nem érhető el. Ha ez továbbra is fennáll, küldd el e-"
-"mailben a névtelenségi funkcióhoz szükséges %1$s kódot a következő címre: "
+"A Duck.ai átmenetileg nem érhető el. Ha ez továbbra is fennáll, küldd el "
+"e-mailben a névtelenségi funkcióhoz szükséges %1$s kódot a következő címre: "
 "%2$s"
 
 # smartling.placeholder_format=C
@@ -6552,8 +6556,7 @@ msgstr ""
 msgctxt "Error message for VQD error"
 msgid ""
 "Duck.ai is temporarily unavailable. Please refresh the page and try again."
-msgstr ""
-"A Duck.ai átmenetileg nem érhető el. Frissítsd az oldalt, és próbálkozz újra."
+msgstr "A Duck.ai átmenetileg nem érhető el. Frissítsd az oldalt, és próbálkozz újra."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -6567,6 +6570,9 @@ msgid ""
 "Duck.ai lets you chat privately with popular AI models. Disabling it hides "
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
+"A Duck.ai lehetővé teszi, hogy privát módon beszélgess népszerű "
+"MI-modellekkel. A kikapcsolása elrejti a Duck.ai gombjait és hivatkozásait, "
+"de továbbra is felkeresheted közvetlenül a %1$sduck.ai%2$s webhelyet."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6644,8 +6650,8 @@ msgid ""
 "AI chat no sign up, OpenAI, Anthropic, Llama, Mistral, open source AI "
 "models, privacy focused AI, no account AI chat"
 msgstr ""
-"Duck.ai, DuckDuckGo AI, privát AI chatbot, csevegőrobot, ingyenes AI-"
-"csevegés, anonim AI-csevegés, AI-csevegés regisztráció nélkül, OpenAI, "
+"Duck.ai, DuckDuckGo AI, privát AI chatbot, csevegőrobot, ingyenes "
+"AI-csevegés, anonim AI-csevegés, AI-csevegés regisztráció nélkül, OpenAI, "
 "Anthropic, Llama, Mistral, nyílt forráskódú AI modellek, adatvédelemre "
 "összpontosító AI, fiók nélküli AI-csevegés"
 
@@ -6693,8 +6699,8 @@ msgid ""
 msgstr ""
 "A DuckAssist nem tud utólagos kérdésekre válaszolni, viszont kínálatunkban "
 "többek között az OpenAI és az Anthropic csevegési modelljeit támogató "
-"%1$sDuckDuckGo AI Chat%2$s is elérhető, amely egy mesterségesintelligencia-"
-"alapú privát csevegési szolgáltatás."
+"%1$sDuckDuckGo AI Chat%2$s is elérhető, amely egy "
+"mesterségesintelligencia-alapú privát csevegési szolgáltatás."
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6822,8 +6828,7 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr ""
-"A DuckDuckGo AI Chat átmenetileg nem érhető el. Próbálkozz újra később."
+msgstr "A DuckDuckGo AI Chat átmenetileg nem érhető el. Próbálkozz újra később."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -6943,8 +6948,8 @@ msgid ""
 "names, email addresses, phone numbers, and identifying metadata."
 msgstr ""
 "A DuckDuckGo automatikusan anonimizálja ezeket a jelentéseket az olyan "
-"személyazonosításra alkalmas adatok eltávolításával, mint a nevek, az e-mail-"
-"címek, a telefonszámok és az azonosításra alkalmas metaadatok."
+"személyazonosításra alkalmas adatok eltávolításával, mint a nevek, az "
+"e-mail-címek, a telefonszámok és az azonosításra alkalmas metaadatok."
 
 # smartling.placeholder_format=C
 #. The first %s is the agree button label ('Agree'). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. The leading sentence mirrors the drawer-style inline disclaimer (DUCKCHAT_TOS_INLINE_DISCLAIMER).
@@ -7217,8 +7222,7 @@ msgstr "Emeld ki a fontos információkat a válaszokban"
 #. Tells users which setting to change to enable location service.
 msgctxt "precise_user_location"
 msgid "Enable 'Sites can ask for my location.'"
-msgstr ""
-"Engedélyezd a „Webhelyek kérhetik a tartózkodási helyemet” lehetőséget."
+msgstr "Engedélyezd a „Webhelyek kérhetik a tartózkodási helyemet” lehetőséget."
 
 # smartling.placeholder_format=C
 #. Button shown during outages to enable AI features
@@ -7313,8 +7317,7 @@ msgstr "Diktálás engedélyezése a Duck.ai felületén"
 #. Prompt to enable location service so that search results can be displayed near the user's current location.
 msgctxt "precise_user_location"
 msgid "Enable location settings on your device to use anonymous location"
-msgstr ""
-"Az anonim hely használatához engedélyezd a készülékeden a helymeghatározást"
+msgstr "Az anonim hely használatához engedélyezd a készülékeden a helymeghatározást"
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -7432,15 +7435,13 @@ msgstr ""
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location Services' is %senabled%s."
-msgstr ""
-"Győződj meg arról, hogy a „Helyszolgáltatások” %1$sengedélyezve vannak%2$s."
+msgstr "Győződj meg arról, hogy a „Helyszolgáltatások” %1$sengedélyezve vannak%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location' is set to %sallow%s"
-msgstr ""
-"Győződj meg arról, hogy a „Hely” %1$sengedélyezés%2$s értékre van állítva"
+msgstr "Győződj meg arról, hogy a „Hely” %1$sengedélyezés%2$s értékre van állítva"
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service.
@@ -7454,8 +7455,7 @@ msgstr ""
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure Location is set to %sAllow%s"
-msgstr ""
-"Győződj meg arról, hogy a Hely %1$sEngedélyezés%2$s értékre van állítva"
+msgstr "Győződj meg arról, hogy a Hely %1$sEngedélyezés%2$s értékre van állítva"
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
@@ -7491,15 +7491,13 @@ msgstr ""
 #. Tells how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed location access"
-msgstr ""
-"Győződj meg arról, hogy a böngészőben engedélyezve van a helyhozzáférés"
+msgstr "Győződj meg arról, hogy a böngészőben engedélyezve van a helyhozzáférés"
 
 # smartling.placeholder_format=C
 #. Tells how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed location access."
-msgstr ""
-"Győződj meg arról, hogy böngésződben engedélyezve van a helyhozzáférés."
+msgstr "Győződj meg arról, hogy böngésződben engedélyezve van a helyhozzáférés."
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -7599,13 +7597,13 @@ msgstr "Eritrea"
 #. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Estimate the nutrition"
-msgstr ""
+msgstr "Tápérték becslése"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Estimate the nutritional information for this recipe."
-msgstr ""
+msgstr "Becsüld meg ennek a receptnek a tápértékadatait."
 
 # smartling.placeholder_format=C
 msgid "Estonia"
@@ -7665,7 +7663,7 @@ msgstr "Még 1 napig érvényes"
 #. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain the accepted answer in simple terms."
-msgstr ""
+msgstr "Magyarázd el egyszerűen az elfogadott választ."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
@@ -7678,43 +7676,43 @@ msgstr "Magyarázd el a fekete lyukak alapvető fogalmait középiskolai szinten
 #. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain the top answer"
-msgstr ""
+msgstr "Legjobb válasz magyarázata"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain this in simple, plain language."
-msgstr ""
+msgstr "Magyarázd el ezt egyszerű, közérthető nyelven."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain this paper"
-msgstr ""
+msgstr "Tanulmány magyarázata"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain this repo"
-msgstr ""
+msgstr "Kódtár magyarázata"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain this research paper in plain language."
-msgstr ""
+msgstr "Magyarázd el ezt a kutatási tanulmányt közérthetően."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain this simply"
-msgstr ""
+msgstr "Magyarázd el egyszerűen"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain what this repository does and how to use it."
-msgstr ""
+msgstr "Magyarázd el, mire szolgál ez a kódtár, és hogyan használható."
 
 # smartling.placeholder_format=C
 #. Label to show if song lyrics contain explicit content
@@ -8005,6 +8003,8 @@ msgctxt "settings"
 msgid ""
 "Filters out known AI spam sites from image search results. %sLearn More%s"
 msgstr ""
+"Kiszűri az ismert MI-spamoldalakat a képkeresési találatok közül. "
+"%1$sTovábbi információk%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the final score of a sporting event.
@@ -8067,7 +8067,7 @@ msgstr "Aktuális információk keresése"
 #. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Find me alternatives"
-msgstr ""
+msgstr "Mutass alternatívákat"
 
 # smartling.placeholder_format=C
 #. Button that searches for results closer to the user's current location.
@@ -8161,8 +8161,8 @@ msgstr ""
 msgctxt "duckai_migration"
 msgid "Follow these steps to move your chats to the new Duck.ai"
 msgstr ""
-"Kövesd az alábbi lépéseket, ha szeretnéd átvinni a csevegéseket az új Duck."
-"ai felületre"
+"Kövesd az alábbi lépéseket, ha szeretnéd átvinni a csevegéseket az új "
+"Duck.ai felületre"
 
 # smartling.placeholder_format=C
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse on mobile
@@ -8267,8 +8267,7 @@ msgstr "Ingyenes és privát csevegések, általunk anonimizálva"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr ""
-"Ingyenes és privát csevegések, általunk anonimizálva. Nincs szükség fiókra."
+msgstr "Ingyenes és privát csevegések, általunk anonimizálva. Nincs szükség fiókra."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -8520,15 +8519,13 @@ msgstr "Általános célú mesterséges intelligencia, beépített erős moderá
 #. Text with short description for an AI (Artificial Intelligence) Model that has a low moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "General purpose AI with low built-in moderation"
-msgstr ""
-"Általános célú mesterséges intelligencia, beépített gyenge moderálással"
+msgstr "Általános célú mesterséges intelligencia, beépített gyenge moderálással"
 
 # smartling.placeholder_format=C
 #. Text with short description for an AI (Artificial Intelligence) Model that has a medium moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "General purpose AI with medium built-in moderation"
-msgstr ""
-"Általános célú mesterséges intelligencia, beépített közepes moderálással"
+msgstr "Általános célú mesterséges intelligencia, beépített közepes moderálással"
 
 # smartling.placeholder_format=C
 #. Text indicating that the AI (Artificial Intelligence) model is a model for general purpose use. General-purpose AI refers to AI systems that can perform a wide range of tasks, rather than being specialized for a specific task.
@@ -8556,7 +8553,7 @@ msgstr "Továbbiak generálása"
 #. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Generate a shopping list"
-msgstr ""
+msgstr "Bevásárlólista generálása"
 
 # smartling.placeholder_format=C
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
@@ -8751,9 +8748,9 @@ msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"Szerezz hozzáférést a Duck.ai fejlett AI-modelljeihez DuckDuckGo-"
-"előfizetéssel, amely a VPN-megoldásunk mellett további prémium adatvédelmi "
-"szolgáltatásokat is tartalmaz."
+"Szerezz hozzáférést a Duck.ai fejlett AI-modelljeihez "
+"DuckDuckGo-előfizetéssel, amely a VPN-megoldásunk mellett további prémium "
+"adatvédelmi szolgáltatásokat is tartalmaz."
 
 # smartling.placeholder_format=C
 #. A button for users to generate an AI generated answer from their query on the duckassist module
@@ -8857,14 +8854,13 @@ msgstr "Kipróbálom"
 #. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Give me a quick background on this person."
-msgstr ""
+msgstr "Adj egy rövid áttekintést erről a személyről."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
-msgstr ""
-"Lépj az %1$sAdatvédelem és biztonság > Helymeghatározás%2$s lehetőségre"
+msgstr "Lépj az %1$sAdatvédelem és biztonság > Helymeghatározás%2$s lehetőségre"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9311,13 +9307,13 @@ msgstr "Segíts terjeszteni az adatvédelmet"
 #. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Help me prep for the interview"
-msgstr ""
+msgstr "Segíts felkészülni az interjúra"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Help me tailor my resume for this job."
-msgstr ""
+msgstr "Segíts hozzáigazítani az önéletrajzomat ehhez az álláshoz."
 
 # smartling.placeholder_format=C
 #. Title of a SERP popup that invites users to take a survey (desktop only)
@@ -9329,8 +9325,7 @@ msgstr "Segíts nekünk a DuckDuckGo fejlesztésében"
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Help us improve DuckDuckGo searches with your feedback"
-msgstr ""
-"A visszajelzéseddel segítesz nekünk a DuckDuckGo-keresések fejlesztésében"
+msgstr "A visszajelzéseddel segítesz nekünk a DuckDuckGo-keresések fejlesztésében"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -9847,7 +9842,7 @@ msgctxt ""
 "Text for the I already have a subscription button in the Duck.ai settings "
 "page"
 msgid "I Already Have a Subscription"
-msgstr ""
+msgstr "Már van előfizetésem"
 
 # smartling.placeholder_format=C
 #. Text for the button that takes the user to the login subscription page.
@@ -10020,8 +10015,7 @@ msgstr ""
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
-msgstr ""
-"Ha támogatni szeretnél minket, segíts a %1$sDuckDuckGo terjesztésében%2$s"
+msgstr "Ha támogatni szeretnél minket, segíts a %1$sDuckDuckGo terjesztésében%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -10222,8 +10216,7 @@ msgstr ""
 
 # smartling.placeholder_format=C
 msgid "In the menu at the top select %sTools%s > %sSettings%s"
-msgstr ""
-"A fenti menüben válaszd az %1$sEszközök%2$s > %3$sBeállítások%4$s lehetőséget"
+msgstr "A fenti menüben válaszd az %1$sEszközök%2$s > %3$sBeállítások%4$s lehetőséget"
 
 #  IE < 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -10440,7 +10433,7 @@ msgstr "Maces böngésző telepítése"
 #. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
 msgctxt "settings"
 msgid "Install Now"
-msgstr ""
+msgstr "Telepítés most"
 
 # smartling.placeholder_format=C
 #. Text of a button to install the DuckDuckGo app
@@ -10543,13 +10536,13 @@ msgstr "A törölt adatok valóban törlésre kerülnek?"
 #. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Is it worth taking?"
-msgstr ""
+msgstr "Érdemes elvégezni?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Is this place any good?"
-msgstr ""
+msgstr "Jó ez a hely?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
@@ -10558,6 +10551,8 @@ msgid ""
 "Is this place any good? Summarize its reputation based on reviews and "
 "ratings."
 msgstr ""
+"Jó ez a hely? Foglald össze a megítélését az értékelések és a vélemények "
+"alapján."
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -10569,13 +10564,13 @@ msgstr "Hasznos a videó?"
 #. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Is this worth watching?"
-msgstr ""
+msgstr "Érdemes megnézni?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Is this worth watching? Give me a spoiler-free take."
-msgstr ""
+msgstr "Érdemes megnézni? Mondj egy spoilermentes véleményt."
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -11193,6 +11188,8 @@ msgstr "Linkek:"
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
 msgstr ""
+"Sorold fel, milyen eszközökre, anyagokra vagy előfeltételekre van szükségem "
+"ehhez."
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -11485,8 +11482,7 @@ msgstr "Ügyelj rá, hogy minden szó helyesen legyen írva."
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Make sure to check %s\"Make this my default search provider\"%s"
-msgstr ""
-"Ne felejtse el bejelölni, hogy %1$s„Legyen ez az alapértelmezett keresőm”%2$s"
+msgstr "Ne felejtse el bejelölni, hogy %1$s„Legyen ez az alapértelmezett keresőm”%2$s"
 
 # smartling.placeholder_format=C
 #. Message prompting users to check the spelling of their search term.
@@ -11607,7 +11603,7 @@ msgstr "Blokkolt webhelyek kezelése"
 #. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
 msgctxt "setting"
 msgid "Manage in Browser Settings"
-msgstr ""
+msgstr "Kezelés a böngészőbeállításokban"
 
 # smartling.placeholder_format=C
 #. Link to the site exclusion settings page
@@ -13470,8 +13466,7 @@ msgctxt "translations_module"
 msgid ""
 "Oops! An unexpected error occurred while translating this text. Please try "
 "again later."
-msgstr ""
-"Hoppá! Váratlan hiba történt a szöveg fordítása közben. Próbáld újra később."
+msgstr "Hoppá! Váratlan hiba történt a szöveg fordítása közben. Próbáld újra később."
 
 # smartling.placeholder_format=C
 #. Title shown in a fatal error modal when Duck.ai fails to load.
@@ -13817,9 +13812,9 @@ msgid ""
 "tracker blocker, encryption enforcer, and more. Available on %siOS & "
 "Android%s."
 msgstr ""
-"Mobiltelefonos böngészőnk keresőmotorunkat, követésvédelmünket, titkosítás-"
-"végrehajtónkat stb. magában foglalva áll rendelkezésedre. %1$siOS és "
-"Android%2$s rendszerhez is elérhető."
+"Mobiltelefonos böngészőnk keresőmotorunkat, követésvédelmünket, "
+"titkosítás-végrehajtónkat stb. magában foglalva áll rendelkezésedre. %1$siOS "
+"és Android%2$s rendszerhez is elérhető."
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the information was out of date.
@@ -14433,8 +14428,7 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this prompt was made by a "
 "human."
-msgstr ""
-"A következő feladat elvégzésével igazold, hogy az utasítást ember adta."
+msgstr "A következő feladat elvégzésével igazold, hogy az utasítást ember adta."
 
 # smartling.placeholder_format=C
 #. Bot challenge explanation
@@ -14442,14 +14436,15 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this search was made by a "
 "human."
-msgstr ""
-"A következő feladat elvégzésével igazold, hogy a keresést ember végezte."
+msgstr "A következő feladat elvégzésével igazold, hogy a keresést ember végezte."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is harmful or illegal. (optional)"
 msgstr ""
+"Írd le, miért káros vagy jogsértő a beszélgetésben kapott válasz. (nem "
+"kötelező)"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
@@ -14488,6 +14483,8 @@ msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is harmful or illegal."
 msgstr ""
+"Illeszd be a kérdésedet és a problémás választ (személyes adatok nélkül), "
+"majd írd le, hogy miért káros vagy jogsértő a tartalom."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -14650,8 +14647,8 @@ msgid ""
 "Plus, what you watch in Duck Player won’t influence your recommendations on "
 "YouTube."
 msgstr ""
-"Ráadásul az, amit a Duck Playerben nézel, nem fogja befolyásolni a YouTube-"
-"javaslataidat."
+"Ráadásul az, amit a Duck Playerben nézel, nem fogja befolyásolni a "
+"YouTube-javaslataidat."
 
 # smartling.placeholder_format=C
 #. A link to the Substack page (https://insideduckduckgo.substack.com/?showWelcome=true)
@@ -14960,7 +14957,7 @@ msgstr "Adatvédelem"
 #. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
 msgctxt "Section heading on the Duck.ai settings page"
 msgid "Privacy & Terms"
-msgstr ""
+msgstr "Adatvédelem és feltételek"
 
 # smartling.placeholder_format=C
 msgid "Privacy Blog"
@@ -15036,7 +15033,7 @@ msgstr "Adatvédelmi szabályzat és szolgáltatási feltételek"
 #. Text for a button that links to the terms of use and privacy policy page.
 msgctxt "Secondary button text in active privacy modal"
 msgid "Privacy Policy and Terms of Service"
-msgstr ""
+msgstr "Adatvédelmi szabályzat és szolgáltatási feltételek"
 
 # smartling.placeholder_format=C
 #. Title displayed on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
@@ -15443,15 +15440,13 @@ msgstr "Érvelő mesterséges intelligencia, magas szintű beépített moderáci
 #. Text with short description for a reasoning AI (Artificial Intelligence) Model that has a low moderation level. Reasoning refers to the AI ability to think logically to draw conclusions before providing an answer. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with low built-in moderation"
-msgstr ""
-"Érvelő mesterséges intelligencia, alacsony szintű beépített moderációval"
+msgstr "Érvelő mesterséges intelligencia, alacsony szintű beépített moderációval"
 
 # smartling.placeholder_format=C
 #. Text with short description for a reasoning AI (Artificial Intelligence) Model that has a medium moderation level. Reasoning refers to the AI ability to think logically to draw conclusions before providing an answer. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with medium built-in moderation"
-msgstr ""
-"Érvelő mesterséges intelligencia, közepes szintű beépített moderációval"
+msgstr "Érvelő mesterséges intelligencia, közepes szintű beépített moderációval"
 
 # smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
@@ -15546,25 +15541,25 @@ msgstr "Ajánlj egy könyvet"
 #. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Recommend similar books"
-msgstr ""
+msgstr "Hasonló könyvek ajánlása"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Recommend similar books."
-msgstr ""
+msgstr "Ajánlj hasonló könyveket."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Recommend similar movies or shows."
-msgstr ""
+msgstr "Ajánlj hasonló filmeket vagy sorozatokat."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Recommend similar titles"
-msgstr ""
+msgstr "Hasonló tartalmak ajánlása"
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
@@ -15790,8 +15785,7 @@ msgstr "Választott beállítás megjegyzése"
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings
 msgid "Remember my choice (this can be changed in %s%s%sSettings%s)"
-msgstr ""
-"Jegyezze meg a választásomat (módosítható a %1$s%2$s%3$sBeállításokban%4$s)"
+msgstr "Jegyezze meg a választásomat (módosítható a %1$s%2$s%3$sBeállításokban%4$s)"
 
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
@@ -15977,7 +15971,7 @@ msgctxt ""
 "feedback form when the user has selected Harmful or Illegal as the feedback "
 "reason"
 msgid "Required for harmful or illegal reports"
-msgstr ""
+msgstr "Káros vagy jogsértő tartalom jelentéséhez kötelező"
 
 # smartling.placeholder_format=C
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
@@ -16045,8 +16039,8 @@ msgid ""
 "answers are subject to our %sTerms of Service%s."
 msgstr ""
 "A válaszok kizárólag tájékoztatási célokat szolgálnak, és nem minősülnek "
-"orvosi, jogi, pénzügyi, befektetési vagy egyéb szakmai tanácsnak. Az AI-"
-"alapú válaszok a %1$sSzolgáltatási feltételek%2$s hatálya alá esnek."
+"orvosi, jogi, pénzügyi, befektetési vagy egyéb szakmai tanácsnak. Az "
+"AI-alapú válaszok a %1$sSzolgáltatási feltételek%2$s hatálya alá esnek."
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -16141,8 +16135,7 @@ msgstr "A találatok nem tartalmazzák a blokkolt webhelyeket."
 #. Informational banner shown at the top of the Maps search results panel when the user has blocked Yelp or TripAdvisor in their settings. Explains why ratings, reviews, and other details may be missing from place listings.
 msgctxt "Exclusion message at top of maps vertical"
 msgid "Results exclude information from blocked sites."
-msgstr ""
-"A találatok nem tartalmazzák a blokkolt webhelyekről származó információkat."
+msgstr "A találatok nem tartalmazzák a blokkolt webhelyekről származó információkat."
 
 # smartling.placeholder_format=C
 #. Message that appears when results exclude blocked sites
@@ -16221,7 +16214,7 @@ msgstr "Vélemények"
 #. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Rewrite this recipe scaled for a different number of servings."
-msgstr ""
+msgstr "Írd át ezt a receptet más adagszámra méretezve."
 
 # smartling.placeholder_format=C
 msgid "Romania"
@@ -16705,8 +16698,7 @@ msgstr "Keresés"
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
 msgid "Search %s to find results closer to you?"
-msgstr ""
-"A helyileg közelebbi találatokhoz a keresési kifejezés legyen inkább „%1$s”?"
+msgstr "A helyileg közelebbi találatokhoz a keresési kifejezés legyen inkább „%1$s”?"
 
 # smartling.placeholder_format=C
 msgid "Search Anonymously"
@@ -17100,8 +17092,7 @@ msgstr "Fényképek megtekintése"
 #. Text for a button that links to the terms of use and privacy policy page.
 msgctxt "Secondary button text in active privacy modal"
 msgid "See Privacy Policy and Terms of Service"
-msgstr ""
-"Tekintse meg az Adatvédelmi szabályzatot és a Szolgáltatási feltételeket"
+msgstr "Tekintse meg az Adatvédelmi szabályzatot és a Szolgáltatási feltételeket"
 
 # smartling.placeholder_format=C
 #. Text of the secondary button in the modal that allows the user to open the terms and privacy policy page.
@@ -17167,8 +17158,7 @@ msgstr "További információ: %1$s"
 # smartling.placeholder_format=C
 #. Title of a notice that DuckDuckGo has noticed the user is blocking its non-tracking ads
 msgid "See more shopping results from popular retailers"
-msgstr ""
-"További vásárlási találatok megtekintése a népszerű kiskereskedők kínálatából"
+msgstr "További vásárlási találatok megtekintése a népszerű kiskereskedők kínálatából"
 
 # smartling.placeholder_format=C
 #. Text for tooltip shown on hover when displaying the number of reviews the product has on an ad, indicating that users can see more ratings on bing.com
@@ -17224,8 +17214,8 @@ msgstr ""
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
 msgstr ""
-"Válaszd az %1$sEgyéni%2$s lehetőséget, és írd be a %3$shttps://duckduckgo."
-"com%4$s címet a beviteli mezőbe"
+"Válaszd az %1$sEgyéni%2$s lehetőséget, és írd be a "
+"%3$shttps://duckduckgo.com%4$s címet a beviteli mezőbe"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
@@ -17273,8 +17263,7 @@ msgstr "Válaszd a %1$sDuckDuckGót%2$s a keresőszolgáltatók listáján"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s under the%sDefault Search Engine%s section"
-msgstr ""
-"Válaszd a %1$sDuckDuckGót%2$s az %3$sAlapértelmezett keresőmotor%4$s menüben"
+msgstr "Válaszd a %1$sDuckDuckGót%2$s az %3$sAlapértelmezett keresőmotor%4$s menüben"
 
 # smartling.placeholder_format=C
 #. Tells the user were in the settings menu they can change their default search engine.
@@ -17285,8 +17274,7 @@ msgstr "Válaszd a %1$sDuckDuckGo%2$s lehetőséget."
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Select %sEdit Search Engines...%sin the dropdown"
-msgstr ""
-"Válaszd a %1$sKeresőmotorok szerkesztése%2$s menüpontot a legördülő menüben"
+msgstr "Válaszd a %1$sKeresőmotorok szerkesztése%2$s menüpontot a legördülő menüben"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -17329,8 +17317,7 @@ msgstr "Válaszd ki a %1$sKeresőmotor%2$s lehetőséget"
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"
-msgstr ""
-"Válaszd a %1$sKeresőmotor%2$s lehetőséget, majd az %3$sEgyéb...%4$s opciót"
+msgstr "Válaszd a %1$sKeresőmotor%2$s lehetőséget, majd az %3$sEgyéb...%4$s opciót"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -17355,8 +17342,7 @@ msgstr "Válaszd ki a %1$sBeállítások%2$s opciót a legördülő menüből."
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sAdvanced settings%s"
-msgstr ""
-"Válaszd a %1$sBeállítások%2$s, majd a %3$sHaladó beállítások%4$s lehetőséget"
+msgstr "Válaszd a %1$sBeállítások%2$s, majd a %3$sHaladó beállítások%4$s lehetőséget"
 
 # smartling.placeholder_format=C
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -17589,7 +17575,7 @@ msgstr "Beállítás most"
 #. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
 msgctxt "Encrypted storage setup button shown in native browsers"
 msgid "Set Up Sync & Backup"
-msgstr ""
+msgstr "Sync & Backup beállítása"
 
 # smartling.placeholder_format=C
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
@@ -17683,8 +17669,7 @@ msgstr "Megosztás"
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "Share DuckDuckGo and help friends take their privacy back!"
-msgstr ""
-"Terjeszd a DuckDuckGót, és segíts a barátaidnak megvédeni az adataikat!"
+msgstr "Terjeszd a DuckDuckGót, és segíts a barátaidnak megvédeni az adataikat!"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button that opens a feedback modal when clicked.
@@ -17711,8 +17696,8 @@ msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
 msgstr ""
-"A relevancia javítása érdekében oszd meg a városi szintű helyadataidat az AI-"
-"modellekkel. A Duck.ai soha nem árulja el nekünk vagy az AI-modelleknek a "
+"A relevancia javítása érdekében oszd meg a városi szintű helyadataidat az "
+"AI-modellekkel. A Duck.ai soha nem árulja el nekünk vagy az AI-modelleknek a "
 "pontos tartózkodási helyedet."
 
 # smartling.placeholder_format=C
@@ -17778,15 +17763,14 @@ msgstr "Pozitív visszajelzés megosztása"
 msgctxt ""
 "Label beside the share-content switch on the Duck.ai response feedback form"
 msgid "Share this conversation with DuckDuckGo"
-msgstr ""
+msgstr "Beszélgetés megosztása a DuckDuckGóval"
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
 msgctxt ""
 "Label beside the share-content switch on the Duck.ai response feedback form"
 msgid "Share your prompt and chat response with DuckDuckGo"
-msgstr ""
-"Oszd meg az utasításodat és a beszélgetésben kapott választ a DuckDuckGóval"
+msgstr "Oszd meg az utasításodat és a beszélgetésben kapott választ a DuckDuckGóval"
 
 # smartling.placeholder_format=C
 #. Variant of the share toggle label that makes sharing mandatory when reporting harmful or illegal content.
@@ -18037,8 +18021,7 @@ msgstr "Minden találat megjelenítése"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show answers more often. (You can also %sturn them off%s.)"
-msgstr ""
-"Gyakrabban jelenítse meg a válaszokat. (%1$sKi is kapcsolhatod%2$s ezeket.)"
+msgstr "Gyakrabban jelenítse meg a válaszokat. (%1$sKi is kapcsolhatod%2$s ezeket.)"
 
 # smartling.placeholder_format=C
 #. Accessible label for the button that reveals a popover listing multiple citation sources in Duck.ai chat responses.
@@ -18187,14 +18170,12 @@ msgstr "A legtöbbször meglátogatott hivatkozások megjelenítése új lapon"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your browser"
-msgstr ""
-"Alkalmi emlékeztetők megjelenítése a DuckDuckGo hozzáadására a böngésződhöz"
+msgstr "Alkalmi emlékeztetők megjelenítése a DuckDuckGo hozzáadására a böngésződhöz"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr ""
-"Alkalmi emlékeztetők megjelenítése a DuckDuckGo hozzáadására az eszközeidhez"
+msgstr "Alkalmi emlékeztetők megjelenítése a DuckDuckGo hozzáadására az eszközeidhez"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18212,8 +18193,7 @@ msgstr "Oldalszám megjelenítése a találati oldalak töréseinél"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows sign-up form for the DuckDuckGo privacy newsletters"
-msgstr ""
-"A DuckDuckGo adatvédelmi hírleveleire való feliratkozási űrlap megjelenítése"
+msgstr "A DuckDuckGo adatvédelmi hírleveleire való feliratkozási űrlap megjelenítése"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/94erFcS.png
@@ -18241,8 +18221,7 @@ msgstr "Üdvözlőüzenet megjelenítése a keresési találati oldal tetején"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message to EU Android preference menu users"
-msgstr ""
-"Üdvözlő üzenet megjelenítése az EU-s Android-preferencia menü felhasználóinak"
+msgstr "Üdvözlő üzenet megjelenítése az EU-s Android-preferencia menü felhasználóinak"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers sometimes.
@@ -18319,8 +18298,7 @@ msgstr "Az oldalkeresés átmenetileg nem érhető el. Dolgozunk a megoldáson."
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Sites you block will be hidden from all your search results"
-msgstr ""
-"Az általad blokkolt webhelyek el lesznek rejtve minden keresési találatból"
+msgstr "Az általad blokkolt webhelyek el lesznek rejtve minden keresési találatból"
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes full name (tooltip)
@@ -19047,18 +19025,20 @@ msgstr "Adj javaslatot egy blogbejegyzés címére"
 msgctxt "Page suggestion prompt"
 msgid "Suggest related articles or topics worth exploring next."
 msgstr ""
+"Javasolj kapcsolódó cikkeket vagy témákat, amelyeket érdemes lenne ezután "
+"megnézni."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Suggest related articles to explore"
-msgstr ""
+msgstr "Kapcsolódó cikkek javaslata"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Suggest some alternatives to this product."
-msgstr ""
+msgstr "Ajánlj néhány alternatívát ehhez a termékhez."
 
 # smartling.placeholder_format=C
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
@@ -19075,7 +19055,7 @@ msgstr "Javaslatok:"
 #. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Sum up the reviews"
-msgstr ""
+msgstr "Értékelések összefoglalása"
 
 # smartling.placeholder_format=C
 #. A short title for the a message asking the AI to summarize a text.
@@ -19087,85 +19067,85 @@ msgstr "Lényegkiemelés"
 #. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize the Q&As"
-msgstr ""
+msgstr "Kérdések és válaszok összefoglalása"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the background and notable work of this person."
-msgstr ""
+msgstr "Foglald össze ennek a személynek a hátterét és jelentősebb munkáit."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the key details of this event."
-msgstr ""
+msgstr "Foglald össze az esemény legfontosabb részleteit."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the questions and answers on this page."
-msgstr ""
+msgstr "Foglald össze az oldalon szereplő kérdéseket és válaszokat."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize their background"
-msgstr ""
+msgstr "Háttér összefoglalása"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this book"
-msgstr ""
+msgstr "Könyv összefoglalása"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this book."
-msgstr ""
+msgstr "Foglald össze ezt a könyvet."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this discussion"
-msgstr ""
+msgstr "Beszélgetés összefoglalása"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this discussion thread."
-msgstr ""
+msgstr "Foglald össze ezt a beszélgetési szálat."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this page"
-msgstr ""
+msgstr "Oldal összefoglalása"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this page."
-msgstr ""
+msgstr "Foglald össze ezt az oldalt."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this video"
-msgstr ""
+msgstr "Videó összefoglalása"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this video."
-msgstr ""
+msgstr "Foglald össze ezt a videót."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize what the reviews say."
-msgstr ""
+msgstr "Foglald össze, mit mondanak az értékelések."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -19499,7 +19479,7 @@ msgstr "Szíria"
 #. Text for a button that enables the theme to follow the operating system's color scheme preference.
 msgctxt "System theme button for theme selector"
 msgid "System"
-msgstr ""
+msgstr "Rendszer"
 
 # smartling.placeholder_format=C
 #. Abbreviation indicating this is the total score for a game
@@ -19533,7 +19513,7 @@ msgstr "tahiti"
 #. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Tailor my resume"
-msgstr ""
+msgstr "Önéletrajz igazítása"
 
 # smartling.placeholder_format=C
 msgid "Taiwan"
@@ -19570,6 +19550,8 @@ msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
+"Töltsd ki ezt a kérdőívet névtelenül, és mondd el, hogyan tehetnénk jobbá a "
+"Duck.ai-t."
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -19638,8 +19620,7 @@ msgstr "Koppints a címsorban található %1$sengedélyek ikonra%2$s"
 #. Tells users which icon to press in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Tap the vertical dots in the DuckDuckGo app."
-msgstr ""
-"Koppints a függőlegesen elhelyezkedő pontokra a DuckDuckGo alkalmazásban."
+msgstr "Koppints a függőlegesen elhelyezkedő pontokra a DuckDuckGo alkalmazásban."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a teacher in its responses.
@@ -19808,21 +19789,18 @@ msgstr "Gambia"
 #. Error message displayed when the total size of all attached files in a conversation exceeds the allowed limit. Placeholder is the combined size limit in megabytes. E.g. The attached files exceed the total size limit of 5 MB
 msgctxt "Error message when combined file size exceeds the limit"
 msgid "The attached files exceed the total size limit of %s MB"
-msgstr ""
-"A csatolt fájlok összmérete meghaladja a maximálisan megengedett %1$s MB-ot"
+msgstr "A csatolt fájlok összmérete meghaladja a maximálisan megengedett %1$s MB-ot"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the total size of all attached files in a conversation exceeds the allowed limit. Placeholder is the combined size limit in megabytes. E.g. The attached files exceed the total size limit of 5 MB
 msgctxt "Error message when combined file size exceeds the limit"
 msgid "The attached files exceed the total size limit of %s MB."
-msgstr ""
-"A csatolt fájlok összmérete meghaladja a maximálisan megengedett %1$s MB-ot."
+msgstr "A csatolt fájlok összmérete meghaladja a maximálisan megengedett %1$s MB-ot."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the server rejects corrupt or unrecognized audio.
 msgid "The audio could not be processed. Please try recording again."
-msgstr ""
-"A hanganyag feldolgozása sikertelen volt. Próbálkozz újra a felvétellel."
+msgstr "A hanganyag feldolgozása sikertelen volt. Próbálkozz újra a felvétellel."
 
 # smartling.placeholder_format=C
 #. Second paragraph explaining where the encryption key is stored on the entry screen.
@@ -19885,7 +19863,7 @@ msgstr "Kinézet"
 #. Text for the theme selector label that allows users to switch between Light and dark theme.
 msgctxt "Label for the theme selector feature"
 msgid "Theme"
-msgstr ""
+msgstr "Téma"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/LpFhb1e.png
@@ -20140,8 +20118,8 @@ msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF"
 msgstr ""
-"Ez a képtípus nem támogatott. Kérjük, csatolj egy JPG-, PNG-, WebP- vagy GIF-"
-"fájlt"
+"Ez a képtípus nem támogatott. Kérjük, csatolj egy JPG-, PNG-, WebP- vagy "
+"GIF-fájlt"
 
 # smartling.placeholder_format=C
 #. Error message displayed when a file that the user tried to upload is not of a supported format
@@ -20149,8 +20127,8 @@ msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF."
 msgstr ""
-"Ez a képtípus nem támogatott. Kérjük, csatolj egy JPG-, PNG-, WebP- vagy GIF-"
-"fájlt."
+"Ez a képtípus nem támogatott. Kérjük, csatolj egy JPG-, PNG-, WebP- vagy "
+"GIF-fájlt."
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
@@ -20234,9 +20212,9 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again."
 msgstr ""
-"Ez a beállítás a böngésződben kerül tárolásra, tehát ha törlöd a duckduckgo."
-"com böngészési adatait, előfordulhat, hogy ismét megjelennek a mesterséges "
-"intelligencia segítségével generált válaszok."
+"Ez a beállítás a böngésződben kerül tárolásra, tehát ha törlöd a "
+"duckduckgo.com böngészési adatait, előfordulhat, hogy ismét megjelennek a "
+"mesterséges intelligencia segítségével generált válaszok."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -20246,9 +20224,9 @@ msgid ""
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
 msgstr ""
-"Ez a beállítás a böngésződben kerül tárolásra, tehát ha törlöd a duckduckgo."
-"com böngészési adatait, előfordulhat, hogy ismét megjelennek a mesterséges "
-"intelligencia segítségével generált válaszok. Ugyanakkor van egy "
+"Ez a beállítás a böngésződben kerül tárolásra, tehát ha törlöd a "
+"duckduckgo.com böngészési adatait, előfordulhat, hogy ismét megjelennek a "
+"mesterséges intelligencia segítségével generált válaszok. Ugyanakkor van egy "
 "kezdőoldalunk, amely soha nem jelenít meg AI-alapú válaszokat: %1$s."
 
 # smartling.placeholder_format=C
@@ -20278,8 +20256,7 @@ msgstr "Ez a videó még nem tekinthető meg itt. Megnézheted itt: %1$s."
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr ""
-"Ez a weboldal nem használ biztonságos, titkosított kapcsolatot (HTTPS)."
+msgstr "Ez a weboldal nem használ biztonságos, titkosított kapcsolatot (HTTPS)."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -20457,8 +20434,8 @@ msgid ""
 "you originally used to set up Sync."
 msgstr ""
 "A szinkronizált adatok visszaállításához szükség lesz a szinkronizálás első "
-"beállításakor mentett helyreállítási kódra. Lehetséges, hogy ez a kód PDF-"
-"fájlként lett mentve a szinkronizálás beállításához eredetileg használt "
+"beállításakor mentett helyreállítási kódra. Lehetséges, hogy ez a kód "
+"PDF-fájlként lett mentve a szinkronizálás beállításához eredetileg használt "
 "eszközre."
 
 # smartling.placeholder_format=C
@@ -20734,13 +20711,13 @@ msgstr ""
 #. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Translate this page"
-msgstr ""
+msgstr "Oldal lefordítása"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
 msgctxt "Page suggestion prompt"
 msgid "Translate this page into %s."
-msgstr ""
+msgstr "Fordítsd le ezt az oldalt %1$s nyelvre."
 
 # smartling.placeholder_format=C
 #. Placeholder text for a region that will display translated text.
@@ -20836,8 +20813,7 @@ msgstr "Próbálkozz ezzel: %1$s"
 # smartling.placeholder_format=C
 #. Prompt for the user to start using our homepage that doesn't show promotional messages. The placeholder is a homepage url (e.g., 'start.duckduckgo.com')
 msgid "Try %s to stop seeing messages like this."
-msgstr ""
-"Próbáld ki a(z) %1$s címet, hogy többé ne jelenjenek meg ilyen üzenetek."
+msgstr "Próbáld ki a(z) %1$s címet, hogy többé ne jelenjenek meg ilyen üzenetek."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that encourages users to try the encrypted AI model whose inference runs in a confidential environment so the model provider cannot access user data. %s is replaced with the model's full display name (e.g. 'GPT-OSS 120B').
@@ -20892,7 +20868,7 @@ msgstr "Ingyenes próba"
 #. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
 msgctxt "settings"
 msgid "Try It Now"
-msgstr ""
+msgstr "Próbáld ki most"
 
 # smartling.placeholder_format=C
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -20958,16 +20934,14 @@ msgstr ""
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
 msgctxt "precise_user_location"
 msgid "Try enabling anonymous location for more accurate results."
-msgstr ""
-"A pontosabb eredmények érdekében próbálkozz az anonim hely engedélyezésével."
+msgstr "A pontosabb eredmények érdekében próbálkozz az anonim hely engedélyezésével."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the screen of the onboarding where the user picks a chat model.
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr ""
-"Próbálj kísérletezni az egyes modellekkel – különböző válaszokat generálnak."
+msgstr "Próbálj kísérletezni az egyes modellekkel – különböző válaszokat generálnak."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
@@ -20995,8 +20969,7 @@ msgstr "Próbáld ki ingyen"
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
-msgstr ""
-"Próbáld ki ingyen! Biztonságos VPN, fejlett és privát MI, és még sok más."
+msgstr "Próbáld ki ingyen! Biztonságos VPN, fejlett és privát MI, és még sok más."
 
 # smartling.placeholder_format=C
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -21023,8 +20996,7 @@ msgstr "Próbáld ki a böngészőnket,"
 # smartling.placeholder_format=C
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
-msgstr ""
-"Próbáld ki a kezdőoldalunkat, ahol soha nem mutatjuk ezeket az üzeneteket:"
+msgstr "Próbáld ki a kezdőoldalunkat, ahol soha nem mutatjuk ezeket az üzeneteket:"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with different words to get more results.
@@ -21145,6 +21117,9 @@ msgid ""
 "Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
+"Szeretnéd letiltani az MI-funkciókat? Telepítsd a(z) %1$sDuckDuckGo No "
+"AI%2$s keresőbővítményt, hogy megjegyezze a beállításaidat. %3$sTovábbi "
+"információk%4$s"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -21153,6 +21128,9 @@ msgid ""
 "Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
+"Szeretnéd letiltani az MI-funkciókat? Válts a(z) %1$sDuckDuckGo No AI%2$s "
+"keresőbővítményre, hogy megjegyezze a beállításaidat. %3$sTovábbi "
+"információk%4$s"
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -21259,8 +21237,7 @@ msgstr "A pontosabb találatokhoz kapcsold be a %1$sPontos hely%2$s funkciót"
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
-msgstr ""
-"Duck Player bekapcsolása a YouTube célzott hirdetések nélküli megtekintéséhez"
+msgstr "Duck Player bekapcsolása a YouTube célzott hirdetések nélküli megtekintéséhez"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service.
@@ -21487,8 +21464,7 @@ msgstr "Az %1$sÁltalános > Kezdőlap%2$s alatt írd be: https://duckduckgo.com
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch Settings%s select %sDuckDuckGo%s"
-msgstr ""
-"A %1$sKeresési beállítások%2$s alatt válaszd a %3$sDuckDuckGo%4$s lehetőséget"
+msgstr "A %1$sKeresési beállítások%2$s alatt válaszd a %3$sDuckDuckGo%4$s lehetőséget"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -21597,8 +21573,8 @@ msgid ""
 "Unlock %s, higher AI reasoning, and 2x higher usage limits than the Plus "
 "plan by upgrading to Pro."
 msgstr ""
-"Válts Pro verzióra, hogy hozzáférj a(z) %1$s modellhez, a fejlettebb MI-"
-"érveléshez és a Plus csomagnál kétszer magasabb használati korlátokhoz."
+"Válts Pro verzióra, hogy hozzáférj a(z) %1$s modellhez, a fejlettebb "
+"MI-érveléshez és a Plus csomagnál kétszer magasabb használati korlátokhoz."
 
 # smartling.placeholder_format=C
 #. Title for the subscription promo shown in the SERP sidemenu.
@@ -21620,8 +21596,8 @@ msgctxt "voice chat limit modal"
 msgid ""
 "Unlock advanced AI models and higher limits with a DuckDuckGo Subscription"
 msgstr ""
-"Fejlett MI-modelleket és nagyobb használati kereteket érhetsz el DuckDuckGo-"
-"előfizetéssel"
+"Fejlett MI-modelleket és nagyobb használati kereteket érhetsz el "
+"DuckDuckGo-előfizetéssel"
 
 # smartling.placeholder_format=C
 #. Text informing the user that advanced AI models can be unlocked with a subscription. The variable is used to insert a link that opens the subscription modal. Example: Unlock advanced AI models with a DuckDuckGo subscription.
@@ -21921,7 +21897,7 @@ msgstr "Uruguay"
 #. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
 msgctxt "Navigation label on the Duck.ai settings page"
 msgid "Usage"
-msgstr ""
+msgstr "Használat"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -22219,9 +22195,9 @@ msgid ""
 "Visit Duck.ai in your other browser and go to %sDuck.ai Settings%s > %sSync "
 "& Backup%s > %sManage%s then select %sSync With Another Device%s."
 msgstr ""
-"Nyisd meg a Duck.ai-t a másik böngésződben, és lépj ide: %1$sDuck.ai-"
-"beállítások%2$s > %3$sSync & Backup%4$s > %5$sKezelés%6$s, majd válaszd a "
-"%7$sSzinkronizálás másik eszközzel%8$s lehetőséget."
+"Nyisd meg a Duck.ai-t a másik böngésződben, és lépj ide: "
+"%1$sDuck.ai-beállítások%2$s > %3$sSync & Backup%4$s > %5$sKezelés%6$s, majd "
+"válaszd a %7$sSzinkronizálás másik eszközzel%8$s lehetőséget."
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -22260,8 +22236,8 @@ msgstr ""
 "Látogass el a Duck.ai oldalra a másik böngésződben vagy a DuckDuckGo "
 "alkalmazásban, és nyisd meg a Duck.ai beállításait. Válaszd a „Bekapcsolás” "
 "lehetőséget a Sync & Backup alatt, és válaszd a „Szinkronizálás másik "
-"eszközzel” opciót. Vagy olvasd be a helyreállítási PDF-ben található QR-"
-"kódot."
+"eszközzel” opciót. Vagy olvasd be a helyreállítási PDF-ben található "
+"QR-kódot."
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -22314,8 +22290,8 @@ msgstr "A hangcsevegés véget ért"
 msgctxt "voice chat"
 msgid "Voice chat is anonymized by us, and never used to train AI models."
 msgstr ""
-"A hangcsevegéseket anonim módon kezeljük, és soha nem használjuk fel MI-"
-"modellek betanítására."
+"A hangcsevegéseket anonim módon kezeljük, és soha nem használjuk fel "
+"MI-modellek betanítására."
 
 # smartling.placeholder_format=C
 #. Title of the modal shown when the user has reached their daily voice chat limit.
@@ -22379,7 +22355,7 @@ msgstr "Wales"
 #. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Walk me through the steps"
-msgstr ""
+msgstr "Vezess végig a lépéseken"
 
 # smartling.placeholder_format=C
 #. Label for walking directions on a map.
@@ -22459,8 +22435,9 @@ msgid ""
 "Watch in Duck Player to block personalized ads on YouTube and prevent your "
 "viewing activity from influencing YouTube recommendations."
 msgstr ""
-"Nézd a tartalmat Duck Playerrel, hogy blokkold a személyre szabott YouTube-"
-"hirdetéseket, és a megtekintéseid ne befolyásolják a YouTube ajánlásait."
+"Nézd a tartalmat Duck Playerrel, hogy blokkold a személyre szabott "
+"YouTube-hirdetéseket, és a megtekintéseid ne befolyásolják a YouTube "
+"ajánlásait."
 
 # smartling.placeholder_format=C
 #. A button that takes a user to another site in order to watch a video. The placeholder is the name of the video site. For example: 'Watch on Vimeo'
@@ -22507,6 +22484,9 @@ msgid ""
 "please share this conversation with DuckDuckGo so we can investigate and "
 "address the issue."
 msgstr ""
+"Csak azt tudjuk kijavítani, amit látunk. Káros vagy jogsértő válasz "
+"jelentéséhez oszd meg ezt a beszélgetést a DuckDuckGóval, hogy ki tudjuk "
+"vizsgálni és kezelni tudjuk a problémát."
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -22526,16 +22506,14 @@ msgstr ""
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can use your anonymous%s location%s to show you nearby results."
-msgstr ""
-"Anonim%1$s helyed%2$s felhasználásával közeli eredményeket mutathatunk neked."
+msgstr "Anonim%1$s helyed%2$s felhasználásával közeli eredményeket mutathatunk neked."
 
 # smartling.placeholder_format=C
 #. Error message displayed when one or more attached files are encrypted and cannot be read.
 msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
-msgstr ""
-"Nem tudjuk olvasni a csatolt fájlokat, mert legalább az egyik titkosítva van."
+msgstr "Nem tudjuk olvasni a csatolt fájlokat, mert legalább az egyik titkosítva van."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -22577,8 +22555,7 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what brought you "
 "back today:"
-msgstr ""
-"Nem követünk téged, ezért tőled kell megkérdeznünk, hogy mi járatban vagy:"
+msgstr "Nem követünk téged, ezért tőled kell megkérdeznünk, hogy mi járatban vagy:"
 
 # smartling.placeholder_format=C
 #. Message prompting users to fill out a feedback form.
@@ -22730,8 +22707,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
-msgstr ""
-"Blokkoljuk a böngészés közben adataid gyűjtésével próbálkozó nyomkövetőket."
+msgstr "Blokkoljuk a böngészés közben adataid gyűjtésével próbálkozó nyomkövetőket."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -22906,8 +22882,8 @@ msgid ""
 "anonymized by us and not used to train AI models."
 msgstr ""
 "Üdvözöl a DuckDuckGo AI Chat! Minden itt folytatott beszélgetésed privát, "
-"anonimizáljuk azokat, és nem használjuk fel mesterségesintelligencia-"
-"modellek tanítására."
+"anonimizáljuk azokat, és nem használjuk fel "
+"mesterségesintelligencia-modellek tanítására."
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened. Example: 'Welcome to DuckDuckGo AI Chat! This chat session is powered by OpenAI’s GPT-3. All of your chats here are private, and are never stored by DuckDuckGo or used to train AI models.'
@@ -22919,15 +22895,14 @@ msgid ""
 msgstr ""
 "Üdvözöl a DuckDuckGo AI Chat! A csevegést a(z) %1$s %2$s technológiája "
 "szolgáltatja. Minden itt folytatott beszélgetésed privát, melyeket a "
-"DuckDuckGo soha nem tárol, és nem használ fel a mesterségesintelligencia-"
-"modellek tanítására."
+"DuckDuckGo soha nem tárol, és nem használ fel a "
+"mesterségesintelligencia-modellek tanítására."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai! You can now import your downloaded chats."
-msgstr ""
-"Üdvözöl az új Duck.ai! Mostantól importálhatod a letöltött csevegéseidet."
+msgstr "Üdvözöl az új Duck.ai! Mostantól importálhatod a letöltött csevegéseidet."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -23026,8 +23001,7 @@ msgstr ""
 #. Text for a prompt suggestion for asking about must-see attractions in Paris for a first-time visitor.
 msgctxt "Full sentence for planning a trip"
 msgid "What are some must-see attractions in Paris for a first-time visitor?"
-msgstr ""
-"Milyen látnivalókat érdemes megnézni Párizsban annak, aki először jár ott?"
+msgstr "Milyen látnivalókat érdemes megnézni Párizsban annak, aki először jár ott?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for finding options for the word 'better' in a specific context.
@@ -23068,98 +23042,98 @@ msgstr ""
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the counterarguments?"
-msgstr ""
+msgstr "Mik az ellenérvek?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the hours & location?"
-msgstr ""
+msgstr "Mi a nyitvatartás rend és a cím?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key contributions of this paper?"
-msgstr ""
+msgstr "Mik a tanulmány főbb eredményei?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key contributions?"
-msgstr ""
+msgstr "Mik a főbb eredmények?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key details?"
-msgstr ""
+msgstr "Mik a legfontosabb részletek?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key points covered in this video?"
-msgstr ""
+msgstr "Melyek a videóban érintett legfontosabb pontok?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key points?"
-msgstr ""
+msgstr "Mik a legfontosabb pontok?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key takeaways from this article?"
-msgstr ""
+msgstr "Mik a cikk legfontosabb tanulságai?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key takeaways?"
-msgstr ""
+msgstr "Melyek a legfontosabb tanulságok?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key things I will learn from this course?"
-msgstr ""
+msgstr "Mik azok a legfontosabb dolgok, amiket megtanulok ezen a kurzuson?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the main counterarguments or criticisms of this?"
-msgstr ""
+msgstr "Mik a fő ellenérvek vagy kritikák ezzel kapcsolatban?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the main questions this page answers?"
-msgstr ""
+msgstr "Melyek a fő kérdések, amelyekre választ ad ez az oldal?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the must-try dishes here?"
-msgstr ""
+msgstr "Melyek a kihagyhatatlan ételek itt?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid ""
 "What are the opening hours, location, and contact details for this place?"
-msgstr ""
+msgstr "Milyen a hely nyitvatartása, hol található, és mik az elérhetőségei?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the pros and cons of this product?"
-msgstr ""
+msgstr "Milyen előnyei és hátrányai vannak ennek a terméknek?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the pros and cons?"
-msgstr ""
+msgstr "Mik az előnyök és a hátrányok?"
 
 # smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
@@ -23265,7 +23239,7 @@ msgstr "Mi a pitvar jelentése egy orvosi cikkel összefüggésben?"
 #. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What does this answer?"
-msgstr ""
+msgstr "Mire ad ez választ?"
 
 # smartling.placeholder_format=C
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
@@ -23283,7 +23257,7 @@ msgstr "Milyen információ kerül mentésre?"
 #. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What interview questions might come up for this role?"
-msgstr ""
+msgstr "Milyen interjúkérdések merülhetnek fel ennél a munkakörnél?"
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -23305,7 +23279,7 @@ msgstr "Mi Albánia fővárosa?"
 #. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What is the overall verdict and rating for this?"
-msgstr ""
+msgstr "Mi az általános vélemény és értékelés erről?"
 
 # smartling.placeholder_format=C
 #. Link to a page with additional information.
@@ -23333,7 +23307,7 @@ msgstr "Ezt mondják az emberek:"
 #. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What should I order?"
-msgstr ""
+msgstr "Mit rendeljek?"
 
 # smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
@@ -23351,13 +23325,13 @@ msgstr "Mi volt a gond a válasszal? (nem kötelező)"
 #. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What will I learn?"
-msgstr ""
+msgstr "Mit fogok megtanulni?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What will I need?"
-msgstr ""
+msgstr "Mire lesz szükségem?"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -23382,7 +23356,7 @@ msgstr "Újdonságok"
 #. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What's the verdict?"
-msgstr ""
+msgstr "Mi a végső vélemény?"
 
 # smartling.placeholder_format=C
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -23402,8 +23376,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "When enabled, Duck.ai will show instant answers in the chat."
-msgstr ""
-"Engedélyezés esetén a Duck.ai azonnali válaszokat jelenít meg a csevegésben."
+msgstr "Engedélyezés esetén a Duck.ai azonnali válaszokat jelenít meg a csevegésben."
 
 # smartling.placeholder_format=C
 #. Text of a button that performs a search for the available streaming services that show a particular movie or tv show
@@ -23421,8 +23394,7 @@ msgstr "Hol nézhető meg a(z) <strong>%1$s</strong>?"
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Where it says Homepage click %sSet to Current Page%s."
-msgstr ""
-"A kezdőoldalon kattints a %1$sJelenlegi oldal beállítása%2$s lehetőségre."
+msgstr "A kezdőoldalon kattints a %1$sJelenlegi oldal beállítása%2$s lehetőségre."
 
 # smartling.placeholder_format=C
 #. Heading of a module showing what streaming services are showing a movie or series, e.g. Where to Watch The Matrix
@@ -23440,7 +23412,7 @@ msgstr "Milyen funkciók hiányoznak? (Opcionális)"
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Which features are missing? (optional)"
-msgstr ""
+msgstr "Milyen funkciók hiányoznak? (nem kötelező)"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
@@ -23462,13 +23434,13 @@ msgstr "Kik vagyunk?"
 #. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Who are the main cast and crew, and what else are they known for?"
-msgstr ""
+msgstr "Kik a legfontosabb szereplők és alkotók, és miről ismertek még?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Who is this person?"
-msgstr ""
+msgstr "Ki ez a személy?"
 
 # smartling.placeholder_format=C
 #. Header above a collection of privacy-related links.
@@ -23878,8 +23850,7 @@ msgstr ""
 #. Text informing the user that they can access DuckDuckGo AI Chat directly at a specific URL. The placeholder %s will be replaced with the link. Example: 'You can access DuckDuckGo AI Chat directly at duck.ai.'
 msgctxt "Information about direct access to DuckDuckGo AI Chat"
 msgid "You can access DuckDuckGo AI Chat directly at %s."
-msgstr ""
-"A DuckDuckGo AI Chat csevegője közvetlenül elérhető a következő címen: %1$s."
+msgstr "A DuckDuckGo AI Chat csevegője közvetlenül elérhető a következő címen: %1$s."
 
 # smartling.placeholder_format=C
 #. Search Assist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate Search Assist.
@@ -23966,8 +23937,7 @@ msgstr "Ezt az emlékeztetőt elrejtheti a %1$sKeresési beállításokban%2$s."
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
-msgstr ""
-"Mostantól akár 100 csevegést is menthetsz ezen az eszközön. Csevegj bátran!"
+msgstr "Mostantól akár 100 csevegést is menthetsz ezen az eszközön. Csevegj bátran!"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -24214,8 +24184,7 @@ msgctxt "Error message for user limit"
 msgid ""
 "You've reached the maximum number of messages for the moment. Please try "
 "again later."
-msgstr ""
-"Elérted az üzenetek pillanatnyi maximális számát. Próbálkozz újra később."
+msgstr "Elérted az üzenetek pillanatnyi maximális számát. Próbálkozz újra később."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -24457,22 +24426,19 @@ msgctxt "duckai_migration"
 msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
-msgstr ""
-"A csevegések importálva lettek. Folytasd ott, ahol abbahagytad a Duck.ai-ban."
+msgstr "A csevegések importálva lettek. Folytasd ott, ahol abbahagytad a Duck.ai-ban."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.
 msgctxt "Description for the joiner-device success screen"
 msgid "Your chats will now sync between these devices."
-msgstr ""
-"A beszélgetéseid mostantól szinkronizálódnak ezek között az eszközök között."
+msgstr "A beszélgetéseid mostantól szinkronizálódnak ezek között az eszközök között."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the success screen after a successful pairing.
 msgctxt "Description for the success screen"
 msgid "Your chats will now sync between these devices."
-msgstr ""
-"A beszélgetéseid mostantól szinkronizálódnak ezek között az eszközök között."
+msgstr "A beszélgetéseid mostantól szinkronizálódnak ezek között az eszközök között."
 
 # smartling.placeholder_format=C
 #. Description explaining why delegation is needed for image generation.
@@ -24601,8 +24567,7 @@ msgstr "Kereséseid nem köthetők hozzád"
 #. Confirms the recovery succeeded. The Next CTA closes the sheet.
 msgctxt "Body copy on the recover-data success sheet"
 msgid "Your synced chats are being restored to this device."
-msgstr ""
-"A szinkronizált csevegéseket a rendszer erre az eszközre állítja vissza."
+msgstr "A szinkronizált csevegéseket a rendszer erre az eszközre állítja vissza."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -24662,8 +24627,7 @@ msgctxt "Error message for user limit"
 msgid ""
 "You’ve reached the maximum number of messages for one day. Please continue "
 "this chat tomorrow."
-msgstr ""
-"Elérted a napi üzenetek maximális számát. Holnap folytasd ezt a csevegést."
+msgstr "Elérted a napi üzenetek maximális számát. Holnap folytasd ezt a csevegést."
 
 # smartling.placeholder_format=C
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
@@ -24966,8 +24930,8 @@ msgstr "hivatalos webhely"
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
 msgstr ""
-"vagy írd ki a választott szín kódját, pl. %1$s (%2$s egy kódolt %3$s-"
-"karakter)."
+"vagy írd ki a választott szín kódját, pl. %1$s (%2$s egy kódolt "
+"%3$s-karakter)."
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "

--- a/locales/hu_HU/LC_MESSAGES/duckduckgo.po
+++ b/locales/hu_HU/LC_MESSAGES/duckduckgo.po
@@ -23048,7 +23048,7 @@ msgstr "Mik az ellenérvek?"
 #. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the hours & location?"
-msgstr "Mi a nyitvatartás rend és a cím?"
+msgstr "Mi a nyitvatartás és a cím?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.

--- a/locales/hu_HU/LC_MESSAGES/duckduckgo.po
+++ b/locales/hu_HU/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: hu_HU\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -176,9 +176,9 @@ msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
 msgstr ""
-"A(z) %1$s csak a Pro verzióval érhető el. Frissítsd újra a "
-"DuckDuckGo-előfizetésedet ebben a böngészőben a csevegés folytatásához, vagy "
-"válts a Plus vagy az ingyenes modellre."
+"A(z) %1$s csak a Pro verzióval érhető el. Frissítsd újra a DuckDuckGo-"
+"előfizetésedet ebben a böngészőben a csevegés folytatásához, vagy válts a "
+"Plus vagy az ingyenes modellre."
 
 # smartling.placeholder_format=C
 #. Text for the disclaimer message that appears when a Plus subscriber tries to use a Pro-only model. %s is replaced with the model name. Example: Claude Opus 4.6 is only available with Pro. Upgrade your DuckDuckGo subscription in this browser again to continue the chat, or switch to a Plus or free model.
@@ -188,9 +188,9 @@ msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
 msgstr ""
-"A(z) %1$s csak a Pro verzióval érhető el. Frissítsd újra a "
-"DuckDuckGo-előfizetésedet ebben a böngészőben a csevegés folytatásához, vagy "
-"válts a Plus vagy az ingyenes modellre."
+"A(z) %1$s csak a Pro verzióval érhető el. Frissítsd újra a DuckDuckGo-"
+"előfizetésedet ebben a böngészőben a csevegés folytatásához, vagy válts a "
+"Plus vagy az ingyenes modellre."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI (Artificial Intelligence) chat model is temporarily unavailable. Example: 'GPT 4o is only available with a DuckDuckGo subscription.'
@@ -468,7 +468,8 @@ msgstr "%1$sTudj meg többet%2$s"
 #. Link to a page with more information about how anonymous location works.
 msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
-msgstr "%1$sTudd meg, hogyan őrizzük meg a tartózkodási helyed bizalmasságát%2$s."
+msgstr ""
+"%1$sTudd meg, hogyan őrizzük meg a tartózkodási helyed bizalmasságát%2$s."
 
 # smartling.placeholder_format=C
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
@@ -483,13 +484,15 @@ msgstr ""
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "%sLearn more%s about how chats are stored privately on your device."
-msgstr "%1$sTovábbi részletek%2$s a csevegések eszközön való privát tárolásáról."
+msgstr ""
+"%1$sTovábbi részletek%2$s a csevegések eszközön való privát tárolásáról."
 
 # smartling.placeholder_format=C
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "%sLong-press%s the DuckDuckGo app icon on the home screen"
-msgstr "%1$sNyomd meg hosszan%2$s a DuckDuckGo alkalmazás ikonját a kezdőképernyőn"
+msgstr ""
+"%1$sNyomd meg hosszan%2$s a DuckDuckGo alkalmazás ikonját a kezdőképernyőn"
 
 # smartling.placeholder_format=C
 #. A message displayed when there is an error loading content or no results on requery
@@ -812,7 +815,8 @@ msgstr "Elérted a 6 órás használati limitet."
 #. Displayed when the user has reached a fixed 6-hour Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "6-hour usage limit reached. You can continue this chat after %s."
-msgstr "Elérted a 6 órás használati limitet. A csevegést %1$s után folytathatod."
+msgstr ""
+"Elérted a 6 órás használati limitet. A csevegést %1$s után folytathatod."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable 6-hour Duck.ai usage limit and can opt in to continue using the daily limit.
@@ -931,9 +935,8 @@ msgstr ""
 "Az AI Chat segítségével névtelen beszélgetéseket folytathatsz harmadik felek "
 "mesterséges intelligencián alapuló csevegési modelljeivel. Ennek "
 "kikapcsolása elrejti az AI Chat funkciót a DuckDuckGo Search "
-"szolgáltatásban. Ha a beállítás ki van kapcsolva, a "
-"%1$sduckduckgo.com/aichat%2$s oldalra látogatva továbbra is elérheted az AI "
-"Chatet."
+"szolgáltatásban. Ha a beállítás ki van kapcsolva, a %1$sduckduckgo.com/"
+"aichat%2$s oldalra látogatva továbbra is elérheted az AI Chatet."
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -997,9 +1000,8 @@ msgstr ""
 "Az AI-alapú válaszokra jelenleg nem tehetők fel közvetlenül további "
 "kérdések. Azonban ha újabb kérdést szeretnél feltenni, az OpenAI, az "
 "Anthropic, valamint más szolgáltatók csevegési modelljeit is támogató "
-"mesterségesintelligencia-alapú privát csevegési szolgáltatásunk, a "
-"%1$sDuck.ai%2$s használatát is felajánljuk, és gyakran megjelenítjük annak "
-"linkjét."
+"mesterségesintelligencia-alapú privát csevegési szolgáltatásunk, a %1$sDuck."
+"ai%2$s használatát is felajánljuk, és gyakran megjelenítjük annak linkjét."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has turned off AI features and will no longer see AI-assisted answers.
@@ -1442,6 +1444,12 @@ msgid "Address is incorrect"
 msgstr "A cím helytelen"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Adjust the servings"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. as in multiple advertisements
 msgid "Ads"
 msgstr "Hirdetések"
@@ -1653,6 +1661,14 @@ msgstr "Minden beszélgetés %1$s. A mesterséges intelligencia hibázhat."
 msgctxt "Empty state heading in Duck.ai chat mode"
 msgid "All chats are %sprivate%s"
 msgstr "Minden csevegés %1$sprivát%2$s"
+
+# smartling.placeholder_format=C
+#. Paragraph in the Privacy & Terms section of the About & Legal page in Duck.ai settings, summarizing how chats are anonymized and are not stored or used to train chat models.
+msgctxt "Privacy & Terms section description on the Duck.ai settings page"
+msgid ""
+"All chats are anonymized by DuckDuckGo, and your conversations are not used "
+"to train chat models by DuckDuckGo or the model providers"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1926,6 +1942,13 @@ msgstr ""
 msgctxt "precise_user_location"
 msgid "Anonymous location enabled"
 msgstr "Névtelen hely engedélyezve"
+
+# smartling.placeholder_format=C
+msgctxt "settings"
+msgid ""
+"Anonymously generates answers for search queries based on web content. "
+"Choose how often you want it to appear, or disable it completely."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -2207,6 +2230,12 @@ msgid "Ask a follow-up with Duck.ai"
 msgstr "Tegyél fel kapcsolódó kérést a Duck.ai segítségével"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
+msgctxt "Page suggestion chip label"
+msgid "Ask about this page"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
 msgctxt "Title for the page context onboarding modal"
 msgid "Ask about this page"
@@ -2274,9 +2303,9 @@ msgstr ""
 "felhasználói felületét a keresési eredményekből), Igény szerint (csak az "
 "Asszisztens gombra kattintás esetén jelennek meg az AI-alapú válaszok), Néha "
 "(csak akkor jelenik meg AI-alapú válasz, ha nagyon releváns), illetve "
-"Gyakran (gyakrabban jelenik meg, szélesebb körű keresések esetén). Az "
-"AI-alapú válaszok egyelőre csak az Egyesült Államok (angol) régiójában "
-"érhetők el."
+"Gyakran (gyakrabban jelenik meg, szélesebb körű keresések esetén). Az AI-"
+"alapú válaszok egyelőre csak az Egyesült Államok (angol) régiójában érhetők "
+"el."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2373,18 +2402,21 @@ msgstr "Hang"
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat ends."
-msgstr "A hanganyagot a csevegés befejezése után mi nem tároljuk, és az OpenAI sem."
+msgstr ""
+"A hanganyagot a csevegés befejezése után mi nem tároljuk, és az OpenAI sem."
 
 # smartling.placeholder_format=C
 #. Description in consent disclaimer informing that audio from the voice chat session is not stored by us or by OpenAI after the voice chat ends.
 msgctxt "voice chat"
 msgid "Audio is not stored by us or by OpenAI after the chat ends."
-msgstr "A hanganyagot a csevegés befejezése után mi nem tároljuk, és az OpenAI sem."
+msgstr ""
+"A hanganyagot a csevegés befejezése után mi nem tároljuk, és az OpenAI sem."
 
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat is transcribed."
-msgstr "A hanganyagot a csevegés átírása után mi nem tároljuk, és az OpenAI sem."
+msgstr ""
+"A hanganyagot a csevegés átírása után mi nem tároljuk, és az OpenAI sem."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when MediaRecorder API is unavailable.
@@ -2624,6 +2656,12 @@ msgid "Barcode"
 msgstr "Vonalkód"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Based on this page, is this course worth taking?"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Basic"
 msgstr "Alap"
@@ -2662,6 +2700,14 @@ msgstr "Ütőjátékos"
 msgctxt "Assistant response placeholder"
 msgid "Before continuing..."
 msgstr "Mielőtt folytatnád…"
+
+# smartling.placeholder_format=C
+#. Explains that before storing the report, DuckDuckGo will anonymize the conversation by removing PII like names, email addresses, and identifying metadata.
+msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
+msgid ""
+"Before storing this report, DuckDuckGo will anonymize your conversation by "
+"removing PII like names, email addresses, and identifying metadata."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -2803,7 +2849,8 @@ msgstr "Webhely blokkolása minden találatból"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Block trackers and take control of your personal data"
-msgstr "Blokkold a nyomkövetőket, és vedd át az irányítást a személyes adataid felett"
+msgstr ""
+"Blokkold a nyomkövetőket, és vedd át az irányítást a személyes adataid felett"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -2978,6 +3025,12 @@ msgstr "Brazília"
 msgctxt "Sports module"
 msgid "Break Points Won"
 msgstr "Megnyert bréklabdák"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Break this down into clear, numbered steps."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -3441,6 +3494,12 @@ msgid "Cast"
 msgstr "Szereposztás"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Cast & Crew"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
 msgctxt "Tone option label for Casual"
 msgid "Casual"
@@ -3525,7 +3584,8 @@ msgstr "Módosítja az eredmények URL-jeinek megjelenítési módját"
 #. This is the description of a user setting
 msgctxt "settings"
 msgid "Changes how the header is displayed and its behavior as you scroll"
-msgstr "Módosítja a fejléc megjelenítési módját és viselkedését görgetés közben."
+msgstr ""
+"Módosítja a fejléc megjelenítési módját és viselkedését görgetés közben."
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/mcZdcaF.png
@@ -3737,8 +3797,8 @@ msgstr "Privát csevegés"
 msgctxt "Promotional text (mobile)"
 msgid "Chat privately on any website with Duck.ai built into our free browser."
 msgstr ""
-"Csevegj privátban bármely webhelyen az ingyenes böngészőnkbe beépített "
-"Duck.ai segítségével."
+"Csevegj privátban bármely webhelyen az ingyenes böngészőnkbe beépített Duck."
+"ai segítségével."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card encouraging third-party browser users to download the DuckDuckGo browser. Not shown in the DuckDuckGo browser or on Linux.
@@ -4227,8 +4287,8 @@ msgid ""
 msgstr ""
 "Kattints a „Több” lehetőségre, ha többet meg szeretnél tudni egy témáról, és "
 "tegyél fel kapcsolódó kérdéseket az OpenAI, az Anthropic és további "
-"csevegési modelleket támogató privát AI-csevegőszolgáltatásunk, a "
-"%1$sDuck.ai%2$s használatával."
+"csevegési modelleket támogató privát AI-csevegőszolgáltatásunk, a %1$sDuck."
+"ai%2$s használatával."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4255,13 +4315,15 @@ msgstr "Kattints a %1$sHozzáadás%2$s lehetőségre"
 #. Instructions on which buttons the user has to click in order to add the DuckDuckGo extension to their browser.
 msgctxt "install-duckduckgo"
 msgid "Click %sAllow%s, then %sAdd%s."
-msgstr "Kattints az %1$sEngedélyezés%2$slehetőségre, majd a %3$sHozzáadás%4$s gombra."
+msgstr ""
+"Kattints az %1$sEngedélyezés%2$slehetőségre, majd a %3$sHozzáadás%4$s gombra."
 
 #  Firefox 33
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Click %sChange Search Settings%s in the drop down"
-msgstr "Kattints a %1$sKeresési beállítások módosítása%2$s sorra a lenyíló menüben"
+msgstr ""
+"Kattints a %1$sKeresési beállítások módosítása%2$s sorra a lenyíló menüben"
 
 #  SeaMonkey default search engine instruction
 # smartling.placeholder_format=C
@@ -4295,7 +4357,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click %sPrivacy and Services%s in the left sidebar."
-msgstr "Kattints a bal oldali sáv %1$sAdatvédelem és szolgáltatások%2$s elemére."
+msgstr ""
+"Kattints a bal oldali sáv %1$sAdatvédelem és szolgáltatások%2$s elemére."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -4376,7 +4439,8 @@ msgstr "Kattints a %1$sBeállítás alapértelmezettként%2$s lehetőségre lent
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click on the %sSearch Providers%s under Add-on Types"
-msgstr "Kattints a %1$sKeresőszolgáltatók%2$s lehetőségre a bővítménytípusoknál"
+msgstr ""
+"Kattints a %1$sKeresőszolgáltatók%2$s lehetőségre a bővítménytípusoknál"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -5047,7 +5111,8 @@ msgstr "Másolás"
 # smartling.placeholder_format=C
 #. Instructions on how to change the default search engine
 msgid "Copy &amp; paste %sabout:preferences#search%s into the address bar"
-msgstr "Másold ki és illeszd be az %1$sabout:preferences#search%2$s címet a címsorba"
+msgstr ""
+"Másold ki és illeszd be az %1$sabout:preferences#search%2$s címet a címsorba"
 
 # smartling.placeholder_format=C
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
@@ -5163,6 +5228,12 @@ msgstr "Kép létrehozása"
 msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr "Kép létrehozása"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Create a shopping list with quantities from this recipe."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed in the input field when starting a new image generation session.
@@ -5807,6 +5878,11 @@ msgid "Dictation limit reached"
 msgstr "Elérted a diktálási korlátot"
 
 # smartling.placeholder_format=C
+#. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
+msgid "Dictation temporarily unavailable"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
@@ -6109,6 +6185,22 @@ msgid "Done"
 msgstr "Kész"
 
 # smartling.placeholder_format=C
+#. Message shown in a modal after DuckDuckGo browser users disable AI features in Settings. The first two placeholders bold noai.duckduckgo.com. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
+"filtered out. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
+"and AI images filtered out. %sLearn more%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Double Faults"
@@ -6223,6 +6315,18 @@ msgstr ""
 "háztartási hűtőszekrény javítási szolgáltatásaira kérsz árajánlatot."
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Draft a cover letter"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Draft a cover letter for this job."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
 msgctxt "Full sentence for drafting a social media post"
 msgid ""
@@ -6310,7 +6414,8 @@ msgstr "Dobd ide a fotókat vagy PDF-fájlokat"
 # smartling.placeholder_format=C
 #. A title explaining what Duck Player (DDG's feature to watch youtube videos more privately) does
 msgid "Duck Player lets you watch YouTube without targeted ads"
-msgstr "A Duck Player segítségével célzott hirdetések nélkül nézheted a YouTube-ot"
+msgstr ""
+"A Duck Player segítségével célzott hirdetések nélkül nézheted a YouTube-ot"
 
 # smartling.placeholder_format=C
 #. This is the DDG version of "Google it", meaning "search it".
@@ -6397,7 +6502,17 @@ msgstr ""
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
-msgstr "A Duck.ai a privát és ingyenes DuckDuckGo böngészőnkben működik a legjobban!"
+msgstr ""
+"A Duck.ai a privát és ingyenes DuckDuckGo böngészőnkben működik a legjobban!"
+
+# smartling.placeholder_format=C
+#. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
+msgctxt "About section description on the Duck.ai settings page"
+msgid ""
+"Duck.ai is created by DuckDuckGo. We're an independent online protection "
+"company for anyone who wants to take back control of their personal "
+"information."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
@@ -6428,8 +6543,8 @@ msgid ""
 "Duck.ai is temporarily unavailable. If this persists, please email this "
 "anonymous code %s to %s"
 msgstr ""
-"A Duck.ai átmenetileg nem érhető el. Ha ez továbbra is fennáll, küldd el "
-"e-mailben a névtelenségi funkcióhoz szükséges %1$s kódot a következő címre: "
+"A Duck.ai átmenetileg nem érhető el. Ha ez továbbra is fennáll, küldd el e-"
+"mailben a névtelenségi funkcióhoz szükséges %1$s kódot a következő címre: "
 "%2$s"
 
 # smartling.placeholder_format=C
@@ -6437,13 +6552,21 @@ msgstr ""
 msgctxt "Error message for VQD error"
 msgid ""
 "Duck.ai is temporarily unavailable. Please refresh the page and try again."
-msgstr "A Duck.ai átmenetileg nem érhető el. Frissítsd az oldalt, és próbálkozz újra."
+msgstr ""
+"A Duck.ai átmenetileg nem érhető el. Frissítsd az oldalt, és próbálkozz újra."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
 msgstr "A Duck.ai átmenetileg nem érhető el. Próbálkozz újra később."
+
+# smartling.placeholder_format=C
+msgctxt "settings"
+msgid ""
+"Duck.ai lets you chat privately with popular AI models. Disabling it hides "
+"Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6521,8 +6644,8 @@ msgid ""
 "AI chat no sign up, OpenAI, Anthropic, Llama, Mistral, open source AI "
 "models, privacy focused AI, no account AI chat"
 msgstr ""
-"Duck.ai, DuckDuckGo AI, privát AI chatbot, csevegőrobot, ingyenes "
-"AI-csevegés, anonim AI-csevegés, AI-csevegés regisztráció nélkül, OpenAI, "
+"Duck.ai, DuckDuckGo AI, privát AI chatbot, csevegőrobot, ingyenes AI-"
+"csevegés, anonim AI-csevegés, AI-csevegés regisztráció nélkül, OpenAI, "
 "Anthropic, Llama, Mistral, nyílt forráskódú AI modellek, adatvédelemre "
 "összpontosító AI, fiók nélküli AI-csevegés"
 
@@ -6570,8 +6693,8 @@ msgid ""
 msgstr ""
 "A DuckAssist nem tud utólagos kérdésekre válaszolni, viszont kínálatunkban "
 "többek között az OpenAI és az Anthropic csevegési modelljeit támogató "
-"%1$sDuckDuckGo AI Chat%2$s is elérhető, amely egy "
-"mesterségesintelligencia-alapú privát csevegési szolgáltatás."
+"%1$sDuckDuckGo AI Chat%2$s is elérhető, amely egy mesterségesintelligencia-"
+"alapú privát csevegési szolgáltatás."
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6699,7 +6822,8 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr "A DuckDuckGo AI Chat átmenetileg nem érhető el. Próbálkozz újra később."
+msgstr ""
+"A DuckDuckGo AI Chat átmenetileg nem érhető el. Próbálkozz újra később."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -6819,8 +6943,8 @@ msgid ""
 "names, email addresses, phone numbers, and identifying metadata."
 msgstr ""
 "A DuckDuckGo automatikusan anonimizálja ezeket a jelentéseket az olyan "
-"személyazonosításra alkalmas adatok eltávolításával, mint a nevek, az "
-"e-mail-címek, a telefonszámok és az azonosításra alkalmas metaadatok."
+"személyazonosításra alkalmas adatok eltávolításával, mint a nevek, az e-mail-"
+"címek, a telefonszámok és az azonosításra alkalmas metaadatok."
 
 # smartling.placeholder_format=C
 #. The first %s is the agree button label ('Agree'). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. The leading sentence mirrors the drawer-style inline disclaimer (DUCKCHAT_TOS_INLINE_DISCLAIMER).
@@ -7093,7 +7217,8 @@ msgstr "Emeld ki a fontos információkat a válaszokban"
 #. Tells users which setting to change to enable location service.
 msgctxt "precise_user_location"
 msgid "Enable 'Sites can ask for my location.'"
-msgstr "Engedélyezd a „Webhelyek kérhetik a tartózkodási helyemet” lehetőséget."
+msgstr ""
+"Engedélyezd a „Webhelyek kérhetik a tartózkodási helyemet” lehetőséget."
 
 # smartling.placeholder_format=C
 #. Button shown during outages to enable AI features
@@ -7188,7 +7313,8 @@ msgstr "Diktálás engedélyezése a Duck.ai felületén"
 #. Prompt to enable location service so that search results can be displayed near the user's current location.
 msgctxt "precise_user_location"
 msgid "Enable location settings on your device to use anonymous location"
-msgstr "Az anonim hely használatához engedélyezd a készülékeden a helymeghatározást"
+msgstr ""
+"Az anonim hely használatához engedélyezd a készülékeden a helymeghatározást"
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -7306,13 +7432,15 @@ msgstr ""
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location Services' is %senabled%s."
-msgstr "Győződj meg arról, hogy a „Helyszolgáltatások” %1$sengedélyezve vannak%2$s."
+msgstr ""
+"Győződj meg arról, hogy a „Helyszolgáltatások” %1$sengedélyezve vannak%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location' is set to %sallow%s"
-msgstr "Győződj meg arról, hogy a „Hely” %1$sengedélyezés%2$s értékre van állítva"
+msgstr ""
+"Győződj meg arról, hogy a „Hely” %1$sengedélyezés%2$s értékre van állítva"
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service.
@@ -7326,7 +7454,8 @@ msgstr ""
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure Location is set to %sAllow%s"
-msgstr "Győződj meg arról, hogy a Hely %1$sEngedélyezés%2$s értékre van állítva"
+msgstr ""
+"Győződj meg arról, hogy a Hely %1$sEngedélyezés%2$s értékre van állítva"
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
@@ -7362,13 +7491,15 @@ msgstr ""
 #. Tells how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed location access"
-msgstr "Győződj meg arról, hogy a böngészőben engedélyezve van a helyhozzáférés"
+msgstr ""
+"Győződj meg arról, hogy a böngészőben engedélyezve van a helyhozzáférés"
 
 # smartling.placeholder_format=C
 #. Tells how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed location access."
-msgstr "Győződj meg arról, hogy böngésződben engedélyezve van a helyhozzáférés."
+msgstr ""
+"Győződj meg arról, hogy böngésződben engedélyezve van a helyhozzáférés."
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -7465,6 +7596,18 @@ msgid "Eritrea"
 msgstr "Eritrea"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Estimate the nutrition"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Estimate the nutritional information for this recipe."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Estonia"
 msgstr "Észtország"
 
@@ -7519,11 +7662,59 @@ msgid "Expires in 1 day"
 msgstr "Még 1 napig érvényes"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain the accepted answer in simple terms."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
 msgstr "Magyarázd el a fekete lyukak alapvető fogalmait középiskolai szinten."
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain the top answer"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this in simple, plain language."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this paper"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this repo"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this research paper in plain language."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this simply"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain what this repository does and how to use it."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label to show if song lyrics contain explicit content
@@ -7810,6 +8001,12 @@ msgstr ""
 "információ%2$s"
 
 # smartling.placeholder_format=C
+msgctxt "settings"
+msgid ""
+"Filters out known AI spam sites from image search results. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the final score of a sporting event.
 msgid "Final"
 msgstr "Végeredmény"
@@ -7865,6 +8062,12 @@ msgstr "Találj egy jobb szót"
 msgctxt "Subtitle for the Web Search tool entry in the Tools dropdown menu"
 msgid "Find current information"
 msgstr "Aktuális információk keresése"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Find me alternatives"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button that searches for results closer to the user's current location.
@@ -7958,8 +8161,8 @@ msgstr ""
 msgctxt "duckai_migration"
 msgid "Follow these steps to move your chats to the new Duck.ai"
 msgstr ""
-"Kövesd az alábbi lépéseket, ha szeretnéd átvinni a csevegéseket az új "
-"Duck.ai felületre"
+"Kövesd az alábbi lépéseket, ha szeretnéd átvinni a csevegéseket az új Duck."
+"ai felületre"
 
 # smartling.placeholder_format=C
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse on mobile
@@ -8064,7 +8267,8 @@ msgstr "Ingyenes és privát csevegések, általunk anonimizálva"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr "Ingyenes és privát csevegések, általunk anonimizálva. Nincs szükség fiókra."
+msgstr ""
+"Ingyenes és privát csevegések, általunk anonimizálva. Nincs szükség fiókra."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -8316,13 +8520,15 @@ msgstr "Általános célú mesterséges intelligencia, beépített erős moderá
 #. Text with short description for an AI (Artificial Intelligence) Model that has a low moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "General purpose AI with low built-in moderation"
-msgstr "Általános célú mesterséges intelligencia, beépített gyenge moderálással"
+msgstr ""
+"Általános célú mesterséges intelligencia, beépített gyenge moderálással"
 
 # smartling.placeholder_format=C
 #. Text with short description for an AI (Artificial Intelligence) Model that has a medium moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "General purpose AI with medium built-in moderation"
-msgstr "Általános célú mesterséges intelligencia, beépített közepes moderálással"
+msgstr ""
+"Általános célú mesterséges intelligencia, beépített közepes moderálással"
 
 # smartling.placeholder_format=C
 #. Text indicating that the AI (Artificial Intelligence) model is a model for general purpose use. General-purpose AI refers to AI systems that can perform a wide range of tasks, rather than being specialized for a specific task.
@@ -8345,6 +8551,12 @@ msgstr "Kép létrehozása"
 #. Text for the button that generates more of an answer from duckassist when the answer has come from a collapsed state
 msgid "Generate More"
 msgstr "Továbbiak generálása"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Generate a shopping list"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
@@ -8539,9 +8751,9 @@ msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"Szerezz hozzáférést a Duck.ai fejlett AI-modelljeihez "
-"DuckDuckGo-előfizetéssel, amely a VPN-megoldásunk mellett további prémium "
-"adatvédelmi szolgáltatásokat is tartalmaz."
+"Szerezz hozzáférést a Duck.ai fejlett AI-modelljeihez DuckDuckGo-"
+"előfizetéssel, amely a VPN-megoldásunk mellett további prémium adatvédelmi "
+"szolgáltatásokat is tartalmaz."
 
 # smartling.placeholder_format=C
 #. A button for users to generate an AI generated answer from their query on the duckassist module
@@ -8642,10 +8854,17 @@ msgid "Give it a Try"
 msgstr "Kipróbálom"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Give me a quick background on this person."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
-msgstr "Lépj az %1$sAdatvédelem és biztonság > Helymeghatározás%2$s lehetőségre"
+msgstr ""
+"Lépj az %1$sAdatvédelem és biztonság > Helymeghatározás%2$s lehetőségre"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9089,6 +9308,18 @@ msgid "Help Spread Privacy"
 msgstr "Segíts terjeszteni az adatvédelmet"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Help me prep for the interview"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Help me tailor my resume for this job."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title of a SERP popup that invites users to take a survey (desktop only)
 msgctxt "User survey popup"
 msgid "Help us improve DuckDuckGo"
@@ -9098,7 +9329,8 @@ msgstr "Segíts nekünk a DuckDuckGo fejlesztésében"
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Help us improve DuckDuckGo searches with your feedback"
-msgstr "A visszajelzéseddel segítesz nekünk a DuckDuckGo-keresések fejlesztésében"
+msgstr ""
+"A visszajelzéseddel segítesz nekünk a DuckDuckGo-keresések fejlesztésében"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -9610,6 +9842,14 @@ msgid "I Agree"
 msgstr "Elfogadom"
 
 # smartling.placeholder_format=C
+#. Text for the button that takes the user to the external DuckDuckGo login subscription page.
+msgctxt ""
+"Text for the I already have a subscription button in the Duck.ai settings "
+"page"
+msgid "I Already Have a Subscription"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for the button that takes the user to the login subscription page.
 msgctxt "Text for the I have a subscription button"
 msgid "I Have a Subscription"
@@ -9780,7 +10020,8 @@ msgstr ""
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
-msgstr "Ha támogatni szeretnél minket, segíts a %1$sDuckDuckGo terjesztésében%2$s"
+msgstr ""
+"Ha támogatni szeretnél minket, segíts a %1$sDuckDuckGo terjesztésében%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -9981,7 +10222,8 @@ msgstr ""
 
 # smartling.placeholder_format=C
 msgid "In the menu at the top select %sTools%s > %sSettings%s"
-msgstr "A fenti menüben válaszd az %1$sEszközök%2$s > %3$sBeállítások%4$s lehetőséget"
+msgstr ""
+"A fenti menüben válaszd az %1$sEszközök%2$s > %3$sBeállítások%4$s lehetőséget"
 
 #  IE < 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -10195,6 +10437,12 @@ msgid "Install Mac Browser"
 msgstr "Maces böngésző telepítése"
 
 # smartling.placeholder_format=C
+#. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
+msgctxt "settings"
+msgid "Install Now"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of a button to install the DuckDuckGo app
 msgctxt "Serp footer content"
 msgid "Install Our App"
@@ -10292,10 +10540,42 @@ msgid "Is deleted data really deleted?"
 msgstr "A törölt adatok valóban törlésre kerülnek?"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is it worth taking?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this place any good?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"Is this place any good? Summarize its reputation based on reviews and "
+"ratings."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "Is this video helpful?"
 msgstr "Hasznos a videó?"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this worth watching?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Is this worth watching? Give me a spoiler-free take."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -10909,6 +11189,12 @@ msgid "Links:"
 msgstr "Linkek:"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "List the tools, materials, or prerequisites I need for this."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
 msgid "Listen"
 msgstr "Meghallgatás"
@@ -11199,7 +11485,8 @@ msgstr "Ügyelj rá, hogy minden szó helyesen legyen írva."
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Make sure to check %s\"Make this my default search provider\"%s"
-msgstr "Ne felejtse el bejelölni, hogy %1$s„Legyen ez az alapértelmezett keresőm”%2$s"
+msgstr ""
+"Ne felejtse el bejelölni, hogy %1$s„Legyen ez az alapértelmezett keresőm”%2$s"
 
 # smartling.placeholder_format=C
 #. Message prompting users to check the spelling of their search term.
@@ -11315,6 +11602,12 @@ msgstr "Előfizetés kezelése"
 msgctxt "Exclusion message manage sites button"
 msgid "Manage blocked sites"
 msgstr "Blokkolt webhelyek kezelése"
+
+# smartling.placeholder_format=C
+#. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
+msgctxt "setting"
+msgid "Manage in Browser Settings"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to the site exclusion settings page
@@ -13177,7 +13470,8 @@ msgctxt "translations_module"
 msgid ""
 "Oops! An unexpected error occurred while translating this text. Please try "
 "again later."
-msgstr "Hoppá! Váratlan hiba történt a szöveg fordítása közben. Próbáld újra később."
+msgstr ""
+"Hoppá! Váratlan hiba történt a szöveg fordítása közben. Próbáld újra később."
 
 # smartling.placeholder_format=C
 #. Title shown in a fatal error modal when Duck.ai fails to load.
@@ -13523,9 +13817,9 @@ msgid ""
 "tracker blocker, encryption enforcer, and more. Available on %siOS & "
 "Android%s."
 msgstr ""
-"Mobiltelefonos böngészőnk keresőmotorunkat, követésvédelmünket, "
-"titkosítás-végrehajtónkat stb. magában foglalva áll rendelkezésedre. %1$siOS "
-"és Android%2$s rendszerhez is elérhető."
+"Mobiltelefonos böngészőnk keresőmotorunkat, követésvédelmünket, titkosítás-"
+"végrehajtónkat stb. magában foglalva áll rendelkezésedre. %1$siOS és "
+"Android%2$s rendszerhez is elérhető."
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the information was out of date.
@@ -14139,7 +14433,8 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this prompt was made by a "
 "human."
-msgstr "A következő feladat elvégzésével igazold, hogy az utasítást ember adta."
+msgstr ""
+"A következő feladat elvégzésével igazold, hogy az utasítást ember adta."
 
 # smartling.placeholder_format=C
 #. Bot challenge explanation
@@ -14147,7 +14442,14 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this search was made by a "
 "human."
-msgstr "A következő feladat elvégzésével igazold, hogy a keresést ember végezte."
+msgstr ""
+"A következő feladat elvégzésével igazold, hogy a keresést ember végezte."
+
+# smartling.placeholder_format=C
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
+msgctxt "Feedback prompt"
+msgid "Please describe why the chat response is harmful or illegal. (optional)"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
@@ -14178,6 +14480,14 @@ msgid ""
 msgstr ""
 "Fontos tudni: ha bármelyik modellel új csevegést indítasz, azzal törlöd az "
 "aktuális csevegést."
+
+# smartling.placeholder_format=C
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
+msgctxt "Feedback prompt"
+msgid ""
+"Please paste your prompt and the problematic output (with any personal "
+"information removed) and describe why the content is harmful or illegal."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -14340,8 +14650,8 @@ msgid ""
 "Plus, what you watch in Duck Player won’t influence your recommendations on "
 "YouTube."
 msgstr ""
-"Ráadásul az, amit a Duck Playerben nézel, nem fogja befolyásolni a "
-"YouTube-javaslataidat."
+"Ráadásul az, amit a Duck Playerben nézel, nem fogja befolyásolni a YouTube-"
+"javaslataidat."
 
 # smartling.placeholder_format=C
 #. A link to the Substack page (https://insideduckduckgo.substack.com/?showWelcome=true)
@@ -14647,6 +14957,12 @@ msgid "Privacy"
 msgstr "Adatvédelem"
 
 # smartling.placeholder_format=C
+#. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
+msgctxt "Section heading on the Duck.ai settings page"
+msgid "Privacy & Terms"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Privacy Blog"
 msgstr "Adatvédelmi blog"
 
@@ -14715,6 +15031,12 @@ msgstr "Adatvédelmi szabályzat és használati feltételek"
 msgctxt "Copy used to compose link in sentences"
 msgid "Privacy Policy and Terms of Service"
 msgstr "Adatvédelmi szabályzat és szolgáltatási feltételek"
+
+# smartling.placeholder_format=C
+#. Text for a button that links to the terms of use and privacy policy page.
+msgctxt "Secondary button text in active privacy modal"
+msgid "Privacy Policy and Terms of Service"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title displayed on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
@@ -15121,13 +15443,15 @@ msgstr "Érvelő mesterséges intelligencia, magas szintű beépített moderáci
 #. Text with short description for a reasoning AI (Artificial Intelligence) Model that has a low moderation level. Reasoning refers to the AI ability to think logically to draw conclusions before providing an answer. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with low built-in moderation"
-msgstr "Érvelő mesterséges intelligencia, alacsony szintű beépített moderációval"
+msgstr ""
+"Érvelő mesterséges intelligencia, alacsony szintű beépített moderációval"
 
 # smartling.placeholder_format=C
 #. Text with short description for a reasoning AI (Artificial Intelligence) Model that has a medium moderation level. Reasoning refers to the AI ability to think logically to draw conclusions before providing an answer. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with medium built-in moderation"
-msgstr "Érvelő mesterséges intelligencia, közepes szintű beépített moderációval"
+msgstr ""
+"Érvelő mesterséges intelligencia, közepes szintű beépített moderációval"
 
 # smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
@@ -15217,6 +15541,30 @@ msgstr "Receptek a következőhöz: %1$s%2$s%3$s"
 msgctxt "Brief for recommending a book"
 msgid "Recommend a book"
 msgstr "Ajánlj egy könyvet"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar books"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar books."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar movies or shows."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar titles"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
@@ -15442,7 +15790,8 @@ msgstr "Választott beállítás megjegyzése"
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings
 msgid "Remember my choice (this can be changed in %s%s%sSettings%s)"
-msgstr "Jegyezze meg a választásomat (módosítható a %1$s%2$s%3$sBeállításokban%4$s)"
+msgstr ""
+"Jegyezze meg a választásomat (módosítható a %1$s%2$s%3$sBeállításokban%4$s)"
 
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
@@ -15622,6 +15971,15 @@ msgid "Republic of Moldova"
 msgstr "Moldovai Köztársaság"
 
 # smartling.placeholder_format=C
+#. Note indicating that sharing the conversation is mandatory when reporting harmful or illegal content. Rendered alongside the standard share label (DUCKCHAT_RESPONSE_FEEDBACK_SHARE_PROMPT_RESPONSE_LABEL), not replacing it.
+msgctxt ""
+"Note shown under the share-content switch label on the Duck.ai response "
+"feedback form when the user has selected Harmful or Illegal as the feedback "
+"reason"
+msgid "Required for harmful or illegal reports"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
 msgctxt "Description for extended reasoning mode in Duck.ai"
 msgid "Researches before responding"
@@ -15687,8 +16045,8 @@ msgid ""
 "answers are subject to our %sTerms of Service%s."
 msgstr ""
 "A válaszok kizárólag tájékoztatási célokat szolgálnak, és nem minősülnek "
-"orvosi, jogi, pénzügyi, befektetési vagy egyéb szakmai tanácsnak. Az "
-"AI-alapú válaszok a %1$sSzolgáltatási feltételek%2$s hatálya alá esnek."
+"orvosi, jogi, pénzügyi, befektetési vagy egyéb szakmai tanácsnak. Az AI-"
+"alapú válaszok a %1$sSzolgáltatási feltételek%2$s hatálya alá esnek."
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -15783,7 +16141,8 @@ msgstr "A találatok nem tartalmazzák a blokkolt webhelyeket."
 #. Informational banner shown at the top of the Maps search results panel when the user has blocked Yelp or TripAdvisor in their settings. Explains why ratings, reviews, and other details may be missing from place listings.
 msgctxt "Exclusion message at top of maps vertical"
 msgid "Results exclude information from blocked sites."
-msgstr "A találatok nem tartalmazzák a blokkolt webhelyekről származó információkat."
+msgstr ""
+"A találatok nem tartalmazzák a blokkolt webhelyekről származó információkat."
 
 # smartling.placeholder_format=C
 #. Message that appears when results exclude blocked sites
@@ -15857,6 +16216,12 @@ msgstr "Vélemények"
 msgctxt "maps_places"
 msgid "Reviews"
 msgstr "Vélemények"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Rewrite this recipe scaled for a different number of servings."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Romania"
@@ -16340,7 +16705,8 @@ msgstr "Keresés"
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
 msgid "Search %s to find results closer to you?"
-msgstr "A helyileg közelebbi találatokhoz a keresési kifejezés legyen inkább „%1$s”?"
+msgstr ""
+"A helyileg közelebbi találatokhoz a keresési kifejezés legyen inkább „%1$s”?"
 
 # smartling.placeholder_format=C
 msgid "Search Anonymously"
@@ -16734,7 +17100,8 @@ msgstr "Fényképek megtekintése"
 #. Text for a button that links to the terms of use and privacy policy page.
 msgctxt "Secondary button text in active privacy modal"
 msgid "See Privacy Policy and Terms of Service"
-msgstr "Tekintse meg az Adatvédelmi szabályzatot és a Szolgáltatási feltételeket"
+msgstr ""
+"Tekintse meg az Adatvédelmi szabályzatot és a Szolgáltatási feltételeket"
 
 # smartling.placeholder_format=C
 #. Text of the secondary button in the modal that allows the user to open the terms and privacy policy page.
@@ -16800,7 +17167,8 @@ msgstr "További információ: %1$s"
 # smartling.placeholder_format=C
 #. Title of a notice that DuckDuckGo has noticed the user is blocking its non-tracking ads
 msgid "See more shopping results from popular retailers"
-msgstr "További vásárlási találatok megtekintése a népszerű kiskereskedők kínálatából"
+msgstr ""
+"További vásárlási találatok megtekintése a népszerű kiskereskedők kínálatából"
 
 # smartling.placeholder_format=C
 #. Text for tooltip shown on hover when displaying the number of reviews the product has on an ad, indicating that users can see more ratings on bing.com
@@ -16856,8 +17224,8 @@ msgstr ""
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
 msgstr ""
-"Válaszd az %1$sEgyéni%2$s lehetőséget, és írd be a "
-"%3$shttps://duckduckgo.com%4$s címet a beviteli mezőbe"
+"Válaszd az %1$sEgyéni%2$s lehetőséget, és írd be a %3$shttps://duckduckgo."
+"com%4$s címet a beviteli mezőbe"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
@@ -16905,7 +17273,8 @@ msgstr "Válaszd a %1$sDuckDuckGót%2$s a keresőszolgáltatók listáján"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s under the%sDefault Search Engine%s section"
-msgstr "Válaszd a %1$sDuckDuckGót%2$s az %3$sAlapértelmezett keresőmotor%4$s menüben"
+msgstr ""
+"Válaszd a %1$sDuckDuckGót%2$s az %3$sAlapértelmezett keresőmotor%4$s menüben"
 
 # smartling.placeholder_format=C
 #. Tells the user were in the settings menu they can change their default search engine.
@@ -16916,7 +17285,8 @@ msgstr "Válaszd a %1$sDuckDuckGo%2$s lehetőséget."
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Select %sEdit Search Engines...%sin the dropdown"
-msgstr "Válaszd a %1$sKeresőmotorok szerkesztése%2$s menüpontot a legördülő menüben"
+msgstr ""
+"Válaszd a %1$sKeresőmotorok szerkesztése%2$s menüpontot a legördülő menüben"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -16959,7 +17329,8 @@ msgstr "Válaszd ki a %1$sKeresőmotor%2$s lehetőséget"
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"
-msgstr "Válaszd a %1$sKeresőmotor%2$s lehetőséget, majd az %3$sEgyéb...%4$s opciót"
+msgstr ""
+"Válaszd a %1$sKeresőmotor%2$s lehetőséget, majd az %3$sEgyéb...%4$s opciót"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -16984,7 +17355,8 @@ msgstr "Válaszd ki a %1$sBeállítások%2$s opciót a legördülő menüből."
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sAdvanced settings%s"
-msgstr "Válaszd a %1$sBeállítások%2$s, majd a %3$sHaladó beállítások%4$s lehetőséget"
+msgstr ""
+"Válaszd a %1$sBeállítások%2$s, majd a %3$sHaladó beállítások%4$s lehetőséget"
 
 # smartling.placeholder_format=C
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -17214,6 +17586,12 @@ msgid "Set Up Now"
 msgstr "Beállítás most"
 
 # smartling.placeholder_format=C
+#. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
+msgctxt "Encrypted storage setup button shown in native browsers"
+msgid "Set Up Sync & Backup"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
 msgctxt "Title for the Sync & Backup intro screen"
 msgid "Set Up Sync & Backup"
@@ -17305,7 +17683,8 @@ msgstr "Megosztás"
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "Share DuckDuckGo and help friends take their privacy back!"
-msgstr "Terjeszd a DuckDuckGót, és segíts a barátaidnak megvédeni az adataikat!"
+msgstr ""
+"Terjeszd a DuckDuckGót, és segíts a barátaidnak megvédeni az adataikat!"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button that opens a feedback modal when clicked.
@@ -17332,8 +17711,8 @@ msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
 msgstr ""
-"A relevancia javítása érdekében oszd meg a városi szintű helyadataidat az "
-"AI-modellekkel. A Duck.ai soha nem árulja el nekünk vagy az AI-modelleknek a "
+"A relevancia javítása érdekében oszd meg a városi szintű helyadataidat az AI-"
+"modellekkel. A Duck.ai soha nem árulja el nekünk vagy az AI-modelleknek a "
 "pontos tartózkodási helyedet."
 
 # smartling.placeholder_format=C
@@ -17395,11 +17774,19 @@ msgid "Share positive feedback"
 msgstr "Pozitív visszajelzés megosztása"
 
 # smartling.placeholder_format=C
+#. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
+msgctxt ""
+"Label beside the share-content switch on the Duck.ai response feedback form"
+msgid "Share this conversation with DuckDuckGo"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
 msgctxt ""
 "Label beside the share-content switch on the Duck.ai response feedback form"
 msgid "Share your prompt and chat response with DuckDuckGo"
-msgstr "Oszd meg az utasításodat és a beszélgetésben kapott választ a DuckDuckGóval"
+msgstr ""
+"Oszd meg az utasításodat és a beszélgetésben kapott választ a DuckDuckGóval"
 
 # smartling.placeholder_format=C
 #. Variant of the share toggle label that makes sharing mandatory when reporting harmful or illegal content.
@@ -17650,7 +18037,8 @@ msgstr "Minden találat megjelenítése"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show answers more often. (You can also %sturn them off%s.)"
-msgstr "Gyakrabban jelenítse meg a válaszokat. (%1$sKi is kapcsolhatod%2$s ezeket.)"
+msgstr ""
+"Gyakrabban jelenítse meg a válaszokat. (%1$sKi is kapcsolhatod%2$s ezeket.)"
 
 # smartling.placeholder_format=C
 #. Accessible label for the button that reveals a popover listing multiple citation sources in Duck.ai chat responses.
@@ -17799,12 +18187,14 @@ msgstr "A legtöbbször meglátogatott hivatkozások megjelenítése új lapon"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your browser"
-msgstr "Alkalmi emlékeztetők megjelenítése a DuckDuckGo hozzáadására a böngésződhöz"
+msgstr ""
+"Alkalmi emlékeztetők megjelenítése a DuckDuckGo hozzáadására a böngésződhöz"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr "Alkalmi emlékeztetők megjelenítése a DuckDuckGo hozzáadására az eszközeidhez"
+msgstr ""
+"Alkalmi emlékeztetők megjelenítése a DuckDuckGo hozzáadására az eszközeidhez"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -17822,7 +18212,8 @@ msgstr "Oldalszám megjelenítése a találati oldalak töréseinél"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows sign-up form for the DuckDuckGo privacy newsletters"
-msgstr "A DuckDuckGo adatvédelmi hírleveleire való feliratkozási űrlap megjelenítése"
+msgstr ""
+"A DuckDuckGo adatvédelmi hírleveleire való feliratkozási űrlap megjelenítése"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/94erFcS.png
@@ -17850,7 +18241,8 @@ msgstr "Üdvözlőüzenet megjelenítése a keresési találati oldal tetején"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message to EU Android preference menu users"
-msgstr "Üdvözlő üzenet megjelenítése az EU-s Android-preferencia menü felhasználóinak"
+msgstr ""
+"Üdvözlő üzenet megjelenítése az EU-s Android-preferencia menü felhasználóinak"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers sometimes.
@@ -17927,7 +18319,8 @@ msgstr "Az oldalkeresés átmenetileg nem érhető el. Dolgozunk a megoldáson."
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Sites you block will be hidden from all your search results"
-msgstr "Az általad blokkolt webhelyek el lesznek rejtve minden keresési találatból"
+msgstr ""
+"Az általad blokkolt webhelyek el lesznek rejtve minden keresési találatból"
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes full name (tooltip)
@@ -18650,6 +19043,24 @@ msgid "Suggest a title for a blog post"
 msgstr "Adj javaslatot egy blogbejegyzés címére"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest related articles or topics worth exploring next."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Suggest related articles to explore"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest some alternatives to this product."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
 msgctxt "directions"
 msgid "Suggestions:"
@@ -18661,10 +19072,100 @@ msgid "Suggestions:"
 msgstr "Javaslatok:"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Sum up the reviews"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A short title for the a message asking the AI to summarize a text.
 msgctxt "Title for the summarize message"
 msgid "Summarize"
 msgstr "Lényegkiemelés"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize the Q&As"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the background and notable work of this person."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the key details of this event."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the questions and answers on this page."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize their background"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this book"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this book."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this discussion"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this discussion thread."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this page"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this page."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this video"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this video."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize what the reviews say."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -18995,6 +19496,12 @@ msgid "Syria"
 msgstr "Szíria"
 
 # smartling.placeholder_format=C
+#. Text for a button that enables the theme to follow the operating system's color scheme preference.
+msgctxt "System theme button for theme selector"
+msgid "System"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Abbreviation indicating this is the total score for a game
 msgctxt "Sports module"
 msgid "T"
@@ -19021,6 +19528,12 @@ msgstr "Tv"
 msgctxt "language_name"
 msgid "Tahitian"
 msgstr "tahiti"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Tailor my resume"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Taiwan"
@@ -19050,6 +19563,13 @@ msgstr "Vedd át az irányítást a személyes adataid fölött"
 msgctxt "homepage ATB modal"
 msgid "Take control of your personal data!"
 msgstr "Vedd át az irányítást a személyes adataid fölött!"
+
+# smartling.placeholder_format=C
+#. Description for the Feedback section of the Duck.ai settings page, asking the user to take an anonymous survey to let us know how we can make Duck.ai better.
+msgctxt "Feedback section description on the Duck.ai settings page"
+msgid ""
+"Take this anonymous survey to let us know how we can make Duck.ai better."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -19118,7 +19638,8 @@ msgstr "Koppints a címsorban található %1$sengedélyek ikonra%2$s"
 #. Tells users which icon to press in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Tap the vertical dots in the DuckDuckGo app."
-msgstr "Koppints a függőlegesen elhelyezkedő pontokra a DuckDuckGo alkalmazásban."
+msgstr ""
+"Koppints a függőlegesen elhelyezkedő pontokra a DuckDuckGo alkalmazásban."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a teacher in its responses.
@@ -19287,18 +19808,21 @@ msgstr "Gambia"
 #. Error message displayed when the total size of all attached files in a conversation exceeds the allowed limit. Placeholder is the combined size limit in megabytes. E.g. The attached files exceed the total size limit of 5 MB
 msgctxt "Error message when combined file size exceeds the limit"
 msgid "The attached files exceed the total size limit of %s MB"
-msgstr "A csatolt fájlok összmérete meghaladja a maximálisan megengedett %1$s MB-ot"
+msgstr ""
+"A csatolt fájlok összmérete meghaladja a maximálisan megengedett %1$s MB-ot"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the total size of all attached files in a conversation exceeds the allowed limit. Placeholder is the combined size limit in megabytes. E.g. The attached files exceed the total size limit of 5 MB
 msgctxt "Error message when combined file size exceeds the limit"
 msgid "The attached files exceed the total size limit of %s MB."
-msgstr "A csatolt fájlok összmérete meghaladja a maximálisan megengedett %1$s MB-ot."
+msgstr ""
+"A csatolt fájlok összmérete meghaladja a maximálisan megengedett %1$s MB-ot."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the server rejects corrupt or unrecognized audio.
 msgid "The audio could not be processed. Please try recording again."
-msgstr "A hanganyag feldolgozása sikertelen volt. Próbálkozz újra a felvétellel."
+msgstr ""
+"A hanganyag feldolgozása sikertelen volt. Próbálkozz újra a felvétellel."
 
 # smartling.placeholder_format=C
 #. Second paragraph explaining where the encryption key is stored on the entry screen.
@@ -19356,6 +19880,12 @@ msgstr "A szerver hibát észlelt, és nem tudta teljesíteni a kérésed."
 #. https://duck.co/media/files/theme.png
 msgid "Theme"
 msgstr "Kinézet"
+
+# smartling.placeholder_format=C
+#. Text for the theme selector label that allows users to switch between Light and dark theme.
+msgctxt "Label for the theme selector feature"
+msgid "Theme"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/LpFhb1e.png
@@ -19610,8 +20140,8 @@ msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF"
 msgstr ""
-"Ez a képtípus nem támogatott. Kérjük, csatolj egy JPG-, PNG-, WebP- vagy "
-"GIF-fájlt"
+"Ez a képtípus nem támogatott. Kérjük, csatolj egy JPG-, PNG-, WebP- vagy GIF-"
+"fájlt"
 
 # smartling.placeholder_format=C
 #. Error message displayed when a file that the user tried to upload is not of a supported format
@@ -19619,8 +20149,8 @@ msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF."
 msgstr ""
-"Ez a képtípus nem támogatott. Kérjük, csatolj egy JPG-, PNG-, WebP- vagy "
-"GIF-fájlt."
+"Ez a képtípus nem támogatott. Kérjük, csatolj egy JPG-, PNG-, WebP- vagy GIF-"
+"fájlt."
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
@@ -19704,9 +20234,9 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again."
 msgstr ""
-"Ez a beállítás a böngésződben kerül tárolásra, tehát ha törlöd a "
-"duckduckgo.com böngészési adatait, előfordulhat, hogy ismét megjelennek a "
-"mesterséges intelligencia segítségével generált válaszok."
+"Ez a beállítás a böngésződben kerül tárolásra, tehát ha törlöd a duckduckgo."
+"com böngészési adatait, előfordulhat, hogy ismét megjelennek a mesterséges "
+"intelligencia segítségével generált válaszok."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -19716,9 +20246,9 @@ msgid ""
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
 msgstr ""
-"Ez a beállítás a böngésződben kerül tárolásra, tehát ha törlöd a "
-"duckduckgo.com böngészési adatait, előfordulhat, hogy ismét megjelennek a "
-"mesterséges intelligencia segítségével generált válaszok. Ugyanakkor van egy "
+"Ez a beállítás a böngésződben kerül tárolásra, tehát ha törlöd a duckduckgo."
+"com böngészési adatait, előfordulhat, hogy ismét megjelennek a mesterséges "
+"intelligencia segítségével generált válaszok. Ugyanakkor van egy "
 "kezdőoldalunk, amely soha nem jelenít meg AI-alapú válaszokat: %1$s."
 
 # smartling.placeholder_format=C
@@ -19748,7 +20278,8 @@ msgstr "Ez a videó még nem tekinthető meg itt. Megnézheted itt: %1$s."
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr "Ez a weboldal nem használ biztonságos, titkosított kapcsolatot (HTTPS)."
+msgstr ""
+"Ez a weboldal nem használ biztonságos, titkosított kapcsolatot (HTTPS)."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -19926,8 +20457,8 @@ msgid ""
 "you originally used to set up Sync."
 msgstr ""
 "A szinkronizált adatok visszaállításához szükség lesz a szinkronizálás első "
-"beállításakor mentett helyreállítási kódra. Lehetséges, hogy ez a kód "
-"PDF-fájlként lett mentve a szinkronizálás beállításához eredetileg használt "
+"beállításakor mentett helyreállítási kódra. Lehetséges, hogy ez a kód PDF-"
+"fájlként lett mentve a szinkronizálás beállításához eredetileg használt "
 "eszközre."
 
 # smartling.placeholder_format=C
@@ -20200,6 +20731,18 @@ msgstr ""
 "moziba?”"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Translate this page"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
+msgctxt "Page suggestion prompt"
+msgid "Translate this page into %s."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text for a region that will display translated text.
 msgctxt "translations_module"
 msgid "Translation"
@@ -20293,7 +20836,8 @@ msgstr "Próbálkozz ezzel: %1$s"
 # smartling.placeholder_format=C
 #. Prompt for the user to start using our homepage that doesn't show promotional messages. The placeholder is a homepage url (e.g., 'start.duckduckgo.com')
 msgid "Try %s to stop seeing messages like this."
-msgstr "Próbáld ki a(z) %1$s címet, hogy többé ne jelenjenek meg ilyen üzenetek."
+msgstr ""
+"Próbáld ki a(z) %1$s címet, hogy többé ne jelenjenek meg ilyen üzenetek."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that encourages users to try the encrypted AI model whose inference runs in a confidential environment so the model provider cannot access user data. %s is replaced with the model's full display name (e.g. 'GPT-OSS 120B').
@@ -20343,6 +20887,12 @@ msgstr "Próbáld újra"
 msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
 msgstr "Ingyenes próba"
+
+# smartling.placeholder_format=C
+#. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
+msgctxt "settings"
+msgid "Try It Now"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -20408,14 +20958,16 @@ msgstr ""
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
 msgctxt "precise_user_location"
 msgid "Try enabling anonymous location for more accurate results."
-msgstr "A pontosabb eredmények érdekében próbálkozz az anonim hely engedélyezésével."
+msgstr ""
+"A pontosabb eredmények érdekében próbálkozz az anonim hely engedélyezésével."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the screen of the onboarding where the user picks a chat model.
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr "Próbálj kísérletezni az egyes modellekkel – különböző válaszokat generálnak."
+msgstr ""
+"Próbálj kísérletezni az egyes modellekkel – különböző válaszokat generálnak."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
@@ -20443,7 +20995,8 @@ msgstr "Próbáld ki ingyen"
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
-msgstr "Próbáld ki ingyen! Biztonságos VPN, fejlett és privát MI, és még sok más."
+msgstr ""
+"Próbáld ki ingyen! Biztonságos VPN, fejlett és privát MI, és még sok más."
 
 # smartling.placeholder_format=C
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -20470,7 +21023,8 @@ msgstr "Próbáld ki a böngészőnket,"
 # smartling.placeholder_format=C
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
-msgstr "Próbáld ki a kezdőoldalunkat, ahol soha nem mutatjuk ezeket az üzeneteket:"
+msgstr ""
+"Próbáld ki a kezdőoldalunkat, ahol soha nem mutatjuk ezeket az üzeneteket:"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with different words to get more results.
@@ -20585,6 +21139,22 @@ msgid "Trying DuckDuckGo again"
 msgstr "Újra kipróbálom a DuckDuckGót"
 
 # smartling.placeholder_format=C
+#. Message shown in a modal after supported third-party browser users disable AI features in Settings. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
 msgctxt "Assistant response placeholder"
 msgid "Trying with %s"
@@ -20689,7 +21259,8 @@ msgstr "A pontosabb találatokhoz kapcsold be a %1$sPontos hely%2$s funkciót"
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
-msgstr "Duck Player bekapcsolása a YouTube célzott hirdetések nélküli megtekintéséhez"
+msgstr ""
+"Duck Player bekapcsolása a YouTube célzott hirdetések nélküli megtekintéséhez"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service.
@@ -20916,7 +21487,8 @@ msgstr "Az %1$sÁltalános > Kezdőlap%2$s alatt írd be: https://duckduckgo.com
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch Settings%s select %sDuckDuckGo%s"
-msgstr "A %1$sKeresési beállítások%2$s alatt válaszd a %3$sDuckDuckGo%4$s lehetőséget"
+msgstr ""
+"A %1$sKeresési beállítások%2$s alatt válaszd a %3$sDuckDuckGo%4$s lehetőséget"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -21025,8 +21597,8 @@ msgid ""
 "Unlock %s, higher AI reasoning, and 2x higher usage limits than the Plus "
 "plan by upgrading to Pro."
 msgstr ""
-"Válts Pro verzióra, hogy hozzáférj a(z) %1$s modellhez, a fejlettebb "
-"MI-érveléshez és a Plus csomagnál kétszer magasabb használati korlátokhoz."
+"Válts Pro verzióra, hogy hozzáférj a(z) %1$s modellhez, a fejlettebb MI-"
+"érveléshez és a Plus csomagnál kétszer magasabb használati korlátokhoz."
 
 # smartling.placeholder_format=C
 #. Title for the subscription promo shown in the SERP sidemenu.
@@ -21048,8 +21620,8 @@ msgctxt "voice chat limit modal"
 msgid ""
 "Unlock advanced AI models and higher limits with a DuckDuckGo Subscription"
 msgstr ""
-"Fejlett MI-modelleket és nagyobb használati kereteket érhetsz el "
-"DuckDuckGo-előfizetéssel"
+"Fejlett MI-modelleket és nagyobb használati kereteket érhetsz el DuckDuckGo-"
+"előfizetéssel"
 
 # smartling.placeholder_format=C
 #. Text informing the user that advanced AI models can be unlocked with a subscription. The variable is used to insert a link that opens the subscription modal. Example: Unlock advanced AI models with a DuckDuckGo subscription.
@@ -21344,6 +21916,12 @@ msgstr "urdu"
 # smartling.placeholder_format=C
 msgid "Uruguay"
 msgstr "Uruguay"
+
+# smartling.placeholder_format=C
+#. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
+msgctxt "Navigation label on the Duck.ai settings page"
+msgid "Usage"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -21641,9 +22219,9 @@ msgid ""
 "Visit Duck.ai in your other browser and go to %sDuck.ai Settings%s > %sSync "
 "& Backup%s > %sManage%s then select %sSync With Another Device%s."
 msgstr ""
-"Nyisd meg a Duck.ai-t a másik böngésződben, és lépj ide: "
-"%1$sDuck.ai-beállítások%2$s > %3$sSync & Backup%4$s > %5$sKezelés%6$s, majd "
-"válaszd a %7$sSzinkronizálás másik eszközzel%8$s lehetőséget."
+"Nyisd meg a Duck.ai-t a másik böngésződben, és lépj ide: %1$sDuck.ai-"
+"beállítások%2$s > %3$sSync & Backup%4$s > %5$sKezelés%6$s, majd válaszd a "
+"%7$sSzinkronizálás másik eszközzel%8$s lehetőséget."
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -21682,8 +22260,8 @@ msgstr ""
 "Látogass el a Duck.ai oldalra a másik böngésződben vagy a DuckDuckGo "
 "alkalmazásban, és nyisd meg a Duck.ai beállításait. Válaszd a „Bekapcsolás” "
 "lehetőséget a Sync & Backup alatt, és válaszd a „Szinkronizálás másik "
-"eszközzel” opciót. Vagy olvasd be a helyreállítási PDF-ben található "
-"QR-kódot."
+"eszközzel” opciót. Vagy olvasd be a helyreállítási PDF-ben található QR-"
+"kódot."
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -21736,8 +22314,8 @@ msgstr "A hangcsevegés véget ért"
 msgctxt "voice chat"
 msgid "Voice chat is anonymized by us, and never used to train AI models."
 msgstr ""
-"A hangcsevegéseket anonim módon kezeljük, és soha nem használjuk fel "
-"MI-modellek betanítására."
+"A hangcsevegéseket anonim módon kezeljük, és soha nem használjuk fel MI-"
+"modellek betanítására."
 
 # smartling.placeholder_format=C
 #. Title of the modal shown when the user has reached their daily voice chat limit.
@@ -21796,6 +22374,12 @@ msgstr "Várakozás a tartózkodási helyre..."
 # smartling.placeholder_format=C
 msgid "Wales"
 msgstr "Wales"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Walk me through the steps"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for walking directions on a map.
@@ -21875,9 +22459,8 @@ msgid ""
 "Watch in Duck Player to block personalized ads on YouTube and prevent your "
 "viewing activity from influencing YouTube recommendations."
 msgstr ""
-"Nézd a tartalmat Duck Playerrel, hogy blokkold a személyre szabott "
-"YouTube-hirdetéseket, és a megtekintéseid ne befolyásolják a YouTube "
-"ajánlásait."
+"Nézd a tartalmat Duck Playerrel, hogy blokkold a személyre szabott YouTube-"
+"hirdetéseket, és a megtekintéseid ne befolyásolják a YouTube ajánlásait."
 
 # smartling.placeholder_format=C
 #. A button that takes a user to another site in order to watch a video. The placeholder is the name of the video site. For example: 'Watch on Vimeo'
@@ -21915,6 +22498,17 @@ msgid "We can anonymize%s your location%s to show you more accurate results."
 msgstr "A pontosabb találatokhoz anonimizálhatjuk a %1$s helyedet%2$s."
 
 # smartling.placeholder_format=C
+#. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
+msgctxt ""
+"Inline warning shown below the share-content toggle when the user selects "
+"Harmful or Illegal but has not enabled sharing"
+msgid ""
+"We can only fix what we can see. To report a harmful or illegal response, "
+"please share this conversation with DuckDuckGo so we can investigate and "
+"address the issue."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
 msgctxt ""
 "Inline warning shown below the share-content toggle when the user selects "
@@ -21932,14 +22526,16 @@ msgstr ""
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can use your anonymous%s location%s to show you nearby results."
-msgstr "Anonim%1$s helyed%2$s felhasználásával közeli eredményeket mutathatunk neked."
+msgstr ""
+"Anonim%1$s helyed%2$s felhasználásával közeli eredményeket mutathatunk neked."
 
 # smartling.placeholder_format=C
 #. Error message displayed when one or more attached files are encrypted and cannot be read.
 msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
-msgstr "Nem tudjuk olvasni a csatolt fájlokat, mert legalább az egyik titkosítva van."
+msgstr ""
+"Nem tudjuk olvasni a csatolt fájlokat, mert legalább az egyik titkosítva van."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -21981,7 +22577,8 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what brought you "
 "back today:"
-msgstr "Nem követünk téged, ezért tőled kell megkérdeznünk, hogy mi járatban vagy:"
+msgstr ""
+"Nem követünk téged, ezért tőled kell megkérdeznünk, hogy mi járatban vagy:"
 
 # smartling.placeholder_format=C
 #. Message prompting users to fill out a feedback form.
@@ -22133,7 +22730,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
-msgstr "Blokkoljuk a böngészés közben adataid gyűjtésével próbálkozó nyomkövetőket."
+msgstr ""
+"Blokkoljuk a böngészés közben adataid gyűjtésével próbálkozó nyomkövetőket."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -22308,8 +22906,8 @@ msgid ""
 "anonymized by us and not used to train AI models."
 msgstr ""
 "Üdvözöl a DuckDuckGo AI Chat! Minden itt folytatott beszélgetésed privát, "
-"anonimizáljuk azokat, és nem használjuk fel "
-"mesterségesintelligencia-modellek tanítására."
+"anonimizáljuk azokat, és nem használjuk fel mesterségesintelligencia-"
+"modellek tanítására."
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened. Example: 'Welcome to DuckDuckGo AI Chat! This chat session is powered by OpenAI’s GPT-3. All of your chats here are private, and are never stored by DuckDuckGo or used to train AI models.'
@@ -22321,14 +22919,15 @@ msgid ""
 msgstr ""
 "Üdvözöl a DuckDuckGo AI Chat! A csevegést a(z) %1$s %2$s technológiája "
 "szolgáltatja. Minden itt folytatott beszélgetésed privát, melyeket a "
-"DuckDuckGo soha nem tárol, és nem használ fel a "
-"mesterségesintelligencia-modellek tanítására."
+"DuckDuckGo soha nem tárol, és nem használ fel a mesterségesintelligencia-"
+"modellek tanítására."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai! You can now import your downloaded chats."
-msgstr "Üdvözöl az új Duck.ai! Mostantól importálhatod a letöltött csevegéseidet."
+msgstr ""
+"Üdvözöl az új Duck.ai! Mostantól importálhatod a letöltött csevegéseidet."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -22427,7 +23026,8 @@ msgstr ""
 #. Text for a prompt suggestion for asking about must-see attractions in Paris for a first-time visitor.
 msgctxt "Full sentence for planning a trip"
 msgid "What are some must-see attractions in Paris for a first-time visitor?"
-msgstr "Milyen látnivalókat érdemes megnézni Párizsban annak, aki először jár ott?"
+msgstr ""
+"Milyen látnivalókat érdemes megnézni Párizsban annak, aki először jár ott?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for finding options for the word 'better' in a specific context.
@@ -22463,6 +23063,103 @@ msgstr ""
 "Legyen elég rövid, egyszerű és könnyen érthető azok számára is, akiknek "
 "kevés mesterséges intelligenciás vagy műszaki tapasztalatuk van, illetve "
 "azok számára is, akiknek több."
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the counterarguments?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the hours & location?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key contributions of this paper?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key contributions?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key details?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key points covered in this video?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key points?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key takeaways from this article?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key takeaways?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key things I will learn from this course?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main counterarguments or criticisms of this?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main questions this page answers?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the must-try dishes here?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"What are the opening hours, location, and contact details for this place?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the pros and cons of this product?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the pros and cons?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
@@ -22565,6 +23262,12 @@ msgid "What does atria mean in the context of a medical article?"
 msgstr "Mi a pitvar jelentése egy orvosi cikkel összefüggésben?"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What does this answer?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
@@ -22575,6 +23278,12 @@ msgstr "Milyen funkció hozzáadását szeretnéd? (opcionális)"
 msgctxt "cloudsave"
 msgid "What information gets saved?"
 msgstr "Milyen információ kerül mentésre?"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What interview questions might come up for this role?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -22591,6 +23300,12 @@ msgstr ""
 msgctxt "Full sentence for looking up basic facts"
 msgid "What is the capital city of Albania?"
 msgstr "Mi Albánia fővárosa?"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What is the overall verdict and rating for this?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to a page with additional information.
@@ -22615,6 +23330,12 @@ msgid "What people say:"
 msgstr "Ezt mondják az emberek:"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What should I order?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
 msgctxt "feedback form"
 msgid "What stood out?"
@@ -22625,6 +23346,18 @@ msgstr "Mi tűnt ki?"
 msgctxt "feedback form"
 msgid "What was wrong with the response? (optional)"
 msgstr "Mi volt a gond a válasszal? (nem kötelező)"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I learn?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I need?"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -22646,6 +23379,12 @@ msgid "What's New"
 msgstr "Újdonságok"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What's the verdict?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to a page featuring the most recent updates from DuckDuckGo.
 msgid "What’s New"
 msgstr "Újdonságok"
@@ -22663,7 +23402,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "When enabled, Duck.ai will show instant answers in the chat."
-msgstr "Engedélyezés esetén a Duck.ai azonnali válaszokat jelenít meg a csevegésben."
+msgstr ""
+"Engedélyezés esetén a Duck.ai azonnali válaszokat jelenít meg a csevegésben."
 
 # smartling.placeholder_format=C
 #. Text of a button that performs a search for the available streaming services that show a particular movie or tv show
@@ -22681,7 +23421,8 @@ msgstr "Hol nézhető meg a(z) <strong>%1$s</strong>?"
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Where it says Homepage click %sSet to Current Page%s."
-msgstr "A kezdőoldalon kattints a %1$sJelenlegi oldal beállítása%2$s lehetőségre."
+msgstr ""
+"A kezdőoldalon kattints a %1$sJelenlegi oldal beállítása%2$s lehetőségre."
 
 # smartling.placeholder_format=C
 #. Heading of a module showing what streaming services are showing a movie or series, e.g. Where to Watch The Matrix
@@ -22694,6 +23435,12 @@ msgstr "Hol nézhető meg a(z) <strong>%1$s</strong>?"
 msgctxt "Feedback prompt"
 msgid "Which features are missing? (Optional)"
 msgstr "Milyen funkciók hiányoznak? (Opcionális)"
+
+# smartling.placeholder_format=C
+#. An invitation for users to leave feedback
+msgctxt "Feedback prompt"
+msgid "Which features are missing? (optional)"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
@@ -22710,6 +23457,18 @@ msgstr "Fehér"
 #. Link to an about us page.
 msgid "Who We Are"
 msgstr "Kik vagyunk?"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Who are the main cast and crew, and what else are they known for?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Who is this person?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Header above a collection of privacy-related links.
@@ -23119,7 +23878,8 @@ msgstr ""
 #. Text informing the user that they can access DuckDuckGo AI Chat directly at a specific URL. The placeholder %s will be replaced with the link. Example: 'You can access DuckDuckGo AI Chat directly at duck.ai.'
 msgctxt "Information about direct access to DuckDuckGo AI Chat"
 msgid "You can access DuckDuckGo AI Chat directly at %s."
-msgstr "A DuckDuckGo AI Chat csevegője közvetlenül elérhető a következő címen: %1$s."
+msgstr ""
+"A DuckDuckGo AI Chat csevegője közvetlenül elérhető a következő címen: %1$s."
 
 # smartling.placeholder_format=C
 #. Search Assist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate Search Assist.
@@ -23206,7 +23966,8 @@ msgstr "Ezt az emlékeztetőt elrejtheti a %1$sKeresési beállításokban%2$s."
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
-msgstr "Mostantól akár 100 csevegést is menthetsz ezen az eszközön. Csevegj bátran!"
+msgstr ""
+"Mostantól akár 100 csevegést is menthetsz ezen az eszközön. Csevegj bátran!"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -23453,7 +24214,8 @@ msgctxt "Error message for user limit"
 msgid ""
 "You've reached the maximum number of messages for the moment. Please try "
 "again later."
-msgstr "Elérted az üzenetek pillanatnyi maximális számát. Próbálkozz újra később."
+msgstr ""
+"Elérted az üzenetek pillanatnyi maximális számát. Próbálkozz újra később."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -23695,19 +24457,22 @@ msgctxt "duckai_migration"
 msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
-msgstr "A csevegések importálva lettek. Folytasd ott, ahol abbahagytad a Duck.ai-ban."
+msgstr ""
+"A csevegések importálva lettek. Folytasd ott, ahol abbahagytad a Duck.ai-ban."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.
 msgctxt "Description for the joiner-device success screen"
 msgid "Your chats will now sync between these devices."
-msgstr "A beszélgetéseid mostantól szinkronizálódnak ezek között az eszközök között."
+msgstr ""
+"A beszélgetéseid mostantól szinkronizálódnak ezek között az eszközök között."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the success screen after a successful pairing.
 msgctxt "Description for the success screen"
 msgid "Your chats will now sync between these devices."
-msgstr "A beszélgetéseid mostantól szinkronizálódnak ezek között az eszközök között."
+msgstr ""
+"A beszélgetéseid mostantól szinkronizálódnak ezek között az eszközök között."
 
 # smartling.placeholder_format=C
 #. Description explaining why delegation is needed for image generation.
@@ -23836,7 +24601,8 @@ msgstr "Kereséseid nem köthetők hozzád"
 #. Confirms the recovery succeeded. The Next CTA closes the sheet.
 msgctxt "Body copy on the recover-data success sheet"
 msgid "Your synced chats are being restored to this device."
-msgstr "A szinkronizált csevegéseket a rendszer erre az eszközre állítja vissza."
+msgstr ""
+"A szinkronizált csevegéseket a rendszer erre az eszközre állítja vissza."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -23896,7 +24662,8 @@ msgctxt "Error message for user limit"
 msgid ""
 "You’ve reached the maximum number of messages for one day. Please continue "
 "this chat tomorrow."
-msgstr "Elérted a napi üzenetek maximális számát. Holnap folytasd ezt a csevegést."
+msgstr ""
+"Elérted a napi üzenetek maximális számát. Holnap folytasd ezt a csevegést."
 
 # smartling.placeholder_format=C
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
@@ -24199,8 +24966,8 @@ msgstr "hivatalos webhely"
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
 msgstr ""
-"vagy írd ki a választott szín kódját, pl. %1$s (%2$s egy kódolt "
-"%3$s-karakter)."
+"vagy írd ki a választott szín kódját, pl. %1$s (%2$s egy kódolt %3$s-"
+"karakter)."
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "

--- a/locales/hu_HU/LC_MESSAGES/duckduckgo.po
+++ b/locales/hu_HU/LC_MESSAGES/duckduckgo.po
@@ -6199,7 +6199,7 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
-"Nem kérsz az MI-ből? Látogass el a %1$snoai.duckduckgo.com%2$s oldalra ha "
+"Nem kérsz az MI-ből? Látogass el a %1$snoai.duckduckgo.com%2$s oldalra, ha "
 "MI-funkciók nélkül, és az MI-képek kiszűrésével szeretnél keresni! "
 "%3$sTovábbi információk%4$s"
 

--- a/locales/hy_AM/LC_MESSAGES/duckduckgo.po
+++ b/locales/hy_AM/LC_MESSAGES/duckduckgo.po
@@ -1165,6 +1165,11 @@ msgctxt "feedback form"
 msgid "Address is incorrect"
 msgstr ""
 
+#. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Adjust the servings"
+msgstr ""
+
 #. as in multiple advertisements
 msgid "Ads"
 msgstr ""
@@ -1336,6 +1341,13 @@ msgstr ""
 #. Heading shown on the empty chat screen. The text between the two %s markers is displayed inside a clickable privacy button. First %s renders a shield icon, second %s is an invisible end marker. Keep the word 'private' between both %s markers.
 msgctxt "Empty state heading in Duck.ai chat mode"
 msgid "All chats are %sprivate%s"
+msgstr ""
+
+#. Paragraph in the Privacy & Terms section of the About & Legal page in Duck.ai settings, summarizing how chats are anonymized and are not stored or used to train chat models.
+msgctxt "Privacy & Terms section description on the Duck.ai settings page"
+msgid ""
+"All chats are anonymized by DuckDuckGo, and your conversations are not used "
+"to train chat models by DuckDuckGo or the model providers"
 msgstr ""
 
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1550,6 +1562,12 @@ msgstr ""
 #. Confirmation message after location service is enabled.
 msgctxt "precise_user_location"
 msgid "Anonymous location enabled"
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Anonymously generates answers for search queries based on web content. "
+"Choose how often you want it to appear, or disable it completely."
 msgstr ""
 
 #. Instant Answer tab name
@@ -1772,6 +1790,11 @@ msgstr ""
 
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse
 msgid "Ask a follow-up with Duck.ai"
+msgstr ""
+
+#. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
+msgctxt "Page suggestion chip label"
+msgid "Ask about this page"
 msgstr ""
 
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2098,6 +2121,11 @@ msgstr ""
 msgid "Barcode"
 msgstr "Շտրիխկոդ"
 
+#. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Based on this page, is this course worth taking?"
+msgstr ""
+
 msgctxt "settings"
 msgid "Basic"
 msgstr "Հիմնական"
@@ -2129,6 +2157,13 @@ msgstr ""
 #. Placeholder text displayed while the assistant waits for the user to choose an action.
 msgctxt "Assistant response placeholder"
 msgid "Before continuing..."
+msgstr ""
+
+#. Explains that before storing the report, DuckDuckGo will anonymize the conversation by removing PII like names, email addresses, and identifying metadata.
+msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
+msgid ""
+"Before storing this report, DuckDuckGo will anonymize your conversation by "
+"removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
 #. Label that's displayed next to a past start date below a web search result.
@@ -2387,6 +2422,11 @@ msgstr "Բրազիլիա"
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Break Points Won"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Break this down into clear, numbered steps."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -2746,6 +2786,11 @@ msgstr "Աշխատանք"
 #. Text of a button that performs a search for the cast of a particular movie or tv show
 msgctxt "Movie/TV Show Title instant answer"
 msgid "Cast"
+msgstr ""
+
+#. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Cast & Crew"
 msgstr ""
 
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -4097,6 +4142,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Create a shopping list with quantities from this recipe."
+msgstr ""
+
 #. Placeholder text displayed in the input field when starting a new image generation session.
 msgctxt "Placeholder text for the image generation input field"
 msgid "Create an image of a cute duck..."
@@ -4623,6 +4673,10 @@ msgstr ""
 msgid "Dictation limit reached"
 msgstr ""
 
+#. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
+msgid "Dictation temporarily unavailable"
+msgstr ""
+
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
@@ -4867,6 +4921,20 @@ msgctxt "precise_user_location"
 msgid "Done"
 msgstr ""
 
+#. Message shown in a modal after DuckDuckGo browser users disable AI features in Settings. The first two placeholders bold noai.duckduckgo.com. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
+"filtered out. %sLearn More%s"
+msgstr ""
+
+#. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
+"and AI images filtered out. %sLearn more%s"
+msgstr ""
+
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Double Faults"
@@ -4957,6 +5025,16 @@ msgctxt "Full sentence for writing an email"
 msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
+msgstr ""
+
+#. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Draft a cover letter"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Draft a cover letter for this job."
 msgstr ""
 
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -5096,6 +5174,14 @@ msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
 msgstr ""
 
+#. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
+msgctxt "About section description on the Duck.ai settings page"
+msgid ""
+"Duck.ai is created by DuckDuckGo. We're an independent online protection "
+"company for anyone who wants to take back control of their personal "
+"information."
+msgstr ""
+
 #. Title shown when an update is required before proceeding.
 msgctxt "duckai_migration"
 msgid "Duck.ai is moving domains"
@@ -5129,6 +5215,12 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Duck.ai lets you chat privately with popular AI models. Disabling it hides "
+"Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
 
 msgctxt "settings"
@@ -5902,6 +5994,16 @@ msgstr ""
 msgid "Eritrea"
 msgstr ""
 
+#. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Estimate the nutrition"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Estimate the nutritional information for this recipe."
+msgstr ""
+
 msgid "Estonia"
 msgstr "Էստոնիա"
 
@@ -5946,10 +6048,50 @@ msgctxt "merchant promotion product ad extension"
 msgid "Expires in 1 day"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain the accepted answer in simple terms."
+msgstr ""
+
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
+msgstr ""
+
+#. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain the top answer"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this in simple, plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this paper"
+msgstr ""
+
+#. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this repo"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this research paper in plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this simply"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain what this repository does and how to use it."
 msgstr ""
 
 #. Label to show if song lyrics contain explicit content
@@ -6180,6 +6322,11 @@ msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
 msgstr ""
 
+msgctxt "settings"
+msgid ""
+"Filters out known AI spam sites from image search results. %sLearn More%s"
+msgstr ""
+
 #. Label for the final score of a sporting event.
 msgid "Final"
 msgstr "Վերջնական"
@@ -6219,6 +6366,11 @@ msgstr ""
 #. Short description shown below the 'Web Search' label in the Tools dropdown.
 msgctxt "Subtitle for the Web Search tool entry in the Tools dropdown menu"
 msgid "Find current information"
+msgstr ""
+
+#. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Find me alternatives"
 msgstr ""
 
 #. Button that searches for results closer to the user's current location.
@@ -6609,6 +6761,11 @@ msgstr ""
 msgid "Generate More"
 msgstr ""
 
+#. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Generate a shopping list"
+msgstr ""
+
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
 msgid "Generate a short answer from the web"
 msgstr ""
@@ -6843,6 +7000,11 @@ msgstr ""
 #. Text for a button inviting users to give it a try for the Duck.ai product. On click, they're taken to the Duck.ai page.
 msgctxt "Onboarding welcome screen button text"
 msgid "Give it a Try"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Give me a quick background on this person."
 msgstr ""
 
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -7210,6 +7372,16 @@ msgstr ""
 #. Link to a page with information about sharing DuckDuckGo with friends.
 msgid "Help Spread Privacy"
 msgstr "Օգնիր տարածել գաղտնիությունը"
+
+#. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Help me prep for the interview"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Help me tailor my resume for this job."
+msgstr ""
 
 #. Title of a SERP popup that invites users to take a survey (desktop only)
 msgctxt "User survey popup"
@@ -7628,6 +7800,13 @@ msgstr ""
 #. Text displayed on the button on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
 msgctxt "Onboarding terms screen button text"
 msgid "I Agree"
+msgstr ""
+
+#. Text for the button that takes the user to the external DuckDuckGo login subscription page.
+msgctxt ""
+"Text for the I already have a subscription button in the Duck.ai settings "
+"page"
+msgid "I Already Have a Subscription"
 msgstr ""
 
 #. Text for the button that takes the user to the login subscription page.
@@ -8082,6 +8261,11 @@ msgctxt "Sidemenu browser promo"
 msgid "Install Mac Browser"
 msgstr ""
 
+#. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
+msgctxt "settings"
+msgid "Install Now"
+msgstr ""
+
 #. Text of a button to install the DuckDuckGo app
 msgctxt "Serp footer content"
 msgid "Install Our App"
@@ -8161,9 +8345,36 @@ msgctxt "cloudsave"
 msgid "Is deleted data really deleted?"
 msgstr "Ջնջված տվյալները իսկապե՞ս ջնջված են:"
 
+#. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is it worth taking?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this place any good?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"Is this place any good? Summarize its reputation based on reviews and "
+"ratings."
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "Is this video helpful?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this worth watching?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Is this worth watching? Give me a spoiler-free take."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -8660,6 +8871,11 @@ msgstr "Հղման տառատեսակ"
 msgid "Links:"
 msgstr "Հղումներ."
 
+#. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "List the tools, materials, or prerequisites I need for this."
+msgstr ""
+
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
 msgid "Listen"
 msgstr "Լսել"
@@ -8994,6 +9210,11 @@ msgstr ""
 #. Label for linke navigating to site exclusion feature on Settings page
 msgctxt "Exclusion message manage sites button"
 msgid "Manage blocked sites"
+msgstr ""
+
+#. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
+msgctxt "setting"
+msgid "Manage in Browser Settings"
 msgstr ""
 
 #. Link to the site exclusion settings page
@@ -11297,6 +11518,11 @@ msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
+msgid "Please describe why the chat response is harmful or illegal. (optional)"
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
+msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
 msgstr ""
 
@@ -11315,6 +11541,13 @@ msgctxt "Modal disclaimer text"
 msgid ""
 "Please note: starting a new chat with any model will delete your current "
 "chat session."
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
+msgctxt "Feedback prompt"
+msgid ""
+"Please paste your prompt and the problematic output (with any personal "
+"information removed) and describe why the content is harmful or illegal."
 msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -11699,6 +11932,11 @@ msgctxt "settings"
 msgid "Privacy"
 msgstr "Գաղտնիություն"
 
+#. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
+msgctxt "Section heading on the Duck.ai settings page"
+msgid "Privacy & Terms"
+msgstr ""
+
 msgid "Privacy Blog"
 msgstr "Գաղտնիության բլոք"
 
@@ -11752,6 +11990,11 @@ msgstr ""
 
 #. Text used in other strings to link to the Privacy Policy and Terms of Service content.
 msgctxt "Copy used to compose link in sentences"
+msgid "Privacy Policy and Terms of Service"
+msgstr ""
+
+#. Text for a button that links to the terms of use and privacy policy page.
+msgctxt "Secondary button text in active privacy modal"
 msgid "Privacy Policy and Terms of Service"
 msgstr ""
 
@@ -12160,6 +12403,26 @@ msgctxt "Brief for recommending a book"
 msgid "Recommend a book"
 msgstr ""
 
+#. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar books"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar books."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar movies or shows."
+msgstr ""
+
+#. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar titles"
+msgstr ""
+
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
 msgid "Recording failed. Please try again."
 msgstr ""
@@ -12479,6 +12742,14 @@ msgstr ""
 msgid "Republic of Moldova"
 msgstr ""
 
+#. Note indicating that sharing the conversation is mandatory when reporting harmful or illegal content. Rendered alongside the standard share label (DUCKCHAT_RESPONSE_FEEDBACK_SHARE_PROMPT_RESPONSE_LABEL), not replacing it.
+msgctxt ""
+"Note shown under the share-content switch label on the Duck.ai response "
+"feedback form when the user has selected Harmful or Illegal as the feedback "
+"reason"
+msgid "Required for harmful or illegal reports"
+msgstr ""
+
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
 msgctxt "Description for extended reasoning mode in Duck.ai"
 msgid "Researches before responding"
@@ -12664,6 +12935,11 @@ msgstr "Դիտումներ"
 #. Label above a list of customer reviews of a business.
 msgctxt "maps_places"
 msgid "Reviews"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Rewrite this recipe scaled for a different number of servings."
 msgstr ""
 
 msgid "Romania"
@@ -13707,6 +13983,11 @@ msgctxt "Setup button for native sync flow"
 msgid "Set Up Now"
 msgstr ""
 
+#. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
+msgctxt "Encrypted storage setup button shown in native browsers"
+msgid "Set Up Sync & Backup"
+msgstr ""
+
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
 msgctxt "Title for the Sync & Backup intro screen"
 msgid "Set Up Sync & Backup"
@@ -13849,6 +14130,12 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
+msgctxt ""
+"Label beside the share-content switch on the Duck.ai response feedback form"
+msgid "Share this conversation with DuckDuckGo"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -14865,6 +15152,21 @@ msgctxt "Brief for suggesting a blog post title"
 msgid "Suggest a title for a blog post"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest related articles or topics worth exploring next."
+msgstr ""
+
+#. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Suggest related articles to explore"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest some alternatives to this product."
+msgstr ""
+
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
 msgctxt "directions"
 msgid "Suggestions:"
@@ -14874,9 +15176,84 @@ msgctxt "noresults"
 msgid "Suggestions:"
 msgstr "Խորհուրդներ."
 
+#. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Sum up the reviews"
+msgstr ""
+
 #. A short title for the a message asking the AI to summarize a text.
 msgctxt "Title for the summarize message"
 msgid "Summarize"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize the Q&As"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the background and notable work of this person."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the key details of this event."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the questions and answers on this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize their background"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this book"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this book."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this discussion"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this discussion thread."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this video"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this video."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize what the reviews say."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -15131,6 +15508,11 @@ msgstr ""
 msgid "Syria"
 msgstr ""
 
+#. Text for a button that enables the theme to follow the operating system's color scheme preference.
+msgctxt "System theme button for theme selector"
+msgid "System"
+msgstr ""
+
 #. Abbreviation indicating this is the total score for a game
 msgctxt "Sports module"
 msgid "T"
@@ -15154,6 +15536,11 @@ msgctxt "language_name"
 msgid "Tahitian"
 msgstr ""
 
+#. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Tailor my resume"
+msgstr ""
+
 msgid "Taiwan"
 msgstr "Թայվան"
 
@@ -15175,6 +15562,12 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "Take control of your personal data!"
+msgstr ""
+
+#. Description for the Feedback section of the Duck.ai settings page, asking the user to take an anonymous survey to let us know how we can make Duck.ai better.
+msgctxt "Feedback section description on the Duck.ai settings page"
+msgid ""
+"Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
 
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -15419,6 +15812,11 @@ msgstr ""
 #. https://duck.co/media/files/theme.png
 msgid "Theme"
 msgstr "Ոճ"
+
+#. Text for the theme selector label that allows users to switch between Light and dark theme.
+msgctxt "Label for the theme selector feature"
+msgid "Theme"
+msgstr ""
 
 #. http://i.imgur.com/LpFhb1e.png
 msgctxt "settings"
@@ -16070,6 +16468,16 @@ msgid ""
 "movie theatre?”"
 msgstr ""
 
+#. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Translate this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
+msgctxt "Page suggestion prompt"
+msgid "Translate this page into %s."
+msgstr ""
+
 #. Placeholder text for a region that will display translated text.
 msgctxt "translations_module"
 msgid "Translation"
@@ -16184,6 +16592,11 @@ msgstr ""
 #. Call-to-action button for the subscription promo in the SERP sidemenu.
 msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
+msgstr ""
+
+#. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
+msgctxt "settings"
+msgid "Try It Now"
 msgstr ""
 
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -16377,6 +16790,20 @@ msgstr "Փորձիր. %s"
 #. Response a user can select in a feedback form, indicating that they're trying DuckDuckGo again.
 msgctxt "new user poll"
 msgid "Trying DuckDuckGo again"
+msgstr ""
+
+#. Message shown in a modal after supported third-party browser users disable AI features in Settings. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+#. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
 msgstr ""
 
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -16977,6 +17404,11 @@ msgstr ""
 msgid "Uruguay"
 msgstr ""
 
+#. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
+msgctxt "Navigation label on the Duck.ai settings page"
+msgid "Usage"
+msgstr ""
+
 #. A feedback suggestion
 msgctxt "Feedback prompt"
 msgid "Usage limit"
@@ -17325,6 +17757,11 @@ msgstr ""
 msgid "Wales"
 msgstr ""
 
+#. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Walk me through the steps"
+msgstr ""
+
 #. Label for walking directions on a map.
 msgctxt "directions"
 msgid "Walking"
@@ -17415,6 +17852,16 @@ msgstr ""
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
+msgstr ""
+
+#. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
+msgctxt ""
+"Inline warning shown below the share-content toggle when the user selects "
+"Harmful or Illegal but has not enabled sharing"
+msgid ""
+"We can only fix what we can see. To report a harmful or illegal response, "
+"please share this conversation with DuckDuckGo so we can investigate and "
+"address the issue."
 msgstr ""
 
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -17834,6 +18281,87 @@ msgid ""
 "experience."
 msgstr ""
 
+#. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the counterarguments?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the hours & location?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key contributions of this paper?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key contributions?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key details?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key points covered in this video?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key points?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key takeaways from this article?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key takeaways?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key things I will learn from this course?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main counterarguments or criticisms of this?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main questions this page answers?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the must-try dishes here?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"What are the opening hours, location, and contact details for this place?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the pros and cons of this product?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the pros and cons?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
 msgctxt "feedback form"
 msgid "What bothered you most?"
@@ -17917,6 +18445,11 @@ msgctxt "Full sentence for defining a term"
 msgid "What does atria mean in the context of a medical article?"
 msgstr ""
 
+#. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What does this answer?"
+msgstr ""
+
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
@@ -17926,6 +18459,11 @@ msgstr ""
 msgctxt "cloudsave"
 msgid "What information gets saved?"
 msgstr "Ի՞նչ տվյալներ պետք է պահպանել"
+
+#. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What interview questions might come up for this role?"
+msgstr ""
 
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
@@ -17937,6 +18475,11 @@ msgstr ""
 #. Text for a prompt suggestion for looking up the capital city of Albania.
 msgctxt "Full sentence for looking up basic facts"
 msgid "What is the capital city of Albania?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What is the overall verdict and rating for this?"
 msgstr ""
 
 #. Link to a page with additional information.
@@ -17957,6 +18500,11 @@ msgctxt "maps_places"
 msgid "What people say:"
 msgstr ""
 
+#. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What should I order?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
 msgctxt "feedback form"
 msgid "What stood out?"
@@ -17965,6 +18513,16 @@ msgstr ""
 #. Question on a feedback form for a negative feedback response.
 msgctxt "feedback form"
 msgid "What was wrong with the response? (optional)"
+msgstr ""
+
+#. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I learn?"
+msgstr ""
+
+#. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I need?"
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -17979,6 +18537,11 @@ msgstr ""
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
 msgctxt "SERP footer content"
 msgid "What's New"
+msgstr ""
+
+#. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What's the verdict?"
 msgstr ""
 
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -18020,6 +18583,11 @@ msgctxt "Feedback prompt"
 msgid "Which features are missing? (Optional)"
 msgstr ""
 
+#. An invitation for users to leave feedback
+msgctxt "Feedback prompt"
+msgid "Which features are missing? (optional)"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
 msgid "White"
 msgstr "Սպիտակ"
@@ -18032,6 +18600,16 @@ msgstr "Սպիտակ"
 #. Link to an about us page.
 msgid "Who We Are"
 msgstr "Ո՞վ ենք մենք"
+
+#. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Who are the main cast and crew, and what else are they known for?"
+msgstr ""
+
+#. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Who is this person?"
+msgstr ""
 
 #. Header above a collection of privacy-related links.
 msgid "Why Privacy"

--- a/locales/id_ID/LC_MESSAGES/duckduckgo.po
+++ b/locales/id_ID/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: id_ID\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -492,8 +492,7 @@ msgstr "%1$sTekan lama%2$s ikon aplikasi DuckDuckGo di layar beranda"
 #. A message displayed when there is an error loading content or no results on requery
 msgctxt "Error or no results message"
 msgid "%sOops!%s%sSomething went wrong. Please %srefresh%s and try again."
-msgstr ""
-"%1$sUps!%2$s%3$sAda yang tidak beres. Silakan %4$srefresh%5$s dan coba lagi."
+msgstr "%1$sUps!%2$s%3$sAda yang tidak beres. Silakan %4$srefresh%5$s dan coba lagi."
 
 # smartling.placeholder_format=C
 #. Tagline in a popover encouraging the user to download the DuckDuckGo browser
@@ -883,16 +882,14 @@ msgstr ""
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of AI Chat is available! Please refresh this page to continue."
-msgstr ""
-"Versi baru AI Chat tersedia! Silakan refresh halaman ini untuk melanjutkan."
+msgstr "Versi baru AI Chat tersedia! Silakan refresh halaman ini untuk melanjutkan."
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of Duck.ai is available and they need to refresh the page.
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of Duck.ai is available! Please refresh this page to continue."
-msgstr ""
-"Versi baru Duck.ai tersedia! Silakan refresh halaman ini untuk melanjutkan."
+msgstr "Versi baru Duck.ai tersedia! Silakan refresh halaman ini untuk melanjutkan."
 
 # smartling.placeholder_format=C
 #. Shown when the Duck.ai desktop app has been open a long time and a newer version exists.
@@ -1439,7 +1436,7 @@ msgstr "Alamat salah"
 #. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Adjust the servings"
-msgstr ""
+msgstr "Sesuaikan porsi"
 
 # smartling.placeholder_format=C
 #. as in multiple advertisements
@@ -1659,6 +1656,8 @@ msgid ""
 "All chats are anonymized by DuckDuckGo, and your conversations are not used "
 "to train chat models by DuckDuckGo or the model providers"
 msgstr ""
+"Semua obrolan dianonimkan oleh DuckDuckGo, dan percakapan Anda tidak "
+"digunakan untuk melatih model obrolan oleh DuckDuckGo atau penyedia model"
 
 # smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1690,8 +1689,7 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "All model providers are prevented from training their AI on your "
 "conversations."
-msgstr ""
-"Semua penyedia model dicegah melatih AI mereka menggunakan percakapan Anda."
+msgstr "Semua penyedia model dicegah melatih AI mereka menggunakan percakapan Anda."
 
 # smartling.placeholder_format=C
 #. Text displayed in the subheader of the modal that allows the user to pick an AI chat model.
@@ -1935,6 +1933,9 @@ msgid ""
 "Anonymously generates answers for search queries based on web content. "
 "Choose how often you want it to appear, or disable it completely."
 msgstr ""
+"Secara anonim menghasilkan jawaban untuk permintaan pencarian berdasarkan "
+"konten web. Pilih seberapa sering Anda ingin itu muncul, atau nonaktifkan "
+"sepenuhnya."
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -2081,15 +2082,13 @@ msgstr "Apa kamu masih di sana?"
 msgctxt "Body text for clear all chats confirmation modal"
 msgid ""
 "Are you sure you want to clear all of your chats? This cannot be undone."
-msgstr ""
-"Apakah kamu yakin ingin menghapus semua obrolanmu? Ini tidak bisa dibatalkan."
+msgstr "Apakah kamu yakin ingin menghapus semua obrolanmu? Ini tidak bisa dibatalkan."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that asks the user if they want to clear the conversation.
 msgctxt "Modal body for clearing conversation"
 msgid "Are you sure you want to clear this conversation and start a new one?"
-msgstr ""
-"Apakah Anda yakin ingin menghapus percakapan ini dan memulai yang baru?"
+msgstr "Apakah Anda yakin ingin menghapus percakapan ini dan memulai yang baru?"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to delete their current chat, explaining that this action cannot be undone.
@@ -2221,7 +2220,7 @@ msgstr "Ajukan pertanyaan lanjutan dengan Duck.ai"
 #. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
 msgctxt "Page suggestion chip label"
 msgid "Ask about this page"
-msgstr ""
+msgstr "Ajukan pertanyaan tentang halaman ini"
 
 # smartling.placeholder_format=C
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2391,21 +2390,18 @@ msgstr "Suara"
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat ends."
-msgstr ""
-"Audio tidak disimpan oleh kami atau oleh OpenAI setelah obrolan berakhir."
+msgstr "Audio tidak disimpan oleh kami atau oleh OpenAI setelah obrolan berakhir."
 
 # smartling.placeholder_format=C
 #. Description in consent disclaimer informing that audio from the voice chat session is not stored by us or by OpenAI after the voice chat ends.
 msgctxt "voice chat"
 msgid "Audio is not stored by us or by OpenAI after the chat ends."
-msgstr ""
-"Audio tidak disimpan oleh kami atau oleh OpenAI setelah obrolan berakhir."
+msgstr "Audio tidak disimpan oleh kami atau oleh OpenAI setelah obrolan berakhir."
 
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat is transcribed."
-msgstr ""
-"Audio tidak disimpan oleh kami atau OpenAI setelah obrolan ditranskripsikan."
+msgstr "Audio tidak disimpan oleh kami atau OpenAI setelah obrolan ditranskripsikan."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when MediaRecorder API is unavailable.
@@ -2649,7 +2645,7 @@ msgstr "Kode Batang"
 #. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Based on this page, is this course worth taking?"
-msgstr ""
+msgstr "Berdasarkan halaman ini, apakah kursus ini layak diikuti?"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2698,6 +2694,8 @@ msgid ""
 "Before storing this report, DuckDuckGo will anonymize your conversation by "
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
+"Sebelum menyimpan laporan ini, DuckDuckGo akan menganonimkan percakapan "
+"dengan menghapus PII seperti nama, alamat email, dan metadata identifikasi."
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -3019,7 +3017,7 @@ msgstr "Break Point Dimenangkan"
 #. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Break this down into clear, numbered steps."
-msgstr ""
+msgstr "Uraikan ini menjadi langkah-langkah yang jelas dan bernomor."
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -3480,7 +3478,7 @@ msgstr "Pemain"
 #. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Cast & Crew"
-msgstr ""
+msgstr "Pemeran & Kru"
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -3592,8 +3590,7 @@ msgstr "Mengubah warna latar belakang hasil hover, modul, dan menu dropdown"
 #. http://i.imgur.com/NdpkbY0.png
 msgctxt "settings"
 msgid "Changes the background color when hovering over a result"
-msgstr ""
-"Mengubah warna latar belakang saat mengarahkan kursor ke atas suatu hasil"
+msgstr "Mengubah warna latar belakang saat mengarahkan kursor ke atas suatu hasil"
 
 # smartling.placeholder_format=C
 #. Description of a setting managing the color of search result snippet text.
@@ -3720,8 +3717,8 @@ msgstr ""
 "anonim dengan model chat AI pihak ketiga, yang mendukung model dari OpenAI, "
 "Anthropic, dan lainnya. Menonaktifkan pengaturan ini akan menyembunyikan "
 "tombol dan tautan Chat di DuckDuckGo Search. Namun, Anda masih dapat "
-"mengakses Chat saat setelan ini dinonaktifkan dengan mengunjungi %1$shttps://"
-"duck.ai%2$s langsung."
+"mengakses Chat saat setelan ini dinonaktifkan dengan mengunjungi "
+"%1$shttps://duck.ai%2$s langsung."
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -3952,8 +3949,7 @@ msgstr ""
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
 msgctxt "noresults"
 msgid "Check the status page for updates on this outage."
-msgstr ""
-"Periksa halaman status untuk mendapatkan pembaruan mengenai gangguan ini."
+msgstr "Periksa halaman status untuk mendapatkan pembaruan mengenai gangguan ini."
 
 # smartling.placeholder_format=C
 #. Title shown to the host device (the one that is logged in) after it sends the pairing code. The host can't confirm the peer applied it, so this is a title-only screen (no body) prompting the user to finish on the other device.
@@ -4323,8 +4319,7 @@ msgstr "Klik %1$sDi sini%2$s untuk mengunduh ekstensi DuckDuckGo"
 # smartling.placeholder_format=C
 #. Link to download the DuckDuckGo browser extension.
 msgid "Click %sOpen%s to download and open the DuckDuckGo Safari extension"
-msgstr ""
-"Klik %1$sBuka%2$s untuk mengunduh dan membuka ekstensi DuckDuckGo di Safari"
+msgstr "Klik %1$sBuka%2$s untuk mengunduh dan membuka ekstensi DuckDuckGo di Safari"
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -4369,8 +4364,7 @@ msgstr "Klik %1$sYa%2$s"
 # smartling.placeholder_format=C
 #. Tells the user where to click to open their browser's settings menu.
 msgid "Click %ssettings/hamburger icon %s on the Chrome toolbar (top right)."
-msgstr ""
-"Klik %1$spengaturan/ikon hamburger %2$s di bilah alat Chrome (kanan atas)."
+msgstr "Klik %1$spengaturan/ikon hamburger %2$s di bilah alat Chrome (kanan atas)."
 
 #  Maxthon default search engine instruction
 # smartling.placeholder_format=C
@@ -5195,7 +5189,7 @@ msgstr "Buat Gambar"
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
-msgstr ""
+msgstr "Buat daftar belanja dengan jumlah dari resep ini."
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed in the input field when starting a new image generation session.
@@ -5844,7 +5838,7 @@ msgstr "Batas dikte tercapai"
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
 msgid "Dictation temporarily unavailable"
-msgstr ""
+msgstr "Dikte untuk sementara tidak tersedia"
 
 # smartling.placeholder_format=C
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
@@ -6038,8 +6032,7 @@ msgstr "Bahasa Tampilan"
 #. This is the description of a user setting
 msgctxt "settings"
 msgid "Displays a checkmark to the left of results you've visited"
-msgstr ""
-"Menampilkan tanda centang di sebelah kiri hasil yang telah kamu kunjungi"
+msgstr "Menampilkan tanda centang di sebelah kiri hasil yang telah kamu kunjungi"
 
 # smartling.placeholder_format=C
 #. This is the description of a user setting
@@ -6154,6 +6147,8 @@ msgid ""
 "Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
 "filtered out. %sLearn More%s"
 msgstr ""
+"Tidak mau AI? %1$snoai.duckduckgo.com%2$s tidak menawarkan fitur AI dan "
+"gambar AI disaring. %3$sPelajari Lebih Lanjut%4$s"
 
 # smartling.placeholder_format=C
 #. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
@@ -6162,6 +6157,8 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
+"Tidak mau AI? Kunjungi %1$snoai.duckduckgo.com%2$s untuk mencari tanpa fitur "
+"AI dan dengan gambar AI yang disaring. %3$sPelajari Lebih Lanjut%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6281,13 +6278,13 @@ msgstr ""
 #. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Draft a cover letter"
-msgstr ""
+msgstr "Buat surat lamaran"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Draft a cover letter for this job."
-msgstr ""
+msgstr "Buat surat lamaran untuk pekerjaan ini."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -6296,8 +6293,8 @@ msgid ""
 "Draft a few options for a social media post inviting people to my upcoming "
 "party."
 msgstr ""
-"Buatlah beberapa opsi untuk postingan media sosial yang mengundang orang-"
-"orang ke pesta saya yang akan datang."
+"Buatlah beberapa opsi untuk postingan media sosial yang mengundang "
+"orang-orang ke pesta saya yang akan datang."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a few options for a blog post title about strategies to increase team collaboration.
@@ -6463,8 +6460,7 @@ msgstr ""
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
-msgstr ""
-"Duck.ai adalah yang terbaik di browser DuckDuckGo pribadi dan gratis kami!"
+msgstr "Duck.ai adalah yang terbaik di browser DuckDuckGo pribadi dan gratis kami!"
 
 # smartling.placeholder_format=C
 #. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
@@ -6474,6 +6470,9 @@ msgid ""
 "company for anyone who wants to take back control of their personal "
 "information."
 msgstr ""
+"Duck.ai dibuat oleh DuckDuckGo. Kami adalah perusahaan perlindungan online "
+"independen bagi siapa saja yang ingin mengambil kembali kendali atas "
+"informasi pribadi mereka."
 
 # smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
@@ -6528,6 +6527,9 @@ msgid ""
 "Duck.ai lets you chat privately with popular AI models. Disabling it hides "
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
+"Duck.ai memungkinkan Anda untuk mengobrol secara pribadi dengan model AI "
+"populer. Menonaktifkannya akan menyembunyikan tombol dan tautan Duck.ai, "
+"tetapi Anda masih bisa mengunjungi %1$sduck.ai%2$s langsung."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6548,8 +6550,7 @@ msgstr ""
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
 msgctxt "Disclaimer text at the bottom of the feedback form."
 msgid "Duck.ai may display inaccurate or offensive information."
-msgstr ""
-"Duck.ai mungkin menampilkan informasi yang tidak akurat atau menyinggung."
+msgstr "Duck.ai mungkin menampilkan informasi yang tidak akurat atau menyinggung."
 
 # smartling.placeholder_format=C
 #. Error modal body line 2.
@@ -6592,8 +6593,7 @@ msgstr "Duck.ai ditingkatkan!"
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
-msgstr ""
-"Duck.ai bekerja paling baik di aplikasi DuckDuckGo pribadi dan gratis kamu!"
+msgstr "Duck.ai bekerja paling baik di aplikasi DuckDuckGo pribadi dan gratis kamu!"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -6779,8 +6779,7 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr ""
-"DuckDuckGo AI Chat untuk sementara tidak tersedia. Silakan coba lagi nanti."
+msgstr "DuckDuckGo AI Chat untuk sementara tidak tersedia. Silakan coba lagi nanti."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -7055,9 +7054,9 @@ msgid ""
 "random words from that list, ensuring that the passphrase is at least 18-20 "
 "characters long."
 msgstr ""
-"Tiap kali kamu meminta saran frasa sandi, kami menerima daftar berisi kata-"
-"kata acak dari server DuckDuckGo. Di browser, kami kemudian memilih 4—5 kata "
-"acak dari daftar itu, dengan memastikan bahwa frasa sandinya minimal "
+"Tiap kali kamu meminta saran frasa sandi, kami menerima daftar berisi "
+"kata-kata acak dari server DuckDuckGo. Di browser, kami kemudian memilih 4—5 "
+"kata acak dari daftar itu, dengan memastikan bahwa frasa sandinya minimal "
 "sepanjang 18—20 karakter."
 
 # smartling.placeholder_format=C
@@ -7268,8 +7267,7 @@ msgstr "Aktifkan Dikte dalam Duck.ai"
 #. Prompt to enable location service so that search results can be displayed near the user's current location.
 msgctxt "precise_user_location"
 msgid "Enable location settings on your device to use anonymous location"
-msgstr ""
-"Aktifkan pengaturan lokasi di perangkatmu untuk menggunakan lokasi anonim"
+msgstr "Aktifkan pengaturan lokasi di perangkatmu untuk menggunakan lokasi anonim"
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -7536,13 +7534,13 @@ msgstr "Eritrea"
 #. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Estimate the nutrition"
-msgstr ""
+msgstr "Perkirakan nutrisi"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Estimate the nutritional information for this recipe."
-msgstr ""
+msgstr "Estimasi informasi nutrisi untuk resep ini."
 
 # smartling.placeholder_format=C
 msgid "Estonia"
@@ -7602,57 +7600,58 @@ msgstr "Kedaluwarsa dalam 1 hari"
 #. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain the accepted answer in simple terms."
-msgstr ""
+msgstr "Jelaskan jawaban yang diterima dengan bahasa yang sederhana."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
-msgstr ""
-"Jelaskan konsep dasar lubang hitam kepada saya di tingkat sekolah menengah."
+msgstr "Jelaskan konsep dasar lubang hitam kepada saya di tingkat sekolah menengah."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain the top answer"
-msgstr ""
+msgstr "Jelaskan jawaban teratas"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain this in simple, plain language."
-msgstr ""
+msgstr "Jelaskan ini dengan bahasa yang sederhana dan mudah dimengerti."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain this paper"
-msgstr ""
+msgstr "Jelaskan makalah ini"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain this repo"
-msgstr ""
+msgstr "Jelaskan repo ini"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain this research paper in plain language."
 msgstr ""
+"Jelaskan makalah penelitian ini dengan bahasa yang sederhana dan mudah "
+"dimengerti."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain this simply"
-msgstr ""
+msgstr "Jelaskan ini dengan sederhana"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain what this repository does and how to use it."
-msgstr ""
+msgstr "Jelaskan apa fungsi repositori ini dan bagaimana cara menggunakannya."
 
 # smartling.placeholder_format=C
 #. Label to show if song lyrics contain explicit content
@@ -7943,6 +7942,8 @@ msgctxt "settings"
 msgid ""
 "Filters out known AI spam sites from image search results. %sLearn More%s"
 msgstr ""
+"Menyaring situs spam AI yang diketahui dari hasil pencarian gambar. "
+"%1$sPelajari Lebih Lanjut%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the final score of a sporting event.
@@ -8003,7 +8004,7 @@ msgstr "Temukan informasi terkini"
 #. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Find me alternatives"
-msgstr ""
+msgstr "Cari alternatif untuk saya"
 
 # smartling.placeholder_format=C
 #. Button that searches for results closer to the user's current location.
@@ -8022,8 +8023,7 @@ msgstr "Temukan hasil yang lebih dekat dari lokasimu."
 msgctxt "Precise user location overlay"
 msgid ""
 "Find results near you. %sYour location stays private, secure, and anonymous."
-msgstr ""
-"Temukan hasil di dekatmu. %1$sLokasimu tetap pribadi, aman, dan anonim."
+msgstr "Temukan hasil di dekatmu. %1$sLokasimu tetap pribadi, aman, dan anonim."
 
 # smartling.placeholder_format=C
 #. Loading message shown while generating explore more follow-up questions
@@ -8094,8 +8094,7 @@ msgstr ""
 #. Privacy reassurance and instructions intro.
 msgctxt "duckai_migration"
 msgid "Follow these steps to move your chats to the new Duck.ai"
-msgstr ""
-"Ikuti langkah-langkah berikut untuk memindahkan obrolanmu ke Duck.ai baru"
+msgstr "Ikuti langkah-langkah berikut untuk memindahkan obrolanmu ke Duck.ai baru"
 
 # smartling.placeholder_format=C
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse on mobile
@@ -8314,8 +8313,8 @@ msgid ""
 "strong>."
 msgstr ""
 "Dari bilah menu aplikasi di Mac, pilih <strong>DuckDuckGo</strong> &gt; "
-"<strong>Periksa Pembaruan...</strong>, lalu pilih <strong>Instal Pembaruan</"
-"strong>."
+"<strong>Periksa Pembaruan...</strong>, lalu pilih <strong>Instal "
+"Pembaruan</strong>."
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -8486,7 +8485,7 @@ msgstr "Hasilkan Lebih Banyak"
 #. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Generate a shopping list"
-msgstr ""
+msgstr "Buat daftar belanja"
 
 # smartling.placeholder_format=C
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
@@ -8785,7 +8784,7 @@ msgstr "Cobalah"
 #. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Give me a quick background on this person."
-msgstr ""
+msgstr "Beri aku latar belakang singkat tentang orang ini."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9237,13 +9236,13 @@ msgstr "Bantu Sebarkan Privasi"
 #. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Help me prep for the interview"
-msgstr ""
+msgstr "Bantu saya bersiap untuk wawancara"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Help me tailor my resume for this job."
-msgstr ""
+msgstr "Bantu saya menyesuaikan resume saya untuk pekerjaan ini."
 
 # smartling.placeholder_format=C
 #. Title of a SERP popup that invites users to take a survey (desktop only)
@@ -9768,7 +9767,7 @@ msgctxt ""
 "Text for the I already have a subscription button in the Duck.ai settings "
 "page"
 msgid "I Already Have a Subscription"
-msgstr ""
+msgstr "Saya sudah punya langganan"
 
 # smartling.placeholder_format=C
 #. Text for the button that takes the user to the login subscription page.
@@ -9812,8 +9811,7 @@ msgstr "Saya tidak paham informasi ini"
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
 msgid "I don’t want to see any information from DuckDuckGo on this page"
-msgstr ""
-"Saya tidak ingin melihat informasi apa pun dari DuckDuckGo di halaman ini"
+msgstr "Saya tidak ingin melihat informasi apa pun dari DuckDuckGo di halaman ini"
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
@@ -9852,8 +9850,7 @@ msgstr ""
 #. Option for feedback when the user needs more help or information on how to use the chat.
 msgctxt "Feedback option for difficulty in using chat"
 msgid "I need more help/info on how to use Chat"
-msgstr ""
-"Saya memerlukan bantuan/informasi lebih lanjut tentang cara menggunakan Chat"
+msgstr "Saya memerlukan bantuan/informasi lebih lanjut tentang cara menggunakan Chat"
 
 # smartling.placeholder_format=C
 msgid "IR Iran"
@@ -10141,8 +10138,7 @@ msgstr "Di menu atas, pilih %1$sAlat%2$s > %3$sPengaturan%4$s"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "In the popup, check %sMake this my default search provider%s"
-msgstr ""
-"Di dalam popup, centang %1$sJadikan sebagai mesin pencari default saya%2$s"
+msgstr "Di dalam popup, centang %1$sJadikan sebagai mesin pencari default saya%2$s"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -10351,7 +10347,7 @@ msgstr "Instal Browser Mac"
 #. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
 msgctxt "settings"
 msgid "Install Now"
-msgstr ""
+msgstr "Instal Sekarang"
 
 # smartling.placeholder_format=C
 #. Text of a button to install the DuckDuckGo app
@@ -10454,13 +10450,13 @@ msgstr "Apakah data yang terhapus akan terhapus selamanya?"
 #. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Is it worth taking?"
-msgstr ""
+msgstr "Apakah ini layak diambil?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Is this place any good?"
-msgstr ""
+msgstr "Apakah tempat ini bagus?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
@@ -10469,6 +10465,8 @@ msgid ""
 "Is this place any good? Summarize its reputation based on reviews and "
 "ratings."
 msgstr ""
+"Apakah tempat ini bagus? Ringkas reputasinya berdasarkan ulasan dan "
+"penilaian."
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -10480,13 +10478,13 @@ msgstr "Apakah video ini berguna?"
 #. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Is this worth watching?"
-msgstr ""
+msgstr "Apakah ini layak ditonton?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Is this worth watching? Give me a spoiler-free take."
-msgstr ""
+msgstr "Apakah ini layak ditonton? Beri aku pendapat tanpa spoiler."
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -10623,8 +10621,7 @@ msgstr "Tetap buka Sync & Backup di kedua perangkat."
 #. An instruction to state that a list of companies/trackers will be updated with continued use
 msgctxt "tracker_stats"
 msgid "Keep browsing to see how many we block"
-msgstr ""
-"Teruslah menjelajah untuk melihat jumlah perusahaan/pelacak yang kami blokir"
+msgstr "Teruslah menjelajah untuk melihat jumlah perusahaan/pelacak yang kami blokir"
 
 # smartling.placeholder_format=C
 #. Header above social media links.
@@ -11103,7 +11100,7 @@ msgstr "Tautan:"
 #. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
-msgstr ""
+msgstr "Sebutkan alat, bahan, atau prasyarat yang saya perlukan untuk ini."
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -11517,7 +11514,7 @@ msgstr "Kelola situs yang diblokir"
 #. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
 msgctxt "setting"
 msgid "Manage in Browser Settings"
-msgstr ""
+msgstr "Kelola di Pengaturan Browser"
 
 # smartling.placeholder_format=C
 #. Link to the site exclusion settings page
@@ -12805,8 +12802,7 @@ msgstr "Hasil tidak ditemukan."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the recording contains no audible speech.
 msgid "No speech detected. Please try again and speak into your microphone."
-msgstr ""
-"Tidak ada ucapan yang terdeteksi. Coba lagi dan bicaralah ke mikrofonmu."
+msgstr "Tidak ada ucapan yang terdeteksi. Coba lagi dan bicaralah ke mikrofonmu."
 
 # smartling.placeholder_format=C
 #. Button that dismisses a feedback form.
@@ -14355,14 +14351,13 @@ msgstr ""
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is harmful or illegal. (optional)"
-msgstr ""
+msgstr "Tolong jelaskan mengapa respons obrolan berbahaya atau ilegal. (opsional)"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
-msgstr ""
-"Tolong jelaskan mengapa respons obrolan ilegal atau berbahaya. (Opsional)"
+msgstr "Tolong jelaskan mengapa respons obrolan ilegal atau berbahaya. (Opsional)"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to enter their passphrase.
@@ -14393,6 +14388,8 @@ msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is harmful or illegal."
 msgstr ""
+"Silakan tempel prompt kamu dan output yang bermasalah (dengan informasi "
+"pribadi dihapus) dan jelaskan mengapa konten tersebut berbahaya atau ilegal."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -14832,8 +14829,7 @@ msgstr "Harga"
 #. Category of feedback a user can select on a feedback form.
 msgctxt "feedback form"
 msgid "Price shown doesn't reflect merchant site"
-msgstr ""
-"Harga yang ditampilkan berbeda dengan yang ditampilkan di situs penjual"
+msgstr "Harga yang ditampilkan berbeda dengan yang ditampilkan di situs penjual"
 
 # smartling.placeholder_format=C
 #. A button that prints the contents of a page.
@@ -14866,7 +14862,7 @@ msgstr "Privasi"
 #. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
 msgctxt "Section heading on the Duck.ai settings page"
 msgid "Privacy & Terms"
-msgstr ""
+msgstr "Privasi & Ketentuan"
 
 # smartling.placeholder_format=C
 msgid "Privacy Blog"
@@ -14942,7 +14938,7 @@ msgstr "Kebijakan Privasi dan Ketentuan Layanan"
 #. Text for a button that links to the terms of use and privacy policy page.
 msgctxt "Secondary button text in active privacy modal"
 msgid "Privacy Policy and Terms of Service"
-msgstr ""
+msgstr "Kebijakan Privasi dan Ketentuan Layanan"
 
 # smartling.placeholder_format=C
 #. Title displayed on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
@@ -15450,25 +15446,25 @@ msgstr "Merekomendasikan buku"
 #. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Recommend similar books"
-msgstr ""
+msgstr "Rekomendasikan buku yang mirip"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Recommend similar books."
-msgstr ""
+msgstr "Rekomendasikan buku yang mirip."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Recommend similar movies or shows."
-msgstr ""
+msgstr "Rekomendasikan film atau acara yang mirip."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Recommend similar titles"
-msgstr ""
+msgstr "Sarankan judul yang mirip"
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
@@ -15879,7 +15875,7 @@ msgctxt ""
 "feedback form when the user has selected Harmful or Illegal as the feedback "
 "reason"
 msgid "Required for harmful or illegal reports"
-msgstr ""
+msgstr "Diperlukan untuk laporan berbahaya atau ilegal"
 
 # smartling.placeholder_format=C
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
@@ -16048,8 +16044,7 @@ msgstr "Hasil mengecualikan informasi dari situs yang diblokir."
 #. Message that appears when results exclude blocked sites
 msgctxt "Blocked sites filter disclaimer"
 msgid "Results exclude your blocked sites, which you can manage in your %s."
-msgstr ""
-"Hasil tidak termasuk situs yang kamu blokir, yang dapat kamu kelola di %1$s."
+msgstr "Hasil tidak termasuk situs yang kamu blokir, yang dapat kamu kelola di %1$s."
 
 # smartling.placeholder_format=C
 #. A label showing the source of the results, e.g. "Results from Reddit"
@@ -16120,7 +16115,7 @@ msgstr "Ulasan"
 #. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Rewrite this recipe scaled for a different number of servings."
-msgstr ""
+msgstr "Tulis ulang resep ini dengan takaran untuk jumlah porsi yang berbeda."
 
 # smartling.placeholder_format=C
 msgid "Romania"
@@ -16377,8 +16372,7 @@ msgstr "Simpan dan Keluar"
 #. Description explaining that sync allows saving more chats than local browser storage.
 msgctxt "Sync feature benefit description"
 msgid "Save more chats than you can in your web browser."
-msgstr ""
-"Simpan lebih banyak obrolan daripada yang kamu bisa di browser web kamu."
+msgstr "Simpan lebih banyak obrolan daripada yang kamu bisa di browser web kamu."
 
 # smartling.placeholder_format=C
 #. List item explaining that users can save more chats when Sync & Backup is enabled.
@@ -16576,8 +16570,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down to the %sServices%s section and click %sAddress bar%s."
-msgstr ""
-"Gulir ke bawah ke bagian %1$sLayanan%2$s, lalu klik %3$sBilah alamat%4$s."
+msgstr "Gulir ke bawah ke bagian %1$sLayanan%2$s, lalu klik %3$sBilah alamat%4$s."
 
 # smartling.placeholder_format=C
 #. Rugby match stats
@@ -16794,8 +16787,8 @@ msgid ""
 "favorite browser, or search directly at %sduckduckgo.com%s."
 msgstr ""
 "Cari secara pribadi dengan aplikasi atau ekstensi kami, tambahkan pencarian "
-"web pribadi ke browser favoritmu, atau cari langsung di %1$sduckduckgo."
-"com%2$s."
+"web pribadi ke browser favoritmu, atau cari langsung di "
+"%1$sduckduckgo.com%2$s."
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/6LZAoqH.png
@@ -16954,8 +16947,7 @@ msgstr ""
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
 msgctxt "Sync feature benefit description"
 msgid "Securely stored on DuckDuckGo's server with end-to-end encryption."
-msgstr ""
-"Tersimpan dengan aman di server DuckDuckGo dengan enkripsi ujung ke ujung."
+msgstr "Tersimpan dengan aman di server DuckDuckGo dengan enkripsi ujung ke ujung."
 
 # smartling.placeholder_format=C
 #. List item explaining that synced chats are stored with end-to-end encryption on DuckDuckGo's server and only the user can access them.
@@ -17139,8 +17131,7 @@ msgstr "Pilih %1$sDuckDuckGo%2$s di menu dropdown Mesin Pencari Default"
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %sDuckDuckGo%s in the list and %sallow%s location access"
-msgstr ""
-"Pilih %1$sDuckDuckGo%2$s dalam daftar dan %3$sbolehkan%4$s akses lokasi"
+msgstr "Pilih %1$sDuckDuckGo%2$s dalam daftar dan %3$sbolehkan%4$s akses lokasi"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -17259,8 +17250,7 @@ msgstr ""
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %syour browser%s in the list and %sallow%s location access"
-msgstr ""
-"Pilih %1$sbrowser Anda%2$s dalam daftar dan %3$sizinkan akses lokasi%4$s"
+msgstr "Pilih %1$sbrowser Anda%2$s dalam daftar dan %3$sizinkan akses lokasi%4$s"
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the modal for deleting all recent chats, that allows the user to select the chats to delete.
@@ -17458,7 +17448,7 @@ msgstr "Siapkan Sekarang"
 #. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
 msgctxt "Encrypted storage setup button shown in native browsers"
 msgid "Set Up Sync & Backup"
-msgstr ""
+msgstr "Atur Sync & Backup"
 
 # smartling.placeholder_format=C
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
@@ -17646,7 +17636,7 @@ msgstr "Bagikan masukan positif"
 msgctxt ""
 "Label beside the share-content switch on the Duck.ai response feedback form"
 msgid "Share this conversation with DuckDuckGo"
-msgstr ""
+msgstr "Bagikan percakapan ini dengan DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -18035,8 +18025,7 @@ msgstr "Menampilkan garis horizontal di pemisah halaman hasil"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows links to instructions for how to add DuckDuckGo to your browser"
-msgstr ""
-"Menampilkan tautan ke petunjuk cara menambahkan DuckDuckGo ke browser-mu"
+msgstr "Menampilkan tautan ke petunjuk cara menambahkan DuckDuckGo ke browser-mu"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers more frequently.
@@ -18052,21 +18041,18 @@ msgstr "Menampilkan tautan yang paling banyak dikunjungi di halaman tab baru"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your browser"
-msgstr ""
-"Sesekali menampilkan pengingat untuk menambahkan DuckDuckGo ke browser-mu"
+msgstr "Sesekali menampilkan pengingat untuk menambahkan DuckDuckGo ke browser-mu"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr ""
-"Sesekali menampilkan pengingat untuk menambahkan DuckDuckGo ke perangkatmu"
+msgstr "Sesekali menampilkan pengingat untuk menambahkan DuckDuckGo ke perangkatmu"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Shows occasional reminders to sign up for the DuckDuckGo privacy newsletters"
-msgstr ""
-"Sesekali menampilkan pengingat untuk mendaftar ke nawala privasi DuckDuckGo"
+msgstr "Sesekali menampilkan pengingat untuk mendaftar ke nawala privasi DuckDuckGo"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18104,8 +18090,7 @@ msgstr "Menampilkan pesan selamat datang di atas halaman hasil pencarian"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message to EU Android preference menu users"
-msgstr ""
-"Menampilkan pesan selamat datang kepada pengguna menu preferensi Android UE"
+msgstr "Menampilkan pesan selamat datang kepada pengguna menu preferensi Android UE"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers sometimes.
@@ -18323,8 +18308,7 @@ msgstr "Terjadi sesuatu yang salah"
 #. Error message indicating that the user's settings weren't able to be saved.
 msgctxt "cloudsave"
 msgid "Something went wrong saving to the server, please try again."
-msgstr ""
-"Terjadi kesalahan saat proses penyimpanan ke server. Silakan coba lagi."
+msgstr "Terjadi kesalahan saat proses penyimpanan ke server. Silakan coba lagi."
 
 # smartling.placeholder_format=C
 #. Body copy displayed under the Set Up Now button when the sync setup call fails.
@@ -18915,19 +18899,19 @@ msgstr "Sarankan judul untuk postingan blog"
 #. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Suggest related articles or topics worth exploring next."
-msgstr ""
+msgstr "Sarankan artikel atau topik terkait yang layak Anda jelajahi selanjutnya."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Suggest related articles to explore"
-msgstr ""
+msgstr "Sarankan artikel terkait untuk dijelajahi"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Suggest some alternatives to this product."
-msgstr ""
+msgstr "Sarankan beberapa alternatif untuk produk ini."
 
 # smartling.placeholder_format=C
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
@@ -18944,7 +18928,7 @@ msgstr "Saran:"
 #. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Sum up the reviews"
-msgstr ""
+msgstr "Ringkas ulasan"
 
 # smartling.placeholder_format=C
 #. A short title for the a message asking the AI to summarize a text.
@@ -18956,85 +18940,85 @@ msgstr "Ringkas"
 #. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize the Q&As"
-msgstr ""
+msgstr "Ringkas Tanya Jawab"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the background and notable work of this person."
-msgstr ""
+msgstr "Ringkas latar belakang dan karya penting orang ini."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the key details of this event."
-msgstr ""
+msgstr "Ringkas detail utama acara ini."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the questions and answers on this page."
-msgstr ""
+msgstr "Ringkas pertanyaan dan jawaban di halaman ini."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize their background"
-msgstr ""
+msgstr "Ringkas latar belakang mereka"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this book"
-msgstr ""
+msgstr "Ringkas buku ini"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this book."
-msgstr ""
+msgstr "Ringkas buku ini."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this discussion"
-msgstr ""
+msgstr "Ringkas diskusi ini"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this discussion thread."
-msgstr ""
+msgstr "Ringkas utas diskusi ini."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this page"
-msgstr ""
+msgstr "Ringkas halaman ini"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this page."
-msgstr ""
+msgstr "Ringkas halaman ini."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this video"
-msgstr ""
+msgstr "Ringkas video ini"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this video."
-msgstr ""
+msgstr "Ringkas video ini."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize what the reviews say."
-msgstr ""
+msgstr "Ringkas apa yang dikatakan ulasan tersebut."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -19188,16 +19172,14 @@ msgstr "Beralih ke model yang lebih efisien"
 # smartling.placeholder_format=C
 #. Text prompting  users to switch their current search engine to the DuckDuckGo private search engine.
 msgid "Switch to the search engine that doesn't track you. Ever."
-msgstr ""
-"Beralihlah ke mesin pencari yang tidak akan pernah melacakmu. Selamanya."
+msgstr "Beralihlah ke mesin pencari yang tidak akan pernah melacakmu. Selamanya."
 
 # smartling.placeholder_format=C
 #. Warning text shown in the model switch dropdown when the user is currently using an encrypted model. Warns that the new model will not have zero provider visibility.
 msgctxt "AI Chat warning when switching from an encrypted model"
 msgid ""
 "Switching will send your chat to a model without zero provider visibility"
-msgstr ""
-"Beralih akan mengirim obrolan kamu ke model tanpa visibilitas penyedia nol"
+msgstr "Beralih akan mengirim obrolan kamu ke model tanpa visibilitas penyedia nol"
 
 # smartling.placeholder_format=C
 msgid "Switzerland"
@@ -19251,8 +19233,7 @@ msgstr "Sync & Backup Diaktifkan!"
 #. Notice shown under the recovery code explaining that backup data has an inactivity expiration.
 msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
-msgstr ""
-"Data Sync & Backup tidak dapat dipulihkan setelah 18 bulan tidak aktif."
+msgstr "Data Sync & Backup tidak dapat dipulihkan setelah 18 bulan tidak aktif."
 
 # smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
@@ -19366,7 +19347,7 @@ msgstr "Syria"
 #. Text for a button that enables the theme to follow the operating system's color scheme preference.
 msgctxt "System theme button for theme selector"
 msgid "System"
-msgstr ""
+msgstr "Sistem"
 
 # smartling.placeholder_format=C
 #. Abbreviation indicating this is the total score for a game
@@ -19400,7 +19381,7 @@ msgstr "Tahiti"
 #. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Tailor my resume"
-msgstr ""
+msgstr "Sesuaikan resume saya"
 
 # smartling.placeholder_format=C
 msgid "Taiwan"
@@ -19437,6 +19418,8 @@ msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
+"Ikuti survei anonim ini untuk memberi tahu kami bagaimana kami bisa membuat "
+"Duck.ai menjadi lebih baik."
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -19608,8 +19591,7 @@ msgstr "Thailand (en)"
 #. Message displayed after the user has submitted feedback. It invites the user to share more feedback.
 msgctxt "Feedback toast"
 msgid "Thank you for your feedback. Have more to share?"
-msgstr ""
-"Terima kasih atas masukan kamu. Apakah kamu punya hal lain untuk dibagikan?"
+msgstr "Terima kasih atas masukan kamu. Apakah kamu punya hal lain untuk dibagikan?"
 
 # smartling.placeholder_format=C
 msgid "Thank you!"
@@ -19636,8 +19618,7 @@ msgstr "Terima kasih atas masukanmu!"
 #. Inform the users that "something" went wrong and we are unable to show any results.
 msgctxt "noresults"
 msgid "Thanks for your patience while we get our ducks in a row!"
-msgstr ""
-"Terima kasih atas kesabaran Anda sementara kami menyelesaikan semuanya!"
+msgstr "Terima kasih atas kesabaran Anda sementara kami menyelesaikan semuanya!"
 
 # smartling.placeholder_format=C
 #. Inform the users that "something" went wrong and we are unable to show any results.
@@ -19739,8 +19720,7 @@ msgstr "Permintaan tersebut mengalami batas waktu. Silakan coba lagi."
 #. Inform the users that "something" went wrong and we are unable to show any results.
 msgctxt "noresults"
 msgid "The server encountered an error and could not complete your request."
-msgstr ""
-"Server mengalami kesalahan dan tidak dapat menyelesaikan permintaan Anda."
+msgstr "Server mengalami kesalahan dan tidak dapat menyelesaikan permintaan Anda."
 
 # smartling.placeholder_format=C
 #. Title for the theme menu:
@@ -19752,7 +19732,7 @@ msgstr "Tema"
 #. Text for the theme selector label that allows users to switch between Light and dark theme.
 msgctxt "Label for the theme selector feature"
 msgid "Theme"
-msgstr ""
+msgstr "Tema"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/LpFhb1e.png
@@ -20006,16 +19986,14 @@ msgstr "Gambar ini tidak dapat dibuat."
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF"
-msgstr ""
-"Jenis gambar ini tidak didukung, tolong lampirkan JPG, PNG, WebP, atau GIF"
+msgstr "Jenis gambar ini tidak didukung, tolong lampirkan JPG, PNG, WebP, atau GIF"
 
 # smartling.placeholder_format=C
 #. Error message displayed when a file that the user tried to upload is not of a supported format
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF."
-msgstr ""
-"Jenis gambar ini tidak didukung, tolong lampirkan JPG, PNG, WebP, atau GIF."
+msgstr "Jenis gambar ini tidak didukung, tolong lampirkan JPG, PNG, WebP, atau GIF."
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
@@ -20143,8 +20121,7 @@ msgstr "Video ini belum bisa ditonton di sini. Kamu bisa menontonnya di %1$s."
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr ""
-"Halaman web ini tidak menggunakan koneksi yang aman dan terenkripsi (HTTPS)."
+msgstr "Halaman web ini tidak menggunakan koneksi yang aman dan terenkripsi (HTTPS)."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -20299,8 +20276,7 @@ msgstr "Untuk melanjutkan, kamu harus menyetujui %1$s dan %2$sDuck.ai"
 msgctxt ""
 "Copy stating agreement to AI Chat Privacy Policy and Terms of Service."
 msgid "To continue, you must agree to DuckDuckGo AI Chat’s %s and %s"
-msgstr ""
-"Untuk melanjutkan, Anda harus menyetujui %1$s dan %2$sDuckDuckGo AI Chat"
+msgstr "Untuk melanjutkan, Anda harus menyetujui %1$s dan %2$sDuckDuckGo AI Chat"
 
 # smartling.placeholder_format=C
 #. Instructions for how to print driving directions.
@@ -20332,8 +20308,8 @@ msgid ""
 "To transfer your chat history to Duck.ai, please update your DuckDuckGo "
 "browser to the latest version and try again."
 msgstr ""
-"Untuk mentransfer riwayat obrolanmu ke Duck.ai, perbarui browser DuckDuckGo-"
-"mu ke versi terbaru dan coba lagi."
+"Untuk mentransfer riwayat obrolanmu ke Duck.ai, perbarui browser "
+"DuckDuckGo-mu ke versi terbaru dan coba lagi."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
@@ -20598,13 +20574,13 @@ msgstr ""
 #. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Translate this page"
-msgstr ""
+msgstr "Terjemahkan halaman ini"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
 msgctxt "Page suggestion prompt"
 msgid "Translate this page into %s."
-msgstr ""
+msgstr "Terjemahkan halaman ini ke dalam %1$s."
 
 # smartling.placeholder_format=C
 #. Placeholder text for a region that will display translated text.
@@ -20751,7 +20727,7 @@ msgstr "Coba Gratis"
 #. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
 msgctxt "settings"
 msgid "Try It Now"
-msgstr ""
+msgstr "Coba Sekarang"
 
 # smartling.placeholder_format=C
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -21000,6 +20976,8 @@ msgid ""
 "Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
+"Ingin menonaktifkan fitur AI? Pasang ekstensi pencarian %1$sDuckDuckGo No "
+"AI%2$s agar pengaturan Anda tersimpan. %3$sPelajari Lebih Lanjut%4$s"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -21008,6 +20986,9 @@ msgid ""
 "Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
+"Ingin menonaktifkan fitur AI? Beralihlah ke ekstensi pencarian "
+"%1$sDuckDuckGo No AI%2$s untuk menyimpan pengaturan Anda. %3$sPelajari Lebih "
+"Lanjut%4$s"
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -21332,8 +21313,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
-msgstr ""
-"Di bagian %1$sMEMULAI > Halaman beranda%2$s, masukkan: https://duckduckgo.com"
+msgstr "Di bagian %1$sMEMULAI > Halaman beranda%2$s, masukkan: https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -21713,8 +21693,7 @@ msgstr ""
 #. Upsell message shown in the voice chat limit and duration limit modals for Plus subscribers, encouraging them to upgrade to Pro.
 msgctxt "voice chat limit modal"
 msgid "Upgrade to Pro to unlock 2x higher usage limits than Plus"
-msgstr ""
-"Tingkatkan ke Pro untuk membuka batas penggunaan 2x lebih tinggi dari Plus"
+msgstr "Tingkatkan ke Pro untuk membuka batas penggunaan 2x lebih tinggi dari Plus"
 
 # smartling.placeholder_format=C
 #. Heading in a promotion for a desktop web browser
@@ -21766,7 +21745,7 @@ msgstr "Uruguay"
 #. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
 msgctxt "Navigation label on the Duck.ai settings page"
 msgid "Usage"
-msgstr ""
+msgstr "Penggunaan"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -22220,7 +22199,7 @@ msgstr "Wales"
 #. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Walk me through the steps"
-msgstr ""
+msgstr "Pandu saya melalui langkah-langkahnya"
 
 # smartling.placeholder_format=C
 #. Label for walking directions on a map.
@@ -22350,6 +22329,9 @@ msgid ""
 "please share this conversation with DuckDuckGo so we can investigate and "
 "address the issue."
 msgstr ""
+"Kita hanya bisa memperbaiki apa yang bisa kita lihat. Untuk melaporkan "
+"tanggapan yang berbahaya atau ilegal, silakan bagikan percakapan ini dengan "
+"DuckDuckGo agar kami dapat menyelidiki dan mengatasi masalah tersebut."
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -22845,8 +22827,8 @@ msgid ""
 "We’re really sorry, but it seems there was a problem loading Duck.ai. Try "
 "reloading the page."
 msgstr ""
-"Kami benar-benar minta maaf, tetapi tampaknya ada masalah saat memuat Duck."
-"ai. Coba muat ulang halaman."
+"Kami benar-benar minta maaf, tetapi tampaknya ada masalah saat memuat "
+"Duck.ai. Coba muat ulang halaman."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to suggest an AI (Artificial Intelligence) model to be added to the product, and this field is optional.
@@ -22868,8 +22850,7 @@ msgstr ""
 #. Text for a prompt suggestion for considering factors when purchasing a computer monitor.
 msgctxt "Full sentence for preparing for a purchase"
 msgid "What are some factors to consider when purchasing a computer monitor?"
-msgstr ""
-"Apa saja faktor yang perlu dipertimbangkan saat membeli monitor komputer?"
+msgstr "Apa saja faktor yang perlu dipertimbangkan saat membeli monitor komputer?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for asking about must-see attractions in Paris for a first-time visitor.
@@ -22917,98 +22898,98 @@ msgstr ""
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the counterarguments?"
-msgstr ""
+msgstr "Apa argumen tandingannya?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the hours & location?"
-msgstr ""
+msgstr "Apa jam operasional & lokasinya?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key contributions of this paper?"
-msgstr ""
+msgstr "Apa saja kontribusi utama dari makalah ini?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key contributions?"
-msgstr ""
+msgstr "Apa saja kontribusi utamanya?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key details?"
-msgstr ""
+msgstr "Apa saja detail utamanya?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key points covered in this video?"
-msgstr ""
+msgstr "Apa saja poin utama yang dibahas dalam video ini?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key points?"
-msgstr ""
+msgstr "Apa saja poin-poin utamanya?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key takeaways from this article?"
-msgstr ""
+msgstr "Apa saja poin utama dari artikel ini?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key takeaways?"
-msgstr ""
+msgstr "Apa saja poin-poin utamanya?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key things I will learn from this course?"
-msgstr ""
+msgstr "Apa saja hal utama yang akan aku pelajari dari kursus ini?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the main counterarguments or criticisms of this?"
-msgstr ""
+msgstr "Apa argumen tandingan atau kritik utama terhadap ini?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the main questions this page answers?"
-msgstr ""
+msgstr "Apa pertanyaan utama yang dijawab oleh halaman ini?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the must-try dishes here?"
-msgstr ""
+msgstr "Apa saja hidangan yang wajib dicoba di sini?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid ""
 "What are the opening hours, location, and contact details for this place?"
-msgstr ""
+msgstr "Apa jam operasional, lokasi, dan detail kontak tempat ini?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the pros and cons of this product?"
-msgstr ""
+msgstr "Apa saja pro dan kontra dari produk ini?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the pros and cons?"
-msgstr ""
+msgstr "Apa saja pro dan kontra?"
 
 # smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
@@ -23114,7 +23095,7 @@ msgstr "Apa arti atrium dalam konteks artikel medis?"
 #. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What does this answer?"
-msgstr ""
+msgstr "Apa yang dijawab ini?"
 
 # smartling.placeholder_format=C
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
@@ -23132,7 +23113,7 @@ msgstr "Informasi apa yang disimpan?"
 #. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What interview questions might come up for this role?"
-msgstr ""
+msgstr "Pertanyaan wawancara apa saja yang mungkin muncul untuk peran ini?"
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -23154,7 +23135,7 @@ msgstr "Apa ibu kota dari Albania?"
 #. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What is the overall verdict and rating for this?"
-msgstr ""
+msgstr "Apa keputusan dan peringkat keseluruhan untuk ini?"
 
 # smartling.placeholder_format=C
 #. Link to a page with additional information.
@@ -23182,7 +23163,7 @@ msgstr "Ulasan pengguna:"
 #. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What should I order?"
-msgstr ""
+msgstr "Apa yang sebaiknya saya pesan?"
 
 # smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
@@ -23200,13 +23181,13 @@ msgstr "Apa yang salah dengan tanggapan tersebut? (Opsional)"
 #. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What will I learn?"
-msgstr ""
+msgstr "Apa yang akan saya pelajari?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What will I need?"
-msgstr ""
+msgstr "Apa yang saya perlukan?"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -23231,7 +23212,7 @@ msgstr "Apa yang Baru"
 #. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What's the verdict?"
-msgstr ""
+msgstr "Apa putusannya?"
 
 # smartling.placeholder_format=C
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -23287,7 +23268,7 @@ msgstr "Fitur apa yang tidak ada? (Opsional)"
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Which features are missing? (optional)"
-msgstr ""
+msgstr "Fitur apa yang tidak ada? (Opsional)"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
@@ -23309,13 +23290,13 @@ msgstr "Profil Kami"
 #. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Who are the main cast and crew, and what else are they known for?"
-msgstr ""
+msgstr "Siapa pemeran dan kru utama, serta dikenal lewat karya apa lagi?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Who is this person?"
-msgstr ""
+msgstr "Siapa orang ini?"
 
 # smartling.placeholder_format=C
 #. Header above a collection of privacy-related links.
@@ -23806,8 +23787,7 @@ msgstr "Kamu bisa menemukan file <b>%1$s</b> di folder unduhanmu."
 # smartling.placeholder_format=C
 #. A link to the settings to where the user can hide the private search reminder from the filter bar of search results
 msgid "You can hide this reminder in %sSearch Settings%s"
-msgstr ""
-"Anda dapat menyembunyikan pengingat ini di %1$sPengaturan Pencarian%2$s"
+msgstr "Anda dapat menyembunyikan pengingat ini di %1$sPengaturan Pencarian%2$s"
 
 # smartling.placeholder_format=C
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
@@ -24465,9 +24445,9 @@ msgid ""
 "You’re now searching privately in Chrome. Use our browser instead of Chrome "
 "for more protection. It’s already installed and can:"
 msgstr ""
-"Anda sedang menelusuri secara pribadi di Chrome. Gunakan browser kami alih-"
-"alih Chrome untuk perlindungan yang lebih baik. Aplikasi sudah terinstal dan "
-"dapat:"
+"Anda sedang menelusuri secara pribadi di Chrome. Gunakan browser kami "
+"alih-alih Chrome untuk perlindungan yang lebih baik. Aplikasi sudah "
+"terinstal dan dapat:"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has exceeded the maximum message size.

--- a/locales/id_ID/LC_MESSAGES/duckduckgo.po
+++ b/locales/id_ID/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: id_ID\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -492,7 +492,8 @@ msgstr "%1$sTekan lama%2$s ikon aplikasi DuckDuckGo di layar beranda"
 #. A message displayed when there is an error loading content or no results on requery
 msgctxt "Error or no results message"
 msgid "%sOops!%s%sSomething went wrong. Please %srefresh%s and try again."
-msgstr "%1$sUps!%2$s%3$sAda yang tidak beres. Silakan %4$srefresh%5$s dan coba lagi."
+msgstr ""
+"%1$sUps!%2$s%3$sAda yang tidak beres. Silakan %4$srefresh%5$s dan coba lagi."
 
 # smartling.placeholder_format=C
 #. Tagline in a popover encouraging the user to download the DuckDuckGo browser
@@ -882,14 +883,16 @@ msgstr ""
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of AI Chat is available! Please refresh this page to continue."
-msgstr "Versi baru AI Chat tersedia! Silakan refresh halaman ini untuk melanjutkan."
+msgstr ""
+"Versi baru AI Chat tersedia! Silakan refresh halaman ini untuk melanjutkan."
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of Duck.ai is available and they need to refresh the page.
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of Duck.ai is available! Please refresh this page to continue."
-msgstr "Versi baru Duck.ai tersedia! Silakan refresh halaman ini untuk melanjutkan."
+msgstr ""
+"Versi baru Duck.ai tersedia! Silakan refresh halaman ini untuk melanjutkan."
 
 # smartling.placeholder_format=C
 #. Shown when the Duck.ai desktop app has been open a long time and a newer version exists.
@@ -1433,6 +1436,12 @@ msgid "Address is incorrect"
 msgstr "Alamat salah"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Adjust the servings"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. as in multiple advertisements
 msgid "Ads"
 msgstr "Iklan"
@@ -1644,6 +1653,14 @@ msgid "All chats are %sprivate%s"
 msgstr "Semua obrolan bersifat %1$spribadi%2$s"
 
 # smartling.placeholder_format=C
+#. Paragraph in the Privacy & Terms section of the About & Legal page in Duck.ai settings, summarizing how chats are anonymized and are not stored or used to train chat models.
+msgctxt "Privacy & Terms section description on the Duck.ai settings page"
+msgid ""
+"All chats are anonymized by DuckDuckGo, and your conversations are not used "
+"to train chat models by DuckDuckGo or the model providers"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
 msgctxt "Privacy modal header in Duck.ai chat"
 msgid "All chats are private"
@@ -1673,7 +1690,8 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "All model providers are prevented from training their AI on your "
 "conversations."
-msgstr "Semua penyedia model dicegah melatih AI mereka menggunakan percakapan Anda."
+msgstr ""
+"Semua penyedia model dicegah melatih AI mereka menggunakan percakapan Anda."
 
 # smartling.placeholder_format=C
 #. Text displayed in the subheader of the modal that allows the user to pick an AI chat model.
@@ -1912,6 +1930,13 @@ msgid "Anonymous location enabled"
 msgstr "Lokasi anonim diaktifkan"
 
 # smartling.placeholder_format=C
+msgctxt "settings"
+msgid ""
+"Anonymously generates answers for search queries based on web content. "
+"Choose how often you want it to appear, or disable it completely."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Instant Answer tab name
 msgid "Answer"
 msgstr "Jawaban"
@@ -2056,13 +2081,15 @@ msgstr "Apa kamu masih di sana?"
 msgctxt "Body text for clear all chats confirmation modal"
 msgid ""
 "Are you sure you want to clear all of your chats? This cannot be undone."
-msgstr "Apakah kamu yakin ingin menghapus semua obrolanmu? Ini tidak bisa dibatalkan."
+msgstr ""
+"Apakah kamu yakin ingin menghapus semua obrolanmu? Ini tidak bisa dibatalkan."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that asks the user if they want to clear the conversation.
 msgctxt "Modal body for clearing conversation"
 msgid "Are you sure you want to clear this conversation and start a new one?"
-msgstr "Apakah Anda yakin ingin menghapus percakapan ini dan memulai yang baru?"
+msgstr ""
+"Apakah Anda yakin ingin menghapus percakapan ini dan memulai yang baru?"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to delete their current chat, explaining that this action cannot be undone.
@@ -2189,6 +2216,12 @@ msgstr "Ajukan pertanyaan lanjutan"
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse
 msgid "Ask a follow-up with Duck.ai"
 msgstr "Ajukan pertanyaan lanjutan dengan Duck.ai"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
+msgctxt "Page suggestion chip label"
+msgid "Ask about this page"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2358,18 +2391,21 @@ msgstr "Suara"
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat ends."
-msgstr "Audio tidak disimpan oleh kami atau oleh OpenAI setelah obrolan berakhir."
+msgstr ""
+"Audio tidak disimpan oleh kami atau oleh OpenAI setelah obrolan berakhir."
 
 # smartling.placeholder_format=C
 #. Description in consent disclaimer informing that audio from the voice chat session is not stored by us or by OpenAI after the voice chat ends.
 msgctxt "voice chat"
 msgid "Audio is not stored by us or by OpenAI after the chat ends."
-msgstr "Audio tidak disimpan oleh kami atau oleh OpenAI setelah obrolan berakhir."
+msgstr ""
+"Audio tidak disimpan oleh kami atau oleh OpenAI setelah obrolan berakhir."
 
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat is transcribed."
-msgstr "Audio tidak disimpan oleh kami atau OpenAI setelah obrolan ditranskripsikan."
+msgstr ""
+"Audio tidak disimpan oleh kami atau OpenAI setelah obrolan ditranskripsikan."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when MediaRecorder API is unavailable.
@@ -2610,6 +2646,12 @@ msgid "Barcode"
 msgstr "Kode Batang"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Based on this page, is this course worth taking?"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Basic"
 msgstr "Dasar"
@@ -2648,6 +2690,14 @@ msgstr "Adonan"
 msgctxt "Assistant response placeholder"
 msgid "Before continuing..."
 msgstr "Sebelum melanjutkan..."
+
+# smartling.placeholder_format=C
+#. Explains that before storing the report, DuckDuckGo will anonymize the conversation by removing PII like names, email addresses, and identifying metadata.
+msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
+msgid ""
+"Before storing this report, DuckDuckGo will anonymize your conversation by "
+"removing PII like names, email addresses, and identifying metadata."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -2964,6 +3014,12 @@ msgstr "Brasil"
 msgctxt "Sports module"
 msgid "Break Points Won"
 msgstr "Break Point Dimenangkan"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Break this down into clear, numbered steps."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -3421,6 +3477,12 @@ msgid "Cast"
 msgstr "Pemain"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Cast & Crew"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
 msgctxt "Tone option label for Casual"
 msgid "Casual"
@@ -3530,7 +3592,8 @@ msgstr "Mengubah warna latar belakang hasil hover, modul, dan menu dropdown"
 #. http://i.imgur.com/NdpkbY0.png
 msgctxt "settings"
 msgid "Changes the background color when hovering over a result"
-msgstr "Mengubah warna latar belakang saat mengarahkan kursor ke atas suatu hasil"
+msgstr ""
+"Mengubah warna latar belakang saat mengarahkan kursor ke atas suatu hasil"
 
 # smartling.placeholder_format=C
 #. Description of a setting managing the color of search result snippet text.
@@ -3657,8 +3720,8 @@ msgstr ""
 "anonim dengan model chat AI pihak ketiga, yang mendukung model dari OpenAI, "
 "Anthropic, dan lainnya. Menonaktifkan pengaturan ini akan menyembunyikan "
 "tombol dan tautan Chat di DuckDuckGo Search. Namun, Anda masih dapat "
-"mengakses Chat saat setelan ini dinonaktifkan dengan mengunjungi "
-"%1$shttps://duck.ai%2$s langsung."
+"mengakses Chat saat setelan ini dinonaktifkan dengan mengunjungi %1$shttps://"
+"duck.ai%2$s langsung."
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -3889,7 +3952,8 @@ msgstr ""
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
 msgctxt "noresults"
 msgid "Check the status page for updates on this outage."
-msgstr "Periksa halaman status untuk mendapatkan pembaruan mengenai gangguan ini."
+msgstr ""
+"Periksa halaman status untuk mendapatkan pembaruan mengenai gangguan ini."
 
 # smartling.placeholder_format=C
 #. Title shown to the host device (the one that is logged in) after it sends the pairing code. The host can't confirm the peer applied it, so this is a title-only screen (no body) prompting the user to finish on the other device.
@@ -4259,7 +4323,8 @@ msgstr "Klik %1$sDi sini%2$s untuk mengunduh ekstensi DuckDuckGo"
 # smartling.placeholder_format=C
 #. Link to download the DuckDuckGo browser extension.
 msgid "Click %sOpen%s to download and open the DuckDuckGo Safari extension"
-msgstr "Klik %1$sBuka%2$s untuk mengunduh dan membuka ekstensi DuckDuckGo di Safari"
+msgstr ""
+"Klik %1$sBuka%2$s untuk mengunduh dan membuka ekstensi DuckDuckGo di Safari"
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -4304,7 +4369,8 @@ msgstr "Klik %1$sYa%2$s"
 # smartling.placeholder_format=C
 #. Tells the user where to click to open their browser's settings menu.
 msgid "Click %ssettings/hamburger icon %s on the Chrome toolbar (top right)."
-msgstr "Klik %1$spengaturan/ikon hamburger %2$s di bilah alat Chrome (kanan atas)."
+msgstr ""
+"Klik %1$spengaturan/ikon hamburger %2$s di bilah alat Chrome (kanan atas)."
 
 #  Maxthon default search engine instruction
 # smartling.placeholder_format=C
@@ -5126,6 +5192,12 @@ msgid "Create Image"
 msgstr "Buat Gambar"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Create a shopping list with quantities from this recipe."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text displayed in the input field when starting a new image generation session.
 msgctxt "Placeholder text for the image generation input field"
 msgid "Create an image of a cute duck..."
@@ -5770,6 +5842,11 @@ msgid "Dictation limit reached"
 msgstr "Batas dikte tercapai"
 
 # smartling.placeholder_format=C
+#. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
+msgid "Dictation temporarily unavailable"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
@@ -5961,7 +6038,8 @@ msgstr "Bahasa Tampilan"
 #. This is the description of a user setting
 msgctxt "settings"
 msgid "Displays a checkmark to the left of results you've visited"
-msgstr "Menampilkan tanda centang di sebelah kiri hasil yang telah kamu kunjungi"
+msgstr ""
+"Menampilkan tanda centang di sebelah kiri hasil yang telah kamu kunjungi"
 
 # smartling.placeholder_format=C
 #. This is the description of a user setting
@@ -6068,6 +6146,22 @@ msgstr "Selesai"
 msgctxt "precise_user_location"
 msgid "Done"
 msgstr "Selesai"
+
+# smartling.placeholder_format=C
+#. Message shown in a modal after DuckDuckGo browser users disable AI features in Settings. The first two placeholders bold noai.duckduckgo.com. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
+"filtered out. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
+"and AI images filtered out. %sLearn more%s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6184,14 +6278,26 @@ msgstr ""
 "perbaikan kulkas rumah."
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Draft a cover letter"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Draft a cover letter for this job."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
 msgctxt "Full sentence for drafting a social media post"
 msgid ""
 "Draft a few options for a social media post inviting people to my upcoming "
 "party."
 msgstr ""
-"Buatlah beberapa opsi untuk postingan media sosial yang mengundang "
-"orang-orang ke pesta saya yang akan datang."
+"Buatlah beberapa opsi untuk postingan media sosial yang mengundang orang-"
+"orang ke pesta saya yang akan datang."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a few options for a blog post title about strategies to increase team collaboration.
@@ -6357,7 +6463,17 @@ msgstr ""
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
-msgstr "Duck.ai adalah yang terbaik di browser DuckDuckGo pribadi dan gratis kami!"
+msgstr ""
+"Duck.ai adalah yang terbaik di browser DuckDuckGo pribadi dan gratis kami!"
+
+# smartling.placeholder_format=C
+#. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
+msgctxt "About section description on the Duck.ai settings page"
+msgid ""
+"Duck.ai is created by DuckDuckGo. We're an independent online protection "
+"company for anyone who wants to take back control of their personal "
+"information."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
@@ -6409,6 +6525,13 @@ msgstr "Duck.ai untuk sementara tidak tersedia. Silakan coba lagi nanti."
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
+"Duck.ai lets you chat privately with popular AI models. Disabling it hides "
+"Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
+msgstr ""
+
+# smartling.placeholder_format=C
+msgctxt "settings"
+msgid ""
 "Duck.ai lets you have anonymous conversations with 3rd-party AI chat models, "
 "including models from OpenAI, Anthropic, and others. Turning this setting "
 "off will hide Duck.ai buttons and links on DuckDuckGo Search. However, you "
@@ -6425,7 +6548,8 @@ msgstr ""
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
 msgctxt "Disclaimer text at the bottom of the feedback form."
 msgid "Duck.ai may display inaccurate or offensive information."
-msgstr "Duck.ai mungkin menampilkan informasi yang tidak akurat atau menyinggung."
+msgstr ""
+"Duck.ai mungkin menampilkan informasi yang tidak akurat atau menyinggung."
 
 # smartling.placeholder_format=C
 #. Error modal body line 2.
@@ -6468,7 +6592,8 @@ msgstr "Duck.ai ditingkatkan!"
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
-msgstr "Duck.ai bekerja paling baik di aplikasi DuckDuckGo pribadi dan gratis kamu!"
+msgstr ""
+"Duck.ai bekerja paling baik di aplikasi DuckDuckGo pribadi dan gratis kamu!"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -6654,7 +6779,8 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr "DuckDuckGo AI Chat untuk sementara tidak tersedia. Silakan coba lagi nanti."
+msgstr ""
+"DuckDuckGo AI Chat untuk sementara tidak tersedia. Silakan coba lagi nanti."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -6929,9 +7055,9 @@ msgid ""
 "random words from that list, ensuring that the passphrase is at least 18-20 "
 "characters long."
 msgstr ""
-"Tiap kali kamu meminta saran frasa sandi, kami menerima daftar berisi "
-"kata-kata acak dari server DuckDuckGo. Di browser, kami kemudian memilih 4—5 "
-"kata acak dari daftar itu, dengan memastikan bahwa frasa sandinya minimal "
+"Tiap kali kamu meminta saran frasa sandi, kami menerima daftar berisi kata-"
+"kata acak dari server DuckDuckGo. Di browser, kami kemudian memilih 4—5 kata "
+"acak dari daftar itu, dengan memastikan bahwa frasa sandinya minimal "
 "sepanjang 18—20 karakter."
 
 # smartling.placeholder_format=C
@@ -7142,7 +7268,8 @@ msgstr "Aktifkan Dikte dalam Duck.ai"
 #. Prompt to enable location service so that search results can be displayed near the user's current location.
 msgctxt "precise_user_location"
 msgid "Enable location settings on your device to use anonymous location"
-msgstr "Aktifkan pengaturan lokasi di perangkatmu untuk menggunakan lokasi anonim"
+msgstr ""
+"Aktifkan pengaturan lokasi di perangkatmu untuk menggunakan lokasi anonim"
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -7406,6 +7533,18 @@ msgid "Eritrea"
 msgstr "Eritrea"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Estimate the nutrition"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Estimate the nutritional information for this recipe."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Estonia"
 msgstr "Estonia"
 
@@ -7460,11 +7599,60 @@ msgid "Expires in 1 day"
 msgstr "Kedaluwarsa dalam 1 hari"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain the accepted answer in simple terms."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
-msgstr "Jelaskan konsep dasar lubang hitam kepada saya di tingkat sekolah menengah."
+msgstr ""
+"Jelaskan konsep dasar lubang hitam kepada saya di tingkat sekolah menengah."
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain the top answer"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this in simple, plain language."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this paper"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this repo"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this research paper in plain language."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this simply"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain what this repository does and how to use it."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label to show if song lyrics contain explicit content
@@ -7751,6 +7939,12 @@ msgstr ""
 "%1$sPelajari lebih lanjut%2$s"
 
 # smartling.placeholder_format=C
+msgctxt "settings"
+msgid ""
+"Filters out known AI spam sites from image search results. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the final score of a sporting event.
 msgid "Final"
 msgstr "Akhir"
@@ -7806,6 +8000,12 @@ msgid "Find current information"
 msgstr "Temukan informasi terkini"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Find me alternatives"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Button that searches for results closer to the user's current location.
 msgctxt "precise_user_location"
 msgid "Find results closer to you"
@@ -7822,7 +8022,8 @@ msgstr "Temukan hasil yang lebih dekat dari lokasimu."
 msgctxt "Precise user location overlay"
 msgid ""
 "Find results near you. %sYour location stays private, secure, and anonymous."
-msgstr "Temukan hasil di dekatmu. %1$sLokasimu tetap pribadi, aman, dan anonim."
+msgstr ""
+"Temukan hasil di dekatmu. %1$sLokasimu tetap pribadi, aman, dan anonim."
 
 # smartling.placeholder_format=C
 #. Loading message shown while generating explore more follow-up questions
@@ -7893,7 +8094,8 @@ msgstr ""
 #. Privacy reassurance and instructions intro.
 msgctxt "duckai_migration"
 msgid "Follow these steps to move your chats to the new Duck.ai"
-msgstr "Ikuti langkah-langkah berikut untuk memindahkan obrolanmu ke Duck.ai baru"
+msgstr ""
+"Ikuti langkah-langkah berikut untuk memindahkan obrolanmu ke Duck.ai baru"
 
 # smartling.placeholder_format=C
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse on mobile
@@ -8112,8 +8314,8 @@ msgid ""
 "strong>."
 msgstr ""
 "Dari bilah menu aplikasi di Mac, pilih <strong>DuckDuckGo</strong> &gt; "
-"<strong>Periksa Pembaruan...</strong>, lalu pilih <strong>Instal "
-"Pembaruan</strong>."
+"<strong>Periksa Pembaruan...</strong>, lalu pilih <strong>Instal Pembaruan</"
+"strong>."
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -8279,6 +8481,12 @@ msgstr "Buat Gambar"
 #. Text for the button that generates more of an answer from duckassist when the answer has come from a collapsed state
 msgid "Generate More"
 msgstr "Hasilkan Lebih Banyak"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Generate a shopping list"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
@@ -8572,6 +8780,12 @@ msgstr "Cobalah"
 msgctxt "Onboarding welcome screen button text"
 msgid "Give it a Try"
 msgstr "Cobalah"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Give me a quick background on this person."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9018,6 +9232,18 @@ msgstr "Bantu Sebarkan DuckDuckGo!"
 #. Link to a page with information about sharing DuckDuckGo with friends.
 msgid "Help Spread Privacy"
 msgstr "Bantu Sebarkan Privasi"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Help me prep for the interview"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Help me tailor my resume for this job."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title of a SERP popup that invites users to take a survey (desktop only)
@@ -9537,6 +9763,14 @@ msgid "I Agree"
 msgstr "Saya Setuju"
 
 # smartling.placeholder_format=C
+#. Text for the button that takes the user to the external DuckDuckGo login subscription page.
+msgctxt ""
+"Text for the I already have a subscription button in the Duck.ai settings "
+"page"
+msgid "I Already Have a Subscription"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for the button that takes the user to the login subscription page.
 msgctxt "Text for the I have a subscription button"
 msgid "I Have a Subscription"
@@ -9578,7 +9812,8 @@ msgstr "Saya tidak paham informasi ini"
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
 msgid "I don’t want to see any information from DuckDuckGo on this page"
-msgstr "Saya tidak ingin melihat informasi apa pun dari DuckDuckGo di halaman ini"
+msgstr ""
+"Saya tidak ingin melihat informasi apa pun dari DuckDuckGo di halaman ini"
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
@@ -9617,7 +9852,8 @@ msgstr ""
 #. Option for feedback when the user needs more help or information on how to use the chat.
 msgctxt "Feedback option for difficulty in using chat"
 msgid "I need more help/info on how to use Chat"
-msgstr "Saya memerlukan bantuan/informasi lebih lanjut tentang cara menggunakan Chat"
+msgstr ""
+"Saya memerlukan bantuan/informasi lebih lanjut tentang cara menggunakan Chat"
 
 # smartling.placeholder_format=C
 msgid "IR Iran"
@@ -9905,7 +10141,8 @@ msgstr "Di menu atas, pilih %1$sAlat%2$s > %3$sPengaturan%4$s"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "In the popup, check %sMake this my default search provider%s"
-msgstr "Di dalam popup, centang %1$sJadikan sebagai mesin pencari default saya%2$s"
+msgstr ""
+"Di dalam popup, centang %1$sJadikan sebagai mesin pencari default saya%2$s"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -10111,6 +10348,12 @@ msgid "Install Mac Browser"
 msgstr "Instal Browser Mac"
 
 # smartling.placeholder_format=C
+#. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
+msgctxt "settings"
+msgid "Install Now"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of a button to install the DuckDuckGo app
 msgctxt "Serp footer content"
 msgid "Install Our App"
@@ -10208,10 +10451,42 @@ msgid "Is deleted data really deleted?"
 msgstr "Apakah data yang terhapus akan terhapus selamanya?"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is it worth taking?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this place any good?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"Is this place any good? Summarize its reputation based on reviews and "
+"ratings."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "Is this video helpful?"
 msgstr "Apakah video ini berguna?"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this worth watching?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Is this worth watching? Give me a spoiler-free take."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -10348,7 +10623,8 @@ msgstr "Tetap buka Sync & Backup di kedua perangkat."
 #. An instruction to state that a list of companies/trackers will be updated with continued use
 msgctxt "tracker_stats"
 msgid "Keep browsing to see how many we block"
-msgstr "Teruslah menjelajah untuk melihat jumlah perusahaan/pelacak yang kami blokir"
+msgstr ""
+"Teruslah menjelajah untuk melihat jumlah perusahaan/pelacak yang kami blokir"
 
 # smartling.placeholder_format=C
 #. Header above social media links.
@@ -10824,6 +11100,12 @@ msgid "Links:"
 msgstr "Tautan:"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "List the tools, materials, or prerequisites I need for this."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
 msgid "Listen"
 msgstr "Dengarkan"
@@ -11230,6 +11512,12 @@ msgstr "Kelola Langganan Kamu"
 msgctxt "Exclusion message manage sites button"
 msgid "Manage blocked sites"
 msgstr "Kelola situs yang diblokir"
+
+# smartling.placeholder_format=C
+#. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
+msgctxt "setting"
+msgid "Manage in Browser Settings"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to the site exclusion settings page
@@ -12517,7 +12805,8 @@ msgstr "Hasil tidak ditemukan."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the recording contains no audible speech.
 msgid "No speech detected. Please try again and speak into your microphone."
-msgstr "Tidak ada ucapan yang terdeteksi. Coba lagi dan bicaralah ke mikrofonmu."
+msgstr ""
+"Tidak ada ucapan yang terdeteksi. Coba lagi dan bicaralah ke mikrofonmu."
 
 # smartling.placeholder_format=C
 #. Button that dismisses a feedback form.
@@ -14065,8 +14354,15 @@ msgstr ""
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
+msgid "Please describe why the chat response is harmful or illegal. (optional)"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
+msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
-msgstr "Tolong jelaskan mengapa respons obrolan ilegal atau berbahaya. (Opsional)"
+msgstr ""
+"Tolong jelaskan mengapa respons obrolan ilegal atau berbahaya. (Opsional)"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to enter their passphrase.
@@ -14089,6 +14385,14 @@ msgid ""
 msgstr ""
 "Harap dicatat: memulai obrolan baru dengan model apa pun akan menghapus sesi "
 "obrolan Anda saat ini."
+
+# smartling.placeholder_format=C
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
+msgctxt "Feedback prompt"
+msgid ""
+"Please paste your prompt and the problematic output (with any personal "
+"information removed) and describe why the content is harmful or illegal."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -14528,7 +14832,8 @@ msgstr "Harga"
 #. Category of feedback a user can select on a feedback form.
 msgctxt "feedback form"
 msgid "Price shown doesn't reflect merchant site"
-msgstr "Harga yang ditampilkan berbeda dengan yang ditampilkan di situs penjual"
+msgstr ""
+"Harga yang ditampilkan berbeda dengan yang ditampilkan di situs penjual"
 
 # smartling.placeholder_format=C
 #. A button that prints the contents of a page.
@@ -14556,6 +14861,12 @@ msgstr "Privasi"
 msgctxt "settings"
 msgid "Privacy"
 msgstr "Privasi"
+
+# smartling.placeholder_format=C
+#. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
+msgctxt "Section heading on the Duck.ai settings page"
+msgid "Privacy & Terms"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Privacy Blog"
@@ -14626,6 +14937,12 @@ msgstr "Kebijakan Privasi & Ketentuan Penggunaan"
 msgctxt "Copy used to compose link in sentences"
 msgid "Privacy Policy and Terms of Service"
 msgstr "Kebijakan Privasi dan Ketentuan Layanan"
+
+# smartling.placeholder_format=C
+#. Text for a button that links to the terms of use and privacy policy page.
+msgctxt "Secondary button text in active privacy modal"
+msgid "Privacy Policy and Terms of Service"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title displayed on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
@@ -15130,6 +15447,30 @@ msgid "Recommend a book"
 msgstr "Merekomendasikan buku"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar books"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar books."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar movies or shows."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar titles"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
 msgid "Recording failed. Please try again."
 msgstr "Perekaman gagal. Silakan coba lagi."
@@ -15532,6 +15873,15 @@ msgid "Republic of Moldova"
 msgstr "Republik Moldova"
 
 # smartling.placeholder_format=C
+#. Note indicating that sharing the conversation is mandatory when reporting harmful or illegal content. Rendered alongside the standard share label (DUCKCHAT_RESPONSE_FEEDBACK_SHARE_PROMPT_RESPONSE_LABEL), not replacing it.
+msgctxt ""
+"Note shown under the share-content switch label on the Duck.ai response "
+"feedback form when the user has selected Harmful or Illegal as the feedback "
+"reason"
+msgid "Required for harmful or illegal reports"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
 msgctxt "Description for extended reasoning mode in Duck.ai"
 msgid "Researches before responding"
@@ -15698,7 +16048,8 @@ msgstr "Hasil mengecualikan informasi dari situs yang diblokir."
 #. Message that appears when results exclude blocked sites
 msgctxt "Blocked sites filter disclaimer"
 msgid "Results exclude your blocked sites, which you can manage in your %s."
-msgstr "Hasil tidak termasuk situs yang kamu blokir, yang dapat kamu kelola di %1$s."
+msgstr ""
+"Hasil tidak termasuk situs yang kamu blokir, yang dapat kamu kelola di %1$s."
 
 # smartling.placeholder_format=C
 #. A label showing the source of the results, e.g. "Results from Reddit"
@@ -15764,6 +16115,12 @@ msgstr "Ulasan"
 msgctxt "maps_places"
 msgid "Reviews"
 msgstr "Ulasan"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Rewrite this recipe scaled for a different number of servings."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Romania"
@@ -16020,7 +16377,8 @@ msgstr "Simpan dan Keluar"
 #. Description explaining that sync allows saving more chats than local browser storage.
 msgctxt "Sync feature benefit description"
 msgid "Save more chats than you can in your web browser."
-msgstr "Simpan lebih banyak obrolan daripada yang kamu bisa di browser web kamu."
+msgstr ""
+"Simpan lebih banyak obrolan daripada yang kamu bisa di browser web kamu."
 
 # smartling.placeholder_format=C
 #. List item explaining that users can save more chats when Sync & Backup is enabled.
@@ -16218,7 +16576,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down to the %sServices%s section and click %sAddress bar%s."
-msgstr "Gulir ke bawah ke bagian %1$sLayanan%2$s, lalu klik %3$sBilah alamat%4$s."
+msgstr ""
+"Gulir ke bawah ke bagian %1$sLayanan%2$s, lalu klik %3$sBilah alamat%4$s."
 
 # smartling.placeholder_format=C
 #. Rugby match stats
@@ -16435,8 +16794,8 @@ msgid ""
 "favorite browser, or search directly at %sduckduckgo.com%s."
 msgstr ""
 "Cari secara pribadi dengan aplikasi atau ekstensi kami, tambahkan pencarian "
-"web pribadi ke browser favoritmu, atau cari langsung di "
-"%1$sduckduckgo.com%2$s."
+"web pribadi ke browser favoritmu, atau cari langsung di %1$sduckduckgo."
+"com%2$s."
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/6LZAoqH.png
@@ -16595,7 +16954,8 @@ msgstr ""
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
 msgctxt "Sync feature benefit description"
 msgid "Securely stored on DuckDuckGo's server with end-to-end encryption."
-msgstr "Tersimpan dengan aman di server DuckDuckGo dengan enkripsi ujung ke ujung."
+msgstr ""
+"Tersimpan dengan aman di server DuckDuckGo dengan enkripsi ujung ke ujung."
 
 # smartling.placeholder_format=C
 #. List item explaining that synced chats are stored with end-to-end encryption on DuckDuckGo's server and only the user can access them.
@@ -16779,7 +17139,8 @@ msgstr "Pilih %1$sDuckDuckGo%2$s di menu dropdown Mesin Pencari Default"
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %sDuckDuckGo%s in the list and %sallow%s location access"
-msgstr "Pilih %1$sDuckDuckGo%2$s dalam daftar dan %3$sbolehkan%4$s akses lokasi"
+msgstr ""
+"Pilih %1$sDuckDuckGo%2$s dalam daftar dan %3$sbolehkan%4$s akses lokasi"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -16898,7 +17259,8 @@ msgstr ""
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %syour browser%s in the list and %sallow%s location access"
-msgstr "Pilih %1$sbrowser Anda%2$s dalam daftar dan %3$sizinkan akses lokasi%4$s"
+msgstr ""
+"Pilih %1$sbrowser Anda%2$s dalam daftar dan %3$sizinkan akses lokasi%4$s"
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the modal for deleting all recent chats, that allows the user to select the chats to delete.
@@ -17093,6 +17455,12 @@ msgid "Set Up Now"
 msgstr "Siapkan Sekarang"
 
 # smartling.placeholder_format=C
+#. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
+msgctxt "Encrypted storage setup button shown in native browsers"
+msgid "Set Up Sync & Backup"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
 msgctxt "Title for the Sync & Backup intro screen"
 msgid "Set Up Sync & Backup"
@@ -17272,6 +17640,13 @@ msgstr "Bagikan URL halaman"
 msgctxt "feedback form"
 msgid "Share positive feedback"
 msgstr "Bagikan masukan positif"
+
+# smartling.placeholder_format=C
+#. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
+msgctxt ""
+"Label beside the share-content switch on the Duck.ai response feedback form"
+msgid "Share this conversation with DuckDuckGo"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -17660,7 +18035,8 @@ msgstr "Menampilkan garis horizontal di pemisah halaman hasil"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows links to instructions for how to add DuckDuckGo to your browser"
-msgstr "Menampilkan tautan ke petunjuk cara menambahkan DuckDuckGo ke browser-mu"
+msgstr ""
+"Menampilkan tautan ke petunjuk cara menambahkan DuckDuckGo ke browser-mu"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers more frequently.
@@ -17676,18 +18052,21 @@ msgstr "Menampilkan tautan yang paling banyak dikunjungi di halaman tab baru"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your browser"
-msgstr "Sesekali menampilkan pengingat untuk menambahkan DuckDuckGo ke browser-mu"
+msgstr ""
+"Sesekali menampilkan pengingat untuk menambahkan DuckDuckGo ke browser-mu"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr "Sesekali menampilkan pengingat untuk menambahkan DuckDuckGo ke perangkatmu"
+msgstr ""
+"Sesekali menampilkan pengingat untuk menambahkan DuckDuckGo ke perangkatmu"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Shows occasional reminders to sign up for the DuckDuckGo privacy newsletters"
-msgstr "Sesekali menampilkan pengingat untuk mendaftar ke nawala privasi DuckDuckGo"
+msgstr ""
+"Sesekali menampilkan pengingat untuk mendaftar ke nawala privasi DuckDuckGo"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -17725,7 +18104,8 @@ msgstr "Menampilkan pesan selamat datang di atas halaman hasil pencarian"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message to EU Android preference menu users"
-msgstr "Menampilkan pesan selamat datang kepada pengguna menu preferensi Android UE"
+msgstr ""
+"Menampilkan pesan selamat datang kepada pengguna menu preferensi Android UE"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers sometimes.
@@ -17943,7 +18323,8 @@ msgstr "Terjadi sesuatu yang salah"
 #. Error message indicating that the user's settings weren't able to be saved.
 msgctxt "cloudsave"
 msgid "Something went wrong saving to the server, please try again."
-msgstr "Terjadi kesalahan saat proses penyimpanan ke server. Silakan coba lagi."
+msgstr ""
+"Terjadi kesalahan saat proses penyimpanan ke server. Silakan coba lagi."
 
 # smartling.placeholder_format=C
 #. Body copy displayed under the Set Up Now button when the sync setup call fails.
@@ -18531,6 +18912,24 @@ msgid "Suggest a title for a blog post"
 msgstr "Sarankan judul untuk postingan blog"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest related articles or topics worth exploring next."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Suggest related articles to explore"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest some alternatives to this product."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
 msgctxt "directions"
 msgid "Suggestions:"
@@ -18542,10 +18941,100 @@ msgid "Suggestions:"
 msgstr "Saran:"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Sum up the reviews"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A short title for the a message asking the AI to summarize a text.
 msgctxt "Title for the summarize message"
 msgid "Summarize"
 msgstr "Ringkas"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize the Q&As"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the background and notable work of this person."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the key details of this event."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the questions and answers on this page."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize their background"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this book"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this book."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this discussion"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this discussion thread."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this page"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this page."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this video"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this video."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize what the reviews say."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -18699,14 +19188,16 @@ msgstr "Beralih ke model yang lebih efisien"
 # smartling.placeholder_format=C
 #. Text prompting  users to switch their current search engine to the DuckDuckGo private search engine.
 msgid "Switch to the search engine that doesn't track you. Ever."
-msgstr "Beralihlah ke mesin pencari yang tidak akan pernah melacakmu. Selamanya."
+msgstr ""
+"Beralihlah ke mesin pencari yang tidak akan pernah melacakmu. Selamanya."
 
 # smartling.placeholder_format=C
 #. Warning text shown in the model switch dropdown when the user is currently using an encrypted model. Warns that the new model will not have zero provider visibility.
 msgctxt "AI Chat warning when switching from an encrypted model"
 msgid ""
 "Switching will send your chat to a model without zero provider visibility"
-msgstr "Beralih akan mengirim obrolan kamu ke model tanpa visibilitas penyedia nol"
+msgstr ""
+"Beralih akan mengirim obrolan kamu ke model tanpa visibilitas penyedia nol"
 
 # smartling.placeholder_format=C
 msgid "Switzerland"
@@ -18760,7 +19251,8 @@ msgstr "Sync & Backup Diaktifkan!"
 #. Notice shown under the recovery code explaining that backup data has an inactivity expiration.
 msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
-msgstr "Data Sync & Backup tidak dapat dipulihkan setelah 18 bulan tidak aktif."
+msgstr ""
+"Data Sync & Backup tidak dapat dipulihkan setelah 18 bulan tidak aktif."
 
 # smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
@@ -18871,6 +19363,12 @@ msgid "Syria"
 msgstr "Syria"
 
 # smartling.placeholder_format=C
+#. Text for a button that enables the theme to follow the operating system's color scheme preference.
+msgctxt "System theme button for theme selector"
+msgid "System"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Abbreviation indicating this is the total score for a game
 msgctxt "Sports module"
 msgid "T"
@@ -18897,6 +19395,12 @@ msgstr "TV"
 msgctxt "language_name"
 msgid "Tahitian"
 msgstr "Tahiti"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Tailor my resume"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Taiwan"
@@ -18926,6 +19430,13 @@ msgstr "Pegang kendali atas data pribadimu"
 msgctxt "homepage ATB modal"
 msgid "Take control of your personal data!"
 msgstr "Pegang kendali atas data pribadimu!"
+
+# smartling.placeholder_format=C
+#. Description for the Feedback section of the Duck.ai settings page, asking the user to take an anonymous survey to let us know how we can make Duck.ai better.
+msgctxt "Feedback section description on the Duck.ai settings page"
+msgid ""
+"Take this anonymous survey to let us know how we can make Duck.ai better."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -19097,7 +19608,8 @@ msgstr "Thailand (en)"
 #. Message displayed after the user has submitted feedback. It invites the user to share more feedback.
 msgctxt "Feedback toast"
 msgid "Thank you for your feedback. Have more to share?"
-msgstr "Terima kasih atas masukan kamu. Apakah kamu punya hal lain untuk dibagikan?"
+msgstr ""
+"Terima kasih atas masukan kamu. Apakah kamu punya hal lain untuk dibagikan?"
 
 # smartling.placeholder_format=C
 msgid "Thank you!"
@@ -19124,7 +19636,8 @@ msgstr "Terima kasih atas masukanmu!"
 #. Inform the users that "something" went wrong and we are unable to show any results.
 msgctxt "noresults"
 msgid "Thanks for your patience while we get our ducks in a row!"
-msgstr "Terima kasih atas kesabaran Anda sementara kami menyelesaikan semuanya!"
+msgstr ""
+"Terima kasih atas kesabaran Anda sementara kami menyelesaikan semuanya!"
 
 # smartling.placeholder_format=C
 #. Inform the users that "something" went wrong and we are unable to show any results.
@@ -19226,13 +19739,20 @@ msgstr "Permintaan tersebut mengalami batas waktu. Silakan coba lagi."
 #. Inform the users that "something" went wrong and we are unable to show any results.
 msgctxt "noresults"
 msgid "The server encountered an error and could not complete your request."
-msgstr "Server mengalami kesalahan dan tidak dapat menyelesaikan permintaan Anda."
+msgstr ""
+"Server mengalami kesalahan dan tidak dapat menyelesaikan permintaan Anda."
 
 # smartling.placeholder_format=C
 #. Title for the theme menu:
 #. https://duck.co/media/files/theme.png
 msgid "Theme"
 msgstr "Tema"
+
+# smartling.placeholder_format=C
+#. Text for the theme selector label that allows users to switch between Light and dark theme.
+msgctxt "Label for the theme selector feature"
+msgid "Theme"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/LpFhb1e.png
@@ -19486,14 +20006,16 @@ msgstr "Gambar ini tidak dapat dibuat."
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF"
-msgstr "Jenis gambar ini tidak didukung, tolong lampirkan JPG, PNG, WebP, atau GIF"
+msgstr ""
+"Jenis gambar ini tidak didukung, tolong lampirkan JPG, PNG, WebP, atau GIF"
 
 # smartling.placeholder_format=C
 #. Error message displayed when a file that the user tried to upload is not of a supported format
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF."
-msgstr "Jenis gambar ini tidak didukung, tolong lampirkan JPG, PNG, WebP, atau GIF."
+msgstr ""
+"Jenis gambar ini tidak didukung, tolong lampirkan JPG, PNG, WebP, atau GIF."
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
@@ -19621,7 +20143,8 @@ msgstr "Video ini belum bisa ditonton di sini. Kamu bisa menontonnya di %1$s."
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr "Halaman web ini tidak menggunakan koneksi yang aman dan terenkripsi (HTTPS)."
+msgstr ""
+"Halaman web ini tidak menggunakan koneksi yang aman dan terenkripsi (HTTPS)."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -19776,7 +20299,8 @@ msgstr "Untuk melanjutkan, kamu harus menyetujui %1$s dan %2$sDuck.ai"
 msgctxt ""
 "Copy stating agreement to AI Chat Privacy Policy and Terms of Service."
 msgid "To continue, you must agree to DuckDuckGo AI Chat’s %s and %s"
-msgstr "Untuk melanjutkan, Anda harus menyetujui %1$s dan %2$sDuckDuckGo AI Chat"
+msgstr ""
+"Untuk melanjutkan, Anda harus menyetujui %1$s dan %2$sDuckDuckGo AI Chat"
 
 # smartling.placeholder_format=C
 #. Instructions for how to print driving directions.
@@ -19808,8 +20332,8 @@ msgid ""
 "To transfer your chat history to Duck.ai, please update your DuckDuckGo "
 "browser to the latest version and try again."
 msgstr ""
-"Untuk mentransfer riwayat obrolanmu ke Duck.ai, perbarui browser "
-"DuckDuckGo-mu ke versi terbaru dan coba lagi."
+"Untuk mentransfer riwayat obrolanmu ke Duck.ai, perbarui browser DuckDuckGo-"
+"mu ke versi terbaru dan coba lagi."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
@@ -20071,6 +20595,18 @@ msgstr ""
 "saya sampai ke bioskop terdekat?”"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Translate this page"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
+msgctxt "Page suggestion prompt"
+msgid "Translate this page into %s."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text for a region that will display translated text.
 msgctxt "translations_module"
 msgid "Translation"
@@ -20210,6 +20746,12 @@ msgstr "Coba Lagi"
 msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
 msgstr "Coba Gratis"
+
+# smartling.placeholder_format=C
+#. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
+msgctxt "settings"
+msgid "Try It Now"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -20450,6 +20992,22 @@ msgstr "Coba: %1$s"
 msgctxt "new user poll"
 msgid "Trying DuckDuckGo again"
 msgstr "Mencoba DuckDuckGo lagi"
+
+# smartling.placeholder_format=C
+#. Message shown in a modal after supported third-party browser users disable AI features in Settings. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -20774,7 +21332,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
-msgstr "Di bagian %1$sMEMULAI > Halaman beranda%2$s, masukkan: https://duckduckgo.com"
+msgstr ""
+"Di bagian %1$sMEMULAI > Halaman beranda%2$s, masukkan: https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -21154,7 +21713,8 @@ msgstr ""
 #. Upsell message shown in the voice chat limit and duration limit modals for Plus subscribers, encouraging them to upgrade to Pro.
 msgctxt "voice chat limit modal"
 msgid "Upgrade to Pro to unlock 2x higher usage limits than Plus"
-msgstr "Tingkatkan ke Pro untuk membuka batas penggunaan 2x lebih tinggi dari Plus"
+msgstr ""
+"Tingkatkan ke Pro untuk membuka batas penggunaan 2x lebih tinggi dari Plus"
 
 # smartling.placeholder_format=C
 #. Heading in a promotion for a desktop web browser
@@ -21201,6 +21761,12 @@ msgstr "Urdu"
 # smartling.placeholder_format=C
 msgid "Uruguay"
 msgstr "Uruguay"
+
+# smartling.placeholder_format=C
+#. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
+msgctxt "Navigation label on the Duck.ai settings page"
+msgid "Usage"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -21651,6 +22217,12 @@ msgid "Wales"
 msgstr "Wales"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Walk me through the steps"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for walking directions on a map.
 msgctxt "directions"
 msgid "Walking"
@@ -21767,6 +22339,17 @@ msgid "We can anonymize%s your location%s to show you more accurate results."
 msgstr ""
 "Kami dapat menganonimkan%1$s lokasi Anda%2$s untuk menunjukkan hasil yang "
 "lebih akurat."
+
+# smartling.placeholder_format=C
+#. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
+msgctxt ""
+"Inline warning shown below the share-content toggle when the user selects "
+"Harmful or Illegal but has not enabled sharing"
+msgid ""
+"We can only fix what we can see. To report a harmful or illegal response, "
+"please share this conversation with DuckDuckGo so we can investigate and "
+"address the issue."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -22262,8 +22845,8 @@ msgid ""
 "We’re really sorry, but it seems there was a problem loading Duck.ai. Try "
 "reloading the page."
 msgstr ""
-"Kami benar-benar minta maaf, tetapi tampaknya ada masalah saat memuat "
-"Duck.ai. Coba muat ulang halaman."
+"Kami benar-benar minta maaf, tetapi tampaknya ada masalah saat memuat Duck."
+"ai. Coba muat ulang halaman."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to suggest an AI (Artificial Intelligence) model to be added to the product, and this field is optional.
@@ -22285,7 +22868,8 @@ msgstr ""
 #. Text for a prompt suggestion for considering factors when purchasing a computer monitor.
 msgctxt "Full sentence for preparing for a purchase"
 msgid "What are some factors to consider when purchasing a computer monitor?"
-msgstr "Apa saja faktor yang perlu dipertimbangkan saat membeli monitor komputer?"
+msgstr ""
+"Apa saja faktor yang perlu dipertimbangkan saat membeli monitor komputer?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for asking about must-see attractions in Paris for a first-time visitor.
@@ -22328,6 +22912,103 @@ msgstr ""
 "dan perlindungan privasi. Buatlah penjelasan yang sangat singkat, sederhana, "
 "dan mudah dipahami bagi orang dengan atau tanpa pengalaman AI atau teknis "
 "yang banyak."
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the counterarguments?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the hours & location?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key contributions of this paper?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key contributions?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key details?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key points covered in this video?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key points?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key takeaways from this article?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key takeaways?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key things I will learn from this course?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main counterarguments or criticisms of this?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main questions this page answers?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the must-try dishes here?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"What are the opening hours, location, and contact details for this place?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the pros and cons of this product?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the pros and cons?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
@@ -22430,6 +23111,12 @@ msgid "What does atria mean in the context of a medical article?"
 msgstr "Apa arti atrium dalam konteks artikel medis?"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What does this answer?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
@@ -22440,6 +23127,12 @@ msgstr "Fitur apa yang Anda ingin kami tambahkan? (opsional)"
 msgctxt "cloudsave"
 msgid "What information gets saved?"
 msgstr "Informasi apa yang disimpan?"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What interview questions might come up for this role?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -22456,6 +23149,12 @@ msgstr ""
 msgctxt "Full sentence for looking up basic facts"
 msgid "What is the capital city of Albania?"
 msgstr "Apa ibu kota dari Albania?"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What is the overall verdict and rating for this?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to a page with additional information.
@@ -22480,6 +23179,12 @@ msgid "What people say:"
 msgstr "Ulasan pengguna:"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What should I order?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
 msgctxt "feedback form"
 msgid "What stood out?"
@@ -22490,6 +23195,18 @@ msgstr "Apa yang menonjol?"
 msgctxt "feedback form"
 msgid "What was wrong with the response? (optional)"
 msgstr "Apa yang salah dengan tanggapan tersebut? (Opsional)"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I learn?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I need?"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -22509,6 +23226,12 @@ msgstr ""
 msgctxt "SERP footer content"
 msgid "What's New"
 msgstr "Apa yang Baru"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What's the verdict?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -22561,6 +23284,12 @@ msgid "Which features are missing? (Optional)"
 msgstr "Fitur apa yang tidak ada? (Opsional)"
 
 # smartling.placeholder_format=C
+#. An invitation for users to leave feedback
+msgctxt "Feedback prompt"
+msgid "Which features are missing? (optional)"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
 msgid "White"
 msgstr "Putih"
@@ -22575,6 +23304,18 @@ msgstr "Putih"
 #. Link to an about us page.
 msgid "Who We Are"
 msgstr "Profil Kami"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Who are the main cast and crew, and what else are they known for?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Who is this person?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Header above a collection of privacy-related links.
@@ -23065,7 +23806,8 @@ msgstr "Kamu bisa menemukan file <b>%1$s</b> di folder unduhanmu."
 # smartling.placeholder_format=C
 #. A link to the settings to where the user can hide the private search reminder from the filter bar of search results
 msgid "You can hide this reminder in %sSearch Settings%s"
-msgstr "Anda dapat menyembunyikan pengingat ini di %1$sPengaturan Pencarian%2$s"
+msgstr ""
+"Anda dapat menyembunyikan pengingat ini di %1$sPengaturan Pencarian%2$s"
 
 # smartling.placeholder_format=C
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
@@ -23723,9 +24465,9 @@ msgid ""
 "You’re now searching privately in Chrome. Use our browser instead of Chrome "
 "for more protection. It’s already installed and can:"
 msgstr ""
-"Anda sedang menelusuri secara pribadi di Chrome. Gunakan browser kami "
-"alih-alih Chrome untuk perlindungan yang lebih baik. Aplikasi sudah "
-"terinstal dan dapat:"
+"Anda sedang menelusuri secara pribadi di Chrome. Gunakan browser kami alih-"
+"alih Chrome untuk perlindungan yang lebih baik. Aplikasi sudah terinstal dan "
+"dapat:"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has exceeded the maximum message size.

--- a/locales/io_XX/LC_MESSAGES/duckduckgo.po
+++ b/locales/io_XX/LC_MESSAGES/duckduckgo.po
@@ -1159,6 +1159,11 @@ msgctxt "feedback form"
 msgid "Address is incorrect"
 msgstr ""
 
+#. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Adjust the servings"
+msgstr ""
+
 #. as in multiple advertisements
 msgid "Ads"
 msgstr ""
@@ -1330,6 +1335,13 @@ msgstr ""
 #. Heading shown on the empty chat screen. The text between the two %s markers is displayed inside a clickable privacy button. First %s renders a shield icon, second %s is an invisible end marker. Keep the word 'private' between both %s markers.
 msgctxt "Empty state heading in Duck.ai chat mode"
 msgid "All chats are %sprivate%s"
+msgstr ""
+
+#. Paragraph in the Privacy & Terms section of the About & Legal page in Duck.ai settings, summarizing how chats are anonymized and are not stored or used to train chat models.
+msgctxt "Privacy & Terms section description on the Duck.ai settings page"
+msgid ""
+"All chats are anonymized by DuckDuckGo, and your conversations are not used "
+"to train chat models by DuckDuckGo or the model providers"
 msgstr ""
 
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1542,6 +1554,12 @@ msgstr ""
 #. Confirmation message after location service is enabled.
 msgctxt "precise_user_location"
 msgid "Anonymous location enabled"
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Anonymously generates answers for search queries based on web content. "
+"Choose how often you want it to appear, or disable it completely."
 msgstr ""
 
 #. Instant Answer tab name
@@ -1764,6 +1782,11 @@ msgstr ""
 
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse
 msgid "Ask a follow-up with Duck.ai"
+msgstr ""
+
+#. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
+msgctxt "Page suggestion chip label"
+msgid "Ask about this page"
 msgstr ""
 
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2088,6 +2111,11 @@ msgstr ""
 msgid "Barcode"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Based on this page, is this course worth taking?"
+msgstr ""
+
 msgctxt "settings"
 msgid "Basic"
 msgstr ""
@@ -2119,6 +2147,13 @@ msgstr ""
 #. Placeholder text displayed while the assistant waits for the user to choose an action.
 msgctxt "Assistant response placeholder"
 msgid "Before continuing..."
+msgstr ""
+
+#. Explains that before storing the report, DuckDuckGo will anonymize the conversation by removing PII like names, email addresses, and identifying metadata.
+msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
+msgid ""
+"Before storing this report, DuckDuckGo will anonymize your conversation by "
+"removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
 #. Label that's displayed next to a past start date below a web search result.
@@ -2377,6 +2412,11 @@ msgstr ""
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Break Points Won"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Break this down into clear, numbered steps."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -2736,6 +2776,11 @@ msgstr ""
 #. Text of a button that performs a search for the cast of a particular movie or tv show
 msgctxt "Movie/TV Show Title instant answer"
 msgid "Cast"
+msgstr ""
+
+#. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Cast & Crew"
 msgstr ""
 
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -4087,6 +4132,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Create a shopping list with quantities from this recipe."
+msgstr ""
+
 #. Placeholder text displayed in the input field when starting a new image generation session.
 msgctxt "Placeholder text for the image generation input field"
 msgid "Create an image of a cute duck..."
@@ -4613,6 +4663,10 @@ msgstr ""
 msgid "Dictation limit reached"
 msgstr ""
 
+#. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
+msgid "Dictation temporarily unavailable"
+msgstr ""
+
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
@@ -4857,6 +4911,20 @@ msgctxt "precise_user_location"
 msgid "Done"
 msgstr ""
 
+#. Message shown in a modal after DuckDuckGo browser users disable AI features in Settings. The first two placeholders bold noai.duckduckgo.com. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
+"filtered out. %sLearn More%s"
+msgstr ""
+
+#. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
+"and AI images filtered out. %sLearn more%s"
+msgstr ""
+
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Double Faults"
@@ -4947,6 +5015,16 @@ msgctxt "Full sentence for writing an email"
 msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
+msgstr ""
+
+#. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Draft a cover letter"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Draft a cover letter for this job."
 msgstr ""
 
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -5086,6 +5164,14 @@ msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
 msgstr ""
 
+#. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
+msgctxt "About section description on the Duck.ai settings page"
+msgid ""
+"Duck.ai is created by DuckDuckGo. We're an independent online protection "
+"company for anyone who wants to take back control of their personal "
+"information."
+msgstr ""
+
 #. Title shown when an update is required before proceeding.
 msgctxt "duckai_migration"
 msgid "Duck.ai is moving domains"
@@ -5119,6 +5205,12 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Duck.ai lets you chat privately with popular AI models. Disabling it hides "
+"Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
 
 msgctxt "settings"
@@ -5884,6 +5976,16 @@ msgstr ""
 msgid "Eritrea"
 msgstr ""
 
+#. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Estimate the nutrition"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Estimate the nutritional information for this recipe."
+msgstr ""
+
 msgid "Estonia"
 msgstr ""
 
@@ -5928,10 +6030,50 @@ msgctxt "merchant promotion product ad extension"
 msgid "Expires in 1 day"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain the accepted answer in simple terms."
+msgstr ""
+
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
+msgstr ""
+
+#. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain the top answer"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this in simple, plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this paper"
+msgstr ""
+
+#. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this repo"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this research paper in plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this simply"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain what this repository does and how to use it."
 msgstr ""
 
 #. Label to show if song lyrics contain explicit content
@@ -6162,6 +6304,11 @@ msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
 msgstr ""
 
+msgctxt "settings"
+msgid ""
+"Filters out known AI spam sites from image search results. %sLearn More%s"
+msgstr ""
+
 #. Label for the final score of a sporting event.
 msgid "Final"
 msgstr ""
@@ -6201,6 +6348,11 @@ msgstr ""
 #. Short description shown below the 'Web Search' label in the Tools dropdown.
 msgctxt "Subtitle for the Web Search tool entry in the Tools dropdown menu"
 msgid "Find current information"
+msgstr ""
+
+#. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Find me alternatives"
 msgstr ""
 
 #. Button that searches for results closer to the user's current location.
@@ -6591,6 +6743,11 @@ msgstr ""
 msgid "Generate More"
 msgstr ""
 
+#. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Generate a shopping list"
+msgstr ""
+
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
 msgid "Generate a short answer from the web"
 msgstr ""
@@ -6825,6 +6982,11 @@ msgstr ""
 #. Text for a button inviting users to give it a try for the Duck.ai product. On click, they're taken to the Duck.ai page.
 msgctxt "Onboarding welcome screen button text"
 msgid "Give it a Try"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Give me a quick background on this person."
 msgstr ""
 
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -7187,6 +7349,16 @@ msgstr ""
 
 #. Link to a page with information about sharing DuckDuckGo with friends.
 msgid "Help Spread Privacy"
+msgstr ""
+
+#. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Help me prep for the interview"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Help me tailor my resume for this job."
 msgstr ""
 
 #. Title of a SERP popup that invites users to take a survey (desktop only)
@@ -7606,6 +7778,13 @@ msgstr ""
 #. Text displayed on the button on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
 msgctxt "Onboarding terms screen button text"
 msgid "I Agree"
+msgstr ""
+
+#. Text for the button that takes the user to the external DuckDuckGo login subscription page.
+msgctxt ""
+"Text for the I already have a subscription button in the Duck.ai settings "
+"page"
+msgid "I Already Have a Subscription"
 msgstr ""
 
 #. Text for the button that takes the user to the login subscription page.
@@ -8058,6 +8237,11 @@ msgctxt "Sidemenu browser promo"
 msgid "Install Mac Browser"
 msgstr ""
 
+#. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
+msgctxt "settings"
+msgid "Install Now"
+msgstr ""
+
 #. Text of a button to install the DuckDuckGo app
 msgctxt "Serp footer content"
 msgid "Install Our App"
@@ -8137,9 +8321,36 @@ msgctxt "cloudsave"
 msgid "Is deleted data really deleted?"
 msgstr "Ka esas efacinta datumi vere efacesas?"
 
+#. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is it worth taking?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this place any good?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"Is this place any good? Summarize its reputation based on reviews and "
+"ratings."
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "Is this video helpful?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this worth watching?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Is this worth watching? Give me a spoiler-free take."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -8636,6 +8847,11 @@ msgstr "Ligilo-tipo:"
 msgid "Links:"
 msgstr "Ligili:"
 
+#. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "List the tools, materials, or prerequisites I need for this."
+msgstr ""
+
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
 msgid "Listen"
 msgstr "Askoltar"
@@ -8968,6 +9184,11 @@ msgstr ""
 #. Label for linke navigating to site exclusion feature on Settings page
 msgctxt "Exclusion message manage sites button"
 msgid "Manage blocked sites"
+msgstr ""
+
+#. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
+msgctxt "setting"
+msgid "Manage in Browser Settings"
 msgstr ""
 
 #. Link to the site exclusion settings page
@@ -11265,6 +11486,11 @@ msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
+msgid "Please describe why the chat response is harmful or illegal. (optional)"
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
+msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
 msgstr ""
 
@@ -11283,6 +11509,13 @@ msgctxt "Modal disclaimer text"
 msgid ""
 "Please note: starting a new chat with any model will delete your current "
 "chat session."
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
+msgctxt "Feedback prompt"
+msgid ""
+"Please paste your prompt and the problematic output (with any personal "
+"information removed) and describe why the content is harmful or illegal."
 msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -11667,6 +11900,11 @@ msgctxt "settings"
 msgid "Privacy"
 msgstr "Privateso"
 
+#. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
+msgctxt "Section heading on the Duck.ai settings page"
+msgid "Privacy & Terms"
+msgstr ""
+
 msgid "Privacy Blog"
 msgstr ""
 
@@ -11720,6 +11958,11 @@ msgstr ""
 
 #. Text used in other strings to link to the Privacy Policy and Terms of Service content.
 msgctxt "Copy used to compose link in sentences"
+msgid "Privacy Policy and Terms of Service"
+msgstr ""
+
+#. Text for a button that links to the terms of use and privacy policy page.
+msgctxt "Secondary button text in active privacy modal"
 msgid "Privacy Policy and Terms of Service"
 msgstr ""
 
@@ -12128,6 +12371,26 @@ msgctxt "Brief for recommending a book"
 msgid "Recommend a book"
 msgstr ""
 
+#. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar books"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar books."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar movies or shows."
+msgstr ""
+
+#. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar titles"
+msgstr ""
+
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
 msgid "Recording failed. Please try again."
 msgstr ""
@@ -12447,6 +12710,14 @@ msgstr ""
 msgid "Republic of Moldova"
 msgstr ""
 
+#. Note indicating that sharing the conversation is mandatory when reporting harmful or illegal content. Rendered alongside the standard share label (DUCKCHAT_RESPONSE_FEEDBACK_SHARE_PROMPT_RESPONSE_LABEL), not replacing it.
+msgctxt ""
+"Note shown under the share-content switch label on the Duck.ai response "
+"feedback form when the user has selected Harmful or Illegal as the feedback "
+"reason"
+msgid "Required for harmful or illegal reports"
+msgstr ""
+
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
 msgctxt "Description for extended reasoning mode in Duck.ai"
 msgid "Researches before responding"
@@ -12632,6 +12903,11 @@ msgstr "Recensi"
 #. Label above a list of customer reviews of a business.
 msgctxt "maps_places"
 msgid "Reviews"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Rewrite this recipe scaled for a different number of servings."
 msgstr ""
 
 msgid "Romania"
@@ -13667,6 +13943,11 @@ msgctxt "Setup button for native sync flow"
 msgid "Set Up Now"
 msgstr ""
 
+#. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
+msgctxt "Encrypted storage setup button shown in native browsers"
+msgid "Set Up Sync & Backup"
+msgstr ""
+
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
 msgctxt "Title for the Sync & Backup intro screen"
 msgid "Set Up Sync & Backup"
@@ -13809,6 +14090,12 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
+msgctxt ""
+"Label beside the share-content switch on the Duck.ai response feedback form"
+msgid "Share this conversation with DuckDuckGo"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -14823,6 +15110,21 @@ msgctxt "Brief for suggesting a blog post title"
 msgid "Suggest a title for a blog post"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest related articles or topics worth exploring next."
+msgstr ""
+
+#. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Suggest related articles to explore"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest some alternatives to this product."
+msgstr ""
+
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
 msgctxt "directions"
 msgid "Suggestions:"
@@ -14832,9 +15134,84 @@ msgctxt "noresults"
 msgid "Suggestions:"
 msgstr ""
 
+#. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Sum up the reviews"
+msgstr ""
+
 #. A short title for the a message asking the AI to summarize a text.
 msgctxt "Title for the summarize message"
 msgid "Summarize"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize the Q&As"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the background and notable work of this person."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the key details of this event."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the questions and answers on this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize their background"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this book"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this book."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this discussion"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this discussion thread."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this video"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this video."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize what the reviews say."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -15089,6 +15466,11 @@ msgstr ""
 msgid "Syria"
 msgstr ""
 
+#. Text for a button that enables the theme to follow the operating system's color scheme preference.
+msgctxt "System theme button for theme selector"
+msgid "System"
+msgstr ""
+
 #. Abbreviation indicating this is the total score for a game
 msgctxt "Sports module"
 msgid "T"
@@ -15112,6 +15494,11 @@ msgctxt "language_name"
 msgid "Tahitian"
 msgstr ""
 
+#. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Tailor my resume"
+msgstr ""
+
 msgid "Taiwan"
 msgstr ""
 
@@ -15133,6 +15520,12 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "Take control of your personal data!"
+msgstr ""
+
+#. Description for the Feedback section of the Duck.ai settings page, asking the user to take an anonymous survey to let us know how we can make Duck.ai better.
+msgctxt "Feedback section description on the Duck.ai settings page"
+msgid ""
+"Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
 
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -15377,6 +15770,11 @@ msgstr ""
 #. https://duck.co/media/files/theme.png
 msgid "Theme"
 msgstr "Temo"
+
+#. Text for the theme selector label that allows users to switch between Light and dark theme.
+msgctxt "Label for the theme selector feature"
+msgid "Theme"
+msgstr ""
 
 #. http://i.imgur.com/LpFhb1e.png
 msgctxt "settings"
@@ -16028,6 +16426,16 @@ msgid ""
 "movie theatre?”"
 msgstr ""
 
+#. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Translate this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
+msgctxt "Page suggestion prompt"
+msgid "Translate this page into %s."
+msgstr ""
+
 #. Placeholder text for a region that will display translated text.
 msgctxt "translations_module"
 msgid "Translation"
@@ -16142,6 +16550,11 @@ msgstr ""
 #. Call-to-action button for the subscription promo in the SERP sidemenu.
 msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
+msgstr ""
+
+#. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
+msgctxt "settings"
+msgid "Try It Now"
 msgstr ""
 
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -16335,6 +16748,20 @@ msgstr "Probez: %s"
 #. Response a user can select in a feedback form, indicating that they're trying DuckDuckGo again.
 msgctxt "new user poll"
 msgid "Trying DuckDuckGo again"
+msgstr ""
+
+#. Message shown in a modal after supported third-party browser users disable AI features in Settings. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+#. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
 msgstr ""
 
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -16935,6 +17362,11 @@ msgstr ""
 msgid "Uruguay"
 msgstr ""
 
+#. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
+msgctxt "Navigation label on the Duck.ai settings page"
+msgid "Usage"
+msgstr ""
+
 #. A feedback suggestion
 msgctxt "Feedback prompt"
 msgid "Usage limit"
@@ -17283,6 +17715,11 @@ msgstr ""
 msgid "Wales"
 msgstr ""
 
+#. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Walk me through the steps"
+msgstr ""
+
 #. Label for walking directions on a map.
 msgctxt "directions"
 msgid "Walking"
@@ -17373,6 +17810,16 @@ msgstr ""
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
+msgstr ""
+
+#. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
+msgctxt ""
+"Inline warning shown below the share-content toggle when the user selects "
+"Harmful or Illegal but has not enabled sharing"
+msgid ""
+"We can only fix what we can see. To report a harmful or illegal response, "
+"please share this conversation with DuckDuckGo so we can investigate and "
+"address the issue."
 msgstr ""
 
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -17792,6 +18239,87 @@ msgid ""
 "experience."
 msgstr ""
 
+#. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the counterarguments?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the hours & location?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key contributions of this paper?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key contributions?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key details?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key points covered in this video?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key points?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key takeaways from this article?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key takeaways?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key things I will learn from this course?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main counterarguments or criticisms of this?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main questions this page answers?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the must-try dishes here?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"What are the opening hours, location, and contact details for this place?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the pros and cons of this product?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the pros and cons?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
 msgctxt "feedback form"
 msgid "What bothered you most?"
@@ -17875,6 +18403,11 @@ msgctxt "Full sentence for defining a term"
 msgid "What does atria mean in the context of a medical article?"
 msgstr ""
 
+#. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What does this answer?"
+msgstr ""
+
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
@@ -17884,6 +18417,11 @@ msgstr ""
 msgctxt "cloudsave"
 msgid "What information gets saved?"
 msgstr "Qua informo konservas?"
+
+#. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What interview questions might come up for this role?"
+msgstr ""
 
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
@@ -17895,6 +18433,11 @@ msgstr ""
 #. Text for a prompt suggestion for looking up the capital city of Albania.
 msgctxt "Full sentence for looking up basic facts"
 msgid "What is the capital city of Albania?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What is the overall verdict and rating for this?"
 msgstr ""
 
 #. Link to a page with additional information.
@@ -17915,6 +18458,11 @@ msgctxt "maps_places"
 msgid "What people say:"
 msgstr ""
 
+#. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What should I order?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
 msgctxt "feedback form"
 msgid "What stood out?"
@@ -17923,6 +18471,16 @@ msgstr ""
 #. Question on a feedback form for a negative feedback response.
 msgctxt "feedback form"
 msgid "What was wrong with the response? (optional)"
+msgstr ""
+
+#. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I learn?"
+msgstr ""
+
+#. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I need?"
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -17937,6 +18495,11 @@ msgstr ""
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
 msgctxt "SERP footer content"
 msgid "What's New"
+msgstr ""
+
+#. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What's the verdict?"
 msgstr ""
 
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -17978,6 +18541,11 @@ msgctxt "Feedback prompt"
 msgid "Which features are missing? (Optional)"
 msgstr ""
 
+#. An invitation for users to leave feedback
+msgctxt "Feedback prompt"
+msgid "Which features are missing? (optional)"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
 msgid "White"
 msgstr "Blanka"
@@ -17989,6 +18557,16 @@ msgstr ""
 
 #. Link to an about us page.
 msgid "Who We Are"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Who are the main cast and crew, and what else are they known for?"
+msgstr ""
+
+#. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Who is this person?"
 msgstr ""
 
 #. Header above a collection of privacy-related links.

--- a/locales/is_IS/LC_MESSAGES/duckduckgo.po
+++ b/locales/is_IS/LC_MESSAGES/duckduckgo.po
@@ -1160,6 +1160,11 @@ msgctxt "feedback form"
 msgid "Address is incorrect"
 msgstr ""
 
+#. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Adjust the servings"
+msgstr ""
+
 #. as in multiple advertisements
 msgid "Ads"
 msgstr "Auglýsingar"
@@ -1331,6 +1336,13 @@ msgstr ""
 #. Heading shown on the empty chat screen. The text between the two %s markers is displayed inside a clickable privacy button. First %s renders a shield icon, second %s is an invisible end marker. Keep the word 'private' between both %s markers.
 msgctxt "Empty state heading in Duck.ai chat mode"
 msgid "All chats are %sprivate%s"
+msgstr ""
+
+#. Paragraph in the Privacy & Terms section of the About & Legal page in Duck.ai settings, summarizing how chats are anonymized and are not stored or used to train chat models.
+msgctxt "Privacy & Terms section description on the Duck.ai settings page"
+msgid ""
+"All chats are anonymized by DuckDuckGo, and your conversations are not used "
+"to train chat models by DuckDuckGo or the model providers"
 msgstr ""
 
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1543,6 +1555,12 @@ msgstr ""
 #. Confirmation message after location service is enabled.
 msgctxt "precise_user_location"
 msgid "Anonymous location enabled"
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Anonymously generates answers for search queries based on web content. "
+"Choose how often you want it to appear, or disable it completely."
 msgstr ""
 
 #. Instant Answer tab name
@@ -1767,6 +1785,11 @@ msgstr ""
 
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse
 msgid "Ask a follow-up with Duck.ai"
+msgstr ""
+
+#. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
+msgctxt "Page suggestion chip label"
+msgid "Ask about this page"
 msgstr ""
 
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2091,6 +2114,11 @@ msgstr ""
 msgid "Barcode"
 msgstr "Strikamerki"
 
+#. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Based on this page, is this course worth taking?"
+msgstr ""
+
 msgctxt "settings"
 msgid "Basic"
 msgstr "Einfalt"
@@ -2122,6 +2150,13 @@ msgstr ""
 #. Placeholder text displayed while the assistant waits for the user to choose an action.
 msgctxt "Assistant response placeholder"
 msgid "Before continuing..."
+msgstr ""
+
+#. Explains that before storing the report, DuckDuckGo will anonymize the conversation by removing PII like names, email addresses, and identifying metadata.
+msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
+msgid ""
+"Before storing this report, DuckDuckGo will anonymize your conversation by "
+"removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
 #. Label that's displayed next to a past start date below a web search result.
@@ -2380,6 +2415,11 @@ msgstr "Brasilía"
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Break Points Won"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Break this down into clear, numbered steps."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -2739,6 +2779,11 @@ msgstr "Störf"
 #. Text of a button that performs a search for the cast of a particular movie or tv show
 msgctxt "Movie/TV Show Title instant answer"
 msgid "Cast"
+msgstr ""
+
+#. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Cast & Crew"
 msgstr ""
 
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -4090,6 +4135,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Create a shopping list with quantities from this recipe."
+msgstr ""
+
 #. Placeholder text displayed in the input field when starting a new image generation session.
 msgctxt "Placeholder text for the image generation input field"
 msgid "Create an image of a cute duck..."
@@ -4616,6 +4666,10 @@ msgstr ""
 msgid "Dictation limit reached"
 msgstr ""
 
+#. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
+msgid "Dictation temporarily unavailable"
+msgstr ""
+
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
@@ -4860,6 +4914,20 @@ msgctxt "precise_user_location"
 msgid "Done"
 msgstr "Búið"
 
+#. Message shown in a modal after DuckDuckGo browser users disable AI features in Settings. The first two placeholders bold noai.duckduckgo.com. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
+"filtered out. %sLearn More%s"
+msgstr ""
+
+#. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
+"and AI images filtered out. %sLearn more%s"
+msgstr ""
+
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Double Faults"
@@ -4950,6 +5018,16 @@ msgctxt "Full sentence for writing an email"
 msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
+msgstr ""
+
+#. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Draft a cover letter"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Draft a cover letter for this job."
 msgstr ""
 
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -5089,6 +5167,14 @@ msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
 msgstr ""
 
+#. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
+msgctxt "About section description on the Duck.ai settings page"
+msgid ""
+"Duck.ai is created by DuckDuckGo. We're an independent online protection "
+"company for anyone who wants to take back control of their personal "
+"information."
+msgstr ""
+
 #. Title shown when an update is required before proceeding.
 msgctxt "duckai_migration"
 msgid "Duck.ai is moving domains"
@@ -5122,6 +5208,12 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Duck.ai lets you chat privately with popular AI models. Disabling it hides "
+"Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
 
 msgctxt "settings"
@@ -5888,6 +5980,16 @@ msgstr ""
 msgid "Eritrea"
 msgstr ""
 
+#. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Estimate the nutrition"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Estimate the nutritional information for this recipe."
+msgstr ""
+
 msgid "Estonia"
 msgstr "Eistland"
 
@@ -5932,10 +6034,50 @@ msgctxt "merchant promotion product ad extension"
 msgid "Expires in 1 day"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain the accepted answer in simple terms."
+msgstr ""
+
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
+msgstr ""
+
+#. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain the top answer"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this in simple, plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this paper"
+msgstr ""
+
+#. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this repo"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this research paper in plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this simply"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain what this repository does and how to use it."
 msgstr ""
 
 #. Label to show if song lyrics contain explicit content
@@ -6164,6 +6306,11 @@ msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
 msgstr ""
 
+msgctxt "settings"
+msgid ""
+"Filters out known AI spam sites from image search results. %sLearn More%s"
+msgstr ""
+
 #. Label for the final score of a sporting event.
 msgid "Final"
 msgstr ""
@@ -6203,6 +6350,11 @@ msgstr ""
 #. Short description shown below the 'Web Search' label in the Tools dropdown.
 msgctxt "Subtitle for the Web Search tool entry in the Tools dropdown menu"
 msgid "Find current information"
+msgstr ""
+
+#. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Find me alternatives"
 msgstr ""
 
 #. Button that searches for results closer to the user's current location.
@@ -6593,6 +6745,11 @@ msgstr ""
 msgid "Generate More"
 msgstr ""
 
+#. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Generate a shopping list"
+msgstr ""
+
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
 msgid "Generate a short answer from the web"
 msgstr ""
@@ -6827,6 +6984,11 @@ msgstr ""
 #. Text for a button inviting users to give it a try for the Duck.ai product. On click, they're taken to the Duck.ai page.
 msgctxt "Onboarding welcome screen button text"
 msgid "Give it a Try"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Give me a quick background on this person."
 msgstr ""
 
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -7189,6 +7351,16 @@ msgstr ""
 
 #. Link to a page with information about sharing DuckDuckGo with friends.
 msgid "Help Spread Privacy"
+msgstr ""
+
+#. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Help me prep for the interview"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Help me tailor my resume for this job."
 msgstr ""
 
 #. Title of a SERP popup that invites users to take a survey (desktop only)
@@ -7608,6 +7780,13 @@ msgstr ""
 #. Text displayed on the button on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
 msgctxt "Onboarding terms screen button text"
 msgid "I Agree"
+msgstr ""
+
+#. Text for the button that takes the user to the external DuckDuckGo login subscription page.
+msgctxt ""
+"Text for the I already have a subscription button in the Duck.ai settings "
+"page"
+msgid "I Already Have a Subscription"
 msgstr ""
 
 #. Text for the button that takes the user to the login subscription page.
@@ -8060,6 +8239,11 @@ msgctxt "Sidemenu browser promo"
 msgid "Install Mac Browser"
 msgstr ""
 
+#. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
+msgctxt "settings"
+msgid "Install Now"
+msgstr ""
+
 #. Text of a button to install the DuckDuckGo app
 msgctxt "Serp footer content"
 msgid "Install Our App"
@@ -8139,9 +8323,36 @@ msgctxt "cloudsave"
 msgid "Is deleted data really deleted?"
 msgstr ""
 
+#. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is it worth taking?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this place any good?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"Is this place any good? Summarize its reputation based on reviews and "
+"ratings."
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "Is this video helpful?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this worth watching?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Is this worth watching? Give me a spoiler-free take."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -8638,6 +8849,11 @@ msgstr "Fontur tengils:"
 msgid "Links:"
 msgstr "Tenglar:"
 
+#. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "List the tools, materials, or prerequisites I need for this."
+msgstr ""
+
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
 msgid "Listen"
 msgstr "Hlusta á"
@@ -8970,6 +9186,11 @@ msgstr ""
 #. Label for linke navigating to site exclusion feature on Settings page
 msgctxt "Exclusion message manage sites button"
 msgid "Manage blocked sites"
+msgstr ""
+
+#. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
+msgctxt "setting"
+msgid "Manage in Browser Settings"
 msgstr ""
 
 #. Link to the site exclusion settings page
@@ -11271,6 +11492,11 @@ msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
+msgid "Please describe why the chat response is harmful or illegal. (optional)"
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
+msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
 msgstr ""
 
@@ -11289,6 +11515,13 @@ msgctxt "Modal disclaimer text"
 msgid ""
 "Please note: starting a new chat with any model will delete your current "
 "chat session."
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
+msgctxt "Feedback prompt"
+msgid ""
+"Please paste your prompt and the problematic output (with any personal "
+"information removed) and describe why the content is harmful or illegal."
 msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -11673,6 +11906,11 @@ msgctxt "settings"
 msgid "Privacy"
 msgstr "Persónuvernd"
 
+#. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
+msgctxt "Section heading on the Duck.ai settings page"
+msgid "Privacy & Terms"
+msgstr ""
+
 msgid "Privacy Blog"
 msgstr "Blogg um persónuvernd"
 
@@ -11726,6 +11964,11 @@ msgstr ""
 
 #. Text used in other strings to link to the Privacy Policy and Terms of Service content.
 msgctxt "Copy used to compose link in sentences"
+msgid "Privacy Policy and Terms of Service"
+msgstr ""
+
+#. Text for a button that links to the terms of use and privacy policy page.
+msgctxt "Secondary button text in active privacy modal"
 msgid "Privacy Policy and Terms of Service"
 msgstr ""
 
@@ -12134,6 +12377,26 @@ msgctxt "Brief for recommending a book"
 msgid "Recommend a book"
 msgstr ""
 
+#. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar books"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar books."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar movies or shows."
+msgstr ""
+
+#. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar titles"
+msgstr ""
+
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
 msgid "Recording failed. Please try again."
 msgstr ""
@@ -12453,6 +12716,14 @@ msgstr ""
 msgid "Republic of Moldova"
 msgstr ""
 
+#. Note indicating that sharing the conversation is mandatory when reporting harmful or illegal content. Rendered alongside the standard share label (DUCKCHAT_RESPONSE_FEEDBACK_SHARE_PROMPT_RESPONSE_LABEL), not replacing it.
+msgctxt ""
+"Note shown under the share-content switch label on the Duck.ai response "
+"feedback form when the user has selected Harmful or Illegal as the feedback "
+"reason"
+msgid "Required for harmful or illegal reports"
+msgstr ""
+
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
 msgctxt "Description for extended reasoning mode in Duck.ai"
 msgid "Researches before responding"
@@ -12639,6 +12910,11 @@ msgstr "Umsagnir"
 msgctxt "maps_places"
 msgid "Reviews"
 msgstr "Umsagnir"
+
+#. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Rewrite this recipe scaled for a different number of servings."
+msgstr ""
 
 msgid "Romania"
 msgstr "Rúmenía"
@@ -13673,6 +13949,11 @@ msgctxt "Setup button for native sync flow"
 msgid "Set Up Now"
 msgstr ""
 
+#. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
+msgctxt "Encrypted storage setup button shown in native browsers"
+msgid "Set Up Sync & Backup"
+msgstr ""
+
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
 msgctxt "Title for the Sync & Backup intro screen"
 msgid "Set Up Sync & Backup"
@@ -13816,6 +14097,12 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
+msgctxt ""
+"Label beside the share-content switch on the Duck.ai response feedback form"
+msgid "Share this conversation with DuckDuckGo"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -14833,6 +15120,21 @@ msgctxt "Brief for suggesting a blog post title"
 msgid "Suggest a title for a blog post"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest related articles or topics worth exploring next."
+msgstr ""
+
+#. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Suggest related articles to explore"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest some alternatives to this product."
+msgstr ""
+
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
 msgctxt "directions"
 msgid "Suggestions:"
@@ -14842,9 +15144,84 @@ msgctxt "noresults"
 msgid "Suggestions:"
 msgstr "Tillögur:"
 
+#. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Sum up the reviews"
+msgstr ""
+
 #. A short title for the a message asking the AI to summarize a text.
 msgctxt "Title for the summarize message"
 msgid "Summarize"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize the Q&As"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the background and notable work of this person."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the key details of this event."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the questions and answers on this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize their background"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this book"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this book."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this discussion"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this discussion thread."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this video"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this video."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize what the reviews say."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -15099,6 +15476,11 @@ msgstr ""
 msgid "Syria"
 msgstr ""
 
+#. Text for a button that enables the theme to follow the operating system's color scheme preference.
+msgctxt "System theme button for theme selector"
+msgid "System"
+msgstr ""
+
 #. Abbreviation indicating this is the total score for a game
 msgctxt "Sports module"
 msgid "T"
@@ -15122,6 +15504,11 @@ msgctxt "language_name"
 msgid "Tahitian"
 msgstr ""
 
+#. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Tailor my resume"
+msgstr ""
+
 msgid "Taiwan"
 msgstr "Taívan"
 
@@ -15143,6 +15530,12 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "Take control of your personal data!"
+msgstr ""
+
+#. Description for the Feedback section of the Duck.ai settings page, asking the user to take an anonymous survey to let us know how we can make Duck.ai better.
+msgctxt "Feedback section description on the Duck.ai settings page"
+msgid ""
+"Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
 
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -15391,6 +15784,11 @@ msgstr ""
 #. https://duck.co/media/files/theme.png
 msgid "Theme"
 msgstr "Hamur"
+
+#. Text for the theme selector label that allows users to switch between Light and dark theme.
+msgctxt "Label for the theme selector feature"
+msgid "Theme"
+msgstr ""
 
 #. http://i.imgur.com/LpFhb1e.png
 msgctxt "settings"
@@ -16044,6 +16442,16 @@ msgid ""
 "movie theatre?”"
 msgstr ""
 
+#. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Translate this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
+msgctxt "Page suggestion prompt"
+msgid "Translate this page into %s."
+msgstr ""
+
 #. Placeholder text for a region that will display translated text.
 msgctxt "translations_module"
 msgid "Translation"
@@ -16158,6 +16566,11 @@ msgstr ""
 #. Call-to-action button for the subscription promo in the SERP sidemenu.
 msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
+msgstr ""
+
+#. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
+msgctxt "settings"
+msgid "Try It Now"
 msgstr ""
 
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -16352,6 +16765,20 @@ msgstr "Prófaðu: %s"
 msgctxt "new user poll"
 msgid "Trying DuckDuckGo again"
 msgstr "Ég er að prófa DuckDuckGo aftur"
+
+#. Message shown in a modal after supported third-party browser users disable AI features in Settings. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+#. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
 
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
 msgctxt "Assistant response placeholder"
@@ -16951,6 +17378,11 @@ msgstr ""
 msgid "Uruguay"
 msgstr ""
 
+#. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
+msgctxt "Navigation label on the Duck.ai settings page"
+msgid "Usage"
+msgstr ""
+
 #. A feedback suggestion
 msgctxt "Feedback prompt"
 msgid "Usage limit"
@@ -17302,6 +17734,11 @@ msgstr ""
 msgid "Wales"
 msgstr ""
 
+#. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Walk me through the steps"
+msgstr ""
+
 #. Label for walking directions on a map.
 msgctxt "directions"
 msgid "Walking"
@@ -17392,6 +17829,16 @@ msgstr ""
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
+msgstr ""
+
+#. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
+msgctxt ""
+"Inline warning shown below the share-content toggle when the user selects "
+"Harmful or Illegal but has not enabled sharing"
+msgid ""
+"We can only fix what we can see. To report a harmful or illegal response, "
+"please share this conversation with DuckDuckGo so we can investigate and "
+"address the issue."
 msgstr ""
 
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -17811,6 +18258,87 @@ msgid ""
 "experience."
 msgstr ""
 
+#. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the counterarguments?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the hours & location?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key contributions of this paper?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key contributions?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key details?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key points covered in this video?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key points?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key takeaways from this article?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key takeaways?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key things I will learn from this course?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main counterarguments or criticisms of this?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main questions this page answers?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the must-try dishes here?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"What are the opening hours, location, and contact details for this place?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the pros and cons of this product?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the pros and cons?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
 msgctxt "feedback form"
 msgid "What bothered you most?"
@@ -17894,6 +18422,11 @@ msgctxt "Full sentence for defining a term"
 msgid "What does atria mean in the context of a medical article?"
 msgstr ""
 
+#. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What does this answer?"
+msgstr ""
+
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
@@ -17903,6 +18436,11 @@ msgstr ""
 msgctxt "cloudsave"
 msgid "What information gets saved?"
 msgstr "Hvaða upplýsingar eru vistaðar?"
+
+#. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What interview questions might come up for this role?"
+msgstr ""
 
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
@@ -17914,6 +18452,11 @@ msgstr ""
 #. Text for a prompt suggestion for looking up the capital city of Albania.
 msgctxt "Full sentence for looking up basic facts"
 msgid "What is the capital city of Albania?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What is the overall verdict and rating for this?"
 msgstr ""
 
 #. Link to a page with additional information.
@@ -17934,6 +18477,11 @@ msgctxt "maps_places"
 msgid "What people say:"
 msgstr ""
 
+#. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What should I order?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
 msgctxt "feedback form"
 msgid "What stood out?"
@@ -17942,6 +18490,16 @@ msgstr ""
 #. Question on a feedback form for a negative feedback response.
 msgctxt "feedback form"
 msgid "What was wrong with the response? (optional)"
+msgstr ""
+
+#. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I learn?"
+msgstr ""
+
+#. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I need?"
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -17956,6 +18514,11 @@ msgstr ""
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
 msgctxt "SERP footer content"
 msgid "What's New"
+msgstr ""
+
+#. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What's the verdict?"
 msgstr ""
 
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -17997,6 +18560,11 @@ msgctxt "Feedback prompt"
 msgid "Which features are missing? (Optional)"
 msgstr ""
 
+#. An invitation for users to leave feedback
+msgctxt "Feedback prompt"
+msgid "Which features are missing? (optional)"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
 msgid "White"
 msgstr "Hvítt"
@@ -18008,6 +18576,16 @@ msgstr "Hvítt"
 
 #. Link to an about us page.
 msgid "Who We Are"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Who are the main cast and crew, and what else are they known for?"
+msgstr ""
+
+#. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Who is this person?"
 msgstr ""
 
 #. Header above a collection of privacy-related links.

--- a/locales/it_IT/LC_MESSAGES/duckduckgo.po
+++ b/locales/it_IT/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: it_IT\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -489,8 +489,7 @@ msgstr ""
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "%sLong-press%s the DuckDuckGo app icon on the home screen"
-msgstr ""
-"%1$sPremi a lungo%2$s l'icona dell'app DuckDuckGo nella schermata principale"
+msgstr "%1$sPremi a lungo%2$s l'icona dell'app DuckDuckGo nella schermata principale"
 
 # smartling.placeholder_format=C
 #. A message displayed when there is an error loading content or no results on requery
@@ -815,8 +814,7 @@ msgstr "Limite di utilizzo di 6 ore raggiunto."
 #. Displayed when the user has reached a fixed 6-hour Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "6-hour usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Limite di utilizzo di 6 ore raggiunto. Puoi continuare questa chat dopo %1$s."
+msgstr "Limite di utilizzo di 6 ore raggiunto. Puoi continuare questa chat dopo %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable 6-hour Duck.ai usage limit and can opt in to continue using the daily limit.
@@ -939,8 +937,8 @@ msgstr ""
 "AI Chat consente di conversare in modo anonimo con modelli di chat di terze "
 "parti dotati di intelligenza artificiale. Disattivando questa funzione, AI "
 "Chat verrà nascosta su DuckDuckGo Search. È comunque possibile accedervi "
-"anche quando questa impostazione è disattivata visitando %1$sduckduckgo.com/"
-"aichat%2$s."
+"anche quando questa impostazione è disattivata visitando "
+"%1$sduckduckgo.com/aichat%2$s."
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -1011,8 +1009,7 @@ msgstr ""
 #. A message that confirms the user has turned off AI features and will no longer see AI-assisted answers.
 msgctxt "duckassist"
 msgid "AI-assisted answers have been turned off!"
-msgstr ""
-"Le risposte assistite dall'intelligenza artificiale sono state disattivate!"
+msgstr "Le risposte assistite dall'intelligenza artificiale sono state disattivate!"
 
 # smartling.placeholder_format=C
 #. Negative feedback suggestion for when user dislikes AI-generated content
@@ -1360,8 +1357,7 @@ msgstr "Aggiungi una casella di ricerca di %1$s al tuo sito!"
 #. Prompt to add locations on a map in order to get directions.
 msgctxt "directions"
 msgid "Add a starting point and destination to find a route."
-msgstr ""
-"Aggiungi un punto di partenza e una destinazione per trovare un percorso."
+msgstr "Aggiungi un punto di partenza e una destinazione per trovare un percorso."
 
 # smartling.placeholder_format=C
 #. Label on the AI model card indicating the model supports file uploads.
@@ -1451,7 +1447,7 @@ msgstr "L'indirizzo non è corretto"
 #. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Adjust the servings"
-msgstr ""
+msgstr "Regola le porzioni"
 
 # smartling.placeholder_format=C
 #. as in multiple advertisements
@@ -1673,6 +1669,9 @@ msgid ""
 "All chats are anonymized by DuckDuckGo, and your conversations are not used "
 "to train chat models by DuckDuckGo or the model providers"
 msgstr ""
+"Tutte le chat sono rese anonime da DuckDuckGo e le tue conversazioni non "
+"vengono utilizzate per addestrare modelli di chat da DuckDuckGo o dai "
+"fornitori dei modelli"
 
 # smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1765,8 +1764,7 @@ msgstr "Consenti annunci che rispettano la privacy"
 # smartling.placeholder_format=C
 #. Title in a dialog informing the user how to disable their ad blocker for DuckDuckGo
 msgid "Allow privacy-respecting ads on DuckDuckGo Private Search"
-msgstr ""
-"Consenti annunci che rispettano la privacy su Private Search DuckDuckGo"
+msgstr "Consenti annunci che rispettano la privacy su Private Search DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Description explaining privacy implications of enabling web search on encrypted models. The first two placeholders are the full model name (e.g. 'gpt-oss 120B'). The third and fourth placeholders wrap a clickable link reading 'zero provider visibility' that opens the privacy modal, please keep those around the link text in your translation. An example full sentence would be: Allows gpt-oss 120B to search the web to improve responses to relevant prompts. Only sends AI-generated queries to a search engine with limited data retention. Prompts and responses with gpt-oss 120B still have zero provider visibility.
@@ -1951,6 +1949,9 @@ msgid ""
 "Anonymously generates answers for search queries based on web content. "
 "Choose how often you want it to appear, or disable it completely."
 msgstr ""
+"Genera in modo anonimo risposte per le query di ricerca basate su contenuti "
+"web. Scegli la frequenza con cui vuoi che la funzione appaia, oppure "
+"disabilitala completamente."
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -2239,7 +2240,7 @@ msgstr "Chiedi un follow-up con Duck.ai"
 #. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
 msgctxt "Page suggestion chip label"
 msgid "Ask about this page"
-msgstr ""
+msgstr "Chiedi informazioni su questa pagina"
 
 # smartling.placeholder_format=C
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2411,15 +2412,13 @@ msgstr "Audio"
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat ends."
-msgstr ""
-"L'audio non viene memorizzato né da noi né da OpenAI dopo la fine della chat."
+msgstr "L'audio non viene memorizzato né da noi né da OpenAI dopo la fine della chat."
 
 # smartling.placeholder_format=C
 #. Description in consent disclaimer informing that audio from the voice chat session is not stored by us or by OpenAI after the voice chat ends.
 msgctxt "voice chat"
 msgid "Audio is not stored by us or by OpenAI after the chat ends."
-msgstr ""
-"L'audio non viene memorizzato né da noi né da OpenAI dopo la fine della chat."
+msgstr "L'audio non viene memorizzato né da noi né da OpenAI dopo la fine della chat."
 
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
@@ -2668,7 +2667,7 @@ msgstr "Codice a barre"
 #. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Based on this page, is this course worth taking?"
-msgstr ""
+msgstr "In base a questa pagina, vale la pena seguire questo corso?"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2717,6 +2716,9 @@ msgid ""
 "Before storing this report, DuckDuckGo will anonymize your conversation by "
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
+"Prima di archiviare questo rapporto, DuckDuckGo renderà anonima la tua "
+"conversazione eliminando le informazioni personali, come nomi, indirizzi "
+"e-mail e metadati identificativi."
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -2842,14 +2844,12 @@ msgstr "Blocca il sistema di tracciamento e-mail e nascondi il tuo indirizzo."
 # smartling.placeholder_format=C
 #. A disclaimer about AI-generated images in search results
 msgid "Block list is not exhaustive and may contain inaccuracies."
-msgstr ""
-"L'elenco dei blocchi non è esaustivo e potrebbe contenere imprecisioni."
+msgstr "L'elenco dei blocchi non è esaustivo e potrebbe contenere imprecisioni."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Block most trackers as you browse."
-msgstr ""
-"Blocca la maggior parte dei sistemi di tracciamento durante la navigazione."
+msgstr "Blocca la maggior parte dei sistemi di tracciamento durante la navigazione."
 
 # smartling.placeholder_format=C
 #. Menu option to block a site from the displayed results
@@ -3042,7 +3042,7 @@ msgstr "Break point vinti"
 #. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Break this down into clear, numbered steps."
-msgstr ""
+msgstr "Suddividilo in passaggi chiari e numerati."
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -3505,7 +3505,7 @@ msgstr "Cast"
 #. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Cast & Crew"
-msgstr ""
+msgstr "Cast e troupe"
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -4455,8 +4455,7 @@ msgstr "Clicca sulla %1$slente di ingrandimento%2$s nella barra di ricerca"
 # smartling.placeholder_format=C
 #. Tells users what icon to click in their browser to change their default search engine.
 msgid "Click on the magnifying glass in the search box at the top right"
-msgstr ""
-"Clicca sulla lente di ingrandimento nella casella di ricerca in alto a destra"
+msgstr "Clicca sulla lente di ingrandimento nella casella di ricerca in alto a destra"
 
 # smartling.placeholder_format=C
 #. Tells users where to click in order to disable the cloud save feature and delete any data backed-up to the cloud.
@@ -4509,21 +4508,18 @@ msgstr "Clicca sui %1$spuntini di sospensione%2$s nella barra degli strumenti."
 #. Tells users where to click in their browser to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Click the %slock icon%s on the address bar."
-msgstr ""
-"Clicca sull'%1$sicona di blocco%2$s presente nella barra degli indirizzi."
+msgstr "Clicca sull'%1$sicona di blocco%2$s presente nella barra degli indirizzi."
 
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Click the %spermissions icon%s in the address bar"
-msgstr ""
-"Clicca sull'%1$sicona delle autorizzazioni%2$s nella barra degli indirizzi"
+msgstr "Clicca sull'%1$sicona delle autorizzazioni%2$s nella barra degli indirizzi"
 
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to search using DuckDuckGo.
 msgid "Click the Duck icon at the top of your browser to search!"
-msgstr ""
-"Clicca sull'icona dell'anatra in alto nel browser per effettuare una ricerca!"
+msgstr "Clicca sull'icona dell'anatra in alto nel browser per effettuare una ricerca!"
 
 #  UC Browser on Android
 # smartling.placeholder_format=C
@@ -5113,8 +5109,7 @@ msgstr "Copia"
 # smartling.placeholder_format=C
 #. Instructions on how to change the default search engine
 msgid "Copy &amp; paste %sabout:preferences#search%s into the address bar"
-msgstr ""
-"Copia e incolla %1$sabout:preferences#search%2$s nella barra degli indirizzi"
+msgstr "Copia e incolla %1$sabout:preferences#search%2$s nella barra degli indirizzi"
 
 # smartling.placeholder_format=C
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
@@ -5184,8 +5179,7 @@ msgstr "Costa Rica"
 #. Inline error shown on the recovery code screen when exportSyncSettings rejects.
 msgctxt "Error message when the recovery code fails to generate"
 msgid "Couldn't load your recovery code. Please close this and try again."
-msgstr ""
-"Impossibile caricare il codice di recupero. Chiudi questa finestra e riprova."
+msgstr "Impossibile caricare il codice di recupero. Chiudi questa finestra e riprova."
 
 # smartling.placeholder_format=C
 #. Pairs with a Retry button. Shown after two consecutive failed attempts to load the device list.
@@ -5234,7 +5228,7 @@ msgstr "Crea immagine"
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
-msgstr ""
+msgstr "Crea una lista della spesa con le quantità di questa ricetta."
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed in the input field when starting a new image generation session.
@@ -5883,7 +5877,7 @@ msgstr "Limite di dettatura raggiunto"
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
 msgid "Dictation temporarily unavailable"
-msgstr ""
+msgstr "Dettatura temporaneamente non disponibile"
 
 # smartling.placeholder_format=C
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
@@ -6192,6 +6186,8 @@ msgid ""
 "Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
 "filtered out. %sLearn More%s"
 msgstr ""
+"Non vuoi l’AI? %1$snoai.duckduckgo.com%2$s non offre funzionalità AI e "
+"filtra le immagini AI. %3$sScopri di più%4$s"
 
 # smartling.placeholder_format=C
 #. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
@@ -6200,6 +6196,8 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
+"Non vuoi l'AI? Visita %1$snoai.duckduckgo.com%2$s per cercare senza "
+"funzionalità AI e con le immagini AI filtrate. %3$sUlteriori informazioni%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6319,13 +6317,13 @@ msgstr ""
 #. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Draft a cover letter"
-msgstr ""
+msgstr "Scrivi una lettera di presentazione"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Draft a cover letter for this job."
-msgstr ""
+msgstr "Scrivi una lettera di presentazione per questo lavoro."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -6511,6 +6509,9 @@ msgid ""
 "company for anyone who wants to take back control of their personal "
 "information."
 msgstr ""
+"Duck.ai è creato da DuckDuckGo. Siamo un'azienda indipendente di protezione "
+"online per chiunque voglia riprendere il controllo delle proprie "
+"informazioni personali."
 
 # smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
@@ -6541,8 +6542,8 @@ msgid ""
 "Duck.ai is temporarily unavailable. If this persists, please email this "
 "anonymous code %s to %s"
 msgstr ""
-"Duck.ai non è al momento disponibile. Se il problema persiste, invia un'e-"
-"mail con il codice anonimo %1$s a %2$s"
+"Duck.ai non è al momento disponibile. Se il problema persiste, invia "
+"un'e-mail con il codice anonimo %1$s a %2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -6563,6 +6564,9 @@ msgid ""
 "Duck.ai lets you chat privately with popular AI models. Disabling it hides "
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
+"Duck.ai ti consente di chattare privatamente con i più diffusi modelli di "
+"AI. Disattivandola, i pulsanti e i link di Duck.ai saranno nascosti, ma puoi "
+"comunque visitare %1$sduck.ai%2$s direttamente."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6626,8 +6630,7 @@ msgstr "Duck.ai è stato aggiornato!"
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
-msgstr ""
-"Duck.ai funziona al meglio nella nostra app DuckDuckGo, privata e gratuita!"
+msgstr "Duck.ai funziona al meglio nella nostra app DuckDuckGo, privata e gratuita!"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -7427,8 +7430,7 @@ msgstr ""
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location Services' is %senabled%s."
-msgstr ""
-"Assicurati che l'opzione \"Servizi di localizzazione\" sia %1$sattivata%2$s."
+msgstr "Assicurati che l'opzione \"Servizi di localizzazione\" sia %1$sattivata%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
@@ -7480,15 +7482,13 @@ msgstr ""
 #. Tells how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed location access"
-msgstr ""
-"Assicurati che il tuo browser sia autorizzato ad accedere alla posizione"
+msgstr "Assicurati che il tuo browser sia autorizzato ad accedere alla posizione"
 
 # smartling.placeholder_format=C
 #. Tells how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed location access."
-msgstr ""
-"Assicurati che il tuo browser sia autorizzato ad accedere alla posizione."
+msgstr "Assicurati che il tuo browser sia autorizzato ad accedere alla posizione."
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -7588,13 +7588,13 @@ msgstr "Eritrea"
 #. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Estimate the nutrition"
-msgstr ""
+msgstr "Stima i valori nutrizionali"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Estimate the nutritional information for this recipe."
-msgstr ""
+msgstr "Stima le informazioni nutrizionali per questa ricetta."
 
 # smartling.placeholder_format=C
 msgid "Estonia"
@@ -7656,7 +7656,7 @@ msgstr "Scade tra 1 giorno"
 #. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain the accepted answer in simple terms."
-msgstr ""
+msgstr "Spiega la risposta accettata in termini semplici."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
@@ -7671,43 +7671,43 @@ msgstr ""
 #. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain the top answer"
-msgstr ""
+msgstr "Spiega la risposta principale"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain this in simple, plain language."
-msgstr ""
+msgstr "Spiega questo concetto in modo semplice e chiaro."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain this paper"
-msgstr ""
+msgstr "Spiega questo documento"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain this repo"
-msgstr ""
+msgstr "Spiega questo repository"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain this research paper in plain language."
-msgstr ""
+msgstr "Spiega questo articolo di ricerca in un linguaggio semplice."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain this simply"
-msgstr ""
+msgstr "Spiegalo in modo semplice"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain what this repository does and how to use it."
-msgstr ""
+msgstr "Spiega cosa fa questo repository e come utilizzarlo."
 
 # smartling.placeholder_format=C
 #. Label to show if song lyrics contain explicit content
@@ -7731,8 +7731,7 @@ msgstr "Testi espliciti"
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
-msgstr ""
-"Esplora gli ultimi aggiornamenti di prodotti e funzionalità di DuckDuckGo."
+msgstr "Esplora gli ultimi aggiornamenti di prodotti e funzionalità di DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Links to a page that provides a list of DuckDuckGo product updates
@@ -8001,6 +8000,8 @@ msgctxt "settings"
 msgid ""
 "Filters out known AI spam sites from image search results. %sLearn More%s"
 msgstr ""
+"Filtra i siti di spam AI noti dai risultati di ricerca delle immagini. "
+"%1$sUlteriori informazioni%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the final score of a sporting event.
@@ -8061,7 +8062,7 @@ msgstr "Trova informazioni correnti"
 #. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Find me alternatives"
-msgstr ""
+msgstr "Trova alternative"
 
 # smartling.placeholder_format=C
 #. Button that searches for results closer to the user's current location.
@@ -8288,8 +8289,7 @@ msgstr "Condivisione e uso commerciale gratuiti"
 #. Description text explaining how to free up sync storage. Pinned chats are chats the user has explicitly marked to keep.
 msgctxt "Sync limit modal description"
 msgid "Free up space by deleting your chats. Pinned chats will not be deleted."
-msgstr ""
-"Libera spazio eliminando le chat. Le chat fissate non verranno eliminate."
+msgstr "Libera spazio eliminando le chat. Le chat fissate non verranno eliminate."
 
 # smartling.placeholder_format=C
 #. Indicates that this streaming service is free to watch but shows ads
@@ -8543,7 +8543,7 @@ msgstr "Genera altro"
 #. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Generate a shopping list"
-msgstr ""
+msgstr "Genera una lista della spesa"
 
 # smartling.placeholder_format=C
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
@@ -8708,8 +8708,7 @@ msgstr "Iniziamo"
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the Privacy Pro subscription.
 msgctxt "SERP footer content"
 msgid "Get a VPN + two more protections in one easy subscription."
-msgstr ""
-"Ottieni una VPN + altre due protezioni in un unico semplice abbonamento."
+msgstr "Ottieni una VPN + altre due protezioni in un unico semplice abbonamento."
 
 # smartling.placeholder_format=C
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
@@ -8841,7 +8840,7 @@ msgstr "Prova"
 #. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Give me a quick background on this person."
-msgstr ""
+msgstr "Dammi alcune informazioni su questa persona."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9112,8 +9111,7 @@ msgstr "Guatemala"
 #. Text for a prompt suggestion for guiding through the basic steps of replacing a window wiper.
 msgctxt "Full sentence for learning a new skill"
 msgid "Guide me through the basic steps of replacing a window wiper."
-msgstr ""
-"Indicami i passaggi fondamentali per la sostituzione di un tergicristallo."
+msgstr "Indicami i passaggi fondamentali per la sostituzione di un tergicristallo."
 
 # smartling.placeholder_format=C
 msgid "Guinea"
@@ -9295,13 +9293,13 @@ msgstr "Aiutaci a diffondere la privacy"
 #. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Help me prep for the interview"
-msgstr ""
+msgstr "Aiutami a prepararmi per il colloquio"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Help me tailor my resume for this job."
-msgstr ""
+msgstr "Aiutami ad adattare il mio curriculum per questo lavoro."
 
 # smartling.placeholder_format=C
 #. Title of a SERP popup that invites users to take a survey (desktop only)
@@ -9502,8 +9500,7 @@ msgstr "Nascondi il tuo indirizzo e-mail"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Hides search term from being shown in browser tab/history"
-msgstr ""
-"Nasconde i termini di ricerca dalla scheda e dalla cronologia del browser"
+msgstr "Nasconde i termini di ricerca dalla scheda e dalla cronologia del browser"
 
 # smartling.placeholder_format=C
 #. The highest stock price in a day
@@ -9747,8 +9744,7 @@ msgstr "Come funziona"
 #. Header for the assist settings modal where the user can choose how often they want AI-assisted answers to appear.
 msgctxt "duckassist"
 msgid "How much do you want AI-assisted answers to appear?"
-msgstr ""
-"Quanto vuoi che appaiano le risposte assistite dall'intelligenza artificiale?"
+msgstr "Quanto vuoi che appaiano le risposte assistite dall'intelligenza artificiale?"
 
 # smartling.placeholder_format=C
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
@@ -9828,7 +9824,7 @@ msgctxt ""
 "Text for the I already have a subscription button in the Duck.ai settings "
 "page"
 msgid "I Already Have a Subscription"
-msgstr ""
+msgstr "Ho già un abbonamento"
 
 # smartling.placeholder_format=C
 #. Text for the button that takes the user to the login subscription page.
@@ -9998,8 +9994,7 @@ msgstr ""
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
-msgstr ""
-"Se vuoi supportarci in altri modi, %1$saiuta a diffondere DuckDuckGo%2$s"
+msgstr "Se vuoi supportarci in altri modi, %1$saiuta a diffondere DuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -10202,8 +10197,7 @@ msgstr "Nel menu in alto seleziona %1$sStrumenti%2$s > %3$sImpostazioni%4$s"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "In the popup, check %sMake this my default search provider%s"
-msgstr ""
-"Nel popup, seleziona %1$sImposta come provider di ricerca predefinito%2$s"
+msgstr "Nel popup, seleziona %1$sImposta come provider di ricerca predefinito%2$s"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -10412,7 +10406,7 @@ msgstr "Installa il browser Mac"
 #. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
 msgctxt "settings"
 msgid "Install Now"
-msgstr ""
+msgstr "Installa ora"
 
 # smartling.placeholder_format=C
 #. Text of a button to install the DuckDuckGo app
@@ -10515,13 +10509,13 @@ msgstr "I dati cancellati vengono realmente eliminati?"
 #. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Is it worth taking?"
-msgstr ""
+msgstr "Vale la pena prenderlo?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Is this place any good?"
-msgstr ""
+msgstr "Com'è questo posto?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
@@ -10530,6 +10524,8 @@ msgid ""
 "Is this place any good? Summarize its reputation based on reviews and "
 "ratings."
 msgstr ""
+"Com'è questo posto? Riassumi la sua reputazione in base a recensioni e "
+"valutazioni."
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -10541,13 +10537,13 @@ msgstr "Questo video è utile?"
 #. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Is this worth watching?"
-msgstr ""
+msgstr "Vale la pena guardarlo?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Is this worth watching? Give me a spoiler-free take."
-msgstr ""
+msgstr "Vale la pena guardarlo? Dammi un parere senza spoiler."
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -11165,7 +11161,7 @@ msgstr "Link:"
 #. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
-msgstr ""
+msgstr "Elenca gli strumenti, i materiali o i prerequisiti che mi servono per questo."
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -11276,8 +11272,7 @@ msgstr "Carica altre immagini durante lo scorrimento"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Loads more results in Images, Videos, and Shopping when scrolling"
-msgstr ""
-"Carica altri risultati in Immagini, Video e Shopping durante lo scorrimento"
+msgstr "Carica altri risultati in Immagini, Video e Shopping durante lo scorrimento"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/WTkvs9I.png
@@ -11580,7 +11575,7 @@ msgstr "Gestisci siti bloccati"
 #. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
 msgctxt "setting"
 msgid "Manage in Browser Settings"
-msgstr ""
+msgstr "Gestisci nelle impostazioni del browser"
 
 # smartling.placeholder_format=C
 #. Link to the site exclusion settings page
@@ -12034,8 +12029,7 @@ msgstr "Limite mensile raggiunto"
 #. Displayed when the user has reached a fixed monthly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Monthly usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Limite di utilizzo mensile raggiunto. Puoi continuare questa chat dopo %1$s."
+msgstr "Limite di utilizzo mensile raggiunto. Puoi continuare questa chat dopo %1$s."
 
 # smartling.placeholder_format=C
 #. Used to point to additional social networking profiles (in results).
@@ -12896,15 +12890,13 @@ msgstr "Nessun sistema di tracciamento bloccato nell'ultima ora"
 #. Refers to how web searches on DuckDuckGo aren't tracked.
 msgctxt "homepage onboarding"
 msgid "No tracking, no ad targeting, just searching!"
-msgstr ""
-"Nessun tracciamento, nessuna pubblicità mirata, solo semplici ricerche!"
+msgstr "Nessun tracciamento, nessuna pubblicità mirata, solo semplici ricerche!"
 
 # smartling.placeholder_format=C
 #. Refers to how web searches on DuckDuckGo aren't tracked.
 msgctxt "homepage onboarding"
 msgid "No tracking, no ad targeting, just searching."
-msgstr ""
-"Nessun tracciamento, nessuna pubblicità mirata, solo semplici ricerche."
+msgstr "Nessun tracciamento, nessuna pubblicità mirata, solo semplici ricerche."
 
 # smartling.placeholder_format=C
 #. Indicates that there were no search results for a user's search. The placeholder is the user's search term. For example: 'No videos found for 'bad dogs''
@@ -14428,14 +14420,13 @@ msgstr ""
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is harmful or illegal. (optional)"
-msgstr ""
+msgstr "Descrivi perché la risposta nella chat è dannosa o illegale. (facoltativo)"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
-msgstr ""
-"Descrivi perché la risposta nella chat è illegale o dannosa. (Opzionale)"
+msgstr "Descrivi perché la risposta nella chat è illegale o dannosa. (Opzionale)"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to enter their passphrase.
@@ -14466,6 +14457,8 @@ msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is harmful or illegal."
 msgstr ""
+"Incolla il prompt e l'output problematico (con qualsiasi informazione "
+"personale rimossa) e descrivi perché il contenuto è dannoso o illegale."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -14938,7 +14931,7 @@ msgstr "Privacy"
 #. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
 msgctxt "Section heading on the Duck.ai settings page"
 msgid "Privacy & Terms"
-msgstr ""
+msgstr "Privacy e termini"
 
 # smartling.placeholder_format=C
 msgid "Privacy Blog"
@@ -15014,7 +15007,7 @@ msgstr "Privacy policy e Termini del servizio"
 #. Text for a button that links to the terms of use and privacy policy page.
 msgctxt "Secondary button text in active privacy modal"
 msgid "Privacy Policy and Terms of Service"
-msgstr ""
+msgstr "Privacy policy e Termini del servizio"
 
 # smartling.placeholder_format=C
 #. Title displayed on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
@@ -15208,8 +15201,7 @@ msgstr "Proteggi i tuoi dati durante le ricerche e la navigazione."
 #. Shown on the Mac and Windows browser promo cards. DuckDuckGo's desktop browser protects your data across search, browsing, and AI chat.
 msgctxt "SERP footer content"
 msgid "Protect your data as you search, browse, and use AI."
-msgstr ""
-"Proteggi i tuoi dati durante le ricerche, la navigazione e l'uso dell'AI."
+msgstr "Proteggi i tuoi dati durante le ricerche, la navigazione e l'uso dell'AI."
 
 # smartling.placeholder_format=C
 #. A title above links to download the DuckDuckGo apps.
@@ -15463,8 +15455,7 @@ msgstr "Schede recenti"
 #. Text explaining that this feature can be adjusted in the settings. Placeholder is for adding a link to 'Settings'. Example: 'Recent chat storage can be adjusted in Settings.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "Recent chat storage can be adjusted in %s."
-msgstr ""
-"Lo spazio di archiviazione delle chat recenti può essere regolato in %1$s."
+msgstr "Lo spazio di archiviazione delle chat recenti può essere regolato in %1$s."
 
 # smartling.placeholder_format=C
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -15524,25 +15515,25 @@ msgstr "Consiglia un libro"
 #. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Recommend similar books"
-msgstr ""
+msgstr "Consiglia libri simili"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Recommend similar books."
-msgstr ""
+msgstr "Consiglia libri simili."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Recommend similar movies or shows."
-msgstr ""
+msgstr "Consiglia film o programmi simili."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Recommend similar titles"
-msgstr ""
+msgstr "Consiglia titoli simili"
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
@@ -15757,8 +15748,8 @@ msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
 msgstr ""
-"Ricarica DuckDuckGo seguendo le istruzioni o facendo clic sul pulsante &quot;"
-"Aggiorna&quot; o &quot;Ricarica&quot; del browser."
+"Ricarica DuckDuckGo seguendo le istruzioni o facendo clic sul pulsante "
+"&quot;Aggiorna&quot; o &quot;Ricarica&quot; del browser."
 
 # smartling.placeholder_format=C
 #. checkbox label that allows the user to save the setting
@@ -15775,8 +15766,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
 msgid "Remember my choice (this can be changed in %sSettings%s)"
-msgstr ""
-"Ricorda la mia scelta (può essere modificata nelle %1$sImpostazioni%2$s)"
+msgstr "Ricorda la mia scelta (può essere modificata nelle %1$sImpostazioni%2$s)"
 
 # smartling.placeholder_format=C
 #. Button to be reminded later to update, shown in a banner that appears in Duck.ai when a subscribed user is using an old version of the DuckDuckGo browser.
@@ -15956,7 +15946,7 @@ msgctxt ""
 "feedback form when the user has selected Harmful or Illegal as the feedback "
 "reason"
 msgid "Required for harmful or illegal reports"
-msgstr ""
+msgstr "Obbligatorio per le segnalazioni di contenuti dannosi o illegali"
 
 # smartling.placeholder_format=C
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
@@ -16199,7 +16189,7 @@ msgstr "Recensioni"
 #. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Rewrite this recipe scaled for a different number of servings."
-msgstr ""
+msgstr "Riscrivi questa ricetta adattandola a un numero diverso di porzioni."
 
 # smartling.placeholder_format=C
 msgid "Romania"
@@ -16488,8 +16478,8 @@ msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
 msgstr ""
-"Salva le tue chat di Duck.ai tra i tuoi dispositivi con crittografia end-to-"
-"end."
+"Salva le tue chat di Duck.ai tra i tuoi dispositivi con crittografia "
+"end-to-end."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -16989,8 +16979,7 @@ msgstr "Settimane della stagione"
 #. Description shown in the Sync & Backup settings section when sync is not yet enabled, explaining the feature.
 msgctxt "Description for sync and backup feature"
 msgid "Securely save and sync your chats across all your devices."
-msgstr ""
-"Salva e sincronizza in modo sicuro le tue chat su tutti i tuoi dispositivi."
+msgstr "Salva e sincronizza in modo sicuro le tue chat su tutti i tuoi dispositivi."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17040,8 +17029,8 @@ msgstr ""
 msgctxt "Sync feature benefit description"
 msgid "Securely stored on DuckDuckGo's server with end-to-end encryption."
 msgstr ""
-"Archiviati in modo sicuro sul server di DuckDuckGo con crittografia end-to-"
-"end."
+"Archiviati in modo sicuro sul server di DuckDuckGo con crittografia "
+"end-to-end."
 
 # smartling.placeholder_format=C
 #. List item explaining that synced chats are stored with end-to-end encryption on DuckDuckGo's server and only the user can access them.
@@ -17050,8 +17039,8 @@ msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
 msgstr ""
-"Archiviati in modo sicuro sul server di DuckDuckGo con crittografia end-to-"
-"end. Nessuno tranne te può vedere i tuoi dati, nemmeno noi."
+"Archiviati in modo sicuro sul server di DuckDuckGo con crittografia "
+"end-to-end. Nessuno tranne te può vedere i tuoi dati, nemmeno noi."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -17200,27 +17189,24 @@ msgstr ""
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
 msgstr ""
-"Scegli %1$sPersonalizzata%2$s e digita nel campo %3$shttps://duckduckgo."
-"com%4$s"
+"Scegli %1$sPersonalizzata%2$s e digita nel campo "
+"%3$shttps://duckduckgo.com%4$s"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
-msgstr ""
-"Seleziona %1$sDuckDuckGo%2$s e clicca su %3$sAggiungi come predefinito%4$s!"
+msgstr "Seleziona %1$sDuckDuckGo%2$s e clicca su %3$sAggiungi come predefinito%4$s!"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s"
-msgstr ""
-"Seleziona %1$sDuckDuckGo%2$s e clicca su %3$sImposta come predefinito%4$s"
+msgstr "Seleziona %1$sDuckDuckGo%2$s e clicca su %3$sImposta come predefinito%4$s"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s."
-msgstr ""
-"Seleziona %1$sDuckDuckGo%2$s e clicca su %3$sImposta come predefinito%4$s."
+msgstr "Seleziona %1$sDuckDuckGo%2$s e clicca su %3$sImposta come predefinito%4$s."
 
 #  Firefox 33
 # smartling.placeholder_format=C
@@ -17335,8 +17321,7 @@ msgstr "Seleziona %1$sImpostazioni%2$s, poi %3$sImpostazioni avanzate%4$s"
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sDefault search engine%s"
-msgstr ""
-"Seleziona %1$sImpostazioni%2$s, poi %3$sMotore di ricerca predefinito%4$s"
+msgstr "Seleziona %1$sImpostazioni%2$s, poi %3$sMotore di ricerca predefinito%4$s"
 
 #  Chrome/Firefox on Android
 # smartling.placeholder_format=C
@@ -17432,8 +17417,7 @@ msgstr "Testo selezionato da %1$s"
 #. Displayed when the user's text selection exceeds the maximum message size for AI tools (summary, translation, etc.).
 msgctxt "Error message for selection input limit"
 msgid "Selected text is too long. Try again with a shorter selection."
-msgstr ""
-"Il testo selezionato è troppo lungo. Riprova con una selezione più breve."
+msgstr "Il testo selezionato è troppo lungo. Riprova con una selezione più breve."
 
 # smartling.placeholder_format=C
 #. Label for the semi-finals knockout stage in e.g. the soccer World Cup
@@ -17558,7 +17542,7 @@ msgstr "Configura ora"
 #. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
 msgctxt "Encrypted storage setup button shown in native browsers"
 msgid "Set Up Sync & Backup"
-msgstr ""
+msgstr "Configura Sync & Backup"
 
 # smartling.placeholder_format=C
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
@@ -17748,7 +17732,7 @@ msgstr "Condividi feedback positivo"
 msgctxt ""
 "Label beside the share-content switch on the Duck.ai response feedback form"
 msgid "Share this conversation with DuckDuckGo"
-msgstr ""
+msgstr "Condividi questa conversazione con DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -18132,14 +18116,12 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows horizontal lines at result page breaks"
-msgstr ""
-"Mostra linee orizzontali a ogni interruzione della pagina dei risultati"
+msgstr "Mostra linee orizzontali a ogni interruzione della pagina dei risultati"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows links to instructions for how to add DuckDuckGo to your browser"
-msgstr ""
-"Mostra link per le istruzioni su come aggiungere DuckDuckGo al tuo browser"
+msgstr "Mostra link per le istruzioni su come aggiungere DuckDuckGo al tuo browser"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers more frequently.
@@ -18160,8 +18142,7 @@ msgstr "Mostra promemoria occasionali per aggiungere DuckDuckGo al tuo browser"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr ""
-"Mostra promemoria occasionali per aggiungere DuckDuckGo ai tuoi dispositivi"
+msgstr "Mostra promemoria occasionali per aggiungere DuckDuckGo ai tuoi dispositivi"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18290,8 +18271,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Sites you block will be hidden from all your search results"
-msgstr ""
-"I siti che blocchi saranno nascosti da tutti i tuoi risultati di ricerca"
+msgstr "I siti che blocchi saranno nascosti da tutti i tuoi risultati di ricerca"
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes full name (tooltip)
@@ -18436,8 +18416,7 @@ msgstr "Qualcosa è andato storto durante il salvataggio nel server, riprova."
 #. Body copy displayed under the Set Up Now button when the sync setup call fails.
 msgctxt "Generic error shown when sync setup fails"
 msgid "Something went wrong while enabling Sync & Backup. Please try again."
-msgstr ""
-"Si è verificato un problema durante l'attivazione di Sync & Backup. Riprova."
+msgstr "Si è verificato un problema durante l'attivazione di Sync & Backup. Riprova."
 
 # smartling.placeholder_format=C
 #. Displayed when the voice chat session ends with an unknown error.
@@ -18461,8 +18440,7 @@ msgstr "A volte"
 #. Generic error message shown when the image generation model cannot process the user's request.
 msgctxt "Error message from the image generation model"
 msgid "Sorry I can't help, please describe your image in a different way."
-msgstr ""
-"Mi dispiace, non posso aiutarti. Descrivi la tua immagine in un modo diverso."
+msgstr "Mi dispiace, non posso aiutarti. Descrivi la tua immagine in un modo diverso."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -18538,8 +18516,7 @@ msgstr ""
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr ""
-"Spiacenti, non siamo riusciti a inviare il tuo feedback. Riprova più tardi."
+msgstr "Spiacenti, non siamo riusciti a inviare il tuo feedback. Riprova più tardi."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -18846,8 +18823,7 @@ msgstr "Interrompi la generazione"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop hidden trackers lurking on other websites."
-msgstr ""
-"Impedisci ai sistemi di tracciamento nascosti di apparire su altri siti."
+msgstr "Impedisci ai sistemi di tracciamento nascosti di apparire su altri siti."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -19027,19 +19003,19 @@ msgstr "Suggerisci un titolo per un post del blog"
 #. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Suggest related articles or topics worth exploring next."
-msgstr ""
+msgstr "Suggerisci articoli o argomenti correlati da esplorare in seguito."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Suggest related articles to explore"
-msgstr ""
+msgstr "Suggerisci articoli correlati da esplorare"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Suggest some alternatives to this product."
-msgstr ""
+msgstr "Suggerisci alcune alternative a questo prodotto."
 
 # smartling.placeholder_format=C
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
@@ -19056,7 +19032,7 @@ msgstr "Suggerimenti:"
 #. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Sum up the reviews"
-msgstr ""
+msgstr "Riassumi le recensioni"
 
 # smartling.placeholder_format=C
 #. A short title for the a message asking the AI to summarize a text.
@@ -19068,85 +19044,85 @@ msgstr "Riassumi"
 #. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize the Q&As"
-msgstr ""
+msgstr "Riassumi le domande e risposte"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the background and notable work of this person."
-msgstr ""
+msgstr "Riassumi il background e il lavoro più rilevante di questa persona."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the key details of this event."
-msgstr ""
+msgstr "Riassumi i dettagli principali di questo evento."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the questions and answers on this page."
-msgstr ""
+msgstr "Riassumi le domande e le risposte presenti in questa pagina."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize their background"
-msgstr ""
+msgstr "Riassumi il suo profilo"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this book"
-msgstr ""
+msgstr "Riassumi questo libro"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this book."
-msgstr ""
+msgstr "Riassumi questo libro."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this discussion"
-msgstr ""
+msgstr "Riassumi questa discussione"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this discussion thread."
-msgstr ""
+msgstr "Riassumi questa discussione."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this page"
-msgstr ""
+msgstr "Riassumi questa pagina"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this page."
-msgstr ""
+msgstr "Riassumi questa pagina."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this video"
-msgstr ""
+msgstr "Riassumi questo video"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this video."
-msgstr ""
+msgstr "Riassumi questo video."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize what the reviews say."
-msgstr ""
+msgstr "Riassumi le opinioni nelle recensioni."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -19300,16 +19276,14 @@ msgstr "Passa a un modello più efficiente"
 # smartling.placeholder_format=C
 #. Text prompting  users to switch their current search engine to the DuckDuckGo private search engine.
 msgid "Switch to the search engine that doesn't track you. Ever."
-msgstr ""
-"Passa al motore di ricerca che non raccoglie i tuoi dati di navigazione. Mai."
+msgstr "Passa al motore di ricerca che non raccoglie i tuoi dati di navigazione. Mai."
 
 # smartling.placeholder_format=C
 #. Warning text shown in the model switch dropdown when the user is currently using an encrypted model. Warns that the new model will not have zero provider visibility.
 msgctxt "AI Chat warning when switching from an encrypted model"
 msgid ""
 "Switching will send your chat to a model without zero provider visibility"
-msgstr ""
-"Il passaggio invierà la chat a un modello senza visibilità zero lato provider"
+msgstr "Il passaggio invierà la chat a un modello senza visibilità zero lato provider"
 
 # smartling.placeholder_format=C
 msgid "Switzerland"
@@ -19425,8 +19399,8 @@ msgstr ""
 "%1$s\n"
 "\n"
 "Come funziona il codice?\n"
-"1. Apri il browser e vai su Duck.ai, quindi apri le impostazioni di Duck."
-"ai.\n"
+"1. Apri il browser e vai su Duck.ai, quindi apri le impostazioni di "
+"Duck.ai.\n"
 "2. Seleziona \"Attiva Sync & Backup\", poi \"Recupera dati sincronizzati\"\n"
 "3. Copia il codice di recupero sopra e incollalo nello spazio \"Incolla qui "
 "il tuo codice\"\n"
@@ -19479,7 +19453,7 @@ msgstr "Siria"
 #. Text for a button that enables the theme to follow the operating system's color scheme preference.
 msgctxt "System theme button for theme selector"
 msgid "System"
-msgstr ""
+msgstr "Sistema"
 
 # smartling.placeholder_format=C
 #. Abbreviation indicating this is the total score for a game
@@ -19513,7 +19487,7 @@ msgstr "Tahitiano"
 #. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Tailor my resume"
-msgstr ""
+msgstr "Personalizza il mio curriculum"
 
 # smartling.placeholder_format=C
 msgid "Taiwan"
@@ -19550,6 +19524,8 @@ msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
+"Partecipa a questo sondaggio anonimo per farci sapere come possiamo "
+"migliorare Duck.ai."
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -19863,7 +19839,7 @@ msgstr "Tema"
 #. Text for the theme selector label that allows users to switch between Light and dark theme.
 msgctxt "Label for the theme selector feature"
 msgid "Theme"
-msgstr ""
+msgstr "Tema"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/LpFhb1e.png
@@ -20124,8 +20100,7 @@ msgstr "Questa immagine non può essere creata."
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF"
-msgstr ""
-"Questo tipo di immagine non è supportato, allega un file JPG, PNG, WebP o GIF"
+msgstr "Questo tipo di immagine non è supportato, allega un file JPG, PNG, WebP o GIF"
 
 # smartling.placeholder_format=C
 #. Error message displayed when a file that the user tried to upload is not of a supported format
@@ -20189,8 +20164,7 @@ msgstr "Questa pagina richiede Javascript per funzionare."
 #. Information tooltip text explaining that the current page's content will be included with the chat message.
 msgctxt "Tooltip explaining that page content will be sent to Duck.ai"
 msgid "This page's content will be sent with your message to Duck.ai"
-msgstr ""
-"Il contenuto di questa pagina verrà inviato con il tuo messaggio a Duck.ai"
+msgstr "Il contenuto di questa pagina verrà inviato con il tuo messaggio a Duck.ai"
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -20647,8 +20621,7 @@ msgstr "Sistemi di tracciamento bloccati nell'ultima ora"
 #. Placeholder for when we cannot report any blocked trackers yet
 msgctxt "tracker_stats"
 msgid "Trackers that DuckDuckGo blocks will appear here"
-msgstr ""
-"I sistemi di tracciamento bloccati da DuckDuckGo vengono visualizzati qui"
+msgstr "I sistemi di tracciamento bloccati da DuckDuckGo vengono visualizzati qui"
 
 # smartling.placeholder_format=C
 #. Placeholder for when we cannot report any blocked trackers yet
@@ -20664,8 +20637,7 @@ msgstr ""
 #. Placeholder for when we cannot report any blocked trackers yet
 msgctxt "tracker_stats"
 msgid "Tracking attempts blocked by DuckDuckGo will appear here"
-msgstr ""
-"I tentativi di tracciamento bloccati da DuckDuckGo verranno visualizzati qui"
+msgstr "I tentativi di tracciamento bloccati da DuckDuckGo verranno visualizzati qui"
 
 # smartling.placeholder_format=C
 #. Tooltip and accessible label for the confirm (checkmark) button that stops recording and sends audio for transcription.
@@ -20724,13 +20696,13 @@ msgstr ""
 #. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Translate this page"
-msgstr ""
+msgstr "Traduci questa pagina"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
 msgctxt "Page suggestion prompt"
 msgid "Translate this page into %s."
-msgstr ""
+msgstr "Traduci questa pagina in %1$s."
 
 # smartling.placeholder_format=C
 #. Placeholder text for a region that will display translated text.
@@ -20877,7 +20849,7 @@ msgstr "Prova gratis"
 #. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
 msgctxt "settings"
 msgid "Try It Now"
-msgstr ""
+msgstr "Provalo ora"
 
 # smartling.placeholder_format=C
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -20950,8 +20922,7 @@ msgstr "Prova ad abilitare la posizione anonima per risultati più accurati."
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr ""
-"Prova a sperimentare con ogni modello: ciascuno fornirà risposte diverse."
+msgstr "Prova a sperimentare con ogni modello: ciascuno fornirà risposte diverse."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
@@ -21125,6 +21096,9 @@ msgid ""
 "Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
+"Stai provando a disabilitare le funzionalità AI? Installa l'estensione di "
+"ricerca %1$sDuckDuckGo senza AI%2$s per memorizzare le tue impostazioni. "
+"%3$sScopri di più%4$s"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -21133,6 +21107,9 @@ msgid ""
 "Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
+"Stai provando a disabilitare le funzionalità AI? Passa all'estensione di "
+"ricerca %1$sDuckDuckGo senza AI%2$s per salvare le impostazioni. %3$sScopri "
+"di più%4$s"
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -21444,8 +21421,8 @@ msgstr ""
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
 msgstr ""
-"In %1$sAll'avvio%2$s, seleziona %3$sPagina Iniziale%4$s e inserisci: https://"
-"duckduckgo.com"
+"In %1$sAll'avvio%2$s, seleziona %3$sPagina Iniziale%4$s e inserisci: "
+"https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -21474,8 +21451,8 @@ msgstr ""
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
 msgstr ""
-"Nella sezione %1$sRicerca%2$s, clicca su %3$sGestisci motori di ricerca..."
-"%4$s"
+"Nella sezione %1$sRicerca%2$s, clicca su %3$sGestisci motori di "
+"ricerca...%4$s"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -21489,8 +21466,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine
 msgid "Under Search click the drop down and select %sDuckDuckGo%s"
-msgstr ""
-"In \"Ricerca\" clicca sul menu a tendina e seleziona %1$sDuckDuckGo%2$s"
+msgstr "In \"Ricerca\" clicca sul menu a tendina e seleziona %1$sDuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings" header
@@ -21894,7 +21870,7 @@ msgstr "Uruguay"
 #. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
 msgctxt "Navigation label on the Duck.ai settings page"
 msgid "Usage"
-msgstr ""
+msgstr "Utilizzo"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -22125,8 +22101,7 @@ msgstr "Visualizza i prezzi per il tuo soggiorno"
 # smartling.placeholder_format=C
 #. A description for the ads tooltip that explains that viewing ads is privacy protected by DuckDuckGo.
 msgid "Viewing ads is privacy protected by DuckDuckGo."
-msgstr ""
-"La visualizzazione degli annunci è protetta dalla privacy di DuckDuckGo."
+msgstr "La visualizzazione degli annunci è protetta dalla privacy di DuckDuckGo."
 
 # smartling.placeholder_format=C
 msgctxt "Ads GDPR, internal use only. Do not change"
@@ -22350,7 +22325,7 @@ msgstr "Galles"
 #. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Walk me through the steps"
-msgstr ""
+msgstr "Guidami nei passaggi"
 
 # smartling.placeholder_format=C
 #. Label for walking directions on a map.
@@ -22481,6 +22456,9 @@ msgid ""
 "please share this conversation with DuckDuckGo so we can investigate and "
 "address the issue."
 msgstr ""
+"Possiamo risolvere solo ciò che possiamo vedere. Per segnalare una risposta "
+"dannosa o illegale, condividi questa conversazione con DuckDuckGo in modo "
+"che possiamo indagare e affrontare il problema."
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -22527,8 +22505,7 @@ msgstr "Non memorizziamo nomi utente né informazioni personali."
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don't store your personal info or track you. Ever."
-msgstr ""
-"Non memorizziamo le tue informazioni personali e non ti tracciamo. Mai."
+msgstr "Non memorizziamo le tue informazioni personali e non ti tracciamo. Mai."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -22676,8 +22653,7 @@ msgstr ""
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
-msgstr ""
-"Ci affidiamo alla tua opinione anonima per migliorare DuckDuckGo per tutti."
+msgstr "Ci affidiamo alla tua opinione anonima per migliorare DuckDuckGo per tutti."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -22904,8 +22880,7 @@ msgstr ""
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai! You can now import your downloaded chats."
-msgstr ""
-"Ti diamo il benvenuto al nuovo Duck.ai! Ora puoi importare le chat scaricate."
+msgstr "Ti diamo il benvenuto al nuovo Duck.ai! Ora puoi importare le chat scaricate."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -23046,98 +23021,98 @@ msgstr ""
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the counterarguments?"
-msgstr ""
+msgstr "Quali sono le controargomentazioni?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the hours & location?"
-msgstr ""
+msgstr "Quali sono gli orari e la posizione?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key contributions of this paper?"
-msgstr ""
+msgstr "Quali sono i contributi chiave di questo documento?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key contributions?"
-msgstr ""
+msgstr "Quali sono i contributi chiave?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key details?"
-msgstr ""
+msgstr "Quali sono i dettagli chiave?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key points covered in this video?"
-msgstr ""
+msgstr "Quali sono i punti chiave trattati in questo video?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key points?"
-msgstr ""
+msgstr "Quali sono i punti chiave?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key takeaways from this article?"
-msgstr ""
+msgstr "Quali sono i punti chiave di questo articolo?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key takeaways?"
-msgstr ""
+msgstr "Quali sono i punti chiave?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key things I will learn from this course?"
-msgstr ""
+msgstr "Quali sono le cose principali che imparerò da questo corso?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the main counterarguments or criticisms of this?"
-msgstr ""
+msgstr "Quali sono le principali obiezioni o critiche a questo?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the main questions this page answers?"
-msgstr ""
+msgstr "Quali sono le domande principali a cui risponde questa pagina?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the must-try dishes here?"
-msgstr ""
+msgstr "Quali sono i piatti da provare in questo caso?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid ""
 "What are the opening hours, location, and contact details for this place?"
-msgstr ""
+msgstr "Quali sono gli orari di apertura, la posizione e i recapiti di questo luogo?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the pros and cons of this product?"
-msgstr ""
+msgstr "Quali sono i pro e i contro di questo prodotto?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the pros and cons?"
-msgstr ""
+msgstr "Quali sono i pro e i contro?"
 
 # smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
@@ -23243,7 +23218,7 @@ msgstr "Cosa significa atri nel contesto di un articolo medico?"
 #. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What does this answer?"
-msgstr ""
+msgstr "A cosa risponde questo?"
 
 # smartling.placeholder_format=C
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
@@ -23261,7 +23236,7 @@ msgstr "Quali informazioni vengono salvate?"
 #. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What interview questions might come up for this role?"
-msgstr ""
+msgstr "Quali domande di colloquio potrebbero emergere per questo ruolo?"
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -23283,7 +23258,7 @@ msgstr "Qual è la capitale dell'Albania?"
 #. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What is the overall verdict and rating for this?"
-msgstr ""
+msgstr "Qual è il verdetto generale e la valutazione per questo?"
 
 # smartling.placeholder_format=C
 #. Link to a page with additional information.
@@ -23311,7 +23286,7 @@ msgstr "Opinioni:"
 #. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What should I order?"
-msgstr ""
+msgstr "Cosa dovrei ordinare?"
 
 # smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
@@ -23329,13 +23304,13 @@ msgstr "Cosa c'era di sbagliato nella risposta? (facoltativo)"
 #. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What will I learn?"
-msgstr ""
+msgstr "Cosa imparerò?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What will I need?"
-msgstr ""
+msgstr "Cosa mi serve?"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -23346,8 +23321,7 @@ msgstr "Su cosa vuoi dare un'opinione?"
 #. Explains the benefits of using our custom video player, the Duck Player
 msgid ""
 "What you watch in DuckDuckGo won't influence your recommendations on YouTube."
-msgstr ""
-"Ciò che guardi in DuckDuckGo non influenzerà i tuoi consigli su YouTube."
+msgstr "Ciò che guardi in DuckDuckGo non influenzerà i tuoi consigli su YouTube."
 
 # smartling.placeholder_format=C
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
@@ -23359,7 +23333,7 @@ msgstr "Novità"
 #. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What's the verdict?"
-msgstr ""
+msgstr "Qual è il verdetto?"
 
 # smartling.placeholder_format=C
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -23417,7 +23391,7 @@ msgstr "Quali funzionalità mancano? (Opzionale)"
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Which features are missing? (optional)"
-msgstr ""
+msgstr "Quali funzionalità mancano? (facoltativo)"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
@@ -23440,12 +23414,14 @@ msgstr "Chi siamo"
 msgctxt "Page suggestion prompt"
 msgid "Who are the main cast and crew, and what else are they known for?"
 msgstr ""
+"Chi sono i principali membri del cast e della troupe, e per cos'altro sono "
+"conosciuti?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Who is this person?"
-msgstr ""
+msgstr "Chi è questa persona?"
 
 # smartling.placeholder_format=C
 #. Header above a collection of privacy-related links.
@@ -23909,8 +23885,7 @@ msgstr ""
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
 msgctxt "Third party map app picker feedback dialog"
 msgid "You can change this any time in %sSearch Settings%s"
-msgstr ""
-"Puoi modificarle in qualsiasi momento in %1$sImpostazioni di ricerca%2$s"
+msgstr "Puoi modificarle in qualsiasi momento in %1$sImpostazioni di ricerca%2$s"
 
 # smartling.placeholder_format=C
 #. Text explaning how to change a passphrase.
@@ -24111,8 +24086,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
 msgid "You won't see this message again unless you clear your browser data."
-msgstr ""
-"Non vedrai più questo messaggio a meno che non elimini i dati del browser."
+msgstr "Non vedrai più questo messaggio a meno che non elimini i dati del browser."
 
 # smartling.placeholder_format=C
 #. The second paragraph of a pop up where we explain how to update the browser manually.
@@ -24197,8 +24171,7 @@ msgstr ""
 #. Description shown when the user has reached the maximum voice chat duration.
 msgctxt "voice chat duration limit modal"
 msgid "You've reached the maximum voice chat duration for a single session."
-msgstr ""
-"Hai raggiunto la durata massima della chat vocale per una singola sessione."
+msgstr "Hai raggiunto la durata massima della chat vocale per una singola sessione."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the daily voice chat limit.
@@ -24210,8 +24183,7 @@ msgstr "Hai raggiunto il limite di chat vocale per oggi. Riprova domani."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
 msgid "You've reached your dictation usage limit. Try again later."
-msgstr ""
-"Hai raggiunto il limite di utilizzo della dettatura. Riprova più tardi."
+msgstr "Hai raggiunto il limite di utilizzo della dettatura. Riprova più tardi."
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -24601,8 +24573,7 @@ msgctxt "Error message for input limit"
 msgid ""
 "You’ve exceeded the maximum message size. Please shorten your message and "
 "try again."
-msgstr ""
-"Hai superato la dimensione massima del messaggio. Accorcialo e riprova."
+msgstr "Hai superato la dimensione massima del messaggio. Accorcialo e riprova."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -24636,8 +24607,7 @@ msgctxt "Error message for user limit"
 msgid ""
 "You’ve reached the maximum number of messages for one day. Please continue "
 "this chat tomorrow."
-msgstr ""
-"Hai raggiunto il numero massimo di messaggi giornalieri. Continua domani."
+msgstr "Hai raggiunto il numero massimo di messaggi giornalieri. Continua domani."
 
 # smartling.placeholder_format=C
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
@@ -24726,8 +24696,7 @@ msgstr "di %1$s"
 #. Trust line shown at the bottom of the explainer panel, summarizing DuckDuckGo's reputation for online protection.
 msgctxt "Footer banner text in the How Duck.ai Works panel"
 msgid "by DuckDuckGo — online protection trusted by millions every day."
-msgstr ""
-"di DuckDuckGo, protezione online scelta da milioni di persone ogni giorno."
+msgstr "di DuckDuckGo, protezione online scelta da milioni di persone ogni giorno."
 
 # smartling.placeholder_format=C
 #. An abreviated unit of time indicating an age, e.g. "2d"

--- a/locales/it_IT/LC_MESSAGES/duckduckgo.po
+++ b/locales/it_IT/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: it_IT\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -489,7 +489,8 @@ msgstr ""
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "%sLong-press%s the DuckDuckGo app icon on the home screen"
-msgstr "%1$sPremi a lungo%2$s l'icona dell'app DuckDuckGo nella schermata principale"
+msgstr ""
+"%1$sPremi a lungo%2$s l'icona dell'app DuckDuckGo nella schermata principale"
 
 # smartling.placeholder_format=C
 #. A message displayed when there is an error loading content or no results on requery
@@ -814,7 +815,8 @@ msgstr "Limite di utilizzo di 6 ore raggiunto."
 #. Displayed when the user has reached a fixed 6-hour Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "6-hour usage limit reached. You can continue this chat after %s."
-msgstr "Limite di utilizzo di 6 ore raggiunto. Puoi continuare questa chat dopo %1$s."
+msgstr ""
+"Limite di utilizzo di 6 ore raggiunto. Puoi continuare questa chat dopo %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable 6-hour Duck.ai usage limit and can opt in to continue using the daily limit.
@@ -937,8 +939,8 @@ msgstr ""
 "AI Chat consente di conversare in modo anonimo con modelli di chat di terze "
 "parti dotati di intelligenza artificiale. Disattivando questa funzione, AI "
 "Chat verrà nascosta su DuckDuckGo Search. È comunque possibile accedervi "
-"anche quando questa impostazione è disattivata visitando "
-"%1$sduckduckgo.com/aichat%2$s."
+"anche quando questa impostazione è disattivata visitando %1$sduckduckgo.com/"
+"aichat%2$s."
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -1009,7 +1011,8 @@ msgstr ""
 #. A message that confirms the user has turned off AI features and will no longer see AI-assisted answers.
 msgctxt "duckassist"
 msgid "AI-assisted answers have been turned off!"
-msgstr "Le risposte assistite dall'intelligenza artificiale sono state disattivate!"
+msgstr ""
+"Le risposte assistite dall'intelligenza artificiale sono state disattivate!"
 
 # smartling.placeholder_format=C
 #. Negative feedback suggestion for when user dislikes AI-generated content
@@ -1357,7 +1360,8 @@ msgstr "Aggiungi una casella di ricerca di %1$s al tuo sito!"
 #. Prompt to add locations on a map in order to get directions.
 msgctxt "directions"
 msgid "Add a starting point and destination to find a route."
-msgstr "Aggiungi un punto di partenza e una destinazione per trovare un percorso."
+msgstr ""
+"Aggiungi un punto di partenza e una destinazione per trovare un percorso."
 
 # smartling.placeholder_format=C
 #. Label on the AI model card indicating the model supports file uploads.
@@ -1442,6 +1446,12 @@ msgstr "Barra indirizzi:"
 msgctxt "feedback form"
 msgid "Address is incorrect"
 msgstr "L'indirizzo non è corretto"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Adjust the servings"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. as in multiple advertisements
@@ -1657,6 +1667,14 @@ msgid "All chats are %sprivate%s"
 msgstr "Tutte le chat sono %1$sprivate%2$s"
 
 # smartling.placeholder_format=C
+#. Paragraph in the Privacy & Terms section of the About & Legal page in Duck.ai settings, summarizing how chats are anonymized and are not stored or used to train chat models.
+msgctxt "Privacy & Terms section description on the Duck.ai settings page"
+msgid ""
+"All chats are anonymized by DuckDuckGo, and your conversations are not used "
+"to train chat models by DuckDuckGo or the model providers"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
 msgctxt "Privacy modal header in Duck.ai chat"
 msgid "All chats are private"
@@ -1747,7 +1765,8 @@ msgstr "Consenti annunci che rispettano la privacy"
 # smartling.placeholder_format=C
 #. Title in a dialog informing the user how to disable their ad blocker for DuckDuckGo
 msgid "Allow privacy-respecting ads on DuckDuckGo Private Search"
-msgstr "Consenti annunci che rispettano la privacy su Private Search DuckDuckGo"
+msgstr ""
+"Consenti annunci che rispettano la privacy su Private Search DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Description explaining privacy implications of enabling web search on encrypted models. The first two placeholders are the full model name (e.g. 'gpt-oss 120B'). The third and fourth placeholders wrap a clickable link reading 'zero provider visibility' that opens the privacy modal, please keep those around the link text in your translation. An example full sentence would be: Allows gpt-oss 120B to search the web to improve responses to relevant prompts. Only sends AI-generated queries to a search engine with limited data retention. Prompts and responses with gpt-oss 120B still have zero provider visibility.
@@ -1925,6 +1944,13 @@ msgstr ""
 msgctxt "precise_user_location"
 msgid "Anonymous location enabled"
 msgstr "Posizione anonima attivata"
+
+# smartling.placeholder_format=C
+msgctxt "settings"
+msgid ""
+"Anonymously generates answers for search queries based on web content. "
+"Choose how often you want it to appear, or disable it completely."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -2210,6 +2236,12 @@ msgid "Ask a follow-up with Duck.ai"
 msgstr "Chiedi un follow-up con Duck.ai"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
+msgctxt "Page suggestion chip label"
+msgid "Ask about this page"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
 msgctxt "Title for the page context onboarding modal"
 msgid "Ask about this page"
@@ -2379,13 +2411,15 @@ msgstr "Audio"
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat ends."
-msgstr "L'audio non viene memorizzato né da noi né da OpenAI dopo la fine della chat."
+msgstr ""
+"L'audio non viene memorizzato né da noi né da OpenAI dopo la fine della chat."
 
 # smartling.placeholder_format=C
 #. Description in consent disclaimer informing that audio from the voice chat session is not stored by us or by OpenAI after the voice chat ends.
 msgctxt "voice chat"
 msgid "Audio is not stored by us or by OpenAI after the chat ends."
-msgstr "L'audio non viene memorizzato né da noi né da OpenAI dopo la fine della chat."
+msgstr ""
+"L'audio non viene memorizzato né da noi né da OpenAI dopo la fine della chat."
 
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
@@ -2631,6 +2665,12 @@ msgid "Barcode"
 msgstr "Codice a barre"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Based on this page, is this course worth taking?"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Basic"
 msgstr "Base"
@@ -2669,6 +2709,14 @@ msgstr "Battitore"
 msgctxt "Assistant response placeholder"
 msgid "Before continuing..."
 msgstr "Prima di continuare..."
+
+# smartling.placeholder_format=C
+#. Explains that before storing the report, DuckDuckGo will anonymize the conversation by removing PII like names, email addresses, and identifying metadata.
+msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
+msgid ""
+"Before storing this report, DuckDuckGo will anonymize your conversation by "
+"removing PII like names, email addresses, and identifying metadata."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -2794,12 +2842,14 @@ msgstr "Blocca il sistema di tracciamento e-mail e nascondi il tuo indirizzo."
 # smartling.placeholder_format=C
 #. A disclaimer about AI-generated images in search results
 msgid "Block list is not exhaustive and may contain inaccuracies."
-msgstr "L'elenco dei blocchi non è esaustivo e potrebbe contenere imprecisioni."
+msgstr ""
+"L'elenco dei blocchi non è esaustivo e potrebbe contenere imprecisioni."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Block most trackers as you browse."
-msgstr "Blocca la maggior parte dei sistemi di tracciamento durante la navigazione."
+msgstr ""
+"Blocca la maggior parte dei sistemi di tracciamento durante la navigazione."
 
 # smartling.placeholder_format=C
 #. Menu option to block a site from the displayed results
@@ -2987,6 +3037,12 @@ msgstr "Brasile"
 msgctxt "Sports module"
 msgid "Break Points Won"
 msgstr "Break point vinti"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Break this down into clear, numbered steps."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -3444,6 +3500,12 @@ msgstr "Lavora con noi"
 msgctxt "Movie/TV Show Title instant answer"
 msgid "Cast"
 msgstr "Cast"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Cast & Crew"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -4393,7 +4455,8 @@ msgstr "Clicca sulla %1$slente di ingrandimento%2$s nella barra di ricerca"
 # smartling.placeholder_format=C
 #. Tells users what icon to click in their browser to change their default search engine.
 msgid "Click on the magnifying glass in the search box at the top right"
-msgstr "Clicca sulla lente di ingrandimento nella casella di ricerca in alto a destra"
+msgstr ""
+"Clicca sulla lente di ingrandimento nella casella di ricerca in alto a destra"
 
 # smartling.placeholder_format=C
 #. Tells users where to click in order to disable the cloud save feature and delete any data backed-up to the cloud.
@@ -4446,18 +4509,21 @@ msgstr "Clicca sui %1$spuntini di sospensione%2$s nella barra degli strumenti."
 #. Tells users where to click in their browser to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Click the %slock icon%s on the address bar."
-msgstr "Clicca sull'%1$sicona di blocco%2$s presente nella barra degli indirizzi."
+msgstr ""
+"Clicca sull'%1$sicona di blocco%2$s presente nella barra degli indirizzi."
 
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Click the %spermissions icon%s in the address bar"
-msgstr "Clicca sull'%1$sicona delle autorizzazioni%2$s nella barra degli indirizzi"
+msgstr ""
+"Clicca sull'%1$sicona delle autorizzazioni%2$s nella barra degli indirizzi"
 
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to search using DuckDuckGo.
 msgid "Click the Duck icon at the top of your browser to search!"
-msgstr "Clicca sull'icona dell'anatra in alto nel browser per effettuare una ricerca!"
+msgstr ""
+"Clicca sull'icona dell'anatra in alto nel browser per effettuare una ricerca!"
 
 #  UC Browser on Android
 # smartling.placeholder_format=C
@@ -5047,7 +5113,8 @@ msgstr "Copia"
 # smartling.placeholder_format=C
 #. Instructions on how to change the default search engine
 msgid "Copy &amp; paste %sabout:preferences#search%s into the address bar"
-msgstr "Copia e incolla %1$sabout:preferences#search%2$s nella barra degli indirizzi"
+msgstr ""
+"Copia e incolla %1$sabout:preferences#search%2$s nella barra degli indirizzi"
 
 # smartling.placeholder_format=C
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
@@ -5117,7 +5184,8 @@ msgstr "Costa Rica"
 #. Inline error shown on the recovery code screen when exportSyncSettings rejects.
 msgctxt "Error message when the recovery code fails to generate"
 msgid "Couldn't load your recovery code. Please close this and try again."
-msgstr "Impossibile caricare il codice di recupero. Chiudi questa finestra e riprova."
+msgstr ""
+"Impossibile caricare il codice di recupero. Chiudi questa finestra e riprova."
 
 # smartling.placeholder_format=C
 #. Pairs with a Retry button. Shown after two consecutive failed attempts to load the device list.
@@ -5161,6 +5229,12 @@ msgstr "Crea immagine"
 msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr "Crea immagine"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Create a shopping list with quantities from this recipe."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed in the input field when starting a new image generation session.
@@ -5807,6 +5881,11 @@ msgid "Dictation limit reached"
 msgstr "Limite di dettatura raggiunto"
 
 # smartling.placeholder_format=C
+#. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
+msgid "Dictation temporarily unavailable"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
@@ -6107,6 +6186,22 @@ msgid "Done"
 msgstr "Fatto"
 
 # smartling.placeholder_format=C
+#. Message shown in a modal after DuckDuckGo browser users disable AI features in Settings. The first two placeholders bold noai.duckduckgo.com. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
+"filtered out. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
+"and AI images filtered out. %sLearn more%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Double Faults"
@@ -6219,6 +6314,18 @@ msgid ""
 msgstr ""
 "Scrivi un'e-mail concisa e dettagliata a un fornitore per richiedere un "
 "preventivo sul servizio di riparazione dei frigoriferi domestici."
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Draft a cover letter"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Draft a cover letter for this job."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -6397,6 +6504,15 @@ msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
 msgstr "Duck.ai è migliore nel nostro browser DuckDuckGo, privato e gratuito!"
 
 # smartling.placeholder_format=C
+#. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
+msgctxt "About section description on the Duck.ai settings page"
+msgid ""
+"Duck.ai is created by DuckDuckGo. We're an independent online protection "
+"company for anyone who wants to take back control of their personal "
+"information."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
 msgctxt "duckai_migration"
 msgid "Duck.ai is moving domains"
@@ -6425,8 +6541,8 @@ msgid ""
 "Duck.ai is temporarily unavailable. If this persists, please email this "
 "anonymous code %s to %s"
 msgstr ""
-"Duck.ai non è al momento disponibile. Se il problema persiste, invia "
-"un'e-mail con il codice anonimo %1$s a %2$s"
+"Duck.ai non è al momento disponibile. Se il problema persiste, invia un'e-"
+"mail con il codice anonimo %1$s a %2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -6440,6 +6556,13 @@ msgstr "Duck.ai non è al momento disponibile. Ricarica la pagina e riprova."
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
 msgstr "Duck.ai non è al momento disponibile. Riprova più tardi."
+
+# smartling.placeholder_format=C
+msgctxt "settings"
+msgid ""
+"Duck.ai lets you chat privately with popular AI models. Disabling it hides "
+"Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6503,7 +6626,8 @@ msgstr "Duck.ai è stato aggiornato!"
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
-msgstr "Duck.ai funziona al meglio nella nostra app DuckDuckGo, privata e gratuita!"
+msgstr ""
+"Duck.ai funziona al meglio nella nostra app DuckDuckGo, privata e gratuita!"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -7303,7 +7427,8 @@ msgstr ""
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location Services' is %senabled%s."
-msgstr "Assicurati che l'opzione \"Servizi di localizzazione\" sia %1$sattivata%2$s."
+msgstr ""
+"Assicurati che l'opzione \"Servizi di localizzazione\" sia %1$sattivata%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
@@ -7355,13 +7480,15 @@ msgstr ""
 #. Tells how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed location access"
-msgstr "Assicurati che il tuo browser sia autorizzato ad accedere alla posizione"
+msgstr ""
+"Assicurati che il tuo browser sia autorizzato ad accedere alla posizione"
 
 # smartling.placeholder_format=C
 #. Tells how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed location access."
-msgstr "Assicurati che il tuo browser sia autorizzato ad accedere alla posizione."
+msgstr ""
+"Assicurati che il tuo browser sia autorizzato ad accedere alla posizione."
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -7458,6 +7585,18 @@ msgid "Eritrea"
 msgstr "Eritrea"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Estimate the nutrition"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Estimate the nutritional information for this recipe."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Estonia"
 msgstr "Estonia"
 
@@ -7514,6 +7653,12 @@ msgid "Expires in 1 day"
 msgstr "Scade tra 1 giorno"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain the accepted answer in simple terms."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
@@ -7521,6 +7666,48 @@ msgid ""
 msgstr ""
 "Spiegami i concetti fondamentali dei buchi neri in un linguaggio da scuola "
 "superiore."
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain the top answer"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this in simple, plain language."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this paper"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this repo"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this research paper in plain language."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this simply"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain what this repository does and how to use it."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label to show if song lyrics contain explicit content
@@ -7544,7 +7731,8 @@ msgstr "Testi espliciti"
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
-msgstr "Esplora gli ultimi aggiornamenti di prodotti e funzionalità di DuckDuckGo."
+msgstr ""
+"Esplora gli ultimi aggiornamenti di prodotti e funzionalità di DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Links to a page that provides a list of DuckDuckGo product updates
@@ -7809,6 +7997,12 @@ msgstr ""
 "ricerca delle immagini. %1$sUlteriori informazioni%2$s"
 
 # smartling.placeholder_format=C
+msgctxt "settings"
+msgid ""
+"Filters out known AI spam sites from image search results. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the final score of a sporting event.
 msgid "Final"
 msgstr "Finale"
@@ -7862,6 +8056,12 @@ msgstr "Trova una parola migliore"
 msgctxt "Subtitle for the Web Search tool entry in the Tools dropdown menu"
 msgid "Find current information"
 msgstr "Trova informazioni correnti"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Find me alternatives"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button that searches for results closer to the user's current location.
@@ -8088,7 +8288,8 @@ msgstr "Condivisione e uso commerciale gratuiti"
 #. Description text explaining how to free up sync storage. Pinned chats are chats the user has explicitly marked to keep.
 msgctxt "Sync limit modal description"
 msgid "Free up space by deleting your chats. Pinned chats will not be deleted."
-msgstr "Libera spazio eliminando le chat. Le chat fissate non verranno eliminate."
+msgstr ""
+"Libera spazio eliminando le chat. Le chat fissate non verranno eliminate."
 
 # smartling.placeholder_format=C
 #. Indicates that this streaming service is free to watch but shows ads
@@ -8339,6 +8540,12 @@ msgid "Generate More"
 msgstr "Genera altro"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Generate a shopping list"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
 msgid "Generate a short answer from the web"
 msgstr "Genera una risposta breve dal web"
@@ -8501,7 +8708,8 @@ msgstr "Iniziamo"
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the Privacy Pro subscription.
 msgctxt "SERP footer content"
 msgid "Get a VPN + two more protections in one easy subscription."
-msgstr "Ottieni una VPN + altre due protezioni in un unico semplice abbonamento."
+msgstr ""
+"Ottieni una VPN + altre due protezioni in un unico semplice abbonamento."
 
 # smartling.placeholder_format=C
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
@@ -8628,6 +8836,12 @@ msgstr "Prova"
 msgctxt "Onboarding welcome screen button text"
 msgid "Give it a Try"
 msgstr "Prova"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Give me a quick background on this person."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -8898,7 +9112,8 @@ msgstr "Guatemala"
 #. Text for a prompt suggestion for guiding through the basic steps of replacing a window wiper.
 msgctxt "Full sentence for learning a new skill"
 msgid "Guide me through the basic steps of replacing a window wiper."
-msgstr "Indicami i passaggi fondamentali per la sostituzione di un tergicristallo."
+msgstr ""
+"Indicami i passaggi fondamentali per la sostituzione di un tergicristallo."
 
 # smartling.placeholder_format=C
 msgid "Guinea"
@@ -9075,6 +9290,18 @@ msgstr "Aiuta a diffondere DuckDuckGo!"
 #. Link to a page with information about sharing DuckDuckGo with friends.
 msgid "Help Spread Privacy"
 msgstr "Aiutaci a diffondere la privacy"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Help me prep for the interview"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Help me tailor my resume for this job."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title of a SERP popup that invites users to take a survey (desktop only)
@@ -9275,7 +9502,8 @@ msgstr "Nascondi il tuo indirizzo e-mail"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Hides search term from being shown in browser tab/history"
-msgstr "Nasconde i termini di ricerca dalla scheda e dalla cronologia del browser"
+msgstr ""
+"Nasconde i termini di ricerca dalla scheda e dalla cronologia del browser"
 
 # smartling.placeholder_format=C
 #. The highest stock price in a day
@@ -9519,7 +9747,8 @@ msgstr "Come funziona"
 #. Header for the assist settings modal where the user can choose how often they want AI-assisted answers to appear.
 msgctxt "duckassist"
 msgid "How much do you want AI-assisted answers to appear?"
-msgstr "Quanto vuoi che appaiano le risposte assistite dall'intelligenza artificiale?"
+msgstr ""
+"Quanto vuoi che appaiano le risposte assistite dall'intelligenza artificiale?"
 
 # smartling.placeholder_format=C
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
@@ -9592,6 +9821,14 @@ msgstr "Uragano"
 msgctxt "Onboarding terms screen button text"
 msgid "I Agree"
 msgstr "Sono d'accordo"
+
+# smartling.placeholder_format=C
+#. Text for the button that takes the user to the external DuckDuckGo login subscription page.
+msgctxt ""
+"Text for the I already have a subscription button in the Duck.ai settings "
+"page"
+msgid "I Already Have a Subscription"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the button that takes the user to the login subscription page.
@@ -9761,7 +9998,8 @@ msgstr ""
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
-msgstr "Se vuoi supportarci in altri modi, %1$saiuta a diffondere DuckDuckGo%2$s"
+msgstr ""
+"Se vuoi supportarci in altri modi, %1$saiuta a diffondere DuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -9964,7 +10202,8 @@ msgstr "Nel menu in alto seleziona %1$sStrumenti%2$s > %3$sImpostazioni%4$s"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "In the popup, check %sMake this my default search provider%s"
-msgstr "Nel popup, seleziona %1$sImposta come provider di ricerca predefinito%2$s"
+msgstr ""
+"Nel popup, seleziona %1$sImposta come provider di ricerca predefinito%2$s"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -10170,6 +10409,12 @@ msgid "Install Mac Browser"
 msgstr "Installa il browser Mac"
 
 # smartling.placeholder_format=C
+#. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
+msgctxt "settings"
+msgid "Install Now"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of a button to install the DuckDuckGo app
 msgctxt "Serp footer content"
 msgid "Install Our App"
@@ -10267,10 +10512,42 @@ msgid "Is deleted data really deleted?"
 msgstr "I dati cancellati vengono realmente eliminati?"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is it worth taking?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this place any good?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"Is this place any good? Summarize its reputation based on reviews and "
+"ratings."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "Is this video helpful?"
 msgstr "Questo video è utile?"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this worth watching?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Is this worth watching? Give me a spoiler-free take."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -10885,6 +11162,12 @@ msgid "Links:"
 msgstr "Link:"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "List the tools, materials, or prerequisites I need for this."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
 msgid "Listen"
 msgstr "Ascolta"
@@ -10993,7 +11276,8 @@ msgstr "Carica altre immagini durante lo scorrimento"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Loads more results in Images, Videos, and Shopping when scrolling"
-msgstr "Carica altri risultati in Immagini, Video e Shopping durante lo scorrimento"
+msgstr ""
+"Carica altri risultati in Immagini, Video e Shopping durante lo scorrimento"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/WTkvs9I.png
@@ -11291,6 +11575,12 @@ msgstr "Gestisci il tuo abbonamento"
 msgctxt "Exclusion message manage sites button"
 msgid "Manage blocked sites"
 msgstr "Gestisci siti bloccati"
+
+# smartling.placeholder_format=C
+#. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
+msgctxt "setting"
+msgid "Manage in Browser Settings"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to the site exclusion settings page
@@ -11744,7 +12034,8 @@ msgstr "Limite mensile raggiunto"
 #. Displayed when the user has reached a fixed monthly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Monthly usage limit reached. You can continue this chat after %s."
-msgstr "Limite di utilizzo mensile raggiunto. Puoi continuare questa chat dopo %1$s."
+msgstr ""
+"Limite di utilizzo mensile raggiunto. Puoi continuare questa chat dopo %1$s."
 
 # smartling.placeholder_format=C
 #. Used to point to additional social networking profiles (in results).
@@ -12605,13 +12896,15 @@ msgstr "Nessun sistema di tracciamento bloccato nell'ultima ora"
 #. Refers to how web searches on DuckDuckGo aren't tracked.
 msgctxt "homepage onboarding"
 msgid "No tracking, no ad targeting, just searching!"
-msgstr "Nessun tracciamento, nessuna pubblicità mirata, solo semplici ricerche!"
+msgstr ""
+"Nessun tracciamento, nessuna pubblicità mirata, solo semplici ricerche!"
 
 # smartling.placeholder_format=C
 #. Refers to how web searches on DuckDuckGo aren't tracked.
 msgctxt "homepage onboarding"
 msgid "No tracking, no ad targeting, just searching."
-msgstr "Nessun tracciamento, nessuna pubblicità mirata, solo semplici ricerche."
+msgstr ""
+"Nessun tracciamento, nessuna pubblicità mirata, solo semplici ricerche."
 
 # smartling.placeholder_format=C
 #. Indicates that there were no search results for a user's search. The placeholder is the user's search term. For example: 'No videos found for 'bad dogs''
@@ -14134,8 +14427,15 @@ msgstr ""
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
+msgid "Please describe why the chat response is harmful or illegal. (optional)"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
+msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
-msgstr "Descrivi perché la risposta nella chat è illegale o dannosa. (Opzionale)"
+msgstr ""
+"Descrivi perché la risposta nella chat è illegale o dannosa. (Opzionale)"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to enter their passphrase.
@@ -14158,6 +14458,14 @@ msgid ""
 msgstr ""
 "Nota bene: l'avvio di una nuova chat con qualsiasi modello cancellerà la tua "
 "sessione di chat attuale."
+
+# smartling.placeholder_format=C
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
+msgctxt "Feedback prompt"
+msgid ""
+"Please paste your prompt and the problematic output (with any personal "
+"information removed) and describe why the content is harmful or illegal."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -14627,6 +14935,12 @@ msgid "Privacy"
 msgstr "Privacy"
 
 # smartling.placeholder_format=C
+#. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
+msgctxt "Section heading on the Duck.ai settings page"
+msgid "Privacy & Terms"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Privacy Blog"
 msgstr "Blog sulla privacy"
 
@@ -14695,6 +15009,12 @@ msgstr "Privacy policy e condizioni d'uso"
 msgctxt "Copy used to compose link in sentences"
 msgid "Privacy Policy and Terms of Service"
 msgstr "Privacy policy e Termini del servizio"
+
+# smartling.placeholder_format=C
+#. Text for a button that links to the terms of use and privacy policy page.
+msgctxt "Secondary button text in active privacy modal"
+msgid "Privacy Policy and Terms of Service"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title displayed on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
@@ -14888,7 +15208,8 @@ msgstr "Proteggi i tuoi dati durante le ricerche e la navigazione."
 #. Shown on the Mac and Windows browser promo cards. DuckDuckGo's desktop browser protects your data across search, browsing, and AI chat.
 msgctxt "SERP footer content"
 msgid "Protect your data as you search, browse, and use AI."
-msgstr "Proteggi i tuoi dati durante le ricerche, la navigazione e l'uso dell'AI."
+msgstr ""
+"Proteggi i tuoi dati durante le ricerche, la navigazione e l'uso dell'AI."
 
 # smartling.placeholder_format=C
 #. A title above links to download the DuckDuckGo apps.
@@ -15142,7 +15463,8 @@ msgstr "Schede recenti"
 #. Text explaining that this feature can be adjusted in the settings. Placeholder is for adding a link to 'Settings'. Example: 'Recent chat storage can be adjusted in Settings.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "Recent chat storage can be adjusted in %s."
-msgstr "Lo spazio di archiviazione delle chat recenti può essere regolato in %1$s."
+msgstr ""
+"Lo spazio di archiviazione delle chat recenti può essere regolato in %1$s."
 
 # smartling.placeholder_format=C
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -15197,6 +15519,30 @@ msgstr "Ricette per %1$s%2$s%3$s"
 msgctxt "Brief for recommending a book"
 msgid "Recommend a book"
 msgstr "Consiglia un libro"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar books"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar books."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar movies or shows."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar titles"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
@@ -15411,8 +15757,8 @@ msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
 msgstr ""
-"Ricarica DuckDuckGo seguendo le istruzioni o facendo clic sul pulsante "
-"&quot;Aggiorna&quot; o &quot;Ricarica&quot; del browser."
+"Ricarica DuckDuckGo seguendo le istruzioni o facendo clic sul pulsante &quot;"
+"Aggiorna&quot; o &quot;Ricarica&quot; del browser."
 
 # smartling.placeholder_format=C
 #. checkbox label that allows the user to save the setting
@@ -15429,7 +15775,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
 msgid "Remember my choice (this can be changed in %sSettings%s)"
-msgstr "Ricorda la mia scelta (può essere modificata nelle %1$sImpostazioni%2$s)"
+msgstr ""
+"Ricorda la mia scelta (può essere modificata nelle %1$sImpostazioni%2$s)"
 
 # smartling.placeholder_format=C
 #. Button to be reminded later to update, shown in a banner that appears in Duck.ai when a subscribed user is using an old version of the DuckDuckGo browser.
@@ -15601,6 +15948,15 @@ msgstr ""
 # smartling.placeholder_format=C
 msgid "Republic of Moldova"
 msgstr "Repubblica di Moldavia"
+
+# smartling.placeholder_format=C
+#. Note indicating that sharing the conversation is mandatory when reporting harmful or illegal content. Rendered alongside the standard share label (DUCKCHAT_RESPONSE_FEEDBACK_SHARE_PROMPT_RESPONSE_LABEL), not replacing it.
+msgctxt ""
+"Note shown under the share-content switch label on the Duck.ai response "
+"feedback form when the user has selected Harmful or Illegal as the feedback "
+"reason"
+msgid "Required for harmful or illegal reports"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
@@ -15838,6 +16194,12 @@ msgstr "Recensioni"
 msgctxt "maps_places"
 msgid "Reviews"
 msgstr "Recensioni"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Rewrite this recipe scaled for a different number of servings."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Romania"
@@ -16126,8 +16488,8 @@ msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
 msgstr ""
-"Salva le tue chat di Duck.ai tra i tuoi dispositivi con crittografia "
-"end-to-end."
+"Salva le tue chat di Duck.ai tra i tuoi dispositivi con crittografia end-to-"
+"end."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -16627,7 +16989,8 @@ msgstr "Settimane della stagione"
 #. Description shown in the Sync & Backup settings section when sync is not yet enabled, explaining the feature.
 msgctxt "Description for sync and backup feature"
 msgid "Securely save and sync your chats across all your devices."
-msgstr "Salva e sincronizza in modo sicuro le tue chat su tutti i tuoi dispositivi."
+msgstr ""
+"Salva e sincronizza in modo sicuro le tue chat su tutti i tuoi dispositivi."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -16677,8 +17040,8 @@ msgstr ""
 msgctxt "Sync feature benefit description"
 msgid "Securely stored on DuckDuckGo's server with end-to-end encryption."
 msgstr ""
-"Archiviati in modo sicuro sul server di DuckDuckGo con crittografia "
-"end-to-end."
+"Archiviati in modo sicuro sul server di DuckDuckGo con crittografia end-to-"
+"end."
 
 # smartling.placeholder_format=C
 #. List item explaining that synced chats are stored with end-to-end encryption on DuckDuckGo's server and only the user can access them.
@@ -16687,8 +17050,8 @@ msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
 msgstr ""
-"Archiviati in modo sicuro sul server di DuckDuckGo con crittografia "
-"end-to-end. Nessuno tranne te può vedere i tuoi dati, nemmeno noi."
+"Archiviati in modo sicuro sul server di DuckDuckGo con crittografia end-to-"
+"end. Nessuno tranne te può vedere i tuoi dati, nemmeno noi."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -16837,24 +17200,27 @@ msgstr ""
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
 msgstr ""
-"Scegli %1$sPersonalizzata%2$s e digita nel campo "
-"%3$shttps://duckduckgo.com%4$s"
+"Scegli %1$sPersonalizzata%2$s e digita nel campo %3$shttps://duckduckgo."
+"com%4$s"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
-msgstr "Seleziona %1$sDuckDuckGo%2$s e clicca su %3$sAggiungi come predefinito%4$s!"
+msgstr ""
+"Seleziona %1$sDuckDuckGo%2$s e clicca su %3$sAggiungi come predefinito%4$s!"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s"
-msgstr "Seleziona %1$sDuckDuckGo%2$s e clicca su %3$sImposta come predefinito%4$s"
+msgstr ""
+"Seleziona %1$sDuckDuckGo%2$s e clicca su %3$sImposta come predefinito%4$s"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s."
-msgstr "Seleziona %1$sDuckDuckGo%2$s e clicca su %3$sImposta come predefinito%4$s."
+msgstr ""
+"Seleziona %1$sDuckDuckGo%2$s e clicca su %3$sImposta come predefinito%4$s."
 
 #  Firefox 33
 # smartling.placeholder_format=C
@@ -16969,7 +17335,8 @@ msgstr "Seleziona %1$sImpostazioni%2$s, poi %3$sImpostazioni avanzate%4$s"
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sDefault search engine%s"
-msgstr "Seleziona %1$sImpostazioni%2$s, poi %3$sMotore di ricerca predefinito%4$s"
+msgstr ""
+"Seleziona %1$sImpostazioni%2$s, poi %3$sMotore di ricerca predefinito%4$s"
 
 #  Chrome/Firefox on Android
 # smartling.placeholder_format=C
@@ -17065,7 +17432,8 @@ msgstr "Testo selezionato da %1$s"
 #. Displayed when the user's text selection exceeds the maximum message size for AI tools (summary, translation, etc.).
 msgctxt "Error message for selection input limit"
 msgid "Selected text is too long. Try again with a shorter selection."
-msgstr "Il testo selezionato è troppo lungo. Riprova con una selezione più breve."
+msgstr ""
+"Il testo selezionato è troppo lungo. Riprova con una selezione più breve."
 
 # smartling.placeholder_format=C
 #. Label for the semi-finals knockout stage in e.g. the soccer World Cup
@@ -17185,6 +17553,12 @@ msgstr "Configura ora"
 msgctxt "Setup button for native sync flow"
 msgid "Set Up Now"
 msgstr "Configura ora"
+
+# smartling.placeholder_format=C
+#. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
+msgctxt "Encrypted storage setup button shown in native browsers"
+msgid "Set Up Sync & Backup"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
@@ -17368,6 +17742,13 @@ msgstr "Condividi l'URL della pagina"
 msgctxt "feedback form"
 msgid "Share positive feedback"
 msgstr "Condividi feedback positivo"
+
+# smartling.placeholder_format=C
+#. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
+msgctxt ""
+"Label beside the share-content switch on the Duck.ai response feedback form"
+msgid "Share this conversation with DuckDuckGo"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -17751,12 +18132,14 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows horizontal lines at result page breaks"
-msgstr "Mostra linee orizzontali a ogni interruzione della pagina dei risultati"
+msgstr ""
+"Mostra linee orizzontali a ogni interruzione della pagina dei risultati"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows links to instructions for how to add DuckDuckGo to your browser"
-msgstr "Mostra link per le istruzioni su come aggiungere DuckDuckGo al tuo browser"
+msgstr ""
+"Mostra link per le istruzioni su come aggiungere DuckDuckGo al tuo browser"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers more frequently.
@@ -17777,7 +18160,8 @@ msgstr "Mostra promemoria occasionali per aggiungere DuckDuckGo al tuo browser"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr "Mostra promemoria occasionali per aggiungere DuckDuckGo ai tuoi dispositivi"
+msgstr ""
+"Mostra promemoria occasionali per aggiungere DuckDuckGo ai tuoi dispositivi"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -17906,7 +18290,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Sites you block will be hidden from all your search results"
-msgstr "I siti che blocchi saranno nascosti da tutti i tuoi risultati di ricerca"
+msgstr ""
+"I siti che blocchi saranno nascosti da tutti i tuoi risultati di ricerca"
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes full name (tooltip)
@@ -18051,7 +18436,8 @@ msgstr "Qualcosa è andato storto durante il salvataggio nel server, riprova."
 #. Body copy displayed under the Set Up Now button when the sync setup call fails.
 msgctxt "Generic error shown when sync setup fails"
 msgid "Something went wrong while enabling Sync & Backup. Please try again."
-msgstr "Si è verificato un problema durante l'attivazione di Sync & Backup. Riprova."
+msgstr ""
+"Si è verificato un problema durante l'attivazione di Sync & Backup. Riprova."
 
 # smartling.placeholder_format=C
 #. Displayed when the voice chat session ends with an unknown error.
@@ -18075,7 +18461,8 @@ msgstr "A volte"
 #. Generic error message shown when the image generation model cannot process the user's request.
 msgctxt "Error message from the image generation model"
 msgid "Sorry I can't help, please describe your image in a different way."
-msgstr "Mi dispiace, non posso aiutarti. Descrivi la tua immagine in un modo diverso."
+msgstr ""
+"Mi dispiace, non posso aiutarti. Descrivi la tua immagine in un modo diverso."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -18151,7 +18538,8 @@ msgstr ""
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr "Spiacenti, non siamo riusciti a inviare il tuo feedback. Riprova più tardi."
+msgstr ""
+"Spiacenti, non siamo riusciti a inviare il tuo feedback. Riprova più tardi."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -18458,7 +18846,8 @@ msgstr "Interrompi la generazione"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop hidden trackers lurking on other websites."
-msgstr "Impedisci ai sistemi di tracciamento nascosti di apparire su altri siti."
+msgstr ""
+"Impedisci ai sistemi di tracciamento nascosti di apparire su altri siti."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -18635,6 +19024,24 @@ msgid "Suggest a title for a blog post"
 msgstr "Suggerisci un titolo per un post del blog"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest related articles or topics worth exploring next."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Suggest related articles to explore"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest some alternatives to this product."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
 msgctxt "directions"
 msgid "Suggestions:"
@@ -18646,10 +19053,100 @@ msgid "Suggestions:"
 msgstr "Suggerimenti:"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Sum up the reviews"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A short title for the a message asking the AI to summarize a text.
 msgctxt "Title for the summarize message"
 msgid "Summarize"
 msgstr "Riassumi"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize the Q&As"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the background and notable work of this person."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the key details of this event."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the questions and answers on this page."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize their background"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this book"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this book."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this discussion"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this discussion thread."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this page"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this page."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this video"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this video."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize what the reviews say."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -18803,14 +19300,16 @@ msgstr "Passa a un modello più efficiente"
 # smartling.placeholder_format=C
 #. Text prompting  users to switch their current search engine to the DuckDuckGo private search engine.
 msgid "Switch to the search engine that doesn't track you. Ever."
-msgstr "Passa al motore di ricerca che non raccoglie i tuoi dati di navigazione. Mai."
+msgstr ""
+"Passa al motore di ricerca che non raccoglie i tuoi dati di navigazione. Mai."
 
 # smartling.placeholder_format=C
 #. Warning text shown in the model switch dropdown when the user is currently using an encrypted model. Warns that the new model will not have zero provider visibility.
 msgctxt "AI Chat warning when switching from an encrypted model"
 msgid ""
 "Switching will send your chat to a model without zero provider visibility"
-msgstr "Il passaggio invierà la chat a un modello senza visibilità zero lato provider"
+msgstr ""
+"Il passaggio invierà la chat a un modello senza visibilità zero lato provider"
 
 # smartling.placeholder_format=C
 msgid "Switzerland"
@@ -18926,8 +19425,8 @@ msgstr ""
 "%1$s\n"
 "\n"
 "Come funziona il codice?\n"
-"1. Apri il browser e vai su Duck.ai, quindi apri le impostazioni di "
-"Duck.ai.\n"
+"1. Apri il browser e vai su Duck.ai, quindi apri le impostazioni di Duck."
+"ai.\n"
 "2. Seleziona \"Attiva Sync & Backup\", poi \"Recupera dati sincronizzati\"\n"
 "3. Copia il codice di recupero sopra e incollalo nello spazio \"Incolla qui "
 "il tuo codice\"\n"
@@ -18977,6 +19476,12 @@ msgid "Syria"
 msgstr "Siria"
 
 # smartling.placeholder_format=C
+#. Text for a button that enables the theme to follow the operating system's color scheme preference.
+msgctxt "System theme button for theme selector"
+msgid "System"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Abbreviation indicating this is the total score for a game
 msgctxt "Sports module"
 msgid "T"
@@ -19003,6 +19508,12 @@ msgstr "TV"
 msgctxt "language_name"
 msgid "Tahitian"
 msgstr "Tahitiano"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Tailor my resume"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Taiwan"
@@ -19032,6 +19543,13 @@ msgstr "Prendi il controllo dei tuoi dati personali"
 msgctxt "homepage ATB modal"
 msgid "Take control of your personal data!"
 msgstr "Prendi il controllo dei tuoi dati personali!"
+
+# smartling.placeholder_format=C
+#. Description for the Feedback section of the Duck.ai settings page, asking the user to take an anonymous survey to let us know how we can make Duck.ai better.
+msgctxt "Feedback section description on the Duck.ai settings page"
+msgid ""
+"Take this anonymous survey to let us know how we can make Duck.ai better."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -19342,6 +19860,12 @@ msgid "Theme"
 msgstr "Tema"
 
 # smartling.placeholder_format=C
+#. Text for the theme selector label that allows users to switch between Light and dark theme.
+msgctxt "Label for the theme selector feature"
+msgid "Theme"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. http://i.imgur.com/LpFhb1e.png
 msgctxt "settings"
 msgid "Theme"
@@ -19600,7 +20124,8 @@ msgstr "Questa immagine non può essere creata."
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF"
-msgstr "Questo tipo di immagine non è supportato, allega un file JPG, PNG, WebP o GIF"
+msgstr ""
+"Questo tipo di immagine non è supportato, allega un file JPG, PNG, WebP o GIF"
 
 # smartling.placeholder_format=C
 #. Error message displayed when a file that the user tried to upload is not of a supported format
@@ -19664,7 +20189,8 @@ msgstr "Questa pagina richiede Javascript per funzionare."
 #. Information tooltip text explaining that the current page's content will be included with the chat message.
 msgctxt "Tooltip explaining that page content will be sent to Duck.ai"
 msgid "This page's content will be sent with your message to Duck.ai"
-msgstr "Il contenuto di questa pagina verrà inviato con il tuo messaggio a Duck.ai"
+msgstr ""
+"Il contenuto di questa pagina verrà inviato con il tuo messaggio a Duck.ai"
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -20121,7 +20647,8 @@ msgstr "Sistemi di tracciamento bloccati nell'ultima ora"
 #. Placeholder for when we cannot report any blocked trackers yet
 msgctxt "tracker_stats"
 msgid "Trackers that DuckDuckGo blocks will appear here"
-msgstr "I sistemi di tracciamento bloccati da DuckDuckGo vengono visualizzati qui"
+msgstr ""
+"I sistemi di tracciamento bloccati da DuckDuckGo vengono visualizzati qui"
 
 # smartling.placeholder_format=C
 #. Placeholder for when we cannot report any blocked trackers yet
@@ -20137,7 +20664,8 @@ msgstr ""
 #. Placeholder for when we cannot report any blocked trackers yet
 msgctxt "tracker_stats"
 msgid "Tracking attempts blocked by DuckDuckGo will appear here"
-msgstr "I tentativi di tracciamento bloccati da DuckDuckGo verranno visualizzati qui"
+msgstr ""
+"I tentativi di tracciamento bloccati da DuckDuckGo verranno visualizzati qui"
 
 # smartling.placeholder_format=C
 #. Tooltip and accessible label for the confirm (checkmark) button that stops recording and sends audio for transcription.
@@ -20191,6 +20719,18 @@ msgid ""
 msgstr ""
 "Traduci questa frase in francese: \"Come faccio a raggiungere il cinema più "
 "vicino?\""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Translate this page"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
+msgctxt "Page suggestion prompt"
+msgid "Translate this page into %s."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder text for a region that will display translated text.
@@ -20334,6 +20874,12 @@ msgid "Try Free"
 msgstr "Prova gratis"
 
 # smartling.placeholder_format=C
+#. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
+msgctxt "settings"
+msgid "Try It Now"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
 msgctxt "Promotional CTA for new AI models"
 msgid "Try Now"
@@ -20404,7 +20950,8 @@ msgstr "Prova ad abilitare la posizione anonima per risultati più accurati."
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr "Prova a sperimentare con ogni modello: ciascuno fornirà risposte diverse."
+msgstr ""
+"Prova a sperimentare con ogni modello: ciascuno fornirà risposte diverse."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
@@ -20570,6 +21117,22 @@ msgstr "Prova: %1$s"
 msgctxt "new user poll"
 msgid "Trying DuckDuckGo again"
 msgstr "Proverò di nuovo DuckDuckGo"
+
+# smartling.placeholder_format=C
+#. Message shown in a modal after supported third-party browser users disable AI features in Settings. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -20881,8 +21444,8 @@ msgstr ""
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
 msgstr ""
-"In %1$sAll'avvio%2$s, seleziona %3$sPagina Iniziale%4$s e inserisci: "
-"https://duckduckgo.com"
+"In %1$sAll'avvio%2$s, seleziona %3$sPagina Iniziale%4$s e inserisci: https://"
+"duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -20911,8 +21474,8 @@ msgstr ""
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
 msgstr ""
-"Nella sezione %1$sRicerca%2$s, clicca su %3$sGestisci motori di "
-"ricerca...%4$s"
+"Nella sezione %1$sRicerca%2$s, clicca su %3$sGestisci motori di ricerca..."
+"%4$s"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -20926,7 +21489,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine
 msgid "Under Search click the drop down and select %sDuckDuckGo%s"
-msgstr "In \"Ricerca\" clicca sul menu a tendina e seleziona %1$sDuckDuckGo%2$s"
+msgstr ""
+"In \"Ricerca\" clicca sul menu a tendina e seleziona %1$sDuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings" header
@@ -21327,6 +21891,12 @@ msgid "Uruguay"
 msgstr "Uruguay"
 
 # smartling.placeholder_format=C
+#. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
+msgctxt "Navigation label on the Duck.ai settings page"
+msgid "Usage"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A feedback suggestion
 msgctxt "Feedback prompt"
 msgid "Usage limit"
@@ -21555,7 +22125,8 @@ msgstr "Visualizza i prezzi per il tuo soggiorno"
 # smartling.placeholder_format=C
 #. A description for the ads tooltip that explains that viewing ads is privacy protected by DuckDuckGo.
 msgid "Viewing ads is privacy protected by DuckDuckGo."
-msgstr "La visualizzazione degli annunci è protetta dalla privacy di DuckDuckGo."
+msgstr ""
+"La visualizzazione degli annunci è protetta dalla privacy di DuckDuckGo."
 
 # smartling.placeholder_format=C
 msgctxt "Ads GDPR, internal use only. Do not change"
@@ -21776,6 +22347,12 @@ msgid "Wales"
 msgstr "Galles"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Walk me through the steps"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for walking directions on a map.
 msgctxt "directions"
 msgid "Walking"
@@ -21895,6 +22472,17 @@ msgstr ""
 "più accurati."
 
 # smartling.placeholder_format=C
+#. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
+msgctxt ""
+"Inline warning shown below the share-content toggle when the user selects "
+"Harmful or Illegal but has not enabled sharing"
+msgid ""
+"We can only fix what we can see. To report a harmful or illegal response, "
+"please share this conversation with DuckDuckGo so we can investigate and "
+"address the issue."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
 msgctxt ""
 "Inline warning shown below the share-content toggle when the user selects "
@@ -21939,7 +22527,8 @@ msgstr "Non memorizziamo nomi utente né informazioni personali."
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don't store your personal info or track you. Ever."
-msgstr "Non memorizziamo le tue informazioni personali e non ti tracciamo. Mai."
+msgstr ""
+"Non memorizziamo le tue informazioni personali e non ti tracciamo. Mai."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -22087,7 +22676,8 @@ msgstr ""
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
-msgstr "Ci affidiamo alla tua opinione anonima per migliorare DuckDuckGo per tutti."
+msgstr ""
+"Ci affidiamo alla tua opinione anonima per migliorare DuckDuckGo per tutti."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -22314,7 +22904,8 @@ msgstr ""
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai! You can now import your downloaded chats."
-msgstr "Ti diamo il benvenuto al nuovo Duck.ai! Ora puoi importare le chat scaricate."
+msgstr ""
+"Ti diamo il benvenuto al nuovo Duck.ai! Ora puoi importare le chat scaricate."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -22452,6 +23043,103 @@ msgstr ""
 "capire per persone con o senza molta esperienza in ambito AI o tecnico."
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the counterarguments?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the hours & location?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key contributions of this paper?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key contributions?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key details?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key points covered in this video?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key points?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key takeaways from this article?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key takeaways?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key things I will learn from this course?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main counterarguments or criticisms of this?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main questions this page answers?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the must-try dishes here?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"What are the opening hours, location, and contact details for this place?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the pros and cons of this product?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the pros and cons?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
 msgctxt "feedback form"
 msgid "What bothered you most?"
@@ -22552,6 +23240,12 @@ msgid "What does atria mean in the context of a medical article?"
 msgstr "Cosa significa atri nel contesto di un articolo medico?"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What does this answer?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
@@ -22562,6 +23256,12 @@ msgstr "Quale funzionalità vorresti che aggiungessimo? (facoltativo)"
 msgctxt "cloudsave"
 msgid "What information gets saved?"
 msgstr "Quali informazioni vengono salvate?"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What interview questions might come up for this role?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -22578,6 +23278,12 @@ msgstr ""
 msgctxt "Full sentence for looking up basic facts"
 msgid "What is the capital city of Albania?"
 msgstr "Qual è la capitale dell'Albania?"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What is the overall verdict and rating for this?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to a page with additional information.
@@ -22602,6 +23308,12 @@ msgid "What people say:"
 msgstr "Opinioni:"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What should I order?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
 msgctxt "feedback form"
 msgid "What stood out?"
@@ -22614,6 +23326,18 @@ msgid "What was wrong with the response? (optional)"
 msgstr "Cosa c'era di sbagliato nella risposta? (facoltativo)"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I learn?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I need?"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid "What would you like to provide feedback on?"
 msgstr "Su cosa vuoi dare un'opinione?"
@@ -22622,13 +23346,20 @@ msgstr "Su cosa vuoi dare un'opinione?"
 #. Explains the benefits of using our custom video player, the Duck Player
 msgid ""
 "What you watch in DuckDuckGo won't influence your recommendations on YouTube."
-msgstr "Ciò che guardi in DuckDuckGo non influenzerà i tuoi consigli su YouTube."
+msgstr ""
+"Ciò che guardi in DuckDuckGo non influenzerà i tuoi consigli su YouTube."
 
 # smartling.placeholder_format=C
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
 msgctxt "SERP footer content"
 msgid "What's New"
 msgstr "Novità"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What's the verdict?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -22683,6 +23414,12 @@ msgid "Which features are missing? (Optional)"
 msgstr "Quali funzionalità mancano? (Opzionale)"
 
 # smartling.placeholder_format=C
+#. An invitation for users to leave feedback
+msgctxt "Feedback prompt"
+msgid "Which features are missing? (optional)"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
 msgid "White"
 msgstr "Bianco"
@@ -22697,6 +23434,18 @@ msgstr "Bianco"
 #. Link to an about us page.
 msgid "Who We Are"
 msgstr "Chi siamo"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Who are the main cast and crew, and what else are they known for?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Who is this person?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Header above a collection of privacy-related links.
@@ -23160,7 +23909,8 @@ msgstr ""
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
 msgctxt "Third party map app picker feedback dialog"
 msgid "You can change this any time in %sSearch Settings%s"
-msgstr "Puoi modificarle in qualsiasi momento in %1$sImpostazioni di ricerca%2$s"
+msgstr ""
+"Puoi modificarle in qualsiasi momento in %1$sImpostazioni di ricerca%2$s"
 
 # smartling.placeholder_format=C
 #. Text explaning how to change a passphrase.
@@ -23361,7 +24111,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
 msgid "You won't see this message again unless you clear your browser data."
-msgstr "Non vedrai più questo messaggio a meno che non elimini i dati del browser."
+msgstr ""
+"Non vedrai più questo messaggio a meno che non elimini i dati del browser."
 
 # smartling.placeholder_format=C
 #. The second paragraph of a pop up where we explain how to update the browser manually.
@@ -23446,7 +24197,8 @@ msgstr ""
 #. Description shown when the user has reached the maximum voice chat duration.
 msgctxt "voice chat duration limit modal"
 msgid "You've reached the maximum voice chat duration for a single session."
-msgstr "Hai raggiunto la durata massima della chat vocale per una singola sessione."
+msgstr ""
+"Hai raggiunto la durata massima della chat vocale per una singola sessione."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the daily voice chat limit.
@@ -23458,7 +24210,8 @@ msgstr "Hai raggiunto il limite di chat vocale per oggi. Riprova domani."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
 msgid "You've reached your dictation usage limit. Try again later."
-msgstr "Hai raggiunto il limite di utilizzo della dettatura. Riprova più tardi."
+msgstr ""
+"Hai raggiunto il limite di utilizzo della dettatura. Riprova più tardi."
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -23848,7 +24601,8 @@ msgctxt "Error message for input limit"
 msgid ""
 "You’ve exceeded the maximum message size. Please shorten your message and "
 "try again."
-msgstr "Hai superato la dimensione massima del messaggio. Accorcialo e riprova."
+msgstr ""
+"Hai superato la dimensione massima del messaggio. Accorcialo e riprova."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -23882,7 +24636,8 @@ msgctxt "Error message for user limit"
 msgid ""
 "You’ve reached the maximum number of messages for one day. Please continue "
 "this chat tomorrow."
-msgstr "Hai raggiunto il numero massimo di messaggi giornalieri. Continua domani."
+msgstr ""
+"Hai raggiunto il numero massimo di messaggi giornalieri. Continua domani."
 
 # smartling.placeholder_format=C
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
@@ -23971,7 +24726,8 @@ msgstr "di %1$s"
 #. Trust line shown at the bottom of the explainer panel, summarizing DuckDuckGo's reputation for online protection.
 msgctxt "Footer banner text in the How Duck.ai Works panel"
 msgid "by DuckDuckGo — online protection trusted by millions every day."
-msgstr "di DuckDuckGo, protezione online scelta da milioni di persone ogni giorno."
+msgstr ""
+"di DuckDuckGo, protezione online scelta da milioni di persone ogni giorno."
 
 # smartling.placeholder_format=C
 #. An abreviated unit of time indicating an age, e.g. "2d"

--- a/locales/ja_JP/LC_MESSAGES/duckduckgo.po
+++ b/locales/ja_JP/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: ja_JP\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -175,10 +175,7 @@ msgctxt "Error message when a Plus subscriber tries to use a Pro-only model"
 msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
-msgstr ""
-"%1$sはProでのみ利用可能です。チャットを続けるには、このブラウザでDuckDuckGoの"
-"サブスクリプションを再度アップグレードするか、Plusまたは無料プランに切り替え"
-"てください。"
+msgstr "%1$sはProでのみ利用可能です。チャットを続けるには、このブラウザでDuckDuckGoのサブスクリプションを再度アップグレードするか、Plusまたは無料プランに切り替えてください。"
 
 # smartling.placeholder_format=C
 #. Text for the disclaimer message that appears when a Plus subscriber tries to use a Pro-only model. %s is replaced with the model name. Example: Claude Opus 4.6 is only available with Pro. Upgrade your DuckDuckGo subscription in this browser again to continue the chat, or switch to a Plus or free model.
@@ -187,10 +184,7 @@ msgctxt ""
 msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
-msgstr ""
-"%1$sはProでのみ利用可能です。チャットを続けるには、このブラウザでDuckDuckGoの"
-"サブスクリプションを再度アップグレードするか、Plusまたは無料プランに切り替え"
-"てください。"
+msgstr "%1$sはProでのみ利用可能です。チャットを続けるには、このブラウザでDuckDuckGoのサブスクリプションを再度アップグレードするか、Plusまたは無料プランに切り替えてください。"
 
 # smartling.placeholder_format=C
 #. Displayed when an AI (Artificial Intelligence) chat model is temporarily unavailable. Example: 'GPT 4o is only available with a DuckDuckGo subscription.'
@@ -205,10 +199,7 @@ msgid ""
 "%s is only available with a DuckDuckGo subscription. Activate your "
 "subscription in this browser again to continue the chat, or switch to a free "
 "model."
-msgstr ""
-"%1$sはDuckDuckGoのサブスクリプションでのみ利用可能です。チャットを続けるに"
-"は、このブラウザでサブスクリプションを再度有効にするか、無料プランに切り替え"
-"てください。"
+msgstr "%1$sはDuckDuckGoのサブスクリプションでのみ利用可能です。チャットを続けるには、このブラウザでサブスクリプションを再度有効にするか、無料プランに切り替えてください。"
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is temporarily unavailable. Example: 'GPT 3.5 Turbo is temporarily unavailable. Please switch to a different model or try again later.'
@@ -216,9 +207,7 @@ msgctxt "Error message for model unavailability"
 msgid ""
 "%s is temporarily unavailable. Please switch to a different model or try "
 "again later."
-msgstr ""
-"%1$sは一時的に利用できません。 別のモデルに切り替えるか、後でもう一度やり直し"
-"てください。"
+msgstr "%1$sは一時的に利用できません。 別のモデルに切り替えるか、後でもう一度やり直してください。"
 
 # smartling.placeholder_format=C
 #. Reddit's "fake internet points". https://support.reddithelp.com/hc/en-us/articles/204511829-What-is-karma
@@ -309,9 +298,8 @@ msgid ""
 "provider can see your prompts or the model’s responses, or save this chat on "
 "their servers."
 msgstr ""
-"%1$sはTrusted Execution Environmentで動作します。つまり、モデルプロバイダーで"
-"さえあなたのプロンプトやモデルの応答を見ることができず、このチャットをサー"
-"バーに保存することもできません。"
+"%1$sはTrusted Execution "
+"Environmentで動作します。つまり、モデルプロバイダーでさえあなたのプロンプトやモデルの応答を見ることができず、このチャットをサーバーに保存することもできません。"
 
 # smartling.placeholder_format=C
 #. Label shown in the batch selection toolbar when exactly one chat is selected. %s is replaced with 1. Use singular agreement where the language requires it.
@@ -390,9 +378,7 @@ msgctxt ""
 msgid ""
 "%s will be leaving Duck.ai in %s days (%s). After that, you can switch "
 "models to continue this chat."
-msgstr ""
-"%1$sは%2$s日後（%3$s）にDuck.aiで利用不可になります。その後、モデルを切り替え"
-"てこのチャットを続けることができます。"
+msgstr "%1$sは%2$s日後（%3$s）にDuck.aiで利用不可になります。その後、モデルを切り替えてこのチャットを続けることができます。"
 
 # smartling.placeholder_format=C
 #. Displayed in a saved chat when its AI model is about to be retired tomorrow. First placeholder is the friendly model name, second placeholder is the removal date formatted in the user's browser locale (e.g., 'June 15, 2026' in en-US). Singular-day form.
@@ -402,9 +388,7 @@ msgctxt ""
 msgid ""
 "%s will be leaving Duck.ai in 1 day (%s). After that, you can switch models "
 "to continue this chat."
-msgstr ""
-"%1$sは1日後（%2$s）にDuck.aiで利用不可になります。その後、モデルを切り替えて"
-"このチャットを続けることができます。"
+msgstr "%1$sは1日後（%2$s）にDuck.aiで利用不可になります。その後、モデルを切り替えてこのチャットを続けることができます。"
 
 # smartling.placeholder_format=C
 #. Shown in a text selection chip when the selection contains multiple words. %s is replaced with the number of words, e.g. '142 words'.
@@ -416,9 +400,7 @@ msgstr "%1$s単語"
 #. Instructions on which buttons and options the user has to click in order to add the DuckDuckGo extension to their browser.
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
-msgstr ""
-"%1$s%2$s追加ボタンをクリックして%3$s%4$s許可%5$sにチェックを入れ、 %6$sOK%7$s"
-"をクリックしてください"
+msgstr "%1$s%2$s追加ボタンをクリックして%3$s%4$s許可%5$sにチェックを入れ、 %6$sOK%7$sをクリックしてください"
 
 # Firefox, obsolete
 # smartling.placeholder_format=C
@@ -426,8 +408,8 @@ msgstr ""
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAllow%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
 msgstr ""
-"%1$s%2$s許可%3$sにチェックを入れて、%4$s追加%5$sをクリックし、%6$s許可%7$s"
-"ボックスをオンにしてから %8$sOK%9$sをクリックしてください"
+"%1$s%2$s許可%3$sにチェックを入れて、%4$s追加%5$sをクリックし、%6$s許可%7$sボックスをオンにしてから "
+"%8$sOK%9$sをクリックしてください"
 
 # Firefox
 # smartling.placeholder_format=C
@@ -437,8 +419,8 @@ msgid ""
 "%sClick %sContinue To Installation%sClick %sAdd%sCheck %sAllow%s, then click "
 "%sOkay%s"
 msgstr ""
-"%1$s%2$sインストールを続行%3$sをクリックして %4$s追加ボタン%5$sを押し、%6$s許"
-"可%7$sにチェックを入れたら%8$sOK%9$sをクリックしてください"
+"%1$s%2$sインストールを続行%3$sをクリックして "
+"%4$s追加ボタン%5$sを押し、%6$s許可%7$sにチェックを入れたら%8$sOK%9$sをクリックしてください"
 
 # smartling.placeholder_format=C
 #. A button that reloads search results when an error occurs.
@@ -446,9 +428,7 @@ msgctxt "noresults"
 msgid ""
 "%sClick here%s to try again, if you think there should be results for this "
 "search."
-msgstr ""
-"この検索の結果について再読み込みする場合は、%1$sこちらをクリック%2$sしてもう"
-"一度試します。"
+msgstr "この検索の結果について再読み込みする場合は、%1$sこちらをクリック%2$sしてもう一度試します。"
 
 # smartling.placeholder_format=C
 #. Header for a page with information about sharing DuckDuckGo.
@@ -466,17 +446,14 @@ msgstr "%1$sさらに詳しく%2$s"
 #. Link to a page with more information about how anonymous location works.
 msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
-msgstr ""
-"%1$sDuckDuckGoが位置情報を保護する方法については、こちらをご覧ください%2$s。"
+msgstr "%1$sDuckDuckGoが位置情報を保護する方法については、こちらをご覧ください%2$s。"
 
 # smartling.placeholder_format=C
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
 msgctxt "Footer text for About Sync modal"
 msgid ""
 "%sLearn more%s about how chats are stored privately on DuckDuckGo's server."
-msgstr ""
-"DuckDuckGoのサーバー上でチャットが非公開で保存される仕組みについては%1$sこち"
-"ら%2$sをご覧ください。"
+msgstr "DuckDuckGoのサーバー上でチャットが非公開で保存される仕組みについては%1$sこちら%2$sをご覧ください。"
 
 # smartling.placeholder_format=C
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
@@ -494,8 +471,7 @@ msgstr "ホーム画面でDuckDuckGoのアプリアイコンを%1$s長押し%2$s
 #. A message displayed when there is an error loading content or no results on requery
 msgctxt "Error or no results message"
 msgid "%sOops!%s%sSomething went wrong. Please %srefresh%s and try again."
-msgstr ""
-"%1$s%2$s%3$s問題が発生しました。%4$s更新%5$sして、もう一度お試しください。"
+msgstr "%1$s%2$s%3$s問題が発生しました。%4$s更新%5$sして、もう一度お試しください。"
 
 # smartling.placeholder_format=C
 #. Tagline in a popover encouraging the user to download the DuckDuckGo browser
@@ -819,8 +795,7 @@ msgstr "6時間の使用制限に達しました。このチャットは%1$s以�
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "6-hour usage limit reached. You can keep chatting by using your daily limit."
-msgstr ""
-"6時間の使用制限に達しました。1日の制限時間を使ってチャットを続行できます。"
+msgstr "6時間の使用制限に達しました。1日の制限時間を使ってチャットを続行できます。"
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes abbreviation
@@ -873,27 +848,21 @@ msgstr "A"
 msgid ""
 "A network issue is preventing Search Assist from generating an answer. "
 "Please check your connection and try again."
-msgstr ""
-"ネットワークの問題により、Search Assistは回答を生成できません。接続を確認し"
-"て、もう一度試してください。"
+msgstr "ネットワークの問題により、Search Assistは回答を生成できません。接続を確認して、もう一度試してください。"
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of AI Chat is available and they need to refresh the page.
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of AI Chat is available! Please refresh this page to continue."
-msgstr ""
-"AI Chatの新バージョンが登場！続行するには、このページを再読み込みしてくださ"
-"い。"
+msgstr "AI Chatの新バージョンが登場！続行するには、このページを再読み込みしてください。"
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of Duck.ai is available and they need to refresh the page.
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of Duck.ai is available! Please refresh this page to continue."
-msgstr ""
-"Duck.aiの新バージョンが登場！続行するには、このページを再読み込みしてくださ"
-"い。"
+msgstr "Duck.aiの新バージョンが登場！続行するには、このページを再読み込みしてください。"
 
 # smartling.placeholder_format=C
 #. Shown when the Duck.ai desktop app has been open a long time and a newer version exists.
@@ -931,9 +900,8 @@ msgid ""
 "still access AI Chat when this setting is off by visiting %sduckduckgo.com/"
 "aichat%s."
 msgstr ""
-"AI Chatでは、サードパーティのAIチャットモデルと匿名で会話できます。設定をオフ"
-"にすると、DuckDuckGo SearchのAI Chat機能は非表示になりますが、%1$sduckduckgo."
-"com/aichat%2$sにアクセスすると、AI Chatをご利用いただけます。"
+"AI Chatでは、サードパーティのAIチャットモデルと匿名で会話できます。設定をオフにすると、DuckDuckGo SearchのAI "
+"Chat機能は非表示になりますが、%1$sduckduckgo.com/aichat%2$sにアクセスすると、AI Chatをご利用いただけます。"
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -993,11 +961,7 @@ msgid ""
 "However, we also offer and often link to %sDuck.ai%s for follow-up "
 "questions, which is our private AI-powered chat service that supports chat "
 "models from OpenAI, and Anthropic, and more."
-msgstr ""
-"AI支援による回答は現在、フォローアップの質問を直接サポートしていません。ただ"
-"し、フォローアップの質問のために%1$sDuck.ai%2$sも（リンク経由を含め）提供して"
-"います。Duck.aiは、OpenAIやAnthropicなどのチャットモデルをサポートするAIを活"
-"用したプライベートチャットサービスです。"
+msgstr "AI支援による回答は現在、フォローアップの質問を直接サポートしていません。ただし、フォローアップの質問のために%1$sDuck.ai%2$sも（リンク経由を含め）提供しています。Duck.aiは、OpenAIやAnthropicなどのチャットモデルをサポートするAIを活用したプライベートチャットサービスです。"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has turned off AI features and will no longer see AI-assisted answers.
@@ -1181,9 +1145,7 @@ msgctxt ""
 msgid ""
 "Activate your %s in this browser again to continue the chat, or switch to a "
 "free model."
-msgstr ""
-"チャットを続けるには、このブラウザで %1$s を再度有効にするか、無料プランに切"
-"り替えてください。"
+msgstr "チャットを続けるには、このブラウザで %1$s を再度有効にするか、無料プランに切り替えてください。"
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an active DuckDuckGo subscription.
@@ -1218,18 +1180,14 @@ msgstr "広告"
 #. An item in the ads tooltip that explains that ad clicks are managed by the ad network and are not used to profile you. The placeholder is the name of the ad network. For example: Microsoft
 msgid ""
 "Ad clicks are managed by %s’s ad network and are not used to profile you."
-msgstr ""
-"広告クリックは%1$sの広告ネットワークによって管理されており、お客様のプロファ"
-"イリングには使用されません。"
+msgstr "広告クリックは%1$sの広告ネットワークによって管理されており、お客様のプロファイリングには使用されません。"
 
 # smartling.placeholder_format=C
 #. Information that ad clicks are managed by Microsoft.
 msgid ""
 "Ad clicks are managed by Microsoft’s ad network and are not used to profile "
 "you."
-msgstr ""
-"広告クリックはMicrosoftの広告ネットワークによって管理されており、お客様のプロ"
-"ファイリングには使用されません。"
+msgstr "広告クリックはMicrosoftの広告ネットワークによって管理されており、お客様のプロファイリングには使用されません。"
 
 # smartling.placeholder_format=C
 #. An item in the ads tooltip that explains that ad clicks aren’t used to profile you.
@@ -1279,9 +1237,7 @@ msgstr "DuckDuckGo拡張機能を追加"
 # smartling.placeholder_format=C
 msgid ""
 "Add DuckDuckGo Privacy Essentials to your browser for free with one download:"
-msgstr ""
-"DuckDuckGo Privacy Essentialsは一度のダウンロードで、ブラウザに無料で追加でき"
-"ます："
+msgstr "DuckDuckGo Privacy Essentialsは一度のダウンロードで、ブラウザに無料で追加できます："
 
 #  IE default search engine instruction
 # smartling.placeholder_format=C
@@ -1439,7 +1395,7 @@ msgstr "アドレスが間違っています"
 #. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Adjust the servings"
-msgstr ""
+msgstr "サービング数を調整"
 
 # smartling.placeholder_format=C
 #. as in multiple advertisements
@@ -1517,16 +1473,13 @@ msgstr "アフリカーンス語"
 # smartling.placeholder_format=C
 #. Instructions on how to install the DuckDuckGo browser extension after it downloads.
 msgid "After it downloads and opens, click %sInstall%s"
-msgstr ""
-"ダウンロード後、ファイルを開いたら%1$sインストール%2$sをクリックしてください"
+msgstr "ダウンロード後、ファイルを開いたら%1$sインストール%2$sをクリックしてください"
 
 # smartling.placeholder_format=C
 #. Instructions on how to install the DuckDuckGo browser extension after it downloads.
 msgid ""
 "After it downloads, locate the extension file and double-click it to install"
-msgstr ""
-"ダウンロード後は拡張ファイルの場所に行き、ダブルクリックしてインストールして"
-"ください"
+msgstr "ダウンロード後は拡張ファイルの場所に行き、ダブルクリックしてインストールしてください"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an age below a web search result.
@@ -1661,7 +1614,7 @@ msgctxt "Privacy & Terms section description on the Duck.ai settings page"
 msgid ""
 "All chats are anonymized by DuckDuckGo, and your conversations are not used "
 "to train chat models by DuckDuckGo or the model providers"
-msgstr ""
+msgstr "すべてのチャットはDuckDuckGoによって匿名化されます。DuckDuckGoやモデルの提供元が学習内容をチャットモデルの学習に利用することはありません"
 
 # smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1693,9 +1646,7 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "All model providers are prevented from training their AI on your "
 "conversations."
-msgstr ""
-"すべてのモデルプロバイダーは、会話内容に基づくAIのトレーニングを禁止されてい"
-"ます。"
+msgstr "すべてのモデルプロバイダーは、会話内容に基づくAIのトレーニングを禁止されています。"
 
 # smartling.placeholder_format=C
 #. Text displayed in the subheader of the modal that allows the user to pick an AI chat model.
@@ -1709,9 +1660,7 @@ msgctxt "Body copy for the anonymized card in the How Duck.ai Works panel"
 msgid ""
 "All personal metadata (for example, your IP address) is removed before "
 "sending a chat to the AI provider."
-msgstr ""
-"AIプロバイダーにチャットを送信する前に、すべての個人メタデータ（IPアドレスな"
-"ど）が削除されます。"
+msgstr "AIプロバイダーにチャットを送信する前に、すべての個人メタデータ（IPアドレスなど）が削除されます。"
 
 # smartling.placeholder_format=C
 #. A filter that shows search results from all countries.
@@ -1736,9 +1685,7 @@ msgstr "すべての種類"
 msgctxt "voice chat"
 msgid ""
 "Allow DuckDuckGo microphone access in System Settings to use voice chat."
-msgstr ""
-"ボイスチャットを使用するには、システム設定でDuckDuckGoのマイクアクセスを許可"
-"してください。"
+msgstr "ボイスチャットを使用するには、システム設定でDuckDuckGoのマイクアクセスを許可してください。"
 
 # smartling.placeholder_format=C
 #. Tells users which icon to press in their browser. Part of a list of instructions on how to enable location service.
@@ -1763,19 +1710,14 @@ msgid ""
 "Allows %s to search the web to improve responses to relevant prompts. Only "
 "sends AI-generated queries to a search engine with limited data retention. "
 "Prompts and responses with %s still have %szero provider visibility%s."
-msgstr ""
-"%1$sがウェブを検索して、関連するプロンプトへの応答を改善できるようにします。"
-"AIが生成したクエリのみをデータ保持が制限された検索エンジンに送信します。%2$s"
-"のプロンプトや応答は依然としてプロバイダーに%3$s一切表示されません%4$s。"
+msgstr "%1$sがウェブを検索して、関連するプロンプトへの応答を改善できるようにします。AIが生成したクエリのみをデータ保持が制限された検索エンジンに送信します。%2$sのプロンプトや応答は依然としてプロバイダーに%3$s一切表示されません%4$s。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Allows Cloud Save key to be stored locally on device (required to use Cloud "
 "Save)"
-msgstr ""
-"デバイス上で Cloud Save キーのローカル保存を許可します (Cloud Save を利用する"
-"場合に必須)"
+msgstr "デバイス上で Cloud Save キーのローカル保存を許可します (Cloud Save を利用する場合に必須)"
 
 # smartling.placeholder_format=C
 #. Pending title indicating near completion.
@@ -1912,9 +1854,7 @@ msgctxt "AI Chat description"
 msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
-msgstr ""
-"%1$s、%2$sに加え、オープンソースの%3$sや%4$sなど、人気のAIモデルに匿名でアク"
-"セスできます。"
+msgstr "%1$s、%2$sに加え、オープンソースの%3$sや%4$sなど、人気のAIモデルに匿名でアクセスできます。"
 
 # smartling.placeholder_format=C
 #. Text with information about Duck.ai and supported AI models, the placeholders list AI models. Example: 'Anonymous access to popular AI models, including GPT, Claude, and open-source Llama and Mistral.'
@@ -1922,9 +1862,7 @@ msgctxt "Duck.ai description"
 msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
-msgstr ""
-"%1$s、%2$sに加え、オープンソースの%3$sや%4$sなど、人気のAIモデルに匿名でアク"
-"セスできます。"
+msgstr "%1$s、%2$sに加え、オープンソースの%3$sや%4$sなど、人気のAIモデルに匿名でアクセスできます。"
 
 # smartling.placeholder_format=C
 #. Confirmation message after location service is enabled.
@@ -1937,7 +1875,7 @@ msgctxt "settings"
 msgid ""
 "Anonymously generates answers for search queries based on web content. "
 "Choose how often you want it to appear, or disable it completely."
-msgstr ""
+msgstr "ウェブコンテンツに基づいて、検索クエリの回答を匿名で生成します。表示頻度を選択するか、完全に無効にすることができます。"
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -1983,9 +1921,7 @@ msgctxt "Placeholder for additional instructions textarea"
 msgid ""
 "Any additional instructions you want Duck.ai to follow. e.g. Always tell me "
 "facts about ducks"
-msgstr ""
-"Duck.aiが従うべき追加の指示はありますか。例えばいつもアヒルについての事実を教"
-"えてください"
+msgstr "Duck.aiが従うべき追加の指示はありますか。例えばいつもアヒルについての事実を教えてください"
 
 # smartling.placeholder_format=C
 #. Shown in video filtering. https://duckduckgo.com/?q=videos+of+cats&iax=videos&ia=videos
@@ -2104,9 +2040,7 @@ msgctxt "Body text for disable chat history confirmation modal"
 msgid ""
 "Are you sure you want to disable history? This will delete all chats, "
 "including pinned chats."
-msgstr ""
-"履歴を無効にしてもよろしいですか？これにより、ピン留めされたチャットを含むす"
-"べてのチャットが削除されます。"
+msgstr "履歴を無効にしてもよろしいですか？これにより、ピン留めされたチャットを含むすべてのチャットが削除されます。"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to disable recent chats, with a warning that it will also delete currently saved chats.
@@ -2114,9 +2048,7 @@ msgctxt "Body text for disable recent chats confirmation modal"
 msgid ""
 "Are you sure you want to disable recent chats? This will also delete any "
 "recent chats that are currently saved."
-msgstr ""
-"最近のチャットを無効にしてもよろしいですか？無効にすると、現在保存されている"
-"最近のチャットも削除されます。"
+msgstr "最近のチャットを無効にしてもよろしいですか？無効にすると、現在保存されている最近のチャットも削除されます。"
 
 # smartling.placeholder_format=C
 #. Question asking user if they want to share the URL of the page they were on when giving feedback
@@ -2153,9 +2085,7 @@ msgstr "最終更新："
 msgid ""
 "As per our privacy policy, we do not collect or share any personal "
 "information ourselves. All of this privacy protection happens on your device."
-msgstr ""
-"私達はプライバシーポリシーに従って、個人情報を収集または共有することはありま"
-"せん。これらのプライバシー保護機能はすべてあなたのデバイスで実行されます。"
+msgstr "私達はプライバシーポリシーに従って、個人情報を収集または共有することはありません。これらのプライバシー保護機能はすべてあなたのデバイスで実行されます。"
 
 # smartling.placeholder_format=C
 #. A button to ask Duck.ai a question
@@ -2221,7 +2151,7 @@ msgstr "Duck.aiにフォローアップの質問をする"
 #. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
 msgctxt "Page suggestion chip label"
 msgid "Ask about this page"
-msgstr ""
+msgstr "このページについて質問"
 
 # smartling.placeholder_format=C
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2285,12 +2215,9 @@ msgid ""
 "(shows more frequently on a wider range of searches). For now, AI-assisted "
 "answers are only available in the U.S. (English) region."
 msgstr ""
-"Assistは、関連するWebコンテンツを要約して、一部の検索に対してAI支援の回答を匿"
-"名で生成できます。Assistの表示頻度は、「なし」（検索結果からAssist UIを完全に"
-"削除）、「オンデマンド」（Assistボタンをクリックした場合にのみAI支援による回"
-"答を表示）、「時々」（関連性の高い場合にのみAI支援による回答を表示）、「頻"
-"繁」（より広範な検索でより頻繁にAIアシストによる回答を表示）から選択できま"
-"す。現時点では、AI支援の回答は米国（英語）地域でのみ利用可能です。"
+""
+"Assistは、関連するWebコンテンツを要約して、一部の検索に対してAI支援の回答を匿名で生成できます。Assistの表示頻度は、「なし」（検索結果からAssist "
+"UIを完全に削除）、「オンデマンド」（Assistボタンをクリックした場合にのみAI支援による回答を表示）、「時々」（関連性の高い場合にのみAI支援による回答を表示）、「頻繁」（より広範な検索でより頻繁にAIアシストによる回答を表示）から選択できます。現時点では、AI支援の回答は米国（英語）地域でのみ利用可能です。"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2301,12 +2228,7 @@ msgid ""
 "generate a brief answer based on relevant information found. It’s important "
 "to remember that responses are auto-generated from cited sources and based "
 "on %scrawling the web%s."
-msgstr ""
-"Assistは、検索クエリに対するAI支援の回答を匿名で生成できる、検索結果のオプ"
-"ション機能です。この機能は、ウェブをスキャンして関連コンテンツを探し、AIを活"
-"用した自然言語技術で見つかった関連情報に基づき、簡単な回答を生成します。回答"
-"は引用元から自動生成され、%1$sウェブのクロール%2$sに基づいて自動生成されるこ"
-"とを覚えておくことが重要です。"
+msgstr "Assistは、検索クエリに対するAI支援の回答を匿名で生成できる、検索結果のオプション機能です。この機能は、ウェブをスキャンして関連コンテンツを探し、AIを活用した自然言語技術で見つかった関連情報に基づき、簡単な回答を生成します。回答は引用元から自動生成され、%1$sウェブのクロール%2$sに基づいて自動生成されることを覚えておくことが重要です。"
 
 # smartling.placeholder_format=C
 #. Title for the dropdown menu where users select the assistant's role. Example: 'Assistant role: Travel guide'
@@ -2397,8 +2319,7 @@ msgstr "チャット終了後、音声は当社または OpenAI によって保�
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat is transcribed."
-msgstr ""
-"チャットの文字起こし後、音声データは当社またはOpenAIによって保存されません。"
+msgstr "チャットの文字起こし後、音声データは当社またはOpenAIによって保存されません。"
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when MediaRecorder API is unavailable.
@@ -2439,24 +2360,18 @@ msgstr "自動応答"
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid "Auto-generated based on listed sources. May contain inaccuracies."
-msgstr ""
-"リストされたソースに基づいて自動生成されます。不正確な情報が含まれる場合があ"
-"ります。"
+msgstr "リストされたソースに基づいて自動生成されます。不正確な情報が含まれる場合があります。"
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid ""
 "Auto-generated based on listed sources. Responses may contain inaccuracies."
-msgstr ""
-"リストされたソースに基づいて自動生成されます。回答には不正確な情報が含まれる"
-"場合があります。"
+msgstr "リストされたソースに基づいて自動生成されます。回答には不正確な情報が含まれる場合があります。"
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI) on mobile
 msgid "Auto-generated from sources. May be inaccurate."
-msgstr ""
-"ソースに基づき自動生成されています。内容に不正確な部分を含む可能性がありま"
-"す。"
+msgstr "ソースに基づき自動生成されています。内容に不正確な部分を含む可能性があります。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2475,10 +2390,7 @@ msgid ""
 "Automatically shows Assist for relevant searches. Assist can anonymously "
 "look up and summarize information in response to some searches. For now, "
 "Assist is only available in English regions."
-msgstr ""
-"関連する検索にAssistを自動表示します。Assistを使用すると、一部の検索に対して"
-"情報を匿名で調べ、要約できます。現時点では、Assistは英語圏でのみ利用可能で"
-"す。"
+msgstr "関連する検索にAssistを自動表示します。Assistを使用すると、一部の検索に対して情報を匿名で調べ、要約できます。現時点では、Assistは英語圏でのみ利用可能です。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2487,16 +2399,14 @@ msgid ""
 "anonymously look up and summarize information in response to some searches. "
 "For now, DuckAssist is only available in English regions."
 msgstr ""
-"関連する検索に DuckAssist を自動表示します。このツールを使用すると、一部の検"
-"索に対して情報を匿名で調べ、要約できます。現時点では、イングランド地域でのみ"
-"利用可能です。"
+"関連する検索に DuckAssist "
+"を自動表示します。このツールを使用すると、一部の検索に対して情報を匿名で調べ、要約できます。現時点では、イングランド地域でのみ利用可能です。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Autoplay short, silent video previews when you hover over video results."
-msgstr ""
-"動画の結果にカーソルを合わせると、プレビューが短時間無音で自動再生されます。"
+msgstr "動画の結果にカーソルを合わせると、プレビューが短時間無音で自動再生されます。"
 
 # smartling.placeholder_format=C
 #. Screen-reader label for the radiogroup of tool options inside the Tools dropdown. Announced when assistive technology enters the group of menuitemradio items.
@@ -2641,7 +2551,7 @@ msgstr "バーコード"
 #. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Based on this page, is this course worth taking?"
-msgstr ""
+msgstr "このページの内容から判断して、この講座を受講する価値はありますか？"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2689,7 +2599,7 @@ msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
 msgid ""
 "Before storing this report, DuckDuckGo will anonymize your conversation by "
 "removing PII like names, email addresses, and identifying metadata."
-msgstr ""
+msgstr "このレポートを保存する前に、DuckDuckGoは名前、メールアドレス、識別メタデータなどのPIIを削除することで、会話を匿名化します。"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -2815,8 +2725,7 @@ msgstr "メールトラッカーをブロックし、アドレスを非表示に
 # smartling.placeholder_format=C
 #. A disclaimer about AI-generated images in search results
 msgid "Block list is not exhaustive and may contain inaccuracies."
-msgstr ""
-"ブロックリストは完全ではなく、不正確な情報が含まれている可能性があります。"
+msgstr "ブロックリストは完全ではなく、不正確な情報が含まれている可能性があります。"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -3012,7 +2921,7 @@ msgstr "ブレークポイント獲得"
 #. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Break this down into clear, numbered steps."
-msgstr ""
+msgstr "明確な番号付きのステップに分けてください。"
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -3070,28 +2979,20 @@ msgstr "ファイルを参照"
 msgid ""
 "Browse as usual while we add privacy protection. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
-msgstr ""
-"DuckDuckGoなら普段どおりに閲覧しながら、プライバシー保護を強化できます。検索"
-"エンジン、トラッカーブロック、高度な暗号化機能をひとつの%1$s%2$s拡張機能%3$s"
-"にまとめました。"
+msgstr "DuckDuckGoなら普段どおりに閲覧しながら、プライバシー保護を強化できます。検索エンジン、トラッカーブロック、高度な暗号化機能をひとつの%1$s%2$s拡張機能%3$sにまとめました。"
 
 # smartling.placeholder_format=C
 msgid ""
 "Browse as usual, and we'll take care of the rest. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
-msgstr ""
-"いつも通り閲覧して、あとは当社におまかせ。検索エンジン、トラッカーブロック、"
-"高度な暗号化機能を1つの%1$s%2$s拡張機能%3$sにまとめました。"
+msgstr "いつも通り閲覧して、あとは当社におまかせ。検索エンジン、トラッカーブロック、高度な暗号化機能を1つの%1$s%2$s拡張機能%3$sにまとめました。"
 
 # smartling.placeholder_format=C
 msgid ""
 "Browse as usual, and we’ll take care of the rest. Get bundled private "
 "search, tracker blocking, and site encryption, all in one download, for "
 "%smajor browsers%s."
-msgstr ""
-"いつも通り閲覧して、あとは当社におまかせ。プライベート検索、トラッカーブロッ"
-"ク、サイトの暗号化機能を1つにまとめた%1$s主要なブラウザ%2$s向けツールをダウン"
-"ロードしましょう。"
+msgstr "いつも通り閲覧して、あとは当社におまかせ。プライベート検索、トラッカーブロック、サイトの暗号化機能を1つにまとめた%1$s主要なブラウザ%2$s向けツールをダウンロードしましょう。"
 
 # smartling.placeholder_format=C
 #. Header for a call to action to browse with the DuckDuckGo browser
@@ -3177,8 +3078,7 @@ msgstr "「%1$s」をクリックすると、当社の%2$sに同意したこと�
 msgctxt ""
 "Copy stating agreement to Duck.ai Privacy Policy and Terms of Service."
 msgid "By clicking “%s,” you accept Duck.ai’s %s and %s."
-msgstr ""
-"「%1$s」をクリックすると、Duck.aiの%2$sと%3$sに同意したことになります。"
+msgstr "「%1$s」をクリックすると、Duck.aiの%2$sと%3$sに同意したことになります。"
 
 # smartling.placeholder_format=C
 #. Text stating agreement to Duck.ai Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'By clicking “Agree and Continue,” you accept Duck.ai’s Privacy Policy and Terms of Service.'
@@ -3199,19 +3099,16 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"初期状態では、設定情報は秘匿されないブラウザのCookieファイル (ブラウザ内) に"
-"保存されます。匿名の Cloud Save 機能を利用すると、設定情報を (クラウド上のリ"
-"モートサーバーに) より長期的に保存できます。個人を特定できる情報がクラウドに"
-"保存されたり、パスフレーズがブラウザ上に残ることもありません。"
+"初期状態では、設定情報は秘匿されないブラウザのCookieファイル (ブラウザ内) に保存されます。匿名の Cloud Save "
+"機能を利用すると、設定情報を (クラウド上のリモートサーバーに) "
+"より長期的に保存できます。個人を特定できる情報がクラウドに保存されたり、パスフレーズがブラウザ上に残ることもありません。"
 
 # smartling.placeholder_format=C
 #. Description for the consent highlight in the dictation consent modal. %s is replaced with a link to the help page.
 msgid ""
 "By enabling dictation, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
-msgstr ""
-"音声入力を有効にすると、この機能の使用のために音声データがOpenAIに送信される"
-"ことに同意したことになります。開始する間に当社の%1$sを確認してください。"
+msgstr "音声入力を有効にすると、この機能の使用のために音声データがOpenAIに送信されることに同意したことになります。開始する間に当社の%1$sを確認してください。"
 
 # smartling.placeholder_format=C
 #. Description for the 'enable voice chat' section of the voice chat consent modal. Placeholder for the voice chat help page link and text. Example: 'By enabling voice chat, you consent to your voice data being sent to OpenAI for the use of this feature. See our voice chat help page before getting started.'
@@ -3220,9 +3117,8 @@ msgid ""
 "By enabling voice chat, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
 msgstr ""
-"ボイスチャットを有効にすると、この機能の使用のために音声データがOpenAI に送信"
-"されることに同意したことになります。開始する間に当社の%1$sを確認してくださ"
-"い。"
+"ボイスチャットを有効にすると、この機能の使用のために音声データがOpenAI "
+"に送信されることに同意したことになります。開始する間に当社の%1$sを確認してください。"
 
 # smartling.placeholder_format=C
 #. Golf leaderboard: player missed the cut
@@ -3471,7 +3367,7 @@ msgstr "キャスト"
 #. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Cast & Crew"
-msgstr ""
+msgstr "キャスト & スタッフ"
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -3577,8 +3473,7 @@ msgstr "サイト全体の背景色を変更する"
 msgctxt "settings"
 msgid ""
 "Changes the background color of results on hover, modules, and dropdown menus"
-msgstr ""
-"マウスオーバー、モジュール、ドロップダウンメニューでの検索結果の背景色を変更"
+msgstr "マウスオーバー、モジュール、ドロップダウンメニューでの検索結果の背景色を変更"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/NdpkbY0.png
@@ -3707,11 +3602,10 @@ msgid ""
 "DuckDuckGo Search. However, you can still access Chat when this setting is "
 "off by visiting %shttps://duck.ai%s directly."
 msgstr ""
-"チャット（Duck.ai サービス経由）を通じて、OpenAI、Anthropicなどのサードパー"
-"ティのAIチャットモデルと匿名で会話することができます。この設定をオフにする"
-"と、DuckDuckGo Searchのチャットボタンとリンクが非表示になります。ただし、この"
-"設定がオフの場合でも、%1$shttps://duck.ai%2$sにアクセスして直接チャットを利用"
-"できます。"
+"チャット（Duck.ai "
+""
+"サービス経由）を通じて、OpenAI、AnthropicなどのサードパーティのAIチャットモデルと匿名で会話することができます。この設定をオフにすると、DuckDuckGo "
+"Searchのチャットボタンとリンクが非表示になります。ただし、この設定がオフの場合でも、%1$shttps://duck.ai%2$sにアクセスして直接チャットを利用できます。"
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -3766,18 +3660,14 @@ msgstr "プライベートチャット"
 #. Mobile variant of DUCKCHAT_BROWSER_UPSELL_PROMO_TEXT. Shorter version for the promotional card encouraging third-party browser users to download the DuckDuckGo browser.
 msgctxt "Promotional text (mobile)"
 msgid "Chat privately on any website with Duck.ai built into our free browser."
-msgstr ""
-"無料ブラウザに内蔵されたDuck.aiがあれば、どのウェブサイトでもプライベートに"
-"チャットできます。"
+msgstr "無料ブラウザに内蔵されたDuck.aiがあれば、どのウェブサイトでもプライベートにチャットできます。"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card encouraging third-party browser users to download the DuckDuckGo browser. Not shown in the DuckDuckGo browser or on Linux.
 msgctxt "Promotional text"
 msgid ""
 "Chat privately on any website with the Duck.ai sidebar in our free browser."
-msgstr ""
-"無料のDuckDuckGoブラウザのDuck.aiサイドバーを使えば、どのウェブサイトでもプラ"
-"イベートにチャットできます。"
+msgstr "無料のDuckDuckGoブラウザのDuck.aiサイドバーを使えば、どのウェブサイトでもプライベートにチャットできます。"
 
 # smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
@@ -3839,10 +3729,7 @@ msgctxt "Description for Chat History feature"
 msgid ""
 "Chats are stored locally on your device instead of on DuckDuckGo servers or "
 "remote servers. Disabling chat history will delete pinned chats."
-msgstr ""
-"チャットは、DuckDuckGoサーバーやリモートサーバーでなく、お使いのデバイスに"
-"ローカルで保存されます。チャット履歴を無効にすると、ピン留めされたチャットが"
-"削除されます。"
+msgstr "チャットは、DuckDuckGoサーバーやリモートサーバーでなく、お使いのデバイスにローカルで保存されます。チャット履歴を無効にすると、ピン留めされたチャットが削除されます。"
 
 # smartling.placeholder_format=C
 #. Text explaining how the Chat History feature stores the user's chats locally to their device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection. Also explains that disabling chat history will delete pinned chats.
@@ -3853,12 +3740,7 @@ msgid ""
 "help recover a chat if you lose your internet connection. Disabling chat "
 "history will delete pinned chats, and disable the temporary storage of new "
 "prompts and responses."
-msgstr ""
-"チャットはデバイスのローカルに保存されます。新しいプロンプトやレスポンスは暗"
-"号化され、送信後はDuckDuckGoサーバーに一時的に保存されます。これは、インター"
-"ネット接続が途切れた場合のチャット復旧に役立ちます。チャット履歴を無効にする"
-"と、固定されたチャットが削除され、新しいプロンプトと応答の一時的な保存が無効"
-"になります。"
+msgstr "チャットはデバイスのローカルに保存されます。新しいプロンプトやレスポンスは暗号化され、送信後はDuckDuckGoサーバーに一時的に保存されます。これは、インターネット接続が途切れた場合のチャット復旧に役立ちます。チャット履歴を無効にすると、固定されたチャットが削除され、新しいプロンプトと応答の一時的な保存が無効になります。"
 
 # smartling.placeholder_format=C
 #. Title shown above the body copy in the Duck.ai recent chats IndexedDB unavailable notice.
@@ -3879,9 +3761,7 @@ msgstr "チャットは安全にダウンロードされました"
 msgctxt "Sync file storage inline disclaimer body"
 msgid ""
 "Chats with attachments have stopped syncing. Free up storage to resume Sync."
-msgstr ""
-"添付ファイル付きのチャットが同期されなくなりました。同期を再開するにはスト"
-"レージを解放してください。"
+msgstr "添付ファイル付きのチャットが同期されなくなりました。同期を再開するにはストレージを解放してください。"
 
 # smartling.placeholder_format=C
 #. Message shown when we have no data from upstream to display
@@ -3940,8 +3820,7 @@ msgstr "この障害に関する最新情報は、DuckDuckGoのサブレディ�
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
 msgctxt "noresults"
 msgid "Check the status page for updates on this outage."
-msgstr ""
-"この停止に関する最新情報については、ステータスページを確認してください。"
+msgstr "この停止に関する最新情報については、ステータスページを確認してください。"
 
 # smartling.placeholder_format=C
 #. Title shown to the host device (the one that is logged in) after it sends the pairing code. The host can't confirm the peer applied it, so this is a title-only screen (no body) prompting the user to finish on the other device.
@@ -4000,8 +3879,7 @@ msgstr "%1$sや%2$sを含むAIモデルの選択"
 # smartling.placeholder_format=C
 #. As in 'Choose to keep DuckDuckGo as your default search engine'. Placeholders are for markup, you can ignore them.
 msgid "Choose %skeep it%s to continue protecting your privacy."
-msgstr ""
-"%1$s初期設定の検索エンジンを保持%2$sを選び、プライバシーを保護しましょう。"
+msgstr "%1$s初期設定の検索エンジンを保持%2$sを選び、プライバシーを保護しましょう。"
 
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
@@ -4216,9 +4094,8 @@ msgid ""
 "Clearing browser data deletes chats. Some browsers may keep recent chats "
 "indefinitely or auto-delete them after 7+ days of no AI Chat use."
 msgstr ""
-"ブラウザのデータを消去すると、チャットも消去されます。一部のブラウザでは、最"
-"近のチャットが無期限に保存される場合、またはAI Chatの未使用期間が7日を超える"
-"と自動的に削除される場合があります。"
+"ブラウザのデータを消去すると、チャットも消去されます。一部のブラウザでは、最近のチャットが無期限に保存される場合、またはAI "
+"Chatの未使用期間が7日を超えると自動的に削除される場合があります。"
 
 # smartling.placeholder_format=C
 #. Text explaining what happens to recent chats when browser data is cleared.
@@ -4227,10 +4104,7 @@ msgid ""
 "Clearing browser data deletes recent chats. Recent chats may be saved "
 "indefinitely or auto-deleted after 7 days without using Duck.ai, depending "
 "on your browser."
-msgstr ""
-"ブラウザのデータを消去すると、最近のチャットが削除されます。最近のチャットは"
-"無期限に保存されるか、Duck.aiを使用しない場合、7日後に自動削除されることがあ"
-"ります。ブラウザによって異なります。"
+msgstr "ブラウザのデータを消去すると、最近のチャットが削除されます。最近のチャットは無期限に保存されるか、Duck.aiを使用しない場合、7日後に自動削除されることがあります。ブラウザによって異なります。"
 
 # smartling.placeholder_format=C
 #. Warning message shown on the Block domain success modal. Blocked sites are stored in localStorage which is cleared alongside cookies when users clear browser data. Followed by a linked 'our free browser' text.
@@ -4238,9 +4112,7 @@ msgctxt "settings"
 msgid ""
 "Clearing browser data will reset your blocked sites. Save your block list "
 "permanently in"
-msgstr ""
-"ブラウザデータを消去すると、ブロックしたサイトがリセットされます。ブロックリ"
-"ストを当社の無料ブラウザに"
+msgstr "ブラウザデータを消去すると、ブロックしたサイトがリセットされます。ブロックリストを当社の無料ブラウザに"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -4248,11 +4120,7 @@ msgid ""
 "Click \"More\" to go deeper on a topic, and ask follow-up questions via "
 "%sDuck.ai%s, our private AI chat service that supports chat models from "
 "OpenAI, Anthropic, and more."
-msgstr ""
-"「詳細」をクリックすると、トピックについてさらに詳しい情報が表示されます。ま"
-"た、フォローアップの質問をするために、%1$sDuck.ai%2$s（OpenAIやAnthropicなど"
-"のチャットモデルをサポートする当社のプライベートAIチャットサービス）も使用で"
-"きます。"
+msgstr "「詳細」をクリックすると、トピックについてさらに詳しい情報が表示されます。また、フォローアップの質問をするために、%1$sDuck.ai%2$s（OpenAIやAnthropicなどのチャットモデルをサポートする当社のプライベートAIチャットサービス）も使用できます。"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4293,9 +4161,7 @@ msgstr "一覧から%1$s検索設定の変更%2$sをクリックしてくださ�
 msgid ""
 "Click %sEdit > Preferences%s (on Windows) %sSeaMonkey > Preferences%s (on "
 "Mac)"
-msgstr ""
-"%1$s編集 > 設定%2$s (Windows) %3$sSeaMonkey > 設定%4$s (Mac) をクリックしてく"
-"ださい"
+msgstr "%1$s編集 > 設定%2$s (Windows) %3$sSeaMonkey > 設定%4$s (Mac) をクリックしてください"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -4306,15 +4172,12 @@ msgstr "%1$sここ%2$sをクリックして検索エンジンとして追加し�
 # smartling.placeholder_format=C
 #. Link to add the DuckDuckGo browser extension to Safari.
 msgid "Click %sHere%s to download the DuckDuckGo extension"
-msgstr ""
-"%1$sここ%2$sをクリックしてDuckDuckGoの拡張機能をダウンロードしてください"
+msgstr "%1$sここ%2$sをクリックしてDuckDuckGoの拡張機能をダウンロードしてください"
 
 # smartling.placeholder_format=C
 #. Link to download the DuckDuckGo browser extension.
 msgid "Click %sOpen%s to download and open the DuckDuckGo Safari extension"
-msgstr ""
-"%1$s開く%2$sをクリックしてDuckDuckGoのSafari拡張設定をダウンロードしてくださ"
-"い"
+msgstr "%1$s開く%2$sをクリックしてDuckDuckGoのSafari拡張設定をダウンロードしてください"
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -4328,9 +4191,7 @@ msgstr "左側のサイドバーにある%1$sプライバシーとサービス%2
 msgid ""
 "Click %sSafari%s in the top menu (On Windows, click the %sgears icon%s in "
 "the top right)"
-msgstr ""
-"%1$sSafari%2$sをトップメニューからクリックしてください(またはWindowsの場合、"
-"右上の%3$s歯車アイコン%4$sをクリックしてください)"
+msgstr "%1$sSafari%2$sをトップメニューからクリックしてください(またはWindowsの場合、右上の%3$s歯車アイコン%4$sをクリックしてください)"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4359,8 +4220,7 @@ msgstr "%1$sはい%2$sをクリックしてください"
 # smartling.placeholder_format=C
 #. Tells the user where to click to open their browser's settings menu.
 msgid "Click %ssettings/hamburger icon %s on the Chrome toolbar (top right)."
-msgstr ""
-"Chromeのツールバーで「%1$ssettings/hamburger icon %2$s」をクリックします。"
+msgstr "Chromeのツールバーで「%1$ssettings/hamburger icon %2$s」をクリックします。"
 
 #  Maxthon default search engine instruction
 # smartling.placeholder_format=C
@@ -4396,8 +4256,7 @@ msgstr "下のほうの %1$sデフォルトに設定%2$s をクリックしま�
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click on the %sSearch Providers%s under Add-on Types"
-msgstr ""
-"アドオンタイプセクションの下にある%1$s検索エンジン%2$sボタンを押してください"
+msgstr "アドオンタイプセクションの下にある%1$s検索エンジン%2$sボタンを押してください"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -4422,10 +4281,7 @@ msgctxt "cloudsave"
 msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Search Settings%s."
-msgstr ""
-"「%1$s自分のデータを削除%2$s」をクリックまたはタップします。データはこの操作"
-"によりクラウドから削除されますが、「%3$sすべての検索設定をリセット%4$s」がク"
-"リックまたはタップされるまでブラウザに残ります。"
+msgstr "「%1$s自分のデータを削除%2$s」をクリックまたはタップします。データはこの操作によりクラウドから削除されますが、「%3$sすべての検索設定をリセット%4$s」がクリックまたはタップされるまでブラウザに残ります。"
 
 # smartling.placeholder_format=C
 #. Tells users where to click in order to disable the cloud save feature and delete any data backed-up to the cloud.
@@ -4435,10 +4291,7 @@ msgctxt "cloudsave"
 msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Settings%s."
-msgstr ""
-"%1$s自分のデータを削除%2$sをクリックまたはタップします。この操作でデータはク"
-"ラウド上から削除されますが、%3$sすべての設定をリセット%4$sをクリック/タップし"
-"ない限り、お使いのブラウザに保存されたままとなります。"
+msgstr "%1$s自分のデータを削除%2$sをクリックまたはタップします。この操作でデータはクラウド上から削除されますが、%3$sすべての設定をリセット%4$sをクリック/タップしない限り、お使いのブラウザに保存されたままとなります。"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -4506,18 +4359,14 @@ msgstr "検索ボックスの選択項目をクリック"
 msgid ""
 "Click the dropdown menu beside %sSearch engine used in the address bar%s and "
 "select %sDuckDuckGo%s."
-msgstr ""
-"%1$s「アドレスバーで使用する検索エンジン」の横にあるドロップダウンメニューを"
-"クリック%2$sして、%3$sDuckDuckGo%4$s を選択します。"
+msgstr "%1$s「アドレスバーで使用する検索エンジン」の横にあるドロップダウンメニューをクリック%2$sして、%3$sDuckDuckGo%4$s を選択します。"
 
 # smartling.placeholder_format=C
 #. First step in a list of steps to take to disable the user's ad blocker
 msgid ""
 "Click the icon of the ad blocker extension. It's usually in the upper right "
 "hand corner of your browser."
-msgstr ""
-"広告ブロッカー拡張機能のアイコンをクリックします。通常、広告ブロッカー拡張機"
-"能のアイコンはブラウザの右上隅に表示されています。"
+msgstr "広告ブロッカー拡張機能のアイコンをクリックします。通常、広告ブロッカー拡張機能のアイコンはブラウザの右上隅に表示されています。"
 
 #  Safari default search engine instruction
 # smartling.placeholder_format=C
@@ -4705,9 +4554,7 @@ msgctxt "cloudsave"
 msgid ""
 "Cloud Save lets you save your settings more permanently by entering a "
 "passphrase. It is entirely optional."
-msgstr ""
-"パスワードを入力すれば、Cloud Saveで自分の設定をずっと保存できます。この機能"
-"を使うかどうかはあなた次第。強制ではありません。"
+msgstr "パスワードを入力すれば、Cloud Saveで自分の設定をずっと保存できます。この機能を使うかどうかはあなた次第。強制ではありません。"
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -5066,8 +4913,7 @@ msgstr "コピー"
 # smartling.placeholder_format=C
 #. Instructions on how to change the default search engine
 msgid "Copy &amp; paste %sabout:preferences#search%s into the address bar"
-msgstr ""
-"「%1$sabout:preferences#search%2$s」をアドレスバーにコピー＆ペーストします"
+msgstr "「%1$sabout:preferences#search%2$s」をアドレスバーにコピー＆ペーストします"
 
 # smartling.placeholder_format=C
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
@@ -5137,9 +4983,7 @@ msgstr "コスタリカ"
 #. Inline error shown on the recovery code screen when exportSyncSettings rejects.
 msgctxt "Error message when the recovery code fails to generate"
 msgid "Couldn't load your recovery code. Please close this and try again."
-msgstr ""
-"リカバリーコードを読み込めませんでした。これを閉じて、もう一度お試しくださ"
-"い。"
+msgstr "リカバリーコードを読み込めませんでした。これを閉じて、もう一度お試しください。"
 
 # smartling.placeholder_format=C
 #. Pairs with a Retry button. Shown after two consecutive failed attempts to load the device list.
@@ -5188,7 +5032,7 @@ msgstr "画像を作成"
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
-msgstr ""
+msgstr "このレシピの買い物リストを分量入りで作成します。"
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed in the input field when starting a new image generation session.
@@ -5452,8 +5296,7 @@ msgstr "1日の使用制限に達しました。このチャットは%1$s以降�
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "Daily usage limit reached. You can keep chatting by using your weekly limit."
-msgstr ""
-"1日の使用制限に達しました。週間制限時間を使ってチャットを続行できます。"
+msgstr "1日の使用制限に達しました。週間制限時間を使ってチャットを続行できます。"
 
 # smartling.placeholder_format=C
 #. The name of the Danish language
@@ -5711,8 +5554,7 @@ msgstr "ストレージを解放するために最も古いチャットを削除
 #. Title shown when user has reached the file storage sync quota (5GB).
 msgctxt "Sync file storage limit modal title"
 msgid "Delete oldest chats with attachments to free up storage?"
-msgstr ""
-"保存容量を空けるために添付ファイル付きの最も古いチャットを削除しますか？"
+msgstr "保存容量を空けるために添付ファイル付きの最も古いチャットを削除しますか？"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to delete all recent chats.
@@ -5821,9 +5663,7 @@ msgstr "Duck.aiの音声入力"
 # smartling.placeholder_format=C
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
-msgstr ""
-"音声入力は当社によって匿名化されており、AIモデルのトレーニングには使用されま"
-"せん。"
+msgstr "音声入力は当社によって匿名化されており、AIモデルのトレーニングには使用されません。"
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
@@ -5833,16 +5673,14 @@ msgstr "音声入力予算の上限に達しました"
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
 msgid "Dictation temporarily unavailable"
-msgstr ""
+msgstr "音声入力は一時的に利用できません"
 
 # smartling.placeholder_format=C
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
 "chat in Duck.ai without having to type."
-msgstr ""
-"音声入力はOpenAIのモデルを使って音声をテキストに変換し、タイピングせずにDuck."
-"aiチャットができます。"
+msgstr "音声入力はOpenAIのモデルを使って音声をテキストに変換し、タイピングせずにDuck.aiチャットができます。"
 
 # smartling.placeholder_format=C
 #. In 0-click box -- link to definition.
@@ -6110,15 +5948,13 @@ msgstr "DuckDuckGoがリストにありませんか？"
 #. Link to download a file again if the user can't find it on their computer.
 msgctxt "install-extension"
 msgid "Don't see it? %s%s%sClick here to re-download%s"
-msgstr ""
-"表示されませんか？ %1$s%2$s%3$s再度ダウンロードするにはここをクリック%4$s"
+msgstr "表示されませんか？ %1$s%2$s%3$s再度ダウンロードするにはここをクリック%4$s"
 
 #  IE < 11 default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Don't see the checkbox? %sFollow these steps%s."
-msgstr ""
-"チェックボックスが表示されない場合は、%1$s以下の手順に従ってください%2$s。"
+msgstr "チェックボックスが表示されない場合は、%1$s以下の手順に従ってください%2$s。"
 
 # smartling.placeholder_format=C
 #. Setting that hides a user's most visited sites when they open a new browser tab.
@@ -6143,7 +5979,7 @@ msgctxt "settings"
 msgid ""
 "Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
 "filtered out. %sLearn More%s"
-msgstr ""
+msgstr "AIが不要な場合は、%1$snoai.duckduckgo.com%2$sにアクセスすると、AI機能は提供されず、AI画像は除外されます。%3$s詳細情報%4$s"
 
 # smartling.placeholder_format=C
 #. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
@@ -6151,7 +5987,7 @@ msgctxt "settings"
 msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
-msgstr ""
+msgstr "AIが不要な場合は、%1$snoai.duckduckgo.com%2$sにアクセスすると、検索時にAI機能は使用されず、AI画像は除外されます。%3$s詳細情報%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6253,9 +6089,7 @@ msgctxt "Full sentence for writing an email"
 msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for "
 "ceiling fan repair services."
-msgstr ""
-"シーリングファンの修理サービスの見積もりを依頼するベンダーにメールを作成しま"
-"す。内容は、簡潔かつ詳細に入力してください。"
+msgstr "シーリングファンの修理サービスの見積もりを依頼するベンダーにメールを作成します。内容は、簡潔かつ詳細に入力してください。"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion asking for an email draft to a vendor requesting a quote for home refrigerator repair services.
@@ -6263,21 +6097,19 @@ msgctxt "Full sentence for writing an email"
 msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
-msgstr ""
-"家庭用冷蔵庫の修理サービスの見積もりを依頼する業者にメールを作成します。内容"
-"は、簡潔かつ詳細に入力してください。"
+msgstr "家庭用冷蔵庫の修理サービスの見積もりを依頼する業者にメールを作成します。内容は、簡潔かつ詳細に入力してください。"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Draft a cover letter"
-msgstr ""
+msgstr "カバーレターの下書きを作成"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Draft a cover letter for this job."
-msgstr ""
+msgstr "この求人のカバーレターの下書きを作成します。"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -6285,9 +6117,7 @@ msgctxt "Full sentence for drafting a social media post"
 msgid ""
 "Draft a few options for a social media post inviting people to my upcoming "
 "party."
-msgstr ""
-"今後のパーティーに人々を招待するソーシャルメディア投稿のオプションをいくつか"
-"作成してください。"
+msgstr "今後のパーティーに人々を招待するソーシャルメディア投稿のオプションをいくつか作成してください。"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a few options for a blog post title about strategies to increase team collaboration.
@@ -6295,9 +6125,7 @@ msgctxt "Full sentence for suggesting a blog post title"
 msgid ""
 "Draft a few options for a title of a post I’m writing about strategies to "
 "increase team collaboration."
-msgstr ""
-"チームコラボレーションを強化するための戦略について書いた投稿のタイトル案をい"
-"くつか作成してください。"
+msgstr "チームコラボレーションを強化するための戦略について書いた投稿のタイトル案をいくつか作成してください。"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for drafting a social media post.
@@ -6425,8 +6253,7 @@ msgid ""
 msgstr ""
 "Duck.aiは、現在表示しているページに関する質問に回答できるようになりました。\n"
 "\n"
-"設定でページを自動添付することを選択しない限り、ページコンテンツは添付したと"
-"きにのみ含まれます。"
+"設定でページを自動添付することを選択しない限り、ページコンテンツは添付したときにのみ含まれます。"
 
 # smartling.placeholder_format=C
 #. Shown in the Duck.ai recent chats list on standalone when the browser API needed to store chats locally is missing or unavailable.
@@ -6435,10 +6262,7 @@ msgctxt ""
 msgid ""
 "Duck.ai can’t access local storage to save your chats. Please check your "
 "browser settings or disable any extensions and try again."
-msgstr ""
-"Duck.aiはローカルストレージにアクセスできないため、チャットを保存できません。"
-"ブラウザの設定を確認するか、拡張機能を無効にしてから、もう一度お試しくださ"
-"い。"
+msgstr "Duck.aiはローカルストレージにアクセスできないため、チャットを保存できません。ブラウザの設定を確認するか、拡張機能を無効にしてから、もう一度お試しください。"
 
 # smartling.placeholder_format=C
 #. Displayed when the chat service has reached the maximum number of messages for one day.
@@ -6446,16 +6270,13 @@ msgctxt "Error message for service limit"
 msgid ""
 "Duck.ai has reached the maximum number of messages for one day. Please "
 "continue this chat tomorrow."
-msgstr ""
-"Duck.aiの1日のメッセージ数の上限に達しました。このチャットは明日続行してくだ"
-"さい。"
+msgstr "Duck.aiの1日のメッセージ数の上限に達しました。このチャットは明日続行してください。"
 
 # smartling.placeholder_format=C
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
-msgstr ""
-"Duck.aiのパワーはプライベートな無料ブラウザDuckDuckGoで最も発揮されます！"
+msgstr "Duck.aiのパワーはプライベートな無料ブラウザDuckDuckGoで最も発揮されます！"
 
 # smartling.placeholder_format=C
 #. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
@@ -6464,7 +6285,7 @@ msgid ""
 "Duck.ai is created by DuckDuckGo. We're an independent online protection "
 "company for anyone who wants to take back control of their personal "
 "information."
-msgstr ""
+msgstr "Duck.aiのクリエイターであるDuckDuckGoは、自分の個人情報に対する主導権を取り戻したいユーザーのためにオンライン保護に取り組む独立系企業です。"
 
 # smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
@@ -6478,9 +6299,7 @@ msgctxt "duckai_migration"
 msgid ""
 "Duck.ai is still a DuckDuckGo product, but will now have an easier to "
 "remember home on the web: https://duck.ai"
-msgstr ""
-"Duck.aiは引き続きDuckDuckGoの製品ですが、今後はウェブ上のホームページが"
-"「https://duck.ai」と覚えやすくなります"
+msgstr "Duck.aiは引き続きDuckDuckGoの製品ですが、今後はウェブ上のホームページが「https://duck.ai」と覚えやすくなります"
 
 # smartling.placeholder_format=C
 #. Headline for domain change notice.
@@ -6494,18 +6313,14 @@ msgctxt "Error message for BOTNET limit."
 msgid ""
 "Duck.ai is temporarily unavailable. If this persists, please email this "
 "anonymous code %s to %s"
-msgstr ""
-"Duck.aiは一時的に利用できません。この問題が続く場合は、匿名コード「%1$s」"
-"を%2$s宛てにメールで送信してください"
+msgstr "Duck.aiは一時的に利用できません。この問題が続く場合は、匿名コード「%1$s」を%2$s宛てにメールで送信してください"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
 msgctxt "Error message for VQD error"
 msgid ""
 "Duck.ai is temporarily unavailable. Please refresh the page and try again."
-msgstr ""
-"Duck.aiは一時的に利用できません。ページを更新して、もう一度やり直してくださ"
-"い。"
+msgstr "Duck.aiは一時的に利用できません。ページを更新して、もう一度やり直してください。"
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -6518,7 +6333,7 @@ msgctxt "settings"
 msgid ""
 "Duck.ai lets you chat privately with popular AI models. Disabling it hides "
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
-msgstr ""
+msgstr "Duck.aiでは、人気のAIモデルと非公開でチャットできます。無効にするとDuck.aiのボタンやリンクは非表示になりますが、%1$sduck.ai%2$sには引き続き直接アクセスできます。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6529,10 +6344,9 @@ msgid ""
 "can still access Duck.ai when this setting is off by visiting %shttps://duck."
 "ai%s directly."
 msgstr ""
-"Duck.aiを使用すると、OpenAIやAnthropicなどのサードパーティのAIチャットモデル"
-"と匿名で会話できます。この設定をオフにすると、DuckDuckGo検索上のDuck.aiのボタ"
-"ンやリンクが非表示になります。ただし、この設定がオフの状態でも、%1$shttps://"
-"duck.ai%2$s に直接アクセスすることでDuck.aiを利用できます。"
+""
+"Duck.aiを使用すると、OpenAIやAnthropicなどのサードパーティのAIチャットモデルと匿名で会話できます。この設定をオフにすると、DuckDuckGo検索上のDuck.aiのボタンやリンクが非表示になります。ただし、この設定がオフの状態でも、%1$shttps://duck.ai%2$s "
+"に直接アクセスすることでDuck.aiを利用できます。"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
@@ -6546,9 +6360,7 @@ msgctxt "duckai_migration"
 msgid ""
 "Duck.ai might have lost your recent chats. You can still use Duck.ai as "
 "usual."
-msgstr ""
-"Duck.aiの最近のチャットが失われた可能性があります。Duck.aiはいつも通りに使用"
-"できます。"
+msgstr "Duck.aiの最近のチャットが失われた可能性があります。Duck.aiはいつも通りに使用できます。"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
@@ -6561,8 +6373,7 @@ msgstr "Duck.aiでPDFを読み、解析できるようになりました。ぜ�
 msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
-msgstr ""
-"Duck.aiの回答は特定の情報源に基づいておらず、正確性も確認されていません。"
+msgstr "Duck.aiの回答は特定の情報源に基づいておらず、正確性も確認されていません。"
 
 # smartling.placeholder_format=C
 #. Title shown when native app needs to reload for service update.
@@ -6580,8 +6391,7 @@ msgstr "Duck.aiがアップグレードしました！"
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
-msgstr ""
-"Duck.aiと最も相性の良いDuckDuckGoは、プライバシーを重視した無料のアプリです。"
+msgstr "Duck.aiと最も相性の良いDuckDuckGoは、プライバシーを重視した無料のアプリです。"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -6591,9 +6401,8 @@ msgid ""
 "AI chat no sign up, OpenAI, Anthropic, Llama, Mistral, open source AI "
 "models, privacy focused AI, no account AI chat"
 msgstr ""
-"Duck.ai、DuckDuckGo AI、プライベートAIチャットボット、無料AIチャット、匿名AI"
-"チャット、サインアップ不要AIチャット、OpenAI、Anthropic、Llama、Mistral、オー"
-"プンソースAIモデル、プライバシー重視AI、アカウント不要AIチャット"
+"Duck.ai、DuckDuckGo "
+"AI、プライベートAIチャットボット、無料AIチャット、匿名AIチャット、サインアップ不要AIチャット、OpenAI、Anthropic、Llama、Mistral、オープンソースAIモデル、プライバシー重視AI、アカウント不要AIチャット"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -6621,11 +6430,9 @@ msgid ""
 "relevant), or Often (shows more frequently on a wider range of searches). "
 "For now, DuckAssist is only available in the U.S. (English) region."
 msgstr ""
-"このツールを使用すると、一部の検索に対して情報を匿名で調べ、要約できます。"
-"DuckAssistの表示頻度は、なし（検索結果からDuckAssist UIを完全に削除）、オンデ"
-"マンド（[アシスト] ボタンをクリックした場合にのみ表示）、時々（関連性の高い場"
-"合にのみ表示）、頻繁（広範な検索でより頻繁に表示）から選択できます。現時点で"
-"は、米国（英語）地域でのみ利用可能です。"
+"このツールを使用すると、一部の検索に対して情報を匿名で調べ、要約できます。DuckAssistの表示頻度は、なし（検索結果からDuckAssist "
+"UIを完全に削除）、オンデマンド（[アシスト] "
+"ボタンをクリックした場合にのみ表示）、時々（関連性の高い場合にのみ表示）、頻繁（広範な検索でより頻繁に表示）から選択できます。現時点では、米国（英語）地域でのみ利用可能です。"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6634,9 +6441,9 @@ msgid ""
 "%sDuckDuckGo AI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI, and Anthropic, and more."
 msgstr ""
-"DuckAssistは追加の質問には回答できません。ただし、OpenAI、Anthropic、その他か"
-"らチャットモデルをサポートするプライベートAI搭載チャットサービ"
-"ス、%1$sDuckDuckGo AI Chat%2$sもご利用いただけます。"
+""
+"DuckAssistは追加の質問には回答できません。ただし、OpenAI、Anthropic、その他からチャットモデルをサポートするプライベートAI搭載チャットサービス、%1$sDuckDuckGo "
+"AI Chat%2$sもご利用いただけます。"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6645,8 +6452,8 @@ msgid ""
 "DuckDuckGo %sAI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI and Anthropic."
 msgstr ""
-"DuckAssistは追加の質問には回答できません。ただし、OpenAIとAnthropicのチャット"
-"モデルをサポートするプライベートAI搭載チャットサービス、DuckDuckGo%1$sAI "
+""
+"DuckAssistは追加の質問には回答できません。ただし、OpenAIとAnthropicのチャットモデルをサポートするプライベートAI搭載チャットサービス、DuckDuckGo%1$sAI "
 "Chat%2$sもご利用いただけます。"
 
 # smartling.placeholder_format=C
@@ -6659,11 +6466,9 @@ msgid ""
 "responses are currently based on Wikipedia and related content and are not "
 "checked for accuracy."
 msgstr ""
-"DuckAssistは、検索クエリに対する回答を匿名で生成できる新しい検索機能です。 こ"
-"れを実現するために、Wikipediaや関連サイトをスキャンして関連コンテンツを探し、"
-"AIを活用した自然言語技術を使用して情報の要約を生成します。 現時点での回答は"
-"Wikipediaおよび関連コンテンツに基づいており、正確性は確認されていないことにご"
-"注意ください。"
+"DuckAssistは、検索クエリに対する回答を匿名で生成できる新しい検索機能です。 "
+"これを実現するために、Wikipediaや関連サイトをスキャンして関連コンテンツを探し、AIを活用した自然言語技術を使用して情報の要約を生成します。 "
+"現時点での回答はWikipediaおよび関連コンテンツに基づいており、正確性は確認されていないことにご注意ください。"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6677,22 +6482,15 @@ msgid ""
 "It’s important to remember that responses are auto-generated from cited "
 "sources and based on %scrawling the web%s."
 msgstr ""
-"DuckAssistは、検索クエリに対する回答を匿名で生成できる、検索結果のオプション"
-"機能です。この機能は、ウェブをスキャンして関連コンテンツを探し、AI を活用した"
-"自然言語技術で見つかった関連情報に基づき、簡単な回答を生成します。DuckAssist"
-"の回答は、常に1つか2つの情報源に直接リンクして回答元を引用しています。そのた"
-"め、より詳細な情報を簡単に取得することができます。回答は引用元から自動生成さ"
-"れ、%1$sウェブのクロール%2$sに基づいて自動生成されることを覚えておくことが重"
-"要です。"
+"DuckAssistは、検索クエリに対する回答を匿名で生成できる、検索結果のオプション機能です。この機能は、ウェブをスキャンして関連コンテンツを探し、AI "
+"を活用した自然言語技術で見つかった関連情報に基づき、簡単な回答を生成します。DuckAssistの回答は、常に1つか2つの情報源に直接リンクして回答元を引用しています。そのため、より詳細な情報を簡単に取得することができます。回答は引用元から自動生成され、%1$sウェブのクロール%2$sに基づいて自動生成されることを覚えておくことが重要です。"
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid ""
 "DuckAssist responses are auto-generated based on listed sources and not "
 "checked for accuracy."
-msgstr ""
-"DuckAssistの回答は記載されている情報源に基づいて自動生成され、正確性は確認さ"
-"れません。"
+msgstr "DuckAssistの回答は記載されている情報源に基づいて自動生成され、正確性は確認されません。"
 
 # smartling.placeholder_format=C
 #. Displayed when the chat service has reached the maximum number of messages for one day.
@@ -6700,9 +6498,7 @@ msgctxt "Error message for service limit"
 msgid ""
 "DuckDuckGo AI Chat has reached the maximum number of messages for one day. "
 "Please continue this chat tomorrow."
-msgstr ""
-"DuckDuckGo AI Chatの1日のメッセージ数の上限に達しました。このチャットは明日続"
-"行してください。"
+msgstr "DuckDuckGo AI Chatの1日のメッセージ数の上限に達しました。このチャットは明日続行してください。"
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the AI chat service and supported AI models. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -6711,8 +6507,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"DuckDuckGo AI Chatは、現在%1$sの%2$sと%3$sの%4$sチャットモデルをサポートして"
-"いるプライベートAI搭載のチャットサービスです。"
+"DuckDuckGo AI "
+"Chatは、現在%1$sの%2$sと%3$sの%4$sチャットモデルをサポートしているプライベートAI搭載のチャットサービスです。"
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the welcome screen of the onboarding. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -6721,8 +6517,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"DuckDuckGo AI Chatは、現在%1$sの%2$sと%3$sの%4$sチャットモデルをサポートして"
-"いるプライベートAI搭載のチャットサービスです。"
+"DuckDuckGo AI "
+"Chatは、現在%1$sの%2$sと%3$sの%4$sチャットモデルをサポートしているプライベートAI搭載のチャットサービスです。"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding DuckDuckGo AI Chat.
@@ -6730,9 +6526,7 @@ msgctxt "Disclaimer text at the bottom of the feedback form."
 msgid ""
 "DuckDuckGo AI Chat is in Beta, it may display inaccurate or offensive "
 "information."
-msgstr ""
-"DuckDuckGo AI Chatはベータ版であるため、不正確な情報や不快な情報が表示される"
-"可能性があります。"
+msgstr "DuckDuckGo AI Chatはベータ版であるため、不正確な情報や不快な情報が表示される可能性があります。"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat making it unavailable, and asking the user to send an email with a specific code if the error persists. E.g. 'DuckDuckGo AI Chat is temporarily unavailable. If this persists, please email this anonymous code abcdefg12345 to aichat-error@duckduckgo.com'
@@ -6740,9 +6534,7 @@ msgctxt "Error message for BOTNET limit."
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. If this persists, please "
 "email this anonymous code %s to %s"
-msgstr ""
-"DuckDuckGo AI Chatは一時的に利用できません。この問題が続く場合は、匿名コード"
-"「%1$s」を%2$s宛てにメールで送信してください"
+msgstr "DuckDuckGo AI Chatは一時的に利用できません。この問題が続く場合は、匿名コード「%1$s」を%2$s宛てにメールで送信してください"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -6750,17 +6542,13 @@ msgctxt "Error message for VQD error"
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. Please refresh the page and "
 "try again."
-msgstr ""
-"DuckDuckGo AI Chatは一時的に利用できません。 ページを更新して、もう一度やり直"
-"してください。"
+msgstr "DuckDuckGo AI Chatは一時的に利用できません。 ページを更新して、もう一度やり直してください。"
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr ""
-"DuckDuckGo AI Chatは一時的に利用できません。 時間を置いてもう一度お試しくださ"
-"い。"
+msgstr "DuckDuckGo AI Chatは一時的に利用できません。 時間を置いてもう一度お試しください。"
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -6878,18 +6666,14 @@ msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
 msgid ""
 "DuckDuckGo anonymizes these reports by automatically removing PII like "
 "names, email addresses, phone numbers, and identifying metadata."
-msgstr ""
-"DuckDuckGoは、名前、メールアドレス、電話番号、識別メタデータなどのPIIを自動的"
-"に削除することで、これらのレポートを匿名化します。"
+msgstr "DuckDuckGoは、名前、メールアドレス、電話番号、識別メタデータなどのPIIを自動的に削除することで、これらのレポートを匿名化します。"
 
 # smartling.placeholder_format=C
 #. The first %s is the agree button label ('Agree'). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. The leading sentence mirrors the drawer-style inline disclaimer (DUCKCHAT_TOS_INLINE_DISCLAIMER).
 msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid ""
 "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to Duck.ai's %s."
-msgstr ""
-"DuckDuckGoはチャットを匿名化します。「%1$s」をクリックすると、Duck.aiの%2$sに"
-"同意したことになります。"
+msgstr "DuckDuckGoはチャットを匿名化します。「%1$s」をクリックすると、Duck.aiの%2$sに同意したことになります。"
 
 # smartling.placeholder_format=C
 #. Shown below the input on the empty state when the user has not yet accepted the terms of service. The first %s is the action button label ('Ask' for chat, 'Create' for image generation). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. Clicking the action button both accepts the terms and submits the prompt.
@@ -6897,9 +6681,7 @@ msgctxt ""
 "Inline terms-of-service disclaimer below chat or image-gen input for new "
 "users"
 msgid "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to our %s."
-msgstr ""
-"DuckDuckGoはチャットを匿名化します。「%1$s」をクリックすると、当社の%2$sに同"
-"意したことになります。"
+msgstr "DuckDuckGoはチャットを匿名化します。「%1$s」をクリックすると、当社の%2$sに同意したことになります。"
 
 # smartling.placeholder_format=C
 #. An information popup explaining that we block trackers
@@ -6907,9 +6689,7 @@ msgid ""
 "DuckDuckGo blocks trackers on websites you visit, including trackers from "
 "companies like Google and Facebook, who often try to track you on other "
 "websites."
-msgstr ""
-"DuckDuckGoでは、アクセスするウェブサイト上でGoogleやFacebookなどの企業による"
-"追跡行為を阻止することができます。"
+msgstr "DuckDuckGoでは、アクセスするウェブサイト上でGoogleやFacebookなどの企業による追跡行為を阻止することができます。"
 
 # smartling.placeholder_format=C
 #. Description of how DuckDuckGo keeps a user's location anonymous while the user searches on a map of their area.
@@ -6921,12 +6701,8 @@ msgid ""
 "away, such that you remain anonymous. %sLearn more about how we designed "
 "this technology to protect your privacy%s."
 msgstr ""
-"DuckDuckGo はプライバシーを保護するように設計されています。位置情報を使用する"
-"場合、ローカルデバイスだけに保存されます。DuckDuckGo は検索時にユーザーのデバ"
-"イスから送信される位置情報を検索結果を向上するために使用します。位置情報は使"
-"用後にすぐ消去されるため、ユーザーは匿名性を保つことができます。%1$sお客様の"
-"プライバシーを保護するため、当社がどのようにこの技術を設計したかについては、"
-"こちらをご覧ください%2$s。"
+"DuckDuckGo はプライバシーを保護するように設計されています。位置情報を使用する場合、ローカルデバイスだけに保存されます。DuckDuckGo "
+"は検索時にユーザーのデバイスから送信される位置情報を検索結果を向上するために使用します。位置情報は使用後にすぐ消去されるため、ユーザーは匿名性を保つことができます。%1$sお客様のプライバシーを保護するため、当社がどのようにこの技術を設計したかについては、こちらをご覧ください%2$s。"
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
@@ -6945,9 +6721,7 @@ msgctxt "settings"
 msgid ""
 "DuckDuckGo only uses your approximate location. That's all we need to "
 "deliver better results, closer to you. %sLearn more%s."
-msgstr ""
-"DuckDuckGo はおおよその位置情報のみを使用します。精度の高いローカル検索結果を"
-"表示するのに充分な情報です。%1$sさらに詳しく%2$s。"
+msgstr "DuckDuckGo はおおよその位置情報のみを使用します。精度の高いローカル検索結果を表示するのに充分な情報です。%1$sさらに詳しく%2$s。"
 
 # smartling.placeholder_format=C
 msgid "DuckDuckGo search"
@@ -7032,10 +6806,7 @@ msgid ""
 "random words from the DuckDuckGo servers. In the browser, we then select 4-5 "
 "random words from that list, ensuring that the passphrase is at least 18-20 "
 "characters long."
-msgstr ""
-"パスフレーズ候補を生成する度、DuckDuckGoサーバーからランダムな単語が多数記載"
-"されたリストを取得します。その後お使いのブラウザ内で、そのリストから最低18～"
-"20字のパスフレーズ候補として4、5個の単語が選ばれます。"
+msgstr "パスフレーズ候補を生成する度、DuckDuckGoサーバーからランダムな単語が多数記載されたリストを取得します。その後お使いのブラウザ内で、そのリストから最低18～20字のパスフレーズ候補として4、5個の単語が選ばれます。"
 
 # smartling.placeholder_format=C
 msgctxt "Sports module"
@@ -7099,8 +6870,7 @@ msgstr "画像を編集中..."
 msgctxt "Info text for the editing message feature"
 msgid ""
 "Editing your message will remove the response below and generate a new one."
-msgstr ""
-"メッセージを編集すると、以下の応答が削除され、新しい応答が生成されます。"
+msgstr "メッセージを編集すると、以下の応答が削除され、新しい応答が生成されます。"
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of an editor in its responses.
@@ -7231,9 +7001,7 @@ msgstr "ウェブ検索を有効にする"
 msgid ""
 "Enable anonymous location for more accurate results. You can always change "
 "your mind later."
-msgstr ""
-"検索結果の精度を高めるには、匿名の位置情報を有効にしてください。この設定は後"
-"でいつでも変更できます。"
+msgstr "検索結果の精度を高めるには、匿名の位置情報を有効にしてください。この設定は後でいつでも変更できます。"
 
 # smartling.placeholder_format=C
 #. Title of the dictation privacy consent modal shown on first use.
@@ -7275,9 +7043,7 @@ msgctxt "precise_user_location"
 msgid ""
 "Enabling anonymous location gives more accurate results but still keeps your "
 "searches and exact location private to DuckDuckGo."
-msgstr ""
-"「匿名の位置情報」機能を有効にすると、より正確な検索結果が得られるうえ、検索"
-"データと正確な位置情報もDuckDuckGoに対して非公開のままとなります。"
+msgstr "「匿名の位置情報」機能を有効にすると、より正確な検索結果が得られるうえ、検索データと正確な位置情報もDuckDuckGoに対して非公開のままとなります。"
 
 # smartling.placeholder_format=C
 msgid "Encrypt Connections"
@@ -7395,8 +7161,7 @@ msgstr "位置情報へのアクセスは必ず %1$s許可%2$s にします。"
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed %slocation access%s"
-msgstr ""
-"ブラウザによる%1$s位置情報へのアクセス%2$sが許可されていることを確認します"
+msgstr "ブラウザによる%1$s位置情報へのアクセス%2$sが許可されていることを確認します"
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service.
@@ -7439,9 +7204,7 @@ msgctxt "cloudsave"
 msgid ""
 "Enter a new passphrase and click/tap %sSave Settings%s. This will save your "
 "data under your new passphrase."
-msgstr ""
-"新しいパスフレーズを入力し、%1$s設定を保存%2$sをクリックまたはタップしてくだ"
-"さい。データが新しいパスフレーズで保存されます。"
+msgstr "新しいパスフレーズを入力し、%1$s設定を保存%2$sをクリックまたはタップしてください。データが新しいパスフレーズで保存されます。"
 
 # smartling.placeholder_format=C
 #. Label for the field where a user enters their passphrase.
@@ -7466,9 +7229,7 @@ msgstr "テキストを入力"
 #. Instructions for how to change the default search engine.
 msgid ""
 "Enter the following details: %sName%s: DuckDuckGo%s URL%s: %s Alias%s: d%s"
-msgstr ""
-"以下の詳細を入力してください: %1$s名前%2$s: DuckDuckGo%3$s URL%4$s: %5$s エイ"
-"リアス%6$s: d%7$s"
+msgstr "以下の詳細を入力してください: %1$s名前%2$s: DuckDuckGo%3$s URL%4$s: %5$s エイリアス%6$s: d%7$s"
 
 # smartling.placeholder_format=C
 #. Prompt to enter a destination for driving directions.
@@ -7512,13 +7273,13 @@ msgstr "エリトリア"
 #. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Estimate the nutrition"
-msgstr ""
+msgstr "栄養価を推定"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Estimate the nutritional information for this recipe."
-msgstr ""
+msgstr "このレシピの栄養情報を推定してください。"
 
 # smartling.placeholder_format=C
 msgid "Estonia"
@@ -7578,7 +7339,7 @@ msgstr "期限まであと1日"
 #. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain the accepted answer in simple terms."
-msgstr ""
+msgstr "採用された回答をわかりやすく説明してください。"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
@@ -7591,43 +7352,43 @@ msgstr "ブラックホールの基本的な概念を高校レベルで説明し
 #. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain the top answer"
-msgstr ""
+msgstr "最上位の回答を説明"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain this in simple, plain language."
-msgstr ""
+msgstr "わかりやすく、平易な言葉で説明してください。"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain this paper"
-msgstr ""
+msgstr "この論文について説明"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain this repo"
-msgstr ""
+msgstr "このリポジトリについて説明"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain this research paper in plain language."
-msgstr ""
+msgstr "この研究論文を平易な言葉で説明してください。"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain this simply"
-msgstr ""
+msgstr "この内容を分かりやすく説明"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain what this repository does and how to use it."
-msgstr ""
+msgstr "このリポジトリの機能と使用方法を説明してください。"
 
 # smartling.placeholder_format=C
 #. Label to show if song lyrics contain explicit content
@@ -7804,9 +7565,7 @@ msgstr "フィードバックが送信されました"
 msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and improvements."
-msgstr ""
-"お寄せくださったフィードバックを私たちの製品の更新と改善に直接活用していきま"
-"す。"
+msgstr "お寄せくださったフィードバックを私たちの製品の更新と改善に直接活用していきます。"
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -7814,19 +7573,14 @@ msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and "
 "improvements. Hopefully we can address the issue you shared too."
-msgstr ""
-"お客様からいただいたフィードバックは、当社の製品のアップデートと改善に活用さ"
-"せていただきます。また、ご指摘についても真摯に受け止め、誠意を持って取り組ん"
-"で参ります。"
+msgstr "お客様からいただいたフィードバックは、当社の製品のアップデートと改善に活用させていただきます。また、ご指摘についても真摯に受け止め、誠意を持って取り組んで参ります。"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box
 msgid ""
 "Feel free to adjust the settings below. Then, just copy and paste the code "
 "into your website."
-msgstr ""
-"以下から自由に設定できます。設定後のコードをあなたのウェブサイトにコピー＆"
-"ペーストしてください。"
+msgstr "以下から自由に設定できます。設定後のコードをあなたのウェブサイトにコピー＆ペーストしてください。"
 
 # smartling.placeholder_format=C
 msgid "Fiji"
@@ -7915,7 +7669,7 @@ msgstr "画像の検索結果からAIで生成されたものを除外します�
 msgctxt "settings"
 msgid ""
 "Filters out known AI spam sites from image search results. %sLearn More%s"
-msgstr ""
+msgstr "画像検索結果から既知のAIスパムサイトが除外されます。%1$s詳細情報%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the final score of a sporting event.
@@ -7944,8 +7698,7 @@ msgstr "金融アドバイザー"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Find %sDuckDuckGo%s and click%sMake default%s"
-msgstr ""
-"%1$sDuckDuckGo%2$sを検索し、%3$sデフォルトに設定 %4$sをクリックしてください"
+msgstr "%1$sDuckDuckGo%2$sを検索し、%3$sデフォルトに設定 %4$sをクリックしてください"
 
 # smartling.placeholder_format=C
 #. Sentence shown after export, includes a placeholder for one or more filenames with bold formatting for the filename(s).
@@ -7957,9 +7710,7 @@ msgstr "ダウンロードフォルダで<b>%1$s</b>を表示"
 # smartling.placeholder_format=C
 #. Tells users how to change their default search engine to DuckDuckGo.
 msgid "Find DuckDuckGo in the displayed list and click %sMake Default%s"
-msgstr ""
-"表示されたリストからDuckDuckGoを探し、%1$sデフォルトに設定%2$sをクリックしま"
-"す"
+msgstr "表示されたリストからDuckDuckGoを探し、%1$sデフォルトに設定%2$sをクリックします"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for finding a better word.
@@ -7977,7 +7728,7 @@ msgstr "最新情報を検索"
 #. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Find me alternatives"
-msgstr ""
+msgstr "他のオプションを探す"
 
 # smartling.placeholder_format=C
 #. Button that searches for results closer to the user's current location.
@@ -7996,9 +7747,7 @@ msgstr "あなたにとって最も的確な結果を見つけます。"
 msgctxt "Precise user location overlay"
 msgid ""
 "Find results near you. %sYour location stays private, secure, and anonymous."
-msgstr ""
-"お近くの結果を検索します。%1$s位置情報は非公開、安全、匿名のまま保持されま"
-"す。"
+msgstr "お近くの結果を検索します。%1$s位置情報は非公開、安全、匿名のまま保持されます。"
 
 # smartling.placeholder_format=C
 #. Loading message shown while generating explore more follow-up questions
@@ -8061,9 +7810,7 @@ msgstr "霧"
 msgid ""
 "Follow the instructions for turning off the ad blocker for DuckDuckGo. You "
 "may have to select a menu option or click a button."
-msgstr ""
-"DuckDuckGoの広告ブロッカーをオフにする手順に沿ってお進みください。メニューオ"
-"プションを選択したり、ボタンをクリックする必要がある場合があります。"
+msgstr "DuckDuckGoの広告ブロッカーをオフにする手順に沿ってお進みください。メニューオプションを選択したり、ボタンをクリックする必要がある場合があります。"
 
 # smartling.placeholder_format=C
 #. Privacy reassurance and instructions intro.
@@ -8204,9 +7951,7 @@ msgstr "営利目的で共有、使用が可能"
 #. Description text explaining how to free up sync storage. Pinned chats are chats the user has explicitly marked to keep.
 msgctxt "Sync limit modal description"
 msgid "Free up space by deleting your chats. Pinned chats will not be deleted."
-msgstr ""
-"チャットを削除して容量を空けましょう。ピン留めされたチャットは削除されませ"
-"ん。"
+msgstr "チャットを削除して容量を空けましょう。ピン留めされたチャットは削除されません。"
 
 # smartling.placeholder_format=C
 #. Indicates that this streaming service is free to watch but shows ads
@@ -8287,9 +8032,8 @@ msgid ""
 "<strong>Check for Updates...</strong>, then select <strong>Install Update</"
 "strong>."
 msgstr ""
-"Macのアプリメニューバーから <strong>[DuckDuckGo]</strong> &gt; <strong>[アッ"
-"プデートを確認...]</strong>、次に<strong>[アップデートをインストール]</"
-"strong> を選択します。"
+"Macのアプリメニューバーから <strong>[DuckDuckGo]</strong> &gt; "
+"<strong>[アップデートを確認...]</strong>、次に<strong>[アップデートをインストール]</strong> を選択します。"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -8460,7 +8204,7 @@ msgstr "もっと生成する"
 #. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Generate a shopping list"
-msgstr ""
+msgstr "買い物リストを作成"
 
 # smartling.placeholder_format=C
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
@@ -8625,9 +8369,7 @@ msgstr "開始"
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the Privacy Pro subscription.
 msgctxt "SERP footer content"
 msgid "Get a VPN + two more protections in one easy subscription."
-msgstr ""
-"VPN1件と追加の保護対策2つを組み合わせた手軽なサブスクリプションはいかがです"
-"か。"
+msgstr "VPN1件と追加の保護対策2つを組み合わせた手軽なサブスクリプションはいかがですか。"
 
 # smartling.placeholder_format=C
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
@@ -8641,9 +8383,7 @@ msgctxt "Description of the modal to upgrade the DuckDuckGo subscription"
 msgid ""
 "Get access to advanced AI models in Duck.ai by subscribing to DuckDuckGo, "
 "which also includes our VPN and other premium privacy protections."
-msgstr ""
-"DuckDuckGoに加入すると、Duck.aiで高度なAIモデルをご利用いただけます。これに"
-"は、VPNやその他のプレミアムなプライバシー保護も含まれています。"
+msgstr "DuckDuckGoに加入すると、Duck.aiで高度なAIモデルをご利用いただけます。これには、VPNやその他のプレミアムなプライバシー保護も含まれています。"
 
 # smartling.placeholder_format=C
 #. Description for the subscription setting where users can subscribe to DuckDuckGo.
@@ -8653,9 +8393,7 @@ msgctxt ""
 msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
-msgstr ""
-"DuckDuckGoのサブスクリプションでDuck.aiの高度なAIモデルにアクセスできます。"
-"VPNやその他のプレミアムなプライバシー保護機能も含まれています。"
+msgstr "DuckDuckGoのサブスクリプションでDuck.aiの高度なAIモデルにアクセスできます。VPNやその他のプレミアムなプライバシー保護機能も含まれています。"
 
 # smartling.placeholder_format=C
 #. A button for users to generate an AI generated answer from their query on the duckassist module
@@ -8689,9 +8427,7 @@ msgstr "当社のブラウザを使用すれば、設定が失われることは
 # smartling.placeholder_format=C
 msgid ""
 "Get seamless privacy protection on your browser for free with one download:"
-msgstr ""
-"ブラウザの個人情報をシームレスに保護する無料ツールをワンクリックでダウンロー"
-"ド："
+msgstr "ブラウザの個人情報をシームレスに保護する無料ツールをワンクリックでダウンロード："
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo app when clicked
@@ -8759,14 +8495,13 @@ msgstr "試してみる"
 #. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Give me a quick background on this person."
-msgstr ""
+msgstr "この人物の経歴を簡単に教えてください。"
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
-msgstr ""
-"%1$s[プライバシーとセキュリティ] > [位置情報サービス]%2$sの順に移動します"
+msgstr "%1$s[プライバシーとセキュリティ] > [位置情報サービス]%2$sの順に移動します"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -8775,8 +8510,8 @@ msgid ""
 "Go to %sSettings > Privacy & Security > Location Services%s, and make sure "
 "“Location Services” is turned on."
 msgstr ""
-"%1$s [設定] > [プライバシーとセキュリティ] > [位置情報サービス] %2$sに移動"
-"し、[位置情報サービス] がオンになっていることを確認します。"
+"%1$s [設定] > [プライバシーとセキュリティ] > [位置情報サービス] %2$sに移動し、[位置情報サービス] "
+"がオンになっていることを確認します。"
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -8785,8 +8520,8 @@ msgid ""
 "Go to %sSettings > Privacy > Permission manager > Location%s and scroll down "
 "to %sDuckDuckGo%s."
 msgstr ""
-"%1$s[設定] > [プライバシー] > [権限マネージャ] > [位置情報]%2$s に移動し、"
-"[DuckDuckGo] まで下にスクロールします。%3$s%4$s"
+"%1$s[設定] > [プライバシー] > [権限マネージャ] > [位置情報]%2$s に移動し、[DuckDuckGo] "
+"まで下にスクロールします。%3$s%4$s"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9212,13 +8947,13 @@ msgstr "みんなに広める"
 #. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Help me prep for the interview"
-msgstr ""
+msgstr "面接準備を手伝う"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Help me tailor my resume for this job."
-msgstr ""
+msgstr "この求人向けに履歴書をアレンジするのを手伝ってください。"
 
 # smartling.placeholder_format=C
 #. Title of a SERP popup that invites users to take a survey (desktop only)
@@ -9456,8 +9191,7 @@ msgctxt "settings"
 msgid ""
 "Highlights key facts in Search Assist answers to help you find important "
 "information faster."
-msgstr ""
-"Search Assistの回答で重要な事実を強調表示し、重要な情報を見つけやすくします。"
+msgstr "Search Assistの回答で重要な事実を強調表示し、重要な情報を見つけやすくします。"
 
 # smartling.placeholder_format=C
 #. The name of the Hindi language
@@ -9484,8 +9218,8 @@ msgid ""
 "Hit %sReturn%s on your keyboard to %ssave DuckDuckGo to the list. %sThen "
 "click %sMake Default%s"
 msgstr ""
-"キーボードの %1$s戻る%2$s キーを押して、%3$sDuckDuckGoをリストに保存しま"
-"す。%4$sそして、%5$sデフォルトに設定%6$sをクリックします"
+"キーボードの %1$s戻る%2$s "
+"キーを押して、%3$sDuckDuckGoをリストに保存します。%4$sそして、%5$sデフォルトに設定%6$sをクリックします"
 
 # smartling.placeholder_format=C
 #. The name of the Hmong Daw language
@@ -9498,9 +9232,7 @@ msgstr "ミャオ語"
 msgid ""
 "Hold on! Changing it back will disable the DuckDuckGo extension and you'll "
 "lose our privacy protection."
-msgstr ""
-"ご注意ください！元の設定に戻すとDuckDuckGoの拡張機能が無効になり、プライバ"
-"シーが保護されなくなります。"
+msgstr "ご注意ください！元の設定に戻すとDuckDuckGoの拡張機能が無効になり、プライバシーが保護されなくなります。"
 
 # smartling.placeholder_format=C
 #. Heading shown above warning messages in the AI chat, for non-critical issues like unsupported file formats or file size limits. Analogous to 'Oops...' for error messages.
@@ -9549,9 +9281,7 @@ msgstr "猛暑"
 msgid ""
 "Hotel ad clicks are managed by Tripadvisor’s ad network and are not used to "
 "profile you."
-msgstr ""
-"ホテルの広告クリックはTripadvisorの広告ネットワークによって管理され、お客様の"
-"プロファイリングには使用されません。"
+msgstr "ホテルの広告クリックはTripadvisorの広告ネットワークによって管理され、お客様のプロファイリングには使用されません。"
 
 # smartling.placeholder_format=C
 #. Refers to hours of operation for a business.
@@ -9738,7 +9468,7 @@ msgctxt ""
 "Text for the I already have a subscription button in the Duck.ai settings "
 "page"
 msgid "I Already Have a Subscription"
-msgstr ""
+msgstr "すでにサブスクリプションがあります"
 
 # smartling.placeholder_format=C
 #. Text for the button that takes the user to the login subscription page.
@@ -9813,9 +9543,7 @@ msgctxt "Full sentence for recommending a book"
 msgid ""
 "I like the book Name of the Wind. What are some other good books/series most "
 "like it and why?"
-msgstr ""
-"私は「風の名前」という本が好きです。 これに最も似ている他の良い本やシリーズは"
-"どんなものですか、またその理由は何ですか？"
+msgstr "私は「風の名前」という本が好きです。 これに最も似ている他の良い本やシリーズはどんなものですか、またその理由は何ですか？"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the user needs more help or information on how to use the chat.
@@ -9850,8 +9578,8 @@ msgid ""
 "If the browser location remains unavailable, then go to %sSettings > General "
 "> Reset > 'Reset Location & Privacy'%s."
 msgstr ""
-"それでもブラウザの位置情報を利用できない場合は、%1$s[設定] > [一般] > [リセッ"
-"ト] > [位置情報とプライバシー設定をリセット]%2$s の順に移動します。"
+"それでもブラウザの位置情報を利用できない場合は、%1$s[設定] > [一般] > [リセット] > [位置情報とプライバシー設定をリセット]%2$s "
+"の順に移動します。"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -9861,9 +9589,8 @@ msgid ""
 "> Menu > Settings > Site settings > Location%s, and ensure DuckDuckGo is "
 "allowed location access."
 msgstr ""
-"それでもブラウザの位置情報を使用できない場合は、ブラウザで、%1$s「⋮」マーク "
-"> [メニュー] > [設定] > [サイト設定] > [位置情報]%2$s の順に移動し、"
-"DuckDuckGo に位置情報へのアクセスを許可しているか確認します。"
+"それでもブラウザの位置情報を使用できない場合は、ブラウザで、%1$s「⋮」マーク > [メニュー] > [設定] > [サイト設定] > "
+"[位置情報]%2$s の順に移動し、DuckDuckGo に位置情報へのアクセスを許可しているか確認します。"
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -9877,9 +9604,7 @@ msgstr "このエラーが続く場合は、%1$sに連絡してください。"
 msgid ""
 "If you don't see %sDuckDuckGo,%s you will need to add it to the list of "
 "%sOther Search Engines%s"
-msgstr ""
-"%1$sDuckDuckGo が表示されない場合、%2$s %3$sほかの検索エンジン%4$s リストに追"
-"加する必要があります"
+msgstr "%1$sDuckDuckGo が表示されない場合、%2$s %3$sほかの検索エンジン%4$s リストに追加する必要があります"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding the AI model providers and links to their support pages. Example: 'If you have concerns about our chat providers or any particular chat response, you can also reach out directly to OpenAI and Anthropic support pages.'
@@ -9888,8 +9613,8 @@ msgid ""
 "If you have concerns about our chat providers or any particular chat "
 "response, you can also reach out directly to %s and %s support pages."
 msgstr ""
-"チャット プロバイダーまたは特定のチャット応答についてご不明な点がある場合"
-"は、%1$sおよび%2$sサポートページに直接お問い合わせいただくこともできます。"
+"チャット "
+"プロバイダーまたは特定のチャット応答についてご不明な点がある場合は、%1$sおよび%2$sサポートページに直接お問い合わせいただくこともできます。"
 
 # smartling.placeholder_format=C
 #. Body copy explaining what the recovery code is for and how it can be saved.
@@ -9897,18 +9622,13 @@ msgctxt "Body for the Sync & Backup recovery code screen"
 msgid ""
 "If you lose access to your devices, you will need this code to recover your "
 "saved chats. You can save this code to your device as a text file."
-msgstr ""
-"デバイスにアクセスできなくなった場合、保存されたチャットを回復するためにこの"
-"コードが必要になります。このコードはテキストファイルとしてデバイスに保存でき"
-"ます。"
+msgstr "デバイスにアクセスできなくなった場合、保存されたチャットを回復するためにこのコードが必要になります。このコードはテキストファイルとしてデバイスに保存できます。"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
-msgstr ""
-"もし、私たちをもっとサポートして頂けるなら、%1$sDuckDuckGoの普及にご協力くだ"
-"さい%2$s"
+msgstr "もし、私たちをもっとサポートして頂けるなら、%1$sDuckDuckGoの普及にご協力ください%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -9917,18 +9637,14 @@ msgstr ""
 msgid ""
 "If you want to use DuckDuckGo without JavaScript, please use our %s or %s "
 "versions."
-msgstr ""
-"Javascript 無しで DuckDuckGo をご利用の場合は、 %1$s、または%2$s バージョンを"
-"ご利用ください。"
+msgstr "Javascript 無しで DuckDuckGo をご利用の場合は、 %1$s、または%2$s バージョンをご利用ください。"
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "If you want, select Home Page next to New windows and New tabs (open with)."
-msgstr ""
-"ご希望であれば、新しいウィンドウと新しいタブの隣に開くホームページを選択して"
-"ください。"
+msgstr "ご希望であれば、新しいウィンドウと新しいタブの隣に開くホームページを選択してください。"
 
 # smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that adds an image to the AI chat message being composed.
@@ -10068,9 +9784,7 @@ msgctxt "settings"
 msgid ""
 "In some older browsers, it's necessary to redirect your clicks through our "
 "server to prevent search leakage. %sLearn more%s."
-msgstr ""
-"古いブラウザの一部では、検索漏れを防ぐため、当社のサーバーを経由してリダイレ"
-"クトする必要があります。%1$sさらに詳しく%2$s。"
+msgstr "古いブラウザの一部では、検索漏れを防ぐため、当社のサーバーを経由してリダイレクトする必要があります。%1$sさらに詳しく%2$s。"
 
 # smartling.placeholder_format=C
 #. Instructions accompanying DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE; tells the user where to use the code on a DuckDuckGo browser.
@@ -10080,9 +9794,7 @@ msgctxt ""
 msgid ""
 "In the DuckDuckGo browser, go to Settings › Sync & Backup, and then “Sync "
 "with another device”."
-msgstr ""
-"DuckDuckGoブラウザで、「設定」＞「Sync & Backup」に移動し、「別のデバイスと同"
-"期」を選択します。"
+msgstr "DuckDuckGoブラウザで、「設定」＞「Sync & Backup」に移動し、「別のデバイスと同期」を選択します。"
 
 #  SeaMonkey default search engine instruction
 # smartling.placeholder_format=C
@@ -10096,9 +9808,7 @@ msgctxt "cloudsave"
 msgid ""
 "In the interest of transparency, this data is not encrypted: You can see "
 "exactly what information we store."
-msgstr ""
-"情報透明性の観点から、このデータは暗号化されていません。つまり、DuckDuckGo に"
-"保存されている情報を正確に知ることができます。"
+msgstr "情報透明性の観点から、このデータは暗号化されていません。つまり、DuckDuckGo に保存されている情報を正確に知ることができます。"
 
 # smartling.placeholder_format=C
 msgid "In the menu at the top select %sTools%s > %sSettings%s"
@@ -10108,8 +9818,7 @@ msgstr "上部のメニューから%1$sツール%2$s > %3$s設定%4$sを選択"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "In the popup, check %sMake this my default search provider%s"
-msgstr ""
-"ポップアップ画面の、%1$s既定の検索エンジンに設定%2$s ボックスをオンにします"
+msgstr "ポップアップ画面の、%1$s既定の検索エンジンに設定%2$s ボックスをオンにします"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -10318,7 +10027,7 @@ msgstr "Macブラウザをインストールする"
 #. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
 msgctxt "settings"
 msgid "Install Now"
-msgstr ""
+msgstr "今すぐインストール"
 
 # smartling.placeholder_format=C
 #. Text of a button to install the DuckDuckGo app
@@ -10421,13 +10130,13 @@ msgstr "削除したデータは、本当に削除されているのですか？
 #. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Is it worth taking?"
-msgstr ""
+msgstr "取得する価値はありますか？"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Is this place any good?"
-msgstr ""
+msgstr "この場所はおすすめですか？"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
@@ -10435,7 +10144,7 @@ msgctxt "Page suggestion prompt"
 msgid ""
 "Is this place any good? Summarize its reputation based on reviews and "
 "ratings."
-msgstr ""
+msgstr "この場所はおすすめですか？レビューと評価に基づいて評判を要約してください。"
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -10447,13 +10156,13 @@ msgstr "この動画は役に立ちましたか？"
 #. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Is this worth watching?"
-msgstr ""
+msgstr "この作品は見る価値がありますか？"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Is this worth watching? Give me a spoiler-free take."
-msgstr ""
+msgstr "この作品は見る価値がありますか？ネタバレなしで感想を教えてください。"
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -10503,11 +10212,7 @@ msgid ""
 "Items are ranked based on relevance to your search terms and are delivered "
 "through Microsoft's Ad Network. Clicks lead directly to merchant landing "
 "pages and unlike ads, DuckDuckGo is not compensated for these results."
-msgstr ""
-"アイテムは検索キーワードとの関連性に基づいてランク付けされ、Microsoftの広告"
-"ネットワークを通じて配信されます。クリック後はマーチャントのランディングペー"
-"ジに移動し、広告とは異なり、DuckDuckGoがクリックされた結果に対して報酬を受け"
-"取ることはありません。"
+msgstr "アイテムは検索キーワードとの関連性に基づいてランク付けされ、Microsoftの広告ネットワークを通じて配信されます。クリック後はマーチャントのランディングページに移動し、広告とは異なり、DuckDuckGoがクリックされた結果に対して報酬を受け取ることはありません。"
 
 # smartling.placeholder_format=C
 #. Text explaining why passphrases use a series of words instead of random numbers and letters.
@@ -10515,9 +10220,7 @@ msgctxt "cloudsave"
 msgid ""
 "It’s easier to remember 4-5 words than 10 random letters and numbers, and "
 "far more secure."
-msgstr ""
-"ランダムな文字や数字を10個覚えるよりは、単語を4～5つ覚える方が簡単な上、ずっ"
-"と安全です。"
+msgstr "ランダムな文字や数字を10個覚えるよりは、単語を4～5つ覚える方が簡単な上、ずっと安全です。"
 
 # smartling.placeholder_format=C
 msgid "Ivory Coast"
@@ -11067,7 +10770,7 @@ msgstr "リンク:"
 #. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
-msgstr ""
+msgstr "これに必要なツール、材料、または前提条件をリストアップしてください。"
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -11479,7 +11182,7 @@ msgstr "ブロックされたサイトを管理する"
 #. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
 msgctxt "setting"
 msgid "Manage in Browser Settings"
-msgstr ""
+msgstr "ブラウザ設定で管理"
 
 # smartling.placeholder_format=C
 #. Link to the site exclusion settings page
@@ -11704,9 +11407,7 @@ msgstr "ミクロネシア"
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
 msgid ""
 "Microphone access was denied. Please allow microphone access and try again."
-msgstr ""
-"マイクへのアクセスが拒否されました。マイクアクセスを許可して、もう一度お試し"
-"ください。"
+msgstr "マイクへのアクセスが拒否されました。マイクアクセスを許可して、もう一度お試しください。"
 
 # smartling.placeholder_format=C
 #. The Microsoft brand name.
@@ -12453,11 +12154,7 @@ msgid ""
 "DuckDuckGo server after being sent, to help recover a chat if you lose your "
 "internet connection. Disabling chat history will delete pinned chats, and "
 "disable the temporary storage of new prompts and responses."
-msgstr ""
-"新しいプロンプトやレスポンスは暗号化され、送信後はDuckDuckGoサーバーに一時的"
-"に保存されます。これは、インターネット接続が途切れた場合のチャット復旧に役立"
-"ちます。チャット履歴を無効にすると、固定されたチャットが削除され、新しいプロ"
-"ンプトと応答の一時的な保存が無効になります。"
+msgstr "新しいプロンプトやレスポンスは暗号化され、送信後はDuckDuckGoサーバーに一時的に保存されます。これは、インターネット接続が途切れた場合のチャット復旧に役立ちます。チャット履歴を無効にすると、固定されたチャットが削除され、新しいプロンプトと応答の一時的な保存が無効になります。"
 
 # smartling.placeholder_format=C
 #. Question in a feedback form.
@@ -12766,8 +12463,7 @@ msgstr "結果が見つかりません。"
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the recording contains no audible speech.
 msgid "No speech detected. Please try again and speak into your microphone."
-msgstr ""
-"音声が検出されませんでした。再試行時には、マイクに向かって話してください。"
+msgstr "音声が検出されませんでした。再試行時には、マイクに向かって話してください。"
 
 # smartling.placeholder_format=C
 #. Button that dismisses a feedback form.
@@ -13273,9 +12969,7 @@ msgstr "オンデマンド"
 msgid ""
 "On Mac, %sClick Maxthon > Preferences%s, On Windows, %sClick the %s icon > "
 "Settings%s"
-msgstr ""
-"Macでは%1$sMaxthon > 環境設定%2$s、Windowsでは%3$s アイコン > 設定%4$sの順"
-"に%5$sクリックしてください"
+msgstr "Macでは%1$sMaxthon > 環境設定%2$s、Windowsでは%3$s アイコン > 設定%4$sの順に%5$sクリックしてください"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
@@ -13296,9 +12990,7 @@ msgctxt ""
 msgid ""
 "One of the files attached has more pages than we support. Please upload "
 "files with %s pages or fewer."
-msgstr ""
-"添付ファイルの1点がサポートページ数を超えています。%1$sページ以下のファイルを"
-"アップロードしてください。"
+msgstr "添付ファイルの1点がサポートページ数を超えています。%1$sページ以下のファイルをアップロードしてください。"
 
 # smartling.placeholder_format=C
 #. Response a user can select in a feedback form, indicating that they heard about DuckDuckGo in an online article.
@@ -13324,8 +13016,7 @@ msgctxt "cloudsave"
 msgid ""
 "Only the settings that you have changed. They are detailed on the %sURL "
 "Parameters%s page."
-msgstr ""
-"変更した設定のみ。これらの詳細は %1$sURLパラメータ%2$s のページにあります。"
+msgstr "変更した設定のみ。これらの詳細は %1$sURLパラメータ%2$s のページにあります。"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers only when the user clicks the Assist button.
@@ -13339,9 +13030,7 @@ msgctxt "translations_module"
 msgid ""
 "Oops! An unexpected error occurred while translating this text. Please try "
 "again later."
-msgstr ""
-"おっと！このテキストの翻訳中に予期しないエラーが発生しました。少し時間をおい"
-"てからもう一度試してください。"
+msgstr "おっと！このテキストの翻訳中に予期しないエラーが発生しました。少し時間をおいてからもう一度試してください。"
 
 # smartling.placeholder_format=C
 #. Title shown in a fatal error modal when Duck.ai fails to load.
@@ -13657,9 +13346,7 @@ msgctxt "homepage onboarding"
 msgid ""
 "Other search engines track your searches even when you’re in private "
 "browsing mode. We don’t track you &mdash; period."
-msgstr ""
-"他社の検索エンジンはあなたの検索をプライベートブラウジングでも追跡していま"
-"す。私たちは追跡しません。"
+msgstr "他社の検索エンジンはあなたの検索をプライベートブラウジングでも追跡しています。私たちは追跡しません。"
 
 # smartling.placeholder_format=C
 msgctxt "SERP footer content"
@@ -13671,18 +13358,14 @@ msgctxt "homepage onboarding"
 msgid ""
 "Our privacy policy is simple: we don’t collect or share any of your personal "
 "information."
-msgstr ""
-"私たちのプライバシーポリシーはシンプルです。ユーザーの個人情報は一切収集しま"
-"せん。"
+msgstr "私たちのプライバシーポリシーはシンプルです。ユーザーの個人情報は一切収集しません。"
 
 # smartling.placeholder_format=C
 msgid ""
 "Our private browser for mobile comes equipped with our search engine, "
 "tracker blocker, encryption enforcer, and more. Available on %siOS & "
 "Android%s."
-msgstr ""
-"当社のモバイル用プライベートブラウザには、検索エンジン、トラッカーブロック、"
-"強制暗号化機能などが備わっています。%1$siOSとAndroid%2$sに対応。"
+msgstr "当社のモバイル用プライベートブラウザには、検索エンジン、トラッカーブロック、強制暗号化機能などが備わっています。%1$siOSとAndroid%2$sに対応。"
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the information was out of date.
@@ -13934,9 +13617,7 @@ msgctxt "cloudsave"
 msgid ""
 "Passphrases cannot be recovered as we don't associate your IP address, "
 "browser fingerprint, or any other information with the file."
-msgstr ""
-"当社は、お客様のIPアドレスやブラウザ上の個人を特定できる情報、その他一切の情"
-"報をファイルに関連付けないため、パスフレーズを復元できません。"
+msgstr "当社は、お客様のIPアドレスやブラウザ上の個人を特定できる情報、その他一切の情報をファイルに関連付けないため、パスフレーズを復元できません。"
 
 # smartling.placeholder_format=C
 #. Label for the section of recent chats that were edited in the past 7 days.
@@ -14129,10 +13810,7 @@ msgid ""
 "assisted answers more likely to appear automatically and often yields better "
 "answers. To turn them off and hide the Assist button visit %sSearch "
 "Settings%s."
-msgstr ""
-"検索を質問として完全な文章で表現すると、AI支援の回答が自動的に表示される可能"
-"性と回答精度が高くなります。オフにしてAssistボタンを非表示にするには、%1$s検"
-"索設定%2$sにアクセスしてください。"
+msgstr "検索を質問として完全な文章で表現すると、AI支援の回答が自動的に表示される可能性と回答精度が高くなります。オフにしてAssistボタンを非表示にするには、%1$s検索設定%2$sにアクセスしてください。"
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -14141,9 +13819,8 @@ msgid ""
 "DuckAssist more likely to appear and often yields better answers. To adjust "
 "how this feature works, or to turn it off, visit %sDuckAssist Settings%s."
 msgstr ""
-"検索を質問として完全な文章で表現すると、DuckAssistが表示される可能性と回答精"
-"度が高くなります。 この機能の動作を調整したり、オフにするには、%1$sDuckAssist"
-"設定%2$sにアクセスしてください。"
+"検索を質問として完全な文章で表現すると、DuckAssistが表示される可能性と回答精度が高くなります。 "
+"この機能の動作を調整したり、オフにするには、%1$sDuckAssist設定%2$sにアクセスしてください。"
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -14152,10 +13829,7 @@ msgid ""
 "DuckAssist more likely to appear automatically and often yields better "
 "answers. To turn it off and hide the Assist button visit %sDuckAssist "
 "Settings%s."
-msgstr ""
-"検索を完全な質問文で表現すると、DuckAssistが自動的に表示される可能性と回答精"
-"度が高くなります。オフにしてAssistボタンを非表示にするには、%1$sDuckAssist設"
-"定%2$sにアクセスしてください。"
+msgstr "検索を完全な質問文で表現すると、DuckAssistが自動的に表示される可能性と回答精度が高くなります。オフにしてAssistボタンを非表示にするには、%1$sDuckAssist設定%2$sにアクセスしてください。"
 
 # smartling.placeholder_format=C
 #. Button that allows users to manually select a location on a map.
@@ -14187,8 +13861,7 @@ msgctxt "Body copy for the chat card in the How Duck.ai Works panel"
 msgid ""
 "Pick a popular AI to chat with, like GPT-5 mini, Claude Haiku 4.5, Mistral, "
 "etc."
-msgstr ""
-"GPT-5 mini、Claude Haiku 4.5、Mistralなど人気のAIからチャット相手を選びます。"
+msgstr "GPT-5 mini、Claude Haiku 4.5、Mistralなど人気のAIからチャット相手を選びます。"
 
 # smartling.placeholder_format=C
 #. Describes the ability to choose from popular AI models. Pairs with a chat-bubble pictogram.
@@ -14196,8 +13869,7 @@ msgctxt "Body copy for the chat card in the How Duck.ai Works panel"
 msgid ""
 "Pick a popular AI to chat with, like GPT-5 mini, Claude Haiku 4.5, "
 "Mistral, etc."
-msgstr ""
-"GPT-5 mini、Claude Haiku 4.5、Mistralなど人気のAIからチャット相手を選びます。"
+msgstr "GPT-5 mini、Claude Haiku 4.5、Mistralなど人気のAIからチャット相手を選びます。"
 
 # smartling.placeholder_format=C
 #. The description of the third party map app picker, shown on iOS when a user is given an option of which app to navigate to a destination with
@@ -14205,9 +13877,7 @@ msgctxt "Third party map app picker"
 msgid ""
 "Pick a service to navigate to your destination. External apps won’t come "
 "with DuckDuckGo protections."
-msgstr ""
-"目的地までの経路案内に使用するサービスを選択します。外部アプリにはDuckDuckGo"
-"の保護が付属しません。"
+msgstr "目的地までの経路案内に使用するサービスを選択します。外部アプリにはDuckDuckGoの保護が付属しません。"
 
 # smartling.placeholder_format=C
 #. Label for a list of problems on a feedback form.
@@ -14289,9 +13959,7 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this prompt was made by a "
 "human."
-msgstr ""
-"このプロンプトがボットにより行われていないことを確認するため、次のチャレンジ"
-"を完了してください。"
+msgstr "このプロンプトがボットにより行われていないことを確認するため、次のチャレンジを完了してください。"
 
 # smartling.placeholder_format=C
 #. Bot challenge explanation
@@ -14299,15 +13967,13 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this search was made by a "
 "human."
-msgstr ""
-"この検索がボットにより行われていないことを確認するため、次のチャレンジを完了"
-"してください。"
+msgstr "この検索がボットにより行われていないことを確認するため、次のチャレンジを完了してください。"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is harmful or illegal. (optional)"
-msgstr ""
+msgstr "チャットの回答が有害または違法である理由を説明してください。（任意）"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
@@ -14333,9 +13999,7 @@ msgctxt "Modal disclaimer text"
 msgid ""
 "Please note: starting a new chat with any model will delete your current "
 "chat session."
-msgstr ""
-"注：モデルとの新しいチャットを開始すると、現在のチャットセッションが削除され"
-"ます。"
+msgstr "注：モデルとの新しいチャットを開始すると、現在のチャットセッションが削除されます。"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -14343,7 +14007,7 @@ msgctxt "Feedback prompt"
 msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is harmful or illegal."
-msgstr ""
+msgstr "プロンプトと問題のある出力（個人情報は削除）を貼り付け、コンテンツが有害または違法である理由を説明してください。"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -14351,9 +14015,7 @@ msgctxt "Feedback prompt"
 msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is illegal or harmful."
-msgstr ""
-"プロンプトと問題のある出力（個人情報は削除）を貼り付け、コンテンツが違法また"
-"は有害である理由を説明してください。"
+msgstr "プロンプトと問題のある出力（個人情報は削除）を貼り付け、コンテンツが違法または有害である理由を説明してください。"
 
 # smartling.placeholder_format=C
 #. Title on a feedback form.
@@ -14814,7 +14476,7 @@ msgstr "プライバシー"
 #. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
 msgctxt "Section heading on the Duck.ai settings page"
 msgid "Privacy & Terms"
-msgstr ""
+msgstr "プライバシーと利用規約"
 
 # smartling.placeholder_format=C
 msgid "Privacy Blog"
@@ -14890,7 +14552,7 @@ msgstr "プライバシーポリシーおよび利用規約"
 #. Text for a button that links to the terms of use and privacy policy page.
 msgctxt "Secondary button text in active privacy modal"
 msgid "Privacy Policy and Terms of Service"
-msgstr ""
+msgstr "プライバシーポリシーおよび利用規約"
 
 # smartling.placeholder_format=C
 #. Title displayed on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
@@ -15064,9 +14726,7 @@ msgstr "確認する"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Prompt me to use my approximate location to get nearby results."
-msgstr ""
-"ローカル検索で利用する、おおよその位置情報の使用を許可するプロンプトを表示し"
-"ます。"
+msgstr "ローカル検索で利用する、おおよその位置情報の使用を許可するプロンプトを表示します。"
 
 # smartling.placeholder_format=C
 #. DuckDuckGo Email Protection removes trackers from emails
@@ -15108,9 +14768,7 @@ msgctxt "Full sentence for critiquing writing"
 msgid ""
 "Provide a few suggestions to make the following text more concise. [Insert "
 "your own text here.]"
-msgstr ""
-"次のテキストをより簡潔にするための提案をいくつか提供してください。 [ここに独"
-"自のテキストを挿入します。]"
+msgstr "次のテキストをより簡潔にするための提案をいくつか提供してください。 [ここに独自のテキストを挿入します。]"
 
 # smartling.placeholder_format=C
 #. In the context of a standings table for NHL (hockey), column title that abbreviates 'Total Points' (the total points of this team)
@@ -15346,9 +15004,7 @@ msgctxt "Description for recent chats feature"
 msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
-msgstr ""
-"最近のチャットは、DuckDuckGoサーバーなどのリモートサーバーでなく、お使いのデ"
-"バイスにローカルで保存されます。"
+msgstr "最近のチャットは、DuckDuckGoサーバーなどのリモートサーバーでなく、お使いのデバイスにローカルで保存されます。"
 
 # smartling.placeholder_format=C
 #. Text explaining that recent chats are stored locally on the user's device.
@@ -15356,9 +15012,7 @@ msgctxt "Description of where recent chats are stored"
 msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
-msgstr ""
-"最近のチャットは、DuckDuckGoサーバーなどのリモートサーバーでなく、お使いのデ"
-"バイスにローカルで保存されます。"
+msgstr "最近のチャットは、DuckDuckGoサーバーなどのリモートサーバーでなく、お使いのデバイスにローカルで保存されます。"
 
 # smartling.placeholder_format=C
 #. Text explaining how recent chats are stored locally on the user's device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection.
@@ -15367,10 +15021,7 @@ msgid ""
 "Recent chats are stored locally on your device. New prompts and responses "
 "are encrypted and temporarily stored on a DuckDuckGo server after being "
 "sent, to help recover a chat if you lose your internet connection."
-msgstr ""
-"最近のチャットはデバイスのローカルに保存されます。新しいプロンプトやレスポン"
-"スは暗号化され、送信後はDuckDuckGoサーバーに一時的に保存されます。これは、イ"
-"ンターネット接続が途切れた場合のチャット復旧に役立ちます。"
+msgstr "最近のチャットはデバイスのローカルに保存されます。新しいプロンプトやレスポンスは暗号化され、送信後はDuckDuckGoサーバーに一時的に保存されます。これは、インターネット接続が途切れた場合のチャット復旧に役立ちます。"
 
 # smartling.placeholder_format=C
 msgctxt "region filter"
@@ -15397,25 +15048,25 @@ msgstr "本を推薦する"
 #. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Recommend similar books"
-msgstr ""
+msgstr "類似の書籍を推薦"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Recommend similar books."
-msgstr ""
+msgstr "類似の書籍を推薦してください。"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Recommend similar movies or shows."
-msgstr ""
+msgstr "類似の映画や番組を推薦してください。"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Recommend similar titles"
-msgstr ""
+msgstr "類似の作品を推薦"
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
@@ -15487,9 +15138,7 @@ msgctxt "settings"
 msgid ""
 "Reduces extra space in and around results and reduces size of result title "
 "text"
-msgstr ""
-"結果の内部と周辺にある余分なスペースを減らし、結果のタイトルテキストのサイズ"
-"を縮小します"
+msgstr "結果の内部と周辺にある余分なスペースを減らし、結果のタイトルテキストのサイズを縮小します"
 
 # smartling.placeholder_format=C
 #. Label for the input field where users specify how they want to be referred to. Example: 'Refer to me as John'
@@ -15630,8 +15279,8 @@ msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
 msgstr ""
-"指示に従ってDuckDuckGoを再度読み込みするか、ブラウザの [Refresh（リフレッ"
-"シュ）]、または [Reload（再読み込み）] ボタンをクリックします。"
+"指示に従ってDuckDuckGoを再度読み込みするか、ブラウザの [Refresh（リフレッシュ）]、または [Reload（再読み込み）] "
+"ボタンをクリックします。"
 
 # smartling.placeholder_format=C
 #. checkbox label that allows the user to save the setting
@@ -15720,18 +15369,14 @@ msgctxt "settings"
 msgid ""
 "Removes the \"Ask\" button so answers appear automatically in response to "
 "relevant searches. Cached answers always display automatically."
-msgstr ""
-"「質問」ボタンを削除して、関連する検索に対して回答が自動的に表示されるように"
-"します。キャッシュされた回答は常に自動的に表示されます。"
+msgstr "「質問」ボタンを削除して、関連する検索に対して回答が自動的に表示されるようにします。キャッシュされた回答は常に自動的に表示されます。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Removes the \"Generate\" button so answers appear automatically in response "
 "to relevant searches. Cached answers always display automatically."
-msgstr ""
-"「生成」ボタンを削除して、関連する検索に対して回答が自動的に表示されるように"
-"します。キャッシュされた回答は常に自動的に表示されます。"
+msgstr "「生成」ボタンを削除して、関連する検索に対して回答が自動的に表示されるようにします。キャッシュされた回答は常に自動的に表示されます。"
 
 # smartling.placeholder_format=C
 #. Text for a button to rename a chat, as in it will allow the user to change the title of the chat.
@@ -15788,18 +15433,14 @@ msgid ""
 "Reports are anonymous and sent to DuckDuckGo to help improve our search "
 "service. Your anonymous feedback is also shared with %s to help improve "
 "their services."
-msgstr ""
-"レポートは匿名で、検索サービスの向上目的でDuckDuckGoに送信されます。お客様の"
-"匿名でのフィードバックはサービス改善に役立てるために%1$sとも共有されます。"
+msgstr "レポートは匿名で、検索サービスの向上目的でDuckDuckGoに送信されます。お客様の匿名でのフィードバックはサービス改善に役立てるために%1$sとも共有されます。"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "Reports sent to DuckDuckGo are anonymous. Please do not include any personal "
 "or identifying information in your feedback."
-msgstr ""
-"DuckDuckGoに送信される報告内容は、匿名です。フィードバックには、個人情報や個"
-"人を特定できる情報を含めないようお願いいたします。"
+msgstr "DuckDuckGoに送信される報告内容は、匿名です。フィードバックには、個人情報や個人を特定できる情報を含めないようお願いいたします。"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -15807,10 +15448,7 @@ msgid ""
 "Reports sent to DuckDuckGo include all of the text you've asked us to "
 "translate during this page load, and are anonymous. Please do not include "
 "any personal or identifying information in your feedback."
-msgstr ""
-"DuckDuckGoに送信されるレポートは、このページの読み込み中に翻訳を希望したすべ"
-"てのテキストを含み、匿名になっています。フィードバックには、個人情報や個人を"
-"特定できる情報を含めないようお願いいたします。"
+msgstr "DuckDuckGoに送信されるレポートは、このページの読み込み中に翻訳を希望したすべてのテキストを含み、匿名になっています。フィードバックには、個人情報や個人を特定できる情報を含めないようお願いいたします。"
 
 # smartling.placeholder_format=C
 msgid "Republic of Moldova"
@@ -15823,7 +15461,7 @@ msgctxt ""
 "feedback form when the user has selected Harmful or Illegal as the feedback "
 "reason"
 msgid "Required for harmful or illegal reports"
-msgstr ""
+msgstr "有害または違法なコンテンツを通報する際は必須"
 
 # smartling.placeholder_format=C
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
@@ -15889,10 +15527,7 @@ msgid ""
 "Responses are for educational purposes only and are not intended as medical, "
 "legal, financial, investment, or other professional advice. AI-assisted "
 "answers are subject to our %sTerms of Service%s."
-msgstr ""
-"回答は教育的な目的のみであり、医療、法律、金融、投資、その他の専門的なアドバ"
-"イスを意図したものではありません。AI支援回答は、当社の%1$s利用規約%2$sの対象"
-"です。"
+msgstr "回答は教育的な目的のみであり、医療、法律、金融、投資、その他の専門的なアドバイスを意図したものではありません。AI支援回答は、当社の%1$s利用規約%2$sの対象です。"
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -15900,10 +15535,7 @@ msgid ""
 "Responses are for educational purposes only and are not intended as medical, "
 "legal, financial, investment, or other professional advice. DuckAssist is "
 "subject to our %sTerms of Service%s."
-msgstr ""
-"回答は教育的な目的のみであり、医療、法律、金融、投資、その他の専門的なアドバ"
-"イスを意図したものではありません。DuckAssistは、当社の%1$s利用規約%2$sの対象"
-"になります。"
+msgstr "回答は教育的な目的のみであり、医療、法律、金融、投資、その他の専門的なアドバイスを意図したものではありません。DuckAssistは、当社の%1$s利用規約%2$sの対象になります。"
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -15913,10 +15545,9 @@ msgid ""
 "generated based on web content and may contain inaccuracies. Search Assist "
 "is subject to our %sTerms of Service%s."
 msgstr ""
-"回答は教育的な目的でのみ提供され、医療、法律、金融、投資、その他の専門的なア"
-"ドバイスの提供を意図したものではありません。回答はウェブコンテンツに基づいて"
-"生成されているため、不正確な情報が含まれている可能性があります。Search Assist"
-"には、当社の%1$s利用規約%2$sが適用されます。"
+""
+"回答は教育的な目的でのみ提供され、医療、法律、金融、投資、その他の専門的なアドバイスの提供を意図したものではありません。回答はウェブコンテンツに基づいて生成されているため、不正確な情報が含まれている可能性があります。Search "
+"Assistには、当社の%1$s利用規約%2$sが適用されます。"
 
 # smartling.placeholder_format=C
 #. Label on the button for restoring all previous website data.
@@ -16063,7 +15694,7 @@ msgstr "評価"
 #. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Rewrite this recipe scaled for a different number of servings."
-msgstr ""
+msgstr "このレシピを別の人数分で書き直してください。"
 
 # smartling.placeholder_format=C
 msgid "Romania"
@@ -16334,9 +15965,7 @@ msgctxt "Description for Chat History feature with Encrypted Storage option"
 msgid ""
 "Save up to 30 of your most recent chats locally on your device, with the "
 "option for more with Encrypted Storage."
-msgstr ""
-"最新のチャットを最大30件デバイス上にローカルに保存できます。暗号化ストレージ"
-"を使用すれば、さらに多くのチャットを保存できます。"
+msgstr "最新のチャットを最大30件デバイス上にローカルに保存できます。暗号化ストレージを使用すれば、さらに多くのチャットを保存できます。"
 
 # smartling.placeholder_format=C
 #. Short text for native DDG browser users explaining how Chat History stores up to 30 of their most recent chats locally on their device.
@@ -16349,9 +15978,7 @@ msgstr "最新のチャットを最大30件デバイスにローカルで保存�
 msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
-msgstr ""
-"エンドツーエンド暗号化を使用して、デバイス間でDuck.aiのチャットを保存しましょ"
-"う。"
+msgstr "エンドツーエンド暗号化を使用して、デバイス間でDuck.aiのチャットを保存しましょう。"
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -16480,9 +16107,7 @@ msgstr "下方向にスクロールし、%1$s詳細設定を表示%2$s をクリ
 msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)"
-msgstr ""
-"%1$sアドレスバーで検索%2$sが見つかるまで下方向にスクロールします。%3$s変"
-"更%4$s (または %5$s新たに追加%6$s) をクリックします"
+msgstr "%1$sアドレスバーで検索%2$sが見つかるまで下方向にスクロールします。%3$s変更%4$s (または %5$s新たに追加%6$s) をクリックします"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
@@ -16491,8 +16116,8 @@ msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)."
 msgstr ""
-"%1$sアドレスバーで検索%2$s が見つかるまで下方向にスクロールします。%3$s変"
-"更%4$s (または %5$s新たに追加%6$s) をクリックします。"
+"%1$sアドレスバーで検索%2$s が見つかるまで下方向にスクロールします。%3$s変更%4$s (または %5$s新たに追加%6$s) "
+"をクリックします。"
 
 # smartling.placeholder_format=C
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -16516,9 +16141,7 @@ msgstr "%1$sDuckDuckGo%2$sまで下にスクロールし、位置情報の使用
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down to the %sServices%s section and click %sAddress bar%s."
-msgstr ""
-"%1$sサービス%2$s セクションまで下方向にスクロールして、%3$sアドレスバー%4$s "
-"をクリックします。"
+msgstr "%1$sサービス%2$s セクションまで下方向にスクロールして、%3$sアドレスバー%4$s をクリックします。"
 
 # smartling.placeholder_format=C
 #. Rugby match stats
@@ -16566,20 +16189,17 @@ msgid ""
 "(on a wide range of searches). For now, Search Assist is only available in a "
 "subset of English speaking regions."
 msgstr ""
-"Search Assistは検索クエリに対する回答を匿名で生成します。そのために、関連コン"
-"テンツをウェブでスキャンしてから、AIを使用して簡潔な回答を生成します。表示頻"
-"度は、「表示しない」、「要求時（Assistがクリックされたときのみ）」、「時々"
-"（関連性が高いとき）」、「頻繁（検索範囲が広いとき）」から選択できます。"
-"Search Assistは現時点で、英語圏の一部の地域でのみ利用可能です。"
+"Search "
+""
+"Assistは検索クエリに対する回答を匿名で生成します。そのために、関連コンテンツをウェブでスキャンしてから、AIを使用して簡潔な回答を生成します。表示頻度は、「表示しない」、「要求時（Assistがクリックされたときのみ）」、「時々（関連性が高いとき）」、「頻繁（検索範囲が広いとき）」から選択できます。Search "
+"Assistは現時点で、英語圏の一部の地域でのみ利用可能です。"
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI) when the answer is not found and the answer is unsourced or with no sources
 msgid ""
 "Search Assist couldn't find enough reliable information to generate an "
 "answer for this question. Try another search."
-msgstr ""
-"Search Assistはこの質問の回答を生成するのに十分な信頼できる情報を見つけること"
-"ができませんでした。別の検索をお試しください。"
+msgstr "Search Assistはこの質問の回答を生成するのに十分な信頼できる情報を見つけることができませんでした。別の検索をお試しください。"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -16588,9 +16208,8 @@ msgid ""
 "search queries. To do this, it %sscans the web%s for relevant content and "
 "then uses AI to generate a brief answer based on information found."
 msgstr ""
-"Search Assistは、検索クエリに対する回答を匿名で生成するオプション機能です。こ"
-"れを行うには、%1$sウェブをスキャンして%2$s関連コンテンツを探し、見つかった情"
-"報に基づいてAIを使って簡潔な回答を生成します。"
+"Search "
+"Assistは、検索クエリに対する回答を匿名で生成するオプション機能です。これを行うには、%1$sウェブをスキャンして%2$s関連コンテンツを探し、見つかった情報に基づいてAIを使って簡潔な回答を生成します。"
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/search_box. top header
@@ -16710,9 +16329,7 @@ msgctxt "noresults"
 msgid ""
 "Search other sites with %s shortcuts: a search for ”!w ducks” will search "
 "for “ducks” directly on Wikipedia."
-msgstr ""
-"%1$sのショートカットで他のサイトを検索します：「!w ducks」を検索すると、"
-"Wikipediaで「ducks」を直接検索します。"
+msgstr "%1$sのショートカットで他のサイトを検索します：「!w ducks」を検索すると、Wikipediaで「ducks」を直接検索します。"
 
 # smartling.placeholder_format=C
 #. Placeholder text for the search form when no text has been entered
@@ -16730,10 +16347,7 @@ msgstr "プライベートに検索し、トラッカーをブロック"
 msgid ""
 "Search privately with our app or extension, add private web search to your "
 "favorite browser, or search directly at %sduckduckgo.com%s."
-msgstr ""
-"検索時のプライバシーが心配なあなたにぴったりのアプリ・拡張機能。お気に入りの"
-"ブラウザにプライベート検索機能を追加するか、%1$sduckduckgo.com%2$sで直接検索"
-"できます。"
+msgstr "検索時のプライバシーが心配なあなたにぴったりのアプリ・拡張機能。お気に入りのブラウザにプライベート検索機能を追加するか、%1$sduckduckgo.com%2$sで直接検索できます。"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/6LZAoqH.png
@@ -16752,10 +16366,8 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"検索設定は、非個人用のブラウザCookieおよびローカルストレージに保存されます"
-"が、設定をクラウド上のリモートサーバーに匿名で保存できるCloud Saveもご利用い"
-"ただけます。クラウドには個人を特定できる情報は一切保存されず、パスフレーズが"
-"ブラウザの外に送信されることもありません。"
+"検索設定は、非個人用のブラウザCookieおよびローカルストレージに保存されますが、設定をクラウド上のリモートサーバーに匿名で保存できるCloud "
+"Saveもご利用いただけます。クラウドには個人を特定できる情報は一切保存されず、パスフレーズがブラウザの外に送信されることもありません。"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -16851,9 +16463,7 @@ msgctxt "Description explaining how native users can enable sync"
 msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
-msgstr ""
-"エンドツーエンド暗号化で、ほぼ無制限のチャットを当社サーバーに安全に保存し、"
-"すべてのデバイスから簡単にアクセスできます。"
+msgstr "エンドツーエンド暗号化で、ほぼ無制限のチャットを当社サーバーに安全に保存し、すべてのデバイスから簡単にアクセスできます。"
 
 # smartling.placeholder_format=C
 #. Text explaining that the Encrypted Storage feature stores the user's chats encrypted on their device.
@@ -16861,9 +16471,7 @@ msgctxt "Description for encrypted storage feature"
 msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
-msgstr ""
-"エンドツーエンド暗号化で、ほぼ無制限のチャットを当社サーバーに安全に保存し、"
-"すべてのデバイスから簡単にアクセスできます。"
+msgstr "エンドツーエンド暗号化で、ほぼ無制限のチャットを当社サーバーに安全に保存し、すべてのデバイスから簡単にアクセスできます。"
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -16871,9 +16479,7 @@ msgctxt "Description explaining how native users can enable sync"
 msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your synced devices."
-msgstr ""
-"エンドツーエンド暗号化で、ほぼ無制限のチャットを当社サーバーに安全に保存し、"
-"すべての同期済みのデバイスから簡単にアクセスできます。"
+msgstr "エンドツーエンド暗号化で、ほぼ無制限のチャットを当社サーバーに安全に保存し、すべての同期済みのデバイスから簡単にアクセスできます。"
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -16881,9 +16487,7 @@ msgctxt "Description explaining how native users can enable sync"
 msgid ""
 "Securely store your chats on our server using end-to-end encryption, and "
 "access them from all your devices."
-msgstr ""
-"チャットはエンドツーエンド暗号化を使用して当社サーバーに安全に保存され、すべ"
-"てのデバイスからアクセスできます。"
+msgstr "チャットはエンドツーエンド暗号化を使用して当社サーバーに安全に保存され、すべてのデバイスからアクセスできます。"
 
 # smartling.placeholder_format=C
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
@@ -16897,9 +16501,7 @@ msgctxt "Chat history with sync modal list item"
 msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
-msgstr ""
-"データはDuckDuckGoのサーバー上にエンドツーエンド暗号化で安全に保存されます。"
-"DuckDuckGoを含めて、本人以外のユーザーは閲覧できません。"
+msgstr "データはDuckDuckGoのサーバー上にエンドツーエンド暗号化で安全に保存されます。DuckDuckGoを含めて、本人以外のユーザーは閲覧できません。"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -17043,41 +16645,35 @@ msgstr "Safariメニューの%1$s「このウェブサイトの設定...」%2$s 
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
-msgstr ""
-"%1$sカスタム%2$s を選択して、入力欄に %3$shttps://duckduckgo.com%4$s と入力"
+msgstr "%1$sカスタム%2$s を選択して、入力欄に %3$shttps://duckduckgo.com%4$s と入力"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
-msgstr ""
-"%1$sDuckDuckGo%2$sを選択し、%3$sデフォルトとして追加%4$sをクリックします。"
+msgstr "%1$sDuckDuckGo%2$sを選択し、%3$sデフォルトとして追加%4$sをクリックします。"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s"
-msgstr ""
-"%1$sDuckDuckGo%2$sを選択し、%3$sデフォルトに設定%4$sをクリックしてください"
+msgstr "%1$sDuckDuckGo%2$sを選択し、%3$sデフォルトに設定%4$sをクリックしてください"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s."
-msgstr ""
-"%1$sDuckDuckGo%2$sを選択し、%3$sデフォルトに設定%4$s をクリックします。"
+msgstr "%1$sDuckDuckGo%2$sを選択し、%3$sデフォルトに設定%4$s をクリックします。"
 
 #  Firefox 33
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Select %sDuckDuckGo%s in the Default Search Engine drop down"
-msgstr ""
-"%1$sDuckDuckGo%2$sをデフォルトの検索エンジン選択メニューから選んでください"
+msgstr "%1$sDuckDuckGo%2$sをデフォルトの検索エンジン選択メニューから選んでください"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %sDuckDuckGo%s in the list and %sallow%s location access"
-msgstr ""
-"リストで%1$sDuckDuckGo%2$sを選択し、位置情報へのアクセスを%3$s許可%4$sします"
+msgstr "リストで%1$sDuckDuckGo%2$sを選択し、位置情報へのアクセスを%3$s許可%4$sします"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -17089,9 +16685,7 @@ msgstr "検索エンジンから%1$sDuckDuckGo%2$sを選択してください"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s under the%sDefault Search Engine%s section"
-msgstr ""
-"%1$sデフォルトの検索エンジン%2$sセクションの中にある%3$sDuckDuckGo%4$sを選択"
-"してください"
+msgstr "%1$sデフォルトの検索エンジン%2$sセクションの中にある%3$sDuckDuckGo%4$sを選択してください"
 
 # smartling.placeholder_format=C
 #. Tells the user were in the settings menu they can change their default search engine.
@@ -17102,8 +16696,7 @@ msgstr "選ぶなら%1$sDuckDuckGo%2$s！"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Select %sEdit Search Engines...%sin the dropdown"
-msgstr ""
-"ドロップダウンの中にある%1$s検索エンジンを編集...%2$sボタンを選択してください"
+msgstr "ドロップダウンの中にある%1$s検索エンジンを編集...%2$sボタンを選択してください"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -17116,9 +16709,7 @@ msgstr "ドロップダウンメニューの%1$sアドオン管理%2$sを選択�
 #. Tells users where in the settings menu they can change their default search engine.
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sMenu > Settings%s (on Windows)"
-msgstr ""
-"Macの場合、%1$sOpera > 設定%2$sの順に選択してください。Windowsの場合は、%3$s"
-"メニュー > 設定%4$sの順に選択してください"
+msgstr "Macの場合、%1$sOpera > 設定%2$sの順に選択してください。Windowsの場合は、%3$sメニュー > 設定%4$sの順に選択してください"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -17126,8 +16717,8 @@ msgstr ""
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sOpera > Options%s (on Windows)"
 msgstr ""
-"Macの場合、%1$sOpera > 環境設定%2$sの順に選択してください。Windowsの場合"
-"は、%3$sOpera > オプション%4$sの順に選択してください"
+"Macの場合、%1$sOpera > 環境設定%2$sの順に選択してください。Windowsの場合は、%3$sOpera > "
+"オプション%4$sの順に選択してください"
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -17146,8 +16737,7 @@ msgstr "%1$s検索エンジン%2$s を選択"
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"
-msgstr ""
-"%1$s検索エンジン%2$sを選択してから、%3$sその他...%4$sをクリックします。"
+msgstr "%1$s検索エンジン%2$sを選択してから、%3$sその他...%4$sをクリックします。"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -17192,17 +16782,13 @@ msgstr "%1$s設定%2$sを選択し、%3$s検索エンジン%4$sを選択して�
 msgid ""
 "Select %sUse this webpage as your only home page%s (or one of the other "
 "options if you prefer)"
-msgstr ""
-"%1$sこのページをホームページに設定%2$sを選択してください(または他のお好みのオ"
-"プションをどれか一つどうぞ)"
+msgstr "%1$sこのページをホームページに設定%2$sを選択してください(または他のお好みのオプションをどれか一つどうぞ)"
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %syour browser%s in the list and %sallow%s location access"
-msgstr ""
-"リストで%1$sお使いのブラウザ%2$sを選択し、位置情報へのアクセスを%3$s許可%4$s"
-"します"
+msgstr "リストで%1$sお使いのブラウザ%2$sを選択し、位置情報へのアクセスを%3$s許可%4$sします"
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the modal for deleting all recent chats, that allows the user to select the chats to delete.
@@ -17274,9 +16860,7 @@ msgstr "選択テキストの参照元：%1$s"
 #. Displayed when the user's text selection exceeds the maximum message size for AI tools (summary, translation, etc.).
 msgctxt "Error message for selection input limit"
 msgid "Selected text is too long. Try again with a shorter selection."
-msgstr ""
-"選択したテキストが長すぎます。ソーステキストを一部選択し、もう一度お試しくだ"
-"さい。"
+msgstr "選択したテキストが長すぎます。ソーステキストを一部選択し、もう一度お試しください。"
 
 # smartling.placeholder_format=C
 #. Label for the semi-finals knockout stage in e.g. the soccer World Cup
@@ -17319,9 +16903,7 @@ msgid ""
 "Sends a prompt to AI models with your messages with instructions on how to "
 "respond. These instructions will apply to all of your conversations going "
 "forward."
-msgstr ""
-"AIモデルに、メッセージに応答する方法を指示したプロンプトを送信します。これら"
-"の指示は、今後のすべての会話に適用されます。"
+msgstr "AIモデルに、メッセージに応答する方法を指示したプロンプトを送信します。これらの指示は、今後のすべての会話に適用されます。"
 
 # smartling.placeholder_format=C
 msgid "Senegal"
@@ -17400,7 +16982,7 @@ msgstr "今すぐセットアップ"
 #. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
 msgctxt "Encrypted storage setup button shown in native browsers"
 msgid "Set Up Sync & Backup"
-msgstr ""
+msgstr "Sync & Backupを設定"
 
 # smartling.placeholder_format=C
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
@@ -17430,9 +17012,7 @@ msgctxt "Chat history about modal list item"
 msgid ""
 "Set up Sync & Backup after turning on Chat History to keep your chats synced "
 "across devices."
-msgstr ""
-"チャット履歴をオンにしてから、チャットがデバイス間で継続的に同期されるように"
-"Sync & Backupを設定します。"
+msgstr "チャット履歴をオンにしてから、チャットがデバイス間で継続的に同期されるようにSync & Backupを設定します。"
 
 # smartling.placeholder_format=C
 #. Prompt for the user to indicate their location on a map, to enable more relevant search results.
@@ -17518,9 +17098,7 @@ msgctxt "Description for Approximate Location feature"
 msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
-msgstr ""
-"都市レベルの位置情報をAIモデルと共有して関連性を向上させます。Duck.ai は、お"
-"客様の正確な位置情報を当社や AI モデルに決して公開しません。"
+msgstr "都市レベルの位置情報をAIモデルと共有して関連性を向上させます。Duck.ai は、お客様の正確な位置情報を当社や AI モデルに決して公開しません。"
 
 # smartling.placeholder_format=C
 #. Menu option to share feedback about a result
@@ -17585,7 +17163,7 @@ msgstr "肯定的なフィードバックを共有する"
 msgctxt ""
 "Label beside the share-content switch on the Duck.ai response feedback form"
 msgid "Share this conversation with DuckDuckGo"
-msgstr ""
+msgstr "この会話をDuckDuckGoと共有"
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -17602,9 +17180,7 @@ msgctxt ""
 msgid ""
 "Share your prompt and chat response with DuckDuckGo (required for illegal "
 "and harmful report)"
-msgstr ""
-"プロンプトとチャットの回答をDuckDuckGoと共有してください（違法および有害な事"
-"象の報告には必須）"
+msgstr "プロンプトとチャットの回答をDuckDuckGoと共有してください（違法および有害な事象の報告には必須）"
 
 # smartling.placeholder_format=C
 #. An invitation for users to leave feedback
@@ -17724,9 +17300,7 @@ msgstr "DuckAssist<sup>ベータ版</sup>を表示"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show DuckAssist more often. (You can also completely %sturn it off%s.)"
-msgstr ""
-"DuckAssistをより頻繁に表示します。（完全に%1$sオフにする%2$sこともできま"
-"す。）"
+msgstr "DuckAssistをより頻繁に表示します。（完全に%1$sオフにする%2$sこともできます。）"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
@@ -17951,18 +17525,14 @@ msgctxt "settings"
 msgid ""
 "Shows a reminder that searches on DuckDuckGo are always private. Turning "
 "this off hides the reminder and never affects search privacy."
-msgstr ""
-"DuckDuckGoでの検索が常に非公開であることのリマインダーを表示します。これをオ"
-"フにすると、リマインダーが非表示になり、検索のプライバシーには影響しません。"
+msgstr "DuckDuckGoでの検索が常に非公開であることのリマインダーを表示します。これをオフにすると、リマインダーが非表示になり、検索のプライバシーには影響しません。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Shows a reminder that searches on DuckDuckGo are always protected. Turning "
 "this off hides the reminder and never affects search protection."
-msgstr ""
-"DuckDuckGoでの検索が常に保護されていることのリマインダーを表示します。これを"
-"オフにするとリマインダーが非表示になりますが、検索の保護には影響しません。"
+msgstr "DuckDuckGoでの検索が常に保護されていることのリマインダーを表示します。これをオフにするとリマインダーが非表示になりますが、検索の保護には影響しません。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -17999,8 +17569,7 @@ msgstr "DuckDuckGoを端末に追加するリマインダーを随時表示"
 msgctxt "settings"
 msgid ""
 "Shows occasional reminders to sign up for the DuckDuckGo privacy newsletters"
-msgstr ""
-"DuckDuckGoのプライバシーニュースレターへの登録に関する通知をときどき表示"
+msgstr "DuckDuckGoのプライバシーニュースレターへの登録に関する通知をときどき表示"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18021,9 +17590,7 @@ msgstr "入力に応じて検索ボックスの下に検索候補を表示"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows the privacy benefits of using DuckDuckGo on the homepage"
-msgstr ""
-"ホームページでDuckDuckGoを利用することで生まれるプライバシー上のメリットを表"
-"示"
+msgstr "ホームページでDuckDuckGoを利用することで生まれるプライバシー上のメリットを表示"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18260,8 +17827,7 @@ msgstr "サーバーへの保存が失敗しました。再度お試しくださ
 #. Body copy displayed under the Set Up Now button when the sync setup call fails.
 msgctxt "Generic error shown when sync setup fails"
 msgid "Something went wrong while enabling Sync & Backup. Please try again."
-msgstr ""
-"Sync & Backupを有効にしている際に問題が発生しました。もう一度お試しください。"
+msgstr "Sync & Backupを有効にしている際に問題が発生しました。もう一度お試しください。"
 
 # smartling.placeholder_format=C
 #. Displayed when the voice chat session ends with an unknown error.
@@ -18285,8 +17851,7 @@ msgstr "時々表示する"
 #. Generic error message shown when the image generation model cannot process the user's request.
 msgctxt "Error message from the image generation model"
 msgid "Sorry I can't help, please describe your image in a different way."
-msgstr ""
-"申し訳ありませんが、お力になれません。別の方法で画像を説明してください。"
+msgstr "申し訳ありませんが、お力になれません。別の方法で画像を説明してください。"
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -18324,9 +17889,7 @@ msgctxt "Error message when an uploaded image cannot be decoded or processed"
 msgid ""
 "Sorry, the uploaded image couldn't be processed. Please try a different "
 "image or format."
-msgstr ""
-"申し訳ありませんが、アップロードした画像を処理できませんでした。別の画像また"
-"は形式を試してください。"
+msgstr "申し訳ありませんが、アップロードした画像を処理できませんでした。別の画像または形式を試してください。"
 
 # smartling.placeholder_format=C
 #. Body copy shown when a scanned or pasted pairing payload fails schema validation.
@@ -18334,17 +17897,13 @@ msgctxt "Description for the wrong code error screen"
 msgid ""
 "Sorry, this code is invalid. Please make sure the correct code was entered "
 "or scanned."
-msgstr ""
-"申し訳ありません。このコードは無効です。正しいコードが入力またはスキャンされ"
-"たことを確認してください。"
+msgstr "申し訳ありません。このコードは無効です。正しいコードが入力またはスキャンされたことを確認してください。"
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
 msgid ""
 "Sorry, we couldn't generate a richer answer. You can try asking Duck.ai."
-msgstr ""
-"申し訳ありませんが、これ以上豊富な回答を出すことはできませんでした。Duck.ai "
-"に聞いてみてください。"
+msgstr "申し訳ありませんが、これ以上豊富な回答を出すことはできませんでした。Duck.ai に聞いてみてください。"
 
 # smartling.placeholder_format=C
 #. Inform the users that "something" went wrong and that they could try to refresh the page to resolve the error. Placeholders are for markup, please ignore.
@@ -18352,17 +17911,13 @@ msgctxt "noresults"
 msgid ""
 "Sorry, we ran into an error displaying these results. %sClick here%s to try "
 "again."
-msgstr ""
-"申し訳ありませんが、これらの結果を表示する際にエラーが発生しました。再試行す"
-"るには、%1$sこちらをクリック%2$sしてください。"
+msgstr "申し訳ありませんが、これらの結果を表示する際にエラーが発生しました。再試行するには、%1$sこちらをクリック%2$sしてください。"
 
 # smartling.placeholder_format=C
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr ""
-"申し訳ありませんが、フィードバックを送信できませんでした。少し時間をおいてか"
-"らもう一度試してください。"
+msgstr "申し訳ありませんが、フィードバックを送信できませんでした。少し時間をおいてからもう一度試してください。"
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -18416,9 +17971,7 @@ msgstr "ソーステキストが消去されました"
 msgctxt "Error message for summary selection input limit"
 msgid ""
 "Source text is too long to summarize. Try again with a shorter selection."
-msgstr ""
-"ソーステキストが長すぎて要約できません。ソーステキストを一部選択し、もう一度"
-"お試しください。"
+msgstr "ソーステキストが長すぎて要約できません。ソーステキストを一部選択し、もう一度お試しください。"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under Interface Settings.in the end. It is a header
@@ -18617,8 +18170,7 @@ msgstr "DuckDuckGoを使用し続ける"
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletter."
-msgstr ""
-"プライバシーニュースレターで、データを常時守り、最新情報を入手しましょう。"
+msgstr "プライバシーニュースレターで、データを常時守り、最新情報を入手しましょう。"
 
 # smartling.placeholder_format=C
 #. Prompt to subscribe to a newsletter.
@@ -18762,9 +18314,7 @@ msgctxt "Description prompting subscription for higher limits"
 msgid ""
 "Subscribe to DuckDuckGo to unlock higher limits in Duck.ai, or come back "
 "later to create more images."
-msgstr ""
-"Duck.aiの制限を引き上げるにはDuckDuckGoに登録するか、後で戻ってきてさらに画像"
-"を作成してください。"
+msgstr "Duck.aiの制限を引き上げるにはDuckDuckGoに登録するか、後で戻ってきてさらに画像を作成してください。"
 
 # smartling.placeholder_format=C
 #. Description shown to free users who have reached their image generation limit, encouraging them to subscribe.
@@ -18832,8 +18382,7 @@ msgctxt "Full sentence for composing a card"
 msgid ""
 "Suggest a phrase to write on a get-well card for someone recovering from a "
 "surgery?"
-msgstr ""
-"手術したばかりの人宛てのお見舞いのカードに書くフレーズを提案してください。"
+msgstr "手術したばかりの人宛てのお見舞いのカードに書くフレーズを提案してください。"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for asking for a suggestion of a blog post title.
@@ -18845,19 +18394,19 @@ msgstr "ブログ記事のタイトルを提案してください"
 #. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Suggest related articles or topics worth exploring next."
-msgstr ""
+msgstr "次に読む価値のある関連記事やトピックを提案してください。"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Suggest related articles to explore"
-msgstr ""
+msgstr "関連記事を提案"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Suggest some alternatives to this product."
-msgstr ""
+msgstr "この製品の他のオプションを提案してください。"
 
 # smartling.placeholder_format=C
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
@@ -18874,7 +18423,7 @@ msgstr "提案:"
 #. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Sum up the reviews"
-msgstr ""
+msgstr "レビューを要約"
 
 # smartling.placeholder_format=C
 #. A short title for the a message asking the AI to summarize a text.
@@ -18886,85 +18435,85 @@ msgstr "要約"
 #. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize the Q&As"
-msgstr ""
+msgstr "Q&Aを要約"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the background and notable work of this person."
-msgstr ""
+msgstr "この人物の経歴と主な業績を要約してください。"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the key details of this event."
-msgstr ""
+msgstr "このイベントの主な情報を要約してください。"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the questions and answers on this page."
-msgstr ""
+msgstr "このページの質問と回答を要約してください。"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize their background"
-msgstr ""
+msgstr "経歴を要約"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this book"
-msgstr ""
+msgstr "この本を要約"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this book."
-msgstr ""
+msgstr "この本を要約してください。"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this discussion"
-msgstr ""
+msgstr "このディスカッションを要約"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this discussion thread."
-msgstr ""
+msgstr "このディスカッションスレッドを要約してください。"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this page"
-msgstr ""
+msgstr "このページを要約"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this page."
-msgstr ""
+msgstr "このページを要約してください。"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this video"
-msgstr ""
+msgstr "この動画のあらすじを作成"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this video."
-msgstr ""
+msgstr "この動画を要約してください。"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize what the reviews say."
-msgstr ""
+msgstr "レビューの内容を要約してください。"
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -19125,8 +18674,7 @@ msgstr "どんなときでも、あなたを追跡しないサーチエンジン
 msgctxt "AI Chat warning when switching from an encrypted model"
 msgid ""
 "Switching will send your chat to a model without zero provider visibility"
-msgstr ""
-"切り替えると、チャットはプロバイダーの可視性がゼロのモデルに送信されます"
+msgstr "切り替えると、チャットはプロバイダーの可視性がゼロのモデルに送信されます"
 
 # smartling.placeholder_format=C
 msgid "Switzerland"
@@ -19229,25 +18777,21 @@ msgid ""
 msgstr ""
 "同期リカバリーコード\n"
 "\n"
-"リカバリーコードを使用すると、パスワード、自動入力データ、Duck.aiチャットが複"
-"数のデバイスで同期されるようになり、デバイスにアクセスできなくなった場合に同"
-"期済みのデータを回復できます。\n"
+""
+""
+"リカバリーコードを使用すると、パスワード、自動入力データ、Duck.aiチャットが複数のデバイスで同期されるようになり、デバイスにアクセスできなくなった場合に同期済みのデータを回復できます。\n"
 "\n"
 "この情報は安全に保管してください。\n"
-"このコードにアクセス可能なユーザーは誰でも同期済みデータにアクセスできま"
-"す。\n"
+"このコードにアクセス可能なユーザーは誰でも同期済みデータにアクセスできます。\n"
 "\n"
 "%1$s\n"
 "\n"
 "このコードの仕組みは？\n"
 "1. ブラウザでDuck.aiにアクセスし、Duck.aiの設定を開きます。\n"
-"2. 「Sync & Backupをオンにする」、「同期されたデータを復元」の順に選択しま"
-"す\n"
-"3. リカバリーコードをコピーし、「ここにコードを貼り付けてください」欄に貼り付"
-"けます\n"
+"2. 「Sync & Backupをオンにする」、「同期されたデータを復元」の順に選択します\n"
+"3. リカバリーコードをコピーし、「ここにコードを貼り付けてください」欄に貼り付けます\n"
 "\n"
-"DuckDuckGoブラウザの未使用期間が18か月を超えると、データはサーバーから削除さ"
-"れ、復元できなくなります。"
+"DuckDuckGoブラウザの未使用期間が18か月を超えると、データはサーバーから削除され、復元できなくなります。"
 
 # smartling.placeholder_format=C
 #. Secondary button label on the Sync & Backup intro screen that takes the user to the camera scan screen to pair with another device.
@@ -19293,7 +18837,7 @@ msgstr "シリア"
 #. Text for a button that enables the theme to follow the operating system's color scheme preference.
 msgctxt "System theme button for theme selector"
 msgid "System"
-msgstr ""
+msgstr "システム"
 
 # smartling.placeholder_format=C
 #. Abbreviation indicating this is the total score for a game
@@ -19327,7 +18871,7 @@ msgstr "タヒチ語"
 #. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Tailor my resume"
-msgstr ""
+msgstr "履歴書をアレンジ"
 
 # smartling.placeholder_format=C
 msgid "Taiwan"
@@ -19363,7 +18907,7 @@ msgstr "個人データを自己管理しましょう！"
 msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
-msgstr ""
+msgstr "この匿名アンケートに回答して、Duck.aiを改善するためのご意見をお寄せください。"
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -19577,10 +19121,7 @@ msgid ""
 "That means information sent between your device and the webpage behind this "
 "link is at increased risk of being intercepted by a third party. In rare "
 "cases this includes passwords, or payment details."
-msgstr ""
-"つまり、お使いのデバイスとこのリンクに接続するウェブページの間で送信される情"
-"報はサードパーティに傍受されるリスクが高いことになります。まれに、パスワード"
-"や支払い情報がこうした情報に含まれる場合もあります。"
+msgstr "つまり、お使いのデバイスとこのリンクに接続するウェブページの間で送信される情報はサードパーティに傍受されるリスクが高いことになります。まれに、パスワードや支払い情報がこうした情報に含まれる場合もあります。"
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -19588,9 +19129,7 @@ msgctxt "cloudsave"
 msgid ""
 "The Cloud Save bookmarklet allows any changes you make to your settings to "
 "automatically save in the cloud."
-msgstr ""
-"Cloud Save ブックマークレットを使用すると、設定上の変更をすべてクラウドに自動"
-"保存できます。"
+msgstr "Cloud Save ブックマークレットを使用すると、設定上の変更をすべてクラウドに自動保存できます。"
 
 # smartling.placeholder_format=C
 msgid "The Gambia"
@@ -19619,18 +19158,14 @@ msgctxt "Second paragraph for the Sync & Backup intro screen"
 msgid ""
 "The encryption key is only saved in your browser's local storage, and only "
 "you can access it."
-msgstr ""
-"暗号化キーはブラウザのローカルストレージにのみ保存され、アクセスできるのは本"
-"人だけです。"
+msgstr "暗号化キーはブラウザのローカルストレージにのみ保存され、アクセスできるのは本人だけです。"
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider deletes all chat data within 30 days.
 msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider deletes any data associated with this chat within 30 days."
-msgstr ""
-"モデルプロバイダーはこのチャットに関連するすべてのデータを30日以内に削除しま"
-"す。"
+msgstr "モデルプロバイダーはこのチャットに関連するすべてのデータを30日以内に削除します。"
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers.
@@ -19644,8 +19179,7 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider does not save this chat or any associated data on their "
 "servers."
-msgstr ""
-"モデルプロバイダーは、このチャットや関連データをサーバーに保存しません。"
+msgstr "モデルプロバイダーは、このチャットや関連データをサーバーに保存しません。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19673,7 +19207,7 @@ msgstr "テーマ"
 #. Text for the theme selector label that allows users to switch between Light and dark theme.
 msgctxt "Label for the theme selector feature"
 msgid "Theme"
-msgstr ""
+msgstr "テーマ"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/LpFhb1e.png
@@ -19703,9 +19237,7 @@ msgctxt "Error message when there was an issue saving a chat to the browser"
 msgid ""
 "There was an error saving this chat locally. Please check your browser "
 "settings to make sure local data storage is enabled."
-msgstr ""
-"このチャットをローカルに保存する際にエラーが発生しました。ブラウザの設定を確"
-"認し、ローカルデータの保存が有効になっていることをご確認ください。"
+msgstr "このチャットをローカルに保存する際にエラーが発生しました。ブラウザの設定を確認し、ローカルデータの保存が有効になっていることをご確認ください。"
 
 # smartling.placeholder_format=C
 #. Error modal body line 1.
@@ -19719,9 +19251,7 @@ msgctxt "noresults"
 msgid ""
 "There was still an error displaying the search results. Please wait a few "
 "minutes before you try again."
-msgstr ""
-"検索結果の表示中にまたエラーが発生しました。数分待ってから再試行してくださ"
-"い。"
+msgstr "検索結果の表示中にまたエラーが発生しました。数分待ってから再試行してください。"
 
 # smartling.placeholder_format=C
 #. Error message for explore more questions when a retryable error occurs (timeout, network)
@@ -19739,10 +19269,7 @@ msgid ""
 "These browser permissions are used to add privacy protection on websites you "
 "visit by blocking hidden trackers, encrypting connections where possible, "
 "and by making DuckDuckGo your default search engine."
-msgstr ""
-"これらのブラウザのアクセス許可は、訪問したWebサイトにプライバシー保護を追加す"
-"るために隠れたトラッカーをブロックし、接続を可能な限り暗号化し、DuckDuckGoを"
-"デフォルトの検索エンジンにするために使用されます。"
+msgstr "これらのブラウザのアクセス許可は、訪問したWebサイトにプライバシー保護を追加するために隠れたトラッカーをブロックし、接続を可能な限り暗号化し、DuckDuckGoをデフォルトの検索エンジンにするために使用されます。"
 
 # smartling.placeholder_format=C
 #. Secondary line under DUCKCHAT_SYNC_PAIRING_ALREADY_SYNCED_TITLE.
@@ -19779,9 +19306,7 @@ msgctxt "AI Chat: Error message for when a model is removed"
 msgid ""
 "This AI model is no longer available. Try starting a new chat with a "
 "different model."
-msgstr ""
-"このAIモデルは使用できなくなりました。別のモデルで新しいチャットを開始してみ"
-"てください。"
+msgstr "このAIモデルは使用できなくなりました。別のモデルで新しいチャットを開始してみてください。"
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is no longer supported because it has been upgraded to a newest version.
@@ -19789,9 +19314,7 @@ msgctxt "AI Chat: Error message for when a model is deprecated"
 msgid ""
 "This AI model version is no longer supported. Try starting a new chat with "
 "the latest version of this model."
-msgstr ""
-"このAIモデル版はサポートされなくなりました。このモデルの最新版で新しいチャッ"
-"トを開始してください。"
+msgstr "このAIモデル版はサポートされなくなりました。このモデルの最新版で新しいチャットを開始してください。"
 
 # smartling.placeholder_format=C
 #. Appears below a type of search results called 'Instant Answers'
@@ -19817,10 +19340,7 @@ msgctxt "Export chat feature in AI Chat"
 msgid ""
 "This conversation was generated with Duck.ai (%s) using %s's %s Model. AI "
 "chats may display inaccurate or offensive information (see %s for more info)."
-msgstr ""
-"この会話は、%2$sの%3$sモデルを使用してDuck.ai（%1$s）で生成されました。AI"
-"チャットでは不正確な情報や不快な情報が表示される場合があります（詳細について"
-"は%4$sを参照してください）。"
+msgstr "この会話は、%2$sの%3$sモデルを使用してDuck.ai（%1$s）で生成されました。AIチャットでは不正確な情報や不快な情報が表示される場合があります（詳細については%4$sを参照してください）。"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with multiple AI models in the same chat, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using multiple chat models. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -19829,10 +19349,7 @@ msgid ""
 "This conversation was generated with Duck.ai (%s) using multiple chat "
 "models. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
-msgstr ""
-"この会話は、複数のチャットモデルを使用してDuck.ai（%1$s）で生成されました。AI"
-"チャットでは不正確な情報や不快な内容が表示される場合があります（詳細について"
-"は%2$sを参照してください）。"
+msgstr "この会話は、複数のチャットモデルを使用してDuck.ai（%1$s）で生成されました。AIチャットでは不正確な情報や不快な内容が表示される場合があります（詳細については%2$sを参照してください）。"
 
 # smartling.placeholder_format=C
 #. When a user exports a transcript of a voice chat they had with the AI. This text goes at the very top of the downloaded file as a header. Placeholders are for links. Example: 'This conversation was generated with Duck.ai voice chat (https://duck.ai). AI may provide inaccurate or offensive information. (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -19840,9 +19357,7 @@ msgctxt "Export chat feature in AI Chat"
 msgid ""
 "This conversation was generated with Duck.ai voice chat (%s). AI may provide "
 "inaccurate or offensive information. (see %s for more info)."
-msgstr ""
-"この会話はDuck.aiボイスチャット(%1$s)で生成されました。AIは不正確または不快な"
-"情報を提供する可能性があります。（詳細は%2$sを参照してください。）"
+msgstr "この会話はDuck.aiボイスチャット(%1$s)で生成されました。AIは不正確または不快な情報を提供する可能性があります。（詳細は%2$sを参照してください。）"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with DuckDuckGo AI Chat (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/aichat/privacy-terms for more info).'
@@ -19852,9 +19367,8 @@ msgid ""
 "Model. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
 msgstr ""
-"この会話は、%2$sの%3$sモデルを使用してDuckDuckGo AI Chat（%1$s）で生成されま"
-"した。AIチャットでは不正確な情報や不快な情報が表示される場合があります（詳細"
-"については%4$sを参照してください）。"
+"この会話は、%2$sの%3$sモデルを使用してDuckDuckGo AI "
+"Chat（%1$s）で生成されました。AIチャットでは不正確な情報や不快な情報が表示される場合があります（詳細については%4$sを参照してください）。"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
@@ -19886,8 +19400,7 @@ msgctxt ""
 "Error message when an uploaded file type is not supported, with list ending "
 "in or"
 msgid "This file type is not supported, please attach a %s or %s"
-msgstr ""
-"このファイル形式はサポートされていません。%1$sまたは%2$sを添付してください。"
+msgstr "このファイル形式はサポートされていません。%1$sまたは%2$sを添付してください。"
 
 # smartling.placeholder_format=C
 #. Error message for unsupported file type when multiple types are accepted. First placeholder is a comma-separated list of all accepted types except the last (e.g. PNG, JPG, WebP, GIF). Second placeholder is the last accepted type (e.g. PDF). Full example: This file type is not supported, please attach a PNG, JPG, WebP, GIF or PDF
@@ -19895,8 +19408,7 @@ msgctxt ""
 "Error message when an uploaded file type is not supported, with list ending "
 "in or"
 msgid "This file type is not supported, please attach a %s or %s."
-msgstr ""
-"このファイル形式はサポートされていません。%1$sまたは%2$sを添付してください。"
+msgstr "このファイル形式はサポートされていません。%1$sまたは%2$sを添付してください。"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to upload an unsupported file type and we know which types are accepted. Placeholder is a single accepted type. E.g. This file type is not supported, please attach a PDF
@@ -19927,18 +19439,14 @@ msgstr "この画像は作成できませんでした。"
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF"
-msgstr ""
-"この画像形式はサポートされていません。JPG、PNG、WebP、またはGIFを添付してくだ"
-"さい。"
+msgstr "この画像形式はサポートされていません。JPG、PNG、WebP、またはGIFを添付してください。"
 
 # smartling.placeholder_format=C
 #. Error message displayed when a file that the user tried to upload is not of a supported format
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF."
-msgstr ""
-"この画像形式はサポートされていません。JPG、PNG、WebP、またはGIFを添付してくだ"
-"さい。"
+msgstr "この画像形式はサポートされていません。JPG、PNG、WebP、またはGIFを添付してください。"
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
@@ -19963,9 +19471,7 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "This model provider deletes data associated with this chat within 30 days. "
 "Other model providers follow a zero data retention model."
-msgstr ""
-"このモデルプロバイダーは、このチャットに関連するデータを30日以内に削除しま"
-"す。他のモデルプロバイダーは、データを一切保持しないモデルを採用しています。"
+msgstr "このモデルプロバイダーは、このチャットに関連するデータを30日以内に削除します。他のモデルプロバイダーは、データを一切保持しないモデルを採用しています。"
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers, and that other providers may retain chat data for a limited time instead.
@@ -19973,9 +19479,7 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "This model provider does not store any data associated with this chat. Other "
 "model providers follow a limited data retention model."
-msgstr ""
-"このモデルプロバイダーはこのチャットに関連するデータを保存していません。他の"
-"モデルプロバイダーは限定的なデータ保持モデルを採用しています。"
+msgstr "このモデルプロバイダーはこのチャットに関連するデータを保存していません。他のモデルプロバイダーは限定的なデータ保持モデルを採用しています。"
 
 # smartling.placeholder_format=C
 #. Info that page may refresh during update.
@@ -20011,9 +19515,7 @@ msgctxt "First paragraph for the Sync & Backup intro screen"
 msgid ""
 "This saves your chats with end-to-end encryption on DuckDuckGo's secure "
 "server, which later can be accessed from any browser."
-msgstr ""
-"チャットはエンドツーエンドの暗号化でDuckDuckGoの安全なサーバーに保存され、後"
-"でどのブラウザからでもアクセスできます。"
+msgstr "チャットはエンドツーエンドの暗号化でDuckDuckGoの安全なサーバーに保存され、後でどのブラウザからでもアクセスできます。"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -20021,9 +19523,7 @@ msgctxt "duckassist"
 msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again."
-msgstr ""
-"この設定はブラウザに保存されているため、duckduckgo.comのブラウザデータを削除"
-"すると、AI支援の回答が再表示されることがあります。"
+msgstr "この設定はブラウザに保存されているため、duckduckgo.comのブラウザデータを削除すると、AI支援の回答が再表示されることがあります。"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -20033,9 +19533,9 @@ msgid ""
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
 msgstr ""
-"この設定はブラウザに保存されているため、duckduckgo.comのブラウザデータを削除"
-"すると、AI支援の回答が再表示されることがあります。ただし、%1$s にはAI支援の回"
-"答が一切表示されないスタートページもご用意しています。"
+""
+"この設定はブラウザに保存されているため、duckduckgo.comのブラウザデータを削除すると、AI支援の回答が再表示されることがあります。ただし、%1$s "
+"にはAI支援の回答が一切表示されないスタートページもご用意しています。"
 
 # smartling.placeholder_format=C
 #. User feedback indicating that a translation is helpful
@@ -20058,16 +19558,13 @@ msgstr "この翻訳は正しくありません"
 # smartling.placeholder_format=C
 #. Label indicating that the video can't be played on the current page, and only on the website that owns the vide. The placeholder is the name of the website that owns the video.
 msgid "This video is not yet able to be watched here. You can watch it on %s."
-msgstr ""
-"この動画はまだここで視聴することはできません。この動画は %1$s 上で視聴可能で"
-"す。"
+msgstr "この動画はまだここで視聴することはできません。この動画は %1$s 上で視聴可能です。"
 
 # smartling.placeholder_format=C
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr ""
-"このウェブページでは「暗号化された安全な接続(HTTPS)」を利用できません。"
+msgstr "このウェブページでは「暗号化された安全な接続(HTTPS)」を利用できません。"
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -20077,9 +19574,8 @@ msgid ""
 "Sync & Backup. You'll still be able to access your chats in other browsers "
 "connected to Sync & Backup."
 msgstr ""
-"このオプションを選択すると、Duck.aiのチャットがこのブラウザからすべて削除さ"
-"れ、Sync & Backupとの接続は解除されます。Sync & Backupに接続している他のブラ"
-"ウザでは、引き続きチャットにアクセスできます。"
+"このオプションを選択すると、Duck.aiのチャットがこのブラウザからすべて削除され、Sync & Backupとの接続は解除されます。Sync & "
+"Backupに接続している他のブラウザでは、引き続きチャットにアクセスできます。"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to clear all recentchats, with a warning that this action cannot be undone.
@@ -20087,9 +19583,7 @@ msgctxt "Body text for clear all recent chats confirmation modal"
 msgid ""
 "This will delete all your recent chats, unless they're pinned. This cannot "
 "be undone."
-msgstr ""
-"これにより、ピン留めされていない限り、最近のチャットがすべて削除されます。こ"
-"の操作は取り消せません。"
+msgstr "これにより、ピン留めされていない限り、最近のチャットがすべて削除されます。この操作は取り消せません。"
 
 # smartling.placeholder_format=C
 #. Message explaining what will happen when the user deletes an image.
@@ -20226,9 +19720,7 @@ msgctxt "directions"
 msgid ""
 "To print directions:%sGo back to the map.%sSelect the route you want to "
 "print.%sClick the print icon.%s"
-msgstr ""
-"ルートの印刷手順：%1$s地図に戻ります。%2$s印刷するルートを選択します。%3$s印"
-"刷アイコンをクリックします。%4$s"
+msgstr "ルートの印刷手順：%1$s地図に戻ります。%2$s印刷するルートを選択します。%3$s印刷アイコンをクリックします。%4$s"
 
 # smartling.placeholder_format=C
 #. Explains where the user can find their recovery code. Figma frame 3703-44420.
@@ -20237,10 +19729,7 @@ msgid ""
 "To restore your synced data, you'll need the Recovery Code you saved when "
 "you first set up Sync. This code may have been saved as a PDF on the device "
 "you originally used to set up Sync."
-msgstr ""
-"同期したデータを復元するには、同期を初めて設定したときに保存したリカバリー"
-"コードが必要です。このコードは、同期設定に最初に使用したデバイスにPDFとして保"
-"存されている可能性があります。"
+msgstr "同期したデータを復元するには、同期を初めて設定したときに保存したリカバリーコードが必要です。このコードは、同期設定に最初に使用したデバイスにPDFとして保存されている可能性があります。"
 
 # smartling.placeholder_format=C
 #. Body text explaining that the user needs to update their DDG browser before migration can proceed.
@@ -20248,18 +19737,14 @@ msgctxt "duckai_migration"
 msgid ""
 "To transfer your chat history to Duck.ai, please update your DuckDuckGo "
 "browser to the latest version and try again."
-msgstr ""
-"チャット履歴をDuck.aiに転送するには、DuckDuckGoブラウザを最新バージョンにアッ"
-"プデートし、再度お試しください。"
+msgstr "チャット履歴をDuck.aiに転送するには、DuckDuckGoブラウザを最新バージョンにアップデートし、再度お試しください。"
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
 msgid ""
 "To use dictation, allow your browser to access the microphone in your system "
 "settings."
-msgstr ""
-"音声入力機能を使用するには、システム設定でブラウザがマイクにアクセスできるよ"
-"うに設定してください。"
+msgstr "音声入力機能を使用するには、システム設定でブラウザがマイクにアクセスできるように設定してください。"
 
 # smartling.placeholder_format=C
 msgid "Today"
@@ -20448,9 +19933,7 @@ msgctxt "tracker_stats"
 msgid ""
 "Tracking attempts blocked by DuckDuckGo appear here. Keep browsing to see "
 "how many we block."
-msgstr ""
-"DuckDuckGoが追跡試行をブロックすると、こちらに表示されます。閲覧を続けると、"
-"ブロック件数が表示されるようになります。"
+msgstr "DuckDuckGoが追跡試行をブロックすると、こちらに表示されます。閲覧を続けると、ブロック件数が表示されるようになります。"
 
 # smartling.placeholder_format=C
 #. Placeholder for when we cannot report any blocked trackers yet
@@ -20497,9 +19980,7 @@ msgctxt "Full sentence for translating text"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr ""
-"この英語の文章をフランス語に翻訳してください。「最寄りの映画館へはどうやって"
-"行けばいいですか？」"
+msgstr "この英語の文章をフランス語に翻訳してください。「最寄りの映画館へはどうやって行けばいいですか？」"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for translating a sentence into another language. Translate the whole sentence and please use target language instead of 'English' and modify the sentence to translate into 'English' instead of 'French'. Example: 'Translate this {target language} sentence into English: “How do I get to the nearest movie theatre?”'
@@ -20507,21 +19988,19 @@ msgctxt "Full sentence for translating text prompt"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr ""
-"この日本語の文章を英語に翻訳してください。「最寄りの映画館へはどうやって行け"
-"ばいいですか？」"
+msgstr "この日本語の文章を英語に翻訳してください。「最寄りの映画館へはどうやって行けばいいですか？」"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Translate this page"
-msgstr ""
+msgstr "このページを翻訳"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
 msgctxt "Page suggestion prompt"
 msgid "Translate this page into %s."
-msgstr ""
+msgstr "このページを%1$sに翻訳してください。"
 
 # smartling.placeholder_format=C
 #. Placeholder text for a region that will display translated text.
@@ -20617,8 +20096,7 @@ msgstr "%1$sを試す"
 # smartling.placeholder_format=C
 #. Prompt for the user to start using our homepage that doesn't show promotional messages. The placeholder is a homepage url (e.g., 'start.duckduckgo.com')
 msgid "Try %s to stop seeing messages like this."
-msgstr ""
-"このようなメッセージが表示されないようにするには、%1$sをお試しください。"
+msgstr "このようなメッセージが表示されないようにするには、%1$sをお試しください。"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that encourages users to try the encrypted AI model whose inference runs in a confidential environment so the model provider cannot access user data. %s is replaced with the model's full display name (e.g. 'GPT-OSS 120B').
@@ -20628,9 +20106,7 @@ msgstr "プロバイダーの可視性がゼロの最初のモデル%1$sをお�
 
 # smartling.placeholder_format=C
 msgid "Try %sDuck.ai%s, our private AI chat service:"
-msgstr ""
-"%1$sDuck.ai%2$sは、個人情報保護に配慮したAIチャットサービスです。ぜひ、お試し"
-"を！"
+msgstr "%1$sDuck.ai%2$sは、個人情報保護に配慮したAIチャットサービスです。ぜひ、お試しを！"
 
 # smartling.placeholder_format=C
 #. Button text to retry loading an explore more question that failed
@@ -20671,7 +20147,7 @@ msgstr "無料で試す"
 #. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
 msgctxt "settings"
 msgid "Try It Now"
-msgstr ""
+msgstr "今すぐ試す"
 
 # smartling.placeholder_format=C
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -20729,16 +20205,13 @@ msgstr "別のキーワードを試してみてください。"
 # smartling.placeholder_format=C
 #. Prompt encouraging the user to turn off their ad blocker to see more results for their query.
 msgid "Try disabling your ad blocker on DuckDuckGo to see more results."
-msgstr ""
-"より多くの結果を表示するには、DuckDuckGoで広告ブロッカーを無効にしてお試しく"
-"ださい。"
+msgstr "より多くの結果を表示するには、DuckDuckGoで広告ブロッカーを無効にしてお試しください。"
 
 # smartling.placeholder_format=C
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
 msgctxt "precise_user_location"
 msgid "Try enabling anonymous location for more accurate results."
-msgstr ""
-"検索結果の精度を高めるには、匿名の位置情報を使用する設定にしてみてください。"
+msgstr "検索結果の精度を高めるには、匿名の位置情報を使用する設定にしてみてください。"
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the screen of the onboarding where the user picks a chat model.
@@ -20823,8 +20296,7 @@ msgstr "位置情報を手動で設定してみてください。"
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Try the %sDuckDuckGo Browser.%s Fast. Free. Private."
-msgstr ""
-"%1$sDuckDuckGoブラウザ%2$sをお試しください。スピーディで無料、プライベート。"
+msgstr "%1$sDuckDuckGoブラウザ%2$sをお試しください。スピーディで無料、プライベート。"
 
 # smartling.placeholder_format=C
 #. Link to a page where users can download the DuckDuckGo Browser for iOS or Android.
@@ -20882,8 +20354,7 @@ msgstr "最近追加されたオープンソースのLlama 3.1とMixtralをお�
 #. Message displayed to suggest the user to try the provided prompts or enter their own.
 msgctxt "Prompt suggestion message"
 msgid "Try these prompts to get started or enter your own prompt below"
-msgstr ""
-"まずはこれらのプロンプトを試すか、以下に独自のプロンプトを入力してください。"
+msgstr "まずはこれらのプロンプトを試すか、以下に独自のプロンプトを入力してください。"
 
 # smartling.placeholder_format=C
 #. Description for the empty state displayed when searching recent chats in Duck.ai returns no results, suggesting the user rephrase their search query.
@@ -20917,6 +20388,8 @@ msgid ""
 "Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
+"AI機能を無効にしようとしています。検索用拡張機能である%1$sDuckDuckGo No "
+"AI%2$sをインストールすると、設定が記憶されます。%3$s詳細情報%4$s"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -20925,6 +20398,8 @@ msgid ""
 "Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
+"AI機能を無効にしようとしています。検索用拡張機能である%1$sDuckDuckGo No "
+"AI%2$sに切り替えると、設定が記憶されます。%3$s詳細情報%4$s"
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -21043,8 +20518,7 @@ msgstr "より正確な結果を得るには、「正確な位置情報」をオ
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on “Use precise location” for more accurate results."
-msgstr ""
-"より正確な結果を得るには、「正確な位置情報を使用」をオンにしてください。"
+msgstr "より正確な結果を得るには、「正確な位置情報を使用」をオンにしてください。"
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Create Image' label in the Tools dropdown.
@@ -21088,17 +20562,14 @@ msgstr "「%1$sDuckDuckGo%2$s」と %3$s フォームの最初のフィールド
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Type %sduckduckgo.com%s in the %ssecond form field"
-msgstr ""
-"「%1$sduckduckgo.com%2$s」と%3$s フォームの2番目のフィールドに入力します"
+msgstr "「%1$sduckduckgo.com%2$s」と%3$s フォームの2番目のフィールドに入力します"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Types out DuckAssist answers as they're generated. Turning this off may "
 "result in a short delay between a search and the answer being displayed."
-msgstr ""
-"DuckAssist が生成した回答を入力します。このオプションをオフにすると、検索して"
-"から回答が表示されるまでに、多少タイムラグが生じる場合があります。"
+msgstr "DuckAssist が生成した回答を入力します。このオプションをオフにすると、検索してから回答が表示されるまでに、多少タイムラグが生じる場合があります。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -21227,18 +20698,14 @@ msgstr "長所と短所を明らかにする"
 msgid ""
 "Under %sOn startup%s, click %sOpen a specific page%s then click %sSet "
 "Pages%s."
-msgstr ""
-"%1$sスタートの時%2$s の下、%3$sとあるページを開く%4$s をクリックして、%5$s"
-"ページがセレクト%6$s クリックします。"
+msgstr "%1$sスタートの時%2$s の下、%3$sとあるページを開く%4$s をクリックして、%5$sページがセレクト%6$s クリックします。"
 
 #  Maxthon homepage instruction
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
-msgstr ""
-"%1$sOn startup%2$sの中から%3$sHomepage%4$sを選択してhttps://duckduckgo.comと"
-"入力してください"
+msgstr "%1$sOn startup%2$sの中から%3$sHomepage%4$sを選択してhttps://duckduckgo.comと入力してください"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -21248,8 +20715,7 @@ msgstr "%1$s開く%2$s の中から %3$s特定のページを開く%4$s を選�
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
-msgstr ""
-"%1$s起動時 > ホームページ%2$sの中で https://duckduckgo.com と入力してください"
+msgstr "%1$s起動時 > ホームページ%2$sの中で https://duckduckgo.com と入力してください"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -21259,17 +20725,13 @@ msgstr "%1$s検索設定%2$sで、%3$sDuckDuckGo%4$sを選択します"
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch in the address bar with%s select %sAdd New%s"
-msgstr ""
-"%1$sアドレスバーでの検索時に使う検索プロバイダー%2$sの下の%3$s新たに追加%4$s"
-"を選択します"
+msgstr "%1$sアドレスバーでの検索時に使う検索プロバイダー%2$sの下の%3$s新たに追加%4$sを選択します"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
-msgstr ""
-"%1$s検索%2$sセクションの下にある「%3$s検索エンジンの管理...%4$s」をクリックし"
-"ます"
+msgstr "%1$s検索%2$sセクションの下にある「%3$s検索エンジンの管理...%4$s」をクリックします"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -21358,9 +20820,7 @@ msgctxt "Description of the modal to upgrade to Pro"
 msgid ""
 "Unlock %s, higher AI reasoning, and 2x higher usage limits than the Plus "
 "plan by upgrading to Pro."
-msgstr ""
-"Proにアップグレードすると、%1$sのロックが解除され、AI推論能力が向上し、使用上"
-"限がPlusプランの2倍になります。"
+msgstr "Proにアップグレードすると、%1$sのロックが解除され、AI推論能力が向上し、使用上限がPlusプランの2倍になります。"
 
 # smartling.placeholder_format=C
 #. Title for the subscription promo shown in the SERP sidemenu.
@@ -21414,9 +20874,7 @@ msgctxt ""
 "Text shown in the subscription promo card, with a trailing call-to-action "
 "link."
 msgid "Unlock more capable AI models with a DuckDuckGo subscription. %s"
-msgstr ""
-"DuckDuckGoのサブスクリプションで、より高性能なAIモデルをアンロックしましょ"
-"う。%1$s"
+msgstr "DuckDuckGoのサブスクリプションで、より高性能なAIモデルをアンロックしましょう。%1$s"
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to unmute the microphone.
@@ -21495,9 +20953,7 @@ msgctxt "Old app version banner component in Duck.ai"
 msgid ""
 "Update the DuckDuckGo browser to activate your subscription in Duck.ai and "
 "access advanced models"
-msgstr ""
-"DuckDuckGo ブラウザを更新して、Duck.ai でサブスクリプションを有効にし、高度な"
-"モデルにアクセスしよう"
+msgstr "DuckDuckGo ブラウザを更新して、Duck.ai でサブスクリプションを有効にし、高度なモデルにアクセスしよう"
 
 # smartling.placeholder_format=C
 #. The placeholder indicates a formatted date (e.g., 'Updated 2 days ago')
@@ -21621,9 +21077,7 @@ msgctxt ""
 msgid ""
 "Upgrade to Pro to unlock 2x higher limits than Plus, or come back later to "
 "create more images."
-msgstr ""
-"ProにアップグレードしてPlusの2倍の制限を活用するか、後で戻ってきてさらに画像"
-"を作成してください。"
+msgstr "ProにアップグレードしてPlusの2倍の制限を活用するか、後で戻ってきてさらに画像を作成してください。"
 
 # smartling.placeholder_format=C
 #. Upsell message shown in the voice chat limit and duration limit modals for Plus subscribers, encouraging them to upgrade to Pro.
@@ -21681,7 +21135,7 @@ msgstr "ウルグアイ"
 #. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
 msgctxt "Navigation label on the Duck.ai settings page"
 msgid "Usage"
-msgstr ""
+msgstr "使用状況"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -21724,10 +21178,7 @@ msgctxt "duckai_seo"
 msgid ""
 "Use ChatGPT, Claude, and other AIs, privately. Protect chats from hackers, "
 "scammers, and companies. Keep info confidential. Free. No account required."
-msgstr ""
-"ChatGPT、Claude、その他のAIをプライベートに使いましょう。チャットをハッカー、"
-"詐欺師、企業から守りましょう。情報の機密を保ちましょう。無料。アカウントは必"
-"要ありません。"
+msgstr "ChatGPT、Claude、その他のAIをプライベートに使いましょう。チャットをハッカー、詐欺師、企業から守りましょう。情報の機密を保ちましょう。無料。アカウントは必要ありません。"
 
 # smartling.placeholder_format=C
 #. Header above instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -21739,8 +21190,7 @@ msgstr "DuckDuckGo Private Searchを使う"
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Use DuckDuckGo private search on your iPad, iPhone, or Android!"
-msgstr ""
-"あなたのiPad、iPhoneまたはAndroidで、DuckDuckGoのプライベート検索を使おう！"
+msgstr "あなたのiPad、iPhoneまたはAndroidで、DuckDuckGoのプライベート検索を使おう！"
 
 # smartling.placeholder_format=C
 #. User clicks this button to share their device's location
@@ -21769,9 +21219,7 @@ msgstr "Safariで使用"
 msgctxt "Description for the recovery section inside Manage"
 msgid ""
 "Use this code to restore your saved chats if you lose access to your devices."
-msgstr ""
-"デバイスへのアクセスを失った場合に、このコードを使用して保存済みのチャットを"
-"復元してください。"
+msgstr "デバイスへのアクセスを失った場合に、このコードを使用して保存済みのチャットを復元してください。"
 
 # smartling.placeholder_format=C
 #. Prompt to ask the user if they want to use their approximate location for more accurate results
@@ -21920,9 +21368,7 @@ msgctxt "Ads GDPR, internal use only. Do not change"
 msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Microsoft's ad network"
-msgstr ""
-"広告表示機能のプライバシーは DuckDuckGo で保護されます。広告のクリックは "
-"Microsoft の広告ネットワークで管理されています"
+msgstr "広告表示機能のプライバシーは DuckDuckGo で保護されます。広告のクリックは Microsoft の広告ネットワークで管理されています"
 
 # smartling.placeholder_format=C
 #. Information about TripAdvisor ads for DuckDuckGo's users. This appears in a tooltip.
@@ -21930,9 +21376,7 @@ msgctxt "Single Place Hotel Offers Module"
 msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "TripAdvisor's ad network."
-msgstr ""
-"広告表示機能のプライバシーは DuckDuckGo で保護されます。広告のクリックは"
-"TripAdvisorの広告ネットワークで管理されています。"
+msgstr "広告表示機能のプライバシーは DuckDuckGo で保護されます。広告のクリックはTripAdvisorの広告ネットワークで管理されています。"
 
 # smartling.placeholder_format=C
 msgid "Virgin Islands"
@@ -21943,9 +21387,7 @@ msgstr "ヴァージン諸島"
 msgctxt "duckassist"
 msgid ""
 "Visit %sAssist Settings%s to adjust how this feature works or turn it off."
-msgstr ""
-"この機能の動作を調整したり、オフにしたりするには、%1$sAssist設定%2$sにアクセ"
-"スしてください。"
+msgstr "この機能の動作を調整したり、オフにしたりするには、%1$sAssist設定%2$sにアクセスしてください。"
 
 # smartling.placeholder_format=C
 #. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
@@ -21953,9 +21395,7 @@ msgctxt "duckassist"
 msgid ""
 "Visit %sDuckAssist Settings%s to adjust how this feature works or turn it "
 "off."
-msgstr ""
-"この機能の動作を調整したり、オフにしたりするには、%1$sDuckAssist設定%2$sにア"
-"クセスしてください。"
+msgstr "この機能の動作を調整したり、オフにしたりするには、%1$sDuckAssist設定%2$sにアクセスしてください。"
 
 # smartling.placeholder_format=C
 #. Prompt to visit DuckDuckGo on another device.
@@ -21963,9 +21403,7 @@ msgctxt "mobile promotion on desktop"
 msgid ""
 "Visit %sDuckDuckGo.com%s on your tablet or phone and follow the provided "
 "instructions."
-msgstr ""
-"タブレットまたは携帯電話で%1$sDuckDuckGo.com%2$sにアクセスして、案内に従って"
-"ください。"
+msgstr "タブレットまたは携帯電話で%1$sDuckDuckGo.com%2$sにアクセスして、案内に従ってください。"
 
 # smartling.placeholder_format=C
 #. Primary button to visit Duck.ai.
@@ -21980,9 +21418,8 @@ msgid ""
 "Visit Duck.ai in your other browser and go to %sDuck.ai Settings%s > %sSync "
 "& Backup%s > %sManage%s then select %sSync With Another Device%s."
 msgstr ""
-"他のブラウザでDuck.aiにアクセスし、%1$sDuck.ai設定%2$s > %3$sSync & "
-"Backup%4$s > %5$s管理%6$s に進み、%7$s別のデバイスと同期%8$sを選択してくださ"
-"い。"
+"他のブラウザでDuck.aiにアクセスし、%1$sDuck.ai設定%2$s > %3$sSync & Backup%4$s > %5$s管理%6$s "
+"に進み、%7$s別のデバイスと同期%8$sを選択してください。"
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -21991,10 +21428,7 @@ msgid ""
 "Visit Duck.ai in your other browser and open Duck.ai Settings. Select “Turn "
 "On” under Sync & Backup and select “Sync With Another Device”. Or scan the "
 "QR on your Recovery PDF."
-msgstr ""
-"別のブラウザでDuck.aiにアクセスし、Duck.aiの設定を開いてください。Sync＆"
-"Backupで「オンにする」を選択し、「別のデバイスと同期」を選択してください。ま"
-"たは、リカバリーPDFのQRコードをスキャンしてください。"
+msgstr "別のブラウザでDuck.aiにアクセスし、Duck.aiの設定を開いてください。Sync＆Backupで「オンにする」を選択し、「別のデバイスと同期」を選択してください。または、リカバリーPDFのQRコードをスキャンしてください。"
 
 # smartling.placeholder_format=C
 #. Shared body copy for every screen in the Sync Another Device flow (QR display, camera scan, camera-unavailable fallback, manual entry). Bold tags wrap navigation breadcrumbs. Render with <Translate /> so the HTML is interpreted; plain `translate()` will trip the html-string warning.
@@ -22004,9 +21438,8 @@ msgid ""
 "ai Settings%s > %sSync & Backup%s > %sManage%s then select %sSync With "
 "Another Device%s."
 msgstr ""
-"他のブラウザまたはDuckDuckGoアプリでDuck.aiにアクセスし、%1$sDuck.ai設定%2$s "
-"> %3$sSync & Backup%4$s > %5$s管理%6$s に進み、%7$s別のデバイスと同期%8$sを選"
-"択してください。"
+"他のブラウザまたはDuckDuckGoアプリでDuck.aiにアクセスし、%1$sDuck.ai設定%2$s > %3$sSync & "
+"Backup%4$s > %5$s管理%6$s に進み、%7$s別のデバイスと同期%8$sを選択してください。"
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -22015,10 +21448,7 @@ msgid ""
 "Visit Duck.ai in your other browser or the DuckDuckGo app and open Duck.ai "
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
-msgstr ""
-"他のブラウザまたはDuckDuckGoアプリでDuck.aiにアクセスし、Duck.aiの設定を開き"
-"ます。Sync＆Backupで「オンにする」を選択し、「別のデバイスと同期」を選択しま"
-"す。または、リカバリーPDFのQRコードをスキャンします。"
+msgstr "他のブラウザまたはDuckDuckGoアプリでDuck.aiにアクセスし、Duck.aiの設定を開きます。Sync＆Backupで「オンにする」を選択し、「別のデバイスと同期」を選択します。または、リカバリーPDFのQRコードをスキャンします。"
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -22070,9 +21500,7 @@ msgstr "ボイスチャットは終了しました"
 #. Description in consent disclaimer informing that voice chats with the AI (Artificial Intelligence) are anonymized by us, and are never used to train AI models.
 msgctxt "voice chat"
 msgid "Voice chat is anonymized by us, and never used to train AI models."
-msgstr ""
-"ボイスチャットは当社によって匿名化されており、AIモデルのトレーニングには使用"
-"されません。"
+msgstr "ボイスチャットは当社によって匿名化されており、AIモデルのトレーニングには使用されません。"
 
 # smartling.placeholder_format=C
 #. Title of the modal shown when the user has reached their daily voice chat limit.
@@ -22136,7 +21564,7 @@ msgstr "ウェールズ"
 #. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Walk me through the steps"
-msgstr ""
+msgstr "手順を順番に説明"
 
 # smartling.placeholder_format=C
 #. Label for walking directions on a map.
@@ -22216,8 +21644,8 @@ msgid ""
 "Watch in Duck Player to block personalized ads on YouTube and prevent your "
 "viewing activity from influencing YouTube recommendations."
 msgstr ""
-"Duck Player で視聴すると、YouTube でパーソナライズ広告がブロックされるため、"
-"YouTube のおすすめに影響されずに動画を視聴できます。"
+"Duck Player で視聴すると、YouTube でパーソナライズ広告がブロックされるため、YouTube "
+"のおすすめに影響されずに動画を視聴できます。"
 
 # smartling.placeholder_format=C
 #. A button that takes a user to another site in order to watch a video. The placeholder is the name of the video site. For example: 'Watch on Vimeo'
@@ -22236,11 +21664,7 @@ msgid ""
 "because we have to stream the content from there. DuckDuckGo is an "
 "independent company and has no relationship with YouTube, where most videos "
 "are hosted."
-msgstr ""
-"このプラットフォームで動画を視聴する場合、ホストするウェブサイトからコンテン"
-"ツが流されるため、そのウェブサイトは視聴者の追跡が可能になります。DuckDuckGo"
-"は独立した会社であり、ほとんどの動画がホストされているYouTubeとは一切関係ござ"
-"いません。"
+msgstr "このプラットフォームで動画を視聴する場合、ホストするウェブサイトからコンテンツが流されるため、そのウェブサイトは視聴者の追跡が可能になります。DuckDuckGoは独立した会社であり、ほとんどの動画がホストされているYouTubeとは一切関係ございません。"
 
 # smartling.placeholder_format=C
 #. Heading for the highlight card explaining anonymized prompt delivery.
@@ -22252,8 +21676,7 @@ msgstr "匿名化に対応"
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
-msgstr ""
-"%1$s位置情報%2$sを匿名化して、より正確な結果が表示されるようにできます。"
+msgstr "%1$s位置情報%2$sを匿名化して、より正確な結果が表示されるようにできます。"
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
@@ -22264,7 +21687,7 @@ msgid ""
 "We can only fix what we can see. To report a harmful or illegal response, "
 "please share this conversation with DuckDuckGo so we can investigate and "
 "address the issue."
-msgstr ""
+msgstr "当社が修正できるのは、目に見えるものだけです。有害または違法な回答を通報するには、DuckDuckGoが問題を調査し、対処できるように、この会話を当社と共有してしてください。"
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -22275,9 +21698,7 @@ msgid ""
 "We can only fix what we can see. To report a harmful or illegal response, "
 "please share your prompt and response so we can investigate and address the "
 "issue."
-msgstr ""
-"当社が修正できるのは、目に見えるものだけです。有害または違法な応答を報告する"
-"場合は、問題を調査し対処するために、プロンプトと応答内容をお知らせください。"
+msgstr "当社が修正できるのは、目に見えるものだけです。有害または違法な応答を報告する場合は、問題を調査し対処するために、プロンプトと応答内容をお知らせください。"
 
 # smartling.placeholder_format=C
 #. Explains how location service is used to show users search results near their current location.
@@ -22290,9 +21711,7 @@ msgstr "匿名の%1$s位置情報%2$sを使用すると、おおよその結果�
 msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
-msgstr ""
-"添付ファイルのうち少なくとも1つが暗号化されているため、内容を読み取ることがで"
-"きません。"
+msgstr "添付ファイルのうち少なくとも1つが暗号化されているため、内容を読み取ることができません。"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -22319,9 +21738,7 @@ msgstr "私たちはあなたの個人情報を保存しません。"
 msgid ""
 "We don't store your personal info. We don't follow you around with ads. We "
 "don't track you. Ever."
-msgstr ""
-"個人情報を保存しません。広告で追い回しません。閲覧状況を追跡しません。お約束"
-"します。"
+msgstr "個人情報を保存しません。広告で追い回しません。閲覧状況を追跡しません。お約束します。"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -22334,9 +21751,7 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what brought you "
 "back today:"
-msgstr ""
-"私たちはあなたを追跡しません。ですから、「もう一度DuckDuckGoを使おうと思った"
-"理由」を教えてください。"
+msgstr "私たちはあなたを追跡しません。ですから、「もう一度DuckDuckGoを使おうと思った理由」を教えてください。"
 
 # smartling.placeholder_format=C
 #. Message prompting users to fill out a feedback form.
@@ -22344,9 +21759,7 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what convinced you "
 "to try us out today:"
-msgstr ""
-"私たちはあなたを追跡しません。ですから、「あなたがDuckDuckGoを使ってみようと"
-"思った理由」を教えてください。"
+msgstr "私たちはあなたを追跡しません。ですから、「あなたがDuckDuckGoを使ってみようと思った理由」を教えてください。"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -22385,23 +21798,18 @@ msgctxt "homepage onboarding"
 msgid ""
 "We don’t store your search history. We therefore have nothing to sell to "
 "advertisers that track you across the Internet."
-msgstr ""
-"私たちは、あなたの検索履歴を保存しません。したがって、インターネット経由であ"
-"なたを追跡して、それを広告主に販売することはありません。"
+msgstr "私たちは、あなたの検索履歴を保存しません。したがって、インターネット経由であなたを追跡して、それを広告主に販売することはありません。"
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don’t track you in or out of private browsing mode."
-msgstr ""
-"私たちは、プライベートブラウジングモードでも、それ以外でも、あなたを追跡しま"
-"せん。"
+msgstr "私たちは、プライベートブラウジングモードでも、それ以外でも、あなたを追跡しません。"
 
 # smartling.placeholder_format=C
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with an Agree button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don’t track you. That’s our Privacy Policy in a nutshell…"
-msgstr ""
-"私たちはあなたを追跡しません。これが私たちのプライバシーポリシーの概要です。"
+msgstr "私たちはあなたを追跡しません。これが私たちのプライバシーポリシーの概要です。"
 
 # smartling.placeholder_format=C
 #. Displayed when the user's voice chat session is ended because of being inactive for too long.
@@ -22415,8 +21823,7 @@ msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
 "We have agreements with all AI providers to ensure your chats aren't used to "
 "train AIs."
-msgstr ""
-"チャットがAIの学習に使用されない旨の契約をAIプロバイダーと結んでいます。"
+msgstr "チャットがAIの学習に使用されない旨の契約をAIプロバイダーと結んでいます。"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -22440,9 +21847,7 @@ msgstr "接続が失われました。メッセージの送信をもう一度お
 msgid ""
 "We make money from %sprivacy-respecting search ads%s, not by exploiting your "
 "data."
-msgstr ""
-"私たちは、あなたのデータを悪用するのではなく、%1$sプライバシーを尊重する検索"
-"広告%2$sから収益を得ています。"
+msgstr "私たちは、あなたのデータを悪用するのではなく、%1$sプライバシーを尊重する検索広告%2$sから収益を得ています。"
 
 # smartling.placeholder_format=C
 #. Message describing how DuckDuckGo users location access anonymously to provide better search results.
@@ -22450,17 +21855,13 @@ msgctxt "precise_user_location"
 msgid ""
 "We only use your anonymous location to deliver better results, closer to "
 "you. You can always change your mind later."
-msgstr ""
-"匿名の位置情報は、表示される結果を比較的近くに絞り込む目的でのみ使用されま"
-"す。この設定は後でいつでも変更できます。"
+msgstr "匿名の位置情報は、表示される結果を比較的近くに絞り込む目的でのみ使用されます。この設定は後でいつでも変更できます。"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
-msgstr ""
-"DuckDuckGoを誰にとってもより良いものにするために、私たちはみなさまからの匿名"
-"でのフィードバックを頼りにしています。"
+msgstr "DuckDuckGoを誰にとってもより良いものにするために、私たちはみなさまからの匿名でのフィードバックを頼りにしています。"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -22480,9 +21881,7 @@ msgid ""
 "We use feedback like this to improve DuckDuckGo. Suggestions will be "
 "incorporated at the discretion of %s. Corrections may not show up in results "
 "right away."
-msgstr ""
-"このようなフィードバックをDuckDuckGoの向上に活用します。%1$sは独自の判断でご"
-"提案を採用します。訂正内容は結果にすぐ表示されない場合があります。"
+msgstr "このようなフィードバックをDuckDuckGoの向上に活用します。%1$sは独自の判断でご提案を採用します。訂正内容は結果にすぐ表示されない場合があります。"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -22495,9 +21894,7 @@ msgctxt "noresults"
 msgid ""
 "We're aware of this issue and are currently working to resolve it. If you "
 "continue to see this error, please reach out to %s."
-msgstr ""
-"当社はこの問題について認識しており、現在解決に向けて取り組んでいます。このエ"
-"ラーが続く場合は、%1$sに連絡してください。"
+msgstr "当社はこの問題について認識しており、現在解決に向けて取り組んでいます。このエラーが続く場合は、%1$sに連絡してください。"
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -22505,9 +21902,7 @@ msgctxt "noresults"
 msgid ""
 "We're aware of this issue and are currently working to resolve it. Sometimes "
 "clearing your browser's cache can help."
-msgstr ""
-"当社はこの問題について認識しており、現在解決に向けて取り組んでいます。ブラウ"
-"ザのキャッシュをクリアすると解決に役立つ場合があります。"
+msgstr "当社はこの問題について認識しており、現在解決に向けて取り組んでいます。ブラウザのキャッシュをクリアすると解決に役立つ場合があります。"
 
 # smartling.placeholder_format=C
 #. Header for a feedback form for new users.
@@ -22521,9 +21916,7 @@ msgctxt "duckai_migration"
 msgid ""
 "We're sorry for this inconvenience. We’re working hard to make your "
 "experience better."
-msgstr ""
-"ご不便をおかけして申し訳ありません。体験の改善のために一生懸命努力していま"
-"す。"
+msgstr "ご不便をおかけして申し訳ありません。体験の改善のために一生懸命努力しています。"
 
 # smartling.placeholder_format=C
 #. Body text explaining the service update requires a page reload.
@@ -22531,9 +21924,7 @@ msgctxt "duckai_migration"
 msgid ""
 "We've updated the Duck.ai service. For the change to take effect, we need to "
 "reload the page."
-msgstr ""
-"Duck.aiサービスを更新しました。変更を有効にするには、ページをリロードする必要"
-"があります。"
+msgstr "Duck.aiサービスを更新しました。変更を有効にするには、ページをリロードする必要があります。"
 
 # smartling.placeholder_format=C
 #. Instant Answer Tab Name
@@ -22648,9 +22039,7 @@ msgctxt "Welcome message in chat"
 msgid ""
 "Welcome to Duck.ai! All of your chats here are private, anonymized by us and "
 "not used to train AI models."
-msgstr ""
-"Duck.aiへようこそ！ここでのチャットはすべて非公開で、匿名化され、AIモデルのト"
-"レーニングには使用されません。"
+msgstr "Duck.aiへようこそ！ここでのチャットはすべて非公開で、匿名化され、AIモデルのトレーニングには使用されません。"
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened.
@@ -22658,9 +22047,7 @@ msgctxt "Welcome message in chat"
 msgid ""
 "Welcome to DuckDuckGo AI Chat! All of your chats here are private, "
 "anonymized by us and not used to train AI models."
-msgstr ""
-"DuckDuckGo AI Chatへようこそ！ここでのチャットはすべて非公開で、匿名化され、"
-"AIモデルのトレーニングには使用されません。"
+msgstr "DuckDuckGo AI Chatへようこそ！ここでのチャットはすべて非公開で、匿名化され、AIモデルのトレーニングには使用されません。"
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened. Example: 'Welcome to DuckDuckGo AI Chat! This chat session is powered by OpenAI’s GPT-3. All of your chats here are private, and are never stored by DuckDuckGo or used to train AI models.'
@@ -22670,17 +22057,14 @@ msgid ""
 "of your chats here are private, and are never stored by DuckDuckGo or used "
 "to train AI models."
 msgstr ""
-"DuckDuckGo AI Chatへようこそ！このチャットセッションは%1$sの%2$sを使用してい"
-"ます。ここでのチャットはすべて非公開で、DuckDuckGoに保存されたり、AIモデルの"
-"トレーニングに使用されたりすることはありません。"
+"DuckDuckGo AI "
+"Chatへようこそ！このチャットセッションは%1$sの%2$sを使用しています。ここでのチャットはすべて非公開で、DuckDuckGoに保存されたり、AIモデルのトレーニングに使用されたりすることはありません。"
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai! You can now import your downloaded chats."
-msgstr ""
-"新しいDuck.aiへようこそ！ダウンロードしたチャットをインポートできるようになり"
-"ました。"
+msgstr "新しいDuck.aiへようこそ！ダウンロードしたチャットをインポートできるようになりました。"
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -22747,9 +22131,7 @@ msgctxt "duckai_fatal_error"
 msgid ""
 "We’re really sorry, but it seems there was a problem loading Duck.ai. Try "
 "reloading the page."
-msgstr ""
-"申し訳ありませんが、Duck.aiの読み込みに問題があったようです。ページを再読み込"
-"みしてみてください。"
+msgstr "申し訳ありませんが、Duck.aiの読み込みに問題があったようです。ページを再読み込みしてみてください。"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to suggest an AI (Artificial Intelligence) model to be added to the product, and this field is optional.
@@ -22763,9 +22145,7 @@ msgctxt "Full sentence for improving arguments"
 msgid ""
 "What are some arguments, counter-arguments, and rebuttals to the concept of "
 "a plant-based diet?"
-msgstr ""
-"プラントベースの食事の概念に対する議論、反論、反駁にはどのようなものがありま"
-"すか？"
+msgstr "プラントベースの食事の概念に対する議論、反論、反駁にはどのようなものがありますか？"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for considering factors when purchasing a computer monitor.
@@ -22785,9 +22165,7 @@ msgctxt "Full sentence for finding a better word"
 msgid ""
 "What are some options for the word ‘better’ in the context of “We really "
 "need to do better.”"
-msgstr ""
-"「私たちは本当にもっとうまくやる必要がある」という文脈で「もっとうまく」をど"
-"う言い換えられますか？"
+msgstr "「私たちは本当にもっとうまくやる必要がある」という文脈で「もっとうまく」をどう言い換えられますか？"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
@@ -22805,109 +22183,104 @@ msgid ""
 "ai integrations, and privacy protections. Keep it quite short, simple, and "
 "easy to understand for people with or without much AI, or technical, "
 "experience."
-msgstr ""
-"Duck.aiの利用に興味があるユーザーが、DuckDuckGoブラウザをダウンロードするメ"
-"リットとは何でしょうか。まず、DuckDuckGoの公式ソースのみ参照します。また、回"
-"答はタイトル付きの明確なセクションに分かれ、Duck.aiの統合とプライバシー保護に"
-"重点が置かれます。簡潔かつシンプルで、AIや技術に関する経験の有無に関わらず、"
-"誰でも簡単に理解できるように回答します。"
+msgstr "Duck.aiの利用に興味があるユーザーが、DuckDuckGoブラウザをダウンロードするメリットとは何でしょうか。まず、DuckDuckGoの公式ソースのみ参照します。また、回答はタイトル付きの明確なセクションに分かれ、Duck.aiの統合とプライバシー保護に重点が置かれます。簡潔かつシンプルで、AIや技術に関する経験の有無に関わらず、誰でも簡単に理解できるように回答します。"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the counterarguments?"
-msgstr ""
+msgstr "反論にはどのようなものがありますか？"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the hours & location?"
-msgstr ""
+msgstr "営業時間と場所は？"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key contributions of this paper?"
-msgstr ""
+msgstr "この論文の主な貢献は何ですか？"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key contributions?"
-msgstr ""
+msgstr "主な貢献は何ですか？"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key details?"
-msgstr ""
+msgstr "主な内容は何ですか？"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key points covered in this video?"
-msgstr ""
+msgstr "この動画の要点は何ですか？"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key points?"
-msgstr ""
+msgstr "要点は何ですか？"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key takeaways from this article?"
-msgstr ""
+msgstr "この記事の要点は何ですか？"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key takeaways?"
-msgstr ""
+msgstr "要点は何ですか？"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key things I will learn from this course?"
-msgstr ""
+msgstr "この講座で学べる主な内容は何ですか？"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the main counterarguments or criticisms of this?"
-msgstr ""
+msgstr "これに対する主な反論や批判は何ですか？"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the main questions this page answers?"
-msgstr ""
+msgstr "このページでは主にどのような質問の回答が得られますか？"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the must-try dishes here?"
-msgstr ""
+msgstr "ここで絶対試すべき料理は何ですか？"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid ""
 "What are the opening hours, location, and contact details for this place?"
-msgstr ""
+msgstr "この場所の営業時間、場所、連絡先を教えてください。"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the pros and cons of this product?"
-msgstr ""
+msgstr "この製品の長所と短所は何ですか？"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the pros and cons?"
-msgstr ""
+msgstr "どのような長所と短所がありますか？"
 
 # smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
@@ -23013,7 +22386,7 @@ msgstr "医学論文の文脈で心房とはどういう意味ですか？"
 #. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What does this answer?"
-msgstr ""
+msgstr "これは何に対する回答ですか？"
 
 # smartling.placeholder_format=C
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
@@ -23031,7 +22404,7 @@ msgstr "どのような情報が保存されますか？"
 #. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What interview questions might come up for this role?"
-msgstr ""
+msgstr "この職務にはどのような質問が面接で想定されますか？"
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -23039,9 +22412,7 @@ msgctxt "cloudsave"
 msgid ""
 "What is the Cloud Save bookmarklet and how does it differ from the URL "
 "parameter bookmarklet?"
-msgstr ""
-"Cloud Saveブックマークレットとは何ですか？URLパラメータ・ブックマークレットと"
-"の違いは？"
+msgstr "Cloud Saveブックマークレットとは何ですか？URLパラメータ・ブックマークレットとの違いは？"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for looking up the capital city of Albania.
@@ -23053,7 +22424,7 @@ msgstr "アルバニアの首都はどこですか？"
 #. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What is the overall verdict and rating for this?"
-msgstr ""
+msgstr "こレニ対する総合的な意見とスコアは？"
 
 # smartling.placeholder_format=C
 #. Link to a page with additional information.
@@ -23081,7 +22452,7 @@ msgstr "評価 :"
 #. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What should I order?"
-msgstr ""
+msgstr "何を注文すればよいですか？"
 
 # smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
@@ -23099,13 +22470,13 @@ msgstr "応答のどこが問題でしたか？（任意）"
 #. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What will I learn?"
-msgstr ""
+msgstr "何を学べますか？"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What will I need?"
-msgstr ""
+msgstr "何が必要ですか？"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -23128,7 +22499,7 @@ msgstr "新着情報"
 #. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What's the verdict?"
-msgstr ""
+msgstr "どのようなご意見ですか？"
 
 # smartling.placeholder_format=C
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -23141,9 +22512,7 @@ msgctxt "Full sentence for identifying product brands"
 msgid ""
 "When buying an electric guitar for a beginner, what are the top product "
 "brands I should consider?"
-msgstr ""
-"初心者向けのエレキギターを購入する場合、考慮すべきトップ製品ブランドは何です"
-"か？"
+msgstr "初心者向けのエレキギターを購入する場合、考慮すべきトップ製品ブランドは何ですか？"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -23184,7 +22553,7 @@ msgstr "どの機能が不足していますか？（任意）"
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Which features are missing? (optional)"
-msgstr ""
+msgstr "どの機能が不足していますか？（任意）"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
@@ -23206,13 +22575,13 @@ msgstr "私たち"
 #. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Who are the main cast and crew, and what else are they known for?"
-msgstr ""
+msgstr "主なキャストとスタッフは誰で、ほかにどのような作品で知られていますか？"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Who is this person?"
-msgstr ""
+msgstr "この人は誰ですか？"
 
 # smartling.placeholder_format=C
 #. Header above a collection of privacy-related links.
@@ -23602,9 +22971,7 @@ msgctxt "Disclaimer bellow chat input - desktop"
 msgid ""
 "You are chatting with %s. AI chats may display inaccurate or offensive "
 "information."
-msgstr ""
-"%1$sとチャット中です。 AIチャットでは不正確な情報や不快な情報が表示される場合"
-"があります。"
+msgstr "%1$sとチャット中です。 AIチャットでは不正確な情報や不快な情報が表示される場合があります。"
 
 # smartling.placeholder_format=C
 #. Provide users with the ability to retry their search on a different search engine. First placeholder will be a link with the text "try your search again" OR "try your search later". Second is a URL to the !bangs page: https://duckduckgo.com/bangs.
@@ -23612,9 +22979,7 @@ msgctxt "noresults"
 msgid ""
 "You can %s or search directly on other search engines from DuckDuckGo using "
 "%s search shortcuts."
-msgstr ""
-"%1$sか、%2$s検索ショートカットを使用してDuckDuckGoや他の検索エンジンで直接検"
-"索できます。"
+msgstr "%1$sか、%2$s検索ショートカットを使用してDuckDuckGoや他の検索エンジンで直接検索できます。"
 
 # smartling.placeholder_format=C
 #. Text informing the user that they can access DuckDuckGo AI Chat directly at a specific URL. The placeholder %s will be replaced with the link. Example: 'You can access DuckDuckGo AI Chat directly at duck.ai.'
@@ -23627,8 +22992,7 @@ msgstr "DuckDuckGo AI Chatには%1$sから直接アクセスできます。"
 msgctxt "duckassist"
 msgid ""
 "You can adjust how %s works or turn it off anytime in %sSearch Settings%s."
-msgstr ""
-"%1$sの動作を調整したり、%2$s検索設定%3$sでいつでも無効にしたりできます。"
+msgstr "%1$sの動作を調整したり、%2$s検索設定%3$sでいつでも無効にしたりできます。"
 
 # smartling.placeholder_format=C
 #. Assist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate Assist.
@@ -23636,22 +23000,17 @@ msgctxt "duckassist"
 msgid ""
 "You can adjust how Assist works or turn it off anytime in %sSearch "
 "Settings%s."
-msgstr ""
-"Assistは、動作を調整したり、%1$s検索設定%2$sでいつでもオフにしたりできます。"
+msgstr "Assistは、動作を調整したり、%1$s検索設定%2$sでいつでもオフにしたりできます。"
 
 # smartling.placeholder_format=C
 msgid "You can also use %sDuck.ai%s to answer questions or summarize text."
-msgstr ""
-"%1$sDuck.ai%2$sを使用して質問に答えたり、テキストを要約したりすることもできま"
-"す。"
+msgstr "%1$sDuck.ai%2$sを使用して質問に答えたり、テキストを要約したりすることもできます。"
 
 # smartling.placeholder_format=C
 msgid ""
 "You can also use %sDuckDuckGo AI Chat%s to answer questions or summarize "
 "text."
-msgstr ""
-"%1$s DuckDuckGo AI Chat%2$sを使用して質問に答えたり、テキストを要約したりする"
-"こともできます。"
+msgstr "%1$s DuckDuckGo AI Chat%2$sを使用して質問に答えたり、テキストを要約したりすることもできます。"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach more text selections than are allowed. Placeholder is the maximum number of text selections. E.g. You can attach up to 5 text selections.
@@ -23664,9 +23023,7 @@ msgstr "添付するテキストは最大%1$sまで選択できます。"
 msgid ""
 "You can change how frequently you see Search Assist, or turn it off "
 "entirely, in %sSearch Settings%s."
-msgstr ""
-"Search Assistは、%1$s検索設定%2$sで表示頻度を変更したり、完全に無効にしたりで"
-"きます。"
+msgstr "Search Assistは、%1$s検索設定%2$sで表示頻度を変更したり、完全に無効にしたりできます。"
 
 # smartling.placeholder_format=C
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
@@ -23680,9 +23037,7 @@ msgctxt "cloudsave"
 msgid ""
 "You can do this by saving your settings under a different passphrase, "
 "optionally deleting the first set."
-msgstr ""
-"設定を別のパスフレーズで保存してください。それまで使っていたパスフレーズも任"
-"意で削除できます。"
+msgstr "設定を別のパスフレーズで保存してください。それまで使っていたパスフレーズも任意で削除できます。"
 
 # smartling.placeholder_format=C
 #. Prefix for filename location sentence.
@@ -23705,8 +23060,7 @@ msgstr "このリマインダーは%1$s検索設定%2$sで非表示にできま�
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
-msgstr ""
-"このデバイスでは最大100件のチャットを保存できます。チャットを開始しましょう！"
+msgstr "このデバイスでは最大100件のチャットを保存できます。チャットを開始しましょう！"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -23762,9 +23116,7 @@ msgctxt "Organic result context menu"
 msgid ""
 "You can only block up to %s sites. To block %s, you'll need to unblock "
 "another site first."
-msgstr ""
-"最大%1$sサイトまでブロックできます。%2$sをブロックするには、まず別のサイトの"
-"ブロックを解除する必要があります。"
+msgstr "最大%1$sサイトまでブロックできます。%2$sをブロックするには、まず別のサイトのブロックを解除する必要があります。"
 
 # smartling.placeholder_format=C
 #. Text explaining the benefits of the cloud save feature.
@@ -23820,8 +23172,7 @@ msgctxt "Description of the post-upgrade success modal"
 msgid ""
 "You now have access to %s, higher AI reasoning, and 2x higher usage limits "
 "than Plus."
-msgstr ""
-"これで%1$s、より高いAI推論、Plusの2倍の使用制限が利用可能になりました。"
+msgstr "これで%1$s、より高いAI推論、Plusの2倍の使用制限が利用可能になりました。"
 
 # smartling.placeholder_format=C
 #. Description text for the welcome modal displayed after the user subscribes to DuckDuckGo.
@@ -23829,9 +23180,7 @@ msgctxt "Description text for the subscription welcome modal"
 msgid ""
 "You now have access to advanced AI models. You can access the VPN and other "
 "DuckDuckGo subscription protections in the DuckDuckGo browser."
-msgstr ""
-"高度なAIモデルへのアクセスが可能になりました。VPNやその他のDuckDuckGoサブスク"
-"リプション保護機能は、DuckDuckGoブラウザ内でご利用いただけます。"
+msgstr "高度なAIモデルへのアクセスが可能になりました。VPNやその他のDuckDuckGoサブスクリプション保護機能は、DuckDuckGoブラウザ内でご利用いただけます。"
 
 # smartling.placeholder_format=C
 #. Welcome message that appears after the DuckDuckGo extension is installed.
@@ -23852,10 +23201,7 @@ msgid ""
 "You will no longer be able to access your saved chats from this browser. The "
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
-msgstr ""
-"このブラウザからは、保存済みのチャットにアクセスできなくなります。直近30件の"
-"チャットはローカルストレージで引き続き利用可能です。これにより、暗号化された"
-"サーバーからチャットデータが削除されることはありません。"
+msgstr "このブラウザからは、保存済みのチャットにアクセスできなくなります。直近30件のチャットはローカルストレージで引き続き利用可能です。これにより、暗号化されたサーバーからチャットデータが削除されることはありません。"
 
 # smartling.placeholder_format=C
 #. Explains that turning off disconnects this browser only; the last 30 chats stay in local storage and the encrypted server backup is not deleted.
@@ -23864,10 +23210,7 @@ msgid ""
 "You will no longer be able to access your saved chats from this browser. The "
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
-msgstr ""
-"このブラウザからは、保存済みのチャットにアクセスできなくなります。直近30件の"
-"チャットはローカルストレージで引き続き利用可能です。この操作により、暗号化さ"
-"れたサーバーからチャットデータが削除されることはありません。"
+msgstr "このブラウザからは、保存済みのチャットにアクセスできなくなります。直近30件のチャットはローカルストレージで引き続き利用可能です。この操作により、暗号化されたサーバーからチャットデータが削除されることはありません。"
 
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
@@ -23880,8 +23223,7 @@ msgctxt "Update browser banner"
 msgid ""
 "You'll receive automatic DuckDuckGo app updates once you have the latest "
 "version."
-msgstr ""
-"最新バージョンを入手すると、DuckDuckGoアプリの自動アップデートが届きます。"
+msgstr "最新バージョンを入手すると、DuckDuckGoアプリの自動アップデートが届きます。"
 
 # smartling.placeholder_format=C
 #. shown when DDG is selected after eu preference menu on android
@@ -23889,10 +23231,7 @@ msgctxt "welcome message eu search preference android"
 msgid ""
 "You're now searching privately in Chrome. Use our app instead of Chrome to "
 "browse privately too. It’s already installed and can:"
-msgstr ""
-"現在、Chromeのプライベート検索を使用しています。Chromeの代わりに当社アプリを"
-"使ってもプライベートに閲覧できます。このアプリはすでにインストールされてお"
-"り、以下が可能になります。"
+msgstr "現在、Chromeのプライベート検索を使用しています。Chromeの代わりに当社アプリを使ってもプライベートに閲覧できます。このアプリはすでにインストールされており、以下が可能になります。"
 
 # smartling.placeholder_format=C
 #. Confirmation message that appears after the DuckDuckGo browser extension is installed.
@@ -23904,9 +23243,7 @@ msgstr "あなたは今、匿名で検索しています！"
 msgid ""
 "You're now searching with privacy. %sGet tips to reduce your footprint even "
 "more."
-msgstr ""
-"今あなたはプライバシーが保護された状態で検索しています。%1$sあなたの痕跡を"
-"もっと減らすヒントを学びましょう。"
+msgstr "今あなたはプライバシーが保護された状態で検索しています。%1$sあなたの痕跡をもっと減らすヒントを学びましょう。"
 
 # smartling.placeholder_format=C
 #. Title of a notice thanking the user for turning off their adblocker
@@ -23949,8 +23286,7 @@ msgctxt "Error message for user limit"
 msgid ""
 "You've reached the maximum number of messages for the moment. Please try "
 "again later."
-msgstr ""
-"現在、メッセージ数の上限に達しています。時間を置いてもう一度お試しください。"
+msgstr "現在、メッセージ数の上限に達しています。時間を置いてもう一度お試しください。"
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -23963,14 +23299,12 @@ msgstr "1回のセッションの最大ボイスチャット時間に達しま�
 msgctxt "voice chat limit modal"
 msgid ""
 "You've reached the voice chat limit for today. Please try again tomorrow."
-msgstr ""
-"本日のボイスチャットの回数制限に達しました。明日もう一度お試しください。"
+msgstr "本日のボイスチャットの回数制限に達しました。明日もう一度お試しください。"
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
 msgid "You've reached your dictation usage limit. Try again later."
-msgstr ""
-"ディクテーションの利用上限に達しました。時間を置いてもう一度お試しください。"
+msgstr "ディクテーションの利用上限に達しました。時間を置いてもう一度お試しください。"
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -23979,9 +23313,8 @@ msgid ""
 "You've run out of Sync & Backup storage for Duck.ai chats with attachments. "
 "Delete the %s oldest chats to resume Sync. Pinned chats will not be deleted."
 msgstr ""
-"添付ファイル付きのDuck.aiチャットのSync & Backup用ストレージ容量が不足してい"
-"ます。%1$s件の最も古いチャットを削除して同期を再開してください。ピン留めされ"
-"たチャットは削除されません。"
+"添付ファイル付きのDuck.aiチャットのSync & "
+"Backup用ストレージ容量が不足しています。%1$s件の最も古いチャットを削除して同期を再開してください。ピン留めされたチャットは削除されません。"
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -23991,9 +23324,8 @@ msgid ""
 "oldest chats with attachments to resume Sync. Pinned chats will not be "
 "deleted."
 msgstr ""
-"Duck.aiチャットのSync & Backup用ストレージ容量が不足しています。同期を再開す"
-"るには、添付ファイル付きの最も古いチャットを%1$s件削除してください。ピン留め"
-"されたチャットは削除されません。"
+"Duck.aiチャットのSync & "
+"Backup用ストレージ容量が不足しています。同期を再開するには、添付ファイル付きの最も古いチャットを%1$s件削除してください。ピン留めされたチャットは削除されません。"
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the sync storage limit.
@@ -24006,9 +23338,7 @@ msgstr "ストレージの容量がいっぱいです"
 msgid ""
 "YouTube (owned by Google) does not let you watch videos anonymously. As "
 "such, watching YouTube videos here will be tracked by YouTube/Google."
-msgstr ""
-"YouTube(Google社)に匿名性はありません。ここで見るビデオはGoogle社によって記録"
-"されています。"
+msgstr "YouTube(Google社)に匿名性はありません。ここで見るビデオはGoogle社によって記録されています。"
 
 # smartling.placeholder_format=C
 #. Label for a privacy disclaimer related to YouTube videos
@@ -24051,10 +23381,7 @@ msgid ""
 "Your backup will be deleted from DuckDuckGo's server. All devices will be "
 "disconnected from sync. Your %s most recent chats will be available in local "
 "storage on these browsers:"
-msgstr ""
-"バックアップデータはDuckDuckGoのサーバーから削除されます。すべてのデバイスの"
-"同期が解除されます。最新のチャット%1$s件は、次のブラウザのローカルストレージ"
-"に保存されます。"
+msgstr "バックアップデータはDuckDuckGoのサーバーから削除されます。すべてのデバイスの同期が解除されます。最新のチャット%1$s件は、次のブラウザのローカルストレージに保存されます。"
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list.
@@ -24063,10 +23390,7 @@ msgid ""
 "Your backup will be deleted from DuckDuckGo's server. All devices will be "
 "disconnected from sync. Your 100 most recent chats will be available in "
 "local storage on these browsers:"
-msgstr ""
-"バックアップデータはDuckDuckGoのサーバーから削除されます。すべてのデバイスの"
-"同期が解除されます。最新のチャット履歴100件は、以下のブラウザのローカルスト"
-"レージに保存されます。"
+msgstr "バックアップデータはDuckDuckGoのサーバーから削除されます。すべてのデバイスの同期が解除されます。最新のチャット履歴100件は、以下のブラウザのローカルストレージに保存されます。"
 
 # smartling.placeholder_format=C
 #. List item indicating that a site exclusion filter is currently active for the search
@@ -24090,18 +23414,14 @@ msgctxt "new tab page"
 msgid ""
 "Your browser provides a list of your most-visited sites. DuckDuckGo never "
 "has access to this data."
-msgstr ""
-"お使いのブラウザでは訪問回数が特に多いサイトリストが作成されます。DuckDuckGo"
-"がこのデータにアクセスすることはありません。"
+msgstr "お使いのブラウザでは訪問回数が特に多いサイトリストが作成されます。DuckDuckGoがこのデータにアクセスすることはありません。"
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
 msgid ""
 "Your browser provides the list of most-visited sites. DuckDuckGo never has "
 "access to this data."
-msgstr ""
-"ブラウザには、あなたがよくアクセスするサイトの一覧のデータがありますが、"
-"DuckDuckGoはこのデータにアクセスすることはできません。"
+msgstr "ブラウザには、あなたがよくアクセスするサイトの一覧のデータがありますが、DuckDuckGoはこのデータにアクセスすることはできません。"
 
 # smartling.placeholder_format=C
 #. Disclaimer text shown bellow chat input. Example: 'You are chatting with GPT-3. AI chats may display inaccurate or offensive information.'
@@ -24109,9 +23429,7 @@ msgctxt "Disclaimer bellow chat input - desktop"
 msgid ""
 "Your chat with %s is private. AI chats may display inaccurate or offensive "
 "information."
-msgstr ""
-"%1$sとのチャットは非公開です。AIチャットでは不正確な情報や不快な情報が表示さ"
-"れる場合があります。"
+msgstr "%1$sとのチャットは非公開です。AIチャットでは不正確な情報や不快な情報が表示される場合があります。"
 
 # smartling.placeholder_format=C
 #. Body copy shown after Sync & Backup is enabled, confirming chats are now syncing.
@@ -24123,50 +23441,41 @@ msgstr "チャットが保存されるようになりました。"
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never saved or used to train AI models"
-msgstr ""
-"チャットは非公開で、保存されたり、AIモデルのトレーニングに使用されることはあ"
-"りません。"
+msgstr "チャットは非公開で、保存されたり、AIモデルのトレーニングに使用されることはありません。"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never used to train AI models"
-msgstr ""
-"チャットは非公開であり、AIモデルのトレーニングに使用されることはありません。"
+msgstr "チャットは非公開であり、AIモデルのトレーニングに使用されることはありません。"
 
 # smartling.placeholder_format=C
 #. Text for a description of the active privacy protection for DuckDuckGo's AI Chat feature.
 msgctxt "Active Privacy protection description"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
-msgstr ""
-"チャットは非公開で、匿名化され、AIモデルのトレーニングには使用されません。"
+msgstr "チャットは非公開で、匿名化され、AIモデルのトレーニングには使用されません。"
 
 # smartling.placeholder_format=C
 #. Text explaining that user chats are private and not used for AI (Artificial Intelligence) training.
 msgctxt "Body text for privacy protection modal"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
-msgstr ""
-"チャットは非公開で、匿名化され、AIモデルのトレーニングには使用されません。"
+msgstr "チャットは非公開で、匿名化され、AIモデルのトレーニングには使用されません。"
 
 # smartling.placeholder_format=C
 #. Text for a menu item that describes the privacy protection feature.
 msgctxt "Menu item description"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
-msgstr ""
-"チャットは非公開で、当社が保存することはなく、AIモデルのトレーニングにも使用"
-"されません。"
+msgstr "チャットは非公開で、当社が保存することはなく、AIモデルのトレーニングにも使用されません。"
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the active privacy protection.
 msgctxt "Modal body for privacy"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
-msgstr ""
-"チャットは非公開で、当社が保存することはなく、AIモデルのトレーニングにも使用"
-"されません。"
+msgstr "チャットは非公開で、当社が保存することはなく、AIモデルのトレーニングにも使用されません。"
 
 # smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that chats are stored locally on the user's device.
@@ -24180,9 +23489,7 @@ msgctxt "duckai_migration"
 msgid ""
 "Your chats are still private, anonymized by us, and not used to train AI "
 "models. Follow these steps to keep your chat history."
-msgstr ""
-"チャットは引き続き非公開で、匿名化され、AIモデルのトレーニングには使用されま"
-"せん。チャット履歴を保持するには、以下の手順に従ってください。"
+msgstr "チャットは引き続き非公開で、匿名化され、AIモデルのトレーニングには使用されません。チャット履歴を保持するには、以下の手順に従ってください。"
 
 # smartling.placeholder_format=C
 #. Body shown after import completes.
@@ -24190,8 +23497,7 @@ msgctxt "duckai_migration"
 msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
-msgstr ""
-"チャットがインポートされました。Duck.aiで中断したところから続けましょう。"
+msgstr "チャットがインポートされました。Duck.aiで中断したところから続けましょう。"
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.
@@ -24222,9 +23528,7 @@ msgctxt "newsletter email collection"
 msgid ""
 "Your email address will not be shared, %sor associated with anonymous "
 "searches. [%sExample message%s]"
-msgstr ""
-"あなたの電子メールアドレスが他人に共有されることはありませし、%1$s匿名での検"
-"索に紐づけられることもありません。(%2$s例文のサンプル%3$s)"
+msgstr "あなたの電子メールアドレスが他人に共有されることはありませし、%1$s匿名での検索に紐づけられることもありません。(%2$s例文のサンプル%3$s)"
 
 # smartling.placeholder_format=C
 #. A prompt for the user to provide feedback on the third party map app directions experience
@@ -24267,10 +23571,10 @@ msgid ""
 "browser. We save the settings file using the key as the name. DuckDuckGo "
 "never knows your passphrase."
 msgstr ""
-"パスフレーズは、Secure Hash Algorithm (%1$sSHA-2%2$s) を使用した512ビットの"
-"キーを生成します。ブラウザには、このキーと関連する設定ファイルのみが残りま"
-"す。この設定ファイルは、キーを名前に用いて保存されます。DuckDuckGo がお客様の"
-"パスフレーズを知ることはありません。"
+"パスフレーズは、Secure Hash Algorithm (%1$sSHA-2%2$s) "
+""
+"を使用した512ビットのキーを生成します。ブラウザには、このキーと関連する設定ファイルのみが残ります。この設定ファイルは、キーを名前に用いて保存されます。DuckDuckGo "
+"がお客様のパスフレーズを知ることはありません。"
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -24284,10 +23588,7 @@ msgid ""
 "Your prompts are relayed through DuckDuckGo servers and stripped of "
 "personally identifiable metadata, so model providers can't tie your "
 "conversations back to you."
-msgstr ""
-"プロンプトはDuckDuckGoのサーバーを介して中継され、個人を特定できるメタデータ"
-"が取り除かれるため、モデルプロバイダーが会話を特定の個人に結びつけることはで"
-"きません。"
+msgstr "プロンプトはDuckDuckGoのサーバーを介して中継され、個人を特定できるメタデータが取り除かれるため、モデルプロバイダーが会話を特定の個人に結びつけることはできません。"
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -24300,9 +23601,7 @@ msgctxt "Popover text for recent chats onboarding"
 msgid ""
 "Your recent chats live here! You can refer to your chats or clear them "
 "anytime."
-msgstr ""
-"最近のチャットはここにあります！チャットはいつでも参照したり、消去したりでき"
-"ます。"
+msgstr "最近のチャットはここにあります！チャットはいつでも参照したり、消去したりできます。"
 
 # smartling.placeholder_format=C
 #. Message on a feedback form.
@@ -24344,10 +23643,7 @@ msgctxt "welcome message eu search preference android"
 msgid ""
 "You’re now searching privately in Chrome. Use our browser instead of Chrome "
 "for more protection. It’s already installed and can:"
-msgstr ""
-"現在、Chromeのプライベート検索を使用しています。Chromeの代わりに当社のブラウ"
-"ザをご使用になると、さらにセキュリティを強化できます。このアプリはすでにイン"
-"ストールされており、以下が可能になります。"
+msgstr "現在、Chromeのプライベート検索を使用しています。Chromeの代わりに当社のブラウザをご使用になると、さらにセキュリティを強化できます。このアプリはすでにインストールされており、以下が可能になります。"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has exceeded the maximum message size.
@@ -24355,9 +23651,7 @@ msgctxt "Error message for input limit"
 msgid ""
 "You’ve exceeded the maximum message size. Please shorten your message and "
 "try again."
-msgstr ""
-"メッセージの最大サイズを超えました。 メッセージを短くして、もう一度やり直して"
-"ください。"
+msgstr "メッセージの最大サイズを超えました。 メッセージを短くして、もう一度やり直してください。"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -24365,9 +23659,7 @@ msgctxt "Error message for conversation limit"
 msgid ""
 "You’ve reached the maximum chat length in this conversation. Clear this "
 "conversation with the Fire Button to continue."
-msgstr ""
-"この会話のチャットの最大時間に達しました。 この会話をFire Buttonでクリアして"
-"続行します。"
+msgstr "この会話のチャットの最大時間に達しました。 この会話をFire Buttonでクリアして続行します。"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -24375,9 +23667,7 @@ msgctxt "Error message for conversation limit"
 msgid ""
 "You’ve reached the maximum chat length in this conversation. Start a new "
 "chat to continue."
-msgstr ""
-"この会話のチャットの最大時間に達しました。続行するには、新しいチャットを開始"
-"します。"
+msgstr "この会話のチャットの最大時間に達しました。続行するには、新しいチャットを開始します。"
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -24391,15 +23681,13 @@ msgctxt "Error message for user limit"
 msgid ""
 "You’ve reached the maximum number of messages for one day. Please continue "
 "this chat tomorrow."
-msgstr ""
-"1日のメッセージ数の上限に達しました。このチャットは明日続行してください。"
+msgstr "1日のメッセージ数の上限に達しました。このチャットは明日続行してください。"
 
 # smartling.placeholder_format=C
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
 msgctxt "voice chat limit modal"
 msgid "You’ve reached the voice chat limit for now. Please try again later."
-msgstr ""
-"ボイスチャットの回数制限に達しました。時間を置いてもう一度お試しください。"
+msgstr "ボイスチャットの回数制限に達しました。時間を置いてもう一度お試しください。"
 
 # smartling.placeholder_format=C
 #. The name of the Yucatec Maya language
@@ -24482,9 +23770,7 @@ msgstr "（%1$s）"
 #. Trust line shown at the bottom of the explainer panel, summarizing DuckDuckGo's reputation for online protection.
 msgctxt "Footer banner text in the How Duck.ai Works panel"
 msgid "by DuckDuckGo — online protection trusted by millions every day."
-msgstr ""
-"DuckDuckGoが提供するオンライン保護は、毎日何百万人ものユーザーから信頼されて"
-"います。"
+msgstr "DuckDuckGoが提供するオンライン保護は、毎日何百万人ものユーザーから信頼されています。"
 
 # smartling.placeholder_format=C
 #. An abreviated unit of time indicating an age, e.g. "2d"
@@ -24697,9 +23983,7 @@ msgstr "公式ウェブサイト"
 #. <em>%s</em> is for a hexadecimal color code as <em>#395323</em>, but it has to be safe encoded, and as <em>#</em> seems not safe, <em>%23</em> must be used in place of the sharp symbol, but they are the same for your browser.
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
-msgstr ""
-"あるいはカラーコードを指定してください。例：%1$s (%2$s は %3$s をエンコードし"
-"たものです)"
+msgstr "あるいはカラーコードを指定してください。例：%1$s (%2$s は %3$s をエンコードしたものです)"
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "

--- a/locales/ja_JP/LC_MESSAGES/duckduckgo.po
+++ b/locales/ja_JP/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: ja_JP\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -175,7 +175,10 @@ msgctxt "Error message when a Plus subscriber tries to use a Pro-only model"
 msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
-msgstr "%1$sはProでのみ利用可能です。チャットを続けるには、このブラウザでDuckDuckGoのサブスクリプションを再度アップグレードするか、Plusまたは無料プランに切り替えてください。"
+msgstr ""
+"%1$sはProでのみ利用可能です。チャットを続けるには、このブラウザでDuckDuckGoの"
+"サブスクリプションを再度アップグレードするか、Plusまたは無料プランに切り替え"
+"てください。"
 
 # smartling.placeholder_format=C
 #. Text for the disclaimer message that appears when a Plus subscriber tries to use a Pro-only model. %s is replaced with the model name. Example: Claude Opus 4.6 is only available with Pro. Upgrade your DuckDuckGo subscription in this browser again to continue the chat, or switch to a Plus or free model.
@@ -184,7 +187,10 @@ msgctxt ""
 msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
-msgstr "%1$sはProでのみ利用可能です。チャットを続けるには、このブラウザでDuckDuckGoのサブスクリプションを再度アップグレードするか、Plusまたは無料プランに切り替えてください。"
+msgstr ""
+"%1$sはProでのみ利用可能です。チャットを続けるには、このブラウザでDuckDuckGoの"
+"サブスクリプションを再度アップグレードするか、Plusまたは無料プランに切り替え"
+"てください。"
 
 # smartling.placeholder_format=C
 #. Displayed when an AI (Artificial Intelligence) chat model is temporarily unavailable. Example: 'GPT 4o is only available with a DuckDuckGo subscription.'
@@ -199,7 +205,10 @@ msgid ""
 "%s is only available with a DuckDuckGo subscription. Activate your "
 "subscription in this browser again to continue the chat, or switch to a free "
 "model."
-msgstr "%1$sはDuckDuckGoのサブスクリプションでのみ利用可能です。チャットを続けるには、このブラウザでサブスクリプションを再度有効にするか、無料プランに切り替えてください。"
+msgstr ""
+"%1$sはDuckDuckGoのサブスクリプションでのみ利用可能です。チャットを続けるに"
+"は、このブラウザでサブスクリプションを再度有効にするか、無料プランに切り替え"
+"てください。"
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is temporarily unavailable. Example: 'GPT 3.5 Turbo is temporarily unavailable. Please switch to a different model or try again later.'
@@ -207,7 +216,9 @@ msgctxt "Error message for model unavailability"
 msgid ""
 "%s is temporarily unavailable. Please switch to a different model or try "
 "again later."
-msgstr "%1$sは一時的に利用できません。 別のモデルに切り替えるか、後でもう一度やり直してください。"
+msgstr ""
+"%1$sは一時的に利用できません。 別のモデルに切り替えるか、後でもう一度やり直し"
+"てください。"
 
 # smartling.placeholder_format=C
 #. Reddit's "fake internet points". https://support.reddithelp.com/hc/en-us/articles/204511829-What-is-karma
@@ -298,8 +309,9 @@ msgid ""
 "provider can see your prompts or the model’s responses, or save this chat on "
 "their servers."
 msgstr ""
-"%1$sはTrusted Execution "
-"Environmentで動作します。つまり、モデルプロバイダーでさえあなたのプロンプトやモデルの応答を見ることができず、このチャットをサーバーに保存することもできません。"
+"%1$sはTrusted Execution Environmentで動作します。つまり、モデルプロバイダーで"
+"さえあなたのプロンプトやモデルの応答を見ることができず、このチャットをサー"
+"バーに保存することもできません。"
 
 # smartling.placeholder_format=C
 #. Label shown in the batch selection toolbar when exactly one chat is selected. %s is replaced with 1. Use singular agreement where the language requires it.
@@ -378,7 +390,9 @@ msgctxt ""
 msgid ""
 "%s will be leaving Duck.ai in %s days (%s). After that, you can switch "
 "models to continue this chat."
-msgstr "%1$sは%2$s日後（%3$s）にDuck.aiで利用不可になります。その後、モデルを切り替えてこのチャットを続けることができます。"
+msgstr ""
+"%1$sは%2$s日後（%3$s）にDuck.aiで利用不可になります。その後、モデルを切り替え"
+"てこのチャットを続けることができます。"
 
 # smartling.placeholder_format=C
 #. Displayed in a saved chat when its AI model is about to be retired tomorrow. First placeholder is the friendly model name, second placeholder is the removal date formatted in the user's browser locale (e.g., 'June 15, 2026' in en-US). Singular-day form.
@@ -388,7 +402,9 @@ msgctxt ""
 msgid ""
 "%s will be leaving Duck.ai in 1 day (%s). After that, you can switch models "
 "to continue this chat."
-msgstr "%1$sは1日後（%2$s）にDuck.aiで利用不可になります。その後、モデルを切り替えてこのチャットを続けることができます。"
+msgstr ""
+"%1$sは1日後（%2$s）にDuck.aiで利用不可になります。その後、モデルを切り替えて"
+"このチャットを続けることができます。"
 
 # smartling.placeholder_format=C
 #. Shown in a text selection chip when the selection contains multiple words. %s is replaced with the number of words, e.g. '142 words'.
@@ -400,7 +416,9 @@ msgstr "%1$s単語"
 #. Instructions on which buttons and options the user has to click in order to add the DuckDuckGo extension to their browser.
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
-msgstr "%1$s%2$s追加ボタンをクリックして%3$s%4$s許可%5$sにチェックを入れ、 %6$sOK%7$sをクリックしてください"
+msgstr ""
+"%1$s%2$s追加ボタンをクリックして%3$s%4$s許可%5$sにチェックを入れ、 %6$sOK%7$s"
+"をクリックしてください"
 
 # Firefox, obsolete
 # smartling.placeholder_format=C
@@ -408,8 +426,8 @@ msgstr "%1$s%2$s追加ボタンをクリックして%3$s%4$s許可%5$sにチェ�
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAllow%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
 msgstr ""
-"%1$s%2$s許可%3$sにチェックを入れて、%4$s追加%5$sをクリックし、%6$s許可%7$sボックスをオンにしてから "
-"%8$sOK%9$sをクリックしてください"
+"%1$s%2$s許可%3$sにチェックを入れて、%4$s追加%5$sをクリックし、%6$s許可%7$s"
+"ボックスをオンにしてから %8$sOK%9$sをクリックしてください"
 
 # Firefox
 # smartling.placeholder_format=C
@@ -419,8 +437,8 @@ msgid ""
 "%sClick %sContinue To Installation%sClick %sAdd%sCheck %sAllow%s, then click "
 "%sOkay%s"
 msgstr ""
-"%1$s%2$sインストールを続行%3$sをクリックして "
-"%4$s追加ボタン%5$sを押し、%6$s許可%7$sにチェックを入れたら%8$sOK%9$sをクリックしてください"
+"%1$s%2$sインストールを続行%3$sをクリックして %4$s追加ボタン%5$sを押し、%6$s許"
+"可%7$sにチェックを入れたら%8$sOK%9$sをクリックしてください"
 
 # smartling.placeholder_format=C
 #. A button that reloads search results when an error occurs.
@@ -428,7 +446,9 @@ msgctxt "noresults"
 msgid ""
 "%sClick here%s to try again, if you think there should be results for this "
 "search."
-msgstr "この検索の結果について再読み込みする場合は、%1$sこちらをクリック%2$sしてもう一度試します。"
+msgstr ""
+"この検索の結果について再読み込みする場合は、%1$sこちらをクリック%2$sしてもう"
+"一度試します。"
 
 # smartling.placeholder_format=C
 #. Header for a page with information about sharing DuckDuckGo.
@@ -446,14 +466,17 @@ msgstr "%1$sさらに詳しく%2$s"
 #. Link to a page with more information about how anonymous location works.
 msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
-msgstr "%1$sDuckDuckGoが位置情報を保護する方法については、こちらをご覧ください%2$s。"
+msgstr ""
+"%1$sDuckDuckGoが位置情報を保護する方法については、こちらをご覧ください%2$s。"
 
 # smartling.placeholder_format=C
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
 msgctxt "Footer text for About Sync modal"
 msgid ""
 "%sLearn more%s about how chats are stored privately on DuckDuckGo's server."
-msgstr "DuckDuckGoのサーバー上でチャットが非公開で保存される仕組みについては%1$sこちら%2$sをご覧ください。"
+msgstr ""
+"DuckDuckGoのサーバー上でチャットが非公開で保存される仕組みについては%1$sこち"
+"ら%2$sをご覧ください。"
 
 # smartling.placeholder_format=C
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
@@ -471,7 +494,8 @@ msgstr "ホーム画面でDuckDuckGoのアプリアイコンを%1$s長押し%2$s
 #. A message displayed when there is an error loading content or no results on requery
 msgctxt "Error or no results message"
 msgid "%sOops!%s%sSomething went wrong. Please %srefresh%s and try again."
-msgstr "%1$s%2$s%3$s問題が発生しました。%4$s更新%5$sして、もう一度お試しください。"
+msgstr ""
+"%1$s%2$s%3$s問題が発生しました。%4$s更新%5$sして、もう一度お試しください。"
 
 # smartling.placeholder_format=C
 #. Tagline in a popover encouraging the user to download the DuckDuckGo browser
@@ -795,7 +819,8 @@ msgstr "6時間の使用制限に達しました。このチャットは%1$s以�
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "6-hour usage limit reached. You can keep chatting by using your daily limit."
-msgstr "6時間の使用制限に達しました。1日の制限時間を使ってチャットを続行できます。"
+msgstr ""
+"6時間の使用制限に達しました。1日の制限時間を使ってチャットを続行できます。"
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes abbreviation
@@ -848,21 +873,27 @@ msgstr "A"
 msgid ""
 "A network issue is preventing Search Assist from generating an answer. "
 "Please check your connection and try again."
-msgstr "ネットワークの問題により、Search Assistは回答を生成できません。接続を確認して、もう一度試してください。"
+msgstr ""
+"ネットワークの問題により、Search Assistは回答を生成できません。接続を確認し"
+"て、もう一度試してください。"
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of AI Chat is available and they need to refresh the page.
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of AI Chat is available! Please refresh this page to continue."
-msgstr "AI Chatの新バージョンが登場！続行するには、このページを再読み込みしてください。"
+msgstr ""
+"AI Chatの新バージョンが登場！続行するには、このページを再読み込みしてくださ"
+"い。"
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of Duck.ai is available and they need to refresh the page.
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of Duck.ai is available! Please refresh this page to continue."
-msgstr "Duck.aiの新バージョンが登場！続行するには、このページを再読み込みしてください。"
+msgstr ""
+"Duck.aiの新バージョンが登場！続行するには、このページを再読み込みしてくださ"
+"い。"
 
 # smartling.placeholder_format=C
 #. Shown when the Duck.ai desktop app has been open a long time and a newer version exists.
@@ -900,8 +931,9 @@ msgid ""
 "still access AI Chat when this setting is off by visiting %sduckduckgo.com/"
 "aichat%s."
 msgstr ""
-"AI Chatでは、サードパーティのAIチャットモデルと匿名で会話できます。設定をオフにすると、DuckDuckGo SearchのAI "
-"Chat機能は非表示になりますが、%1$sduckduckgo.com/aichat%2$sにアクセスすると、AI Chatをご利用いただけます。"
+"AI Chatでは、サードパーティのAIチャットモデルと匿名で会話できます。設定をオフ"
+"にすると、DuckDuckGo SearchのAI Chat機能は非表示になりますが、%1$sduckduckgo."
+"com/aichat%2$sにアクセスすると、AI Chatをご利用いただけます。"
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -961,7 +993,11 @@ msgid ""
 "However, we also offer and often link to %sDuck.ai%s for follow-up "
 "questions, which is our private AI-powered chat service that supports chat "
 "models from OpenAI, and Anthropic, and more."
-msgstr "AI支援による回答は現在、フォローアップの質問を直接サポートしていません。ただし、フォローアップの質問のために%1$sDuck.ai%2$sも（リンク経由を含め）提供しています。Duck.aiは、OpenAIやAnthropicなどのチャットモデルをサポートするAIを活用したプライベートチャットサービスです。"
+msgstr ""
+"AI支援による回答は現在、フォローアップの質問を直接サポートしていません。ただ"
+"し、フォローアップの質問のために%1$sDuck.ai%2$sも（リンク経由を含め）提供して"
+"います。Duck.aiは、OpenAIやAnthropicなどのチャットモデルをサポートするAIを活"
+"用したプライベートチャットサービスです。"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has turned off AI features and will no longer see AI-assisted answers.
@@ -1145,7 +1181,9 @@ msgctxt ""
 msgid ""
 "Activate your %s in this browser again to continue the chat, or switch to a "
 "free model."
-msgstr "チャットを続けるには、このブラウザで %1$s を再度有効にするか、無料プランに切り替えてください。"
+msgstr ""
+"チャットを続けるには、このブラウザで %1$s を再度有効にするか、無料プランに切"
+"り替えてください。"
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an active DuckDuckGo subscription.
@@ -1180,14 +1218,18 @@ msgstr "広告"
 #. An item in the ads tooltip that explains that ad clicks are managed by the ad network and are not used to profile you. The placeholder is the name of the ad network. For example: Microsoft
 msgid ""
 "Ad clicks are managed by %s’s ad network and are not used to profile you."
-msgstr "広告クリックは%1$sの広告ネットワークによって管理されており、お客様のプロファイリングには使用されません。"
+msgstr ""
+"広告クリックは%1$sの広告ネットワークによって管理されており、お客様のプロファ"
+"イリングには使用されません。"
 
 # smartling.placeholder_format=C
 #. Information that ad clicks are managed by Microsoft.
 msgid ""
 "Ad clicks are managed by Microsoft’s ad network and are not used to profile "
 "you."
-msgstr "広告クリックはMicrosoftの広告ネットワークによって管理されており、お客様のプロファイリングには使用されません。"
+msgstr ""
+"広告クリックはMicrosoftの広告ネットワークによって管理されており、お客様のプロ"
+"ファイリングには使用されません。"
 
 # smartling.placeholder_format=C
 #. An item in the ads tooltip that explains that ad clicks aren’t used to profile you.
@@ -1237,7 +1279,9 @@ msgstr "DuckDuckGo拡張機能を追加"
 # smartling.placeholder_format=C
 msgid ""
 "Add DuckDuckGo Privacy Essentials to your browser for free with one download:"
-msgstr "DuckDuckGo Privacy Essentialsは一度のダウンロードで、ブラウザに無料で追加できます："
+msgstr ""
+"DuckDuckGo Privacy Essentialsは一度のダウンロードで、ブラウザに無料で追加でき"
+"ます："
 
 #  IE default search engine instruction
 # smartling.placeholder_format=C
@@ -1392,6 +1436,12 @@ msgid "Address is incorrect"
 msgstr "アドレスが間違っています"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Adjust the servings"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. as in multiple advertisements
 msgid "Ads"
 msgstr "広告"
@@ -1467,13 +1517,16 @@ msgstr "アフリカーンス語"
 # smartling.placeholder_format=C
 #. Instructions on how to install the DuckDuckGo browser extension after it downloads.
 msgid "After it downloads and opens, click %sInstall%s"
-msgstr "ダウンロード後、ファイルを開いたら%1$sインストール%2$sをクリックしてください"
+msgstr ""
+"ダウンロード後、ファイルを開いたら%1$sインストール%2$sをクリックしてください"
 
 # smartling.placeholder_format=C
 #. Instructions on how to install the DuckDuckGo browser extension after it downloads.
 msgid ""
 "After it downloads, locate the extension file and double-click it to install"
-msgstr "ダウンロード後は拡張ファイルの場所に行き、ダブルクリックしてインストールしてください"
+msgstr ""
+"ダウンロード後は拡張ファイルの場所に行き、ダブルクリックしてインストールして"
+"ください"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an age below a web search result.
@@ -1603,6 +1656,14 @@ msgid "All chats are %sprivate%s"
 msgstr "すべてのチャットは%1$s非公開%2$sです"
 
 # smartling.placeholder_format=C
+#. Paragraph in the Privacy & Terms section of the About & Legal page in Duck.ai settings, summarizing how chats are anonymized and are not stored or used to train chat models.
+msgctxt "Privacy & Terms section description on the Duck.ai settings page"
+msgid ""
+"All chats are anonymized by DuckDuckGo, and your conversations are not used "
+"to train chat models by DuckDuckGo or the model providers"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
 msgctxt "Privacy modal header in Duck.ai chat"
 msgid "All chats are private"
@@ -1632,7 +1693,9 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "All model providers are prevented from training their AI on your "
 "conversations."
-msgstr "すべてのモデルプロバイダーは、会話内容に基づくAIのトレーニングを禁止されています。"
+msgstr ""
+"すべてのモデルプロバイダーは、会話内容に基づくAIのトレーニングを禁止されてい"
+"ます。"
 
 # smartling.placeholder_format=C
 #. Text displayed in the subheader of the modal that allows the user to pick an AI chat model.
@@ -1646,7 +1709,9 @@ msgctxt "Body copy for the anonymized card in the How Duck.ai Works panel"
 msgid ""
 "All personal metadata (for example, your IP address) is removed before "
 "sending a chat to the AI provider."
-msgstr "AIプロバイダーにチャットを送信する前に、すべての個人メタデータ（IPアドレスなど）が削除されます。"
+msgstr ""
+"AIプロバイダーにチャットを送信する前に、すべての個人メタデータ（IPアドレスな"
+"ど）が削除されます。"
 
 # smartling.placeholder_format=C
 #. A filter that shows search results from all countries.
@@ -1671,7 +1736,9 @@ msgstr "すべての種類"
 msgctxt "voice chat"
 msgid ""
 "Allow DuckDuckGo microphone access in System Settings to use voice chat."
-msgstr "ボイスチャットを使用するには、システム設定でDuckDuckGoのマイクアクセスを許可してください。"
+msgstr ""
+"ボイスチャットを使用するには、システム設定でDuckDuckGoのマイクアクセスを許可"
+"してください。"
 
 # smartling.placeholder_format=C
 #. Tells users which icon to press in their browser. Part of a list of instructions on how to enable location service.
@@ -1696,14 +1763,19 @@ msgid ""
 "Allows %s to search the web to improve responses to relevant prompts. Only "
 "sends AI-generated queries to a search engine with limited data retention. "
 "Prompts and responses with %s still have %szero provider visibility%s."
-msgstr "%1$sがウェブを検索して、関連するプロンプトへの応答を改善できるようにします。AIが生成したクエリのみをデータ保持が制限された検索エンジンに送信します。%2$sのプロンプトや応答は依然としてプロバイダーに%3$s一切表示されません%4$s。"
+msgstr ""
+"%1$sがウェブを検索して、関連するプロンプトへの応答を改善できるようにします。"
+"AIが生成したクエリのみをデータ保持が制限された検索エンジンに送信します。%2$s"
+"のプロンプトや応答は依然としてプロバイダーに%3$s一切表示されません%4$s。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Allows Cloud Save key to be stored locally on device (required to use Cloud "
 "Save)"
-msgstr "デバイス上で Cloud Save キーのローカル保存を許可します (Cloud Save を利用する場合に必須)"
+msgstr ""
+"デバイス上で Cloud Save キーのローカル保存を許可します (Cloud Save を利用する"
+"場合に必須)"
 
 # smartling.placeholder_format=C
 #. Pending title indicating near completion.
@@ -1840,7 +1912,9 @@ msgctxt "AI Chat description"
 msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
-msgstr "%1$s、%2$sに加え、オープンソースの%3$sや%4$sなど、人気のAIモデルに匿名でアクセスできます。"
+msgstr ""
+"%1$s、%2$sに加え、オープンソースの%3$sや%4$sなど、人気のAIモデルに匿名でアク"
+"セスできます。"
 
 # smartling.placeholder_format=C
 #. Text with information about Duck.ai and supported AI models, the placeholders list AI models. Example: 'Anonymous access to popular AI models, including GPT, Claude, and open-source Llama and Mistral.'
@@ -1848,13 +1922,22 @@ msgctxt "Duck.ai description"
 msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
-msgstr "%1$s、%2$sに加え、オープンソースの%3$sや%4$sなど、人気のAIモデルに匿名でアクセスできます。"
+msgstr ""
+"%1$s、%2$sに加え、オープンソースの%3$sや%4$sなど、人気のAIモデルに匿名でアク"
+"セスできます。"
 
 # smartling.placeholder_format=C
 #. Confirmation message after location service is enabled.
 msgctxt "precise_user_location"
 msgid "Anonymous location enabled"
 msgstr "匿名の位置情報を有効化しました"
+
+# smartling.placeholder_format=C
+msgctxt "settings"
+msgid ""
+"Anonymously generates answers for search queries based on web content. "
+"Choose how often you want it to appear, or disable it completely."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -1900,7 +1983,9 @@ msgctxt "Placeholder for additional instructions textarea"
 msgid ""
 "Any additional instructions you want Duck.ai to follow. e.g. Always tell me "
 "facts about ducks"
-msgstr "Duck.aiが従うべき追加の指示はありますか。例えばいつもアヒルについての事実を教えてください"
+msgstr ""
+"Duck.aiが従うべき追加の指示はありますか。例えばいつもアヒルについての事実を教"
+"えてください"
 
 # smartling.placeholder_format=C
 #. Shown in video filtering. https://duckduckgo.com/?q=videos+of+cats&iax=videos&ia=videos
@@ -2019,7 +2104,9 @@ msgctxt "Body text for disable chat history confirmation modal"
 msgid ""
 "Are you sure you want to disable history? This will delete all chats, "
 "including pinned chats."
-msgstr "履歴を無効にしてもよろしいですか？これにより、ピン留めされたチャットを含むすべてのチャットが削除されます。"
+msgstr ""
+"履歴を無効にしてもよろしいですか？これにより、ピン留めされたチャットを含むす"
+"べてのチャットが削除されます。"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to disable recent chats, with a warning that it will also delete currently saved chats.
@@ -2027,7 +2114,9 @@ msgctxt "Body text for disable recent chats confirmation modal"
 msgid ""
 "Are you sure you want to disable recent chats? This will also delete any "
 "recent chats that are currently saved."
-msgstr "最近のチャットを無効にしてもよろしいですか？無効にすると、現在保存されている最近のチャットも削除されます。"
+msgstr ""
+"最近のチャットを無効にしてもよろしいですか？無効にすると、現在保存されている"
+"最近のチャットも削除されます。"
 
 # smartling.placeholder_format=C
 #. Question asking user if they want to share the URL of the page they were on when giving feedback
@@ -2064,7 +2153,9 @@ msgstr "最終更新："
 msgid ""
 "As per our privacy policy, we do not collect or share any personal "
 "information ourselves. All of this privacy protection happens on your device."
-msgstr "私達はプライバシーポリシーに従って、個人情報を収集または共有することはありません。これらのプライバシー保護機能はすべてあなたのデバイスで実行されます。"
+msgstr ""
+"私達はプライバシーポリシーに従って、個人情報を収集または共有することはありま"
+"せん。これらのプライバシー保護機能はすべてあなたのデバイスで実行されます。"
 
 # smartling.placeholder_format=C
 #. A button to ask Duck.ai a question
@@ -2125,6 +2216,12 @@ msgstr "フォローアップの質問をする"
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse
 msgid "Ask a follow-up with Duck.ai"
 msgstr "Duck.aiにフォローアップの質問をする"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
+msgctxt "Page suggestion chip label"
+msgid "Ask about this page"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2188,9 +2285,12 @@ msgid ""
 "(shows more frequently on a wider range of searches). For now, AI-assisted "
 "answers are only available in the U.S. (English) region."
 msgstr ""
-""
-"Assistは、関連するWebコンテンツを要約して、一部の検索に対してAI支援の回答を匿名で生成できます。Assistの表示頻度は、「なし」（検索結果からAssist "
-"UIを完全に削除）、「オンデマンド」（Assistボタンをクリックした場合にのみAI支援による回答を表示）、「時々」（関連性の高い場合にのみAI支援による回答を表示）、「頻繁」（より広範な検索でより頻繁にAIアシストによる回答を表示）から選択できます。現時点では、AI支援の回答は米国（英語）地域でのみ利用可能です。"
+"Assistは、関連するWebコンテンツを要約して、一部の検索に対してAI支援の回答を匿"
+"名で生成できます。Assistの表示頻度は、「なし」（検索結果からAssist UIを完全に"
+"削除）、「オンデマンド」（Assistボタンをクリックした場合にのみAI支援による回"
+"答を表示）、「時々」（関連性の高い場合にのみAI支援による回答を表示）、「頻"
+"繁」（より広範な検索でより頻繁にAIアシストによる回答を表示）から選択できま"
+"す。現時点では、AI支援の回答は米国（英語）地域でのみ利用可能です。"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2201,7 +2301,12 @@ msgid ""
 "generate a brief answer based on relevant information found. It’s important "
 "to remember that responses are auto-generated from cited sources and based "
 "on %scrawling the web%s."
-msgstr "Assistは、検索クエリに対するAI支援の回答を匿名で生成できる、検索結果のオプション機能です。この機能は、ウェブをスキャンして関連コンテンツを探し、AIを活用した自然言語技術で見つかった関連情報に基づき、簡単な回答を生成します。回答は引用元から自動生成され、%1$sウェブのクロール%2$sに基づいて自動生成されることを覚えておくことが重要です。"
+msgstr ""
+"Assistは、検索クエリに対するAI支援の回答を匿名で生成できる、検索結果のオプ"
+"ション機能です。この機能は、ウェブをスキャンして関連コンテンツを探し、AIを活"
+"用した自然言語技術で見つかった関連情報に基づき、簡単な回答を生成します。回答"
+"は引用元から自動生成され、%1$sウェブのクロール%2$sに基づいて自動生成されるこ"
+"とを覚えておくことが重要です。"
 
 # smartling.placeholder_format=C
 #. Title for the dropdown menu where users select the assistant's role. Example: 'Assistant role: Travel guide'
@@ -2292,7 +2397,8 @@ msgstr "チャット終了後、音声は当社または OpenAI によって保�
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat is transcribed."
-msgstr "チャットの文字起こし後、音声データは当社またはOpenAIによって保存されません。"
+msgstr ""
+"チャットの文字起こし後、音声データは当社またはOpenAIによって保存されません。"
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when MediaRecorder API is unavailable.
@@ -2333,18 +2439,24 @@ msgstr "自動応答"
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid "Auto-generated based on listed sources. May contain inaccuracies."
-msgstr "リストされたソースに基づいて自動生成されます。不正確な情報が含まれる場合があります。"
+msgstr ""
+"リストされたソースに基づいて自動生成されます。不正確な情報が含まれる場合があ"
+"ります。"
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid ""
 "Auto-generated based on listed sources. Responses may contain inaccuracies."
-msgstr "リストされたソースに基づいて自動生成されます。回答には不正確な情報が含まれる場合があります。"
+msgstr ""
+"リストされたソースに基づいて自動生成されます。回答には不正確な情報が含まれる"
+"場合があります。"
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI) on mobile
 msgid "Auto-generated from sources. May be inaccurate."
-msgstr "ソースに基づき自動生成されています。内容に不正確な部分を含む可能性があります。"
+msgstr ""
+"ソースに基づき自動生成されています。内容に不正確な部分を含む可能性がありま"
+"す。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2363,7 +2475,10 @@ msgid ""
 "Automatically shows Assist for relevant searches. Assist can anonymously "
 "look up and summarize information in response to some searches. For now, "
 "Assist is only available in English regions."
-msgstr "関連する検索にAssistを自動表示します。Assistを使用すると、一部の検索に対して情報を匿名で調べ、要約できます。現時点では、Assistは英語圏でのみ利用可能です。"
+msgstr ""
+"関連する検索にAssistを自動表示します。Assistを使用すると、一部の検索に対して"
+"情報を匿名で調べ、要約できます。現時点では、Assistは英語圏でのみ利用可能で"
+"す。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2372,14 +2487,16 @@ msgid ""
 "anonymously look up and summarize information in response to some searches. "
 "For now, DuckAssist is only available in English regions."
 msgstr ""
-"関連する検索に DuckAssist "
-"を自動表示します。このツールを使用すると、一部の検索に対して情報を匿名で調べ、要約できます。現時点では、イングランド地域でのみ利用可能です。"
+"関連する検索に DuckAssist を自動表示します。このツールを使用すると、一部の検"
+"索に対して情報を匿名で調べ、要約できます。現時点では、イングランド地域でのみ"
+"利用可能です。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Autoplay short, silent video previews when you hover over video results."
-msgstr "動画の結果にカーソルを合わせると、プレビューが短時間無音で自動再生されます。"
+msgstr ""
+"動画の結果にカーソルを合わせると、プレビューが短時間無音で自動再生されます。"
 
 # smartling.placeholder_format=C
 #. Screen-reader label for the radiogroup of tool options inside the Tools dropdown. Announced when assistive technology enters the group of menuitemradio items.
@@ -2521,6 +2638,12 @@ msgid "Barcode"
 msgstr "バーコード"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Based on this page, is this course worth taking?"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Basic"
 msgstr "基本テーマ"
@@ -2559,6 +2682,14 @@ msgstr "打者"
 msgctxt "Assistant response placeholder"
 msgid "Before continuing..."
 msgstr "続行する前に..."
+
+# smartling.placeholder_format=C
+#. Explains that before storing the report, DuckDuckGo will anonymize the conversation by removing PII like names, email addresses, and identifying metadata.
+msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
+msgid ""
+"Before storing this report, DuckDuckGo will anonymize your conversation by "
+"removing PII like names, email addresses, and identifying metadata."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -2684,7 +2815,8 @@ msgstr "メールトラッカーをブロックし、アドレスを非表示に
 # smartling.placeholder_format=C
 #. A disclaimer about AI-generated images in search results
 msgid "Block list is not exhaustive and may contain inaccuracies."
-msgstr "ブロックリストは完全ではなく、不正確な情報が含まれている可能性があります。"
+msgstr ""
+"ブロックリストは完全ではなく、不正確な情報が含まれている可能性があります。"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -2877,6 +3009,12 @@ msgid "Break Points Won"
 msgstr "ブレークポイント獲得"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Break this down into clear, numbered steps."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
 msgctxt "Weather IA"
 msgid "Breezy"
@@ -2932,20 +3070,28 @@ msgstr "ファイルを参照"
 msgid ""
 "Browse as usual while we add privacy protection. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
-msgstr "DuckDuckGoなら普段どおりに閲覧しながら、プライバシー保護を強化できます。検索エンジン、トラッカーブロック、高度な暗号化機能をひとつの%1$s%2$s拡張機能%3$sにまとめました。"
+msgstr ""
+"DuckDuckGoなら普段どおりに閲覧しながら、プライバシー保護を強化できます。検索"
+"エンジン、トラッカーブロック、高度な暗号化機能をひとつの%1$s%2$s拡張機能%3$s"
+"にまとめました。"
 
 # smartling.placeholder_format=C
 msgid ""
 "Browse as usual, and we'll take care of the rest. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
-msgstr "いつも通り閲覧して、あとは当社におまかせ。検索エンジン、トラッカーブロック、高度な暗号化機能を1つの%1$s%2$s拡張機能%3$sにまとめました。"
+msgstr ""
+"いつも通り閲覧して、あとは当社におまかせ。検索エンジン、トラッカーブロック、"
+"高度な暗号化機能を1つの%1$s%2$s拡張機能%3$sにまとめました。"
 
 # smartling.placeholder_format=C
 msgid ""
 "Browse as usual, and we’ll take care of the rest. Get bundled private "
 "search, tracker blocking, and site encryption, all in one download, for "
 "%smajor browsers%s."
-msgstr "いつも通り閲覧して、あとは当社におまかせ。プライベート検索、トラッカーブロック、サイトの暗号化機能を1つにまとめた%1$s主要なブラウザ%2$s向けツールをダウンロードしましょう。"
+msgstr ""
+"いつも通り閲覧して、あとは当社におまかせ。プライベート検索、トラッカーブロッ"
+"ク、サイトの暗号化機能を1つにまとめた%1$s主要なブラウザ%2$s向けツールをダウン"
+"ロードしましょう。"
 
 # smartling.placeholder_format=C
 #. Header for a call to action to browse with the DuckDuckGo browser
@@ -3031,7 +3177,8 @@ msgstr "「%1$s」をクリックすると、当社の%2$sに同意したこと�
 msgctxt ""
 "Copy stating agreement to Duck.ai Privacy Policy and Terms of Service."
 msgid "By clicking “%s,” you accept Duck.ai’s %s and %s."
-msgstr "「%1$s」をクリックすると、Duck.aiの%2$sと%3$sに同意したことになります。"
+msgstr ""
+"「%1$s」をクリックすると、Duck.aiの%2$sと%3$sに同意したことになります。"
 
 # smartling.placeholder_format=C
 #. Text stating agreement to Duck.ai Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'By clicking “Agree and Continue,” you accept Duck.ai’s Privacy Policy and Terms of Service.'
@@ -3052,16 +3199,19 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"初期状態では、設定情報は秘匿されないブラウザのCookieファイル (ブラウザ内) に保存されます。匿名の Cloud Save "
-"機能を利用すると、設定情報を (クラウド上のリモートサーバーに) "
-"より長期的に保存できます。個人を特定できる情報がクラウドに保存されたり、パスフレーズがブラウザ上に残ることもありません。"
+"初期状態では、設定情報は秘匿されないブラウザのCookieファイル (ブラウザ内) に"
+"保存されます。匿名の Cloud Save 機能を利用すると、設定情報を (クラウド上のリ"
+"モートサーバーに) より長期的に保存できます。個人を特定できる情報がクラウドに"
+"保存されたり、パスフレーズがブラウザ上に残ることもありません。"
 
 # smartling.placeholder_format=C
 #. Description for the consent highlight in the dictation consent modal. %s is replaced with a link to the help page.
 msgid ""
 "By enabling dictation, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
-msgstr "音声入力を有効にすると、この機能の使用のために音声データがOpenAIに送信されることに同意したことになります。開始する間に当社の%1$sを確認してください。"
+msgstr ""
+"音声入力を有効にすると、この機能の使用のために音声データがOpenAIに送信される"
+"ことに同意したことになります。開始する間に当社の%1$sを確認してください。"
 
 # smartling.placeholder_format=C
 #. Description for the 'enable voice chat' section of the voice chat consent modal. Placeholder for the voice chat help page link and text. Example: 'By enabling voice chat, you consent to your voice data being sent to OpenAI for the use of this feature. See our voice chat help page before getting started.'
@@ -3070,8 +3220,9 @@ msgid ""
 "By enabling voice chat, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
 msgstr ""
-"ボイスチャットを有効にすると、この機能の使用のために音声データがOpenAI "
-"に送信されることに同意したことになります。開始する間に当社の%1$sを確認してください。"
+"ボイスチャットを有効にすると、この機能の使用のために音声データがOpenAI に送信"
+"されることに同意したことになります。開始する間に当社の%1$sを確認してくださ"
+"い。"
 
 # smartling.placeholder_format=C
 #. Golf leaderboard: player missed the cut
@@ -3317,6 +3468,12 @@ msgid "Cast"
 msgstr "キャスト"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Cast & Crew"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
 msgctxt "Tone option label for Casual"
 msgid "Casual"
@@ -3420,7 +3577,8 @@ msgstr "サイト全体の背景色を変更する"
 msgctxt "settings"
 msgid ""
 "Changes the background color of results on hover, modules, and dropdown menus"
-msgstr "マウスオーバー、モジュール、ドロップダウンメニューでの検索結果の背景色を変更"
+msgstr ""
+"マウスオーバー、モジュール、ドロップダウンメニューでの検索結果の背景色を変更"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/NdpkbY0.png
@@ -3549,10 +3707,11 @@ msgid ""
 "DuckDuckGo Search. However, you can still access Chat when this setting is "
 "off by visiting %shttps://duck.ai%s directly."
 msgstr ""
-"チャット（Duck.ai "
-""
-"サービス経由）を通じて、OpenAI、AnthropicなどのサードパーティのAIチャットモデルと匿名で会話することができます。この設定をオフにすると、DuckDuckGo "
-"Searchのチャットボタンとリンクが非表示になります。ただし、この設定がオフの場合でも、%1$shttps://duck.ai%2$sにアクセスして直接チャットを利用できます。"
+"チャット（Duck.ai サービス経由）を通じて、OpenAI、Anthropicなどのサードパー"
+"ティのAIチャットモデルと匿名で会話することができます。この設定をオフにする"
+"と、DuckDuckGo Searchのチャットボタンとリンクが非表示になります。ただし、この"
+"設定がオフの場合でも、%1$shttps://duck.ai%2$sにアクセスして直接チャットを利用"
+"できます。"
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -3607,14 +3766,18 @@ msgstr "プライベートチャット"
 #. Mobile variant of DUCKCHAT_BROWSER_UPSELL_PROMO_TEXT. Shorter version for the promotional card encouraging third-party browser users to download the DuckDuckGo browser.
 msgctxt "Promotional text (mobile)"
 msgid "Chat privately on any website with Duck.ai built into our free browser."
-msgstr "無料ブラウザに内蔵されたDuck.aiがあれば、どのウェブサイトでもプライベートにチャットできます。"
+msgstr ""
+"無料ブラウザに内蔵されたDuck.aiがあれば、どのウェブサイトでもプライベートに"
+"チャットできます。"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card encouraging third-party browser users to download the DuckDuckGo browser. Not shown in the DuckDuckGo browser or on Linux.
 msgctxt "Promotional text"
 msgid ""
 "Chat privately on any website with the Duck.ai sidebar in our free browser."
-msgstr "無料のDuckDuckGoブラウザのDuck.aiサイドバーを使えば、どのウェブサイトでもプライベートにチャットできます。"
+msgstr ""
+"無料のDuckDuckGoブラウザのDuck.aiサイドバーを使えば、どのウェブサイトでもプラ"
+"イベートにチャットできます。"
 
 # smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
@@ -3676,7 +3839,10 @@ msgctxt "Description for Chat History feature"
 msgid ""
 "Chats are stored locally on your device instead of on DuckDuckGo servers or "
 "remote servers. Disabling chat history will delete pinned chats."
-msgstr "チャットは、DuckDuckGoサーバーやリモートサーバーでなく、お使いのデバイスにローカルで保存されます。チャット履歴を無効にすると、ピン留めされたチャットが削除されます。"
+msgstr ""
+"チャットは、DuckDuckGoサーバーやリモートサーバーでなく、お使いのデバイスに"
+"ローカルで保存されます。チャット履歴を無効にすると、ピン留めされたチャットが"
+"削除されます。"
 
 # smartling.placeholder_format=C
 #. Text explaining how the Chat History feature stores the user's chats locally to their device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection. Also explains that disabling chat history will delete pinned chats.
@@ -3687,7 +3853,12 @@ msgid ""
 "help recover a chat if you lose your internet connection. Disabling chat "
 "history will delete pinned chats, and disable the temporary storage of new "
 "prompts and responses."
-msgstr "チャットはデバイスのローカルに保存されます。新しいプロンプトやレスポンスは暗号化され、送信後はDuckDuckGoサーバーに一時的に保存されます。これは、インターネット接続が途切れた場合のチャット復旧に役立ちます。チャット履歴を無効にすると、固定されたチャットが削除され、新しいプロンプトと応答の一時的な保存が無効になります。"
+msgstr ""
+"チャットはデバイスのローカルに保存されます。新しいプロンプトやレスポンスは暗"
+"号化され、送信後はDuckDuckGoサーバーに一時的に保存されます。これは、インター"
+"ネット接続が途切れた場合のチャット復旧に役立ちます。チャット履歴を無効にする"
+"と、固定されたチャットが削除され、新しいプロンプトと応答の一時的な保存が無効"
+"になります。"
 
 # smartling.placeholder_format=C
 #. Title shown above the body copy in the Duck.ai recent chats IndexedDB unavailable notice.
@@ -3708,7 +3879,9 @@ msgstr "チャットは安全にダウンロードされました"
 msgctxt "Sync file storage inline disclaimer body"
 msgid ""
 "Chats with attachments have stopped syncing. Free up storage to resume Sync."
-msgstr "添付ファイル付きのチャットが同期されなくなりました。同期を再開するにはストレージを解放してください。"
+msgstr ""
+"添付ファイル付きのチャットが同期されなくなりました。同期を再開するにはスト"
+"レージを解放してください。"
 
 # smartling.placeholder_format=C
 #. Message shown when we have no data from upstream to display
@@ -3767,7 +3940,8 @@ msgstr "この障害に関する最新情報は、DuckDuckGoのサブレディ�
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
 msgctxt "noresults"
 msgid "Check the status page for updates on this outage."
-msgstr "この停止に関する最新情報については、ステータスページを確認してください。"
+msgstr ""
+"この停止に関する最新情報については、ステータスページを確認してください。"
 
 # smartling.placeholder_format=C
 #. Title shown to the host device (the one that is logged in) after it sends the pairing code. The host can't confirm the peer applied it, so this is a title-only screen (no body) prompting the user to finish on the other device.
@@ -3826,7 +4000,8 @@ msgstr "%1$sや%2$sを含むAIモデルの選択"
 # smartling.placeholder_format=C
 #. As in 'Choose to keep DuckDuckGo as your default search engine'. Placeholders are for markup, you can ignore them.
 msgid "Choose %skeep it%s to continue protecting your privacy."
-msgstr "%1$s初期設定の検索エンジンを保持%2$sを選び、プライバシーを保護しましょう。"
+msgstr ""
+"%1$s初期設定の検索エンジンを保持%2$sを選び、プライバシーを保護しましょう。"
 
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
@@ -4041,8 +4216,9 @@ msgid ""
 "Clearing browser data deletes chats. Some browsers may keep recent chats "
 "indefinitely or auto-delete them after 7+ days of no AI Chat use."
 msgstr ""
-"ブラウザのデータを消去すると、チャットも消去されます。一部のブラウザでは、最近のチャットが無期限に保存される場合、またはAI "
-"Chatの未使用期間が7日を超えると自動的に削除される場合があります。"
+"ブラウザのデータを消去すると、チャットも消去されます。一部のブラウザでは、最"
+"近のチャットが無期限に保存される場合、またはAI Chatの未使用期間が7日を超える"
+"と自動的に削除される場合があります。"
 
 # smartling.placeholder_format=C
 #. Text explaining what happens to recent chats when browser data is cleared.
@@ -4051,7 +4227,10 @@ msgid ""
 "Clearing browser data deletes recent chats. Recent chats may be saved "
 "indefinitely or auto-deleted after 7 days without using Duck.ai, depending "
 "on your browser."
-msgstr "ブラウザのデータを消去すると、最近のチャットが削除されます。最近のチャットは無期限に保存されるか、Duck.aiを使用しない場合、7日後に自動削除されることがあります。ブラウザによって異なります。"
+msgstr ""
+"ブラウザのデータを消去すると、最近のチャットが削除されます。最近のチャットは"
+"無期限に保存されるか、Duck.aiを使用しない場合、7日後に自動削除されることがあ"
+"ります。ブラウザによって異なります。"
 
 # smartling.placeholder_format=C
 #. Warning message shown on the Block domain success modal. Blocked sites are stored in localStorage which is cleared alongside cookies when users clear browser data. Followed by a linked 'our free browser' text.
@@ -4059,7 +4238,9 @@ msgctxt "settings"
 msgid ""
 "Clearing browser data will reset your blocked sites. Save your block list "
 "permanently in"
-msgstr "ブラウザデータを消去すると、ブロックしたサイトがリセットされます。ブロックリストを当社の無料ブラウザに"
+msgstr ""
+"ブラウザデータを消去すると、ブロックしたサイトがリセットされます。ブロックリ"
+"ストを当社の無料ブラウザに"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -4067,7 +4248,11 @@ msgid ""
 "Click \"More\" to go deeper on a topic, and ask follow-up questions via "
 "%sDuck.ai%s, our private AI chat service that supports chat models from "
 "OpenAI, Anthropic, and more."
-msgstr "「詳細」をクリックすると、トピックについてさらに詳しい情報が表示されます。また、フォローアップの質問をするために、%1$sDuck.ai%2$s（OpenAIやAnthropicなどのチャットモデルをサポートする当社のプライベートAIチャットサービス）も使用できます。"
+msgstr ""
+"「詳細」をクリックすると、トピックについてさらに詳しい情報が表示されます。ま"
+"た、フォローアップの質問をするために、%1$sDuck.ai%2$s（OpenAIやAnthropicなど"
+"のチャットモデルをサポートする当社のプライベートAIチャットサービス）も使用で"
+"きます。"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4108,7 +4293,9 @@ msgstr "一覧から%1$s検索設定の変更%2$sをクリックしてくださ�
 msgid ""
 "Click %sEdit > Preferences%s (on Windows) %sSeaMonkey > Preferences%s (on "
 "Mac)"
-msgstr "%1$s編集 > 設定%2$s (Windows) %3$sSeaMonkey > 設定%4$s (Mac) をクリックしてください"
+msgstr ""
+"%1$s編集 > 設定%2$s (Windows) %3$sSeaMonkey > 設定%4$s (Mac) をクリックしてく"
+"ださい"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -4119,12 +4306,15 @@ msgstr "%1$sここ%2$sをクリックして検索エンジンとして追加し�
 # smartling.placeholder_format=C
 #. Link to add the DuckDuckGo browser extension to Safari.
 msgid "Click %sHere%s to download the DuckDuckGo extension"
-msgstr "%1$sここ%2$sをクリックしてDuckDuckGoの拡張機能をダウンロードしてください"
+msgstr ""
+"%1$sここ%2$sをクリックしてDuckDuckGoの拡張機能をダウンロードしてください"
 
 # smartling.placeholder_format=C
 #. Link to download the DuckDuckGo browser extension.
 msgid "Click %sOpen%s to download and open the DuckDuckGo Safari extension"
-msgstr "%1$s開く%2$sをクリックしてDuckDuckGoのSafari拡張設定をダウンロードしてください"
+msgstr ""
+"%1$s開く%2$sをクリックしてDuckDuckGoのSafari拡張設定をダウンロードしてくださ"
+"い"
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -4138,7 +4328,9 @@ msgstr "左側のサイドバーにある%1$sプライバシーとサービス%2
 msgid ""
 "Click %sSafari%s in the top menu (On Windows, click the %sgears icon%s in "
 "the top right)"
-msgstr "%1$sSafari%2$sをトップメニューからクリックしてください(またはWindowsの場合、右上の%3$s歯車アイコン%4$sをクリックしてください)"
+msgstr ""
+"%1$sSafari%2$sをトップメニューからクリックしてください(またはWindowsの場合、"
+"右上の%3$s歯車アイコン%4$sをクリックしてください)"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4167,7 +4359,8 @@ msgstr "%1$sはい%2$sをクリックしてください"
 # smartling.placeholder_format=C
 #. Tells the user where to click to open their browser's settings menu.
 msgid "Click %ssettings/hamburger icon %s on the Chrome toolbar (top right)."
-msgstr "Chromeのツールバーで「%1$ssettings/hamburger icon %2$s」をクリックします。"
+msgstr ""
+"Chromeのツールバーで「%1$ssettings/hamburger icon %2$s」をクリックします。"
 
 #  Maxthon default search engine instruction
 # smartling.placeholder_format=C
@@ -4203,7 +4396,8 @@ msgstr "下のほうの %1$sデフォルトに設定%2$s をクリックしま�
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click on the %sSearch Providers%s under Add-on Types"
-msgstr "アドオンタイプセクションの下にある%1$s検索エンジン%2$sボタンを押してください"
+msgstr ""
+"アドオンタイプセクションの下にある%1$s検索エンジン%2$sボタンを押してください"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -4228,7 +4422,10 @@ msgctxt "cloudsave"
 msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Search Settings%s."
-msgstr "「%1$s自分のデータを削除%2$s」をクリックまたはタップします。データはこの操作によりクラウドから削除されますが、「%3$sすべての検索設定をリセット%4$s」がクリックまたはタップされるまでブラウザに残ります。"
+msgstr ""
+"「%1$s自分のデータを削除%2$s」をクリックまたはタップします。データはこの操作"
+"によりクラウドから削除されますが、「%3$sすべての検索設定をリセット%4$s」がク"
+"リックまたはタップされるまでブラウザに残ります。"
 
 # smartling.placeholder_format=C
 #. Tells users where to click in order to disable the cloud save feature and delete any data backed-up to the cloud.
@@ -4238,7 +4435,10 @@ msgctxt "cloudsave"
 msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Settings%s."
-msgstr "%1$s自分のデータを削除%2$sをクリックまたはタップします。この操作でデータはクラウド上から削除されますが、%3$sすべての設定をリセット%4$sをクリック/タップしない限り、お使いのブラウザに保存されたままとなります。"
+msgstr ""
+"%1$s自分のデータを削除%2$sをクリックまたはタップします。この操作でデータはク"
+"ラウド上から削除されますが、%3$sすべての設定をリセット%4$sをクリック/タップし"
+"ない限り、お使いのブラウザに保存されたままとなります。"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -4306,14 +4506,18 @@ msgstr "検索ボックスの選択項目をクリック"
 msgid ""
 "Click the dropdown menu beside %sSearch engine used in the address bar%s and "
 "select %sDuckDuckGo%s."
-msgstr "%1$s「アドレスバーで使用する検索エンジン」の横にあるドロップダウンメニューをクリック%2$sして、%3$sDuckDuckGo%4$s を選択します。"
+msgstr ""
+"%1$s「アドレスバーで使用する検索エンジン」の横にあるドロップダウンメニューを"
+"クリック%2$sして、%3$sDuckDuckGo%4$s を選択します。"
 
 # smartling.placeholder_format=C
 #. First step in a list of steps to take to disable the user's ad blocker
 msgid ""
 "Click the icon of the ad blocker extension. It's usually in the upper right "
 "hand corner of your browser."
-msgstr "広告ブロッカー拡張機能のアイコンをクリックします。通常、広告ブロッカー拡張機能のアイコンはブラウザの右上隅に表示されています。"
+msgstr ""
+"広告ブロッカー拡張機能のアイコンをクリックします。通常、広告ブロッカー拡張機"
+"能のアイコンはブラウザの右上隅に表示されています。"
 
 #  Safari default search engine instruction
 # smartling.placeholder_format=C
@@ -4501,7 +4705,9 @@ msgctxt "cloudsave"
 msgid ""
 "Cloud Save lets you save your settings more permanently by entering a "
 "passphrase. It is entirely optional."
-msgstr "パスワードを入力すれば、Cloud Saveで自分の設定をずっと保存できます。この機能を使うかどうかはあなた次第。強制ではありません。"
+msgstr ""
+"パスワードを入力すれば、Cloud Saveで自分の設定をずっと保存できます。この機能"
+"を使うかどうかはあなた次第。強制ではありません。"
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -4860,7 +5066,8 @@ msgstr "コピー"
 # smartling.placeholder_format=C
 #. Instructions on how to change the default search engine
 msgid "Copy &amp; paste %sabout:preferences#search%s into the address bar"
-msgstr "「%1$sabout:preferences#search%2$s」をアドレスバーにコピー＆ペーストします"
+msgstr ""
+"「%1$sabout:preferences#search%2$s」をアドレスバーにコピー＆ペーストします"
 
 # smartling.placeholder_format=C
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
@@ -4930,7 +5137,9 @@ msgstr "コスタリカ"
 #. Inline error shown on the recovery code screen when exportSyncSettings rejects.
 msgctxt "Error message when the recovery code fails to generate"
 msgid "Couldn't load your recovery code. Please close this and try again."
-msgstr "リカバリーコードを読み込めませんでした。これを閉じて、もう一度お試しください。"
+msgstr ""
+"リカバリーコードを読み込めませんでした。これを閉じて、もう一度お試しくださ"
+"い。"
 
 # smartling.placeholder_format=C
 #. Pairs with a Retry button. Shown after two consecutive failed attempts to load the device list.
@@ -4974,6 +5183,12 @@ msgstr "画像を作成"
 msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr "画像を作成"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Create a shopping list with quantities from this recipe."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed in the input field when starting a new image generation session.
@@ -5237,7 +5452,8 @@ msgstr "1日の使用制限に達しました。このチャットは%1$s以降�
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "Daily usage limit reached. You can keep chatting by using your weekly limit."
-msgstr "1日の使用制限に達しました。週間制限時間を使ってチャットを続行できます。"
+msgstr ""
+"1日の使用制限に達しました。週間制限時間を使ってチャットを続行できます。"
 
 # smartling.placeholder_format=C
 #. The name of the Danish language
@@ -5495,7 +5711,8 @@ msgstr "ストレージを解放するために最も古いチャットを削除
 #. Title shown when user has reached the file storage sync quota (5GB).
 msgctxt "Sync file storage limit modal title"
 msgid "Delete oldest chats with attachments to free up storage?"
-msgstr "保存容量を空けるために添付ファイル付きの最も古いチャットを削除しますか？"
+msgstr ""
+"保存容量を空けるために添付ファイル付きの最も古いチャットを削除しますか？"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to delete all recent chats.
@@ -5604,7 +5821,9 @@ msgstr "Duck.aiの音声入力"
 # smartling.placeholder_format=C
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
-msgstr "音声入力は当社によって匿名化されており、AIモデルのトレーニングには使用されません。"
+msgstr ""
+"音声入力は当社によって匿名化されており、AIモデルのトレーニングには使用されま"
+"せん。"
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
@@ -5612,11 +5831,18 @@ msgid "Dictation limit reached"
 msgstr "音声入力予算の上限に達しました"
 
 # smartling.placeholder_format=C
+#. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
+msgid "Dictation temporarily unavailable"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
 "chat in Duck.ai without having to type."
-msgstr "音声入力はOpenAIのモデルを使って音声をテキストに変換し、タイピングせずにDuck.aiチャットができます。"
+msgstr ""
+"音声入力はOpenAIのモデルを使って音声をテキストに変換し、タイピングせずにDuck."
+"aiチャットができます。"
 
 # smartling.placeholder_format=C
 #. In 0-click box -- link to definition.
@@ -5884,13 +6110,15 @@ msgstr "DuckDuckGoがリストにありませんか？"
 #. Link to download a file again if the user can't find it on their computer.
 msgctxt "install-extension"
 msgid "Don't see it? %s%s%sClick here to re-download%s"
-msgstr "表示されませんか？ %1$s%2$s%3$s再度ダウンロードするにはここをクリック%4$s"
+msgstr ""
+"表示されませんか？ %1$s%2$s%3$s再度ダウンロードするにはここをクリック%4$s"
 
 #  IE < 11 default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Don't see the checkbox? %sFollow these steps%s."
-msgstr "チェックボックスが表示されない場合は、%1$s以下の手順に従ってください%2$s。"
+msgstr ""
+"チェックボックスが表示されない場合は、%1$s以下の手順に従ってください%2$s。"
 
 # smartling.placeholder_format=C
 #. Setting that hides a user's most visited sites when they open a new browser tab.
@@ -5908,6 +6136,22 @@ msgstr "完了"
 msgctxt "precise_user_location"
 msgid "Done"
 msgstr "完了"
+
+# smartling.placeholder_format=C
+#. Message shown in a modal after DuckDuckGo browser users disable AI features in Settings. The first two placeholders bold noai.duckduckgo.com. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
+"filtered out. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
+"and AI images filtered out. %sLearn more%s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6009,7 +6253,9 @@ msgctxt "Full sentence for writing an email"
 msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for "
 "ceiling fan repair services."
-msgstr "シーリングファンの修理サービスの見積もりを依頼するベンダーにメールを作成します。内容は、簡潔かつ詳細に入力してください。"
+msgstr ""
+"シーリングファンの修理サービスの見積もりを依頼するベンダーにメールを作成しま"
+"す。内容は、簡潔かつ詳細に入力してください。"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion asking for an email draft to a vendor requesting a quote for home refrigerator repair services.
@@ -6017,7 +6263,21 @@ msgctxt "Full sentence for writing an email"
 msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
-msgstr "家庭用冷蔵庫の修理サービスの見積もりを依頼する業者にメールを作成します。内容は、簡潔かつ詳細に入力してください。"
+msgstr ""
+"家庭用冷蔵庫の修理サービスの見積もりを依頼する業者にメールを作成します。内容"
+"は、簡潔かつ詳細に入力してください。"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Draft a cover letter"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Draft a cover letter for this job."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -6025,7 +6285,9 @@ msgctxt "Full sentence for drafting a social media post"
 msgid ""
 "Draft a few options for a social media post inviting people to my upcoming "
 "party."
-msgstr "今後のパーティーに人々を招待するソーシャルメディア投稿のオプションをいくつか作成してください。"
+msgstr ""
+"今後のパーティーに人々を招待するソーシャルメディア投稿のオプションをいくつか"
+"作成してください。"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a few options for a blog post title about strategies to increase team collaboration.
@@ -6033,7 +6295,9 @@ msgctxt "Full sentence for suggesting a blog post title"
 msgid ""
 "Draft a few options for a title of a post I’m writing about strategies to "
 "increase team collaboration."
-msgstr "チームコラボレーションを強化するための戦略について書いた投稿のタイトル案をいくつか作成してください。"
+msgstr ""
+"チームコラボレーションを強化するための戦略について書いた投稿のタイトル案をい"
+"くつか作成してください。"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for drafting a social media post.
@@ -6161,7 +6425,8 @@ msgid ""
 msgstr ""
 "Duck.aiは、現在表示しているページに関する質問に回答できるようになりました。\n"
 "\n"
-"設定でページを自動添付することを選択しない限り、ページコンテンツは添付したときにのみ含まれます。"
+"設定でページを自動添付することを選択しない限り、ページコンテンツは添付したと"
+"きにのみ含まれます。"
 
 # smartling.placeholder_format=C
 #. Shown in the Duck.ai recent chats list on standalone when the browser API needed to store chats locally is missing or unavailable.
@@ -6170,7 +6435,10 @@ msgctxt ""
 msgid ""
 "Duck.ai can’t access local storage to save your chats. Please check your "
 "browser settings or disable any extensions and try again."
-msgstr "Duck.aiはローカルストレージにアクセスできないため、チャットを保存できません。ブラウザの設定を確認するか、拡張機能を無効にしてから、もう一度お試しください。"
+msgstr ""
+"Duck.aiはローカルストレージにアクセスできないため、チャットを保存できません。"
+"ブラウザの設定を確認するか、拡張機能を無効にしてから、もう一度お試しくださ"
+"い。"
 
 # smartling.placeholder_format=C
 #. Displayed when the chat service has reached the maximum number of messages for one day.
@@ -6178,13 +6446,25 @@ msgctxt "Error message for service limit"
 msgid ""
 "Duck.ai has reached the maximum number of messages for one day. Please "
 "continue this chat tomorrow."
-msgstr "Duck.aiの1日のメッセージ数の上限に達しました。このチャットは明日続行してください。"
+msgstr ""
+"Duck.aiの1日のメッセージ数の上限に達しました。このチャットは明日続行してくだ"
+"さい。"
 
 # smartling.placeholder_format=C
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
-msgstr "Duck.aiのパワーはプライベートな無料ブラウザDuckDuckGoで最も発揮されます！"
+msgstr ""
+"Duck.aiのパワーはプライベートな無料ブラウザDuckDuckGoで最も発揮されます！"
+
+# smartling.placeholder_format=C
+#. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
+msgctxt "About section description on the Duck.ai settings page"
+msgid ""
+"Duck.ai is created by DuckDuckGo. We're an independent online protection "
+"company for anyone who wants to take back control of their personal "
+"information."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
@@ -6198,7 +6478,9 @@ msgctxt "duckai_migration"
 msgid ""
 "Duck.ai is still a DuckDuckGo product, but will now have an easier to "
 "remember home on the web: https://duck.ai"
-msgstr "Duck.aiは引き続きDuckDuckGoの製品ですが、今後はウェブ上のホームページが「https://duck.ai」と覚えやすくなります"
+msgstr ""
+"Duck.aiは引き続きDuckDuckGoの製品ですが、今後はウェブ上のホームページが"
+"「https://duck.ai」と覚えやすくなります"
 
 # smartling.placeholder_format=C
 #. Headline for domain change notice.
@@ -6212,14 +6494,18 @@ msgctxt "Error message for BOTNET limit."
 msgid ""
 "Duck.ai is temporarily unavailable. If this persists, please email this "
 "anonymous code %s to %s"
-msgstr "Duck.aiは一時的に利用できません。この問題が続く場合は、匿名コード「%1$s」を%2$s宛てにメールで送信してください"
+msgstr ""
+"Duck.aiは一時的に利用できません。この問題が続く場合は、匿名コード「%1$s」"
+"を%2$s宛てにメールで送信してください"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
 msgctxt "Error message for VQD error"
 msgid ""
 "Duck.ai is temporarily unavailable. Please refresh the page and try again."
-msgstr "Duck.aiは一時的に利用できません。ページを更新して、もう一度やり直してください。"
+msgstr ""
+"Duck.aiは一時的に利用できません。ページを更新して、もう一度やり直してくださ"
+"い。"
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -6230,15 +6516,23 @@ msgstr "Duck.aiは一時的に利用できません。時間を置いてもう�
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
+"Duck.ai lets you chat privately with popular AI models. Disabling it hides "
+"Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
+msgstr ""
+
+# smartling.placeholder_format=C
+msgctxt "settings"
+msgid ""
 "Duck.ai lets you have anonymous conversations with 3rd-party AI chat models, "
 "including models from OpenAI, Anthropic, and others. Turning this setting "
 "off will hide Duck.ai buttons and links on DuckDuckGo Search. However, you "
 "can still access Duck.ai when this setting is off by visiting %shttps://duck."
 "ai%s directly."
 msgstr ""
-""
-"Duck.aiを使用すると、OpenAIやAnthropicなどのサードパーティのAIチャットモデルと匿名で会話できます。この設定をオフにすると、DuckDuckGo検索上のDuck.aiのボタンやリンクが非表示になります。ただし、この設定がオフの状態でも、%1$shttps://duck.ai%2$s "
-"に直接アクセスすることでDuck.aiを利用できます。"
+"Duck.aiを使用すると、OpenAIやAnthropicなどのサードパーティのAIチャットモデル"
+"と匿名で会話できます。この設定をオフにすると、DuckDuckGo検索上のDuck.aiのボタ"
+"ンやリンクが非表示になります。ただし、この設定がオフの状態でも、%1$shttps://"
+"duck.ai%2$s に直接アクセスすることでDuck.aiを利用できます。"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
@@ -6252,7 +6546,9 @@ msgctxt "duckai_migration"
 msgid ""
 "Duck.ai might have lost your recent chats. You can still use Duck.ai as "
 "usual."
-msgstr "Duck.aiの最近のチャットが失われた可能性があります。Duck.aiはいつも通りに使用できます。"
+msgstr ""
+"Duck.aiの最近のチャットが失われた可能性があります。Duck.aiはいつも通りに使用"
+"できます。"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
@@ -6265,7 +6561,8 @@ msgstr "Duck.aiでPDFを読み、解析できるようになりました。ぜ�
 msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
-msgstr "Duck.aiの回答は特定の情報源に基づいておらず、正確性も確認されていません。"
+msgstr ""
+"Duck.aiの回答は特定の情報源に基づいておらず、正確性も確認されていません。"
 
 # smartling.placeholder_format=C
 #. Title shown when native app needs to reload for service update.
@@ -6283,7 +6580,8 @@ msgstr "Duck.aiがアップグレードしました！"
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
-msgstr "Duck.aiと最も相性の良いDuckDuckGoは、プライバシーを重視した無料のアプリです。"
+msgstr ""
+"Duck.aiと最も相性の良いDuckDuckGoは、プライバシーを重視した無料のアプリです。"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -6293,8 +6591,9 @@ msgid ""
 "AI chat no sign up, OpenAI, Anthropic, Llama, Mistral, open source AI "
 "models, privacy focused AI, no account AI chat"
 msgstr ""
-"Duck.ai、DuckDuckGo "
-"AI、プライベートAIチャットボット、無料AIチャット、匿名AIチャット、サインアップ不要AIチャット、OpenAI、Anthropic、Llama、Mistral、オープンソースAIモデル、プライバシー重視AI、アカウント不要AIチャット"
+"Duck.ai、DuckDuckGo AI、プライベートAIチャットボット、無料AIチャット、匿名AI"
+"チャット、サインアップ不要AIチャット、OpenAI、Anthropic、Llama、Mistral、オー"
+"プンソースAIモデル、プライバシー重視AI、アカウント不要AIチャット"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -6322,9 +6621,11 @@ msgid ""
 "relevant), or Often (shows more frequently on a wider range of searches). "
 "For now, DuckAssist is only available in the U.S. (English) region."
 msgstr ""
-"このツールを使用すると、一部の検索に対して情報を匿名で調べ、要約できます。DuckAssistの表示頻度は、なし（検索結果からDuckAssist "
-"UIを完全に削除）、オンデマンド（[アシスト] "
-"ボタンをクリックした場合にのみ表示）、時々（関連性の高い場合にのみ表示）、頻繁（広範な検索でより頻繁に表示）から選択できます。現時点では、米国（英語）地域でのみ利用可能です。"
+"このツールを使用すると、一部の検索に対して情報を匿名で調べ、要約できます。"
+"DuckAssistの表示頻度は、なし（検索結果からDuckAssist UIを完全に削除）、オンデ"
+"マンド（[アシスト] ボタンをクリックした場合にのみ表示）、時々（関連性の高い場"
+"合にのみ表示）、頻繁（広範な検索でより頻繁に表示）から選択できます。現時点で"
+"は、米国（英語）地域でのみ利用可能です。"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6333,9 +6634,9 @@ msgid ""
 "%sDuckDuckGo AI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI, and Anthropic, and more."
 msgstr ""
-""
-"DuckAssistは追加の質問には回答できません。ただし、OpenAI、Anthropic、その他からチャットモデルをサポートするプライベートAI搭載チャットサービス、%1$sDuckDuckGo "
-"AI Chat%2$sもご利用いただけます。"
+"DuckAssistは追加の質問には回答できません。ただし、OpenAI、Anthropic、その他か"
+"らチャットモデルをサポートするプライベートAI搭載チャットサービ"
+"ス、%1$sDuckDuckGo AI Chat%2$sもご利用いただけます。"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6344,8 +6645,8 @@ msgid ""
 "DuckDuckGo %sAI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI and Anthropic."
 msgstr ""
-""
-"DuckAssistは追加の質問には回答できません。ただし、OpenAIとAnthropicのチャットモデルをサポートするプライベートAI搭載チャットサービス、DuckDuckGo%1$sAI "
+"DuckAssistは追加の質問には回答できません。ただし、OpenAIとAnthropicのチャット"
+"モデルをサポートするプライベートAI搭載チャットサービス、DuckDuckGo%1$sAI "
 "Chat%2$sもご利用いただけます。"
 
 # smartling.placeholder_format=C
@@ -6358,9 +6659,11 @@ msgid ""
 "responses are currently based on Wikipedia and related content and are not "
 "checked for accuracy."
 msgstr ""
-"DuckAssistは、検索クエリに対する回答を匿名で生成できる新しい検索機能です。 "
-"これを実現するために、Wikipediaや関連サイトをスキャンして関連コンテンツを探し、AIを活用した自然言語技術を使用して情報の要約を生成します。 "
-"現時点での回答はWikipediaおよび関連コンテンツに基づいており、正確性は確認されていないことにご注意ください。"
+"DuckAssistは、検索クエリに対する回答を匿名で生成できる新しい検索機能です。 こ"
+"れを実現するために、Wikipediaや関連サイトをスキャンして関連コンテンツを探し、"
+"AIを活用した自然言語技術を使用して情報の要約を生成します。 現時点での回答は"
+"Wikipediaおよび関連コンテンツに基づいており、正確性は確認されていないことにご"
+"注意ください。"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6374,15 +6677,22 @@ msgid ""
 "It’s important to remember that responses are auto-generated from cited "
 "sources and based on %scrawling the web%s."
 msgstr ""
-"DuckAssistは、検索クエリに対する回答を匿名で生成できる、検索結果のオプション機能です。この機能は、ウェブをスキャンして関連コンテンツを探し、AI "
-"を活用した自然言語技術で見つかった関連情報に基づき、簡単な回答を生成します。DuckAssistの回答は、常に1つか2つの情報源に直接リンクして回答元を引用しています。そのため、より詳細な情報を簡単に取得することができます。回答は引用元から自動生成され、%1$sウェブのクロール%2$sに基づいて自動生成されることを覚えておくことが重要です。"
+"DuckAssistは、検索クエリに対する回答を匿名で生成できる、検索結果のオプション"
+"機能です。この機能は、ウェブをスキャンして関連コンテンツを探し、AI を活用した"
+"自然言語技術で見つかった関連情報に基づき、簡単な回答を生成します。DuckAssist"
+"の回答は、常に1つか2つの情報源に直接リンクして回答元を引用しています。そのた"
+"め、より詳細な情報を簡単に取得することができます。回答は引用元から自動生成さ"
+"れ、%1$sウェブのクロール%2$sに基づいて自動生成されることを覚えておくことが重"
+"要です。"
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid ""
 "DuckAssist responses are auto-generated based on listed sources and not "
 "checked for accuracy."
-msgstr "DuckAssistの回答は記載されている情報源に基づいて自動生成され、正確性は確認されません。"
+msgstr ""
+"DuckAssistの回答は記載されている情報源に基づいて自動生成され、正確性は確認さ"
+"れません。"
 
 # smartling.placeholder_format=C
 #. Displayed when the chat service has reached the maximum number of messages for one day.
@@ -6390,7 +6700,9 @@ msgctxt "Error message for service limit"
 msgid ""
 "DuckDuckGo AI Chat has reached the maximum number of messages for one day. "
 "Please continue this chat tomorrow."
-msgstr "DuckDuckGo AI Chatの1日のメッセージ数の上限に達しました。このチャットは明日続行してください。"
+msgstr ""
+"DuckDuckGo AI Chatの1日のメッセージ数の上限に達しました。このチャットは明日続"
+"行してください。"
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the AI chat service and supported AI models. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -6399,8 +6711,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"DuckDuckGo AI "
-"Chatは、現在%1$sの%2$sと%3$sの%4$sチャットモデルをサポートしているプライベートAI搭載のチャットサービスです。"
+"DuckDuckGo AI Chatは、現在%1$sの%2$sと%3$sの%4$sチャットモデルをサポートして"
+"いるプライベートAI搭載のチャットサービスです。"
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the welcome screen of the onboarding. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -6409,8 +6721,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"DuckDuckGo AI "
-"Chatは、現在%1$sの%2$sと%3$sの%4$sチャットモデルをサポートしているプライベートAI搭載のチャットサービスです。"
+"DuckDuckGo AI Chatは、現在%1$sの%2$sと%3$sの%4$sチャットモデルをサポートして"
+"いるプライベートAI搭載のチャットサービスです。"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding DuckDuckGo AI Chat.
@@ -6418,7 +6730,9 @@ msgctxt "Disclaimer text at the bottom of the feedback form."
 msgid ""
 "DuckDuckGo AI Chat is in Beta, it may display inaccurate or offensive "
 "information."
-msgstr "DuckDuckGo AI Chatはベータ版であるため、不正確な情報や不快な情報が表示される可能性があります。"
+msgstr ""
+"DuckDuckGo AI Chatはベータ版であるため、不正確な情報や不快な情報が表示される"
+"可能性があります。"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat making it unavailable, and asking the user to send an email with a specific code if the error persists. E.g. 'DuckDuckGo AI Chat is temporarily unavailable. If this persists, please email this anonymous code abcdefg12345 to aichat-error@duckduckgo.com'
@@ -6426,7 +6740,9 @@ msgctxt "Error message for BOTNET limit."
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. If this persists, please "
 "email this anonymous code %s to %s"
-msgstr "DuckDuckGo AI Chatは一時的に利用できません。この問題が続く場合は、匿名コード「%1$s」を%2$s宛てにメールで送信してください"
+msgstr ""
+"DuckDuckGo AI Chatは一時的に利用できません。この問題が続く場合は、匿名コード"
+"「%1$s」を%2$s宛てにメールで送信してください"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -6434,13 +6750,17 @@ msgctxt "Error message for VQD error"
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. Please refresh the page and "
 "try again."
-msgstr "DuckDuckGo AI Chatは一時的に利用できません。 ページを更新して、もう一度やり直してください。"
+msgstr ""
+"DuckDuckGo AI Chatは一時的に利用できません。 ページを更新して、もう一度やり直"
+"してください。"
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr "DuckDuckGo AI Chatは一時的に利用できません。 時間を置いてもう一度お試しください。"
+msgstr ""
+"DuckDuckGo AI Chatは一時的に利用できません。 時間を置いてもう一度お試しくださ"
+"い。"
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -6558,14 +6878,18 @@ msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
 msgid ""
 "DuckDuckGo anonymizes these reports by automatically removing PII like "
 "names, email addresses, phone numbers, and identifying metadata."
-msgstr "DuckDuckGoは、名前、メールアドレス、電話番号、識別メタデータなどのPIIを自動的に削除することで、これらのレポートを匿名化します。"
+msgstr ""
+"DuckDuckGoは、名前、メールアドレス、電話番号、識別メタデータなどのPIIを自動的"
+"に削除することで、これらのレポートを匿名化します。"
 
 # smartling.placeholder_format=C
 #. The first %s is the agree button label ('Agree'). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. The leading sentence mirrors the drawer-style inline disclaimer (DUCKCHAT_TOS_INLINE_DISCLAIMER).
 msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid ""
 "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to Duck.ai's %s."
-msgstr "DuckDuckGoはチャットを匿名化します。「%1$s」をクリックすると、Duck.aiの%2$sに同意したことになります。"
+msgstr ""
+"DuckDuckGoはチャットを匿名化します。「%1$s」をクリックすると、Duck.aiの%2$sに"
+"同意したことになります。"
 
 # smartling.placeholder_format=C
 #. Shown below the input on the empty state when the user has not yet accepted the terms of service. The first %s is the action button label ('Ask' for chat, 'Create' for image generation). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. Clicking the action button both accepts the terms and submits the prompt.
@@ -6573,7 +6897,9 @@ msgctxt ""
 "Inline terms-of-service disclaimer below chat or image-gen input for new "
 "users"
 msgid "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to our %s."
-msgstr "DuckDuckGoはチャットを匿名化します。「%1$s」をクリックすると、当社の%2$sに同意したことになります。"
+msgstr ""
+"DuckDuckGoはチャットを匿名化します。「%1$s」をクリックすると、当社の%2$sに同"
+"意したことになります。"
 
 # smartling.placeholder_format=C
 #. An information popup explaining that we block trackers
@@ -6581,7 +6907,9 @@ msgid ""
 "DuckDuckGo blocks trackers on websites you visit, including trackers from "
 "companies like Google and Facebook, who often try to track you on other "
 "websites."
-msgstr "DuckDuckGoでは、アクセスするウェブサイト上でGoogleやFacebookなどの企業による追跡行為を阻止することができます。"
+msgstr ""
+"DuckDuckGoでは、アクセスするウェブサイト上でGoogleやFacebookなどの企業による"
+"追跡行為を阻止することができます。"
 
 # smartling.placeholder_format=C
 #. Description of how DuckDuckGo keeps a user's location anonymous while the user searches on a map of their area.
@@ -6593,8 +6921,12 @@ msgid ""
 "away, such that you remain anonymous. %sLearn more about how we designed "
 "this technology to protect your privacy%s."
 msgstr ""
-"DuckDuckGo はプライバシーを保護するように設計されています。位置情報を使用する場合、ローカルデバイスだけに保存されます。DuckDuckGo "
-"は検索時にユーザーのデバイスから送信される位置情報を検索結果を向上するために使用します。位置情報は使用後にすぐ消去されるため、ユーザーは匿名性を保つことができます。%1$sお客様のプライバシーを保護するため、当社がどのようにこの技術を設計したかについては、こちらをご覧ください%2$s。"
+"DuckDuckGo はプライバシーを保護するように設計されています。位置情報を使用する"
+"場合、ローカルデバイスだけに保存されます。DuckDuckGo は検索時にユーザーのデバ"
+"イスから送信される位置情報を検索結果を向上するために使用します。位置情報は使"
+"用後にすぐ消去されるため、ユーザーは匿名性を保つことができます。%1$sお客様の"
+"プライバシーを保護するため、当社がどのようにこの技術を設計したかについては、"
+"こちらをご覧ください%2$s。"
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
@@ -6613,7 +6945,9 @@ msgctxt "settings"
 msgid ""
 "DuckDuckGo only uses your approximate location. That's all we need to "
 "deliver better results, closer to you. %sLearn more%s."
-msgstr "DuckDuckGo はおおよその位置情報のみを使用します。精度の高いローカル検索結果を表示するのに充分な情報です。%1$sさらに詳しく%2$s。"
+msgstr ""
+"DuckDuckGo はおおよその位置情報のみを使用します。精度の高いローカル検索結果を"
+"表示するのに充分な情報です。%1$sさらに詳しく%2$s。"
 
 # smartling.placeholder_format=C
 msgid "DuckDuckGo search"
@@ -6698,7 +7032,10 @@ msgid ""
 "random words from the DuckDuckGo servers. In the browser, we then select 4-5 "
 "random words from that list, ensuring that the passphrase is at least 18-20 "
 "characters long."
-msgstr "パスフレーズ候補を生成する度、DuckDuckGoサーバーからランダムな単語が多数記載されたリストを取得します。その後お使いのブラウザ内で、そのリストから最低18～20字のパスフレーズ候補として4、5個の単語が選ばれます。"
+msgstr ""
+"パスフレーズ候補を生成する度、DuckDuckGoサーバーからランダムな単語が多数記載"
+"されたリストを取得します。その後お使いのブラウザ内で、そのリストから最低18～"
+"20字のパスフレーズ候補として4、5個の単語が選ばれます。"
 
 # smartling.placeholder_format=C
 msgctxt "Sports module"
@@ -6762,7 +7099,8 @@ msgstr "画像を編集中..."
 msgctxt "Info text for the editing message feature"
 msgid ""
 "Editing your message will remove the response below and generate a new one."
-msgstr "メッセージを編集すると、以下の応答が削除され、新しい応答が生成されます。"
+msgstr ""
+"メッセージを編集すると、以下の応答が削除され、新しい応答が生成されます。"
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of an editor in its responses.
@@ -6893,7 +7231,9 @@ msgstr "ウェブ検索を有効にする"
 msgid ""
 "Enable anonymous location for more accurate results. You can always change "
 "your mind later."
-msgstr "検索結果の精度を高めるには、匿名の位置情報を有効にしてください。この設定は後でいつでも変更できます。"
+msgstr ""
+"検索結果の精度を高めるには、匿名の位置情報を有効にしてください。この設定は後"
+"でいつでも変更できます。"
 
 # smartling.placeholder_format=C
 #. Title of the dictation privacy consent modal shown on first use.
@@ -6935,7 +7275,9 @@ msgctxt "precise_user_location"
 msgid ""
 "Enabling anonymous location gives more accurate results but still keeps your "
 "searches and exact location private to DuckDuckGo."
-msgstr "「匿名の位置情報」機能を有効にすると、より正確な検索結果が得られるうえ、検索データと正確な位置情報もDuckDuckGoに対して非公開のままとなります。"
+msgstr ""
+"「匿名の位置情報」機能を有効にすると、より正確な検索結果が得られるうえ、検索"
+"データと正確な位置情報もDuckDuckGoに対して非公開のままとなります。"
 
 # smartling.placeholder_format=C
 msgid "Encrypt Connections"
@@ -7053,7 +7395,8 @@ msgstr "位置情報へのアクセスは必ず %1$s許可%2$s にします。"
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed %slocation access%s"
-msgstr "ブラウザによる%1$s位置情報へのアクセス%2$sが許可されていることを確認します"
+msgstr ""
+"ブラウザによる%1$s位置情報へのアクセス%2$sが許可されていることを確認します"
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service.
@@ -7096,7 +7439,9 @@ msgctxt "cloudsave"
 msgid ""
 "Enter a new passphrase and click/tap %sSave Settings%s. This will save your "
 "data under your new passphrase."
-msgstr "新しいパスフレーズを入力し、%1$s設定を保存%2$sをクリックまたはタップしてください。データが新しいパスフレーズで保存されます。"
+msgstr ""
+"新しいパスフレーズを入力し、%1$s設定を保存%2$sをクリックまたはタップしてくだ"
+"さい。データが新しいパスフレーズで保存されます。"
 
 # smartling.placeholder_format=C
 #. Label for the field where a user enters their passphrase.
@@ -7121,7 +7466,9 @@ msgstr "テキストを入力"
 #. Instructions for how to change the default search engine.
 msgid ""
 "Enter the following details: %sName%s: DuckDuckGo%s URL%s: %s Alias%s: d%s"
-msgstr "以下の詳細を入力してください: %1$s名前%2$s: DuckDuckGo%3$s URL%4$s: %5$s エイリアス%6$s: d%7$s"
+msgstr ""
+"以下の詳細を入力してください: %1$s名前%2$s: DuckDuckGo%3$s URL%4$s: %5$s エイ"
+"リアス%6$s: d%7$s"
 
 # smartling.placeholder_format=C
 #. Prompt to enter a destination for driving directions.
@@ -7160,6 +7507,18 @@ msgstr "%1$sFire Button%2$sを使用して閲覧データを瞬時に消去"
 # smartling.placeholder_format=C
 msgid "Eritrea"
 msgstr "エリトリア"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Estimate the nutrition"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Estimate the nutritional information for this recipe."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Estonia"
@@ -7216,11 +7575,59 @@ msgid "Expires in 1 day"
 msgstr "期限まであと1日"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain the accepted answer in simple terms."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
 msgstr "ブラックホールの基本的な概念を高校レベルで説明してください。"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain the top answer"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this in simple, plain language."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this paper"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this repo"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this research paper in plain language."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this simply"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain what this repository does and how to use it."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label to show if song lyrics contain explicit content
@@ -7397,7 +7804,9 @@ msgstr "フィードバックが送信されました"
 msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and improvements."
-msgstr "お寄せくださったフィードバックを私たちの製品の更新と改善に直接活用していきます。"
+msgstr ""
+"お寄せくださったフィードバックを私たちの製品の更新と改善に直接活用していきま"
+"す。"
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -7405,14 +7814,19 @@ msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and "
 "improvements. Hopefully we can address the issue you shared too."
-msgstr "お客様からいただいたフィードバックは、当社の製品のアップデートと改善に活用させていただきます。また、ご指摘についても真摯に受け止め、誠意を持って取り組んで参ります。"
+msgstr ""
+"お客様からいただいたフィードバックは、当社の製品のアップデートと改善に活用さ"
+"せていただきます。また、ご指摘についても真摯に受け止め、誠意を持って取り組ん"
+"で参ります。"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box
 msgid ""
 "Feel free to adjust the settings below. Then, just copy and paste the code "
 "into your website."
-msgstr "以下から自由に設定できます。設定後のコードをあなたのウェブサイトにコピー＆ペーストしてください。"
+msgstr ""
+"以下から自由に設定できます。設定後のコードをあなたのウェブサイトにコピー＆"
+"ペーストしてください。"
 
 # smartling.placeholder_format=C
 msgid "Fiji"
@@ -7498,6 +7912,12 @@ msgid ""
 msgstr "画像の検索結果からAIで生成されたものを除外します。%1$s詳細情報%2$s"
 
 # smartling.placeholder_format=C
+msgctxt "settings"
+msgid ""
+"Filters out known AI spam sites from image search results. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the final score of a sporting event.
 msgid "Final"
 msgstr "最終版"
@@ -7524,7 +7944,8 @@ msgstr "金融アドバイザー"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Find %sDuckDuckGo%s and click%sMake default%s"
-msgstr "%1$sDuckDuckGo%2$sを検索し、%3$sデフォルトに設定 %4$sをクリックしてください"
+msgstr ""
+"%1$sDuckDuckGo%2$sを検索し、%3$sデフォルトに設定 %4$sをクリックしてください"
 
 # smartling.placeholder_format=C
 #. Sentence shown after export, includes a placeholder for one or more filenames with bold formatting for the filename(s).
@@ -7536,7 +7957,9 @@ msgstr "ダウンロードフォルダで<b>%1$s</b>を表示"
 # smartling.placeholder_format=C
 #. Tells users how to change their default search engine to DuckDuckGo.
 msgid "Find DuckDuckGo in the displayed list and click %sMake Default%s"
-msgstr "表示されたリストからDuckDuckGoを探し、%1$sデフォルトに設定%2$sをクリックします"
+msgstr ""
+"表示されたリストからDuckDuckGoを探し、%1$sデフォルトに設定%2$sをクリックしま"
+"す"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for finding a better word.
@@ -7549,6 +7972,12 @@ msgstr "より良い言葉を見つける"
 msgctxt "Subtitle for the Web Search tool entry in the Tools dropdown menu"
 msgid "Find current information"
 msgstr "最新情報を検索"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Find me alternatives"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button that searches for results closer to the user's current location.
@@ -7567,7 +7996,9 @@ msgstr "あなたにとって最も的確な結果を見つけます。"
 msgctxt "Precise user location overlay"
 msgid ""
 "Find results near you. %sYour location stays private, secure, and anonymous."
-msgstr "お近くの結果を検索します。%1$s位置情報は非公開、安全、匿名のまま保持されます。"
+msgstr ""
+"お近くの結果を検索します。%1$s位置情報は非公開、安全、匿名のまま保持されま"
+"す。"
 
 # smartling.placeholder_format=C
 #. Loading message shown while generating explore more follow-up questions
@@ -7630,7 +8061,9 @@ msgstr "霧"
 msgid ""
 "Follow the instructions for turning off the ad blocker for DuckDuckGo. You "
 "may have to select a menu option or click a button."
-msgstr "DuckDuckGoの広告ブロッカーをオフにする手順に沿ってお進みください。メニューオプションを選択したり、ボタンをクリックする必要がある場合があります。"
+msgstr ""
+"DuckDuckGoの広告ブロッカーをオフにする手順に沿ってお進みください。メニューオ"
+"プションを選択したり、ボタンをクリックする必要がある場合があります。"
 
 # smartling.placeholder_format=C
 #. Privacy reassurance and instructions intro.
@@ -7771,7 +8204,9 @@ msgstr "営利目的で共有、使用が可能"
 #. Description text explaining how to free up sync storage. Pinned chats are chats the user has explicitly marked to keep.
 msgctxt "Sync limit modal description"
 msgid "Free up space by deleting your chats. Pinned chats will not be deleted."
-msgstr "チャットを削除して容量を空けましょう。ピン留めされたチャットは削除されません。"
+msgstr ""
+"チャットを削除して容量を空けましょう。ピン留めされたチャットは削除されませ"
+"ん。"
 
 # smartling.placeholder_format=C
 #. Indicates that this streaming service is free to watch but shows ads
@@ -7852,8 +8287,9 @@ msgid ""
 "<strong>Check for Updates...</strong>, then select <strong>Install Update</"
 "strong>."
 msgstr ""
-"Macのアプリメニューバーから <strong>[DuckDuckGo]</strong> &gt; "
-"<strong>[アップデートを確認...]</strong>、次に<strong>[アップデートをインストール]</strong> を選択します。"
+"Macのアプリメニューバーから <strong>[DuckDuckGo]</strong> &gt; <strong>[アッ"
+"プデートを確認...]</strong>、次に<strong>[アップデートをインストール]</"
+"strong> を選択します。"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -8021,6 +8457,12 @@ msgid "Generate More"
 msgstr "もっと生成する"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Generate a shopping list"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
 msgid "Generate a short answer from the web"
 msgstr "Webから短い回答を生成します"
@@ -8183,7 +8625,9 @@ msgstr "開始"
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the Privacy Pro subscription.
 msgctxt "SERP footer content"
 msgid "Get a VPN + two more protections in one easy subscription."
-msgstr "VPN1件と追加の保護対策2つを組み合わせた手軽なサブスクリプションはいかがですか。"
+msgstr ""
+"VPN1件と追加の保護対策2つを組み合わせた手軽なサブスクリプションはいかがです"
+"か。"
 
 # smartling.placeholder_format=C
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
@@ -8197,7 +8641,9 @@ msgctxt "Description of the modal to upgrade the DuckDuckGo subscription"
 msgid ""
 "Get access to advanced AI models in Duck.ai by subscribing to DuckDuckGo, "
 "which also includes our VPN and other premium privacy protections."
-msgstr "DuckDuckGoに加入すると、Duck.aiで高度なAIモデルをご利用いただけます。これには、VPNやその他のプレミアムなプライバシー保護も含まれています。"
+msgstr ""
+"DuckDuckGoに加入すると、Duck.aiで高度なAIモデルをご利用いただけます。これに"
+"は、VPNやその他のプレミアムなプライバシー保護も含まれています。"
 
 # smartling.placeholder_format=C
 #. Description for the subscription setting where users can subscribe to DuckDuckGo.
@@ -8207,7 +8653,9 @@ msgctxt ""
 msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
-msgstr "DuckDuckGoのサブスクリプションでDuck.aiの高度なAIモデルにアクセスできます。VPNやその他のプレミアムなプライバシー保護機能も含まれています。"
+msgstr ""
+"DuckDuckGoのサブスクリプションでDuck.aiの高度なAIモデルにアクセスできます。"
+"VPNやその他のプレミアムなプライバシー保護機能も含まれています。"
 
 # smartling.placeholder_format=C
 #. A button for users to generate an AI generated answer from their query on the duckassist module
@@ -8241,7 +8689,9 @@ msgstr "当社のブラウザを使用すれば、設定が失われることは
 # smartling.placeholder_format=C
 msgid ""
 "Get seamless privacy protection on your browser for free with one download:"
-msgstr "ブラウザの個人情報をシームレスに保護する無料ツールをワンクリックでダウンロード："
+msgstr ""
+"ブラウザの個人情報をシームレスに保護する無料ツールをワンクリックでダウンロー"
+"ド："
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo app when clicked
@@ -8306,10 +8756,17 @@ msgid "Give it a Try"
 msgstr "試してみる"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Give me a quick background on this person."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
-msgstr "%1$s[プライバシーとセキュリティ] > [位置情報サービス]%2$sの順に移動します"
+msgstr ""
+"%1$s[プライバシーとセキュリティ] > [位置情報サービス]%2$sの順に移動します"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -8318,8 +8775,8 @@ msgid ""
 "Go to %sSettings > Privacy & Security > Location Services%s, and make sure "
 "“Location Services” is turned on."
 msgstr ""
-"%1$s [設定] > [プライバシーとセキュリティ] > [位置情報サービス] %2$sに移動し、[位置情報サービス] "
-"がオンになっていることを確認します。"
+"%1$s [設定] > [プライバシーとセキュリティ] > [位置情報サービス] %2$sに移動"
+"し、[位置情報サービス] がオンになっていることを確認します。"
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -8328,8 +8785,8 @@ msgid ""
 "Go to %sSettings > Privacy > Permission manager > Location%s and scroll down "
 "to %sDuckDuckGo%s."
 msgstr ""
-"%1$s[設定] > [プライバシー] > [権限マネージャ] > [位置情報]%2$s に移動し、[DuckDuckGo] "
-"まで下にスクロールします。%3$s%4$s"
+"%1$s[設定] > [プライバシー] > [権限マネージャ] > [位置情報]%2$s に移動し、"
+"[DuckDuckGo] まで下にスクロールします。%3$s%4$s"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -8752,6 +9209,18 @@ msgid "Help Spread Privacy"
 msgstr "みんなに広める"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Help me prep for the interview"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Help me tailor my resume for this job."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title of a SERP popup that invites users to take a survey (desktop only)
 msgctxt "User survey popup"
 msgid "Help us improve DuckDuckGo"
@@ -8987,7 +9456,8 @@ msgctxt "settings"
 msgid ""
 "Highlights key facts in Search Assist answers to help you find important "
 "information faster."
-msgstr "Search Assistの回答で重要な事実を強調表示し、重要な情報を見つけやすくします。"
+msgstr ""
+"Search Assistの回答で重要な事実を強調表示し、重要な情報を見つけやすくします。"
 
 # smartling.placeholder_format=C
 #. The name of the Hindi language
@@ -9014,8 +9484,8 @@ msgid ""
 "Hit %sReturn%s on your keyboard to %ssave DuckDuckGo to the list. %sThen "
 "click %sMake Default%s"
 msgstr ""
-"キーボードの %1$s戻る%2$s "
-"キーを押して、%3$sDuckDuckGoをリストに保存します。%4$sそして、%5$sデフォルトに設定%6$sをクリックします"
+"キーボードの %1$s戻る%2$s キーを押して、%3$sDuckDuckGoをリストに保存しま"
+"す。%4$sそして、%5$sデフォルトに設定%6$sをクリックします"
 
 # smartling.placeholder_format=C
 #. The name of the Hmong Daw language
@@ -9028,7 +9498,9 @@ msgstr "ミャオ語"
 msgid ""
 "Hold on! Changing it back will disable the DuckDuckGo extension and you'll "
 "lose our privacy protection."
-msgstr "ご注意ください！元の設定に戻すとDuckDuckGoの拡張機能が無効になり、プライバシーが保護されなくなります。"
+msgstr ""
+"ご注意ください！元の設定に戻すとDuckDuckGoの拡張機能が無効になり、プライバ"
+"シーが保護されなくなります。"
 
 # smartling.placeholder_format=C
 #. Heading shown above warning messages in the AI chat, for non-critical issues like unsupported file formats or file size limits. Analogous to 'Oops...' for error messages.
@@ -9077,7 +9549,9 @@ msgstr "猛暑"
 msgid ""
 "Hotel ad clicks are managed by Tripadvisor’s ad network and are not used to "
 "profile you."
-msgstr "ホテルの広告クリックはTripadvisorの広告ネットワークによって管理され、お客様のプロファイリングには使用されません。"
+msgstr ""
+"ホテルの広告クリックはTripadvisorの広告ネットワークによって管理され、お客様の"
+"プロファイリングには使用されません。"
 
 # smartling.placeholder_format=C
 #. Refers to hours of operation for a business.
@@ -9259,6 +9733,14 @@ msgid "I Agree"
 msgstr "同意"
 
 # smartling.placeholder_format=C
+#. Text for the button that takes the user to the external DuckDuckGo login subscription page.
+msgctxt ""
+"Text for the I already have a subscription button in the Duck.ai settings "
+"page"
+msgid "I Already Have a Subscription"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for the button that takes the user to the login subscription page.
 msgctxt "Text for the I have a subscription button"
 msgid "I Have a Subscription"
@@ -9331,7 +9813,9 @@ msgctxt "Full sentence for recommending a book"
 msgid ""
 "I like the book Name of the Wind. What are some other good books/series most "
 "like it and why?"
-msgstr "私は「風の名前」という本が好きです。 これに最も似ている他の良い本やシリーズはどんなものですか、またその理由は何ですか？"
+msgstr ""
+"私は「風の名前」という本が好きです。 これに最も似ている他の良い本やシリーズは"
+"どんなものですか、またその理由は何ですか？"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the user needs more help or information on how to use the chat.
@@ -9366,8 +9850,8 @@ msgid ""
 "If the browser location remains unavailable, then go to %sSettings > General "
 "> Reset > 'Reset Location & Privacy'%s."
 msgstr ""
-"それでもブラウザの位置情報を利用できない場合は、%1$s[設定] > [一般] > [リセット] > [位置情報とプライバシー設定をリセット]%2$s "
-"の順に移動します。"
+"それでもブラウザの位置情報を利用できない場合は、%1$s[設定] > [一般] > [リセッ"
+"ト] > [位置情報とプライバシー設定をリセット]%2$s の順に移動します。"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -9377,8 +9861,9 @@ msgid ""
 "> Menu > Settings > Site settings > Location%s, and ensure DuckDuckGo is "
 "allowed location access."
 msgstr ""
-"それでもブラウザの位置情報を使用できない場合は、ブラウザで、%1$s「⋮」マーク > [メニュー] > [設定] > [サイト設定] > "
-"[位置情報]%2$s の順に移動し、DuckDuckGo に位置情報へのアクセスを許可しているか確認します。"
+"それでもブラウザの位置情報を使用できない場合は、ブラウザで、%1$s「⋮」マーク "
+"> [メニュー] > [設定] > [サイト設定] > [位置情報]%2$s の順に移動し、"
+"DuckDuckGo に位置情報へのアクセスを許可しているか確認します。"
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -9392,7 +9877,9 @@ msgstr "このエラーが続く場合は、%1$sに連絡してください。"
 msgid ""
 "If you don't see %sDuckDuckGo,%s you will need to add it to the list of "
 "%sOther Search Engines%s"
-msgstr "%1$sDuckDuckGo が表示されない場合、%2$s %3$sほかの検索エンジン%4$s リストに追加する必要があります"
+msgstr ""
+"%1$sDuckDuckGo が表示されない場合、%2$s %3$sほかの検索エンジン%4$s リストに追"
+"加する必要があります"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding the AI model providers and links to their support pages. Example: 'If you have concerns about our chat providers or any particular chat response, you can also reach out directly to OpenAI and Anthropic support pages.'
@@ -9401,8 +9888,8 @@ msgid ""
 "If you have concerns about our chat providers or any particular chat "
 "response, you can also reach out directly to %s and %s support pages."
 msgstr ""
-"チャット "
-"プロバイダーまたは特定のチャット応答についてご不明な点がある場合は、%1$sおよび%2$sサポートページに直接お問い合わせいただくこともできます。"
+"チャット プロバイダーまたは特定のチャット応答についてご不明な点がある場合"
+"は、%1$sおよび%2$sサポートページに直接お問い合わせいただくこともできます。"
 
 # smartling.placeholder_format=C
 #. Body copy explaining what the recovery code is for and how it can be saved.
@@ -9410,13 +9897,18 @@ msgctxt "Body for the Sync & Backup recovery code screen"
 msgid ""
 "If you lose access to your devices, you will need this code to recover your "
 "saved chats. You can save this code to your device as a text file."
-msgstr "デバイスにアクセスできなくなった場合、保存されたチャットを回復するためにこのコードが必要になります。このコードはテキストファイルとしてデバイスに保存できます。"
+msgstr ""
+"デバイスにアクセスできなくなった場合、保存されたチャットを回復するためにこの"
+"コードが必要になります。このコードはテキストファイルとしてデバイスに保存でき"
+"ます。"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
-msgstr "もし、私たちをもっとサポートして頂けるなら、%1$sDuckDuckGoの普及にご協力ください%2$s"
+msgstr ""
+"もし、私たちをもっとサポートして頂けるなら、%1$sDuckDuckGoの普及にご協力くだ"
+"さい%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -9425,14 +9917,18 @@ msgstr "もし、私たちをもっとサポートして頂けるなら、%1$sDu
 msgid ""
 "If you want to use DuckDuckGo without JavaScript, please use our %s or %s "
 "versions."
-msgstr "Javascript 無しで DuckDuckGo をご利用の場合は、 %1$s、または%2$s バージョンをご利用ください。"
+msgstr ""
+"Javascript 無しで DuckDuckGo をご利用の場合は、 %1$s、または%2$s バージョンを"
+"ご利用ください。"
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "If you want, select Home Page next to New windows and New tabs (open with)."
-msgstr "ご希望であれば、新しいウィンドウと新しいタブの隣に開くホームページを選択してください。"
+msgstr ""
+"ご希望であれば、新しいウィンドウと新しいタブの隣に開くホームページを選択して"
+"ください。"
 
 # smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that adds an image to the AI chat message being composed.
@@ -9572,7 +10068,9 @@ msgctxt "settings"
 msgid ""
 "In some older browsers, it's necessary to redirect your clicks through our "
 "server to prevent search leakage. %sLearn more%s."
-msgstr "古いブラウザの一部では、検索漏れを防ぐため、当社のサーバーを経由してリダイレクトする必要があります。%1$sさらに詳しく%2$s。"
+msgstr ""
+"古いブラウザの一部では、検索漏れを防ぐため、当社のサーバーを経由してリダイレ"
+"クトする必要があります。%1$sさらに詳しく%2$s。"
 
 # smartling.placeholder_format=C
 #. Instructions accompanying DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE; tells the user where to use the code on a DuckDuckGo browser.
@@ -9582,7 +10080,9 @@ msgctxt ""
 msgid ""
 "In the DuckDuckGo browser, go to Settings › Sync & Backup, and then “Sync "
 "with another device”."
-msgstr "DuckDuckGoブラウザで、「設定」＞「Sync & Backup」に移動し、「別のデバイスと同期」を選択します。"
+msgstr ""
+"DuckDuckGoブラウザで、「設定」＞「Sync & Backup」に移動し、「別のデバイスと同"
+"期」を選択します。"
 
 #  SeaMonkey default search engine instruction
 # smartling.placeholder_format=C
@@ -9596,7 +10096,9 @@ msgctxt "cloudsave"
 msgid ""
 "In the interest of transparency, this data is not encrypted: You can see "
 "exactly what information we store."
-msgstr "情報透明性の観点から、このデータは暗号化されていません。つまり、DuckDuckGo に保存されている情報を正確に知ることができます。"
+msgstr ""
+"情報透明性の観点から、このデータは暗号化されていません。つまり、DuckDuckGo に"
+"保存されている情報を正確に知ることができます。"
 
 # smartling.placeholder_format=C
 msgid "In the menu at the top select %sTools%s > %sSettings%s"
@@ -9606,7 +10108,8 @@ msgstr "上部のメニューから%1$sツール%2$s > %3$s設定%4$sを選択"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "In the popup, check %sMake this my default search provider%s"
-msgstr "ポップアップ画面の、%1$s既定の検索エンジンに設定%2$s ボックスをオンにします"
+msgstr ""
+"ポップアップ画面の、%1$s既定の検索エンジンに設定%2$s ボックスをオンにします"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -9812,6 +10315,12 @@ msgid "Install Mac Browser"
 msgstr "Macブラウザをインストールする"
 
 # smartling.placeholder_format=C
+#. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
+msgctxt "settings"
+msgid "Install Now"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of a button to install the DuckDuckGo app
 msgctxt "Serp footer content"
 msgid "Install Our App"
@@ -9909,10 +10418,42 @@ msgid "Is deleted data really deleted?"
 msgstr "削除したデータは、本当に削除されているのですか？"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is it worth taking?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this place any good?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"Is this place any good? Summarize its reputation based on reviews and "
+"ratings."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "Is this video helpful?"
 msgstr "この動画は役に立ちましたか？"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this worth watching?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Is this worth watching? Give me a spoiler-free take."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -9962,7 +10503,11 @@ msgid ""
 "Items are ranked based on relevance to your search terms and are delivered "
 "through Microsoft's Ad Network. Clicks lead directly to merchant landing "
 "pages and unlike ads, DuckDuckGo is not compensated for these results."
-msgstr "アイテムは検索キーワードとの関連性に基づいてランク付けされ、Microsoftの広告ネットワークを通じて配信されます。クリック後はマーチャントのランディングページに移動し、広告とは異なり、DuckDuckGoがクリックされた結果に対して報酬を受け取ることはありません。"
+msgstr ""
+"アイテムは検索キーワードとの関連性に基づいてランク付けされ、Microsoftの広告"
+"ネットワークを通じて配信されます。クリック後はマーチャントのランディングペー"
+"ジに移動し、広告とは異なり、DuckDuckGoがクリックされた結果に対して報酬を受け"
+"取ることはありません。"
 
 # smartling.placeholder_format=C
 #. Text explaining why passphrases use a series of words instead of random numbers and letters.
@@ -9970,7 +10515,9 @@ msgctxt "cloudsave"
 msgid ""
 "It’s easier to remember 4-5 words than 10 random letters and numbers, and "
 "far more secure."
-msgstr "ランダムな文字や数字を10個覚えるよりは、単語を4～5つ覚える方が簡単な上、ずっと安全です。"
+msgstr ""
+"ランダムな文字や数字を10個覚えるよりは、単語を4～5つ覚える方が簡単な上、ずっ"
+"と安全です。"
 
 # smartling.placeholder_format=C
 msgid "Ivory Coast"
@@ -10517,6 +11064,12 @@ msgid "Links:"
 msgstr "リンク:"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "List the tools, materials, or prerequisites I need for this."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
 msgid "Listen"
 msgstr "聞いてください"
@@ -10923,6 +11476,12 @@ msgid "Manage blocked sites"
 msgstr "ブロックされたサイトを管理する"
 
 # smartling.placeholder_format=C
+#. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
+msgctxt "setting"
+msgid "Manage in Browser Settings"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to the site exclusion settings page
 msgctxt "Organic result context menu"
 msgid "Manage sites you've blocked"
@@ -11145,7 +11704,9 @@ msgstr "ミクロネシア"
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
 msgid ""
 "Microphone access was denied. Please allow microphone access and try again."
-msgstr "マイクへのアクセスが拒否されました。マイクアクセスを許可して、もう一度お試しください。"
+msgstr ""
+"マイクへのアクセスが拒否されました。マイクアクセスを許可して、もう一度お試し"
+"ください。"
 
 # smartling.placeholder_format=C
 #. The Microsoft brand name.
@@ -11892,7 +12453,11 @@ msgid ""
 "DuckDuckGo server after being sent, to help recover a chat if you lose your "
 "internet connection. Disabling chat history will delete pinned chats, and "
 "disable the temporary storage of new prompts and responses."
-msgstr "新しいプロンプトやレスポンスは暗号化され、送信後はDuckDuckGoサーバーに一時的に保存されます。これは、インターネット接続が途切れた場合のチャット復旧に役立ちます。チャット履歴を無効にすると、固定されたチャットが削除され、新しいプロンプトと応答の一時的な保存が無効になります。"
+msgstr ""
+"新しいプロンプトやレスポンスは暗号化され、送信後はDuckDuckGoサーバーに一時的"
+"に保存されます。これは、インターネット接続が途切れた場合のチャット復旧に役立"
+"ちます。チャット履歴を無効にすると、固定されたチャットが削除され、新しいプロ"
+"ンプトと応答の一時的な保存が無効になります。"
 
 # smartling.placeholder_format=C
 #. Question in a feedback form.
@@ -12201,7 +12766,8 @@ msgstr "結果が見つかりません。"
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the recording contains no audible speech.
 msgid "No speech detected. Please try again and speak into your microphone."
-msgstr "音声が検出されませんでした。再試行時には、マイクに向かって話してください。"
+msgstr ""
+"音声が検出されませんでした。再試行時には、マイクに向かって話してください。"
 
 # smartling.placeholder_format=C
 #. Button that dismisses a feedback form.
@@ -12707,7 +13273,9 @@ msgstr "オンデマンド"
 msgid ""
 "On Mac, %sClick Maxthon > Preferences%s, On Windows, %sClick the %s icon > "
 "Settings%s"
-msgstr "Macでは%1$sMaxthon > 環境設定%2$s、Windowsでは%3$s アイコン > 設定%4$sの順に%5$sクリックしてください"
+msgstr ""
+"Macでは%1$sMaxthon > 環境設定%2$s、Windowsでは%3$s アイコン > 設定%4$sの順"
+"に%5$sクリックしてください"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
@@ -12728,7 +13296,9 @@ msgctxt ""
 msgid ""
 "One of the files attached has more pages than we support. Please upload "
 "files with %s pages or fewer."
-msgstr "添付ファイルの1点がサポートページ数を超えています。%1$sページ以下のファイルをアップロードしてください。"
+msgstr ""
+"添付ファイルの1点がサポートページ数を超えています。%1$sページ以下のファイルを"
+"アップロードしてください。"
 
 # smartling.placeholder_format=C
 #. Response a user can select in a feedback form, indicating that they heard about DuckDuckGo in an online article.
@@ -12754,7 +13324,8 @@ msgctxt "cloudsave"
 msgid ""
 "Only the settings that you have changed. They are detailed on the %sURL "
 "Parameters%s page."
-msgstr "変更した設定のみ。これらの詳細は %1$sURLパラメータ%2$s のページにあります。"
+msgstr ""
+"変更した設定のみ。これらの詳細は %1$sURLパラメータ%2$s のページにあります。"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers only when the user clicks the Assist button.
@@ -12768,7 +13339,9 @@ msgctxt "translations_module"
 msgid ""
 "Oops! An unexpected error occurred while translating this text. Please try "
 "again later."
-msgstr "おっと！このテキストの翻訳中に予期しないエラーが発生しました。少し時間をおいてからもう一度試してください。"
+msgstr ""
+"おっと！このテキストの翻訳中に予期しないエラーが発生しました。少し時間をおい"
+"てからもう一度試してください。"
 
 # smartling.placeholder_format=C
 #. Title shown in a fatal error modal when Duck.ai fails to load.
@@ -13084,7 +13657,9 @@ msgctxt "homepage onboarding"
 msgid ""
 "Other search engines track your searches even when you’re in private "
 "browsing mode. We don’t track you &mdash; period."
-msgstr "他社の検索エンジンはあなたの検索をプライベートブラウジングでも追跡しています。私たちは追跡しません。"
+msgstr ""
+"他社の検索エンジンはあなたの検索をプライベートブラウジングでも追跡していま"
+"す。私たちは追跡しません。"
 
 # smartling.placeholder_format=C
 msgctxt "SERP footer content"
@@ -13096,14 +13671,18 @@ msgctxt "homepage onboarding"
 msgid ""
 "Our privacy policy is simple: we don’t collect or share any of your personal "
 "information."
-msgstr "私たちのプライバシーポリシーはシンプルです。ユーザーの個人情報は一切収集しません。"
+msgstr ""
+"私たちのプライバシーポリシーはシンプルです。ユーザーの個人情報は一切収集しま"
+"せん。"
 
 # smartling.placeholder_format=C
 msgid ""
 "Our private browser for mobile comes equipped with our search engine, "
 "tracker blocker, encryption enforcer, and more. Available on %siOS & "
 "Android%s."
-msgstr "当社のモバイル用プライベートブラウザには、検索エンジン、トラッカーブロック、強制暗号化機能などが備わっています。%1$siOSとAndroid%2$sに対応。"
+msgstr ""
+"当社のモバイル用プライベートブラウザには、検索エンジン、トラッカーブロック、"
+"強制暗号化機能などが備わっています。%1$siOSとAndroid%2$sに対応。"
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the information was out of date.
@@ -13355,7 +13934,9 @@ msgctxt "cloudsave"
 msgid ""
 "Passphrases cannot be recovered as we don't associate your IP address, "
 "browser fingerprint, or any other information with the file."
-msgstr "当社は、お客様のIPアドレスやブラウザ上の個人を特定できる情報、その他一切の情報をファイルに関連付けないため、パスフレーズを復元できません。"
+msgstr ""
+"当社は、お客様のIPアドレスやブラウザ上の個人を特定できる情報、その他一切の情"
+"報をファイルに関連付けないため、パスフレーズを復元できません。"
 
 # smartling.placeholder_format=C
 #. Label for the section of recent chats that were edited in the past 7 days.
@@ -13548,7 +14129,10 @@ msgid ""
 "assisted answers more likely to appear automatically and often yields better "
 "answers. To turn them off and hide the Assist button visit %sSearch "
 "Settings%s."
-msgstr "検索を質問として完全な文章で表現すると、AI支援の回答が自動的に表示される可能性と回答精度が高くなります。オフにしてAssistボタンを非表示にするには、%1$s検索設定%2$sにアクセスしてください。"
+msgstr ""
+"検索を質問として完全な文章で表現すると、AI支援の回答が自動的に表示される可能"
+"性と回答精度が高くなります。オフにしてAssistボタンを非表示にするには、%1$s検"
+"索設定%2$sにアクセスしてください。"
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -13557,8 +14141,9 @@ msgid ""
 "DuckAssist more likely to appear and often yields better answers. To adjust "
 "how this feature works, or to turn it off, visit %sDuckAssist Settings%s."
 msgstr ""
-"検索を質問として完全な文章で表現すると、DuckAssistが表示される可能性と回答精度が高くなります。 "
-"この機能の動作を調整したり、オフにするには、%1$sDuckAssist設定%2$sにアクセスしてください。"
+"検索を質問として完全な文章で表現すると、DuckAssistが表示される可能性と回答精"
+"度が高くなります。 この機能の動作を調整したり、オフにするには、%1$sDuckAssist"
+"設定%2$sにアクセスしてください。"
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -13567,7 +14152,10 @@ msgid ""
 "DuckAssist more likely to appear automatically and often yields better "
 "answers. To turn it off and hide the Assist button visit %sDuckAssist "
 "Settings%s."
-msgstr "検索を完全な質問文で表現すると、DuckAssistが自動的に表示される可能性と回答精度が高くなります。オフにしてAssistボタンを非表示にするには、%1$sDuckAssist設定%2$sにアクセスしてください。"
+msgstr ""
+"検索を完全な質問文で表現すると、DuckAssistが自動的に表示される可能性と回答精"
+"度が高くなります。オフにしてAssistボタンを非表示にするには、%1$sDuckAssist設"
+"定%2$sにアクセスしてください。"
 
 # smartling.placeholder_format=C
 #. Button that allows users to manually select a location on a map.
@@ -13599,7 +14187,8 @@ msgctxt "Body copy for the chat card in the How Duck.ai Works panel"
 msgid ""
 "Pick a popular AI to chat with, like GPT-5 mini, Claude Haiku 4.5, Mistral, "
 "etc."
-msgstr "GPT-5 mini、Claude Haiku 4.5、Mistralなど人気のAIからチャット相手を選びます。"
+msgstr ""
+"GPT-5 mini、Claude Haiku 4.5、Mistralなど人気のAIからチャット相手を選びます。"
 
 # smartling.placeholder_format=C
 #. Describes the ability to choose from popular AI models. Pairs with a chat-bubble pictogram.
@@ -13607,7 +14196,8 @@ msgctxt "Body copy for the chat card in the How Duck.ai Works panel"
 msgid ""
 "Pick a popular AI to chat with, like GPT-5 mini, Claude Haiku 4.5, "
 "Mistral, etc."
-msgstr "GPT-5 mini、Claude Haiku 4.5、Mistralなど人気のAIからチャット相手を選びます。"
+msgstr ""
+"GPT-5 mini、Claude Haiku 4.5、Mistralなど人気のAIからチャット相手を選びます。"
 
 # smartling.placeholder_format=C
 #. The description of the third party map app picker, shown on iOS when a user is given an option of which app to navigate to a destination with
@@ -13615,7 +14205,9 @@ msgctxt "Third party map app picker"
 msgid ""
 "Pick a service to navigate to your destination. External apps won’t come "
 "with DuckDuckGo protections."
-msgstr "目的地までの経路案内に使用するサービスを選択します。外部アプリにはDuckDuckGoの保護が付属しません。"
+msgstr ""
+"目的地までの経路案内に使用するサービスを選択します。外部アプリにはDuckDuckGo"
+"の保護が付属しません。"
 
 # smartling.placeholder_format=C
 #. Label for a list of problems on a feedback form.
@@ -13697,7 +14289,9 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this prompt was made by a "
 "human."
-msgstr "このプロンプトがボットにより行われていないことを確認するため、次のチャレンジを完了してください。"
+msgstr ""
+"このプロンプトがボットにより行われていないことを確認するため、次のチャレンジ"
+"を完了してください。"
 
 # smartling.placeholder_format=C
 #. Bot challenge explanation
@@ -13705,7 +14299,15 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this search was made by a "
 "human."
-msgstr "この検索がボットにより行われていないことを確認するため、次のチャレンジを完了してください。"
+msgstr ""
+"この検索がボットにより行われていないことを確認するため、次のチャレンジを完了"
+"してください。"
+
+# smartling.placeholder_format=C
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
+msgctxt "Feedback prompt"
+msgid "Please describe why the chat response is harmful or illegal. (optional)"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
@@ -13731,7 +14333,17 @@ msgctxt "Modal disclaimer text"
 msgid ""
 "Please note: starting a new chat with any model will delete your current "
 "chat session."
-msgstr "注：モデルとの新しいチャットを開始すると、現在のチャットセッションが削除されます。"
+msgstr ""
+"注：モデルとの新しいチャットを開始すると、現在のチャットセッションが削除され"
+"ます。"
+
+# smartling.placeholder_format=C
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
+msgctxt "Feedback prompt"
+msgid ""
+"Please paste your prompt and the problematic output (with any personal "
+"information removed) and describe why the content is harmful or illegal."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -13739,7 +14351,9 @@ msgctxt "Feedback prompt"
 msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is illegal or harmful."
-msgstr "プロンプトと問題のある出力（個人情報は削除）を貼り付け、コンテンツが違法または有害である理由を説明してください。"
+msgstr ""
+"プロンプトと問題のある出力（個人情報は削除）を貼り付け、コンテンツが違法また"
+"は有害である理由を説明してください。"
 
 # smartling.placeholder_format=C
 #. Title on a feedback form.
@@ -14197,6 +14811,12 @@ msgid "Privacy"
 msgstr "プライバシー"
 
 # smartling.placeholder_format=C
+#. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
+msgctxt "Section heading on the Duck.ai settings page"
+msgid "Privacy & Terms"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Privacy Blog"
 msgstr "ブログ"
 
@@ -14265,6 +14885,12 @@ msgstr "プライバシーポリシーと利用規約"
 msgctxt "Copy used to compose link in sentences"
 msgid "Privacy Policy and Terms of Service"
 msgstr "プライバシーポリシーおよび利用規約"
+
+# smartling.placeholder_format=C
+#. Text for a button that links to the terms of use and privacy policy page.
+msgctxt "Secondary button text in active privacy modal"
+msgid "Privacy Policy and Terms of Service"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title displayed on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
@@ -14438,7 +15064,9 @@ msgstr "確認する"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Prompt me to use my approximate location to get nearby results."
-msgstr "ローカル検索で利用する、おおよその位置情報の使用を許可するプロンプトを表示します。"
+msgstr ""
+"ローカル検索で利用する、おおよその位置情報の使用を許可するプロンプトを表示し"
+"ます。"
 
 # smartling.placeholder_format=C
 #. DuckDuckGo Email Protection removes trackers from emails
@@ -14480,7 +15108,9 @@ msgctxt "Full sentence for critiquing writing"
 msgid ""
 "Provide a few suggestions to make the following text more concise. [Insert "
 "your own text here.]"
-msgstr "次のテキストをより簡潔にするための提案をいくつか提供してください。 [ここに独自のテキストを挿入します。]"
+msgstr ""
+"次のテキストをより簡潔にするための提案をいくつか提供してください。 [ここに独"
+"自のテキストを挿入します。]"
 
 # smartling.placeholder_format=C
 #. In the context of a standings table for NHL (hockey), column title that abbreviates 'Total Points' (the total points of this team)
@@ -14716,7 +15346,9 @@ msgctxt "Description for recent chats feature"
 msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
-msgstr "最近のチャットは、DuckDuckGoサーバーなどのリモートサーバーでなく、お使いのデバイスにローカルで保存されます。"
+msgstr ""
+"最近のチャットは、DuckDuckGoサーバーなどのリモートサーバーでなく、お使いのデ"
+"バイスにローカルで保存されます。"
 
 # smartling.placeholder_format=C
 #. Text explaining that recent chats are stored locally on the user's device.
@@ -14724,7 +15356,9 @@ msgctxt "Description of where recent chats are stored"
 msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
-msgstr "最近のチャットは、DuckDuckGoサーバーなどのリモートサーバーでなく、お使いのデバイスにローカルで保存されます。"
+msgstr ""
+"最近のチャットは、DuckDuckGoサーバーなどのリモートサーバーでなく、お使いのデ"
+"バイスにローカルで保存されます。"
 
 # smartling.placeholder_format=C
 #. Text explaining how recent chats are stored locally on the user's device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection.
@@ -14733,7 +15367,10 @@ msgid ""
 "Recent chats are stored locally on your device. New prompts and responses "
 "are encrypted and temporarily stored on a DuckDuckGo server after being "
 "sent, to help recover a chat if you lose your internet connection."
-msgstr "最近のチャットはデバイスのローカルに保存されます。新しいプロンプトやレスポンスは暗号化され、送信後はDuckDuckGoサーバーに一時的に保存されます。これは、インターネット接続が途切れた場合のチャット復旧に役立ちます。"
+msgstr ""
+"最近のチャットはデバイスのローカルに保存されます。新しいプロンプトやレスポン"
+"スは暗号化され、送信後はDuckDuckGoサーバーに一時的に保存されます。これは、イ"
+"ンターネット接続が途切れた場合のチャット復旧に役立ちます。"
 
 # smartling.placeholder_format=C
 msgctxt "region filter"
@@ -14755,6 +15392,30 @@ msgstr "%1$s%2$s%3$sのレシピ"
 msgctxt "Brief for recommending a book"
 msgid "Recommend a book"
 msgstr "本を推薦する"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar books"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar books."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar movies or shows."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar titles"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
@@ -14826,7 +15487,9 @@ msgctxt "settings"
 msgid ""
 "Reduces extra space in and around results and reduces size of result title "
 "text"
-msgstr "結果の内部と周辺にある余分なスペースを減らし、結果のタイトルテキストのサイズを縮小します"
+msgstr ""
+"結果の内部と周辺にある余分なスペースを減らし、結果のタイトルテキストのサイズ"
+"を縮小します"
 
 # smartling.placeholder_format=C
 #. Label for the input field where users specify how they want to be referred to. Example: 'Refer to me as John'
@@ -14967,8 +15630,8 @@ msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
 msgstr ""
-"指示に従ってDuckDuckGoを再度読み込みするか、ブラウザの [Refresh（リフレッシュ）]、または [Reload（再読み込み）] "
-"ボタンをクリックします。"
+"指示に従ってDuckDuckGoを再度読み込みするか、ブラウザの [Refresh（リフレッ"
+"シュ）]、または [Reload（再読み込み）] ボタンをクリックします。"
 
 # smartling.placeholder_format=C
 #. checkbox label that allows the user to save the setting
@@ -15057,14 +15720,18 @@ msgctxt "settings"
 msgid ""
 "Removes the \"Ask\" button so answers appear automatically in response to "
 "relevant searches. Cached answers always display automatically."
-msgstr "「質問」ボタンを削除して、関連する検索に対して回答が自動的に表示されるようにします。キャッシュされた回答は常に自動的に表示されます。"
+msgstr ""
+"「質問」ボタンを削除して、関連する検索に対して回答が自動的に表示されるように"
+"します。キャッシュされた回答は常に自動的に表示されます。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Removes the \"Generate\" button so answers appear automatically in response "
 "to relevant searches. Cached answers always display automatically."
-msgstr "「生成」ボタンを削除して、関連する検索に対して回答が自動的に表示されるようにします。キャッシュされた回答は常に自動的に表示されます。"
+msgstr ""
+"「生成」ボタンを削除して、関連する検索に対して回答が自動的に表示されるように"
+"します。キャッシュされた回答は常に自動的に表示されます。"
 
 # smartling.placeholder_format=C
 #. Text for a button to rename a chat, as in it will allow the user to change the title of the chat.
@@ -15121,14 +15788,18 @@ msgid ""
 "Reports are anonymous and sent to DuckDuckGo to help improve our search "
 "service. Your anonymous feedback is also shared with %s to help improve "
 "their services."
-msgstr "レポートは匿名で、検索サービスの向上目的でDuckDuckGoに送信されます。お客様の匿名でのフィードバックはサービス改善に役立てるために%1$sとも共有されます。"
+msgstr ""
+"レポートは匿名で、検索サービスの向上目的でDuckDuckGoに送信されます。お客様の"
+"匿名でのフィードバックはサービス改善に役立てるために%1$sとも共有されます。"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "Reports sent to DuckDuckGo are anonymous. Please do not include any personal "
 "or identifying information in your feedback."
-msgstr "DuckDuckGoに送信される報告内容は、匿名です。フィードバックには、個人情報や個人を特定できる情報を含めないようお願いいたします。"
+msgstr ""
+"DuckDuckGoに送信される報告内容は、匿名です。フィードバックには、個人情報や個"
+"人を特定できる情報を含めないようお願いいたします。"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -15136,11 +15807,23 @@ msgid ""
 "Reports sent to DuckDuckGo include all of the text you've asked us to "
 "translate during this page load, and are anonymous. Please do not include "
 "any personal or identifying information in your feedback."
-msgstr "DuckDuckGoに送信されるレポートは、このページの読み込み中に翻訳を希望したすべてのテキストを含み、匿名になっています。フィードバックには、個人情報や個人を特定できる情報を含めないようお願いいたします。"
+msgstr ""
+"DuckDuckGoに送信されるレポートは、このページの読み込み中に翻訳を希望したすべ"
+"てのテキストを含み、匿名になっています。フィードバックには、個人情報や個人を"
+"特定できる情報を含めないようお願いいたします。"
 
 # smartling.placeholder_format=C
 msgid "Republic of Moldova"
 msgstr "モルドバ共和国"
+
+# smartling.placeholder_format=C
+#. Note indicating that sharing the conversation is mandatory when reporting harmful or illegal content. Rendered alongside the standard share label (DUCKCHAT_RESPONSE_FEEDBACK_SHARE_PROMPT_RESPONSE_LABEL), not replacing it.
+msgctxt ""
+"Note shown under the share-content switch label on the Duck.ai response "
+"feedback form when the user has selected Harmful or Illegal as the feedback "
+"reason"
+msgid "Required for harmful or illegal reports"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
@@ -15206,7 +15889,10 @@ msgid ""
 "Responses are for educational purposes only and are not intended as medical, "
 "legal, financial, investment, or other professional advice. AI-assisted "
 "answers are subject to our %sTerms of Service%s."
-msgstr "回答は教育的な目的のみであり、医療、法律、金融、投資、その他の専門的なアドバイスを意図したものではありません。AI支援回答は、当社の%1$s利用規約%2$sの対象です。"
+msgstr ""
+"回答は教育的な目的のみであり、医療、法律、金融、投資、その他の専門的なアドバ"
+"イスを意図したものではありません。AI支援回答は、当社の%1$s利用規約%2$sの対象"
+"です。"
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -15214,7 +15900,10 @@ msgid ""
 "Responses are for educational purposes only and are not intended as medical, "
 "legal, financial, investment, or other professional advice. DuckAssist is "
 "subject to our %sTerms of Service%s."
-msgstr "回答は教育的な目的のみであり、医療、法律、金融、投資、その他の専門的なアドバイスを意図したものではありません。DuckAssistは、当社の%1$s利用規約%2$sの対象になります。"
+msgstr ""
+"回答は教育的な目的のみであり、医療、法律、金融、投資、その他の専門的なアドバ"
+"イスを意図したものではありません。DuckAssistは、当社の%1$s利用規約%2$sの対象"
+"になります。"
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -15224,9 +15913,10 @@ msgid ""
 "generated based on web content and may contain inaccuracies. Search Assist "
 "is subject to our %sTerms of Service%s."
 msgstr ""
-""
-"回答は教育的な目的でのみ提供され、医療、法律、金融、投資、その他の専門的なアドバイスの提供を意図したものではありません。回答はウェブコンテンツに基づいて生成されているため、不正確な情報が含まれている可能性があります。Search "
-"Assistには、当社の%1$s利用規約%2$sが適用されます。"
+"回答は教育的な目的でのみ提供され、医療、法律、金融、投資、その他の専門的なア"
+"ドバイスの提供を意図したものではありません。回答はウェブコンテンツに基づいて"
+"生成されているため、不正確な情報が含まれている可能性があります。Search Assist"
+"には、当社の%1$s利用規約%2$sが適用されます。"
 
 # smartling.placeholder_format=C
 #. Label on the button for restoring all previous website data.
@@ -15368,6 +16058,12 @@ msgstr "評価"
 msgctxt "maps_places"
 msgid "Reviews"
 msgstr "評価"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Rewrite this recipe scaled for a different number of servings."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Romania"
@@ -15638,7 +16334,9 @@ msgctxt "Description for Chat History feature with Encrypted Storage option"
 msgid ""
 "Save up to 30 of your most recent chats locally on your device, with the "
 "option for more with Encrypted Storage."
-msgstr "最新のチャットを最大30件デバイス上にローカルに保存できます。暗号化ストレージを使用すれば、さらに多くのチャットを保存できます。"
+msgstr ""
+"最新のチャットを最大30件デバイス上にローカルに保存できます。暗号化ストレージ"
+"を使用すれば、さらに多くのチャットを保存できます。"
 
 # smartling.placeholder_format=C
 #. Short text for native DDG browser users explaining how Chat History stores up to 30 of their most recent chats locally on their device.
@@ -15651,7 +16349,9 @@ msgstr "最新のチャットを最大30件デバイスにローカルで保存�
 msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
-msgstr "エンドツーエンド暗号化を使用して、デバイス間でDuck.aiのチャットを保存しましょう。"
+msgstr ""
+"エンドツーエンド暗号化を使用して、デバイス間でDuck.aiのチャットを保存しましょ"
+"う。"
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -15780,7 +16480,9 @@ msgstr "下方向にスクロールし、%1$s詳細設定を表示%2$s をクリ
 msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)"
-msgstr "%1$sアドレスバーで検索%2$sが見つかるまで下方向にスクロールします。%3$s変更%4$s (または %5$s新たに追加%6$s) をクリックします"
+msgstr ""
+"%1$sアドレスバーで検索%2$sが見つかるまで下方向にスクロールします。%3$s変"
+"更%4$s (または %5$s新たに追加%6$s) をクリックします"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
@@ -15789,8 +16491,8 @@ msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)."
 msgstr ""
-"%1$sアドレスバーで検索%2$s が見つかるまで下方向にスクロールします。%3$s変更%4$s (または %5$s新たに追加%6$s) "
-"をクリックします。"
+"%1$sアドレスバーで検索%2$s が見つかるまで下方向にスクロールします。%3$s変"
+"更%4$s (または %5$s新たに追加%6$s) をクリックします。"
 
 # smartling.placeholder_format=C
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -15814,7 +16516,9 @@ msgstr "%1$sDuckDuckGo%2$sまで下にスクロールし、位置情報の使用
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down to the %sServices%s section and click %sAddress bar%s."
-msgstr "%1$sサービス%2$s セクションまで下方向にスクロールして、%3$sアドレスバー%4$s をクリックします。"
+msgstr ""
+"%1$sサービス%2$s セクションまで下方向にスクロールして、%3$sアドレスバー%4$s "
+"をクリックします。"
 
 # smartling.placeholder_format=C
 #. Rugby match stats
@@ -15862,17 +16566,20 @@ msgid ""
 "(on a wide range of searches). For now, Search Assist is only available in a "
 "subset of English speaking regions."
 msgstr ""
-"Search "
-""
-"Assistは検索クエリに対する回答を匿名で生成します。そのために、関連コンテンツをウェブでスキャンしてから、AIを使用して簡潔な回答を生成します。表示頻度は、「表示しない」、「要求時（Assistがクリックされたときのみ）」、「時々（関連性が高いとき）」、「頻繁（検索範囲が広いとき）」から選択できます。Search "
-"Assistは現時点で、英語圏の一部の地域でのみ利用可能です。"
+"Search Assistは検索クエリに対する回答を匿名で生成します。そのために、関連コン"
+"テンツをウェブでスキャンしてから、AIを使用して簡潔な回答を生成します。表示頻"
+"度は、「表示しない」、「要求時（Assistがクリックされたときのみ）」、「時々"
+"（関連性が高いとき）」、「頻繁（検索範囲が広いとき）」から選択できます。"
+"Search Assistは現時点で、英語圏の一部の地域でのみ利用可能です。"
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI) when the answer is not found and the answer is unsourced or with no sources
 msgid ""
 "Search Assist couldn't find enough reliable information to generate an "
 "answer for this question. Try another search."
-msgstr "Search Assistはこの質問の回答を生成するのに十分な信頼できる情報を見つけることができませんでした。別の検索をお試しください。"
+msgstr ""
+"Search Assistはこの質問の回答を生成するのに十分な信頼できる情報を見つけること"
+"ができませんでした。別の検索をお試しください。"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -15881,8 +16588,9 @@ msgid ""
 "search queries. To do this, it %sscans the web%s for relevant content and "
 "then uses AI to generate a brief answer based on information found."
 msgstr ""
-"Search "
-"Assistは、検索クエリに対する回答を匿名で生成するオプション機能です。これを行うには、%1$sウェブをスキャンして%2$s関連コンテンツを探し、見つかった情報に基づいてAIを使って簡潔な回答を生成します。"
+"Search Assistは、検索クエリに対する回答を匿名で生成するオプション機能です。こ"
+"れを行うには、%1$sウェブをスキャンして%2$s関連コンテンツを探し、見つかった情"
+"報に基づいてAIを使って簡潔な回答を生成します。"
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/search_box. top header
@@ -16002,7 +16710,9 @@ msgctxt "noresults"
 msgid ""
 "Search other sites with %s shortcuts: a search for ”!w ducks” will search "
 "for “ducks” directly on Wikipedia."
-msgstr "%1$sのショートカットで他のサイトを検索します：「!w ducks」を検索すると、Wikipediaで「ducks」を直接検索します。"
+msgstr ""
+"%1$sのショートカットで他のサイトを検索します：「!w ducks」を検索すると、"
+"Wikipediaで「ducks」を直接検索します。"
 
 # smartling.placeholder_format=C
 #. Placeholder text for the search form when no text has been entered
@@ -16020,7 +16730,10 @@ msgstr "プライベートに検索し、トラッカーをブロック"
 msgid ""
 "Search privately with our app or extension, add private web search to your "
 "favorite browser, or search directly at %sduckduckgo.com%s."
-msgstr "検索時のプライバシーが心配なあなたにぴったりのアプリ・拡張機能。お気に入りのブラウザにプライベート検索機能を追加するか、%1$sduckduckgo.com%2$sで直接検索できます。"
+msgstr ""
+"検索時のプライバシーが心配なあなたにぴったりのアプリ・拡張機能。お気に入りの"
+"ブラウザにプライベート検索機能を追加するか、%1$sduckduckgo.com%2$sで直接検索"
+"できます。"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/6LZAoqH.png
@@ -16039,8 +16752,10 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"検索設定は、非個人用のブラウザCookieおよびローカルストレージに保存されますが、設定をクラウド上のリモートサーバーに匿名で保存できるCloud "
-"Saveもご利用いただけます。クラウドには個人を特定できる情報は一切保存されず、パスフレーズがブラウザの外に送信されることもありません。"
+"検索設定は、非個人用のブラウザCookieおよびローカルストレージに保存されます"
+"が、設定をクラウド上のリモートサーバーに匿名で保存できるCloud Saveもご利用い"
+"ただけます。クラウドには個人を特定できる情報は一切保存されず、パスフレーズが"
+"ブラウザの外に送信されることもありません。"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -16136,7 +16851,9 @@ msgctxt "Description explaining how native users can enable sync"
 msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
-msgstr "エンドツーエンド暗号化で、ほぼ無制限のチャットを当社サーバーに安全に保存し、すべてのデバイスから簡単にアクセスできます。"
+msgstr ""
+"エンドツーエンド暗号化で、ほぼ無制限のチャットを当社サーバーに安全に保存し、"
+"すべてのデバイスから簡単にアクセスできます。"
 
 # smartling.placeholder_format=C
 #. Text explaining that the Encrypted Storage feature stores the user's chats encrypted on their device.
@@ -16144,7 +16861,9 @@ msgctxt "Description for encrypted storage feature"
 msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
-msgstr "エンドツーエンド暗号化で、ほぼ無制限のチャットを当社サーバーに安全に保存し、すべてのデバイスから簡単にアクセスできます。"
+msgstr ""
+"エンドツーエンド暗号化で、ほぼ無制限のチャットを当社サーバーに安全に保存し、"
+"すべてのデバイスから簡単にアクセスできます。"
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -16152,7 +16871,9 @@ msgctxt "Description explaining how native users can enable sync"
 msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your synced devices."
-msgstr "エンドツーエンド暗号化で、ほぼ無制限のチャットを当社サーバーに安全に保存し、すべての同期済みのデバイスから簡単にアクセスできます。"
+msgstr ""
+"エンドツーエンド暗号化で、ほぼ無制限のチャットを当社サーバーに安全に保存し、"
+"すべての同期済みのデバイスから簡単にアクセスできます。"
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -16160,7 +16881,9 @@ msgctxt "Description explaining how native users can enable sync"
 msgid ""
 "Securely store your chats on our server using end-to-end encryption, and "
 "access them from all your devices."
-msgstr "チャットはエンドツーエンド暗号化を使用して当社サーバーに安全に保存され、すべてのデバイスからアクセスできます。"
+msgstr ""
+"チャットはエンドツーエンド暗号化を使用して当社サーバーに安全に保存され、すべ"
+"てのデバイスからアクセスできます。"
 
 # smartling.placeholder_format=C
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
@@ -16174,7 +16897,9 @@ msgctxt "Chat history with sync modal list item"
 msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
-msgstr "データはDuckDuckGoのサーバー上にエンドツーエンド暗号化で安全に保存されます。DuckDuckGoを含めて、本人以外のユーザーは閲覧できません。"
+msgstr ""
+"データはDuckDuckGoのサーバー上にエンドツーエンド暗号化で安全に保存されます。"
+"DuckDuckGoを含めて、本人以外のユーザーは閲覧できません。"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -16318,35 +17043,41 @@ msgstr "Safariメニューの%1$s「このウェブサイトの設定...」%2$s 
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
-msgstr "%1$sカスタム%2$s を選択して、入力欄に %3$shttps://duckduckgo.com%4$s と入力"
+msgstr ""
+"%1$sカスタム%2$s を選択して、入力欄に %3$shttps://duckduckgo.com%4$s と入力"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
-msgstr "%1$sDuckDuckGo%2$sを選択し、%3$sデフォルトとして追加%4$sをクリックします。"
+msgstr ""
+"%1$sDuckDuckGo%2$sを選択し、%3$sデフォルトとして追加%4$sをクリックします。"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s"
-msgstr "%1$sDuckDuckGo%2$sを選択し、%3$sデフォルトに設定%4$sをクリックしてください"
+msgstr ""
+"%1$sDuckDuckGo%2$sを選択し、%3$sデフォルトに設定%4$sをクリックしてください"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s."
-msgstr "%1$sDuckDuckGo%2$sを選択し、%3$sデフォルトに設定%4$s をクリックします。"
+msgstr ""
+"%1$sDuckDuckGo%2$sを選択し、%3$sデフォルトに設定%4$s をクリックします。"
 
 #  Firefox 33
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Select %sDuckDuckGo%s in the Default Search Engine drop down"
-msgstr "%1$sDuckDuckGo%2$sをデフォルトの検索エンジン選択メニューから選んでください"
+msgstr ""
+"%1$sDuckDuckGo%2$sをデフォルトの検索エンジン選択メニューから選んでください"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %sDuckDuckGo%s in the list and %sallow%s location access"
-msgstr "リストで%1$sDuckDuckGo%2$sを選択し、位置情報へのアクセスを%3$s許可%4$sします"
+msgstr ""
+"リストで%1$sDuckDuckGo%2$sを選択し、位置情報へのアクセスを%3$s許可%4$sします"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -16358,7 +17089,9 @@ msgstr "検索エンジンから%1$sDuckDuckGo%2$sを選択してください"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s under the%sDefault Search Engine%s section"
-msgstr "%1$sデフォルトの検索エンジン%2$sセクションの中にある%3$sDuckDuckGo%4$sを選択してください"
+msgstr ""
+"%1$sデフォルトの検索エンジン%2$sセクションの中にある%3$sDuckDuckGo%4$sを選択"
+"してください"
 
 # smartling.placeholder_format=C
 #. Tells the user were in the settings menu they can change their default search engine.
@@ -16369,7 +17102,8 @@ msgstr "選ぶなら%1$sDuckDuckGo%2$s！"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Select %sEdit Search Engines...%sin the dropdown"
-msgstr "ドロップダウンの中にある%1$s検索エンジンを編集...%2$sボタンを選択してください"
+msgstr ""
+"ドロップダウンの中にある%1$s検索エンジンを編集...%2$sボタンを選択してください"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -16382,7 +17116,9 @@ msgstr "ドロップダウンメニューの%1$sアドオン管理%2$sを選択�
 #. Tells users where in the settings menu they can change their default search engine.
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sMenu > Settings%s (on Windows)"
-msgstr "Macの場合、%1$sOpera > 設定%2$sの順に選択してください。Windowsの場合は、%3$sメニュー > 設定%4$sの順に選択してください"
+msgstr ""
+"Macの場合、%1$sOpera > 設定%2$sの順に選択してください。Windowsの場合は、%3$s"
+"メニュー > 設定%4$sの順に選択してください"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -16390,8 +17126,8 @@ msgstr "Macの場合、%1$sOpera > 設定%2$sの順に選択してください�
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sOpera > Options%s (on Windows)"
 msgstr ""
-"Macの場合、%1$sOpera > 環境設定%2$sの順に選択してください。Windowsの場合は、%3$sOpera > "
-"オプション%4$sの順に選択してください"
+"Macの場合、%1$sOpera > 環境設定%2$sの順に選択してください。Windowsの場合"
+"は、%3$sOpera > オプション%4$sの順に選択してください"
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -16410,7 +17146,8 @@ msgstr "%1$s検索エンジン%2$s を選択"
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"
-msgstr "%1$s検索エンジン%2$sを選択してから、%3$sその他...%4$sをクリックします。"
+msgstr ""
+"%1$s検索エンジン%2$sを選択してから、%3$sその他...%4$sをクリックします。"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -16455,13 +17192,17 @@ msgstr "%1$s設定%2$sを選択し、%3$s検索エンジン%4$sを選択して�
 msgid ""
 "Select %sUse this webpage as your only home page%s (or one of the other "
 "options if you prefer)"
-msgstr "%1$sこのページをホームページに設定%2$sを選択してください(または他のお好みのオプションをどれか一つどうぞ)"
+msgstr ""
+"%1$sこのページをホームページに設定%2$sを選択してください(または他のお好みのオ"
+"プションをどれか一つどうぞ)"
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %syour browser%s in the list and %sallow%s location access"
-msgstr "リストで%1$sお使いのブラウザ%2$sを選択し、位置情報へのアクセスを%3$s許可%4$sします"
+msgstr ""
+"リストで%1$sお使いのブラウザ%2$sを選択し、位置情報へのアクセスを%3$s許可%4$s"
+"します"
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the modal for deleting all recent chats, that allows the user to select the chats to delete.
@@ -16533,7 +17274,9 @@ msgstr "選択テキストの参照元：%1$s"
 #. Displayed when the user's text selection exceeds the maximum message size for AI tools (summary, translation, etc.).
 msgctxt "Error message for selection input limit"
 msgid "Selected text is too long. Try again with a shorter selection."
-msgstr "選択したテキストが長すぎます。ソーステキストを一部選択し、もう一度お試しください。"
+msgstr ""
+"選択したテキストが長すぎます。ソーステキストを一部選択し、もう一度お試しくだ"
+"さい。"
 
 # smartling.placeholder_format=C
 #. Label for the semi-finals knockout stage in e.g. the soccer World Cup
@@ -16576,7 +17319,9 @@ msgid ""
 "Sends a prompt to AI models with your messages with instructions on how to "
 "respond. These instructions will apply to all of your conversations going "
 "forward."
-msgstr "AIモデルに、メッセージに応答する方法を指示したプロンプトを送信します。これらの指示は、今後のすべての会話に適用されます。"
+msgstr ""
+"AIモデルに、メッセージに応答する方法を指示したプロンプトを送信します。これら"
+"の指示は、今後のすべての会話に適用されます。"
 
 # smartling.placeholder_format=C
 msgid "Senegal"
@@ -16652,6 +17397,12 @@ msgid "Set Up Now"
 msgstr "今すぐセットアップ"
 
 # smartling.placeholder_format=C
+#. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
+msgctxt "Encrypted storage setup button shown in native browsers"
+msgid "Set Up Sync & Backup"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
 msgctxt "Title for the Sync & Backup intro screen"
 msgid "Set Up Sync & Backup"
@@ -16679,7 +17430,9 @@ msgctxt "Chat history about modal list item"
 msgid ""
 "Set up Sync & Backup after turning on Chat History to keep your chats synced "
 "across devices."
-msgstr "チャット履歴をオンにしてから、チャットがデバイス間で継続的に同期されるようにSync & Backupを設定します。"
+msgstr ""
+"チャット履歴をオンにしてから、チャットがデバイス間で継続的に同期されるように"
+"Sync & Backupを設定します。"
 
 # smartling.placeholder_format=C
 #. Prompt for the user to indicate their location on a map, to enable more relevant search results.
@@ -16765,7 +17518,9 @@ msgctxt "Description for Approximate Location feature"
 msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
-msgstr "都市レベルの位置情報をAIモデルと共有して関連性を向上させます。Duck.ai は、お客様の正確な位置情報を当社や AI モデルに決して公開しません。"
+msgstr ""
+"都市レベルの位置情報をAIモデルと共有して関連性を向上させます。Duck.ai は、お"
+"客様の正確な位置情報を当社や AI モデルに決して公開しません。"
 
 # smartling.placeholder_format=C
 #. Menu option to share feedback about a result
@@ -16826,6 +17581,13 @@ msgid "Share positive feedback"
 msgstr "肯定的なフィードバックを共有する"
 
 # smartling.placeholder_format=C
+#. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
+msgctxt ""
+"Label beside the share-content switch on the Duck.ai response feedback form"
+msgid "Share this conversation with DuckDuckGo"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
 msgctxt ""
 "Label beside the share-content switch on the Duck.ai response feedback form"
@@ -16840,7 +17602,9 @@ msgctxt ""
 msgid ""
 "Share your prompt and chat response with DuckDuckGo (required for illegal "
 "and harmful report)"
-msgstr "プロンプトとチャットの回答をDuckDuckGoと共有してください（違法および有害な事象の報告には必須）"
+msgstr ""
+"プロンプトとチャットの回答をDuckDuckGoと共有してください（違法および有害な事"
+"象の報告には必須）"
 
 # smartling.placeholder_format=C
 #. An invitation for users to leave feedback
@@ -16960,7 +17724,9 @@ msgstr "DuckAssist<sup>ベータ版</sup>を表示"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show DuckAssist more often. (You can also completely %sturn it off%s.)"
-msgstr "DuckAssistをより頻繁に表示します。（完全に%1$sオフにする%2$sこともできます。）"
+msgstr ""
+"DuckAssistをより頻繁に表示します。（完全に%1$sオフにする%2$sこともできま"
+"す。）"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
@@ -17185,14 +17951,18 @@ msgctxt "settings"
 msgid ""
 "Shows a reminder that searches on DuckDuckGo are always private. Turning "
 "this off hides the reminder and never affects search privacy."
-msgstr "DuckDuckGoでの検索が常に非公開であることのリマインダーを表示します。これをオフにすると、リマインダーが非表示になり、検索のプライバシーには影響しません。"
+msgstr ""
+"DuckDuckGoでの検索が常に非公開であることのリマインダーを表示します。これをオ"
+"フにすると、リマインダーが非表示になり、検索のプライバシーには影響しません。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Shows a reminder that searches on DuckDuckGo are always protected. Turning "
 "this off hides the reminder and never affects search protection."
-msgstr "DuckDuckGoでの検索が常に保護されていることのリマインダーを表示します。これをオフにするとリマインダーが非表示になりますが、検索の保護には影響しません。"
+msgstr ""
+"DuckDuckGoでの検索が常に保護されていることのリマインダーを表示します。これを"
+"オフにするとリマインダーが非表示になりますが、検索の保護には影響しません。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -17229,7 +17999,8 @@ msgstr "DuckDuckGoを端末に追加するリマインダーを随時表示"
 msgctxt "settings"
 msgid ""
 "Shows occasional reminders to sign up for the DuckDuckGo privacy newsletters"
-msgstr "DuckDuckGoのプライバシーニュースレターへの登録に関する通知をときどき表示"
+msgstr ""
+"DuckDuckGoのプライバシーニュースレターへの登録に関する通知をときどき表示"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -17250,7 +18021,9 @@ msgstr "入力に応じて検索ボックスの下に検索候補を表示"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows the privacy benefits of using DuckDuckGo on the homepage"
-msgstr "ホームページでDuckDuckGoを利用することで生まれるプライバシー上のメリットを表示"
+msgstr ""
+"ホームページでDuckDuckGoを利用することで生まれるプライバシー上のメリットを表"
+"示"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -17487,7 +18260,8 @@ msgstr "サーバーへの保存が失敗しました。再度お試しくださ
 #. Body copy displayed under the Set Up Now button when the sync setup call fails.
 msgctxt "Generic error shown when sync setup fails"
 msgid "Something went wrong while enabling Sync & Backup. Please try again."
-msgstr "Sync & Backupを有効にしている際に問題が発生しました。もう一度お試しください。"
+msgstr ""
+"Sync & Backupを有効にしている際に問題が発生しました。もう一度お試しください。"
 
 # smartling.placeholder_format=C
 #. Displayed when the voice chat session ends with an unknown error.
@@ -17511,7 +18285,8 @@ msgstr "時々表示する"
 #. Generic error message shown when the image generation model cannot process the user's request.
 msgctxt "Error message from the image generation model"
 msgid "Sorry I can't help, please describe your image in a different way."
-msgstr "申し訳ありませんが、お力になれません。別の方法で画像を説明してください。"
+msgstr ""
+"申し訳ありませんが、お力になれません。別の方法で画像を説明してください。"
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -17549,7 +18324,9 @@ msgctxt "Error message when an uploaded image cannot be decoded or processed"
 msgid ""
 "Sorry, the uploaded image couldn't be processed. Please try a different "
 "image or format."
-msgstr "申し訳ありませんが、アップロードした画像を処理できませんでした。別の画像または形式を試してください。"
+msgstr ""
+"申し訳ありませんが、アップロードした画像を処理できませんでした。別の画像また"
+"は形式を試してください。"
 
 # smartling.placeholder_format=C
 #. Body copy shown when a scanned or pasted pairing payload fails schema validation.
@@ -17557,13 +18334,17 @@ msgctxt "Description for the wrong code error screen"
 msgid ""
 "Sorry, this code is invalid. Please make sure the correct code was entered "
 "or scanned."
-msgstr "申し訳ありません。このコードは無効です。正しいコードが入力またはスキャンされたことを確認してください。"
+msgstr ""
+"申し訳ありません。このコードは無効です。正しいコードが入力またはスキャンされ"
+"たことを確認してください。"
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
 msgid ""
 "Sorry, we couldn't generate a richer answer. You can try asking Duck.ai."
-msgstr "申し訳ありませんが、これ以上豊富な回答を出すことはできませんでした。Duck.ai に聞いてみてください。"
+msgstr ""
+"申し訳ありませんが、これ以上豊富な回答を出すことはできませんでした。Duck.ai "
+"に聞いてみてください。"
 
 # smartling.placeholder_format=C
 #. Inform the users that "something" went wrong and that they could try to refresh the page to resolve the error. Placeholders are for markup, please ignore.
@@ -17571,13 +18352,17 @@ msgctxt "noresults"
 msgid ""
 "Sorry, we ran into an error displaying these results. %sClick here%s to try "
 "again."
-msgstr "申し訳ありませんが、これらの結果を表示する際にエラーが発生しました。再試行するには、%1$sこちらをクリック%2$sしてください。"
+msgstr ""
+"申し訳ありませんが、これらの結果を表示する際にエラーが発生しました。再試行す"
+"るには、%1$sこちらをクリック%2$sしてください。"
 
 # smartling.placeholder_format=C
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr "申し訳ありませんが、フィードバックを送信できませんでした。少し時間をおいてからもう一度試してください。"
+msgstr ""
+"申し訳ありませんが、フィードバックを送信できませんでした。少し時間をおいてか"
+"らもう一度試してください。"
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -17631,7 +18416,9 @@ msgstr "ソーステキストが消去されました"
 msgctxt "Error message for summary selection input limit"
 msgid ""
 "Source text is too long to summarize. Try again with a shorter selection."
-msgstr "ソーステキストが長すぎて要約できません。ソーステキストを一部選択し、もう一度お試しください。"
+msgstr ""
+"ソーステキストが長すぎて要約できません。ソーステキストを一部選択し、もう一度"
+"お試しください。"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under Interface Settings.in the end. It is a header
@@ -17830,7 +18617,8 @@ msgstr "DuckDuckGoを使用し続ける"
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletter."
-msgstr "プライバシーニュースレターで、データを常時守り、最新情報を入手しましょう。"
+msgstr ""
+"プライバシーニュースレターで、データを常時守り、最新情報を入手しましょう。"
 
 # smartling.placeholder_format=C
 #. Prompt to subscribe to a newsletter.
@@ -17974,7 +18762,9 @@ msgctxt "Description prompting subscription for higher limits"
 msgid ""
 "Subscribe to DuckDuckGo to unlock higher limits in Duck.ai, or come back "
 "later to create more images."
-msgstr "Duck.aiの制限を引き上げるにはDuckDuckGoに登録するか、後で戻ってきてさらに画像を作成してください。"
+msgstr ""
+"Duck.aiの制限を引き上げるにはDuckDuckGoに登録するか、後で戻ってきてさらに画像"
+"を作成してください。"
 
 # smartling.placeholder_format=C
 #. Description shown to free users who have reached their image generation limit, encouraging them to subscribe.
@@ -18042,13 +18832,32 @@ msgctxt "Full sentence for composing a card"
 msgid ""
 "Suggest a phrase to write on a get-well card for someone recovering from a "
 "surgery?"
-msgstr "手術したばかりの人宛てのお見舞いのカードに書くフレーズを提案してください。"
+msgstr ""
+"手術したばかりの人宛てのお見舞いのカードに書くフレーズを提案してください。"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for asking for a suggestion of a blog post title.
 msgctxt "Brief for suggesting a blog post title"
 msgid "Suggest a title for a blog post"
 msgstr "ブログ記事のタイトルを提案してください"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest related articles or topics worth exploring next."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Suggest related articles to explore"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest some alternatives to this product."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
@@ -18062,10 +18871,100 @@ msgid "Suggestions:"
 msgstr "提案:"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Sum up the reviews"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A short title for the a message asking the AI to summarize a text.
 msgctxt "Title for the summarize message"
 msgid "Summarize"
 msgstr "要約"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize the Q&As"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the background and notable work of this person."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the key details of this event."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the questions and answers on this page."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize their background"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this book"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this book."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this discussion"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this discussion thread."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this page"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this page."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this video"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this video."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize what the reviews say."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -18226,7 +19125,8 @@ msgstr "どんなときでも、あなたを追跡しないサーチエンジン
 msgctxt "AI Chat warning when switching from an encrypted model"
 msgid ""
 "Switching will send your chat to a model without zero provider visibility"
-msgstr "切り替えると、チャットはプロバイダーの可視性がゼロのモデルに送信されます"
+msgstr ""
+"切り替えると、チャットはプロバイダーの可視性がゼロのモデルに送信されます"
 
 # smartling.placeholder_format=C
 msgid "Switzerland"
@@ -18329,21 +19229,25 @@ msgid ""
 msgstr ""
 "同期リカバリーコード\n"
 "\n"
-""
-""
-"リカバリーコードを使用すると、パスワード、自動入力データ、Duck.aiチャットが複数のデバイスで同期されるようになり、デバイスにアクセスできなくなった場合に同期済みのデータを回復できます。\n"
+"リカバリーコードを使用すると、パスワード、自動入力データ、Duck.aiチャットが複"
+"数のデバイスで同期されるようになり、デバイスにアクセスできなくなった場合に同"
+"期済みのデータを回復できます。\n"
 "\n"
 "この情報は安全に保管してください。\n"
-"このコードにアクセス可能なユーザーは誰でも同期済みデータにアクセスできます。\n"
+"このコードにアクセス可能なユーザーは誰でも同期済みデータにアクセスできま"
+"す。\n"
 "\n"
 "%1$s\n"
 "\n"
 "このコードの仕組みは？\n"
 "1. ブラウザでDuck.aiにアクセスし、Duck.aiの設定を開きます。\n"
-"2. 「Sync & Backupをオンにする」、「同期されたデータを復元」の順に選択します\n"
-"3. リカバリーコードをコピーし、「ここにコードを貼り付けてください」欄に貼り付けます\n"
+"2. 「Sync & Backupをオンにする」、「同期されたデータを復元」の順に選択しま"
+"す\n"
+"3. リカバリーコードをコピーし、「ここにコードを貼り付けてください」欄に貼り付"
+"けます\n"
 "\n"
-"DuckDuckGoブラウザの未使用期間が18か月を超えると、データはサーバーから削除され、復元できなくなります。"
+"DuckDuckGoブラウザの未使用期間が18か月を超えると、データはサーバーから削除さ"
+"れ、復元できなくなります。"
 
 # smartling.placeholder_format=C
 #. Secondary button label on the Sync & Backup intro screen that takes the user to the camera scan screen to pair with another device.
@@ -18386,6 +19290,12 @@ msgid "Syria"
 msgstr "シリア"
 
 # smartling.placeholder_format=C
+#. Text for a button that enables the theme to follow the operating system's color scheme preference.
+msgctxt "System theme button for theme selector"
+msgid "System"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Abbreviation indicating this is the total score for a game
 msgctxt "Sports module"
 msgid "T"
@@ -18412,6 +19322,12 @@ msgstr "テレビ"
 msgctxt "language_name"
 msgid "Tahitian"
 msgstr "タヒチ語"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Tailor my resume"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Taiwan"
@@ -18441,6 +19357,13 @@ msgstr "個人データを自己管理できます"
 msgctxt "homepage ATB modal"
 msgid "Take control of your personal data!"
 msgstr "個人データを自己管理しましょう！"
+
+# smartling.placeholder_format=C
+#. Description for the Feedback section of the Duck.ai settings page, asking the user to take an anonymous survey to let us know how we can make Duck.ai better.
+msgctxt "Feedback section description on the Duck.ai settings page"
+msgid ""
+"Take this anonymous survey to let us know how we can make Duck.ai better."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -18654,7 +19577,10 @@ msgid ""
 "That means information sent between your device and the webpage behind this "
 "link is at increased risk of being intercepted by a third party. In rare "
 "cases this includes passwords, or payment details."
-msgstr "つまり、お使いのデバイスとこのリンクに接続するウェブページの間で送信される情報はサードパーティに傍受されるリスクが高いことになります。まれに、パスワードや支払い情報がこうした情報に含まれる場合もあります。"
+msgstr ""
+"つまり、お使いのデバイスとこのリンクに接続するウェブページの間で送信される情"
+"報はサードパーティに傍受されるリスクが高いことになります。まれに、パスワード"
+"や支払い情報がこうした情報に含まれる場合もあります。"
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -18662,7 +19588,9 @@ msgctxt "cloudsave"
 msgid ""
 "The Cloud Save bookmarklet allows any changes you make to your settings to "
 "automatically save in the cloud."
-msgstr "Cloud Save ブックマークレットを使用すると、設定上の変更をすべてクラウドに自動保存できます。"
+msgstr ""
+"Cloud Save ブックマークレットを使用すると、設定上の変更をすべてクラウドに自動"
+"保存できます。"
 
 # smartling.placeholder_format=C
 msgid "The Gambia"
@@ -18691,14 +19619,18 @@ msgctxt "Second paragraph for the Sync & Backup intro screen"
 msgid ""
 "The encryption key is only saved in your browser's local storage, and only "
 "you can access it."
-msgstr "暗号化キーはブラウザのローカルストレージにのみ保存され、アクセスできるのは本人だけです。"
+msgstr ""
+"暗号化キーはブラウザのローカルストレージにのみ保存され、アクセスできるのは本"
+"人だけです。"
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider deletes all chat data within 30 days.
 msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider deletes any data associated with this chat within 30 days."
-msgstr "モデルプロバイダーはこのチャットに関連するすべてのデータを30日以内に削除します。"
+msgstr ""
+"モデルプロバイダーはこのチャットに関連するすべてのデータを30日以内に削除しま"
+"す。"
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers.
@@ -18712,7 +19644,8 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider does not save this chat or any associated data on their "
 "servers."
-msgstr "モデルプロバイダーは、このチャットや関連データをサーバーに保存しません。"
+msgstr ""
+"モデルプロバイダーは、このチャットや関連データをサーバーに保存しません。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18735,6 +19668,12 @@ msgstr "サーバーがエラーを起こし、リクエストを完了できま
 #. https://duck.co/media/files/theme.png
 msgid "Theme"
 msgstr "テーマ"
+
+# smartling.placeholder_format=C
+#. Text for the theme selector label that allows users to switch between Light and dark theme.
+msgctxt "Label for the theme selector feature"
+msgid "Theme"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/LpFhb1e.png
@@ -18764,7 +19703,9 @@ msgctxt "Error message when there was an issue saving a chat to the browser"
 msgid ""
 "There was an error saving this chat locally. Please check your browser "
 "settings to make sure local data storage is enabled."
-msgstr "このチャットをローカルに保存する際にエラーが発生しました。ブラウザの設定を確認し、ローカルデータの保存が有効になっていることをご確認ください。"
+msgstr ""
+"このチャットをローカルに保存する際にエラーが発生しました。ブラウザの設定を確"
+"認し、ローカルデータの保存が有効になっていることをご確認ください。"
 
 # smartling.placeholder_format=C
 #. Error modal body line 1.
@@ -18778,7 +19719,9 @@ msgctxt "noresults"
 msgid ""
 "There was still an error displaying the search results. Please wait a few "
 "minutes before you try again."
-msgstr "検索結果の表示中にまたエラーが発生しました。数分待ってから再試行してください。"
+msgstr ""
+"検索結果の表示中にまたエラーが発生しました。数分待ってから再試行してくださ"
+"い。"
 
 # smartling.placeholder_format=C
 #. Error message for explore more questions when a retryable error occurs (timeout, network)
@@ -18796,7 +19739,10 @@ msgid ""
 "These browser permissions are used to add privacy protection on websites you "
 "visit by blocking hidden trackers, encrypting connections where possible, "
 "and by making DuckDuckGo your default search engine."
-msgstr "これらのブラウザのアクセス許可は、訪問したWebサイトにプライバシー保護を追加するために隠れたトラッカーをブロックし、接続を可能な限り暗号化し、DuckDuckGoをデフォルトの検索エンジンにするために使用されます。"
+msgstr ""
+"これらのブラウザのアクセス許可は、訪問したWebサイトにプライバシー保護を追加す"
+"るために隠れたトラッカーをブロックし、接続を可能な限り暗号化し、DuckDuckGoを"
+"デフォルトの検索エンジンにするために使用されます。"
 
 # smartling.placeholder_format=C
 #. Secondary line under DUCKCHAT_SYNC_PAIRING_ALREADY_SYNCED_TITLE.
@@ -18833,7 +19779,9 @@ msgctxt "AI Chat: Error message for when a model is removed"
 msgid ""
 "This AI model is no longer available. Try starting a new chat with a "
 "different model."
-msgstr "このAIモデルは使用できなくなりました。別のモデルで新しいチャットを開始してみてください。"
+msgstr ""
+"このAIモデルは使用できなくなりました。別のモデルで新しいチャットを開始してみ"
+"てください。"
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is no longer supported because it has been upgraded to a newest version.
@@ -18841,7 +19789,9 @@ msgctxt "AI Chat: Error message for when a model is deprecated"
 msgid ""
 "This AI model version is no longer supported. Try starting a new chat with "
 "the latest version of this model."
-msgstr "このAIモデル版はサポートされなくなりました。このモデルの最新版で新しいチャットを開始してください。"
+msgstr ""
+"このAIモデル版はサポートされなくなりました。このモデルの最新版で新しいチャッ"
+"トを開始してください。"
 
 # smartling.placeholder_format=C
 #. Appears below a type of search results called 'Instant Answers'
@@ -18867,7 +19817,10 @@ msgctxt "Export chat feature in AI Chat"
 msgid ""
 "This conversation was generated with Duck.ai (%s) using %s's %s Model. AI "
 "chats may display inaccurate or offensive information (see %s for more info)."
-msgstr "この会話は、%2$sの%3$sモデルを使用してDuck.ai（%1$s）で生成されました。AIチャットでは不正確な情報や不快な情報が表示される場合があります（詳細については%4$sを参照してください）。"
+msgstr ""
+"この会話は、%2$sの%3$sモデルを使用してDuck.ai（%1$s）で生成されました。AI"
+"チャットでは不正確な情報や不快な情報が表示される場合があります（詳細について"
+"は%4$sを参照してください）。"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with multiple AI models in the same chat, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using multiple chat models. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -18876,7 +19829,10 @@ msgid ""
 "This conversation was generated with Duck.ai (%s) using multiple chat "
 "models. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
-msgstr "この会話は、複数のチャットモデルを使用してDuck.ai（%1$s）で生成されました。AIチャットでは不正確な情報や不快な内容が表示される場合があります（詳細については%2$sを参照してください）。"
+msgstr ""
+"この会話は、複数のチャットモデルを使用してDuck.ai（%1$s）で生成されました。AI"
+"チャットでは不正確な情報や不快な内容が表示される場合があります（詳細について"
+"は%2$sを参照してください）。"
 
 # smartling.placeholder_format=C
 #. When a user exports a transcript of a voice chat they had with the AI. This text goes at the very top of the downloaded file as a header. Placeholders are for links. Example: 'This conversation was generated with Duck.ai voice chat (https://duck.ai). AI may provide inaccurate or offensive information. (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -18884,7 +19840,9 @@ msgctxt "Export chat feature in AI Chat"
 msgid ""
 "This conversation was generated with Duck.ai voice chat (%s). AI may provide "
 "inaccurate or offensive information. (see %s for more info)."
-msgstr "この会話はDuck.aiボイスチャット(%1$s)で生成されました。AIは不正確または不快な情報を提供する可能性があります。（詳細は%2$sを参照してください。）"
+msgstr ""
+"この会話はDuck.aiボイスチャット(%1$s)で生成されました。AIは不正確または不快な"
+"情報を提供する可能性があります。（詳細は%2$sを参照してください。）"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with DuckDuckGo AI Chat (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/aichat/privacy-terms for more info).'
@@ -18894,8 +19852,9 @@ msgid ""
 "Model. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
 msgstr ""
-"この会話は、%2$sの%3$sモデルを使用してDuckDuckGo AI "
-"Chat（%1$s）で生成されました。AIチャットでは不正確な情報や不快な情報が表示される場合があります（詳細については%4$sを参照してください）。"
+"この会話は、%2$sの%3$sモデルを使用してDuckDuckGo AI Chat（%1$s）で生成されま"
+"した。AIチャットでは不正確な情報や不快な情報が表示される場合があります（詳細"
+"については%4$sを参照してください）。"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
@@ -18927,7 +19886,8 @@ msgctxt ""
 "Error message when an uploaded file type is not supported, with list ending "
 "in or"
 msgid "This file type is not supported, please attach a %s or %s"
-msgstr "このファイル形式はサポートされていません。%1$sまたは%2$sを添付してください。"
+msgstr ""
+"このファイル形式はサポートされていません。%1$sまたは%2$sを添付してください。"
 
 # smartling.placeholder_format=C
 #. Error message for unsupported file type when multiple types are accepted. First placeholder is a comma-separated list of all accepted types except the last (e.g. PNG, JPG, WebP, GIF). Second placeholder is the last accepted type (e.g. PDF). Full example: This file type is not supported, please attach a PNG, JPG, WebP, GIF or PDF
@@ -18935,7 +19895,8 @@ msgctxt ""
 "Error message when an uploaded file type is not supported, with list ending "
 "in or"
 msgid "This file type is not supported, please attach a %s or %s."
-msgstr "このファイル形式はサポートされていません。%1$sまたは%2$sを添付してください。"
+msgstr ""
+"このファイル形式はサポートされていません。%1$sまたは%2$sを添付してください。"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to upload an unsupported file type and we know which types are accepted. Placeholder is a single accepted type. E.g. This file type is not supported, please attach a PDF
@@ -18966,14 +19927,18 @@ msgstr "この画像は作成できませんでした。"
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF"
-msgstr "この画像形式はサポートされていません。JPG、PNG、WebP、またはGIFを添付してください。"
+msgstr ""
+"この画像形式はサポートされていません。JPG、PNG、WebP、またはGIFを添付してくだ"
+"さい。"
 
 # smartling.placeholder_format=C
 #. Error message displayed when a file that the user tried to upload is not of a supported format
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF."
-msgstr "この画像形式はサポートされていません。JPG、PNG、WebP、またはGIFを添付してください。"
+msgstr ""
+"この画像形式はサポートされていません。JPG、PNG、WebP、またはGIFを添付してくだ"
+"さい。"
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
@@ -18998,7 +19963,9 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "This model provider deletes data associated with this chat within 30 days. "
 "Other model providers follow a zero data retention model."
-msgstr "このモデルプロバイダーは、このチャットに関連するデータを30日以内に削除します。他のモデルプロバイダーは、データを一切保持しないモデルを採用しています。"
+msgstr ""
+"このモデルプロバイダーは、このチャットに関連するデータを30日以内に削除しま"
+"す。他のモデルプロバイダーは、データを一切保持しないモデルを採用しています。"
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers, and that other providers may retain chat data for a limited time instead.
@@ -19006,7 +19973,9 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "This model provider does not store any data associated with this chat. Other "
 "model providers follow a limited data retention model."
-msgstr "このモデルプロバイダーはこのチャットに関連するデータを保存していません。他のモデルプロバイダーは限定的なデータ保持モデルを採用しています。"
+msgstr ""
+"このモデルプロバイダーはこのチャットに関連するデータを保存していません。他の"
+"モデルプロバイダーは限定的なデータ保持モデルを採用しています。"
 
 # smartling.placeholder_format=C
 #. Info that page may refresh during update.
@@ -19042,7 +20011,9 @@ msgctxt "First paragraph for the Sync & Backup intro screen"
 msgid ""
 "This saves your chats with end-to-end encryption on DuckDuckGo's secure "
 "server, which later can be accessed from any browser."
-msgstr "チャットはエンドツーエンドの暗号化でDuckDuckGoの安全なサーバーに保存され、後でどのブラウザからでもアクセスできます。"
+msgstr ""
+"チャットはエンドツーエンドの暗号化でDuckDuckGoの安全なサーバーに保存され、後"
+"でどのブラウザからでもアクセスできます。"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -19050,7 +20021,9 @@ msgctxt "duckassist"
 msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again."
-msgstr "この設定はブラウザに保存されているため、duckduckgo.comのブラウザデータを削除すると、AI支援の回答が再表示されることがあります。"
+msgstr ""
+"この設定はブラウザに保存されているため、duckduckgo.comのブラウザデータを削除"
+"すると、AI支援の回答が再表示されることがあります。"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -19060,9 +20033,9 @@ msgid ""
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
 msgstr ""
-""
-"この設定はブラウザに保存されているため、duckduckgo.comのブラウザデータを削除すると、AI支援の回答が再表示されることがあります。ただし、%1$s "
-"にはAI支援の回答が一切表示されないスタートページもご用意しています。"
+"この設定はブラウザに保存されているため、duckduckgo.comのブラウザデータを削除"
+"すると、AI支援の回答が再表示されることがあります。ただし、%1$s にはAI支援の回"
+"答が一切表示されないスタートページもご用意しています。"
 
 # smartling.placeholder_format=C
 #. User feedback indicating that a translation is helpful
@@ -19085,13 +20058,16 @@ msgstr "この翻訳は正しくありません"
 # smartling.placeholder_format=C
 #. Label indicating that the video can't be played on the current page, and only on the website that owns the vide. The placeholder is the name of the website that owns the video.
 msgid "This video is not yet able to be watched here. You can watch it on %s."
-msgstr "この動画はまだここで視聴することはできません。この動画は %1$s 上で視聴可能です。"
+msgstr ""
+"この動画はまだここで視聴することはできません。この動画は %1$s 上で視聴可能で"
+"す。"
 
 # smartling.placeholder_format=C
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr "このウェブページでは「暗号化された安全な接続(HTTPS)」を利用できません。"
+msgstr ""
+"このウェブページでは「暗号化された安全な接続(HTTPS)」を利用できません。"
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -19101,8 +20077,9 @@ msgid ""
 "Sync & Backup. You'll still be able to access your chats in other browsers "
 "connected to Sync & Backup."
 msgstr ""
-"このオプションを選択すると、Duck.aiのチャットがこのブラウザからすべて削除され、Sync & Backupとの接続は解除されます。Sync & "
-"Backupに接続している他のブラウザでは、引き続きチャットにアクセスできます。"
+"このオプションを選択すると、Duck.aiのチャットがこのブラウザからすべて削除さ"
+"れ、Sync & Backupとの接続は解除されます。Sync & Backupに接続している他のブラ"
+"ウザでは、引き続きチャットにアクセスできます。"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to clear all recentchats, with a warning that this action cannot be undone.
@@ -19110,7 +20087,9 @@ msgctxt "Body text for clear all recent chats confirmation modal"
 msgid ""
 "This will delete all your recent chats, unless they're pinned. This cannot "
 "be undone."
-msgstr "これにより、ピン留めされていない限り、最近のチャットがすべて削除されます。この操作は取り消せません。"
+msgstr ""
+"これにより、ピン留めされていない限り、最近のチャットがすべて削除されます。こ"
+"の操作は取り消せません。"
 
 # smartling.placeholder_format=C
 #. Message explaining what will happen when the user deletes an image.
@@ -19247,7 +20226,9 @@ msgctxt "directions"
 msgid ""
 "To print directions:%sGo back to the map.%sSelect the route you want to "
 "print.%sClick the print icon.%s"
-msgstr "ルートの印刷手順：%1$s地図に戻ります。%2$s印刷するルートを選択します。%3$s印刷アイコンをクリックします。%4$s"
+msgstr ""
+"ルートの印刷手順：%1$s地図に戻ります。%2$s印刷するルートを選択します。%3$s印"
+"刷アイコンをクリックします。%4$s"
 
 # smartling.placeholder_format=C
 #. Explains where the user can find their recovery code. Figma frame 3703-44420.
@@ -19256,7 +20237,10 @@ msgid ""
 "To restore your synced data, you'll need the Recovery Code you saved when "
 "you first set up Sync. This code may have been saved as a PDF on the device "
 "you originally used to set up Sync."
-msgstr "同期したデータを復元するには、同期を初めて設定したときに保存したリカバリーコードが必要です。このコードは、同期設定に最初に使用したデバイスにPDFとして保存されている可能性があります。"
+msgstr ""
+"同期したデータを復元するには、同期を初めて設定したときに保存したリカバリー"
+"コードが必要です。このコードは、同期設定に最初に使用したデバイスにPDFとして保"
+"存されている可能性があります。"
 
 # smartling.placeholder_format=C
 #. Body text explaining that the user needs to update their DDG browser before migration can proceed.
@@ -19264,14 +20248,18 @@ msgctxt "duckai_migration"
 msgid ""
 "To transfer your chat history to Duck.ai, please update your DuckDuckGo "
 "browser to the latest version and try again."
-msgstr "チャット履歴をDuck.aiに転送するには、DuckDuckGoブラウザを最新バージョンにアップデートし、再度お試しください。"
+msgstr ""
+"チャット履歴をDuck.aiに転送するには、DuckDuckGoブラウザを最新バージョンにアッ"
+"プデートし、再度お試しください。"
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
 msgid ""
 "To use dictation, allow your browser to access the microphone in your system "
 "settings."
-msgstr "音声入力機能を使用するには、システム設定でブラウザがマイクにアクセスできるように設定してください。"
+msgstr ""
+"音声入力機能を使用するには、システム設定でブラウザがマイクにアクセスできるよ"
+"うに設定してください。"
 
 # smartling.placeholder_format=C
 msgid "Today"
@@ -19460,7 +20448,9 @@ msgctxt "tracker_stats"
 msgid ""
 "Tracking attempts blocked by DuckDuckGo appear here. Keep browsing to see "
 "how many we block."
-msgstr "DuckDuckGoが追跡試行をブロックすると、こちらに表示されます。閲覧を続けると、ブロック件数が表示されるようになります。"
+msgstr ""
+"DuckDuckGoが追跡試行をブロックすると、こちらに表示されます。閲覧を続けると、"
+"ブロック件数が表示されるようになります。"
 
 # smartling.placeholder_format=C
 #. Placeholder for when we cannot report any blocked trackers yet
@@ -19507,7 +20497,9 @@ msgctxt "Full sentence for translating text"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr "この英語の文章をフランス語に翻訳してください。「最寄りの映画館へはどうやって行けばいいですか？」"
+msgstr ""
+"この英語の文章をフランス語に翻訳してください。「最寄りの映画館へはどうやって"
+"行けばいいですか？」"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for translating a sentence into another language. Translate the whole sentence and please use target language instead of 'English' and modify the sentence to translate into 'English' instead of 'French'. Example: 'Translate this {target language} sentence into English: “How do I get to the nearest movie theatre?”'
@@ -19515,7 +20507,21 @@ msgctxt "Full sentence for translating text prompt"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr "この日本語の文章を英語に翻訳してください。「最寄りの映画館へはどうやって行けばいいですか？」"
+msgstr ""
+"この日本語の文章を英語に翻訳してください。「最寄りの映画館へはどうやって行け"
+"ばいいですか？」"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Translate this page"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
+msgctxt "Page suggestion prompt"
+msgid "Translate this page into %s."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder text for a region that will display translated text.
@@ -19611,7 +20617,8 @@ msgstr "%1$sを試す"
 # smartling.placeholder_format=C
 #. Prompt for the user to start using our homepage that doesn't show promotional messages. The placeholder is a homepage url (e.g., 'start.duckduckgo.com')
 msgid "Try %s to stop seeing messages like this."
-msgstr "このようなメッセージが表示されないようにするには、%1$sをお試しください。"
+msgstr ""
+"このようなメッセージが表示されないようにするには、%1$sをお試しください。"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that encourages users to try the encrypted AI model whose inference runs in a confidential environment so the model provider cannot access user data. %s is replaced with the model's full display name (e.g. 'GPT-OSS 120B').
@@ -19621,7 +20628,9 @@ msgstr "プロバイダーの可視性がゼロの最初のモデル%1$sをお�
 
 # smartling.placeholder_format=C
 msgid "Try %sDuck.ai%s, our private AI chat service:"
-msgstr "%1$sDuck.ai%2$sは、個人情報保護に配慮したAIチャットサービスです。ぜひ、お試しを！"
+msgstr ""
+"%1$sDuck.ai%2$sは、個人情報保護に配慮したAIチャットサービスです。ぜひ、お試し"
+"を！"
 
 # smartling.placeholder_format=C
 #. Button text to retry loading an explore more question that failed
@@ -19657,6 +20666,12 @@ msgstr "もう一度試す"
 msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
 msgstr "無料で試す"
+
+# smartling.placeholder_format=C
+#. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
+msgctxt "settings"
+msgid "Try It Now"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -19714,13 +20729,16 @@ msgstr "別のキーワードを試してみてください。"
 # smartling.placeholder_format=C
 #. Prompt encouraging the user to turn off their ad blocker to see more results for their query.
 msgid "Try disabling your ad blocker on DuckDuckGo to see more results."
-msgstr "より多くの結果を表示するには、DuckDuckGoで広告ブロッカーを無効にしてお試しください。"
+msgstr ""
+"より多くの結果を表示するには、DuckDuckGoで広告ブロッカーを無効にしてお試しく"
+"ださい。"
 
 # smartling.placeholder_format=C
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
 msgctxt "precise_user_location"
 msgid "Try enabling anonymous location for more accurate results."
-msgstr "検索結果の精度を高めるには、匿名の位置情報を使用する設定にしてみてください。"
+msgstr ""
+"検索結果の精度を高めるには、匿名の位置情報を使用する設定にしてみてください。"
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the screen of the onboarding where the user picks a chat model.
@@ -19805,7 +20823,8 @@ msgstr "位置情報を手動で設定してみてください。"
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Try the %sDuckDuckGo Browser.%s Fast. Free. Private."
-msgstr "%1$sDuckDuckGoブラウザ%2$sをお試しください。スピーディで無料、プライベート。"
+msgstr ""
+"%1$sDuckDuckGoブラウザ%2$sをお試しください。スピーディで無料、プライベート。"
 
 # smartling.placeholder_format=C
 #. Link to a page where users can download the DuckDuckGo Browser for iOS or Android.
@@ -19863,7 +20882,8 @@ msgstr "最近追加されたオープンソースのLlama 3.1とMixtralをお�
 #. Message displayed to suggest the user to try the provided prompts or enter their own.
 msgctxt "Prompt suggestion message"
 msgid "Try these prompts to get started or enter your own prompt below"
-msgstr "まずはこれらのプロンプトを試すか、以下に独自のプロンプトを入力してください。"
+msgstr ""
+"まずはこれらのプロンプトを試すか、以下に独自のプロンプトを入力してください。"
 
 # smartling.placeholder_format=C
 #. Description for the empty state displayed when searching recent chats in Duck.ai returns no results, suggesting the user rephrase their search query.
@@ -19889,6 +20909,22 @@ msgstr "こちらも: %1$s"
 msgctxt "new user poll"
 msgid "Trying DuckDuckGo again"
 msgstr "DuckDuckGoを、もう一度試してみる"
+
+# smartling.placeholder_format=C
+#. Message shown in a modal after supported third-party browser users disable AI features in Settings. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -20007,7 +21043,8 @@ msgstr "より正確な結果を得るには、「正確な位置情報」をオ
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on “Use precise location” for more accurate results."
-msgstr "より正確な結果を得るには、「正確な位置情報を使用」をオンにしてください。"
+msgstr ""
+"より正確な結果を得るには、「正確な位置情報を使用」をオンにしてください。"
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Create Image' label in the Tools dropdown.
@@ -20051,14 +21088,17 @@ msgstr "「%1$sDuckDuckGo%2$s」と %3$s フォームの最初のフィールド
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Type %sduckduckgo.com%s in the %ssecond form field"
-msgstr "「%1$sduckduckgo.com%2$s」と%3$s フォームの2番目のフィールドに入力します"
+msgstr ""
+"「%1$sduckduckgo.com%2$s」と%3$s フォームの2番目のフィールドに入力します"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Types out DuckAssist answers as they're generated. Turning this off may "
 "result in a short delay between a search and the answer being displayed."
-msgstr "DuckAssist が生成した回答を入力します。このオプションをオフにすると、検索してから回答が表示されるまでに、多少タイムラグが生じる場合があります。"
+msgstr ""
+"DuckAssist が生成した回答を入力します。このオプションをオフにすると、検索して"
+"から回答が表示されるまでに、多少タイムラグが生じる場合があります。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -20187,14 +21227,18 @@ msgstr "長所と短所を明らかにする"
 msgid ""
 "Under %sOn startup%s, click %sOpen a specific page%s then click %sSet "
 "Pages%s."
-msgstr "%1$sスタートの時%2$s の下、%3$sとあるページを開く%4$s をクリックして、%5$sページがセレクト%6$s クリックします。"
+msgstr ""
+"%1$sスタートの時%2$s の下、%3$sとあるページを開く%4$s をクリックして、%5$s"
+"ページがセレクト%6$s クリックします。"
 
 #  Maxthon homepage instruction
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
-msgstr "%1$sOn startup%2$sの中から%3$sHomepage%4$sを選択してhttps://duckduckgo.comと入力してください"
+msgstr ""
+"%1$sOn startup%2$sの中から%3$sHomepage%4$sを選択してhttps://duckduckgo.comと"
+"入力してください"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -20204,7 +21248,8 @@ msgstr "%1$s開く%2$s の中から %3$s特定のページを開く%4$s を選�
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
-msgstr "%1$s起動時 > ホームページ%2$sの中で https://duckduckgo.com と入力してください"
+msgstr ""
+"%1$s起動時 > ホームページ%2$sの中で https://duckduckgo.com と入力してください"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -20214,13 +21259,17 @@ msgstr "%1$s検索設定%2$sで、%3$sDuckDuckGo%4$sを選択します"
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch in the address bar with%s select %sAdd New%s"
-msgstr "%1$sアドレスバーでの検索時に使う検索プロバイダー%2$sの下の%3$s新たに追加%4$sを選択します"
+msgstr ""
+"%1$sアドレスバーでの検索時に使う検索プロバイダー%2$sの下の%3$s新たに追加%4$s"
+"を選択します"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
-msgstr "%1$s検索%2$sセクションの下にある「%3$s検索エンジンの管理...%4$s」をクリックします"
+msgstr ""
+"%1$s検索%2$sセクションの下にある「%3$s検索エンジンの管理...%4$s」をクリックし"
+"ます"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -20309,7 +21358,9 @@ msgctxt "Description of the modal to upgrade to Pro"
 msgid ""
 "Unlock %s, higher AI reasoning, and 2x higher usage limits than the Plus "
 "plan by upgrading to Pro."
-msgstr "Proにアップグレードすると、%1$sのロックが解除され、AI推論能力が向上し、使用上限がPlusプランの2倍になります。"
+msgstr ""
+"Proにアップグレードすると、%1$sのロックが解除され、AI推論能力が向上し、使用上"
+"限がPlusプランの2倍になります。"
 
 # smartling.placeholder_format=C
 #. Title for the subscription promo shown in the SERP sidemenu.
@@ -20363,7 +21414,9 @@ msgctxt ""
 "Text shown in the subscription promo card, with a trailing call-to-action "
 "link."
 msgid "Unlock more capable AI models with a DuckDuckGo subscription. %s"
-msgstr "DuckDuckGoのサブスクリプションで、より高性能なAIモデルをアンロックしましょう。%1$s"
+msgstr ""
+"DuckDuckGoのサブスクリプションで、より高性能なAIモデルをアンロックしましょ"
+"う。%1$s"
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to unmute the microphone.
@@ -20442,7 +21495,9 @@ msgctxt "Old app version banner component in Duck.ai"
 msgid ""
 "Update the DuckDuckGo browser to activate your subscription in Duck.ai and "
 "access advanced models"
-msgstr "DuckDuckGo ブラウザを更新して、Duck.ai でサブスクリプションを有効にし、高度なモデルにアクセスしよう"
+msgstr ""
+"DuckDuckGo ブラウザを更新して、Duck.ai でサブスクリプションを有効にし、高度な"
+"モデルにアクセスしよう"
 
 # smartling.placeholder_format=C
 #. The placeholder indicates a formatted date (e.g., 'Updated 2 days ago')
@@ -20566,7 +21621,9 @@ msgctxt ""
 msgid ""
 "Upgrade to Pro to unlock 2x higher limits than Plus, or come back later to "
 "create more images."
-msgstr "ProにアップグレードしてPlusの2倍の制限を活用するか、後で戻ってきてさらに画像を作成してください。"
+msgstr ""
+"ProにアップグレードしてPlusの2倍の制限を活用するか、後で戻ってきてさらに画像"
+"を作成してください。"
 
 # smartling.placeholder_format=C
 #. Upsell message shown in the voice chat limit and duration limit modals for Plus subscribers, encouraging them to upgrade to Pro.
@@ -20621,6 +21678,12 @@ msgid "Uruguay"
 msgstr "ウルグアイ"
 
 # smartling.placeholder_format=C
+#. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
+msgctxt "Navigation label on the Duck.ai settings page"
+msgid "Usage"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A feedback suggestion
 msgctxt "Feedback prompt"
 msgid "Usage limit"
@@ -20661,7 +21724,10 @@ msgctxt "duckai_seo"
 msgid ""
 "Use ChatGPT, Claude, and other AIs, privately. Protect chats from hackers, "
 "scammers, and companies. Keep info confidential. Free. No account required."
-msgstr "ChatGPT、Claude、その他のAIをプライベートに使いましょう。チャットをハッカー、詐欺師、企業から守りましょう。情報の機密を保ちましょう。無料。アカウントは必要ありません。"
+msgstr ""
+"ChatGPT、Claude、その他のAIをプライベートに使いましょう。チャットをハッカー、"
+"詐欺師、企業から守りましょう。情報の機密を保ちましょう。無料。アカウントは必"
+"要ありません。"
 
 # smartling.placeholder_format=C
 #. Header above instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -20673,7 +21739,8 @@ msgstr "DuckDuckGo Private Searchを使う"
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Use DuckDuckGo private search on your iPad, iPhone, or Android!"
-msgstr "あなたのiPad、iPhoneまたはAndroidで、DuckDuckGoのプライベート検索を使おう！"
+msgstr ""
+"あなたのiPad、iPhoneまたはAndroidで、DuckDuckGoのプライベート検索を使おう！"
 
 # smartling.placeholder_format=C
 #. User clicks this button to share their device's location
@@ -20702,7 +21769,9 @@ msgstr "Safariで使用"
 msgctxt "Description for the recovery section inside Manage"
 msgid ""
 "Use this code to restore your saved chats if you lose access to your devices."
-msgstr "デバイスへのアクセスを失った場合に、このコードを使用して保存済みのチャットを復元してください。"
+msgstr ""
+"デバイスへのアクセスを失った場合に、このコードを使用して保存済みのチャットを"
+"復元してください。"
 
 # smartling.placeholder_format=C
 #. Prompt to ask the user if they want to use their approximate location for more accurate results
@@ -20851,7 +21920,9 @@ msgctxt "Ads GDPR, internal use only. Do not change"
 msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Microsoft's ad network"
-msgstr "広告表示機能のプライバシーは DuckDuckGo で保護されます。広告のクリックは Microsoft の広告ネットワークで管理されています"
+msgstr ""
+"広告表示機能のプライバシーは DuckDuckGo で保護されます。広告のクリックは "
+"Microsoft の広告ネットワークで管理されています"
 
 # smartling.placeholder_format=C
 #. Information about TripAdvisor ads for DuckDuckGo's users. This appears in a tooltip.
@@ -20859,7 +21930,9 @@ msgctxt "Single Place Hotel Offers Module"
 msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "TripAdvisor's ad network."
-msgstr "広告表示機能のプライバシーは DuckDuckGo で保護されます。広告のクリックはTripAdvisorの広告ネットワークで管理されています。"
+msgstr ""
+"広告表示機能のプライバシーは DuckDuckGo で保護されます。広告のクリックは"
+"TripAdvisorの広告ネットワークで管理されています。"
 
 # smartling.placeholder_format=C
 msgid "Virgin Islands"
@@ -20870,7 +21943,9 @@ msgstr "ヴァージン諸島"
 msgctxt "duckassist"
 msgid ""
 "Visit %sAssist Settings%s to adjust how this feature works or turn it off."
-msgstr "この機能の動作を調整したり、オフにしたりするには、%1$sAssist設定%2$sにアクセスしてください。"
+msgstr ""
+"この機能の動作を調整したり、オフにしたりするには、%1$sAssist設定%2$sにアクセ"
+"スしてください。"
 
 # smartling.placeholder_format=C
 #. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
@@ -20878,7 +21953,9 @@ msgctxt "duckassist"
 msgid ""
 "Visit %sDuckAssist Settings%s to adjust how this feature works or turn it "
 "off."
-msgstr "この機能の動作を調整したり、オフにしたりするには、%1$sDuckAssist設定%2$sにアクセスしてください。"
+msgstr ""
+"この機能の動作を調整したり、オフにしたりするには、%1$sDuckAssist設定%2$sにア"
+"クセスしてください。"
 
 # smartling.placeholder_format=C
 #. Prompt to visit DuckDuckGo on another device.
@@ -20886,7 +21963,9 @@ msgctxt "mobile promotion on desktop"
 msgid ""
 "Visit %sDuckDuckGo.com%s on your tablet or phone and follow the provided "
 "instructions."
-msgstr "タブレットまたは携帯電話で%1$sDuckDuckGo.com%2$sにアクセスして、案内に従ってください。"
+msgstr ""
+"タブレットまたは携帯電話で%1$sDuckDuckGo.com%2$sにアクセスして、案内に従って"
+"ください。"
 
 # smartling.placeholder_format=C
 #. Primary button to visit Duck.ai.
@@ -20901,8 +21980,9 @@ msgid ""
 "Visit Duck.ai in your other browser and go to %sDuck.ai Settings%s > %sSync "
 "& Backup%s > %sManage%s then select %sSync With Another Device%s."
 msgstr ""
-"他のブラウザでDuck.aiにアクセスし、%1$sDuck.ai設定%2$s > %3$sSync & Backup%4$s > %5$s管理%6$s "
-"に進み、%7$s別のデバイスと同期%8$sを選択してください。"
+"他のブラウザでDuck.aiにアクセスし、%1$sDuck.ai設定%2$s > %3$sSync & "
+"Backup%4$s > %5$s管理%6$s に進み、%7$s別のデバイスと同期%8$sを選択してくださ"
+"い。"
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -20911,7 +21991,10 @@ msgid ""
 "Visit Duck.ai in your other browser and open Duck.ai Settings. Select “Turn "
 "On” under Sync & Backup and select “Sync With Another Device”. Or scan the "
 "QR on your Recovery PDF."
-msgstr "別のブラウザでDuck.aiにアクセスし、Duck.aiの設定を開いてください。Sync＆Backupで「オンにする」を選択し、「別のデバイスと同期」を選択してください。または、リカバリーPDFのQRコードをスキャンしてください。"
+msgstr ""
+"別のブラウザでDuck.aiにアクセスし、Duck.aiの設定を開いてください。Sync＆"
+"Backupで「オンにする」を選択し、「別のデバイスと同期」を選択してください。ま"
+"たは、リカバリーPDFのQRコードをスキャンしてください。"
 
 # smartling.placeholder_format=C
 #. Shared body copy for every screen in the Sync Another Device flow (QR display, camera scan, camera-unavailable fallback, manual entry). Bold tags wrap navigation breadcrumbs. Render with <Translate /> so the HTML is interpreted; plain `translate()` will trip the html-string warning.
@@ -20921,8 +22004,9 @@ msgid ""
 "ai Settings%s > %sSync & Backup%s > %sManage%s then select %sSync With "
 "Another Device%s."
 msgstr ""
-"他のブラウザまたはDuckDuckGoアプリでDuck.aiにアクセスし、%1$sDuck.ai設定%2$s > %3$sSync & "
-"Backup%4$s > %5$s管理%6$s に進み、%7$s別のデバイスと同期%8$sを選択してください。"
+"他のブラウザまたはDuckDuckGoアプリでDuck.aiにアクセスし、%1$sDuck.ai設定%2$s "
+"> %3$sSync & Backup%4$s > %5$s管理%6$s に進み、%7$s別のデバイスと同期%8$sを選"
+"択してください。"
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -20931,7 +22015,10 @@ msgid ""
 "Visit Duck.ai in your other browser or the DuckDuckGo app and open Duck.ai "
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
-msgstr "他のブラウザまたはDuckDuckGoアプリでDuck.aiにアクセスし、Duck.aiの設定を開きます。Sync＆Backupで「オンにする」を選択し、「別のデバイスと同期」を選択します。または、リカバリーPDFのQRコードをスキャンします。"
+msgstr ""
+"他のブラウザまたはDuckDuckGoアプリでDuck.aiにアクセスし、Duck.aiの設定を開き"
+"ます。Sync＆Backupで「オンにする」を選択し、「別のデバイスと同期」を選択しま"
+"す。または、リカバリーPDFのQRコードをスキャンします。"
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -20983,7 +22070,9 @@ msgstr "ボイスチャットは終了しました"
 #. Description in consent disclaimer informing that voice chats with the AI (Artificial Intelligence) are anonymized by us, and are never used to train AI models.
 msgctxt "voice chat"
 msgid "Voice chat is anonymized by us, and never used to train AI models."
-msgstr "ボイスチャットは当社によって匿名化されており、AIモデルのトレーニングには使用されません。"
+msgstr ""
+"ボイスチャットは当社によって匿名化されており、AIモデルのトレーニングには使用"
+"されません。"
 
 # smartling.placeholder_format=C
 #. Title of the modal shown when the user has reached their daily voice chat limit.
@@ -21042,6 +22131,12 @@ msgstr "位置情報を取得中..."
 # smartling.placeholder_format=C
 msgid "Wales"
 msgstr "ウェールズ"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Walk me through the steps"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for walking directions on a map.
@@ -21121,8 +22216,8 @@ msgid ""
 "Watch in Duck Player to block personalized ads on YouTube and prevent your "
 "viewing activity from influencing YouTube recommendations."
 msgstr ""
-"Duck Player で視聴すると、YouTube でパーソナライズ広告がブロックされるため、YouTube "
-"のおすすめに影響されずに動画を視聴できます。"
+"Duck Player で視聴すると、YouTube でパーソナライズ広告がブロックされるため、"
+"YouTube のおすすめに影響されずに動画を視聴できます。"
 
 # smartling.placeholder_format=C
 #. A button that takes a user to another site in order to watch a video. The placeholder is the name of the video site. For example: 'Watch on Vimeo'
@@ -21141,7 +22236,11 @@ msgid ""
 "because we have to stream the content from there. DuckDuckGo is an "
 "independent company and has no relationship with YouTube, where most videos "
 "are hosted."
-msgstr "このプラットフォームで動画を視聴する場合、ホストするウェブサイトからコンテンツが流されるため、そのウェブサイトは視聴者の追跡が可能になります。DuckDuckGoは独立した会社であり、ほとんどの動画がホストされているYouTubeとは一切関係ございません。"
+msgstr ""
+"このプラットフォームで動画を視聴する場合、ホストするウェブサイトからコンテン"
+"ツが流されるため、そのウェブサイトは視聴者の追跡が可能になります。DuckDuckGo"
+"は独立した会社であり、ほとんどの動画がホストされているYouTubeとは一切関係ござ"
+"いません。"
 
 # smartling.placeholder_format=C
 #. Heading for the highlight card explaining anonymized prompt delivery.
@@ -21153,7 +22252,19 @@ msgstr "匿名化に対応"
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
-msgstr "%1$s位置情報%2$sを匿名化して、より正確な結果が表示されるようにできます。"
+msgstr ""
+"%1$s位置情報%2$sを匿名化して、より正確な結果が表示されるようにできます。"
+
+# smartling.placeholder_format=C
+#. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
+msgctxt ""
+"Inline warning shown below the share-content toggle when the user selects "
+"Harmful or Illegal but has not enabled sharing"
+msgid ""
+"We can only fix what we can see. To report a harmful or illegal response, "
+"please share this conversation with DuckDuckGo so we can investigate and "
+"address the issue."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -21164,7 +22275,9 @@ msgid ""
 "We can only fix what we can see. To report a harmful or illegal response, "
 "please share your prompt and response so we can investigate and address the "
 "issue."
-msgstr "当社が修正できるのは、目に見えるものだけです。有害または違法な応答を報告する場合は、問題を調査し対処するために、プロンプトと応答内容をお知らせください。"
+msgstr ""
+"当社が修正できるのは、目に見えるものだけです。有害または違法な応答を報告する"
+"場合は、問題を調査し対処するために、プロンプトと応答内容をお知らせください。"
 
 # smartling.placeholder_format=C
 #. Explains how location service is used to show users search results near their current location.
@@ -21177,7 +22290,9 @@ msgstr "匿名の%1$s位置情報%2$sを使用すると、おおよその結果�
 msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
-msgstr "添付ファイルのうち少なくとも1つが暗号化されているため、内容を読み取ることができません。"
+msgstr ""
+"添付ファイルのうち少なくとも1つが暗号化されているため、内容を読み取ることがで"
+"きません。"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -21204,7 +22319,9 @@ msgstr "私たちはあなたの個人情報を保存しません。"
 msgid ""
 "We don't store your personal info. We don't follow you around with ads. We "
 "don't track you. Ever."
-msgstr "個人情報を保存しません。広告で追い回しません。閲覧状況を追跡しません。お約束します。"
+msgstr ""
+"個人情報を保存しません。広告で追い回しません。閲覧状況を追跡しません。お約束"
+"します。"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -21217,7 +22334,9 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what brought you "
 "back today:"
-msgstr "私たちはあなたを追跡しません。ですから、「もう一度DuckDuckGoを使おうと思った理由」を教えてください。"
+msgstr ""
+"私たちはあなたを追跡しません。ですから、「もう一度DuckDuckGoを使おうと思った"
+"理由」を教えてください。"
 
 # smartling.placeholder_format=C
 #. Message prompting users to fill out a feedback form.
@@ -21225,7 +22344,9 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what convinced you "
 "to try us out today:"
-msgstr "私たちはあなたを追跡しません。ですから、「あなたがDuckDuckGoを使ってみようと思った理由」を教えてください。"
+msgstr ""
+"私たちはあなたを追跡しません。ですから、「あなたがDuckDuckGoを使ってみようと"
+"思った理由」を教えてください。"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -21264,18 +22385,23 @@ msgctxt "homepage onboarding"
 msgid ""
 "We don’t store your search history. We therefore have nothing to sell to "
 "advertisers that track you across the Internet."
-msgstr "私たちは、あなたの検索履歴を保存しません。したがって、インターネット経由であなたを追跡して、それを広告主に販売することはありません。"
+msgstr ""
+"私たちは、あなたの検索履歴を保存しません。したがって、インターネット経由であ"
+"なたを追跡して、それを広告主に販売することはありません。"
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don’t track you in or out of private browsing mode."
-msgstr "私たちは、プライベートブラウジングモードでも、それ以外でも、あなたを追跡しません。"
+msgstr ""
+"私たちは、プライベートブラウジングモードでも、それ以外でも、あなたを追跡しま"
+"せん。"
 
 # smartling.placeholder_format=C
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with an Agree button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don’t track you. That’s our Privacy Policy in a nutshell…"
-msgstr "私たちはあなたを追跡しません。これが私たちのプライバシーポリシーの概要です。"
+msgstr ""
+"私たちはあなたを追跡しません。これが私たちのプライバシーポリシーの概要です。"
 
 # smartling.placeholder_format=C
 #. Displayed when the user's voice chat session is ended because of being inactive for too long.
@@ -21289,7 +22415,8 @@ msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
 "We have agreements with all AI providers to ensure your chats aren't used to "
 "train AIs."
-msgstr "チャットがAIの学習に使用されない旨の契約をAIプロバイダーと結んでいます。"
+msgstr ""
+"チャットがAIの学習に使用されない旨の契約をAIプロバイダーと結んでいます。"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -21313,7 +22440,9 @@ msgstr "接続が失われました。メッセージの送信をもう一度お
 msgid ""
 "We make money from %sprivacy-respecting search ads%s, not by exploiting your "
 "data."
-msgstr "私たちは、あなたのデータを悪用するのではなく、%1$sプライバシーを尊重する検索広告%2$sから収益を得ています。"
+msgstr ""
+"私たちは、あなたのデータを悪用するのではなく、%1$sプライバシーを尊重する検索"
+"広告%2$sから収益を得ています。"
 
 # smartling.placeholder_format=C
 #. Message describing how DuckDuckGo users location access anonymously to provide better search results.
@@ -21321,13 +22450,17 @@ msgctxt "precise_user_location"
 msgid ""
 "We only use your anonymous location to deliver better results, closer to "
 "you. You can always change your mind later."
-msgstr "匿名の位置情報は、表示される結果を比較的近くに絞り込む目的でのみ使用されます。この設定は後でいつでも変更できます。"
+msgstr ""
+"匿名の位置情報は、表示される結果を比較的近くに絞り込む目的でのみ使用されま"
+"す。この設定は後でいつでも変更できます。"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
-msgstr "DuckDuckGoを誰にとってもより良いものにするために、私たちはみなさまからの匿名でのフィードバックを頼りにしています。"
+msgstr ""
+"DuckDuckGoを誰にとってもより良いものにするために、私たちはみなさまからの匿名"
+"でのフィードバックを頼りにしています。"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -21347,7 +22480,9 @@ msgid ""
 "We use feedback like this to improve DuckDuckGo. Suggestions will be "
 "incorporated at the discretion of %s. Corrections may not show up in results "
 "right away."
-msgstr "このようなフィードバックをDuckDuckGoの向上に活用します。%1$sは独自の判断でご提案を採用します。訂正内容は結果にすぐ表示されない場合があります。"
+msgstr ""
+"このようなフィードバックをDuckDuckGoの向上に活用します。%1$sは独自の判断でご"
+"提案を採用します。訂正内容は結果にすぐ表示されない場合があります。"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -21360,7 +22495,9 @@ msgctxt "noresults"
 msgid ""
 "We're aware of this issue and are currently working to resolve it. If you "
 "continue to see this error, please reach out to %s."
-msgstr "当社はこの問題について認識しており、現在解決に向けて取り組んでいます。このエラーが続く場合は、%1$sに連絡してください。"
+msgstr ""
+"当社はこの問題について認識しており、現在解決に向けて取り組んでいます。このエ"
+"ラーが続く場合は、%1$sに連絡してください。"
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -21368,7 +22505,9 @@ msgctxt "noresults"
 msgid ""
 "We're aware of this issue and are currently working to resolve it. Sometimes "
 "clearing your browser's cache can help."
-msgstr "当社はこの問題について認識しており、現在解決に向けて取り組んでいます。ブラウザのキャッシュをクリアすると解決に役立つ場合があります。"
+msgstr ""
+"当社はこの問題について認識しており、現在解決に向けて取り組んでいます。ブラウ"
+"ザのキャッシュをクリアすると解決に役立つ場合があります。"
 
 # smartling.placeholder_format=C
 #. Header for a feedback form for new users.
@@ -21382,7 +22521,9 @@ msgctxt "duckai_migration"
 msgid ""
 "We're sorry for this inconvenience. We’re working hard to make your "
 "experience better."
-msgstr "ご不便をおかけして申し訳ありません。体験の改善のために一生懸命努力しています。"
+msgstr ""
+"ご不便をおかけして申し訳ありません。体験の改善のために一生懸命努力していま"
+"す。"
 
 # smartling.placeholder_format=C
 #. Body text explaining the service update requires a page reload.
@@ -21390,7 +22531,9 @@ msgctxt "duckai_migration"
 msgid ""
 "We've updated the Duck.ai service. For the change to take effect, we need to "
 "reload the page."
-msgstr "Duck.aiサービスを更新しました。変更を有効にするには、ページをリロードする必要があります。"
+msgstr ""
+"Duck.aiサービスを更新しました。変更を有効にするには、ページをリロードする必要"
+"があります。"
 
 # smartling.placeholder_format=C
 #. Instant Answer Tab Name
@@ -21505,7 +22648,9 @@ msgctxt "Welcome message in chat"
 msgid ""
 "Welcome to Duck.ai! All of your chats here are private, anonymized by us and "
 "not used to train AI models."
-msgstr "Duck.aiへようこそ！ここでのチャットはすべて非公開で、匿名化され、AIモデルのトレーニングには使用されません。"
+msgstr ""
+"Duck.aiへようこそ！ここでのチャットはすべて非公開で、匿名化され、AIモデルのト"
+"レーニングには使用されません。"
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened.
@@ -21513,7 +22658,9 @@ msgctxt "Welcome message in chat"
 msgid ""
 "Welcome to DuckDuckGo AI Chat! All of your chats here are private, "
 "anonymized by us and not used to train AI models."
-msgstr "DuckDuckGo AI Chatへようこそ！ここでのチャットはすべて非公開で、匿名化され、AIモデルのトレーニングには使用されません。"
+msgstr ""
+"DuckDuckGo AI Chatへようこそ！ここでのチャットはすべて非公開で、匿名化され、"
+"AIモデルのトレーニングには使用されません。"
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened. Example: 'Welcome to DuckDuckGo AI Chat! This chat session is powered by OpenAI’s GPT-3. All of your chats here are private, and are never stored by DuckDuckGo or used to train AI models.'
@@ -21523,14 +22670,17 @@ msgid ""
 "of your chats here are private, and are never stored by DuckDuckGo or used "
 "to train AI models."
 msgstr ""
-"DuckDuckGo AI "
-"Chatへようこそ！このチャットセッションは%1$sの%2$sを使用しています。ここでのチャットはすべて非公開で、DuckDuckGoに保存されたり、AIモデルのトレーニングに使用されたりすることはありません。"
+"DuckDuckGo AI Chatへようこそ！このチャットセッションは%1$sの%2$sを使用してい"
+"ます。ここでのチャットはすべて非公開で、DuckDuckGoに保存されたり、AIモデルの"
+"トレーニングに使用されたりすることはありません。"
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai! You can now import your downloaded chats."
-msgstr "新しいDuck.aiへようこそ！ダウンロードしたチャットをインポートできるようになりました。"
+msgstr ""
+"新しいDuck.aiへようこそ！ダウンロードしたチャットをインポートできるようになり"
+"ました。"
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -21597,7 +22747,9 @@ msgctxt "duckai_fatal_error"
 msgid ""
 "We’re really sorry, but it seems there was a problem loading Duck.ai. Try "
 "reloading the page."
-msgstr "申し訳ありませんが、Duck.aiの読み込みに問題があったようです。ページを再読み込みしてみてください。"
+msgstr ""
+"申し訳ありませんが、Duck.aiの読み込みに問題があったようです。ページを再読み込"
+"みしてみてください。"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to suggest an AI (Artificial Intelligence) model to be added to the product, and this field is optional.
@@ -21611,7 +22763,9 @@ msgctxt "Full sentence for improving arguments"
 msgid ""
 "What are some arguments, counter-arguments, and rebuttals to the concept of "
 "a plant-based diet?"
-msgstr "プラントベースの食事の概念に対する議論、反論、反駁にはどのようなものがありますか？"
+msgstr ""
+"プラントベースの食事の概念に対する議論、反論、反駁にはどのようなものがありま"
+"すか？"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for considering factors when purchasing a computer monitor.
@@ -21631,7 +22785,9 @@ msgctxt "Full sentence for finding a better word"
 msgid ""
 "What are some options for the word ‘better’ in the context of “We really "
 "need to do better.”"
-msgstr "「私たちは本当にもっとうまくやる必要がある」という文脈で「もっとうまく」をどう言い換えられますか？"
+msgstr ""
+"「私たちは本当にもっとうまくやる必要がある」という文脈で「もっとうまく」をど"
+"う言い換えられますか？"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
@@ -21649,7 +22805,109 @@ msgid ""
 "ai integrations, and privacy protections. Keep it quite short, simple, and "
 "easy to understand for people with or without much AI, or technical, "
 "experience."
-msgstr "Duck.aiの利用に興味があるユーザーが、DuckDuckGoブラウザをダウンロードするメリットとは何でしょうか。まず、DuckDuckGoの公式ソースのみ参照します。また、回答はタイトル付きの明確なセクションに分かれ、Duck.aiの統合とプライバシー保護に重点が置かれます。簡潔かつシンプルで、AIや技術に関する経験の有無に関わらず、誰でも簡単に理解できるように回答します。"
+msgstr ""
+"Duck.aiの利用に興味があるユーザーが、DuckDuckGoブラウザをダウンロードするメ"
+"リットとは何でしょうか。まず、DuckDuckGoの公式ソースのみ参照します。また、回"
+"答はタイトル付きの明確なセクションに分かれ、Duck.aiの統合とプライバシー保護に"
+"重点が置かれます。簡潔かつシンプルで、AIや技術に関する経験の有無に関わらず、"
+"誰でも簡単に理解できるように回答します。"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the counterarguments?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the hours & location?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key contributions of this paper?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key contributions?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key details?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key points covered in this video?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key points?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key takeaways from this article?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key takeaways?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key things I will learn from this course?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main counterarguments or criticisms of this?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main questions this page answers?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the must-try dishes here?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"What are the opening hours, location, and contact details for this place?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the pros and cons of this product?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the pros and cons?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
@@ -21752,6 +23010,12 @@ msgid "What does atria mean in the context of a medical article?"
 msgstr "医学論文の文脈で心房とはどういう意味ですか？"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What does this answer?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
@@ -21764,18 +23028,32 @@ msgid "What information gets saved?"
 msgstr "どのような情報が保存されますか？"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What interview questions might come up for this role?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
 msgid ""
 "What is the Cloud Save bookmarklet and how does it differ from the URL "
 "parameter bookmarklet?"
-msgstr "Cloud Saveブックマークレットとは何ですか？URLパラメータ・ブックマークレットとの違いは？"
+msgstr ""
+"Cloud Saveブックマークレットとは何ですか？URLパラメータ・ブックマークレットと"
+"の違いは？"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for looking up the capital city of Albania.
 msgctxt "Full sentence for looking up basic facts"
 msgid "What is the capital city of Albania?"
 msgstr "アルバニアの首都はどこですか？"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What is the overall verdict and rating for this?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to a page with additional information.
@@ -21800,6 +23078,12 @@ msgid "What people say:"
 msgstr "評価 :"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What should I order?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
 msgctxt "feedback form"
 msgid "What stood out?"
@@ -21810,6 +23094,18 @@ msgstr "特にどの点が優れていましたか？"
 msgctxt "feedback form"
 msgid "What was wrong with the response? (optional)"
 msgstr "応答のどこが問題でしたか？（任意）"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I learn?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I need?"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -21829,6 +23125,12 @@ msgid "What's New"
 msgstr "新着情報"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What's the verdict?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to a page featuring the most recent updates from DuckDuckGo.
 msgid "What’s New"
 msgstr "新着情報"
@@ -21839,7 +23141,9 @@ msgctxt "Full sentence for identifying product brands"
 msgid ""
 "When buying an electric guitar for a beginner, what are the top product "
 "brands I should consider?"
-msgstr "初心者向けのエレキギターを購入する場合、考慮すべきトップ製品ブランドは何ですか？"
+msgstr ""
+"初心者向けのエレキギターを購入する場合、考慮すべきトップ製品ブランドは何です"
+"か？"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -21877,6 +23181,12 @@ msgid "Which features are missing? (Optional)"
 msgstr "どの機能が不足していますか？（任意）"
 
 # smartling.placeholder_format=C
+#. An invitation for users to leave feedback
+msgctxt "Feedback prompt"
+msgid "Which features are missing? (optional)"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
 msgid "White"
 msgstr "白"
@@ -21891,6 +23201,18 @@ msgstr "白"
 #. Link to an about us page.
 msgid "Who We Are"
 msgstr "私たち"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Who are the main cast and crew, and what else are they known for?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Who is this person?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Header above a collection of privacy-related links.
@@ -22280,7 +23602,9 @@ msgctxt "Disclaimer bellow chat input - desktop"
 msgid ""
 "You are chatting with %s. AI chats may display inaccurate or offensive "
 "information."
-msgstr "%1$sとチャット中です。 AIチャットでは不正確な情報や不快な情報が表示される場合があります。"
+msgstr ""
+"%1$sとチャット中です。 AIチャットでは不正確な情報や不快な情報が表示される場合"
+"があります。"
 
 # smartling.placeholder_format=C
 #. Provide users with the ability to retry their search on a different search engine. First placeholder will be a link with the text "try your search again" OR "try your search later". Second is a URL to the !bangs page: https://duckduckgo.com/bangs.
@@ -22288,7 +23612,9 @@ msgctxt "noresults"
 msgid ""
 "You can %s or search directly on other search engines from DuckDuckGo using "
 "%s search shortcuts."
-msgstr "%1$sか、%2$s検索ショートカットを使用してDuckDuckGoや他の検索エンジンで直接検索できます。"
+msgstr ""
+"%1$sか、%2$s検索ショートカットを使用してDuckDuckGoや他の検索エンジンで直接検"
+"索できます。"
 
 # smartling.placeholder_format=C
 #. Text informing the user that they can access DuckDuckGo AI Chat directly at a specific URL. The placeholder %s will be replaced with the link. Example: 'You can access DuckDuckGo AI Chat directly at duck.ai.'
@@ -22301,7 +23627,8 @@ msgstr "DuckDuckGo AI Chatには%1$sから直接アクセスできます。"
 msgctxt "duckassist"
 msgid ""
 "You can adjust how %s works or turn it off anytime in %sSearch Settings%s."
-msgstr "%1$sの動作を調整したり、%2$s検索設定%3$sでいつでも無効にしたりできます。"
+msgstr ""
+"%1$sの動作を調整したり、%2$s検索設定%3$sでいつでも無効にしたりできます。"
 
 # smartling.placeholder_format=C
 #. Assist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate Assist.
@@ -22309,17 +23636,22 @@ msgctxt "duckassist"
 msgid ""
 "You can adjust how Assist works or turn it off anytime in %sSearch "
 "Settings%s."
-msgstr "Assistは、動作を調整したり、%1$s検索設定%2$sでいつでもオフにしたりできます。"
+msgstr ""
+"Assistは、動作を調整したり、%1$s検索設定%2$sでいつでもオフにしたりできます。"
 
 # smartling.placeholder_format=C
 msgid "You can also use %sDuck.ai%s to answer questions or summarize text."
-msgstr "%1$sDuck.ai%2$sを使用して質問に答えたり、テキストを要約したりすることもできます。"
+msgstr ""
+"%1$sDuck.ai%2$sを使用して質問に答えたり、テキストを要約したりすることもできま"
+"す。"
 
 # smartling.placeholder_format=C
 msgid ""
 "You can also use %sDuckDuckGo AI Chat%s to answer questions or summarize "
 "text."
-msgstr "%1$s DuckDuckGo AI Chat%2$sを使用して質問に答えたり、テキストを要約したりすることもできます。"
+msgstr ""
+"%1$s DuckDuckGo AI Chat%2$sを使用して質問に答えたり、テキストを要約したりする"
+"こともできます。"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach more text selections than are allowed. Placeholder is the maximum number of text selections. E.g. You can attach up to 5 text selections.
@@ -22332,7 +23664,9 @@ msgstr "添付するテキストは最大%1$sまで選択できます。"
 msgid ""
 "You can change how frequently you see Search Assist, or turn it off "
 "entirely, in %sSearch Settings%s."
-msgstr "Search Assistは、%1$s検索設定%2$sで表示頻度を変更したり、完全に無効にしたりできます。"
+msgstr ""
+"Search Assistは、%1$s検索設定%2$sで表示頻度を変更したり、完全に無効にしたりで"
+"きます。"
 
 # smartling.placeholder_format=C
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
@@ -22346,7 +23680,9 @@ msgctxt "cloudsave"
 msgid ""
 "You can do this by saving your settings under a different passphrase, "
 "optionally deleting the first set."
-msgstr "設定を別のパスフレーズで保存してください。それまで使っていたパスフレーズも任意で削除できます。"
+msgstr ""
+"設定を別のパスフレーズで保存してください。それまで使っていたパスフレーズも任"
+"意で削除できます。"
 
 # smartling.placeholder_format=C
 #. Prefix for filename location sentence.
@@ -22369,7 +23705,8 @@ msgstr "このリマインダーは%1$s検索設定%2$sで非表示にできま�
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
-msgstr "このデバイスでは最大100件のチャットを保存できます。チャットを開始しましょう！"
+msgstr ""
+"このデバイスでは最大100件のチャットを保存できます。チャットを開始しましょう！"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -22425,7 +23762,9 @@ msgctxt "Organic result context menu"
 msgid ""
 "You can only block up to %s sites. To block %s, you'll need to unblock "
 "another site first."
-msgstr "最大%1$sサイトまでブロックできます。%2$sをブロックするには、まず別のサイトのブロックを解除する必要があります。"
+msgstr ""
+"最大%1$sサイトまでブロックできます。%2$sをブロックするには、まず別のサイトの"
+"ブロックを解除する必要があります。"
 
 # smartling.placeholder_format=C
 #. Text explaining the benefits of the cloud save feature.
@@ -22481,7 +23820,8 @@ msgctxt "Description of the post-upgrade success modal"
 msgid ""
 "You now have access to %s, higher AI reasoning, and 2x higher usage limits "
 "than Plus."
-msgstr "これで%1$s、より高いAI推論、Plusの2倍の使用制限が利用可能になりました。"
+msgstr ""
+"これで%1$s、より高いAI推論、Plusの2倍の使用制限が利用可能になりました。"
 
 # smartling.placeholder_format=C
 #. Description text for the welcome modal displayed after the user subscribes to DuckDuckGo.
@@ -22489,7 +23829,9 @@ msgctxt "Description text for the subscription welcome modal"
 msgid ""
 "You now have access to advanced AI models. You can access the VPN and other "
 "DuckDuckGo subscription protections in the DuckDuckGo browser."
-msgstr "高度なAIモデルへのアクセスが可能になりました。VPNやその他のDuckDuckGoサブスクリプション保護機能は、DuckDuckGoブラウザ内でご利用いただけます。"
+msgstr ""
+"高度なAIモデルへのアクセスが可能になりました。VPNやその他のDuckDuckGoサブスク"
+"リプション保護機能は、DuckDuckGoブラウザ内でご利用いただけます。"
 
 # smartling.placeholder_format=C
 #. Welcome message that appears after the DuckDuckGo extension is installed.
@@ -22510,7 +23852,10 @@ msgid ""
 "You will no longer be able to access your saved chats from this browser. The "
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
-msgstr "このブラウザからは、保存済みのチャットにアクセスできなくなります。直近30件のチャットはローカルストレージで引き続き利用可能です。これにより、暗号化されたサーバーからチャットデータが削除されることはありません。"
+msgstr ""
+"このブラウザからは、保存済みのチャットにアクセスできなくなります。直近30件の"
+"チャットはローカルストレージで引き続き利用可能です。これにより、暗号化された"
+"サーバーからチャットデータが削除されることはありません。"
 
 # smartling.placeholder_format=C
 #. Explains that turning off disconnects this browser only; the last 30 chats stay in local storage and the encrypted server backup is not deleted.
@@ -22519,7 +23864,10 @@ msgid ""
 "You will no longer be able to access your saved chats from this browser. The "
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
-msgstr "このブラウザからは、保存済みのチャットにアクセスできなくなります。直近30件のチャットはローカルストレージで引き続き利用可能です。この操作により、暗号化されたサーバーからチャットデータが削除されることはありません。"
+msgstr ""
+"このブラウザからは、保存済みのチャットにアクセスできなくなります。直近30件の"
+"チャットはローカルストレージで引き続き利用可能です。この操作により、暗号化さ"
+"れたサーバーからチャットデータが削除されることはありません。"
 
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
@@ -22532,7 +23880,8 @@ msgctxt "Update browser banner"
 msgid ""
 "You'll receive automatic DuckDuckGo app updates once you have the latest "
 "version."
-msgstr "最新バージョンを入手すると、DuckDuckGoアプリの自動アップデートが届きます。"
+msgstr ""
+"最新バージョンを入手すると、DuckDuckGoアプリの自動アップデートが届きます。"
 
 # smartling.placeholder_format=C
 #. shown when DDG is selected after eu preference menu on android
@@ -22540,7 +23889,10 @@ msgctxt "welcome message eu search preference android"
 msgid ""
 "You're now searching privately in Chrome. Use our app instead of Chrome to "
 "browse privately too. It’s already installed and can:"
-msgstr "現在、Chromeのプライベート検索を使用しています。Chromeの代わりに当社アプリを使ってもプライベートに閲覧できます。このアプリはすでにインストールされており、以下が可能になります。"
+msgstr ""
+"現在、Chromeのプライベート検索を使用しています。Chromeの代わりに当社アプリを"
+"使ってもプライベートに閲覧できます。このアプリはすでにインストールされてお"
+"り、以下が可能になります。"
 
 # smartling.placeholder_format=C
 #. Confirmation message that appears after the DuckDuckGo browser extension is installed.
@@ -22552,7 +23904,9 @@ msgstr "あなたは今、匿名で検索しています！"
 msgid ""
 "You're now searching with privacy. %sGet tips to reduce your footprint even "
 "more."
-msgstr "今あなたはプライバシーが保護された状態で検索しています。%1$sあなたの痕跡をもっと減らすヒントを学びましょう。"
+msgstr ""
+"今あなたはプライバシーが保護された状態で検索しています。%1$sあなたの痕跡を"
+"もっと減らすヒントを学びましょう。"
 
 # smartling.placeholder_format=C
 #. Title of a notice thanking the user for turning off their adblocker
@@ -22595,7 +23949,8 @@ msgctxt "Error message for user limit"
 msgid ""
 "You've reached the maximum number of messages for the moment. Please try "
 "again later."
-msgstr "現在、メッセージ数の上限に達しています。時間を置いてもう一度お試しください。"
+msgstr ""
+"現在、メッセージ数の上限に達しています。時間を置いてもう一度お試しください。"
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -22608,12 +23963,14 @@ msgstr "1回のセッションの最大ボイスチャット時間に達しま�
 msgctxt "voice chat limit modal"
 msgid ""
 "You've reached the voice chat limit for today. Please try again tomorrow."
-msgstr "本日のボイスチャットの回数制限に達しました。明日もう一度お試しください。"
+msgstr ""
+"本日のボイスチャットの回数制限に達しました。明日もう一度お試しください。"
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
 msgid "You've reached your dictation usage limit. Try again later."
-msgstr "ディクテーションの利用上限に達しました。時間を置いてもう一度お試しください。"
+msgstr ""
+"ディクテーションの利用上限に達しました。時間を置いてもう一度お試しください。"
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -22622,8 +23979,9 @@ msgid ""
 "You've run out of Sync & Backup storage for Duck.ai chats with attachments. "
 "Delete the %s oldest chats to resume Sync. Pinned chats will not be deleted."
 msgstr ""
-"添付ファイル付きのDuck.aiチャットのSync & "
-"Backup用ストレージ容量が不足しています。%1$s件の最も古いチャットを削除して同期を再開してください。ピン留めされたチャットは削除されません。"
+"添付ファイル付きのDuck.aiチャットのSync & Backup用ストレージ容量が不足してい"
+"ます。%1$s件の最も古いチャットを削除して同期を再開してください。ピン留めされ"
+"たチャットは削除されません。"
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -22633,8 +23991,9 @@ msgid ""
 "oldest chats with attachments to resume Sync. Pinned chats will not be "
 "deleted."
 msgstr ""
-"Duck.aiチャットのSync & "
-"Backup用ストレージ容量が不足しています。同期を再開するには、添付ファイル付きの最も古いチャットを%1$s件削除してください。ピン留めされたチャットは削除されません。"
+"Duck.aiチャットのSync & Backup用ストレージ容量が不足しています。同期を再開す"
+"るには、添付ファイル付きの最も古いチャットを%1$s件削除してください。ピン留め"
+"されたチャットは削除されません。"
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the sync storage limit.
@@ -22647,7 +24006,9 @@ msgstr "ストレージの容量がいっぱいです"
 msgid ""
 "YouTube (owned by Google) does not let you watch videos anonymously. As "
 "such, watching YouTube videos here will be tracked by YouTube/Google."
-msgstr "YouTube(Google社)に匿名性はありません。ここで見るビデオはGoogle社によって記録されています。"
+msgstr ""
+"YouTube(Google社)に匿名性はありません。ここで見るビデオはGoogle社によって記録"
+"されています。"
 
 # smartling.placeholder_format=C
 #. Label for a privacy disclaimer related to YouTube videos
@@ -22690,7 +24051,10 @@ msgid ""
 "Your backup will be deleted from DuckDuckGo's server. All devices will be "
 "disconnected from sync. Your %s most recent chats will be available in local "
 "storage on these browsers:"
-msgstr "バックアップデータはDuckDuckGoのサーバーから削除されます。すべてのデバイスの同期が解除されます。最新のチャット%1$s件は、次のブラウザのローカルストレージに保存されます。"
+msgstr ""
+"バックアップデータはDuckDuckGoのサーバーから削除されます。すべてのデバイスの"
+"同期が解除されます。最新のチャット%1$s件は、次のブラウザのローカルストレージ"
+"に保存されます。"
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list.
@@ -22699,7 +24063,10 @@ msgid ""
 "Your backup will be deleted from DuckDuckGo's server. All devices will be "
 "disconnected from sync. Your 100 most recent chats will be available in "
 "local storage on these browsers:"
-msgstr "バックアップデータはDuckDuckGoのサーバーから削除されます。すべてのデバイスの同期が解除されます。最新のチャット履歴100件は、以下のブラウザのローカルストレージに保存されます。"
+msgstr ""
+"バックアップデータはDuckDuckGoのサーバーから削除されます。すべてのデバイスの"
+"同期が解除されます。最新のチャット履歴100件は、以下のブラウザのローカルスト"
+"レージに保存されます。"
 
 # smartling.placeholder_format=C
 #. List item indicating that a site exclusion filter is currently active for the search
@@ -22723,14 +24090,18 @@ msgctxt "new tab page"
 msgid ""
 "Your browser provides a list of your most-visited sites. DuckDuckGo never "
 "has access to this data."
-msgstr "お使いのブラウザでは訪問回数が特に多いサイトリストが作成されます。DuckDuckGoがこのデータにアクセスすることはありません。"
+msgstr ""
+"お使いのブラウザでは訪問回数が特に多いサイトリストが作成されます。DuckDuckGo"
+"がこのデータにアクセスすることはありません。"
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
 msgid ""
 "Your browser provides the list of most-visited sites. DuckDuckGo never has "
 "access to this data."
-msgstr "ブラウザには、あなたがよくアクセスするサイトの一覧のデータがありますが、DuckDuckGoはこのデータにアクセスすることはできません。"
+msgstr ""
+"ブラウザには、あなたがよくアクセスするサイトの一覧のデータがありますが、"
+"DuckDuckGoはこのデータにアクセスすることはできません。"
 
 # smartling.placeholder_format=C
 #. Disclaimer text shown bellow chat input. Example: 'You are chatting with GPT-3. AI chats may display inaccurate or offensive information.'
@@ -22738,7 +24109,9 @@ msgctxt "Disclaimer bellow chat input - desktop"
 msgid ""
 "Your chat with %s is private. AI chats may display inaccurate or offensive "
 "information."
-msgstr "%1$sとのチャットは非公開です。AIチャットでは不正確な情報や不快な情報が表示される場合があります。"
+msgstr ""
+"%1$sとのチャットは非公開です。AIチャットでは不正確な情報や不快な情報が表示さ"
+"れる場合があります。"
 
 # smartling.placeholder_format=C
 #. Body copy shown after Sync & Backup is enabled, confirming chats are now syncing.
@@ -22750,41 +24123,50 @@ msgstr "チャットが保存されるようになりました。"
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never saved or used to train AI models"
-msgstr "チャットは非公開で、保存されたり、AIモデルのトレーニングに使用されることはありません。"
+msgstr ""
+"チャットは非公開で、保存されたり、AIモデルのトレーニングに使用されることはあ"
+"りません。"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never used to train AI models"
-msgstr "チャットは非公開であり、AIモデルのトレーニングに使用されることはありません。"
+msgstr ""
+"チャットは非公開であり、AIモデルのトレーニングに使用されることはありません。"
 
 # smartling.placeholder_format=C
 #. Text for a description of the active privacy protection for DuckDuckGo's AI Chat feature.
 msgctxt "Active Privacy protection description"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
-msgstr "チャットは非公開で、匿名化され、AIモデルのトレーニングには使用されません。"
+msgstr ""
+"チャットは非公開で、匿名化され、AIモデルのトレーニングには使用されません。"
 
 # smartling.placeholder_format=C
 #. Text explaining that user chats are private and not used for AI (Artificial Intelligence) training.
 msgctxt "Body text for privacy protection modal"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
-msgstr "チャットは非公開で、匿名化され、AIモデルのトレーニングには使用されません。"
+msgstr ""
+"チャットは非公開で、匿名化され、AIモデルのトレーニングには使用されません。"
 
 # smartling.placeholder_format=C
 #. Text for a menu item that describes the privacy protection feature.
 msgctxt "Menu item description"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
-msgstr "チャットは非公開で、当社が保存することはなく、AIモデルのトレーニングにも使用されません。"
+msgstr ""
+"チャットは非公開で、当社が保存することはなく、AIモデルのトレーニングにも使用"
+"されません。"
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the active privacy protection.
 msgctxt "Modal body for privacy"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
-msgstr "チャットは非公開で、当社が保存することはなく、AIモデルのトレーニングにも使用されません。"
+msgstr ""
+"チャットは非公開で、当社が保存することはなく、AIモデルのトレーニングにも使用"
+"されません。"
 
 # smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that chats are stored locally on the user's device.
@@ -22798,7 +24180,9 @@ msgctxt "duckai_migration"
 msgid ""
 "Your chats are still private, anonymized by us, and not used to train AI "
 "models. Follow these steps to keep your chat history."
-msgstr "チャットは引き続き非公開で、匿名化され、AIモデルのトレーニングには使用されません。チャット履歴を保持するには、以下の手順に従ってください。"
+msgstr ""
+"チャットは引き続き非公開で、匿名化され、AIモデルのトレーニングには使用されま"
+"せん。チャット履歴を保持するには、以下の手順に従ってください。"
 
 # smartling.placeholder_format=C
 #. Body shown after import completes.
@@ -22806,7 +24190,8 @@ msgctxt "duckai_migration"
 msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
-msgstr "チャットがインポートされました。Duck.aiで中断したところから続けましょう。"
+msgstr ""
+"チャットがインポートされました。Duck.aiで中断したところから続けましょう。"
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.
@@ -22837,7 +24222,9 @@ msgctxt "newsletter email collection"
 msgid ""
 "Your email address will not be shared, %sor associated with anonymous "
 "searches. [%sExample message%s]"
-msgstr "あなたの電子メールアドレスが他人に共有されることはありませし、%1$s匿名での検索に紐づけられることもありません。(%2$s例文のサンプル%3$s)"
+msgstr ""
+"あなたの電子メールアドレスが他人に共有されることはありませし、%1$s匿名での検"
+"索に紐づけられることもありません。(%2$s例文のサンプル%3$s)"
 
 # smartling.placeholder_format=C
 #. A prompt for the user to provide feedback on the third party map app directions experience
@@ -22880,10 +24267,10 @@ msgid ""
 "browser. We save the settings file using the key as the name. DuckDuckGo "
 "never knows your passphrase."
 msgstr ""
-"パスフレーズは、Secure Hash Algorithm (%1$sSHA-2%2$s) "
-""
-"を使用した512ビットのキーを生成します。ブラウザには、このキーと関連する設定ファイルのみが残ります。この設定ファイルは、キーを名前に用いて保存されます。DuckDuckGo "
-"がお客様のパスフレーズを知ることはありません。"
+"パスフレーズは、Secure Hash Algorithm (%1$sSHA-2%2$s) を使用した512ビットの"
+"キーを生成します。ブラウザには、このキーと関連する設定ファイルのみが残りま"
+"す。この設定ファイルは、キーを名前に用いて保存されます。DuckDuckGo がお客様の"
+"パスフレーズを知ることはありません。"
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -22897,7 +24284,10 @@ msgid ""
 "Your prompts are relayed through DuckDuckGo servers and stripped of "
 "personally identifiable metadata, so model providers can't tie your "
 "conversations back to you."
-msgstr "プロンプトはDuckDuckGoのサーバーを介して中継され、個人を特定できるメタデータが取り除かれるため、モデルプロバイダーが会話を特定の個人に結びつけることはできません。"
+msgstr ""
+"プロンプトはDuckDuckGoのサーバーを介して中継され、個人を特定できるメタデータ"
+"が取り除かれるため、モデルプロバイダーが会話を特定の個人に結びつけることはで"
+"きません。"
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -22910,7 +24300,9 @@ msgctxt "Popover text for recent chats onboarding"
 msgid ""
 "Your recent chats live here! You can refer to your chats or clear them "
 "anytime."
-msgstr "最近のチャットはここにあります！チャットはいつでも参照したり、消去したりできます。"
+msgstr ""
+"最近のチャットはここにあります！チャットはいつでも参照したり、消去したりでき"
+"ます。"
 
 # smartling.placeholder_format=C
 #. Message on a feedback form.
@@ -22952,7 +24344,10 @@ msgctxt "welcome message eu search preference android"
 msgid ""
 "You’re now searching privately in Chrome. Use our browser instead of Chrome "
 "for more protection. It’s already installed and can:"
-msgstr "現在、Chromeのプライベート検索を使用しています。Chromeの代わりに当社のブラウザをご使用になると、さらにセキュリティを強化できます。このアプリはすでにインストールされており、以下が可能になります。"
+msgstr ""
+"現在、Chromeのプライベート検索を使用しています。Chromeの代わりに当社のブラウ"
+"ザをご使用になると、さらにセキュリティを強化できます。このアプリはすでにイン"
+"ストールされており、以下が可能になります。"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has exceeded the maximum message size.
@@ -22960,7 +24355,9 @@ msgctxt "Error message for input limit"
 msgid ""
 "You’ve exceeded the maximum message size. Please shorten your message and "
 "try again."
-msgstr "メッセージの最大サイズを超えました。 メッセージを短くして、もう一度やり直してください。"
+msgstr ""
+"メッセージの最大サイズを超えました。 メッセージを短くして、もう一度やり直して"
+"ください。"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -22968,7 +24365,9 @@ msgctxt "Error message for conversation limit"
 msgid ""
 "You’ve reached the maximum chat length in this conversation. Clear this "
 "conversation with the Fire Button to continue."
-msgstr "この会話のチャットの最大時間に達しました。 この会話をFire Buttonでクリアして続行します。"
+msgstr ""
+"この会話のチャットの最大時間に達しました。 この会話をFire Buttonでクリアして"
+"続行します。"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -22976,7 +24375,9 @@ msgctxt "Error message for conversation limit"
 msgid ""
 "You’ve reached the maximum chat length in this conversation. Start a new "
 "chat to continue."
-msgstr "この会話のチャットの最大時間に達しました。続行するには、新しいチャットを開始します。"
+msgstr ""
+"この会話のチャットの最大時間に達しました。続行するには、新しいチャットを開始"
+"します。"
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -22990,13 +24391,15 @@ msgctxt "Error message for user limit"
 msgid ""
 "You’ve reached the maximum number of messages for one day. Please continue "
 "this chat tomorrow."
-msgstr "1日のメッセージ数の上限に達しました。このチャットは明日続行してください。"
+msgstr ""
+"1日のメッセージ数の上限に達しました。このチャットは明日続行してください。"
 
 # smartling.placeholder_format=C
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
 msgctxt "voice chat limit modal"
 msgid "You’ve reached the voice chat limit for now. Please try again later."
-msgstr "ボイスチャットの回数制限に達しました。時間を置いてもう一度お試しください。"
+msgstr ""
+"ボイスチャットの回数制限に達しました。時間を置いてもう一度お試しください。"
 
 # smartling.placeholder_format=C
 #. The name of the Yucatec Maya language
@@ -23079,7 +24482,9 @@ msgstr "（%1$s）"
 #. Trust line shown at the bottom of the explainer panel, summarizing DuckDuckGo's reputation for online protection.
 msgctxt "Footer banner text in the How Duck.ai Works panel"
 msgid "by DuckDuckGo — online protection trusted by millions every day."
-msgstr "DuckDuckGoが提供するオンライン保護は、毎日何百万人ものユーザーから信頼されています。"
+msgstr ""
+"DuckDuckGoが提供するオンライン保護は、毎日何百万人ものユーザーから信頼されて"
+"います。"
 
 # smartling.placeholder_format=C
 #. An abreviated unit of time indicating an age, e.g. "2d"
@@ -23292,7 +24697,9 @@ msgstr "公式ウェブサイト"
 #. <em>%s</em> is for a hexadecimal color code as <em>#395323</em>, but it has to be safe encoded, and as <em>#</em> seems not safe, <em>%23</em> must be used in place of the sharp symbol, but they are the same for your browser.
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
-msgstr "あるいはカラーコードを指定してください。例：%1$s (%2$s は %3$s をエンコードしたものです)"
+msgstr ""
+"あるいはカラーコードを指定してください。例：%1$s (%2$s は %3$s をエンコードし"
+"たものです)"
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "

--- a/locales/ka_GE/LC_MESSAGES/duckduckgo.po
+++ b/locales/ka_GE/LC_MESSAGES/duckduckgo.po
@@ -1159,6 +1159,11 @@ msgctxt "feedback form"
 msgid "Address is incorrect"
 msgstr ""
 
+#. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Adjust the servings"
+msgstr ""
+
 #. as in multiple advertisements
 msgid "Ads"
 msgstr ""
@@ -1330,6 +1335,13 @@ msgstr ""
 #. Heading shown on the empty chat screen. The text between the two %s markers is displayed inside a clickable privacy button. First %s renders a shield icon, second %s is an invisible end marker. Keep the word 'private' between both %s markers.
 msgctxt "Empty state heading in Duck.ai chat mode"
 msgid "All chats are %sprivate%s"
+msgstr ""
+
+#. Paragraph in the Privacy & Terms section of the About & Legal page in Duck.ai settings, summarizing how chats are anonymized and are not stored or used to train chat models.
+msgctxt "Privacy & Terms section description on the Duck.ai settings page"
+msgid ""
+"All chats are anonymized by DuckDuckGo, and your conversations are not used "
+"to train chat models by DuckDuckGo or the model providers"
 msgstr ""
 
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1542,6 +1554,12 @@ msgstr ""
 #. Confirmation message after location service is enabled.
 msgctxt "precise_user_location"
 msgid "Anonymous location enabled"
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Anonymously generates answers for search queries based on web content. "
+"Choose how often you want it to appear, or disable it completely."
 msgstr ""
 
 #. Instant Answer tab name
@@ -1764,6 +1782,11 @@ msgstr ""
 
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse
 msgid "Ask a follow-up with Duck.ai"
+msgstr ""
+
+#. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
+msgctxt "Page suggestion chip label"
+msgid "Ask about this page"
 msgstr ""
 
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2088,6 +2111,11 @@ msgstr ""
 msgid "Barcode"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Based on this page, is this course worth taking?"
+msgstr ""
+
 msgctxt "settings"
 msgid "Basic"
 msgstr ""
@@ -2119,6 +2147,13 @@ msgstr ""
 #. Placeholder text displayed while the assistant waits for the user to choose an action.
 msgctxt "Assistant response placeholder"
 msgid "Before continuing..."
+msgstr ""
+
+#. Explains that before storing the report, DuckDuckGo will anonymize the conversation by removing PII like names, email addresses, and identifying metadata.
+msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
+msgid ""
+"Before storing this report, DuckDuckGo will anonymize your conversation by "
+"removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
 #. Label that's displayed next to a past start date below a web search result.
@@ -2377,6 +2412,11 @@ msgstr ""
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Break Points Won"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Break this down into clear, numbered steps."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -2736,6 +2776,11 @@ msgstr ""
 #. Text of a button that performs a search for the cast of a particular movie or tv show
 msgctxt "Movie/TV Show Title instant answer"
 msgid "Cast"
+msgstr ""
+
+#. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Cast & Crew"
 msgstr ""
 
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -4087,6 +4132,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Create a shopping list with quantities from this recipe."
+msgstr ""
+
 #. Placeholder text displayed in the input field when starting a new image generation session.
 msgctxt "Placeholder text for the image generation input field"
 msgid "Create an image of a cute duck..."
@@ -4613,6 +4663,10 @@ msgstr ""
 msgid "Dictation limit reached"
 msgstr ""
 
+#. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
+msgid "Dictation temporarily unavailable"
+msgstr ""
+
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
@@ -4857,6 +4911,20 @@ msgctxt "precise_user_location"
 msgid "Done"
 msgstr ""
 
+#. Message shown in a modal after DuckDuckGo browser users disable AI features in Settings. The first two placeholders bold noai.duckduckgo.com. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
+"filtered out. %sLearn More%s"
+msgstr ""
+
+#. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
+"and AI images filtered out. %sLearn more%s"
+msgstr ""
+
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Double Faults"
@@ -4947,6 +5015,16 @@ msgctxt "Full sentence for writing an email"
 msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
+msgstr ""
+
+#. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Draft a cover letter"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Draft a cover letter for this job."
 msgstr ""
 
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -5086,6 +5164,14 @@ msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
 msgstr ""
 
+#. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
+msgctxt "About section description on the Duck.ai settings page"
+msgid ""
+"Duck.ai is created by DuckDuckGo. We're an independent online protection "
+"company for anyone who wants to take back control of their personal "
+"information."
+msgstr ""
+
 #. Title shown when an update is required before proceeding.
 msgctxt "duckai_migration"
 msgid "Duck.ai is moving domains"
@@ -5119,6 +5205,12 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Duck.ai lets you chat privately with popular AI models. Disabling it hides "
+"Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
 
 msgctxt "settings"
@@ -5884,6 +5976,16 @@ msgstr ""
 msgid "Eritrea"
 msgstr ""
 
+#. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Estimate the nutrition"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Estimate the nutritional information for this recipe."
+msgstr ""
+
 msgid "Estonia"
 msgstr ""
 
@@ -5928,10 +6030,50 @@ msgctxt "merchant promotion product ad extension"
 msgid "Expires in 1 day"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain the accepted answer in simple terms."
+msgstr ""
+
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
+msgstr ""
+
+#. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain the top answer"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this in simple, plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this paper"
+msgstr ""
+
+#. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this repo"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this research paper in plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this simply"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain what this repository does and how to use it."
 msgstr ""
 
 #. Label to show if song lyrics contain explicit content
@@ -6160,6 +6302,11 @@ msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
 msgstr ""
 
+msgctxt "settings"
+msgid ""
+"Filters out known AI spam sites from image search results. %sLearn More%s"
+msgstr ""
+
 #. Label for the final score of a sporting event.
 msgid "Final"
 msgstr ""
@@ -6199,6 +6346,11 @@ msgstr ""
 #. Short description shown below the 'Web Search' label in the Tools dropdown.
 msgctxt "Subtitle for the Web Search tool entry in the Tools dropdown menu"
 msgid "Find current information"
+msgstr ""
+
+#. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Find me alternatives"
 msgstr ""
 
 #. Button that searches for results closer to the user's current location.
@@ -6589,6 +6741,11 @@ msgstr ""
 msgid "Generate More"
 msgstr ""
 
+#. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Generate a shopping list"
+msgstr ""
+
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
 msgid "Generate a short answer from the web"
 msgstr ""
@@ -6823,6 +6980,11 @@ msgstr ""
 #. Text for a button inviting users to give it a try for the Duck.ai product. On click, they're taken to the Duck.ai page.
 msgctxt "Onboarding welcome screen button text"
 msgid "Give it a Try"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Give me a quick background on this person."
 msgstr ""
 
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -7185,6 +7347,16 @@ msgstr ""
 
 #. Link to a page with information about sharing DuckDuckGo with friends.
 msgid "Help Spread Privacy"
+msgstr ""
+
+#. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Help me prep for the interview"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Help me tailor my resume for this job."
 msgstr ""
 
 #. Title of a SERP popup that invites users to take a survey (desktop only)
@@ -7604,6 +7776,13 @@ msgstr ""
 #. Text displayed on the button on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
 msgctxt "Onboarding terms screen button text"
 msgid "I Agree"
+msgstr ""
+
+#. Text for the button that takes the user to the external DuckDuckGo login subscription page.
+msgctxt ""
+"Text for the I already have a subscription button in the Duck.ai settings "
+"page"
+msgid "I Already Have a Subscription"
 msgstr ""
 
 #. Text for the button that takes the user to the login subscription page.
@@ -8056,6 +8235,11 @@ msgctxt "Sidemenu browser promo"
 msgid "Install Mac Browser"
 msgstr ""
 
+#. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
+msgctxt "settings"
+msgid "Install Now"
+msgstr ""
+
 #. Text of a button to install the DuckDuckGo app
 msgctxt "Serp footer content"
 msgid "Install Our App"
@@ -8135,9 +8319,36 @@ msgctxt "cloudsave"
 msgid "Is deleted data really deleted?"
 msgstr "წაშლილი მონაცემები  ნამდვილად წაშლილია?"
 
+#. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is it worth taking?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this place any good?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"Is this place any good? Summarize its reputation based on reviews and "
+"ratings."
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "Is this video helpful?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this worth watching?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Is this worth watching? Give me a spoiler-free take."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -8634,6 +8845,11 @@ msgstr "ბმულის ფონტი"
 msgid "Links:"
 msgstr "ბმულები:"
 
+#. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "List the tools, materials, or prerequisites I need for this."
+msgstr ""
+
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
 msgid "Listen"
 msgstr "მოუსმინეთ"
@@ -8966,6 +9182,11 @@ msgstr ""
 #. Label for linke navigating to site exclusion feature on Settings page
 msgctxt "Exclusion message manage sites button"
 msgid "Manage blocked sites"
+msgstr ""
+
+#. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
+msgctxt "setting"
+msgid "Manage in Browser Settings"
 msgstr ""
 
 #. Link to the site exclusion settings page
@@ -11263,6 +11484,11 @@ msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
+msgid "Please describe why the chat response is harmful or illegal. (optional)"
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
+msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
 msgstr ""
 
@@ -11281,6 +11507,13 @@ msgctxt "Modal disclaimer text"
 msgid ""
 "Please note: starting a new chat with any model will delete your current "
 "chat session."
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
+msgctxt "Feedback prompt"
+msgid ""
+"Please paste your prompt and the problematic output (with any personal "
+"information removed) and describe why the content is harmful or illegal."
 msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -11665,6 +11898,11 @@ msgctxt "settings"
 msgid "Privacy"
 msgstr ""
 
+#. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
+msgctxt "Section heading on the Duck.ai settings page"
+msgid "Privacy & Terms"
+msgstr ""
+
 msgid "Privacy Blog"
 msgstr ""
 
@@ -11718,6 +11956,11 @@ msgstr ""
 
 #. Text used in other strings to link to the Privacy Policy and Terms of Service content.
 msgctxt "Copy used to compose link in sentences"
+msgid "Privacy Policy and Terms of Service"
+msgstr ""
+
+#. Text for a button that links to the terms of use and privacy policy page.
+msgctxt "Secondary button text in active privacy modal"
 msgid "Privacy Policy and Terms of Service"
 msgstr ""
 
@@ -12126,6 +12369,26 @@ msgctxt "Brief for recommending a book"
 msgid "Recommend a book"
 msgstr ""
 
+#. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar books"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar books."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar movies or shows."
+msgstr ""
+
+#. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar titles"
+msgstr ""
+
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
 msgid "Recording failed. Please try again."
 msgstr ""
@@ -12445,6 +12708,14 @@ msgstr ""
 msgid "Republic of Moldova"
 msgstr ""
 
+#. Note indicating that sharing the conversation is mandatory when reporting harmful or illegal content. Rendered alongside the standard share label (DUCKCHAT_RESPONSE_FEEDBACK_SHARE_PROMPT_RESPONSE_LABEL), not replacing it.
+msgctxt ""
+"Note shown under the share-content switch label on the Duck.ai response "
+"feedback form when the user has selected Harmful or Illegal as the feedback "
+"reason"
+msgid "Required for harmful or illegal reports"
+msgstr ""
+
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
 msgctxt "Description for extended reasoning mode in Duck.ai"
 msgid "Researches before responding"
@@ -12630,6 +12901,11 @@ msgstr "მიმოხილვები"
 #. Label above a list of customer reviews of a business.
 msgctxt "maps_places"
 msgid "Reviews"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Rewrite this recipe scaled for a different number of servings."
 msgstr ""
 
 msgid "Romania"
@@ -13665,6 +13941,11 @@ msgctxt "Setup button for native sync flow"
 msgid "Set Up Now"
 msgstr ""
 
+#. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
+msgctxt "Encrypted storage setup button shown in native browsers"
+msgid "Set Up Sync & Backup"
+msgstr ""
+
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
 msgctxt "Title for the Sync & Backup intro screen"
 msgid "Set Up Sync & Backup"
@@ -13807,6 +14088,12 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
+msgctxt ""
+"Label beside the share-content switch on the Duck.ai response feedback form"
+msgid "Share this conversation with DuckDuckGo"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -14821,6 +15108,21 @@ msgctxt "Brief for suggesting a blog post title"
 msgid "Suggest a title for a blog post"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest related articles or topics worth exploring next."
+msgstr ""
+
+#. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Suggest related articles to explore"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest some alternatives to this product."
+msgstr ""
+
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
 msgctxt "directions"
 msgid "Suggestions:"
@@ -14830,9 +15132,84 @@ msgctxt "noresults"
 msgid "Suggestions:"
 msgstr ""
 
+#. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Sum up the reviews"
+msgstr ""
+
 #. A short title for the a message asking the AI to summarize a text.
 msgctxt "Title for the summarize message"
 msgid "Summarize"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize the Q&As"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the background and notable work of this person."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the key details of this event."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the questions and answers on this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize their background"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this book"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this book."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this discussion"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this discussion thread."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this video"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this video."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize what the reviews say."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -15087,6 +15464,11 @@ msgstr ""
 msgid "Syria"
 msgstr ""
 
+#. Text for a button that enables the theme to follow the operating system's color scheme preference.
+msgctxt "System theme button for theme selector"
+msgid "System"
+msgstr ""
+
 #. Abbreviation indicating this is the total score for a game
 msgctxt "Sports module"
 msgid "T"
@@ -15110,6 +15492,11 @@ msgctxt "language_name"
 msgid "Tahitian"
 msgstr ""
 
+#. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Tailor my resume"
+msgstr ""
+
 msgid "Taiwan"
 msgstr ""
 
@@ -15131,6 +15518,12 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "Take control of your personal data!"
+msgstr ""
+
+#. Description for the Feedback section of the Duck.ai settings page, asking the user to take an anonymous survey to let us know how we can make Duck.ai better.
+msgctxt "Feedback section description on the Duck.ai settings page"
+msgid ""
+"Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
 
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -15373,6 +15766,11 @@ msgstr ""
 
 #. Title for the theme menu:
 #. https://duck.co/media/files/theme.png
+msgid "Theme"
+msgstr ""
+
+#. Text for the theme selector label that allows users to switch between Light and dark theme.
+msgctxt "Label for the theme selector feature"
 msgid "Theme"
 msgstr ""
 
@@ -16026,6 +16424,16 @@ msgid ""
 "movie theatre?”"
 msgstr ""
 
+#. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Translate this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
+msgctxt "Page suggestion prompt"
+msgid "Translate this page into %s."
+msgstr ""
+
 #. Placeholder text for a region that will display translated text.
 msgctxt "translations_module"
 msgid "Translation"
@@ -16140,6 +16548,11 @@ msgstr ""
 #. Call-to-action button for the subscription promo in the SERP sidemenu.
 msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
+msgstr ""
+
+#. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
+msgctxt "settings"
+msgid "Try It Now"
 msgstr ""
 
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -16333,6 +16746,20 @@ msgstr "სცადეთ: %s"
 #. Response a user can select in a feedback form, indicating that they're trying DuckDuckGo again.
 msgctxt "new user poll"
 msgid "Trying DuckDuckGo again"
+msgstr ""
+
+#. Message shown in a modal after supported third-party browser users disable AI features in Settings. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+#. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
 msgstr ""
 
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -16933,6 +17360,11 @@ msgstr ""
 msgid "Uruguay"
 msgstr ""
 
+#. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
+msgctxt "Navigation label on the Duck.ai settings page"
+msgid "Usage"
+msgstr ""
+
 #. A feedback suggestion
 msgctxt "Feedback prompt"
 msgid "Usage limit"
@@ -17281,6 +17713,11 @@ msgstr ""
 msgid "Wales"
 msgstr ""
 
+#. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Walk me through the steps"
+msgstr ""
+
 #. Label for walking directions on a map.
 msgctxt "directions"
 msgid "Walking"
@@ -17371,6 +17808,16 @@ msgstr ""
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
+msgstr ""
+
+#. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
+msgctxt ""
+"Inline warning shown below the share-content toggle when the user selects "
+"Harmful or Illegal but has not enabled sharing"
+msgid ""
+"We can only fix what we can see. To report a harmful or illegal response, "
+"please share this conversation with DuckDuckGo so we can investigate and "
+"address the issue."
 msgstr ""
 
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -17790,6 +18237,87 @@ msgid ""
 "experience."
 msgstr ""
 
+#. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the counterarguments?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the hours & location?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key contributions of this paper?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key contributions?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key details?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key points covered in this video?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key points?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key takeaways from this article?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key takeaways?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key things I will learn from this course?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main counterarguments or criticisms of this?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main questions this page answers?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the must-try dishes here?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"What are the opening hours, location, and contact details for this place?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the pros and cons of this product?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the pros and cons?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
 msgctxt "feedback form"
 msgid "What bothered you most?"
@@ -17873,6 +18401,11 @@ msgctxt "Full sentence for defining a term"
 msgid "What does atria mean in the context of a medical article?"
 msgstr ""
 
+#. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What does this answer?"
+msgstr ""
+
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
@@ -17881,6 +18414,11 @@ msgstr ""
 #. Header above a list of types of information that gets saved by the cloud save feature.
 msgctxt "cloudsave"
 msgid "What information gets saved?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What interview questions might come up for this role?"
 msgstr ""
 
 #. Text explaining how the cloud save feature works.
@@ -17893,6 +18431,11 @@ msgstr ""
 #. Text for a prompt suggestion for looking up the capital city of Albania.
 msgctxt "Full sentence for looking up basic facts"
 msgid "What is the capital city of Albania?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What is the overall verdict and rating for this?"
 msgstr ""
 
 #. Link to a page with additional information.
@@ -17913,6 +18456,11 @@ msgctxt "maps_places"
 msgid "What people say:"
 msgstr ""
 
+#. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What should I order?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
 msgctxt "feedback form"
 msgid "What stood out?"
@@ -17921,6 +18469,16 @@ msgstr ""
 #. Question on a feedback form for a negative feedback response.
 msgctxt "feedback form"
 msgid "What was wrong with the response? (optional)"
+msgstr ""
+
+#. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I learn?"
+msgstr ""
+
+#. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I need?"
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -17935,6 +18493,11 @@ msgstr ""
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
 msgctxt "SERP footer content"
 msgid "What's New"
+msgstr ""
+
+#. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What's the verdict?"
 msgstr ""
 
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -17976,6 +18539,11 @@ msgctxt "Feedback prompt"
 msgid "Which features are missing? (Optional)"
 msgstr ""
 
+#. An invitation for users to leave feedback
+msgctxt "Feedback prompt"
+msgid "Which features are missing? (optional)"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
 msgid "White"
 msgstr "თეთრი"
@@ -17987,6 +18555,16 @@ msgstr ""
 
 #. Link to an about us page.
 msgid "Who We Are"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Who are the main cast and crew, and what else are they known for?"
+msgstr ""
+
+#. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Who is this person?"
 msgstr ""
 
 #. Header above a collection of privacy-related links.

--- a/locales/kab_DZ/LC_MESSAGES/duckduckgo.po
+++ b/locales/kab_DZ/LC_MESSAGES/duckduckgo.po
@@ -1159,6 +1159,11 @@ msgctxt "feedback form"
 msgid "Address is incorrect"
 msgstr "Tansa ala yelha"
 
+#. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Adjust the servings"
+msgstr ""
+
 #. as in multiple advertisements
 msgid "Ads"
 msgstr "Adellel"
@@ -1332,6 +1337,13 @@ msgstr ""
 #. Heading shown on the empty chat screen. The text between the two %s markers is displayed inside a clickable privacy button. First %s renders a shield icon, second %s is an invisible end marker. Keep the word 'private' between both %s markers.
 msgctxt "Empty state heading in Duck.ai chat mode"
 msgid "All chats are %sprivate%s"
+msgstr ""
+
+#. Paragraph in the Privacy & Terms section of the About & Legal page in Duck.ai settings, summarizing how chats are anonymized and are not stored or used to train chat models.
+msgctxt "Privacy & Terms section description on the Duck.ai settings page"
+msgid ""
+"All chats are anonymized by DuckDuckGo, and your conversations are not used "
+"to train chat models by DuckDuckGo or the model providers"
 msgstr ""
 
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1545,6 +1557,12 @@ msgstr ""
 msgctxt "precise_user_location"
 msgid "Anonymous location enabled"
 msgstr "Yisem mawqieuk sit"
+
+msgctxt "settings"
+msgid ""
+"Anonymously generates answers for search queries based on web content. "
+"Choose how often you want it to appear, or disable it completely."
+msgstr ""
 
 #. Instant Answer tab name
 msgid "Answer"
@@ -1768,6 +1786,11 @@ msgstr ""
 
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse
 msgid "Ask a follow-up with Duck.ai"
+msgstr ""
+
+#. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
+msgctxt "Page suggestion chip label"
+msgid "Ask about this page"
 msgstr ""
 
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2092,6 +2115,11 @@ msgstr ""
 msgid "Barcode"
 msgstr "Tangalt s yifeggagen"
 
+#. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Based on this page, is this course worth taking?"
+msgstr ""
+
 msgctxt "settings"
 msgid "Basic"
 msgstr "Azadur"
@@ -2123,6 +2151,13 @@ msgstr ""
 #. Placeholder text displayed while the assistant waits for the user to choose an action.
 msgctxt "Assistant response placeholder"
 msgid "Before continuing..."
+msgstr ""
+
+#. Explains that before storing the report, DuckDuckGo will anonymize the conversation by removing PII like names, email addresses, and identifying metadata.
+msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
+msgid ""
+"Before storing this report, DuckDuckGo will anonymize your conversation by "
+"removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
 #. Label that's displayed next to a past start date below a web search result.
@@ -2381,6 +2416,11 @@ msgstr "Brazil"
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Break Points Won"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Break this down into clear, numbered steps."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -2740,6 +2780,11 @@ msgstr "Axeddim"
 #. Text of a button that performs a search for the cast of a particular movie or tv show
 msgctxt "Movie/TV Show Title instant answer"
 msgid "Cast"
+msgstr ""
+
+#. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Cast & Crew"
 msgstr ""
 
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -4100,6 +4145,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Create a shopping list with quantities from this recipe."
+msgstr ""
+
 #. Placeholder text displayed in the input field when starting a new image generation session.
 msgctxt "Placeholder text for the image generation input field"
 msgid "Create an image of a cute duck..."
@@ -4626,6 +4676,10 @@ msgstr ""
 msgid "Dictation limit reached"
 msgstr ""
 
+#. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
+msgid "Dictation temporarily unavailable"
+msgstr ""
+
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
@@ -4870,6 +4924,20 @@ msgctxt "precise_user_location"
 msgid "Done"
 msgstr ""
 
+#. Message shown in a modal after DuckDuckGo browser users disable AI features in Settings. The first two placeholders bold noai.duckduckgo.com. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
+"filtered out. %sLearn More%s"
+msgstr ""
+
+#. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
+"and AI images filtered out. %sLearn more%s"
+msgstr ""
+
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Double Faults"
@@ -4960,6 +5028,16 @@ msgctxt "Full sentence for writing an email"
 msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
+msgstr ""
+
+#. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Draft a cover letter"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Draft a cover letter for this job."
 msgstr ""
 
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -5099,6 +5177,14 @@ msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
 msgstr ""
 
+#. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
+msgctxt "About section description on the Duck.ai settings page"
+msgid ""
+"Duck.ai is created by DuckDuckGo. We're an independent online protection "
+"company for anyone who wants to take back control of their personal "
+"information."
+msgstr ""
+
 #. Title shown when an update is required before proceeding.
 msgctxt "duckai_migration"
 msgid "Duck.ai is moving domains"
@@ -5132,6 +5218,12 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Duck.ai lets you chat privately with popular AI models. Disabling it hides "
+"Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
 
 msgctxt "settings"
@@ -5897,6 +5989,16 @@ msgstr ""
 msgid "Eritrea"
 msgstr ""
 
+#. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Estimate the nutrition"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Estimate the nutritional information for this recipe."
+msgstr ""
+
 msgid "Estonia"
 msgstr "Isṭuni"
 
@@ -5941,10 +6043,50 @@ msgctxt "merchant promotion product ad extension"
 msgid "Expires in 1 day"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain the accepted answer in simple terms."
+msgstr ""
+
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
+msgstr ""
+
+#. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain the top answer"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this in simple, plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this paper"
+msgstr ""
+
+#. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this repo"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this research paper in plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this simply"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain what this repository does and how to use it."
 msgstr ""
 
 #. Label to show if song lyrics contain explicit content
@@ -6175,6 +6317,11 @@ msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
 msgstr ""
 
+msgctxt "settings"
+msgid ""
+"Filters out known AI spam sites from image search results. %sLearn More%s"
+msgstr ""
+
 #. Label for the final score of a sporting event.
 msgid "Final"
 msgstr "Aneggaru"
@@ -6216,6 +6363,11 @@ msgstr ""
 #. Short description shown below the 'Web Search' label in the Tools dropdown.
 msgctxt "Subtitle for the Web Search tool entry in the Tools dropdown menu"
 msgid "Find current information"
+msgstr ""
+
+#. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Find me alternatives"
 msgstr ""
 
 #. Button that searches for results closer to the user's current location.
@@ -6606,6 +6758,11 @@ msgstr ""
 msgid "Generate More"
 msgstr ""
 
+#. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Generate a shopping list"
+msgstr ""
+
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
 msgid "Generate a short answer from the web"
 msgstr ""
@@ -6840,6 +6997,11 @@ msgstr ""
 #. Text for a button inviting users to give it a try for the Duck.ai product. On click, they're taken to the Duck.ai page.
 msgctxt "Onboarding welcome screen button text"
 msgid "Give it a Try"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Give me a quick background on this person."
 msgstr ""
 
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -7203,6 +7365,16 @@ msgstr ""
 #. Link to a page with information about sharing DuckDuckGo with friends.
 msgid "Help Spread Privacy"
 msgstr "Mudd afus i uzuzer n tbaḍnit"
+
+#. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Help me prep for the interview"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Help me tailor my resume for this job."
+msgstr ""
 
 #. Title of a SERP popup that invites users to take a survey (desktop only)
 msgctxt "User survey popup"
@@ -7623,6 +7795,13 @@ msgstr ""
 #. Text displayed on the button on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
 msgctxt "Onboarding terms screen button text"
 msgid "I Agree"
+msgstr ""
+
+#. Text for the button that takes the user to the external DuckDuckGo login subscription page.
+msgctxt ""
+"Text for the I already have a subscription button in the Duck.ai settings "
+"page"
+msgid "I Already Have a Subscription"
 msgstr ""
 
 #. Text for the button that takes the user to the login subscription page.
@@ -8079,6 +8258,11 @@ msgctxt "Sidemenu browser promo"
 msgid "Install Mac Browser"
 msgstr ""
 
+#. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
+msgctxt "settings"
+msgid "Install Now"
+msgstr ""
+
 #. Text of a button to install the DuckDuckGo app
 msgctxt "Serp footer content"
 msgid "Install Our App"
@@ -8158,9 +8342,36 @@ msgctxt "cloudsave"
 msgid "Is deleted data really deleted?"
 msgstr "S tidet ttwakksen isefka yettwakksen?"
 
+#. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is it worth taking?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this place any good?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"Is this place any good? Summarize its reputation based on reviews and "
+"ratings."
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "Is this video helpful?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this worth watching?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Is this worth watching? Give me a spoiler-free take."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -8657,6 +8868,11 @@ msgstr "Tasefsit n yiseɣwan:"
 msgid "Links:"
 msgstr "Iseɣwan:"
 
+#. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "List the tools, materials, or prerequisites I need for this."
+msgstr ""
+
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
 msgid "Listen"
 msgstr "Sɣed"
@@ -8989,6 +9205,11 @@ msgstr ""
 #. Label for linke navigating to site exclusion feature on Settings page
 msgctxt "Exclusion message manage sites button"
 msgid "Manage blocked sites"
+msgstr ""
+
+#. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
+msgctxt "setting"
+msgid "Manage in Browser Settings"
 msgstr ""
 
 #. Link to the site exclusion settings page
@@ -11293,6 +11514,11 @@ msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
+msgid "Please describe why the chat response is harmful or illegal. (optional)"
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
+msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
 msgstr ""
 
@@ -11311,6 +11537,13 @@ msgctxt "Modal disclaimer text"
 msgid ""
 "Please note: starting a new chat with any model will delete your current "
 "chat session."
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
+msgctxt "Feedback prompt"
+msgid ""
+"Please paste your prompt and the problematic output (with any personal "
+"information removed) and describe why the content is harmful or illegal."
 msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -11695,6 +11928,11 @@ msgctxt "settings"
 msgid "Privacy"
 msgstr "Tabaḍnit"
 
+#. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
+msgctxt "Section heading on the Duck.ai settings page"
+msgid "Privacy & Terms"
+msgstr ""
+
 msgid "Privacy Blog"
 msgstr "Ablug uslig"
 
@@ -11748,6 +11986,11 @@ msgstr ""
 
 #. Text used in other strings to link to the Privacy Policy and Terms of Service content.
 msgctxt "Copy used to compose link in sentences"
+msgid "Privacy Policy and Terms of Service"
+msgstr ""
+
+#. Text for a button that links to the terms of use and privacy policy page.
+msgctxt "Secondary button text in active privacy modal"
 msgid "Privacy Policy and Terms of Service"
 msgstr ""
 
@@ -12156,6 +12399,26 @@ msgctxt "Brief for recommending a book"
 msgid "Recommend a book"
 msgstr ""
 
+#. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar books"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar books."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar movies or shows."
+msgstr ""
+
+#. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar titles"
+msgstr ""
+
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
 msgid "Recording failed. Please try again."
 msgstr ""
@@ -12475,6 +12738,14 @@ msgstr ""
 msgid "Republic of Moldova"
 msgstr ""
 
+#. Note indicating that sharing the conversation is mandatory when reporting harmful or illegal content. Rendered alongside the standard share label (DUCKCHAT_RESPONSE_FEEDBACK_SHARE_PROMPT_RESPONSE_LABEL), not replacing it.
+msgctxt ""
+"Note shown under the share-content switch label on the Duck.ai response "
+"feedback form when the user has selected Harmful or Illegal as the feedback "
+"reason"
+msgid "Required for harmful or illegal reports"
+msgstr ""
+
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
 msgctxt "Description for extended reasoning mode in Duck.ai"
 msgid "Researches before responding"
@@ -12661,6 +12932,11 @@ msgstr "Iceggiren"
 msgctxt "maps_places"
 msgid "Reviews"
 msgstr "Iceggiren"
+
+#. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Rewrite this recipe scaled for a different number of servings."
+msgstr ""
 
 msgid "Romania"
 msgstr "Rumanya"
@@ -13706,6 +13982,11 @@ msgctxt "Setup button for native sync flow"
 msgid "Set Up Now"
 msgstr ""
 
+#. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
+msgctxt "Encrypted storage setup button shown in native browsers"
+msgid "Set Up Sync & Backup"
+msgstr ""
+
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
 msgctxt "Title for the Sync & Backup intro screen"
 msgid "Set Up Sync & Backup"
@@ -13848,6 +14129,12 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
+msgctxt ""
+"Label beside the share-content switch on the Duck.ai response feedback form"
+msgid "Share this conversation with DuckDuckGo"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -14862,6 +15149,21 @@ msgctxt "Brief for suggesting a blog post title"
 msgid "Suggest a title for a blog post"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest related articles or topics worth exploring next."
+msgstr ""
+
+#. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Suggest related articles to explore"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest some alternatives to this product."
+msgstr ""
+
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
 msgctxt "directions"
 msgid "Suggestions:"
@@ -14871,9 +15173,84 @@ msgctxt "noresults"
 msgid "Suggestions:"
 msgstr "Isumar"
 
+#. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Sum up the reviews"
+msgstr ""
+
 #. A short title for the a message asking the AI to summarize a text.
 msgctxt "Title for the summarize message"
 msgid "Summarize"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize the Q&As"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the background and notable work of this person."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the key details of this event."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the questions and answers on this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize their background"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this book"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this book."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this discussion"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this discussion thread."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this video"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this video."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize what the reviews say."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -15128,6 +15505,11 @@ msgstr ""
 msgid "Syria"
 msgstr ""
 
+#. Text for a button that enables the theme to follow the operating system's color scheme preference.
+msgctxt "System theme button for theme selector"
+msgid "System"
+msgstr ""
+
 #. Abbreviation indicating this is the total score for a game
 msgctxt "Sports module"
 msgid "T"
@@ -15151,6 +15533,11 @@ msgctxt "language_name"
 msgid "Tahitian"
 msgstr ""
 
+#. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Tailor my resume"
+msgstr ""
+
 msgid "Taiwan"
 msgstr "Ṭaywan"
 
@@ -15172,6 +15559,12 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "Take control of your personal data!"
+msgstr ""
+
+#. Description for the Feedback section of the Duck.ai settings page, asking the user to take an anonymous survey to let us know how we can make Duck.ai better.
+msgctxt "Feedback section description on the Duck.ai settings page"
+msgid ""
+"Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
 
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -15419,6 +15812,11 @@ msgstr ""
 #. https://duck.co/media/files/theme.png
 msgid "Theme"
 msgstr "Asentel"
+
+#. Text for the theme selector label that allows users to switch between Light and dark theme.
+msgctxt "Label for the theme selector feature"
+msgid "Theme"
+msgstr ""
 
 #. http://i.imgur.com/LpFhb1e.png
 msgctxt "settings"
@@ -16076,6 +16474,16 @@ msgid ""
 "movie theatre?”"
 msgstr ""
 
+#. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Translate this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
+msgctxt "Page suggestion prompt"
+msgid "Translate this page into %s."
+msgstr ""
+
 #. Placeholder text for a region that will display translated text.
 msgctxt "translations_module"
 msgid "Translation"
@@ -16190,6 +16598,11 @@ msgstr ""
 #. Call-to-action button for the subscription promo in the SERP sidemenu.
 msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
+msgstr ""
+
+#. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
+msgctxt "settings"
+msgid "Try It Now"
 msgstr ""
 
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -16384,6 +16797,20 @@ msgstr "Ɛreḍ: %s"
 msgctxt "new user poll"
 msgid "Trying DuckDuckGo again"
 msgstr "Aɛraḍ n DuckDuckGo tikkelt-nniḍen"
+
+#. Message shown in a modal after supported third-party browser users disable AI features in Settings. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+#. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
 
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
 msgctxt "Assistant response placeholder"
@@ -16987,6 +17414,11 @@ msgstr ""
 msgid "Uruguay"
 msgstr ""
 
+#. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
+msgctxt "Navigation label on the Duck.ai settings page"
+msgid "Usage"
+msgstr ""
+
 #. A feedback suggestion
 msgctxt "Feedback prompt"
 msgid "Usage limit"
@@ -17337,6 +17769,11 @@ msgstr ""
 msgid "Wales"
 msgstr ""
 
+#. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Walk me through the steps"
+msgstr ""
+
 #. Label for walking directions on a map.
 msgctxt "directions"
 msgid "Walking"
@@ -17427,6 +17864,16 @@ msgstr ""
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
+msgstr ""
+
+#. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
+msgctxt ""
+"Inline warning shown below the share-content toggle when the user selects "
+"Harmful or Illegal but has not enabled sharing"
+msgid ""
+"We can only fix what we can see. To report a harmful or illegal response, "
+"please share this conversation with DuckDuckGo so we can investigate and "
+"address the issue."
 msgstr ""
 
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -17852,6 +18299,87 @@ msgid ""
 "experience."
 msgstr ""
 
+#. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the counterarguments?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the hours & location?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key contributions of this paper?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key contributions?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key details?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key points covered in this video?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key points?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key takeaways from this article?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key takeaways?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key things I will learn from this course?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main counterarguments or criticisms of this?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main questions this page answers?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the must-try dishes here?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"What are the opening hours, location, and contact details for this place?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the pros and cons of this product?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the pros and cons?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
 msgctxt "feedback form"
 msgid "What bothered you most?"
@@ -17935,6 +18463,11 @@ msgctxt "Full sentence for defining a term"
 msgid "What does atria mean in the context of a medical article?"
 msgstr ""
 
+#. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What does this answer?"
+msgstr ""
+
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
@@ -17944,6 +18477,11 @@ msgstr ""
 msgctxt "cloudsave"
 msgid "What information gets saved?"
 msgstr "D anta-tt telɣut ara yettwaskelsen?"
+
+#. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What interview questions might come up for this role?"
+msgstr ""
 
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
@@ -17955,6 +18493,11 @@ msgstr ""
 #. Text for a prompt suggestion for looking up the capital city of Albania.
 msgctxt "Full sentence for looking up basic facts"
 msgid "What is the capital city of Albania?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What is the overall verdict and rating for this?"
 msgstr ""
 
 #. Link to a page with additional information.
@@ -17975,6 +18518,11 @@ msgctxt "maps_places"
 msgid "What people say:"
 msgstr ""
 
+#. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What should I order?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
 msgctxt "feedback form"
 msgid "What stood out?"
@@ -17983,6 +18531,16 @@ msgstr ""
 #. Question on a feedback form for a negative feedback response.
 msgctxt "feedback form"
 msgid "What was wrong with the response? (optional)"
+msgstr ""
+
+#. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I learn?"
+msgstr ""
+
+#. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I need?"
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -17997,6 +18555,11 @@ msgstr ""
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
 msgctxt "SERP footer content"
 msgid "What's New"
+msgstr ""
+
+#. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What's the verdict?"
 msgstr ""
 
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -18038,6 +18601,11 @@ msgctxt "Feedback prompt"
 msgid "Which features are missing? (Optional)"
 msgstr ""
 
+#. An invitation for users to leave feedback
+msgctxt "Feedback prompt"
+msgid "Which features are missing? (optional)"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
 msgid "White"
 msgstr "Amellal"
@@ -18050,6 +18618,16 @@ msgstr "Amellal"
 #. Link to an about us page.
 msgid "Who We Are"
 msgstr "D anwa-aɣ"
+
+#. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Who are the main cast and crew, and what else are they known for?"
+msgstr ""
+
+#. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Who is this person?"
+msgstr ""
 
 #. Header above a collection of privacy-related links.
 msgid "Why Privacy"

--- a/locales/kn_IN/LC_MESSAGES/duckduckgo.po
+++ b/locales/kn_IN/LC_MESSAGES/duckduckgo.po
@@ -1161,6 +1161,11 @@ msgctxt "feedback form"
 msgid "Address is incorrect"
 msgstr ""
 
+#. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Adjust the servings"
+msgstr ""
+
 #. as in multiple advertisements
 msgid "Ads"
 msgstr ""
@@ -1332,6 +1337,13 @@ msgstr ""
 #. Heading shown on the empty chat screen. The text between the two %s markers is displayed inside a clickable privacy button. First %s renders a shield icon, second %s is an invisible end marker. Keep the word 'private' between both %s markers.
 msgctxt "Empty state heading in Duck.ai chat mode"
 msgid "All chats are %sprivate%s"
+msgstr ""
+
+#. Paragraph in the Privacy & Terms section of the About & Legal page in Duck.ai settings, summarizing how chats are anonymized and are not stored or used to train chat models.
+msgctxt "Privacy & Terms section description on the Duck.ai settings page"
+msgid ""
+"All chats are anonymized by DuckDuckGo, and your conversations are not used "
+"to train chat models by DuckDuckGo or the model providers"
 msgstr ""
 
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1544,6 +1556,12 @@ msgstr ""
 #. Confirmation message after location service is enabled.
 msgctxt "precise_user_location"
 msgid "Anonymous location enabled"
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Anonymously generates answers for search queries based on web content. "
+"Choose how often you want it to appear, or disable it completely."
 msgstr ""
 
 #. Instant Answer tab name
@@ -1766,6 +1784,11 @@ msgstr ""
 
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse
 msgid "Ask a follow-up with Duck.ai"
+msgstr ""
+
+#. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
+msgctxt "Page suggestion chip label"
+msgid "Ask about this page"
 msgstr ""
 
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2090,6 +2113,11 @@ msgstr ""
 msgid "Barcode"
 msgstr "ಬಾರ್ಕೋಡ್"
 
+#. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Based on this page, is this course worth taking?"
+msgstr ""
+
 msgctxt "settings"
 msgid "Basic"
 msgstr ""
@@ -2121,6 +2149,13 @@ msgstr ""
 #. Placeholder text displayed while the assistant waits for the user to choose an action.
 msgctxt "Assistant response placeholder"
 msgid "Before continuing..."
+msgstr ""
+
+#. Explains that before storing the report, DuckDuckGo will anonymize the conversation by removing PII like names, email addresses, and identifying metadata.
+msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
+msgid ""
+"Before storing this report, DuckDuckGo will anonymize your conversation by "
+"removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
 #. Label that's displayed next to a past start date below a web search result.
@@ -2379,6 +2414,11 @@ msgstr ""
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Break Points Won"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Break this down into clear, numbered steps."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -2738,6 +2778,11 @@ msgstr ""
 #. Text of a button that performs a search for the cast of a particular movie or tv show
 msgctxt "Movie/TV Show Title instant answer"
 msgid "Cast"
+msgstr ""
+
+#. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Cast & Crew"
 msgstr ""
 
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -4090,6 +4135,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Create a shopping list with quantities from this recipe."
+msgstr ""
+
 #. Placeholder text displayed in the input field when starting a new image generation session.
 msgctxt "Placeholder text for the image generation input field"
 msgid "Create an image of a cute duck..."
@@ -4616,6 +4666,10 @@ msgstr ""
 msgid "Dictation limit reached"
 msgstr ""
 
+#. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
+msgid "Dictation temporarily unavailable"
+msgstr ""
+
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
@@ -4860,6 +4914,20 @@ msgctxt "precise_user_location"
 msgid "Done"
 msgstr ""
 
+#. Message shown in a modal after DuckDuckGo browser users disable AI features in Settings. The first two placeholders bold noai.duckduckgo.com. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
+"filtered out. %sLearn More%s"
+msgstr ""
+
+#. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
+"and AI images filtered out. %sLearn more%s"
+msgstr ""
+
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Double Faults"
@@ -4950,6 +5018,16 @@ msgctxt "Full sentence for writing an email"
 msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
+msgstr ""
+
+#. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Draft a cover letter"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Draft a cover letter for this job."
 msgstr ""
 
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -5089,6 +5167,14 @@ msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
 msgstr ""
 
+#. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
+msgctxt "About section description on the Duck.ai settings page"
+msgid ""
+"Duck.ai is created by DuckDuckGo. We're an independent online protection "
+"company for anyone who wants to take back control of their personal "
+"information."
+msgstr ""
+
 #. Title shown when an update is required before proceeding.
 msgctxt "duckai_migration"
 msgid "Duck.ai is moving domains"
@@ -5122,6 +5208,12 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Duck.ai lets you chat privately with popular AI models. Disabling it hides "
+"Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
 
 msgctxt "settings"
@@ -5889,6 +5981,16 @@ msgstr ""
 msgid "Eritrea"
 msgstr ""
 
+#. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Estimate the nutrition"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Estimate the nutritional information for this recipe."
+msgstr ""
+
 msgid "Estonia"
 msgstr ""
 
@@ -5933,10 +6035,50 @@ msgctxt "merchant promotion product ad extension"
 msgid "Expires in 1 day"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain the accepted answer in simple terms."
+msgstr ""
+
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
+msgstr ""
+
+#. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain the top answer"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this in simple, plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this paper"
+msgstr ""
+
+#. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this repo"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this research paper in plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this simply"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain what this repository does and how to use it."
 msgstr ""
 
 #. Label to show if song lyrics contain explicit content
@@ -6167,6 +6309,11 @@ msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
 msgstr ""
 
+msgctxt "settings"
+msgid ""
+"Filters out known AI spam sites from image search results. %sLearn More%s"
+msgstr ""
+
 #. Label for the final score of a sporting event.
 msgid "Final"
 msgstr ""
@@ -6206,6 +6353,11 @@ msgstr ""
 #. Short description shown below the 'Web Search' label in the Tools dropdown.
 msgctxt "Subtitle for the Web Search tool entry in the Tools dropdown menu"
 msgid "Find current information"
+msgstr ""
+
+#. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Find me alternatives"
 msgstr ""
 
 #. Button that searches for results closer to the user's current location.
@@ -6596,6 +6748,11 @@ msgstr ""
 msgid "Generate More"
 msgstr ""
 
+#. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Generate a shopping list"
+msgstr ""
+
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
 msgid "Generate a short answer from the web"
 msgstr ""
@@ -6830,6 +6987,11 @@ msgstr ""
 #. Text for a button inviting users to give it a try for the Duck.ai product. On click, they're taken to the Duck.ai page.
 msgctxt "Onboarding welcome screen button text"
 msgid "Give it a Try"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Give me a quick background on this person."
 msgstr ""
 
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -7192,6 +7354,16 @@ msgstr ""
 
 #. Link to a page with information about sharing DuckDuckGo with friends.
 msgid "Help Spread Privacy"
+msgstr ""
+
+#. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Help me prep for the interview"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Help me tailor my resume for this job."
 msgstr ""
 
 #. Title of a SERP popup that invites users to take a survey (desktop only)
@@ -7611,6 +7783,13 @@ msgstr ""
 #. Text displayed on the button on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
 msgctxt "Onboarding terms screen button text"
 msgid "I Agree"
+msgstr ""
+
+#. Text for the button that takes the user to the external DuckDuckGo login subscription page.
+msgctxt ""
+"Text for the I already have a subscription button in the Duck.ai settings "
+"page"
+msgid "I Already Have a Subscription"
 msgstr ""
 
 #. Text for the button that takes the user to the login subscription page.
@@ -8064,6 +8243,11 @@ msgctxt "Sidemenu browser promo"
 msgid "Install Mac Browser"
 msgstr ""
 
+#. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
+msgctxt "settings"
+msgid "Install Now"
+msgstr ""
+
 #. Text of a button to install the DuckDuckGo app
 msgctxt "Serp footer content"
 msgid "Install Our App"
@@ -8143,9 +8327,36 @@ msgctxt "cloudsave"
 msgid "Is deleted data really deleted?"
 msgstr "ಅಳಿಸಲಾಗಿದೆ ದಶಮಾಂಶ ನಿಜವಾಗಿಯೂ ಅಳಿಸಲಾಗಿದೆ?"
 
+#. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is it worth taking?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this place any good?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"Is this place any good? Summarize its reputation based on reviews and "
+"ratings."
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "Is this video helpful?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this worth watching?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Is this worth watching? Give me a spoiler-free take."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -8642,6 +8853,11 @@ msgstr "ಲಿಂಕ್ ಫಾಂಟ್:"
 msgid "Links:"
 msgstr "ಲಿಂಕ್ "
 
+#. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "List the tools, materials, or prerequisites I need for this."
+msgstr ""
+
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
 msgid "Listen"
 msgstr "ಕೇಳಿ"
@@ -8974,6 +9190,11 @@ msgstr ""
 #. Label for linke navigating to site exclusion feature on Settings page
 msgctxt "Exclusion message manage sites button"
 msgid "Manage blocked sites"
+msgstr ""
+
+#. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
+msgctxt "setting"
+msgid "Manage in Browser Settings"
 msgstr ""
 
 #. Link to the site exclusion settings page
@@ -11271,6 +11492,11 @@ msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
+msgid "Please describe why the chat response is harmful or illegal. (optional)"
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
+msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
 msgstr ""
 
@@ -11289,6 +11515,13 @@ msgctxt "Modal disclaimer text"
 msgid ""
 "Please note: starting a new chat with any model will delete your current "
 "chat session."
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
+msgctxt "Feedback prompt"
+msgid ""
+"Please paste your prompt and the problematic output (with any personal "
+"information removed) and describe why the content is harmful or illegal."
 msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -11673,6 +11906,11 @@ msgctxt "settings"
 msgid "Privacy"
 msgstr "ಗೌಪ್ಯತೆ"
 
+#. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
+msgctxt "Section heading on the Duck.ai settings page"
+msgid "Privacy & Terms"
+msgstr ""
+
 msgid "Privacy Blog"
 msgstr ""
 
@@ -11726,6 +11964,11 @@ msgstr ""
 
 #. Text used in other strings to link to the Privacy Policy and Terms of Service content.
 msgctxt "Copy used to compose link in sentences"
+msgid "Privacy Policy and Terms of Service"
+msgstr ""
+
+#. Text for a button that links to the terms of use and privacy policy page.
+msgctxt "Secondary button text in active privacy modal"
 msgid "Privacy Policy and Terms of Service"
 msgstr ""
 
@@ -12134,6 +12377,26 @@ msgctxt "Brief for recommending a book"
 msgid "Recommend a book"
 msgstr ""
 
+#. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar books"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar books."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar movies or shows."
+msgstr ""
+
+#. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar titles"
+msgstr ""
+
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
 msgid "Recording failed. Please try again."
 msgstr ""
@@ -12453,6 +12716,14 @@ msgstr ""
 msgid "Republic of Moldova"
 msgstr ""
 
+#. Note indicating that sharing the conversation is mandatory when reporting harmful or illegal content. Rendered alongside the standard share label (DUCKCHAT_RESPONSE_FEEDBACK_SHARE_PROMPT_RESPONSE_LABEL), not replacing it.
+msgctxt ""
+"Note shown under the share-content switch label on the Duck.ai response "
+"feedback form when the user has selected Harmful or Illegal as the feedback "
+"reason"
+msgid "Required for harmful or illegal reports"
+msgstr ""
+
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
 msgctxt "Description for extended reasoning mode in Duck.ai"
 msgid "Researches before responding"
@@ -12638,6 +12909,11 @@ msgstr "ವಿಮರ್ಶೆಗಳು"
 #. Label above a list of customer reviews of a business.
 msgctxt "maps_places"
 msgid "Reviews"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Rewrite this recipe scaled for a different number of servings."
 msgstr ""
 
 msgid "Romania"
@@ -13675,6 +13951,11 @@ msgctxt "Setup button for native sync flow"
 msgid "Set Up Now"
 msgstr ""
 
+#. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
+msgctxt "Encrypted storage setup button shown in native browsers"
+msgid "Set Up Sync & Backup"
+msgstr ""
+
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
 msgctxt "Title for the Sync & Backup intro screen"
 msgid "Set Up Sync & Backup"
@@ -13817,6 +14098,12 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
+msgctxt ""
+"Label beside the share-content switch on the Duck.ai response feedback form"
+msgid "Share this conversation with DuckDuckGo"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -14831,6 +15118,21 @@ msgctxt "Brief for suggesting a blog post title"
 msgid "Suggest a title for a blog post"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest related articles or topics worth exploring next."
+msgstr ""
+
+#. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Suggest related articles to explore"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest some alternatives to this product."
+msgstr ""
+
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
 msgctxt "directions"
 msgid "Suggestions:"
@@ -14840,9 +15142,84 @@ msgctxt "noresults"
 msgid "Suggestions:"
 msgstr ""
 
+#. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Sum up the reviews"
+msgstr ""
+
 #. A short title for the a message asking the AI to summarize a text.
 msgctxt "Title for the summarize message"
 msgid "Summarize"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize the Q&As"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the background and notable work of this person."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the key details of this event."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the questions and answers on this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize their background"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this book"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this book."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this discussion"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this discussion thread."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this video"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this video."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize what the reviews say."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -15097,6 +15474,11 @@ msgstr ""
 msgid "Syria"
 msgstr ""
 
+#. Text for a button that enables the theme to follow the operating system's color scheme preference.
+msgctxt "System theme button for theme selector"
+msgid "System"
+msgstr ""
+
 #. Abbreviation indicating this is the total score for a game
 msgctxt "Sports module"
 msgid "T"
@@ -15120,6 +15502,11 @@ msgctxt "language_name"
 msgid "Tahitian"
 msgstr ""
 
+#. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Tailor my resume"
+msgstr ""
+
 msgid "Taiwan"
 msgstr ""
 
@@ -15141,6 +15528,12 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "Take control of your personal data!"
+msgstr ""
+
+#. Description for the Feedback section of the Duck.ai settings page, asking the user to take an anonymous survey to let us know how we can make Duck.ai better.
+msgctxt "Feedback section description on the Duck.ai settings page"
+msgid ""
+"Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
 
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -15385,6 +15778,11 @@ msgstr ""
 #. https://duck.co/media/files/theme.png
 msgid "Theme"
 msgstr "ಥೀಮ್"
+
+#. Text for the theme selector label that allows users to switch between Light and dark theme.
+msgctxt "Label for the theme selector feature"
+msgid "Theme"
+msgstr ""
 
 #. http://i.imgur.com/LpFhb1e.png
 msgctxt "settings"
@@ -16036,6 +16434,16 @@ msgid ""
 "movie theatre?”"
 msgstr ""
 
+#. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Translate this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
+msgctxt "Page suggestion prompt"
+msgid "Translate this page into %s."
+msgstr ""
+
 #. Placeholder text for a region that will display translated text.
 msgctxt "translations_module"
 msgid "Translation"
@@ -16150,6 +16558,11 @@ msgstr ""
 #. Call-to-action button for the subscription promo in the SERP sidemenu.
 msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
+msgstr ""
+
+#. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
+msgctxt "settings"
+msgid "Try It Now"
 msgstr ""
 
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -16343,6 +16756,20 @@ msgstr "ಇದನ್ನು ಪ್ರಯತ್ನಿಸಿ: %s"
 #. Response a user can select in a feedback form, indicating that they're trying DuckDuckGo again.
 msgctxt "new user poll"
 msgid "Trying DuckDuckGo again"
+msgstr ""
+
+#. Message shown in a modal after supported third-party browser users disable AI features in Settings. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+#. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
 msgstr ""
 
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -16943,6 +17370,11 @@ msgstr ""
 msgid "Uruguay"
 msgstr ""
 
+#. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
+msgctxt "Navigation label on the Duck.ai settings page"
+msgid "Usage"
+msgstr ""
+
 #. A feedback suggestion
 msgctxt "Feedback prompt"
 msgid "Usage limit"
@@ -17291,6 +17723,11 @@ msgstr ""
 msgid "Wales"
 msgstr ""
 
+#. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Walk me through the steps"
+msgstr ""
+
 #. Label for walking directions on a map.
 msgctxt "directions"
 msgid "Walking"
@@ -17381,6 +17818,16 @@ msgstr ""
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
+msgstr ""
+
+#. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
+msgctxt ""
+"Inline warning shown below the share-content toggle when the user selects "
+"Harmful or Illegal but has not enabled sharing"
+msgid ""
+"We can only fix what we can see. To report a harmful or illegal response, "
+"please share this conversation with DuckDuckGo so we can investigate and "
+"address the issue."
 msgstr ""
 
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -17800,6 +18247,87 @@ msgid ""
 "experience."
 msgstr ""
 
+#. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the counterarguments?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the hours & location?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key contributions of this paper?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key contributions?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key details?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key points covered in this video?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key points?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key takeaways from this article?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key takeaways?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key things I will learn from this course?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main counterarguments or criticisms of this?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main questions this page answers?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the must-try dishes here?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"What are the opening hours, location, and contact details for this place?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the pros and cons of this product?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the pros and cons?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
 msgctxt "feedback form"
 msgid "What bothered you most?"
@@ -17883,6 +18411,11 @@ msgctxt "Full sentence for defining a term"
 msgid "What does atria mean in the context of a medical article?"
 msgstr ""
 
+#. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What does this answer?"
+msgstr ""
+
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
@@ -17892,6 +18425,11 @@ msgstr ""
 msgctxt "cloudsave"
 msgid "What information gets saved?"
 msgstr "ಯಾವ ಮಾಹಿತಿಯನ್ನು ಉಳಿಸಿದ ಸಿಗುತ್ತದೆ?"
+
+#. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What interview questions might come up for this role?"
+msgstr ""
 
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
@@ -17903,6 +18441,11 @@ msgstr ""
 #. Text for a prompt suggestion for looking up the capital city of Albania.
 msgctxt "Full sentence for looking up basic facts"
 msgid "What is the capital city of Albania?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What is the overall verdict and rating for this?"
 msgstr ""
 
 #. Link to a page with additional information.
@@ -17923,6 +18466,11 @@ msgctxt "maps_places"
 msgid "What people say:"
 msgstr ""
 
+#. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What should I order?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
 msgctxt "feedback form"
 msgid "What stood out?"
@@ -17931,6 +18479,16 @@ msgstr ""
 #. Question on a feedback form for a negative feedback response.
 msgctxt "feedback form"
 msgid "What was wrong with the response? (optional)"
+msgstr ""
+
+#. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I learn?"
+msgstr ""
+
+#. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I need?"
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -17945,6 +18503,11 @@ msgstr ""
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
 msgctxt "SERP footer content"
 msgid "What's New"
+msgstr ""
+
+#. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What's the verdict?"
 msgstr ""
 
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -17986,6 +18549,11 @@ msgctxt "Feedback prompt"
 msgid "Which features are missing? (Optional)"
 msgstr ""
 
+#. An invitation for users to leave feedback
+msgctxt "Feedback prompt"
+msgid "Which features are missing? (optional)"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
 msgid "White"
 msgstr "ವೈಟ್"
@@ -17997,6 +18565,16 @@ msgstr ""
 
 #. Link to an about us page.
 msgid "Who We Are"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Who are the main cast and crew, and what else are they known for?"
+msgstr ""
+
+#. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Who is this person?"
 msgstr ""
 
 #. Header above a collection of privacy-related links.

--- a/locales/ko_KR/LC_MESSAGES/duckduckgo.po
+++ b/locales/ko_KR/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: ko_KR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -176,9 +176,8 @@ msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
 msgstr ""
-"%1$s는 Pro를 구독하셔야 이용할 수 있습니다. 이 브라우저에서 DuckDuckGo 구독"
-"을 다시 업그레이드하여 채팅을 계속 이용하거나, Plus 또는 무료 모델로 전환하세"
-"요."
+"%1$s는 Pro를 구독하셔야 이용할 수 있습니다. 이 브라우저에서 DuckDuckGo 구독을 다시 업그레이드하여 채팅을 계속 "
+"이용하거나, Plus 또는 무료 모델로 전환하세요."
 
 # smartling.placeholder_format=C
 #. Text for the disclaimer message that appears when a Plus subscriber tries to use a Pro-only model. %s is replaced with the model name. Example: Claude Opus 4.6 is only available with Pro. Upgrade your DuckDuckGo subscription in this browser again to continue the chat, or switch to a Plus or free model.
@@ -188,9 +187,8 @@ msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
 msgstr ""
-"%1$s는 Pro를 구독하셔야 이용할 수 있습니다. 이 브라우저에서 DuckDuckGo 구독"
-"을 다시 업그레이드하여 채팅을 계속 이용하거나, Plus 또는 무료 모델로 전환하세"
-"요."
+"%1$s는 Pro를 구독하셔야 이용할 수 있습니다. 이 브라우저에서 DuckDuckGo 구독을 다시 업그레이드하여 채팅을 계속 "
+"이용하거나, Plus 또는 무료 모델로 전환하세요."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI (Artificial Intelligence) chat model is temporarily unavailable. Example: 'GPT 4o is only available with a DuckDuckGo subscription.'
@@ -206,8 +204,8 @@ msgid ""
 "subscription in this browser again to continue the chat, or switch to a free "
 "model."
 msgstr ""
-"%1$s 서비스는 DuckDuckGo를 구독하셔야 이용할 수 있습니다. 이 브라우저에서 구"
-"독을 다시 활성화해서 채팅을 계속 이용하거나, 무료 모델로 전환하세요."
+"%1$s 서비스는 DuckDuckGo를 구독하셔야 이용할 수 있습니다. 이 브라우저에서 구독을 다시 활성화해서 채팅을 계속 이용하거나, "
+"무료 모델로 전환하세요."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is temporarily unavailable. Example: 'GPT 3.5 Turbo is temporarily unavailable. Please switch to a different model or try again later.'
@@ -215,9 +213,7 @@ msgctxt "Error message for model unavailability"
 msgid ""
 "%s is temporarily unavailable. Please switch to a different model or try "
 "again later."
-msgstr ""
-"%1$s 모델을 일시적으로 사용할 수 없습니다. 다른 모델로 전환하거나 나중에 다"
-"시 시도하세요."
+msgstr "%1$s 모델을 일시적으로 사용할 수 없습니다. 다른 모델로 전환하거나 나중에 다시 시도하세요."
 
 # smartling.placeholder_format=C
 #. Reddit's "fake internet points". https://support.reddithelp.com/hc/en-us/articles/204511829-What-is-karma
@@ -308,8 +304,8 @@ msgid ""
 "provider can see your prompts or the model’s responses, or save this chat on "
 "their servers."
 msgstr ""
-"%1$s(은)는 신뢰할 수 있는 실행 환경에서 실행됩니다. 즉, 모델 제공자조차도 사"
-"용자의 메시지나 모델의 응답을 보거나 서버에 이 채팅을 저장할 수 없습니다."
+"%1$s(은)는 신뢰할 수 있는 실행 환경에서 실행됩니다. 즉, 모델 제공자조차도 사용자의 메시지나 모델의 응답을 보거나 서버에 이 "
+"채팅을 저장할 수 없습니다."
 
 # smartling.placeholder_format=C
 #. Label shown in the batch selection toolbar when exactly one chat is selected. %s is replaced with 1. Use singular agreement where the language requires it.
@@ -388,9 +384,7 @@ msgctxt ""
 msgid ""
 "%s will be leaving Duck.ai in %s days (%s). After that, you can switch "
 "models to continue this chat."
-msgstr ""
-"%1$s 모델은 %2$s일 후(%3$s)에 Duck.ai에서 제거됩니다. 그 후에는 모델을 바꿔"
-"서 이 채팅을 계속할 수 있습니다."
+msgstr "%1$s 모델은 %2$s일 후(%3$s)에 Duck.ai에서 제거됩니다. 그 후에는 모델을 바꿔서 이 채팅을 계속할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Displayed in a saved chat when its AI model is about to be retired tomorrow. First placeholder is the friendly model name, second placeholder is the removal date formatted in the user's browser locale (e.g., 'June 15, 2026' in en-US). Singular-day form.
@@ -400,9 +394,7 @@ msgctxt ""
 msgid ""
 "%s will be leaving Duck.ai in 1 day (%s). After that, you can switch models "
 "to continue this chat."
-msgstr ""
-"%1$s 모델은 %2$s일 후에 Duck.ai에서 제거됩니다. 그 후에는 모델을 바꿔서 이 채"
-"팅을 계속할 수 있습니다."
+msgstr "%1$s 모델은 %2$s일 후에 Duck.ai에서 제거됩니다. 그 후에는 모델을 바꿔서 이 채팅을 계속할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Shown in a text selection chip when the selection contains multiple words. %s is replaced with the number of words, e.g. '142 words'.
@@ -414,9 +406,7 @@ msgstr "단어 %1$s개"
 #. Instructions on which buttons and options the user has to click in order to add the DuckDuckGo extension to their browser.
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
-msgstr ""
-"%1$s추가%2$s를 클릭합니다.%3$s허용%4$s에 체크 표시한 후%5$s 확인%6$s을 클릭합"
-"니다.%7$s"
+msgstr "%1$s추가%2$s를 클릭합니다.%3$s허용%4$s에 체크 표시한 후%5$s 확인%6$s을 클릭합니다.%7$s"
 
 # Firefox, obsolete
 # smartling.placeholder_format=C
@@ -424,8 +414,8 @@ msgstr ""
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAllow%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
 msgstr ""
-"%1$s허용%2$s을 클릭합니다.%3$s추가%4$s를 클릭합니다.%5$s허용%6$s에 %7$s체크 "
-"표시한 후 %8$s확인%9$s을 클릭합니다."
+"%1$s허용%2$s을 클릭합니다.%3$s추가%4$s를 클릭합니다.%5$s허용%6$s에 %7$s체크 표시한 후 %8$s확인%9$s을 "
+"클릭합니다."
 
 # Firefox
 # smartling.placeholder_format=C
@@ -435,8 +425,8 @@ msgid ""
 "%sClick %sContinue To Installation%sClick %sAdd%sCheck %sAllow%s, then click "
 "%sOkay%s"
 msgstr ""
-"%1$s설치 진행하기%2$s를 클릭합니다.%3$s%4$s추가%5$s를 클릭합니다.%6$s허용%7$s"
-"에 체크 표시한 후 %8$s확인%9$s을 클릭합니다."
+"%1$s설치 진행하기%2$s를 클릭합니다.%3$s%4$s추가%5$s를 클릭합니다.%6$s허용%7$s에 체크 표시한 후 "
+"%8$s확인%9$s을 클릭합니다."
 
 # smartling.placeholder_format=C
 #. A button that reloads search results when an error occurs.
@@ -444,9 +434,7 @@ msgctxt "noresults"
 msgid ""
 "%sClick here%s to try again, if you think there should be results for this "
 "search."
-msgstr ""
-"이 검색 결과가 표시되어야 한다고 생각되는 경우 %1$s여기%2$s를 클릭해서 다시 "
-"시도해 보세요."
+msgstr "이 검색 결과가 표시되어야 한다고 생각되는 경우 %1$s여기%2$s를 클릭해서 다시 시도해 보세요."
 
 # smartling.placeholder_format=C
 #. Header for a page with information about sharing DuckDuckGo.
@@ -464,16 +452,14 @@ msgstr "%1$s더 알아보기%2$s."
 #. Link to a page with more information about how anonymous location works.
 msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
-msgstr ""
-"%1$sDuckDuckGo가 사용자의 위치 정보를 어떻게 보호하는지 알아보세요%2$s."
+msgstr "%1$sDuckDuckGo가 사용자의 위치 정보를 어떻게 보호하는지 알아보세요%2$s."
 
 # smartling.placeholder_format=C
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
 msgctxt "Footer text for About Sync modal"
 msgid ""
 "%sLearn more%s about how chats are stored privately on DuckDuckGo's server."
-msgstr ""
-"DuckDuckGo 서버에 채팅이 비공개로 저장되는 방식 %1$s자세히 알아보기%2$s"
+msgstr "DuckDuckGo 서버에 채팅이 비공개로 저장되는 방식 %1$s자세히 알아보기%2$s"
 
 # smartling.placeholder_format=C
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
@@ -491,8 +477,7 @@ msgstr "홈 화면에서 DuckDuckGo 앱 아이콘을 %1$s길게 누릅니다%2$s
 #. A message displayed when there is an error loading content or no results on requery
 msgctxt "Error or no results message"
 msgid "%sOops!%s%sSomething went wrong. Please %srefresh%s and try again."
-msgstr ""
-"%1$s이런!%2$s%3$s문제가 발생했습니다. %4$s새로고침%5$s하고 다시 시도하세요."
+msgstr "%1$s이런!%2$s%3$s문제가 발생했습니다. %4$s새로고침%5$s하고 다시 시도하세요."
 
 # smartling.placeholder_format=C
 #. Tagline in a popover encouraging the user to download the DuckDuckGo browser
@@ -809,17 +794,14 @@ msgstr "6시간 사용 제한에 도달했습니다."
 #. Displayed when the user has reached a fixed 6-hour Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "6-hour usage limit reached. You can continue this chat after %s."
-msgstr ""
-"6시간 사용 한도에 도달했습니다. %1$s 이후에 이 채팅을 이어갈 수 있습니다."
+msgstr "6시간 사용 한도에 도달했습니다. %1$s 이후에 이 채팅을 이어갈 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable 6-hour Duck.ai usage limit and can opt in to continue using the daily limit.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "6-hour usage limit reached. You can keep chatting by using your daily limit."
-msgstr ""
-"6시간 사용 한도에 도달했습니다. 일일 한도를 사용해서 채팅을 이어갈 수 있습니"
-"다."
+msgstr "6시간 사용 한도에 도달했습니다. 일일 한도를 사용해서 채팅을 이어갈 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes abbreviation
@@ -872,17 +854,14 @@ msgstr "A"
 msgid ""
 "A network issue is preventing Search Assist from generating an answer. "
 "Please check your connection and try again."
-msgstr ""
-"Search Assist가 네트워크 문제로 답변을 생성하지 못하고 있습니다. 연결 상태를 "
-"확인하고 다시 시도하세요."
+msgstr "Search Assist가 네트워크 문제로 답변을 생성하지 못하고 있습니다. 연결 상태를 확인하고 다시 시도하세요."
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of AI Chat is available and they need to refresh the page.
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of AI Chat is available! Please refresh this page to continue."
-msgstr ""
-"새로운 버전의 AI Chat이 나왔습니다! 이 페이지를 새로고침해서 진행하세요."
+msgstr "새로운 버전의 AI Chat이 나왔습니다! 이 페이지를 새로고침해서 진행하세요."
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of Duck.ai is available and they need to refresh the page.
@@ -927,9 +906,9 @@ msgid ""
 "still access AI Chat when this setting is off by visiting %sduckduckgo.com/"
 "aichat%s."
 msgstr ""
-"AI Chat을 사용하면 외부 AI Chat 모델과 익명으로 대화할 수 있습니다. 이 기능"
-"을 끄면 DuckDuckGo Search의 AI Chat 기능이 숨겨집니다. 이 설정이 꺼져 있어도 "
-"%1$sduckduckgo.com/aichat%2$s를 통해 AI Chat을 계속 이용할 수 있습니다."
+"AI Chat을 사용하면 외부 AI Chat 모델과 익명으로 대화할 수 있습니다. 이 기능을 끄면 DuckDuckGo Search의 AI "
+"Chat 기능이 숨겨집니다. 이 설정이 꺼져 있어도 %1$sduckduckgo.com/aichat%2$s를 통해 AI Chat을 계속 "
+"이용할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -990,10 +969,9 @@ msgid ""
 "questions, which is our private AI-powered chat service that supports chat "
 "models from OpenAI, and Anthropic, and more."
 msgstr ""
-"현재 AI 지원 답변은 직접적인 후속 질문을 지원하지 않습니다. 하지만 후속 질문"
-"을 위해 %1$sDuck.ai%2$s를 제안하고 링크를 제공하는 경우는 많습니다. Duck.ai"
-"는 OpenAI와 Anthropic 등의 채팅 모델을 지원하는 DuckDuckGo의 비공개 AI 기반 "
-"채팅 서비스입니다."
+"현재 AI 지원 답변은 직접적인 후속 질문을 지원하지 않습니다. 하지만 후속 질문을 위해 %1$sDuck.ai%2$s를 제안하고 링크를 "
+"제공하는 경우는 많습니다. Duck.ai는 OpenAI와 Anthropic 등의 채팅 모델을 지원하는 DuckDuckGo의 비공개 AI "
+"기반 채팅 서비스입니다."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has turned off AI features and will no longer see AI-assisted answers.
@@ -1177,9 +1155,7 @@ msgctxt ""
 msgid ""
 "Activate your %s in this browser again to continue the chat, or switch to a "
 "free model."
-msgstr ""
-"이 브라우저에서 %1$s을 다시 활성화해서 채팅을 계속 이용하거나, 무료 모델로 전"
-"환하세요."
+msgstr "이 브라우저에서 %1$s을 다시 활성화해서 채팅을 계속 이용하거나, 무료 모델로 전환하세요."
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an active DuckDuckGo subscription.
@@ -1214,18 +1190,14 @@ msgstr "광고"
 #. An item in the ads tooltip that explains that ad clicks are managed by the ad network and are not used to profile you. The placeholder is the name of the ad network. For example: Microsoft
 msgid ""
 "Ad clicks are managed by %s’s ad network and are not used to profile you."
-msgstr ""
-"광고 클릭은 %1$s의 광고 네트워크에서 관리되며 사용자의 정보를 수집하는 데 사"
-"용되지 않습니다."
+msgstr "광고 클릭은 %1$s의 광고 네트워크에서 관리되며 사용자의 정보를 수집하는 데 사용되지 않습니다."
 
 # smartling.placeholder_format=C
 #. Information that ad clicks are managed by Microsoft.
 msgid ""
 "Ad clicks are managed by Microsoft’s ad network and are not used to profile "
 "you."
-msgstr ""
-"광고 클릭은 Microsoft의 광고 네트워크에서 관리되며 사용자의 정보를 수집하는 "
-"데 사용되지 않습니다."
+msgstr "광고 클릭은 Microsoft의 광고 네트워크에서 관리되며 사용자의 정보를 수집하는 데 사용되지 않습니다."
 
 # smartling.placeholder_format=C
 #. An item in the ads tooltip that explains that ad clicks aren’t used to profile you.
@@ -1275,9 +1247,7 @@ msgstr "DuckDuckGo 확장 프로그램 추가"
 # smartling.placeholder_format=C
 msgid ""
 "Add DuckDuckGo Privacy Essentials to your browser for free with one download:"
-msgstr ""
-"다운로드 한 번으로 브라우저에 DuckDuckGo Privacy Essentials를 무료로 추가하세"
-"요."
+msgstr "다운로드 한 번으로 브라우저에 DuckDuckGo Privacy Essentials를 무료로 추가하세요."
 
 #  IE default search engine instruction
 # smartling.placeholder_format=C
@@ -1435,7 +1405,7 @@ msgstr "주소가 올바르지 않습니다."
 #. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Adjust the servings"
-msgstr ""
+msgstr "제공량 변경"
 
 # smartling.placeholder_format=C
 #. as in multiple advertisements
@@ -1519,8 +1489,7 @@ msgstr "다운로드가 완료되고 파일이 열리면 %1$s설치%2$s를 클�
 #. Instructions on how to install the DuckDuckGo browser extension after it downloads.
 msgid ""
 "After it downloads, locate the extension file and double-click it to install"
-msgstr ""
-"다운로드가 완료되면 확장 프로그램 파일을 찾아 더블 클릭하여 설치합니다."
+msgstr "다운로드가 완료되면 확장 프로그램 파일을 찾아 더블 클릭하여 설치합니다."
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an age below a web search result.
@@ -1656,6 +1625,8 @@ msgid ""
 "All chats are anonymized by DuckDuckGo, and your conversations are not used "
 "to train chat models by DuckDuckGo or the model providers"
 msgstr ""
+"DuckDuckGo가 모든 채팅을 익명화하며, DuckDuckGo 또는 모델 공급사는 사용자의 대화 내용을 채팅 모델 훈련에 사용하지 "
+"않습니다."
 
 # smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1687,8 +1658,7 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "All model providers are prevented from training their AI on your "
 "conversations."
-msgstr ""
-"모든 모델 제공사가 사용자의 대화를 AI에 학습시킬 수 없도록 금지되어 있습니다."
+msgstr "모든 모델 제공사가 사용자의 대화를 AI에 학습시킬 수 없도록 금지되어 있습니다."
 
 # smartling.placeholder_format=C
 #. Text displayed in the subheader of the modal that allows the user to pick an AI chat model.
@@ -1702,9 +1672,7 @@ msgctxt "Body copy for the anonymized card in the How Duck.ai Works panel"
 msgid ""
 "All personal metadata (for example, your IP address) is removed before "
 "sending a chat to the AI provider."
-msgstr ""
-"AI 제공자에 채팅을 보내기 전에 모든 개인 메타데이터(예: IP 주소)가 제거됩니"
-"다."
+msgstr "AI 제공자에 채팅을 보내기 전에 모든 개인 메타데이터(예: IP 주소)가 제거됩니다."
 
 # smartling.placeholder_format=C
 #. A filter that shows search results from all countries.
@@ -1729,8 +1697,7 @@ msgstr "모든 종류"
 msgctxt "voice chat"
 msgid ""
 "Allow DuckDuckGo microphone access in System Settings to use voice chat."
-msgstr ""
-"음성 채팅을 사용하려면 시스템 설정에서 DuckDuckGo 마이크 접근을 허용하세요."
+msgstr "음성 채팅을 사용하려면 시스템 설정에서 DuckDuckGo 마이크 접근을 허용하세요."
 
 # smartling.placeholder_format=C
 #. Tells users which icon to press in their browser. Part of a list of instructions on how to enable location service.
@@ -1756,17 +1723,15 @@ msgid ""
 "sends AI-generated queries to a search engine with limited data retention. "
 "Prompts and responses with %s still have %szero provider visibility%s."
 msgstr ""
-"%1$s 모델의 웹 검색을 허용하여 관련 프롬프트에 대한 응답을 향상합니다. 데이"
-"터 보유가 제한된 검색 엔진에만 AI가 생성한 쿼리를 보냅니다. %2$s 모델의 프롬"
-"프트 및 응답은 계속해서 %3$s제공자에게 전혀 노출되지 않습니다%4$s."
+"%1$s 모델의 웹 검색을 허용하여 관련 프롬프트에 대한 응답을 향상합니다. 데이터 보유가 제한된 검색 엔진에만 AI가 생성한 쿼리를 "
+"보냅니다. %2$s 모델의 프롬프트 및 응답은 계속해서 %3$s제공자에게 전혀 노출되지 않습니다%4$s."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Allows Cloud Save key to be stored locally on device (required to use Cloud "
 "Save)"
-msgstr ""
-"Cloud Save 키가 기기에 로컬로 저장되도록 허용(Cloud Save를 사용하는 데 필요)"
+msgstr "Cloud Save 키가 기기에 로컬로 저장되도록 허용(Cloud Save를 사용하는 데 필요)"
 
 # smartling.placeholder_format=C
 #. Pending title indicating near completion.
@@ -1903,8 +1868,7 @@ msgctxt "AI Chat description"
 msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
-msgstr ""
-"%1$s 및 %2$s, 오픈 소스 %3$s 및 %4$s 같은 인기 AI 모델에 익명으로 접속하세요."
+msgstr "%1$s 및 %2$s, 오픈 소스 %3$s 및 %4$s 같은 인기 AI 모델에 익명으로 접속하세요."
 
 # smartling.placeholder_format=C
 #. Text with information about Duck.ai and supported AI models, the placeholders list AI models. Example: 'Anonymous access to popular AI models, including GPT, Claude, and open-source Llama and Mistral.'
@@ -1912,8 +1876,7 @@ msgctxt "Duck.ai description"
 msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
-msgstr ""
-"%1$s 및 %2$s, 오픈 소스 %3$s 및 %4$s 같은 인기 AI 모델에 익명으로 접속하세요."
+msgstr "%1$s 및 %2$s, 오픈 소스 %3$s 및 %4$s 같은 인기 AI 모델에 익명으로 접속하세요."
 
 # smartling.placeholder_format=C
 #. Confirmation message after location service is enabled.
@@ -1926,7 +1889,7 @@ msgctxt "settings"
 msgid ""
 "Anonymously generates answers for search queries based on web content. "
 "Choose how often you want it to appear, or disable it completely."
-msgstr ""
+msgstr "웹 콘텐츠를 기반으로 검색 질의에 익명으로 답변을 생성합니다. 표시 빈도를 선택하거나 완전히 비활성화할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -1972,9 +1935,7 @@ msgctxt "Placeholder for additional instructions textarea"
 msgid ""
 "Any additional instructions you want Duck.ai to follow. e.g. Always tell me "
 "facts about ducks"
-msgstr ""
-"Duck.ai가 따랐으면 하는 그 밖의 지침이 있으신가요(예: 항상 오리에 대한 정보"
-"를 들려줘)?"
+msgstr "Duck.ai가 따랐으면 하는 그 밖의 지침이 있으신가요(예: 항상 오리에 대한 정보를 들려줘)?"
 
 # smartling.placeholder_format=C
 #. Shown in video filtering. https://duckduckgo.com/?q=videos+of+cats&iax=videos&ia=videos
@@ -2139,8 +2100,8 @@ msgid ""
 "As per our privacy policy, we do not collect or share any personal "
 "information ourselves. All of this privacy protection happens on your device."
 msgstr ""
-"DuckDuckGo의 개인정보 보호정책에 따라 DuckDuckGo는 어떠한 개인정보도 수집하거"
-"나 공유하지 않습니다. 모든 개인정보 보호는 사용자의 기기에서 이루어집니다."
+"DuckDuckGo의 개인정보 보호정책에 따라 DuckDuckGo는 어떠한 개인정보도 수집하거나 공유하지 않습니다. 모든 개인정보 보호는 "
+"사용자의 기기에서 이루어집니다."
 
 # smartling.placeholder_format=C
 #. A button to ask Duck.ai a question
@@ -2206,7 +2167,7 @@ msgstr "Duck.ai로 후속 질문하기"
 #. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
 msgctxt "Page suggestion chip label"
 msgid "Ask about this page"
-msgstr ""
+msgstr "이 페이지에 대한 질문"
 
 # smartling.placeholder_format=C
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2270,11 +2231,10 @@ msgid ""
 "(shows more frequently on a wider range of searches). For now, AI-assisted "
 "answers are only available in the U.S. (English) region."
 msgstr ""
-"Assist는 일부 검색에 대해 관련 웹 콘텐츠를 요약하여 익명으로 AI 지원 답변을 "
-"생성할 수 있습니다. Assist 표시 빈도 선택 가능: 안 함(검색 결과에서 Assist UI"
-"를 완전히 제거), 주문형(Assist 버튼을 클릭할 때만 AI 지원 답변 표시), 가끔(관"
-"련성이 높은 경우에만 AI 지원 답변 표시), 자주(광범위한 검색에서 더 자주 표"
-"시). 현재 AI 지원 답변은 미국(영어) 지역에서만 이용 가능합니다."
+"Assist는 일부 검색에 대해 관련 웹 콘텐츠를 요약하여 익명으로 AI 지원 답변을 생성할 수 있습니다. Assist 표시 빈도 선택 "
+"가능: 안 함(검색 결과에서 Assist UI를 완전히 제거), 주문형(Assist 버튼을 클릭할 때만 AI 지원 답변 표시), "
+"가끔(관련성이 높은 경우에만 AI 지원 답변 표시), 자주(광범위한 검색에서 더 자주 표시). 현재 AI 지원 답변은 미국(영어) "
+"지역에서만 이용 가능합니다."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2286,10 +2246,9 @@ msgid ""
 "to remember that responses are auto-generated from cited sources and based "
 "on %scrawling the web%s."
 msgstr ""
-"Assist는 검색 질의에 익명으로 AI 지원 답변을 생성하는 검색 결과 옵션 기능이"
-"며 웹에서 관련 콘텐츠를 검색한 다음 AI 기반 자연어 기술을 사용하여, 검색된 관"
-"련 정보를 바탕으로 간단한 답변을 생성합니다. 답변은 인용된 출처와 %1$s웹 크롤"
-"링%2$s을 기반으로 자동 생성합니다."
+"Assist는 검색 질의에 익명으로 AI 지원 답변을 생성하는 검색 결과 옵션 기능이며 웹에서 관련 콘텐츠를 검색한 다음 AI 기반 "
+"자연어 기술을 사용하여, 검색된 관련 정보를 바탕으로 간단한 답변을 생성합니다. 답변은 인용된 출처와 %1$s웹 크롤링%2$s을 기반으로 "
+"자동 생성합니다."
 
 # smartling.placeholder_format=C
 #. Title for the dropdown menu where users select the assistant's role. Example: 'Assistant role: Travel guide'
@@ -2421,17 +2380,13 @@ msgstr "자동 응답"
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid "Auto-generated based on listed sources. May contain inaccuracies."
-msgstr ""
-"나열된 자료를 바탕으로 자동 생성된 응답이며 부정확한 내용이 섞여있을 수 있습"
-"니다."
+msgstr "나열된 자료를 바탕으로 자동 생성된 응답이며 부정확한 내용이 섞여있을 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid ""
 "Auto-generated based on listed sources. Responses may contain inaccuracies."
-msgstr ""
-"나열된 자료를 바탕으로 자동 생성된 응답이며 부정확한 내용이 포함되어 있을 수 "
-"있습니다."
+msgstr "나열된 자료를 바탕으로 자동 생성된 응답이며 부정확한 내용이 포함되어 있을 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI) on mobile
@@ -2456,9 +2411,8 @@ msgid ""
 "look up and summarize information in response to some searches. For now, "
 "Assist is only available in English regions."
 msgstr ""
-"관련 검색어에 대한 Assist를 자동으로 표시합니다. Assist는 일부 검색에 대하여 "
-"익명으로 정보를 조회하고 요약할 수 있습니다. 현재 Assist 서비스는 영어 사용 "
-"지역에서만 제공됩니다."
+"관련 검색어에 대한 Assist를 자동으로 표시합니다. Assist는 일부 검색에 대하여 익명으로 정보를 조회하고 요약할 수 있습니다. "
+"현재 Assist 서비스는 영어 사용 지역에서만 제공됩니다."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2467,16 +2421,14 @@ msgid ""
 "anonymously look up and summarize information in response to some searches. "
 "For now, DuckAssist is only available in English regions."
 msgstr ""
-"관련 검색어에 대한 DuckAssist를 자동으로 표시합니다. DuckAssist는 일부 검색"
-"에 대하여 익명으로 정보를 조회하고 요약할 수 있습니다. 현재 DuckAssist 서비스"
-"는 영어 사용 지역에서만 제공됩니다."
+"관련 검색어에 대한 DuckAssist를 자동으로 표시합니다. DuckAssist는 일부 검색에 대하여 익명으로 정보를 조회하고 요약할 "
+"수 있습니다. 현재 DuckAssist 서비스는 영어 사용 지역에서만 제공됩니다."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Autoplay short, silent video previews when you hover over video results."
-msgstr ""
-"영상 결과에 마우스를 올리면 짧은 무음 영상 미리 보기가 자동으로 재생됩니다."
+msgstr "영상 결과에 마우스를 올리면 짧은 무음 영상 미리 보기가 자동으로 재생됩니다."
 
 # smartling.placeholder_format=C
 #. Screen-reader label for the radiogroup of tool options inside the Tools dropdown. Announced when assistive technology enters the group of menuitemradio items.
@@ -2621,7 +2573,7 @@ msgstr "바코드"
 #. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Based on this page, is this course worth taking?"
-msgstr ""
+msgstr "이 페이지를 기준으로 할 때 이 강의는 들을 가치가 있어?"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2670,6 +2622,8 @@ msgid ""
 "Before storing this report, DuckDuckGo will anonymize your conversation by "
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
+"이 보고서를 저장하기 전에 DuckDuckGo는 이름, 이메일 주소, 식별 가능한 메타데이터와 같은 개인정보(PII)를 제거하여 대화 "
+"내용을 익명화합니다."
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -2991,7 +2945,7 @@ msgstr "획득한 브레이크 포인트"
 #. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Break this down into clear, numbered steps."
-msgstr ""
+msgstr "번호를 매겨서 단계별로 명확하게 정리해줘."
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -3050,18 +3004,16 @@ msgid ""
 "Browse as usual while we add privacy protection. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
 msgstr ""
-"기존과 동일하게 검색하세요. 개인정보는 저희가 보호해 드릴게요. 하나의 "
-"%1$s%2$s확장 프로그램%3$s으로 검색 엔진, 추적 차단, 암호화 보호 강화 기능을 "
-"이용할 수 있습니다."
+"기존과 동일하게 검색하세요. 개인정보는 저희가 보호해 드릴게요. 하나의 %1$s%2$s확장 프로그램%3$s으로 검색 엔진, 추적 차단, "
+"암호화 보호 강화 기능을 이용할 수 있습니다."
 
 # smartling.placeholder_format=C
 msgid ""
 "Browse as usual, and we'll take care of the rest. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
 msgstr ""
-"기존과 동일하게 검색하세요. 검색 기록이 저장되지 않습니다. 하나의 %1$s%2$s확"
-"장 프로그램%3$s으로 검색 엔진, 추적 차단, 암호화 보호 강화 기능을 이용할 수 "
-"있습니다."
+"기존과 동일하게 검색하세요. 검색 기록이 저장되지 않습니다. 하나의 %1$s%2$s확장 프로그램%3$s으로 검색 엔진, 추적 차단, "
+"암호화 보호 강화 기능을 이용할 수 있습니다."
 
 # smartling.placeholder_format=C
 msgid ""
@@ -3069,9 +3021,8 @@ msgid ""
 "search, tracker blocking, and site encryption, all in one download, for "
 "%smajor browsers%s."
 msgstr ""
-"기존과 동일하게 검색하세요. 검색 기록이 저장되지 않습니다. 다운로드 한 번으"
-"로 %1$s주요 브라우저%2$s에서 비공개 검색, 추적 차단, 사이트 암호화 기능을 이"
-"용할 수 있습니다."
+"기존과 동일하게 검색하세요. 검색 기록이 저장되지 않습니다. 다운로드 한 번으로 %1$s주요 브라우저%2$s에서 비공개 검색, 추적 "
+"차단, 사이트 암호화 기능을 이용할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Header for a call to action to browse with the DuckDuckGo browser
@@ -3178,10 +3129,9 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"기본적으로 설정은 비개인 브라우저 쿠키(사용자의 브라우저)에 저장됩니다. 익명 "
-"Cloud Save를 사용하여 설정을 보다 영구적으로 저장할 수 있습니다(클라우드의 원"
-"격 서버에 저장). 클라우드에는 사용자의 개인 신원 정보가 저장되지 않으며, 암"
-"호 또한 서버에 저장되지 않습니다."
+"기본적으로 설정은 비개인 브라우저 쿠키(사용자의 브라우저)에 저장됩니다. 익명 Cloud Save를 사용하여 설정을 보다 영구적으로 "
+"저장할 수 있습니다(클라우드의 원격 서버에 저장). 클라우드에는 사용자의 개인 신원 정보가 저장되지 않으며, 암호 또한 서버에 저장되지 "
+"않습니다."
 
 # smartling.placeholder_format=C
 #. Description for the consent highlight in the dictation consent modal. %s is replaced with a link to the help page.
@@ -3189,8 +3139,8 @@ msgid ""
 "By enabling dictation, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
 msgstr ""
-"받아쓰기를 활성화함으로써, 이 기능을 사용하기 위해 본인의 음성 데이터가 "
-"OpenAI로 전송되는 것에 동의합니다. 시작하기 전에 %1$s 페이지를 확인하세요."
+"받아쓰기를 활성화함으로써, 이 기능을 사용하기 위해 본인의 음성 데이터가 OpenAI로 전송되는 것에 동의합니다. 시작하기 전에 %1$s "
+"페이지를 확인하세요."
 
 # smartling.placeholder_format=C
 #. Description for the 'enable voice chat' section of the voice chat consent modal. Placeholder for the voice chat help page link and text. Example: 'By enabling voice chat, you consent to your voice data being sent to OpenAI for the use of this feature. See our voice chat help page before getting started.'
@@ -3199,8 +3149,8 @@ msgid ""
 "By enabling voice chat, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
 msgstr ""
-"음성 채팅을 활성화함으로써, 이 기능을 사용하기 위해 본인의 음성 데이터가 "
-"OpenAI로 전송되는 것에 동의합니다. 시작하기 전에 %1$s 페이지를 확인하세요."
+"음성 채팅을 활성화함으로써, 이 기능을 사용하기 위해 본인의 음성 데이터가 OpenAI로 전송되는 것에 동의합니다. 시작하기 전에 "
+"%1$s 페이지를 확인하세요."
 
 # smartling.placeholder_format=C
 #. Golf leaderboard: player missed the cut
@@ -3235,8 +3185,7 @@ msgstr "카메룬"
 #. Text for a prompt suggestion for creating a few simple recipes using chicken, broccoli, and rice.
 msgctxt "Full sentence for crafting a recipe"
 msgid "Can you create a few simple recipes using chicken, broccoli, and rice?"
-msgstr ""
-"닭고기, 브로콜리, 쌀을 재료로 한 몇 가지 간단한 요리법을 만들 수 있나요?"
+msgstr "닭고기, 브로콜리, 쌀을 재료로 한 몇 가지 간단한 요리법을 만들 수 있나요?"
 
 # smartling.placeholder_format=C
 msgid "Canada"
@@ -3450,7 +3399,7 @@ msgstr "캐스트"
 #. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Cast & Crew"
-msgstr ""
+msgstr "출연진 및 제작진"
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -3556,9 +3505,7 @@ msgstr "전체 사이트에 적용되는 배경 색상을 변경합니다."
 msgctxt "settings"
 msgid ""
 "Changes the background color of results on hover, modules, and dropdown menus"
-msgstr ""
-"검색 결과(마우스 커서를 올렸을 때), 모듈 및 드롭다운 메뉴의 배경 색상을 변경"
-"합니다."
+msgstr "검색 결과(마우스 커서를 올렸을 때), 모듈 및 드롭다운 메뉴의 배경 색상을 변경합니다."
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/NdpkbY0.png
@@ -3687,9 +3634,8 @@ msgid ""
 "DuckDuckGo Search. However, you can still access Chat when this setting is "
 "off by visiting %shttps://duck.ai%s directly."
 msgstr ""
-"Duck.ai 서비스를 통한 채팅을 사용하면 OpenAI, Anthropic 등의 모델을 지원하는 "
-"타사 AI 채팅 모델과 익명으로 대화할 수 있습니다. 이 설정을 끄면 DuckDuckGo "
-"Search에서 채팅 버튼과 링크가 보이지 않습니다. 하지만 이 설정이 꺼져 있어도 "
+"Duck.ai 서비스를 통한 채팅을 사용하면 OpenAI, Anthropic 등의 모델을 지원하는 타사 AI 채팅 모델과 익명으로 대화할 "
+"수 있습니다. 이 설정을 끄면 DuckDuckGo Search에서 채팅 버튼과 링크가 보이지 않습니다. 하지만 이 설정이 꺼져 있어도 "
 "%1$shttps://duck.ai%2$s에 바로 접속해서 채팅을 이용할 수 있습니다."
 
 # smartling.placeholder_format=C
@@ -3745,18 +3691,14 @@ msgstr "비공개로 채팅하기"
 #. Mobile variant of DUCKCHAT_BROWSER_UPSELL_PROMO_TEXT. Shorter version for the promotional card encouraging third-party browser users to download the DuckDuckGo browser.
 msgctxt "Promotional text (mobile)"
 msgid "Chat privately on any website with Duck.ai built into our free browser."
-msgstr ""
-"DuckDuckGo 무료 브라우저에 내장된 Duck.ai로 어떤 웹사이트에서든 비공개로 채팅"
-"하세요."
+msgstr "DuckDuckGo 무료 브라우저에 내장된 Duck.ai로 어떤 웹사이트에서든 비공개로 채팅하세요."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card encouraging third-party browser users to download the DuckDuckGo browser. Not shown in the DuckDuckGo browser or on Linux.
 msgctxt "Promotional text"
 msgid ""
 "Chat privately on any website with the Duck.ai sidebar in our free browser."
-msgstr ""
-"DuckDuckGo 무료 브라우저에서 Duck.ai 사이드바를 통해 어떤 웹사이트에서든 비공"
-"개로 채팅하세요."
+msgstr "DuckDuckGo 무료 브라우저에서 Duck.ai 사이드바를 통해 어떤 웹사이트에서든 비공개로 채팅하세요."
 
 # smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
@@ -3818,9 +3760,7 @@ msgctxt "Description for Chat History feature"
 msgid ""
 "Chats are stored locally on your device instead of on DuckDuckGo servers or "
 "remote servers. Disabling chat history will delete pinned chats."
-msgstr ""
-"채팅은 DuckDuckGo 서버나 원격 서버가 아닌 사용자의 기기 자체에 저장됩니다. 채"
-"팅 기록을 비활성화하면 고정된 채팅이 삭제돼."
+msgstr "채팅은 DuckDuckGo 서버나 원격 서버가 아닌 사용자의 기기 자체에 저장됩니다. 채팅 기록을 비활성화하면 고정된 채팅이 삭제돼."
 
 # smartling.placeholder_format=C
 #. Text explaining how the Chat History feature stores the user's chats locally to their device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection. Also explains that disabling chat history will delete pinned chats.
@@ -3832,10 +3772,9 @@ msgid ""
 "history will delete pinned chats, and disable the temporary storage of new "
 "prompts and responses."
 msgstr ""
-"채팅은 사용자의 기기에 직접 저장됩니다. 사용자의 인터넷 연결이 끊겼을 때 채팅"
-"을 복원할 수 있도록, 전송된 새 프롬프트와 응답을 암호화하여 DuckDuckGo 서버"
-"에 임시로 저장합니다. 채팅 기록을 비활성화하면 고정된 채팅이 삭제되고, 새로"
-"운 프롬프트와 응답의 임시 저장이 중단됩니다."
+"채팅은 사용자의 기기에 직접 저장됩니다. 사용자의 인터넷 연결이 끊겼을 때 채팅을 복원할 수 있도록, 전송된 새 프롬프트와 응답을 "
+"암호화하여 DuckDuckGo 서버에 임시로 저장합니다. 채팅 기록을 비활성화하면 고정된 채팅이 삭제되고, 새로운 프롬프트와 응답의 임시 "
+"저장이 중단됩니다."
 
 # smartling.placeholder_format=C
 #. Title shown above the body copy in the Duck.ai recent chats IndexedDB unavailable notice.
@@ -3856,9 +3795,7 @@ msgstr "채팅을 안전하게 내려받았습니다"
 msgctxt "Sync file storage inline disclaimer body"
 msgid ""
 "Chats with attachments have stopped syncing. Free up storage to resume Sync."
-msgstr ""
-"첨부 파일이 있는 채팅의 동기화가 중단되었습니다. 저장 공간을 확보하면 동기화"
-"를 재개할 수 있습니다."
+msgstr "첨부 파일이 있는 채팅의 동기화가 중단되었습니다. 저장 공간을 확보하면 동기화를 재개할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Message shown when we have no data from upstream to display
@@ -3911,8 +3848,7 @@ msgstr "철자 검사"
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
 msgctxt "noresults"
 msgid "Check the DuckDuckGo subreddit for updates on this outage."
-msgstr ""
-"DuckDuckGo 서브레딧에서 이번 서비스 중단에 대한 최신 소식을 확인하세요."
+msgstr "DuckDuckGo 서브레딧에서 이번 서비스 중단에 대한 최신 소식을 확인하세요."
 
 # smartling.placeholder_format=C
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
@@ -4192,9 +4128,8 @@ msgid ""
 "Clearing browser data deletes chats. Some browsers may keep recent chats "
 "indefinitely or auto-delete them after 7+ days of no AI Chat use."
 msgstr ""
-"브라우저 데이터를 삭제하면 채팅이 사라집니다. 일부 브라우저는 최근 채팅을 무"
-"기한으로 보관하거나, AI Chat을 7일 이상 사용하지 않으면 자동으로 삭제할 수 있"
-"습니다."
+"브라우저 데이터를 삭제하면 채팅이 사라집니다. 일부 브라우저는 최근 채팅을 무기한으로 보관하거나, AI Chat을 7일 이상 사용하지 "
+"않으면 자동으로 삭제할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Text explaining what happens to recent chats when browser data is cleared.
@@ -4204,9 +4139,8 @@ msgid ""
 "indefinitely or auto-deleted after 7 days without using Duck.ai, depending "
 "on your browser."
 msgstr ""
-"브라우저 데이터를 삭제하면 최근 채팅이 삭제됩니다. 브라우저에 따라 최근 채팅"
-"이 무기한으로 저장될 수도 있고, Duck.ai를 7일 이상 사용하지 않으면 자동으로 "
-"삭제될 수도 있습니다."
+"브라우저 데이터를 삭제하면 최근 채팅이 삭제됩니다. 브라우저에 따라 최근 채팅이 무기한으로 저장될 수도 있고, Duck.ai를 7일 이상 "
+"사용하지 않으면 자동으로 삭제될 수도 있습니다."
 
 # smartling.placeholder_format=C
 #. Warning message shown on the Block domain success modal. Blocked sites are stored in localStorage which is cleared alongside cookies when users clear browser data. Followed by a linked 'our free browser' text.
@@ -4214,9 +4148,7 @@ msgctxt "settings"
 msgid ""
 "Clearing browser data will reset your blocked sites. Save your block list "
 "permanently in"
-msgstr ""
-"브라우저 데이터를 삭제하면 차단된 사이트가 초기화됩니다. 차단 목록을 "
-"DuckDuckGo 무료 브라우저에"
+msgstr "브라우저 데이터를 삭제하면 차단된 사이트가 초기화됩니다. 차단 목록을 DuckDuckGo 무료 브라우저에"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -4225,9 +4157,8 @@ msgid ""
 "%sDuck.ai%s, our private AI chat service that supports chat models from "
 "OpenAI, Anthropic, and more."
 msgstr ""
-"'더 보기'를 클릭해서 주제를 더 깊이 탐색하고, OpenAI와 Anthropic 등의 채팅 모"
-"델을 지원하는 DuckDuckGo의 비공개 AI 기반 채팅 서비스 %1$sDuck.ai%2$s를 통해 "
-"후속 질문을 하세요."
+"'더 보기'를 클릭해서 주제를 더 깊이 탐색하고, OpenAI와 Anthropic 등의 채팅 모델을 지원하는 DuckDuckGo의 비공개 "
+"AI 기반 채팅 서비스 %1$sDuck.ai%2$s를 통해 후속 질문을 하세요."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4268,9 +4199,7 @@ msgstr "드롭다운 메뉴에서 %1$s검색 설정 변경%2$s을 클릭하세�
 msgid ""
 "Click %sEdit > Preferences%s (on Windows) %sSeaMonkey > Preferences%s (on "
 "Mac)"
-msgstr ""
-"Windows에서는 %1$s편집 > 환경설정%2$s을 클릭하고, Mac에서는%3$sSeaMonkey > 환"
-"경설정%4$s을 클릭하세요."
+msgstr "Windows에서는 %1$s편집 > 환경설정%2$s을 클릭하고, Mac에서는%3$sSeaMonkey > 환경설정%4$s을 클릭하세요."
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -4286,9 +4215,7 @@ msgstr "DuckDuckGo 확장 프로그램을 다운로드하려면 %1$s여기%2$s�
 # smartling.placeholder_format=C
 #. Link to download the DuckDuckGo browser extension.
 msgid "Click %sOpen%s to download and open the DuckDuckGo Safari extension"
-msgstr ""
-"%1$s열기%2$s를 클릭해서 DuckDuckGo Safari 확장 프로그램을 다운로드하고 여세"
-"요."
+msgstr "%1$s열기%2$s를 클릭해서 DuckDuckGo Safari 확장 프로그램을 다운로드하고 여세요."
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -4302,9 +4229,7 @@ msgstr "왼쪽 사이드바에서 %1$s개인정보 및 서비스%2$s를 클릭�
 msgid ""
 "Click %sSafari%s in the top menu (On Windows, click the %sgears icon%s in "
 "the top right)"
-msgstr ""
-"상단 메뉴의 %1$sSafari%2$s를 클릭하세요(Windows에서는 오른쪽 상단에 있는 %3$s"
-"기어 모양 아이콘%4$s을 클릭하세요)."
+msgstr "상단 메뉴의 %1$sSafari%2$s를 클릭하세요(Windows에서는 오른쪽 상단에 있는 %3$s기어 모양 아이콘%4$s을 클릭하세요)."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4333,8 +4258,7 @@ msgstr "%1$s예%2$s를 클릭하세요."
 # smartling.placeholder_format=C
 #. Tells the user where to click to open their browser's settings menu.
 msgid "Click %ssettings/hamburger icon %s on the Chrome toolbar (top right)."
-msgstr ""
-"Chrome 툴바(오른쪽 상단)에서 %1$ssettings/hamburger icon%2$s을 클릭하세요."
+msgstr "Chrome 툴바(오른쪽 상단)에서 %1$ssettings/hamburger icon%2$s을 클릭하세요."
 
 #  Maxthon default search engine instruction
 # smartling.placeholder_format=C
@@ -4396,9 +4320,8 @@ msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Search Settings%s."
 msgstr ""
-"%1$s데이터 삭제하기%2$s를 클릭하거나 누르면 클라우드에서는 데이터가 제거되지"
-"만 브라우저에는 남아있습니다. 남아있는 데이터를 제거하려면 %3$s모든 검색 설"
-"정 초기화%4$s를 클릭하거나 누르세요."
+"%1$s데이터 삭제하기%2$s를 클릭하거나 누르면 클라우드에서는 데이터가 제거되지만 브라우저에는 남아있습니다. 남아있는 데이터를 "
+"제거하려면 %3$s모든 검색 설정 초기화%4$s를 클릭하거나 누르세요."
 
 # smartling.placeholder_format=C
 #. Tells users where to click in order to disable the cloud save feature and delete any data backed-up to the cloud.
@@ -4409,9 +4332,8 @@ msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Settings%s."
 msgstr ""
-"%1$s내 데이터 삭제%2$s를 클릭하거나 누릅니다. 이 작업을 수행하면 클라우드에서"
-"는 데이터가 삭제되지만, %3$s모든 설정 초기화%4$s를 클릭하거나 누를 때까지 브"
-"라우저에는 데이터가 남아 있게 됩니다."
+"%1$s내 데이터 삭제%2$s를 클릭하거나 누릅니다. 이 작업을 수행하면 클라우드에서는 데이터가 삭제되지만, %3$s모든 설정 "
+"초기화%4$s를 클릭하거나 누를 때까지 브라우저에는 데이터가 남아 있게 됩니다."
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -4479,18 +4401,14 @@ msgstr "검색 창에서 드롭다운을 클릭하세요."
 msgid ""
 "Click the dropdown menu beside %sSearch engine used in the address bar%s and "
 "select %sDuckDuckGo%s."
-msgstr ""
-"주소 표시줄%2$s에 사용된 %1$s검색 엔진 옆 드롭다운 메뉴를 클릭하고 "
-"%3$sDuckDuckGo%4$s를 선택하세요."
+msgstr "주소 표시줄%2$s에 사용된 %1$s검색 엔진 옆 드롭다운 메뉴를 클릭하고 %3$sDuckDuckGo%4$s를 선택하세요."
 
 # smartling.placeholder_format=C
 #. First step in a list of steps to take to disable the user's ad blocker
 msgid ""
 "Click the icon of the ad blocker extension. It's usually in the upper right "
 "hand corner of your browser."
-msgstr ""
-"광고 차단 확장 프로그램 아이콘을 클릭하세요. 주로 브라우저 오른쪽 상단 모서리"
-"에 있습니다."
+msgstr "광고 차단 확장 프로그램 아이콘을 클릭하세요. 주로 브라우저 오른쪽 상단 모서리에 있습니다."
 
 #  Safari default search engine instruction
 # smartling.placeholder_format=C
@@ -4678,9 +4596,7 @@ msgctxt "cloudsave"
 msgid ""
 "Cloud Save lets you save your settings more permanently by entering a "
 "passphrase. It is entirely optional."
-msgstr ""
-"Cloud Save는 현재 설정을 영구적으로 저장하고 암호를 입력해 간편하게 불러올 "
-"수 있는 기능으로, 꼭 사용하실 필요는 없습니다."
+msgstr "Cloud Save는 현재 설정을 영구적으로 저장하고 암호를 입력해 간편하게 불러올 수 있는 기능으로, 꼭 사용하실 필요는 없습니다."
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -5039,8 +4955,7 @@ msgstr "복사"
 # smartling.placeholder_format=C
 #. Instructions on how to change the default search engine
 msgid "Copy &amp; paste %sabout:preferences#search%s into the address bar"
-msgstr ""
-"주소 표시줄에 %1$sabout:preferences#search%2$s를 복사하여 붙여넣으세요."
+msgstr "주소 표시줄에 %1$sabout:preferences#search%2$s를 복사하여 붙여넣으세요."
 
 # smartling.placeholder_format=C
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
@@ -5159,7 +5074,7 @@ msgstr "이미지 만들기"
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
-msgstr ""
+msgstr "이 레시피에 있는 수량을 기준으로 장보기 목록을 만들어줘."
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed in the input field when starting a new image generation session.
@@ -5416,17 +5331,14 @@ msgstr "일일 한도에 도달했습니다."
 #. Displayed when the user has reached a fixed daily Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Daily usage limit reached. You can continue this chat after %s."
-msgstr ""
-"일일 사용 한도에 도달했습니다. %1$s 이후에 이 채팅을 이어갈 수 있습니다."
+msgstr "일일 사용 한도에 도달했습니다. %1$s 이후에 이 채팅을 이어갈 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable daily Duck.ai usage limit and can opt in to continue using the weekly limit.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "Daily usage limit reached. You can keep chatting by using your weekly limit."
-msgstr ""
-"일일 사용 한도에 도달했습니다. 주간 채팅 제한을 이용해서 채팅을 이어갈 수 있"
-"습니다."
+msgstr "일일 사용 한도에 도달했습니다. 주간 채팅 제한을 이용해서 채팅을 이어갈 수 있습니다."
 
 # smartling.placeholder_format=C
 #. The name of the Danish language
@@ -5793,8 +5705,7 @@ msgstr "Duck.ai 받아쓰기"
 # smartling.placeholder_format=C
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
-msgstr ""
-"당사는 받아쓰기 내용을 익명화하며, AI 모델 학습에 절대 사용하지 않습니다."
+msgstr "당사는 받아쓰기 내용을 익명화하며, AI 모델 학습에 절대 사용하지 않습니다."
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
@@ -5804,16 +5715,14 @@ msgstr "받아쓰기 한도에 도달했습니다"
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
 msgid "Dictation temporarily unavailable"
-msgstr ""
+msgstr "받아쓰기를 일시적으로 사용할 수 없습니다"
 
 # smartling.placeholder_format=C
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
 "chat in Duck.ai without having to type."
-msgstr ""
-"받아쓰기 기능은 OpenAI 모델을 사용하여 음성을 텍스트로 변환하므로, 직접 입력"
-"하지 않고도 Duck.ai에서 채팅을 할 수 있습니다."
+msgstr "받아쓰기 기능은 OpenAI 모델을 사용하여 음성을 텍스트로 변환하므로, 직접 입력하지 않고도 Duck.ai에서 채팅을 할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. In 0-click box -- link to definition.
@@ -6081,9 +5990,7 @@ msgstr "목록에 DuckDuckGo가 보이지 않으시나요?"
 #. Link to download a file again if the user can't find it on their computer.
 msgctxt "install-extension"
 msgid "Don't see it? %s%s%sClick here to re-download%s"
-msgstr ""
-"파일을 찾을 수 없으신가요? %1$s%2$s%3$s여기를 클릭하여 다시 다운로드하세요."
-"%4$s"
+msgstr "파일을 찾을 수 없으신가요? %1$s%2$s%3$s여기를 클릭하여 다시 다운로드하세요.%4$s"
 
 #  IE < 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -6115,6 +6022,8 @@ msgid ""
 "Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
 "filtered out. %sLearn More%s"
 msgstr ""
+"AI를 원치 않으시나요? %1$snoai.duckduckgo.com%2$s은 AI 기능을 제공하지 않고 AI 이미지를 걸러냅니다. "
+"%3$s자세히 알아보세요%4$s"
 
 # smartling.placeholder_format=C
 #. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
@@ -6123,6 +6032,8 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
+"AI를 원치 않으시나요? %1$snoai.duckduckgo.com%2$s은 검색에 AI 기능을 사용하지 않고 AI 이미지를 걸러냅니다. "
+"%3$s자세히 알아보세요%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6224,9 +6135,7 @@ msgctxt "Full sentence for writing an email"
 msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for "
 "ceiling fan repair services."
-msgstr ""
-"실링 팬 수리 업체에 보낼 견적 요청 이메일 초안을 간결하면서도 상세하게 작성하"
-"세요."
+msgstr "실링 팬 수리 업체에 보낼 견적 요청 이메일 초안을 간결하면서도 상세하게 작성하세요."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion asking for an email draft to a vendor requesting a quote for home refrigerator repair services.
@@ -6234,21 +6143,19 @@ msgctxt "Full sentence for writing an email"
 msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
-msgstr ""
-"가정용 냉장고 수리 업체에 보낼 견적 요청 이메일 초안을 간결하면서도 상세하게 "
-"작성하세요."
+msgstr "가정용 냉장고 수리 업체에 보낼 견적 요청 이메일 초안을 간결하면서도 상세하게 작성하세요."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Draft a cover letter"
-msgstr ""
+msgstr "자기소개서 초안 작성"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Draft a cover letter for this job."
-msgstr ""
+msgstr "이 직무에 맞는 자기소개서를 써줘"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -6256,9 +6163,7 @@ msgctxt "Full sentence for drafting a social media post"
 msgid ""
 "Draft a few options for a social media post inviting people to my upcoming "
 "party."
-msgstr ""
-"다가오는 파티에 사람들을 초대하기 위해 SNS에 올릴 글을 몇 가지 버전으로 작성"
-"하세요."
+msgstr "다가오는 파티에 사람들을 초대하기 위해 SNS에 올릴 글을 몇 가지 버전으로 작성하세요."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a few options for a blog post title about strategies to increase team collaboration.
@@ -6266,9 +6171,7 @@ msgctxt "Full sentence for suggesting a blog post title"
 msgid ""
 "Draft a few options for a title of a post I’m writing about strategies to "
 "increase team collaboration."
-msgstr ""
-"팀 협업 강화 전략에 대해 내가 쓰고 있는 게시물의 제목을 여러 가지 버전으로 써"
-"보세요."
+msgstr "팀 협업 강화 전략에 대해 내가 쓰고 있는 게시물의 제목을 여러 가지 버전으로 써보세요."
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for drafting a social media post.
@@ -6394,9 +6297,8 @@ msgid ""
 "content is only included when you attach it, unless you choose to attach "
 "pages automatically in Settings."
 msgstr ""
-"이제 내가 보고있는 페이지에 대해 궁금한 점이 있을 때 Duck.ai가 답해드릴 수 있"
-"습니다. 페이지 내용은 사용자가 첨부할 때만 포함됩니다. 또는 설정에서 페이지 "
-"자동 첨부를 선택하세요."
+"이제 내가 보고있는 페이지에 대해 궁금한 점이 있을 때 Duck.ai가 답해드릴 수 있습니다. 페이지 내용은 사용자가 첨부할 때만 "
+"포함됩니다. 또는 설정에서 페이지 자동 첨부를 선택하세요."
 
 # smartling.placeholder_format=C
 #. Shown in the Duck.ai recent chats list on standalone when the browser API needed to store chats locally is missing or unavailable.
@@ -6406,8 +6308,8 @@ msgid ""
 "Duck.ai can’t access local storage to save your chats. Please check your "
 "browser settings or disable any extensions and try again."
 msgstr ""
-"Duck.ai가 채팅을 저장하기 위해 로컬 저장소에 액세스할 수 없습니다. 브라우저 "
-"설정을 확인하거나 확장 프로그램을 비활성화한 후 다시 시도하세요."
+"Duck.ai가 채팅을 저장하기 위해 로컬 저장소에 액세스할 수 없습니다. 브라우저 설정을 확인하거나 확장 프로그램을 비활성화한 후 다시 "
+"시도하세요."
 
 # smartling.placeholder_format=C
 #. Displayed when the chat service has reached the maximum number of messages for one day.
@@ -6415,16 +6317,13 @@ msgctxt "Error message for service limit"
 msgid ""
 "Duck.ai has reached the maximum number of messages for one day. Please "
 "continue this chat tomorrow."
-msgstr ""
-"Duck.ai의 하루 메시지 전송 한도에 도달했습니다. 내일 대화를 이어가세요."
+msgstr "Duck.ai의 하루 메시지 전송 한도에 도달했습니다. 내일 대화를 이어가세요."
 
 # smartling.placeholder_format=C
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
-msgstr ""
-"Duck.ai는 개인정보가 보호되는 무료 브라우저 DuckDuckGo에서 최고 성능을 발휘합"
-"니다!"
+msgstr "Duck.ai는 개인정보가 보호되는 무료 브라우저 DuckDuckGo에서 최고 성능을 발휘합니다!"
 
 # smartling.placeholder_format=C
 #. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
@@ -6433,7 +6332,7 @@ msgid ""
 "Duck.ai is created by DuckDuckGo. We're an independent online protection "
 "company for anyone who wants to take back control of their personal "
 "information."
-msgstr ""
+msgstr "Duck.ai를 만든 DuckDuckGo는 자신의 개인정보에 대한 통제권을 되찾고자 하는 사람들을 위한 독립된 온라인 보호 기업입니다."
 
 # smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
@@ -6447,9 +6346,7 @@ msgctxt "duckai_migration"
 msgid ""
 "Duck.ai is still a DuckDuckGo product, but will now have an easier to "
 "remember home on the web: https://duck.ai"
-msgstr ""
-"Duck.ai는 여전히 DuckDuckGo 제품이지만, 웹사이트 주소가 https://duck.ai로 기"
-"억하기 쉽게 바뀌었습니다."
+msgstr "Duck.ai는 여전히 DuckDuckGo 제품이지만, 웹사이트 주소가 https://duck.ai로 기억하기 쉽게 바뀌었습니다."
 
 # smartling.placeholder_format=C
 #. Headline for domain change notice.
@@ -6463,18 +6360,14 @@ msgctxt "Error message for BOTNET limit."
 msgid ""
 "Duck.ai is temporarily unavailable. If this persists, please email this "
 "anonymous code %s to %s"
-msgstr ""
-"Duck.ai를 일시적으로 사용할 수 없습니다. 문제가 지속되면 이 익명 코드(%1$s)"
-"를 %2$s 이메일로 보내주세요"
+msgstr "Duck.ai를 일시적으로 사용할 수 없습니다. 문제가 지속되면 이 익명 코드(%1$s)를 %2$s 이메일로 보내주세요"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
 msgctxt "Error message for VQD error"
 msgid ""
 "Duck.ai is temporarily unavailable. Please refresh the page and try again."
-msgstr ""
-"Duck.ai를 일시적으로 사용할 수 없습니다. 페이지를 새로고침한 후 다시 시도하세"
-"요."
+msgstr "Duck.ai를 일시적으로 사용할 수 없습니다. 페이지를 새로고침한 후 다시 시도하세요."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -6488,6 +6381,8 @@ msgid ""
 "Duck.ai lets you chat privately with popular AI models. Disabling it hides "
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
+"Duck.ai를 사용하면 인기 AI 모델과 비공개로 채팅할 수 있습니다. 이 기능을 끄면 Duck.ai 버튼과 링크가 숨겨지지만 "
+"%1$sduck.ai%2$s에 들어가서 직접 기능을 이용할 수 있습니다."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6498,10 +6393,9 @@ msgid ""
 "can still access Duck.ai when this setting is off by visiting %shttps://duck."
 "ai%s directly."
 msgstr ""
-"Duck.ai를 사용하면 OpenAI, Anthropic 등의 외부 AI 채팅 모델과 익명으로 대화"
-"할 수 있습니다. 이 설정을 끄면 DuckDuckGo Search에서 Duck.ai 버튼과 링크가 보"
-"이지 않습니다. 하지만 이 설정이 꺼져 있어도 %1$shttps://duck.ai%2$s에 바로 접"
-"속해서 Duck.ai를 이용할 수 있습니다."
+"Duck.ai를 사용하면 OpenAI, Anthropic 등의 외부 AI 채팅 모델과 익명으로 대화할 수 있습니다. 이 설정을 끄면 "
+"DuckDuckGo Search에서 Duck.ai 버튼과 링크가 보이지 않습니다. 하지만 이 설정이 꺼져 있어도 "
+"%1$shttps://duck.ai%2$s에 바로 접속해서 Duck.ai를 이용할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
@@ -6515,9 +6409,7 @@ msgctxt "duckai_migration"
 msgid ""
 "Duck.ai might have lost your recent chats. You can still use Duck.ai as "
 "usual."
-msgstr ""
-"Duck.ai에서 나의 최근 채팅이 사라졌을 수 있습니다. Duck.ai는 평소처럼 사용하"
-"실 수 있습니다."
+msgstr "Duck.ai에서 나의 최근 채팅이 사라졌을 수 있습니다. Duck.ai는 평소처럼 사용하실 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
@@ -6548,8 +6440,7 @@ msgstr "Duck.ai가 업그레이드되었습니다!"
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
-msgstr ""
-"Duck.ai는 개인정보가 보호되는 무료 DuckDuckGo 앱에서 최고 성능을 발휘합니다!"
+msgstr "Duck.ai는 개인정보가 보호되는 무료 DuckDuckGo 앱에서 최고 성능을 발휘합니다!"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -6559,9 +6450,8 @@ msgid ""
 "AI chat no sign up, OpenAI, Anthropic, Llama, Mistral, open source AI "
 "models, privacy focused AI, no account AI chat"
 msgstr ""
-"Duck.ai, DuckDuckGo AI, 비공개 AI 챗봇, 무료 AI 채팅, 익명 AI 채팅, 가입 필"
-"요 없는 AI 채팅, OpenAI, Anthropic, Llama, Mistral, 오픈 소스 AI 모델, 프라이"
-"버시 중심 AI, 계정 필요 없는 AI 채팅"
+"Duck.ai, DuckDuckGo AI, 비공개 AI 챗봇, 무료 AI 채팅, 익명 AI 채팅, 가입 필요 없는 AI 채팅, "
+"OpenAI, Anthropic, Llama, Mistral, 오픈 소스 AI 모델, 프라이버시 중심 AI, 계정 필요 없는 AI 채팅"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -6589,11 +6479,9 @@ msgid ""
 "relevant), or Often (shows more frequently on a wider range of searches). "
 "For now, DuckAssist is only available in the U.S. (English) region."
 msgstr ""
-"DuckAssist는 일부 검색에 대하여 익명으로 정보를 조회하고 요약할 수 있습니다. "
-"DuckAssist 표시 빈도 선택 가능: 안 함(검색 결과에서 DuckAssist UI를 완전히 제"
-"거), 주문형(Assist 버튼을 클릭할 때만 표시), 가끔(관련성이 높은 경우에만 표"
-"시), 자주(광범위한 검색에서 더 자주 표시). 현재 DuckAssist 서비스는 미국(영"
-"어) 지역에서만 제공됩니다."
+"DuckAssist는 일부 검색에 대하여 익명으로 정보를 조회하고 요약할 수 있습니다. DuckAssist 표시 빈도 선택 가능: 안 "
+"함(검색 결과에서 DuckAssist UI를 완전히 제거), 주문형(Assist 버튼을 클릭할 때만 표시), 가끔(관련성이 높은 경우에만 "
+"표시), 자주(광범위한 검색에서 더 자주 표시). 현재 DuckAssist 서비스는 미국(영어) 지역에서만 제공됩니다."
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6602,9 +6490,8 @@ msgid ""
 "%sDuckDuckGo AI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI, and Anthropic, and more."
 msgstr ""
-"DuckAssist는 후속 질문에 답변할 수 없지만 OpenAI 및 Anthropic의 채팅 모델을 "
-"지원하는 비공개 AI 기반 채팅 서비스인 %1$sDuckDuckGo AI Chat%2$s도 제공합니"
-"다."
+"DuckAssist는 후속 질문에 답변할 수 없지만 OpenAI 및 Anthropic의 채팅 모델을 지원하는 비공개 AI 기반 채팅 "
+"서비스인 %1$sDuckDuckGo AI Chat%2$s도 제공합니다."
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6613,9 +6500,8 @@ msgid ""
 "DuckDuckGo %sAI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI and Anthropic."
 msgstr ""
-"DuckAssist는 후속 질문에 답변할 수 없지만 OpenAI 및 Anthropic의 채팅 모델을 "
-"지원하는 비공개 AI 기반 채팅 서비스인 DuckDuckGo %1$sAI Chat%2$s도 제공합니"
-"다."
+"DuckAssist는 후속 질문에 답변할 수 없지만 OpenAI 및 Anthropic의 채팅 모델을 지원하는 비공개 AI 기반 채팅 "
+"서비스인 DuckDuckGo %1$sAI Chat%2$s도 제공합니다."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6627,10 +6513,9 @@ msgid ""
 "responses are currently based on Wikipedia and related content and are not "
 "checked for accuracy."
 msgstr ""
-"DuckAssist는 검색 질의에 익명으로 답변을 생성하는 새 기능입니다. Wikipedia와 "
-"관련 사이트에서 의미있는 콘텐츠를 검색한 다음 AI 기반 자연어 기술을 사용하여 "
-"해당 정보를 요약하는 방식으로 답변을 생성합니다. 현재 Wikipedia와 관련 내용"
-"을 기반으로 답변을 제공하며 정확성 검사는 하지 않습니다."
+"DuckAssist는 검색 질의에 익명으로 답변을 생성하는 새 기능입니다. Wikipedia와 관련 사이트에서 의미있는 콘텐츠를 검색한 "
+"다음 AI 기반 자연어 기술을 사용하여 해당 정보를 요약하는 방식으로 답변을 생성합니다. 현재 Wikipedia와 관련 내용을 기반으로 "
+"답변을 제공하며 정확성 검사는 하지 않습니다."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6644,21 +6529,17 @@ msgid ""
 "It’s important to remember that responses are auto-generated from cited "
 "sources and based on %scrawling the web%s."
 msgstr ""
-"DuckAssist는 검색 질의에 익명으로 답변을 생성하는 옵션 기능입니다. 웹에서 관"
-"련 콘텐츠를 검색한 다음 AI 기반 자연어 기술을 사용하여, 검색된 관련 정보를 바"
-"탕으로 간단한 답변을 생성합니다. DuckAssist는 응답을 할 때 항상 출처 1~2개를 "
-"바로 링크하고 답변 출처를 인용하기 때문에 사용자가 쉽게 이동하여 더 자세한 정"
-"보를 얻을 수 있습니다. 답변은 인용된 출처와 %1$s웹 크롤링%2$s을 기반으로 자"
-"동 생성합니다."
+"DuckAssist는 검색 질의에 익명으로 답변을 생성하는 옵션 기능입니다. 웹에서 관련 콘텐츠를 검색한 다음 AI 기반 자연어 기술을 "
+"사용하여, 검색된 관련 정보를 바탕으로 간단한 답변을 생성합니다. DuckAssist는 응답을 할 때 항상 출처 1~2개를 바로 링크하고 "
+"답변 출처를 인용하기 때문에 사용자가 쉽게 이동하여 더 자세한 정보를 얻을 수 있습니다. 답변은 인용된 출처와 %1$s웹 크롤링%2$s을 "
+"기반으로 자동 생성합니다."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid ""
 "DuckAssist responses are auto-generated based on listed sources and not "
 "checked for accuracy."
-msgstr ""
-"DuckAssist 응답은 나열된 소스를 기반으로 자동 생성하며 정확성을 확인하지 않습"
-"니다."
+msgstr "DuckAssist 응답은 나열된 소스를 기반으로 자동 생성하며 정확성을 확인하지 않습니다."
 
 # smartling.placeholder_format=C
 #. Displayed when the chat service has reached the maximum number of messages for one day.
@@ -6666,9 +6547,7 @@ msgctxt "Error message for service limit"
 msgid ""
 "DuckDuckGo AI Chat has reached the maximum number of messages for one day. "
 "Please continue this chat tomorrow."
-msgstr ""
-"하루에 보낼 수 있는 DuckDuckGo AI Chat 메시지 개수 한도에 도달했습니다. 이 채"
-"팅은 내일 계속하세요."
+msgstr "하루에 보낼 수 있는 DuckDuckGo AI Chat 메시지 개수 한도에 도달했습니다. 이 채팅은 내일 계속하세요."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the AI chat service and supported AI models. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -6677,8 +6556,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"DuckDuckGo AI Chat은 현재 %1$s의 %2$s, %3$s의 %4$s 채팅 모델을 지원하는 비공"
-"개 AI 기반 채팅 서비스입니다."
+"DuckDuckGo AI Chat은 현재 %1$s의 %2$s, %3$s의 %4$s 채팅 모델을 지원하는 비공개 AI 기반 채팅 "
+"서비스입니다."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the welcome screen of the onboarding. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -6687,8 +6566,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"DuckDuckGo AI Chat은 현재 %1$s의 %2$s, %3$s의 %4$s 채팅 모델을 지원하는 비공"
-"개 AI 기반 채팅 서비스입니다."
+"DuckDuckGo AI Chat은 현재 %1$s의 %2$s, %3$s의 %4$s 채팅 모델을 지원하는 비공개 AI 기반 채팅 "
+"서비스입니다."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding DuckDuckGo AI Chat.
@@ -6696,9 +6575,7 @@ msgctxt "Disclaimer text at the bottom of the feedback form."
 msgid ""
 "DuckDuckGo AI Chat is in Beta, it may display inaccurate or offensive "
 "information."
-msgstr ""
-"DuckDuckGo AI Chat은 베타 버전이므로 부정확하거나 불쾌한 정보가 표시될 수 있"
-"습니다."
+msgstr "DuckDuckGo AI Chat은 베타 버전이므로 부정확하거나 불쾌한 정보가 표시될 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat making it unavailable, and asking the user to send an email with a specific code if the error persists. E.g. 'DuckDuckGo AI Chat is temporarily unavailable. If this persists, please email this anonymous code abcdefg12345 to aichat-error@duckduckgo.com'
@@ -6706,9 +6583,7 @@ msgctxt "Error message for BOTNET limit."
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. If this persists, please "
 "email this anonymous code %s to %s"
-msgstr ""
-"DuckDuckGo AI Chat을 일시적으로 사용할 수 없습니다. 문제가 지속되면 이 익명 "
-"코드(%1$s)를 %2$s 이메일로 보내주세요"
+msgstr "DuckDuckGo AI Chat을 일시적으로 사용할 수 없습니다. 문제가 지속되면 이 익명 코드(%1$s)를 %2$s 이메일로 보내주세요"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -6716,16 +6591,13 @@ msgctxt "Error message for VQD error"
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. Please refresh the page and "
 "try again."
-msgstr ""
-"DuckDuckGo AI Chat을 일시적으로 사용할 수 없습니다. 페이지를 새로고침한 후 다"
-"시 시도하세요."
+msgstr "DuckDuckGo AI Chat을 일시적으로 사용할 수 없습니다. 페이지를 새로고침한 후 다시 시도하세요."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr ""
-"DuckDuckGo AI Chat을 일시적으로 사용할 수 없습니다. 잠시 후 다시 시도하세요."
+msgstr "DuckDuckGo AI Chat을 일시적으로 사용할 수 없습니다. 잠시 후 다시 시도하세요."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -6844,17 +6716,15 @@ msgid ""
 "DuckDuckGo anonymizes these reports by automatically removing PII like "
 "names, email addresses, phone numbers, and identifying metadata."
 msgstr ""
-"DuckDuckGo는 이름, 이메일 주소, 전화번호, 식별 가능한 메타데이터 같은 개인정"
-"보(PII)를 자동으로 제거해 이러한 보고서를 익명화합니다."
+"DuckDuckGo는 이름, 이메일 주소, 전화번호, 식별 가능한 메타데이터 같은 개인정보(PII)를 자동으로 제거해 이러한 보고서를 "
+"익명화합니다."
 
 # smartling.placeholder_format=C
 #. The first %s is the agree button label ('Agree'). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. The leading sentence mirrors the drawer-style inline disclaimer (DUCKCHAT_TOS_INLINE_DISCLAIMER).
 msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid ""
 "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to Duck.ai's %s."
-msgstr ""
-"DuckDuckGo는 채팅을 익명으로 처리합니다. %1$s 클릭을 통해 Duck.ai의 %2$s에 동"
-"의합니다."
+msgstr "DuckDuckGo는 채팅을 익명으로 처리합니다. %1$s 클릭을 통해 Duck.ai의 %2$s에 동의합니다."
 
 # smartling.placeholder_format=C
 #. Shown below the input on the empty state when the user has not yet accepted the terms of service. The first %s is the action button label ('Ask' for chat, 'Create' for image generation). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. Clicking the action button both accepts the terms and submits the prompt.
@@ -6862,9 +6732,7 @@ msgctxt ""
 "Inline terms-of-service disclaimer below chat or image-gen input for new "
 "users"
 msgid "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to our %s."
-msgstr ""
-"DuckDuckGo는 채팅을 익명으로 처리합니다. %1$s 클릭을 통해 DuckDuckGo의 %2$s"
-"에 동의합니다."
+msgstr "DuckDuckGo는 채팅을 익명으로 처리합니다. %1$s 클릭을 통해 DuckDuckGo의 %2$s에 동의합니다."
 
 # smartling.placeholder_format=C
 #. An information popup explaining that we block trackers
@@ -6873,8 +6741,8 @@ msgid ""
 "companies like Google and Facebook, who often try to track you on other "
 "websites."
 msgstr ""
-"DuckDuckGo는 사용자가 방문하는 웹사이트의 추적기를 차단하며, 다른 웹사이트에"
-"서 사용자 추적을 시도하는 Google과 Facebook 등의 추적기도 차단합니다."
+"DuckDuckGo는 사용자가 방문하는 웹사이트의 추적기를 차단하며, 다른 웹사이트에서 사용자 추적을 시도하는 Google과 "
+"Facebook 등의 추적기도 차단합니다."
 
 # smartling.placeholder_format=C
 #. Description of how DuckDuckGo keeps a user's location anonymous while the user searches on a map of their area.
@@ -6886,11 +6754,10 @@ msgid ""
 "away, such that you remain anonymous. %sLearn more about how we designed "
 "this technology to protect your privacy%s."
 msgstr ""
-"DuckDuckGo는 개인정보 보호를 위한 검색 엔진입니다. 위치 기능을 활성화하면 위"
-"치 정보는 로컬 기기에만 저장됩니다. 사용자가 검색을 하면 사용자의 기기는 해"
-"당 검색 정보를 DuckDuckGo로 전송하며, DuckDuckGo는 이를 검색 결과를 개선하는 "
-"데 사용한 후 즉시 폐기하여 사용자의 검색 기록을 남기지 않습니다. %1$s개인정보"
-"를 보호하기 위해 개발된 DuckDuckGo의 기술에 대해 자세히 알아보세요%2$s."
+"DuckDuckGo는 개인정보 보호를 위한 검색 엔진입니다. 위치 기능을 활성화하면 위치 정보는 로컬 기기에만 저장됩니다. 사용자가 "
+"검색을 하면 사용자의 기기는 해당 검색 정보를 DuckDuckGo로 전송하며, DuckDuckGo는 이를 검색 결과를 개선하는 데 사용한 "
+"후 즉시 폐기하여 사용자의 검색 기록을 남기지 않습니다. %1$s개인정보를 보호하기 위해 개발된 DuckDuckGo의 기술에 대해 자세히 "
+"알아보세요%2$s."
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
@@ -6910,8 +6777,8 @@ msgid ""
 "DuckDuckGo only uses your approximate location. That's all we need to "
 "deliver better results, closer to you. %sLearn more%s."
 msgstr ""
-"DuckDuckGo는 사용자의 대략적인 위치만 사용합니다. 이 정보만으로도 충분히 좋"
-"은 결과를 제공할 수 있습니다. %1$s자세히 알아보세요%2$s."
+"DuckDuckGo는 사용자의 대략적인 위치만 사용합니다. 이 정보만으로도 충분히 좋은 결과를 제공할 수 있습니다. %1$s자세히 "
+"알아보세요%2$s."
 
 # smartling.placeholder_format=C
 msgid "DuckDuckGo search"
@@ -6997,9 +6864,8 @@ msgid ""
 "random words from that list, ensuring that the passphrase is at least 18-20 "
 "characters long."
 msgstr ""
-"암호 제안 버튼을 클릭할 때마다 DuckDuckGo는 서버에서 무작위 단어로 조합된 긴 "
-"목록을 받습니다. 그러 다음 브라우저에서 목록에 포함된 4~5개의 무작위 단어를 "
-"선택하여 최소 18~20자 이상의 암호를 만듭니다."
+"암호 제안 버튼을 클릭할 때마다 DuckDuckGo는 서버에서 무작위 단어로 조합된 긴 목록을 받습니다. 그러 다음 브라우저에서 목록에 "
+"포함된 4~5개의 무작위 단어를 선택하여 최소 18~20자 이상의 암호를 만듭니다."
 
 # smartling.placeholder_format=C
 msgctxt "Sports module"
@@ -7194,9 +7060,7 @@ msgstr "웹 검색 활성화"
 msgid ""
 "Enable anonymous location for more accurate results. You can always change "
 "your mind later."
-msgstr ""
-"보다 정확한 결과를 얻으려면 익명 위치 기능을 활성화하세요. 언제든지 설정을 변"
-"경할 수 있습니다."
+msgstr "보다 정확한 결과를 얻으려면 익명 위치 기능을 활성화하세요. 언제든지 설정을 변경할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Title of the dictation privacy consent modal shown on first use.
@@ -7238,9 +7102,7 @@ msgctxt "precise_user_location"
 msgid ""
 "Enabling anonymous location gives more accurate results but still keeps your "
 "searches and exact location private to DuckDuckGo."
-msgstr ""
-"익명 위치를 활성화하면 더 정확한 결과를 얻으면서도 사용자의 검색과 정확한 위"
-"치는 DuckDuckGo에 공개하지 않을 수 있습니다."
+msgstr "익명 위치를 활성화하면 더 정확한 결과를 얻으면서도 사용자의 검색과 정확한 위치는 DuckDuckGo에 공개하지 않을 수 있습니다."
 
 # smartling.placeholder_format=C
 msgid "Encrypt Connections"
@@ -7401,9 +7263,7 @@ msgctxt "cloudsave"
 msgid ""
 "Enter a new passphrase and click/tap %sSave Settings%s. This will save your "
 "data under your new passphrase."
-msgstr ""
-"새 암호를 입력하고 %1$s설정 저장%2$s을 클릭하거나 누르세요. 그러면 해당 데이"
-"터가 새 암호로 저장됩니다."
+msgstr "새 암호를 입력하고 %1$s설정 저장%2$s을 클릭하거나 누르세요. 그러면 해당 데이터가 새 암호로 저장됩니다."
 
 # smartling.placeholder_format=C
 #. Label for the field where a user enters their passphrase.
@@ -7428,9 +7288,7 @@ msgstr "번역할 내용 입력하기"
 #. Instructions for how to change the default search engine.
 msgid ""
 "Enter the following details: %sName%s: DuckDuckGo%s URL%s: %s Alias%s: d%s"
-msgstr ""
-"다음 내용을 적어주세요: %1$s이름%2$s: DuckDuckGo%3$s URL%4$s: %5$s 닉네"
-"임%6$s: d%7$s"
+msgstr "다음 내용을 적어주세요: %1$s이름%2$s: DuckDuckGo%3$s URL%4$s: %5$s 닉네임%6$s: d%7$s"
 
 # smartling.placeholder_format=C
 #. Prompt to enter a destination for driving directions.
@@ -7474,13 +7332,13 @@ msgstr "에리트레아"
 #. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Estimate the nutrition"
-msgstr ""
+msgstr "영양 정보 추정"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Estimate the nutritional information for this recipe."
-msgstr ""
+msgstr "이 레시피의 영양 정보를 추정해줘"
 
 # smartling.placeholder_format=C
 msgid "Estonia"
@@ -7516,9 +7374,7 @@ msgstr "지도 확장하기"
 #. Subtitle for the Collaborations promotional card at the bottom of search results. Describes the branded merchandise line. 'Give a duck' is a wordplay on the DuckDuckGo brand name.
 msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
-msgstr ""
-"개인 정보 보호를 덕히 중요하게 생각하는 사람들을 위해 전문성을 다해 만들었습"
-"니다."
+msgstr "개인 정보 보호를 덕히 중요하게 생각하는 사람들을 위해 전문성을 다해 만들었습니다."
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
@@ -7542,7 +7398,7 @@ msgstr "1일 후 만료"
 #. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain the accepted answer in simple terms."
-msgstr ""
+msgstr "채택된 답변을 쉬운 용어로 설명해줘"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
@@ -7555,43 +7411,43 @@ msgstr "블랙홀의 기본 개념을 고등학교 수준으로 설명해 주세
 #. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain the top answer"
-msgstr ""
+msgstr "최상단 답변 설명"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain this in simple, plain language."
-msgstr ""
+msgstr "쉽고 간단한 언어로 설명해 주세요."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain this paper"
-msgstr ""
+msgstr "이 논문 설명"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain this repo"
-msgstr ""
+msgstr "이 저장소 설명"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain this research paper in plain language."
-msgstr ""
+msgstr "이 연구 논문을 쉬운 언어로 설명해 주세요."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain this simply"
-msgstr ""
+msgstr "간단히 설명해 주세요"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain what this repository does and how to use it."
-msgstr ""
+msgstr "이 저장소의 기능과 사용 방법을 설명해 주세요."
 
 # smartling.placeholder_format=C
 #. Label to show if song lyrics contain explicit content
@@ -7768,8 +7624,7 @@ msgstr "피드백이 성공적으로 전송되었습니다."
 msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and improvements."
-msgstr ""
-"여러분이 주시는 피드백은 제품 업데이트와 개선에 직접적인 영향을 미칩니다."
+msgstr "여러분이 주시는 피드백은 제품 업데이트와 개선에 직접적인 영향을 미칩니다."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -7777,9 +7632,7 @@ msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and "
 "improvements. Hopefully we can address the issue you shared too."
-msgstr ""
-"여러분이 주시는 피드백은 제품 업데이트와 개선에 직접적인 영향을 미칩니다. 사"
-"용자님이 보내주신 문제도 해결하기 위해 노력하겠습니다."
+msgstr "여러분이 주시는 피드백은 제품 업데이트와 개선에 직접적인 영향을 미칩니다. 사용자님이 보내주신 문제도 해결하기 위해 노력하겠습니다."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box
@@ -7869,14 +7722,13 @@ msgstr "이미지 검색 결과에서 AI가 생성한 이미지를 걸러냅니�
 msgctxt "settings"
 msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
-msgstr ""
-"이미지 검색 결과에서 AI가 생성한 이미지를 걸러냅니다. %1$s자세히 알아보기%2$s"
+msgstr "이미지 검색 결과에서 AI가 생성한 이미지를 걸러냅니다. %1$s자세히 알아보기%2$s"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Filters out known AI spam sites from image search results. %sLearn More%s"
-msgstr ""
+msgstr "이미지 검색 결과에서 알려진 AI 스팸 사이트를 걸러냅니다. %1$s자세히 알아보세요%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the final score of a sporting event.
@@ -7917,8 +7769,7 @@ msgstr "다운로드 폴더에서 <b>%1$s</b> 파일을 찾으세요"
 # smartling.placeholder_format=C
 #. Tells users how to change their default search engine to DuckDuckGo.
 msgid "Find DuckDuckGo in the displayed list and click %sMake Default%s"
-msgstr ""
-"표시된 목록에서 DuckDuckGo를 찾아 %1$s기본값으로 설정%2$s을 클릭하세요."
+msgstr "표시된 목록에서 DuckDuckGo를 찾아 %1$s기본값으로 설정%2$s을 클릭하세요."
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for finding a better word.
@@ -7936,7 +7787,7 @@ msgstr "최신 정보 찾기"
 #. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Find me alternatives"
-msgstr ""
+msgstr "대안 찾기"
 
 # smartling.placeholder_format=C
 #. Button that searches for results closer to the user's current location.
@@ -7955,8 +7806,7 @@ msgstr "여러분과 보다 관련있는 결과를 찾아보세요."
 msgctxt "Precise user location overlay"
 msgid ""
 "Find results near you. %sYour location stays private, secure, and anonymous."
-msgstr ""
-"내 주변 결과를 보세요. %1$s내 위치는 익명 비공개로 안전하게 유지됩니다."
+msgstr "내 주변 결과를 보세요. %1$s내 위치는 익명 비공개로 안전하게 유지됩니다."
 
 # smartling.placeholder_format=C
 #. Loading message shown while generating explore more follow-up questions
@@ -8019,9 +7869,7 @@ msgstr "안개"
 msgid ""
 "Follow the instructions for turning off the ad blocker for DuckDuckGo. You "
 "may have to select a menu option or click a button."
-msgstr ""
-"안내에 따라 DuckDuckGo의 광고 차단기를 끄세요. 메뉴 옵션을 선택하거나 버튼을 "
-"클릭해야 할 수도 있습니다."
+msgstr "안내에 따라 DuckDuckGo의 광고 차단기를 끄세요. 메뉴 옵션을 선택하거나 버튼을 클릭해야 할 수도 있습니다."
 
 # smartling.placeholder_format=C
 #. Privacy reassurance and instructions intro.
@@ -8132,8 +7980,7 @@ msgstr "DuckDuckGo가 익명화하는 무료 비공개 채팅"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr ""
-"DuckDuckGo가 익명화하는 무료 비공개 채팅입니다. 계정이 없어도 괜찮습니다."
+msgstr "DuckDuckGo가 익명화하는 무료 비공개 채팅입니다. 계정이 없어도 괜찮습니다."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -8244,8 +8091,8 @@ msgid ""
 "<strong>Check for Updates...</strong>, then select <strong>Install Update</"
 "strong>."
 msgstr ""
-"Mac의 앱 메뉴 표시줄에서 <strong>DuckDuckGo</strong> &gt; <strong>업데이트 확"
-"인...</strong>을 선택한 후 <strong>업데이트 설치</strong>를 선택합니다."
+"Mac의 앱 메뉴 표시줄에서 <strong>DuckDuckGo</strong> &gt; <strong>업데이트 "
+"확인...</strong>을 선택한 후 <strong>업데이트 설치</strong>를 선택합니다."
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -8416,7 +8263,7 @@ msgstr "더 많이 생성하세요"
 #. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Generate a shopping list"
-msgstr ""
+msgstr "장보기 목록 만들기"
 
 # smartling.placeholder_format=C
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
@@ -8595,9 +8442,7 @@ msgctxt "Description of the modal to upgrade the DuckDuckGo subscription"
 msgid ""
 "Get access to advanced AI models in Duck.ai by subscribing to DuckDuckGo, "
 "which also includes our VPN and other premium privacy protections."
-msgstr ""
-"VPN을 비롯한 프리미엄 개인 정보 보호 기능이 제공되는 DuckDuckGo를 구독해 "
-"Duck.ai의 고급 AI 모델을 이용하세요."
+msgstr "VPN을 비롯한 프리미엄 개인 정보 보호 기능이 제공되는 DuckDuckGo를 구독해 Duck.ai의 고급 AI 모델을 이용하세요."
 
 # smartling.placeholder_format=C
 #. Description for the subscription setting where users can subscribe to DuckDuckGo.
@@ -8607,9 +8452,7 @@ msgctxt ""
 msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
-msgstr ""
-"VPN을 비롯한 프리미엄 개인 정보 보호 기능이 제공되는 DuckDuckGo 구독을 통해 "
-"Duck.ai의 고급 AI 모델을 이용하세요."
+msgstr "VPN을 비롯한 프리미엄 개인 정보 보호 기능이 제공되는 DuckDuckGo 구독을 통해 Duck.ai의 고급 AI 모델을 이용하세요."
 
 # smartling.placeholder_format=C
 #. A button for users to generate an AI generated answer from their query on the duckassist module
@@ -8643,9 +8486,7 @@ msgstr "설정이 사라지지 않도록 DuckDuckGo 브라우저를 이용하세
 # smartling.placeholder_format=C
 msgid ""
 "Get seamless privacy protection on your browser for free with one download:"
-msgstr ""
-"다운로드 한 번으로 브라우저에서 무료로 개인정보 보호 기능을 원활하게 이용할 "
-"수 있습니다."
+msgstr "다운로드 한 번으로 브라우저에서 무료로 개인정보 보호 기능을 원활하게 이용할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo app when clicked
@@ -8713,7 +8554,7 @@ msgstr "사용해보기기"
 #. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Give me a quick background on this person."
-msgstr ""
+msgstr "이 사람의 배경에 대해 간단히 알려줘"
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -8727,9 +8568,7 @@ msgctxt "precise_user_location"
 msgid ""
 "Go to %sSettings > Privacy & Security > Location Services%s, and make sure "
 "“Location Services” is turned on."
-msgstr ""
-"%1$s설정 > 개인 정보 보호 및 보안 > 위치 서비스%2$s로 이동하여 '위치 서비"
-"스'가 켜져 있는지 확인합니다."
+msgstr "%1$s설정 > 개인 정보 보호 및 보안 > 위치 서비스%2$s로 이동하여 '위치 서비스'가 켜져 있는지 확인합니다."
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -8737,9 +8576,7 @@ msgctxt "precise_user_location"
 msgid ""
 "Go to %sSettings > Privacy > Permission manager > Location%s and scroll down "
 "to %sDuckDuckGo%s."
-msgstr ""
-"%1$s 설정 > 개인 정보 보호 > 권한 관리자 > 위치%2$s에서 화면을 내려 "
-"%3$sDuckDuckGo%4$s를 찾습니다."
+msgstr "%1$s 설정 > 개인 정보 보호 > 권한 관리자 > 위치%2$s에서 화면을 내려 %3$sDuckDuckGo%4$s를 찾습니다."
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9165,13 +9002,13 @@ msgstr "개인정보 보호의 중요성 알리기"
 #. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Help me prep for the interview"
-msgstr ""
+msgstr "면접 준비를 도와줘"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Help me tailor my resume for this job."
-msgstr ""
+msgstr "이 직무에 맞게 이력서를 고쳐줘."
 
 # smartling.placeholder_format=C
 #. Title of a SERP popup that invites users to take a survey (desktop only)
@@ -9409,9 +9246,7 @@ msgctxt "settings"
 msgid ""
 "Highlights key facts in Search Assist answers to help you find important "
 "information faster."
-msgstr ""
-"중요한 정보를 더 빨리 찾는 데 도움이 되도록 Search Assist 답변의 주요 사실을 "
-"강조 표시합니다."
+msgstr "중요한 정보를 더 빨리 찾는 데 도움이 되도록 Search Assist 답변의 주요 사실을 강조 표시합니다."
 
 # smartling.placeholder_format=C
 #. The name of the Hindi language
@@ -9438,8 +9273,8 @@ msgid ""
 "Hit %sReturn%s on your keyboard to %ssave DuckDuckGo to the list. %sThen "
 "click %sMake Default%s"
 msgstr ""
-"키보드의 %1$sReturn%2$s 키를 눌러 %3$sDuckDuckGo를 목록에 저장하세요. %4$s그"
-"런 다음 %5$s기본값으로 설정%6$s을 클릭하세요"
+"키보드의 %1$sReturn%2$s 키를 눌러 %3$sDuckDuckGo를 목록에 저장하세요. %4$s그런 다음 %5$s기본값으로 "
+"설정%6$s을 클릭하세요"
 
 # smartling.placeholder_format=C
 #. The name of the Hmong Daw language
@@ -9452,9 +9287,7 @@ msgstr "몽족어"
 msgid ""
 "Hold on! Changing it back will disable the DuckDuckGo extension and you'll "
 "lose our privacy protection."
-msgstr ""
-"잠깐만요! 다시 변경하면 DuckDuckGo 확장 기능프로그램이 비활성화되어 개인정보 "
-"보호 기능을 사용할 수 없게 됩니다."
+msgstr "잠깐만요! 다시 변경하면 DuckDuckGo 확장 기능프로그램이 비활성화되어 개인정보 보호 기능을 사용할 수 없게 됩니다."
 
 # smartling.placeholder_format=C
 #. Heading shown above warning messages in the AI chat, for non-critical issues like unsupported file formats or file size limits. Analogous to 'Oops...' for error messages.
@@ -9503,9 +9336,7 @@ msgstr "더움"
 msgid ""
 "Hotel ad clicks are managed by Tripadvisor’s ad network and are not used to "
 "profile you."
-msgstr ""
-"호텔 광고 클릭은 Tripadvisor의 광고 네트워크에서 관리되며 사용자의 정보를 수"
-"집하는 데 사용되지 않습니다."
+msgstr "호텔 광고 클릭은 Tripadvisor의 광고 네트워크에서 관리되며 사용자의 정보를 수집하는 데 사용되지 않습니다."
 
 # smartling.placeholder_format=C
 #. Refers to hours of operation for a business.
@@ -9692,7 +9523,7 @@ msgctxt ""
 "Text for the I already have a subscription button in the Duck.ai settings "
 "page"
 msgid "I Already Have a Subscription"
-msgstr ""
+msgstr "이미 구독 중"
 
 # smartling.placeholder_format=C
 #. Text for the button that takes the user to the login subscription page.
@@ -9767,9 +9598,7 @@ msgctxt "Full sentence for recommending a book"
 msgid ""
 "I like the book Name of the Wind. What are some other good books/series most "
 "like it and why?"
-msgstr ""
-"바람의 이름이라는 책을 좋아합니다. 다른 재미있는 책/시리즈에는 무엇이 있으"
-"며, 그 이유는 무엇인가요?"
+msgstr "바람의 이름이라는 책을 좋아합니다. 다른 재미있는 책/시리즈에는 무엇이 있으며, 그 이유는 무엇인가요?"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the user needs more help or information on how to use the chat.
@@ -9803,9 +9632,7 @@ msgctxt "precise_user_location"
 msgid ""
 "If the browser location remains unavailable, then go to %sSettings > General "
 "> Reset > 'Reset Location & Privacy'%s."
-msgstr ""
-"여전히 브라우저 위치를 사용할 수 없는 경우 %1$s설정 > 일반 > 재설정 > 위치 "
-"및 개인정보 보호 재설정%2$s으로 이동하세요."
+msgstr "여전히 브라우저 위치를 사용할 수 없는 경우 %1$s설정 > 일반 > 재설정 > 위치 및 개인정보 보호 재설정%2$s으로 이동하세요."
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -9815,8 +9642,8 @@ msgid ""
 "> Menu > Settings > Site settings > Location%s, and ensure DuckDuckGo is "
 "allowed location access."
 msgstr ""
-"여전히 브라우저 위치를 사용할 수 없는 경우 브라우저에서 %1$s메뉴 > 설정 > 사"
-"이트 설정 > 위치%2$s로 이동하여 DuckDuckGo의 위치 접근을 허용하세요."
+"여전히 브라우저 위치를 사용할 수 없는 경우 브라우저에서 %1$s메뉴 > 설정 > 사이트 설정 > 위치%2$s로 이동하여 "
+"DuckDuckGo의 위치 접근을 허용하세요."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -9830,9 +9657,7 @@ msgstr "이 오류가 계속되면 %1$s에 문의하세요."
 msgid ""
 "If you don't see %sDuckDuckGo,%s you will need to add it to the list of "
 "%sOther Search Engines%s"
-msgstr ""
-"만약 %1$sDuckDuckGo%2$s가 보이지 않는다면 %3$s기타 검색 엔진%4$s 목록에 추가"
-"해야 합니다."
+msgstr "만약 %1$sDuckDuckGo%2$s가 보이지 않는다면 %3$s기타 검색 엔진%4$s 목록에 추가해야 합니다."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding the AI model providers and links to their support pages. Example: 'If you have concerns about our chat providers or any particular chat response, you can also reach out directly to OpenAI and Anthropic support pages.'
@@ -9840,9 +9665,7 @@ msgctxt "Disclaimer text at the bottom of the feedback form."
 msgid ""
 "If you have concerns about our chat providers or any particular chat "
 "response, you can also reach out directly to %s and %s support pages."
-msgstr ""
-"채팅 또는 특정 채팅 응답에 대해 우려되는 부분이 있으면 %1$s 및 %2$s 지원 페이"
-"지에 직접 문의하실 수도 있습니다."
+msgstr "채팅 또는 특정 채팅 응답에 대해 우려되는 부분이 있으면 %1$s 및 %2$s 지원 페이지에 직접 문의하실 수도 있습니다."
 
 # smartling.placeholder_format=C
 #. Body copy explaining what the recovery code is for and how it can be saved.
@@ -9850,17 +9673,13 @@ msgctxt "Body for the Sync & Backup recovery code screen"
 msgid ""
 "If you lose access to your devices, you will need this code to recover your "
 "saved chats. You can save this code to your device as a text file."
-msgstr ""
-"기기에 접근할 수 없게 되었을 때 저장된 채팅을 복구하려면 이 코드가 필요합니"
-"다. 이 코드를 기기에 텍스트 파일로 저장할 수 있습니다."
+msgstr "기기에 접근할 수 없게 되었을 때 저장된 채팅을 복구하려면 이 코드가 필요합니다. 이 코드를 기기에 텍스트 파일로 저장할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
-msgstr ""
-"저희를 계속 지원하고 싶으시다면, %1$sDuckDuckGo를 더 많은 사람들에게 소개해주"
-"세요%2$s"
+msgstr "저희를 계속 지원하고 싶으시다면, %1$sDuckDuckGo를 더 많은 사람들에게 소개해주세요%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -9869,8 +9688,7 @@ msgstr ""
 msgid ""
 "If you want to use DuckDuckGo without JavaScript, please use our %s or %s "
 "versions."
-msgstr ""
-"JavaScript 없이 DuckDuckGo를 사용하려면 %1$s 또는 %2$s버전을 사용하세요."
+msgstr "JavaScript 없이 DuckDuckGo를 사용하려면 %1$s 또는 %2$s버전을 사용하세요."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -10018,8 +9836,8 @@ msgid ""
 "In some older browsers, it's necessary to redirect your clicks through our "
 "server to prevent search leakage. %sLearn more%s."
 msgstr ""
-"일부 이전 버전의 브라우저에서는 검색 결과 유출을 방지하기 위해 클릭한 정보가 "
-"서버를 통해 처리되도록 경로 변경이 필요합니다. %1$s자세히 알아보세요%2$s."
+"일부 이전 버전의 브라우저에서는 검색 결과 유출을 방지하기 위해 클릭한 정보가 서버를 통해 처리되도록 경로 변경이 필요합니다. "
+"%1$s자세히 알아보세요%2$s."
 
 # smartling.placeholder_format=C
 #. Instructions accompanying DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE; tells the user where to use the code on a DuckDuckGo browser.
@@ -10029,9 +9847,7 @@ msgctxt ""
 msgid ""
 "In the DuckDuckGo browser, go to Settings › Sync & Backup, and then “Sync "
 "with another device”."
-msgstr ""
-"DuckDuckGo 브라우저에서 설정 > Sync & Backup으로 이동한 다음 “다른 장치와 동"
-"기화”로 이동하세요."
+msgstr "DuckDuckGo 브라우저에서 설정 > Sync & Backup으로 이동한 다음 “다른 장치와 동기화”로 이동하세요."
 
 #  SeaMonkey default search engine instruction
 # smartling.placeholder_format=C
@@ -10045,9 +9861,7 @@ msgctxt "cloudsave"
 msgid ""
 "In the interest of transparency, this data is not encrypted: You can see "
 "exactly what information we store."
-msgstr ""
-"투명성을 위해 이 정보는 암호화되지 않으며, 저장된 정보는 전부 사용자에게 공개"
-"됩니다."
+msgstr "투명성을 위해 이 정보는 암호화되지 않으며, 저장된 정보는 전부 사용자에게 공개됩니다."
 
 # smartling.placeholder_format=C
 msgid "In the menu at the top select %sTools%s > %sSettings%s"
@@ -10266,7 +10080,7 @@ msgstr "Mac 브라우저 설치"
 #. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
 msgctxt "settings"
 msgid "Install Now"
-msgstr ""
+msgstr "지금 설치"
 
 # smartling.placeholder_format=C
 #. Text of a button to install the DuckDuckGo app
@@ -10369,13 +10183,13 @@ msgstr "데이터가 정말로 삭제되나요?"
 #. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Is it worth taking?"
-msgstr ""
+msgstr "할 만한가요?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Is this place any good?"
-msgstr ""
+msgstr "이곳은 어떤가요?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
@@ -10383,7 +10197,7 @@ msgctxt "Page suggestion prompt"
 msgid ""
 "Is this place any good? Summarize its reputation based on reviews and "
 "ratings."
-msgstr ""
+msgstr "이곳은 어떤가요? 리뷰와 평점을 바탕으로 평판을 요약해 주세요."
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -10395,13 +10209,13 @@ msgstr "이 영상이 유용했나요?"
 #. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Is this worth watching?"
-msgstr ""
+msgstr "볼 만한가요?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Is this worth watching? Give me a spoiler-free take."
-msgstr ""
+msgstr "이거 볼 만한가요? 스포일러 없이 알려 주세요."
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -10452,9 +10266,8 @@ msgid ""
 "through Microsoft's Ad Network. Clicks lead directly to merchant landing "
 "pages and unlike ads, DuckDuckGo is not compensated for these results."
 msgstr ""
-"항목은 검색어와의 관련성에 따라 순위가 지정되며 Microsoft의 광고 네트워크를 "
-"통해 제공됩니다. 클릭하면 판매자 랜딩 페이지로 바로 연결되며, 광고와는 달리 "
-"DuckDuckGo는 이러한 결과에 대해 수익을 얻지 않습니다."
+"항목은 검색어와의 관련성에 따라 순위가 지정되며 Microsoft의 광고 네트워크를 통해 제공됩니다. 클릭하면 판매자 랜딩 페이지로 바로 "
+"연결되며, 광고와는 달리 DuckDuckGo는 이러한 결과에 대해 수익을 얻지 않습니다."
 
 # smartling.placeholder_format=C
 #. Text explaining why passphrases use a series of words instead of random numbers and letters.
@@ -10462,8 +10275,7 @@ msgctxt "cloudsave"
 msgid ""
 "It’s easier to remember 4-5 words than 10 random letters and numbers, and "
 "far more secure."
-msgstr ""
-"임의의 문자 및 숫자 10개보다 단어 4~5개를 기억하는 것이 훨씬 쉽고 안전합니다."
+msgstr "임의의 문자 및 숫자 10개보다 단어 4~5개를 기억하는 것이 훨씬 쉽고 안전합니다."
 
 # smartling.placeholder_format=C
 msgid "Ivory Coast"
@@ -11013,7 +10825,7 @@ msgstr "링크:"
 #. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
-msgstr ""
+msgstr "이 작업에 필요한 도구, 재료, 준비할 것을 알려줘"
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -11425,7 +11237,7 @@ msgstr "차단된 사이트 관리"
 #. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
 msgctxt "setting"
 msgid "Manage in Browser Settings"
-msgstr ""
+msgstr "브라우저 설정에서 관리"
 
 # smartling.placeholder_format=C
 #. Link to the site exclusion settings page
@@ -11650,8 +11462,7 @@ msgstr "미크로네시아"
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
 msgid ""
 "Microphone access was denied. Please allow microphone access and try again."
-msgstr ""
-"마이크 액세스가 거부되었습니다. 마이크 액세스를 허용하고 다시 시도하세요."
+msgstr "마이크 액세스가 거부되었습니다. 마이크 액세스를 허용하고 다시 시도하세요."
 
 # smartling.placeholder_format=C
 #. The Microsoft brand name.
@@ -12399,10 +12210,8 @@ msgid ""
 "internet connection. Disabling chat history will delete pinned chats, and "
 "disable the temporary storage of new prompts and responses."
 msgstr ""
-"사용자의 인터넷 연결이 끊겼을 때 채팅을 복원할 수 있도록, 전송된 새 프롬프트"
-"와 응답을 암호화하여 DuckDuckGo 서버에 임시로 저장합니다. 채팅 기록을 비활성"
-"화하면 고정된 채팅이 삭제되고, 새로운 프롬프트와 응답의 임시 저장이 중단됩니"
-"다."
+"사용자의 인터넷 연결이 끊겼을 때 채팅을 복원할 수 있도록, 전송된 새 프롬프트와 응답을 암호화하여 DuckDuckGo 서버에 임시로 "
+"저장합니다. 채팅 기록을 비활성화하면 고정된 채팅이 삭제되고, 새로운 프롬프트와 응답의 임시 저장이 중단됩니다."
 
 # smartling.placeholder_format=C
 #. Question in a feedback form.
@@ -12711,8 +12520,7 @@ msgstr "검색 결과가 없습니다."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the recording contains no audible speech.
 msgid "No speech detected. Please try again and speak into your microphone."
-msgstr ""
-"음성이 감지되지 않았습니다. 다시 시도해 주세요. 마이크에 대고 말씀해 주세요."
+msgstr "음성이 감지되지 않았습니다. 다시 시도해 주세요. 마이크에 대고 말씀해 주세요."
 
 # smartling.placeholder_format=C
 #. Button that dismisses a feedback form.
@@ -13218,9 +13026,7 @@ msgstr "요청 시"
 msgid ""
 "On Mac, %sClick Maxthon > Preferences%s, On Windows, %sClick the %s icon > "
 "Settings%s"
-msgstr ""
-"Mac에서는 %1$sMaxthon > 환경설정%2$s을 클릭하고, Windows%3$s에서는 %4$s아이"
-"콘 > 설정을 클릭하세요.%5$s"
+msgstr "Mac에서는 %1$sMaxthon > 환경설정%2$s을 클릭하고, Windows%3$s에서는 %4$s아이콘 > 설정을 클릭하세요.%5$s"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
@@ -13241,9 +13047,7 @@ msgctxt ""
 msgid ""
 "One of the files attached has more pages than we support. Please upload "
 "files with %s pages or fewer."
-msgstr ""
-"첨부된 파일 중 하나가 지원 가능한 페이지 수를 초과합니다. %1$s페이지 이하의 "
-"파일을 업로드하세요."
+msgstr "첨부된 파일 중 하나가 지원 가능한 페이지 수를 초과합니다. %1$s페이지 이하의 파일을 업로드하세요."
 
 # smartling.placeholder_format=C
 #. Response a user can select in a feedback form, indicating that they heard about DuckDuckGo in an online article.
@@ -13269,9 +13073,7 @@ msgctxt "cloudsave"
 msgid ""
 "Only the settings that you have changed. They are detailed on the %sURL "
 "Parameters%s page."
-msgstr ""
-"사용자가 변경한 설정만 저장됩니다. 자세한 내용은 %1$sURL 매개 변수%2$s 페이지"
-"를 참고하세요."
+msgstr "사용자가 변경한 설정만 저장됩니다. 자세한 내용은 %1$sURL 매개 변수%2$s 페이지를 참고하세요."
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers only when the user clicks the Assist button.
@@ -13285,8 +13087,7 @@ msgctxt "translations_module"
 msgid ""
 "Oops! An unexpected error occurred while translating this text. Please try "
 "again later."
-msgstr ""
-"이런! 번역 중 예기치 않은 오류가 발생했습니다. 나중에 다시 시도해 주세요."
+msgstr "이런! 번역 중 예기치 않은 오류가 발생했습니다. 나중에 다시 시도해 주세요."
 
 # smartling.placeholder_format=C
 #. Title shown in a fatal error modal when Duck.ai fails to load.
@@ -13602,9 +13403,7 @@ msgctxt "homepage onboarding"
 msgid ""
 "Other search engines track your searches even when you’re in private "
 "browsing mode. We don’t track you &mdash; period."
-msgstr ""
-"다른 검색 엔진은 시크릿 모드에서도 사용자를 추적하지만, DuckDuckGo는 절대로 "
-"추적하지 않습니다."
+msgstr "다른 검색 엔진은 시크릿 모드에서도 사용자를 추적하지만, DuckDuckGo는 절대로 추적하지 않습니다."
 
 # smartling.placeholder_format=C
 msgctxt "SERP footer content"
@@ -13616,9 +13415,7 @@ msgctxt "homepage onboarding"
 msgid ""
 "Our privacy policy is simple: we don’t collect or share any of your personal "
 "information."
-msgstr ""
-"DuckDuckGo의 개인정보 보호정책은 간단합니다. 어떠한 개인 정보도 수집하거나 공"
-"유하지 않습니다."
+msgstr "DuckDuckGo의 개인정보 보호정책은 간단합니다. 어떠한 개인 정보도 수집하거나 공유하지 않습니다."
 
 # smartling.placeholder_format=C
 msgid ""
@@ -13626,8 +13423,8 @@ msgid ""
 "tracker blocker, encryption enforcer, and more. Available on %siOS & "
 "Android%s."
 msgstr ""
-"DuckDuckGo 모바일용 비공개 브라우저에는 검색 엔진, 추적 차단, 암호화 보호 강"
-"화 등의 기능이 탑재되어 있습니다. %1$siOS 및 Android%2$s에서 다운로드하세요."
+"DuckDuckGo 모바일용 비공개 브라우저에는 검색 엔진, 추적 차단, 암호화 보호 강화 등의 기능이 탑재되어 있습니다. %1$siOS "
+"및 Android%2$s에서 다운로드하세요."
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the information was out of date.
@@ -13879,9 +13676,7 @@ msgctxt "cloudsave"
 msgid ""
 "Passphrases cannot be recovered as we don't associate your IP address, "
 "browser fingerprint, or any other information with the file."
-msgstr ""
-"해당 파일에는 사용자의 IP 주소, 브라우저 지문 또는 기타 정보가 연결되어 있지 "
-"않기 때문에 암호를 복구할 수 없습니다."
+msgstr "해당 파일에는 사용자의 IP 주소, 브라우저 지문 또는 기타 정보가 연결되어 있지 않기 때문에 암호를 복구할 수 없습니다."
 
 # smartling.placeholder_format=C
 #. Label for the section of recent chats that were edited in the past 7 days.
@@ -14075,9 +13870,8 @@ msgid ""
 "answers. To turn them off and hide the Assist button visit %sSearch "
 "Settings%s."
 msgstr ""
-"검색어를 완전한 문장 형태의 질문으로 작성하면 AI 지원 답변이 자동으로 나오고 "
-"답변 수준이 높아질 수 있습니다. 이 기능을 끄고 Assist 버튼을 숨기려면 %1$s검"
-"색 설정%2$s으로 들어가세요."
+"검색어를 완전한 문장 형태의 질문으로 작성하면 AI 지원 답변이 자동으로 나오고 답변 수준이 높아질 수 있습니다. 이 기능을 끄고 "
+"Assist 버튼을 숨기려면 %1$s검색 설정%2$s으로 들어가세요."
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -14086,9 +13880,8 @@ msgid ""
 "DuckAssist more likely to appear and often yields better answers. To adjust "
 "how this feature works, or to turn it off, visit %sDuckAssist Settings%s."
 msgstr ""
-"검색어를 완전한 문장 형태의 질문으로 작성하면 DuckAssist가 나타나고 더 뛰어"
-"난 답을 얻을 가능성이 높아집니다. %1$sDuckAssist 설정%2$s에서 이 기능을 끄거"
-"나 작동 방식을 조정할 수 있습니다."
+"검색어를 완전한 문장 형태의 질문으로 작성하면 DuckAssist가 나타나고 더 뛰어난 답을 얻을 가능성이 높아집니다. "
+"%1$sDuckAssist 설정%2$s에서 이 기능을 끄거나 작동 방식을 조정할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -14098,9 +13891,8 @@ msgid ""
 "answers. To turn it off and hide the Assist button visit %sDuckAssist "
 "Settings%s."
 msgstr ""
-"검색어를 완전한 문장 형태의 질문으로 작성하면, DuckAssist가 자동으로 나오고 "
-"더 좋은 답을 얻을 가능성이 높아집니다. 이 기능을 끄고 Assist 버튼을 감추려면 "
-"%1$sDuckAssist 설정%2$s을 방문하세요."
+"검색어를 완전한 문장 형태의 질문으로 작성하면, DuckAssist가 자동으로 나오고 더 좋은 답을 얻을 가능성이 높아집니다. 이 기능을 "
+"끄고 Assist 버튼을 감추려면 %1$sDuckAssist 설정%2$s을 방문하세요."
 
 # smartling.placeholder_format=C
 #. Button that allows users to manually select a location on a map.
@@ -14132,9 +13924,7 @@ msgctxt "Body copy for the chat card in the How Duck.ai Works panel"
 msgid ""
 "Pick a popular AI to chat with, like GPT-5 mini, Claude Haiku 4.5, Mistral, "
 "etc."
-msgstr ""
-"GPT-5 mini, Claude Haiku 4.5, Mistral 등 인기 있는 AI를 선택하여 대화를 나눠"
-"보세요."
+msgstr "GPT-5 mini, Claude Haiku 4.5, Mistral 등 인기 있는 AI를 선택하여 대화를 나눠보세요."
 
 # smartling.placeholder_format=C
 #. Describes the ability to choose from popular AI models. Pairs with a chat-bubble pictogram.
@@ -14142,9 +13932,7 @@ msgctxt "Body copy for the chat card in the How Duck.ai Works panel"
 msgid ""
 "Pick a popular AI to chat with, like GPT-5 mini, Claude Haiku 4.5, "
 "Mistral, etc."
-msgstr ""
-"GPT-5 mini, Claude Haiku 4.5, Mistral 등 인기 있는 AI를 선택하여 대화를 나눠"
-"보세요."
+msgstr "GPT-5 mini, Claude Haiku 4.5, Mistral 등 인기 있는 AI를 선택하여 대화를 나눠보세요."
 
 # smartling.placeholder_format=C
 #. The description of the third party map app picker, shown on iOS when a user is given an option of which app to navigate to a destination with
@@ -14152,9 +13940,7 @@ msgctxt "Third party map app picker"
 msgid ""
 "Pick a service to navigate to your destination. External apps won’t come "
 "with DuckDuckGo protections."
-msgstr ""
-"목적지로 가능 방법을 확인할 서비스를 선택하세요. 외부 앱에서는 DuckDuckGo 보"
-"호 기능이 제공되지 않습니다."
+msgstr "목적지로 가능 방법을 확인할 서비스를 선택하세요. 외부 앱에서는 DuckDuckGo 보호 기능이 제공되지 않습니다."
 
 # smartling.placeholder_format=C
 #. Label for a list of problems on a feedback form.
@@ -14250,7 +14036,7 @@ msgstr "사람이 검색한 것임을 확인할 수 있도록 다음 과제를  
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is harmful or illegal. (optional)"
-msgstr ""
+msgstr "채팅 응답이 유해하거나 불법적인 이유를 설명해 주세요. (선택 사항)"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
@@ -14284,7 +14070,7 @@ msgctxt "Feedback prompt"
 msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is harmful or illegal."
-msgstr ""
+msgstr "해당 프롬프트와 문제가 있는 산출물(개인 정보 제거)을 붙여 넣고, 콘텐츠가 유해하거나 불법적인 이유를 설명해 주세요."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -14292,9 +14078,7 @@ msgctxt "Feedback prompt"
 msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is illegal or harmful."
-msgstr ""
-"해당 프롬프트와 문제가 있는 산출물(개인 정보 제거)을 붙여 넣고, 콘텐츠가 불법"
-"이거나 해로운 이유를 설명해 주세요."
+msgstr "해당 프롬프트와 문제가 있는 산출물(개인 정보 제거)을 붙여 넣고, 콘텐츠가 불법이거나 해로운 이유를 설명해 주세요."
 
 # smartling.placeholder_format=C
 #. Title on a feedback form.
@@ -14446,9 +14230,7 @@ msgstr "DuckDuckGo를 구독하면 더 많은 프리미엄 기능들도 따라�
 msgid ""
 "Plus, what you watch in Duck Player won’t influence your recommendations on "
 "YouTube."
-msgstr ""
-"또한 Duck Player에서 시청하는 콘텐츠는 YouTube의 추천에 영향을 미치지 않습니"
-"다."
+msgstr "또한 Duck Player에서 시청하는 콘텐츠는 YouTube의 추천에 영향을 미치지 않습니다."
 
 # smartling.placeholder_format=C
 #. A link to the Substack page (https://insideduckduckgo.substack.com/?showWelcome=true)
@@ -14757,7 +14539,7 @@ msgstr "개인정보 보호"
 #. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
 msgctxt "Section heading on the Duck.ai settings page"
 msgid "Privacy & Terms"
-msgstr ""
+msgstr "개인정보 보호정책 & 약관"
 
 # smartling.placeholder_format=C
 msgid "Privacy Blog"
@@ -14833,7 +14615,7 @@ msgstr "개인정보 보호정책 및 서비스 약관"
 #. Text for a button that links to the terms of use and privacy policy page.
 msgctxt "Secondary button text in active privacy modal"
 msgid "Privacy Policy and Terms of Service"
-msgstr ""
+msgstr "개인정보 보호정책 및 서비스 약관"
 
 # smartling.placeholder_format=C
 #. Title displayed on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
@@ -14935,8 +14717,7 @@ msgstr "DuckDuckGo는 절대 저장하지 않는 비공개 채팅"
 #. The device location shared is is not logged by us
 msgctxt "precise_user_location"
 msgid "Private to us and secured on your device"
-msgstr ""
-"DuckDuckGo에는 정보가 기록되지 않고 사용자의 기기에서 보안이 유지됩니다."
+msgstr "DuckDuckGo에는 정보가 기록되지 않고 사용자의 기기에서 보안이 유지됩니다."
 
 # smartling.placeholder_format=C
 #. Heading above the group of Pro-tier locked models in the model picker dropdown, when the user is on the Plus tier.
@@ -15008,9 +14789,7 @@ msgstr "재생하기 전에 물어보기"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Prompt me to use my approximate location to get nearby results."
-msgstr ""
-"내 대략적인 위치를 사용하여 주변 결과를 표시하라는 메시지가 표시되도록 합니"
-"다."
+msgstr "내 대략적인 위치를 사용하여 주변 결과를 표시하라는 메시지가 표시되도록 합니다."
 
 # smartling.placeholder_format=C
 #. DuckDuckGo Email Protection removes trackers from emails
@@ -15028,8 +14807,7 @@ msgstr "검색과 인터넷 이용 과정에서 데이터를 보호하세요."
 #. Shown on the Mac and Windows browser promo cards. DuckDuckGo's desktop browser protects your data across search, browsing, and AI chat.
 msgctxt "SERP footer content"
 msgid "Protect your data as you search, browse, and use AI."
-msgstr ""
-"검색하고, 인터넷을 이용하고 AI를 사용하는 과정에서 데이터를 보호하세요."
+msgstr "검색하고, 인터넷을 이용하고 AI를 사용하는 과정에서 데이터를 보호하세요."
 
 # smartling.placeholder_format=C
 #. A title above links to download the DuckDuckGo apps.
@@ -15053,9 +14831,7 @@ msgctxt "Full sentence for critiquing writing"
 msgid ""
 "Provide a few suggestions to make the following text more concise. [Insert "
 "your own text here.]"
-msgstr ""
-"다음 글을 더 간결하게 정리하기 위한 제안을 몇 가지 해주세요. [여기에 바로 입"
-"력]"
+msgstr "다음 글을 더 간결하게 정리하기 위한 제안을 몇 가지 해주세요. [여기에 바로 입력]"
 
 # smartling.placeholder_format=C
 #. In the context of a standings table for NHL (hockey), column title that abbreviates 'Total Points' (the total points of this team)
@@ -15291,9 +15067,7 @@ msgctxt "Description for recent chats feature"
 msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
-msgstr ""
-"최근 채팅은 DuckDuckGo 서버나 다른 원격 서버가 아닌 사용자의 기기 자체에 저장"
-"됩니다."
+msgstr "최근 채팅은 DuckDuckGo 서버나 다른 원격 서버가 아닌 사용자의 기기 자체에 저장됩니다."
 
 # smartling.placeholder_format=C
 #. Text explaining that recent chats are stored locally on the user's device.
@@ -15301,9 +15075,7 @@ msgctxt "Description of where recent chats are stored"
 msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
-msgstr ""
-"최근 채팅은 DuckDuckGo 서버나 다른 원격 서버가 아닌 사용자의 기기 자체에 저장"
-"됩니다."
+msgstr "최근 채팅은 DuckDuckGo 서버나 다른 원격 서버가 아닌 사용자의 기기 자체에 저장됩니다."
 
 # smartling.placeholder_format=C
 #. Text explaining how recent chats are stored locally on the user's device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection.
@@ -15313,9 +15085,8 @@ msgid ""
 "are encrypted and temporarily stored on a DuckDuckGo server after being "
 "sent, to help recover a chat if you lose your internet connection."
 msgstr ""
-"최근 채팅은 사용자의 기기에 직접 저장됩니다. 사용자의 인터넷 연결이 끊겼을 "
-"때 채팅을 복원할 수 있도록, 전송된 새 프롬프트와 응답을 암호화하여 "
-"DuckDuckGo 서버에 임시로 저장합니다."
+"최근 채팅은 사용자의 기기에 직접 저장됩니다. 사용자의 인터넷 연결이 끊겼을 때 채팅을 복원할 수 있도록, 전송된 새 프롬프트와 응답을 "
+"암호화하여 DuckDuckGo 서버에 임시로 저장합니다."
 
 # smartling.placeholder_format=C
 msgctxt "region filter"
@@ -15342,25 +15113,25 @@ msgstr "책 추천"
 #. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Recommend similar books"
-msgstr ""
+msgstr "비슷한 책 추천"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Recommend similar books."
-msgstr ""
+msgstr "비슷한 책을 추천해줘."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Recommend similar movies or shows."
-msgstr ""
+msgstr "비슷한 영화 또는 방송 추천해줘."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Recommend similar titles"
-msgstr ""
+msgstr "비슷한 작품 추천"
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
@@ -15572,9 +15343,7 @@ msgstr "Duck.ai를 다시 불러오기"
 msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
-msgstr ""
-"안내된 방법을 따르거나 브라우저에서 '새로고침' 또는 'Reload' 버튼을 눌러 "
-"DuckDuckGo를 새로고침하세요."
+msgstr "안내된 방법을 따르거나 브라우저에서 '새로고침' 또는 'Reload' 버튼을 눌러 DuckDuckGo를 새로고침하세요."
 
 # smartling.placeholder_format=C
 #. checkbox label that allows the user to save the setting
@@ -15663,18 +15432,14 @@ msgctxt "settings"
 msgid ""
 "Removes the \"Ask\" button so answers appear automatically in response to "
 "relevant searches. Cached answers always display automatically."
-msgstr ""
-"'Ask' 버튼을 제거하면 관련 검색 시 답변이 자동으로 표시됩니다. 캐시된 답변이 "
-"항상 자동으로 표시됩니다."
+msgstr "'Ask' 버튼을 제거하면 관련 검색 시 답변이 자동으로 표시됩니다. 캐시된 답변이 항상 자동으로 표시됩니다."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Removes the \"Generate\" button so answers appear automatically in response "
 "to relevant searches. Cached answers always display automatically."
-msgstr ""
-"'생성' 버튼을 제거하면 관련 검색 시 답변이 자동으로 표시됩니다. 캐시된 답변"
-"이 항상 자동으로 표시됩니다."
+msgstr "'생성' 버튼을 제거하면 관련 검색 시 답변이 자동으로 표시됩니다. 캐시된 답변이 항상 자동으로 표시됩니다."
 
 # smartling.placeholder_format=C
 #. Text for a button to rename a chat, as in it will allow the user to change the title of the chat.
@@ -15732,18 +15497,15 @@ msgid ""
 "service. Your anonymous feedback is also shared with %s to help improve "
 "their services."
 msgstr ""
-"보고서는 익명으로 제공되며, 검색 서비스 향상을 위해 DuckDuckGo로 전송됩니다. "
-"사용자님이 익명으로 보내주신 의견은 %1$s 사에도 서비스 개선을 위해 제공됩니"
-"다."
+"보고서는 익명으로 제공되며, 검색 서비스 향상을 위해 DuckDuckGo로 전송됩니다. 사용자님이 익명으로 보내주신 의견은 %1$s "
+"사에도 서비스 개선을 위해 제공됩니다."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "Reports sent to DuckDuckGo are anonymous. Please do not include any personal "
 "or identifying information in your feedback."
-msgstr ""
-"DuckDuckGo로 전송되는 보고서는 익명입니다. 피드백에 개인 정보나 식별 정보를 "
-"기재하지 마세요."
+msgstr "DuckDuckGo로 전송되는 보고서는 익명입니다. 피드백에 개인 정보나 식별 정보를 기재하지 마세요."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -15752,9 +15514,8 @@ msgid ""
 "translate during this page load, and are anonymous. Please do not include "
 "any personal or identifying information in your feedback."
 msgstr ""
-"DuckDuckGo로 전송되는 보고서에는 사용자가 이 페이지를 불러오는 중 번역하도록 "
-"요청하는 모든 텍스트가 들어있으며, 이 텍스트는 익명 상태입니다. 피드백에 개"
-"인 정보나 식별 정보를 기재하지 마세요."
+"DuckDuckGo로 전송되는 보고서에는 사용자가 이 페이지를 불러오는 중 번역하도록 요청하는 모든 텍스트가 들어있으며, 이 텍스트는 "
+"익명 상태입니다. 피드백에 개인 정보나 식별 정보를 기재하지 마세요."
 
 # smartling.placeholder_format=C
 msgid "Republic of Moldova"
@@ -15767,7 +15528,7 @@ msgctxt ""
 "feedback form when the user has selected Harmful or Illegal as the feedback "
 "reason"
 msgid "Required for harmful or illegal reports"
-msgstr ""
+msgstr "유해하거나 불법적인 콘텐츠 신고 시 필수"
 
 # smartling.placeholder_format=C
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
@@ -15834,9 +15595,8 @@ msgid ""
 "legal, financial, investment, or other professional advice. AI-assisted "
 "answers are subject to our %sTerms of Service%s."
 msgstr ""
-"응답은 교육 목적으로만 제공되며 의학적, 법률적, 금융적, 투자, 그 밖의 전문적"
-"인 조언을 제공하기 위한 것이 아닙니다. AI 지원 답변에는 %1$s서비스 약관%2$s"
-"이 적용됩니다."
+"응답은 교육 목적으로만 제공되며 의학적, 법률적, 금융적, 투자, 그 밖의 전문적인 조언을 제공하기 위한 것이 아닙니다. AI 지원 "
+"답변에는 %1$s서비스 약관%2$s이 적용됩니다."
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -15845,9 +15605,8 @@ msgid ""
 "legal, financial, investment, or other professional advice. DuckAssist is "
 "subject to our %sTerms of Service%s."
 msgstr ""
-"응답은 교육 목적으로만 제공되며 의학적, 법률적, 금융적, 투자, 그 밖의 전문적"
-"인 조언을 제공하기 위한 것이 아닙니다. DuckAssist에는 %1$s서비스 약관%2$s이 "
-"적용됩니다."
+"응답은 교육 목적으로만 제공되며 의학적, 법률적, 금융적, 투자, 그 밖의 전문적인 조언을 제공하기 위한 것이 아닙니다. "
+"DuckAssist에는 %1$s서비스 약관%2$s이 적용됩니다."
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -15857,10 +15616,8 @@ msgid ""
 "generated based on web content and may contain inaccuracies. Search Assist "
 "is subject to our %sTerms of Service%s."
 msgstr ""
-"응답은 교육 목적으로만 제공되며 의학적, 법률적, 금융적, 투자, 그 밖의 전문적"
-"인 조언을 제공하기 위한 것이 아닙니다. 웹 콘텐츠를 바탕으로 자동 생성된 응답"
-"이며 부정확한 내용이 섞여있을 수 있습니다. Search Assist에는 %1$s서비스 약"
-"관%2$s이 적용됩니다."
+"응답은 교육 목적으로만 제공되며 의학적, 법률적, 금융적, 투자, 그 밖의 전문적인 조언을 제공하기 위한 것이 아닙니다. 웹 콘텐츠를 "
+"바탕으로 자동 생성된 응답이며 부정확한 내용이 섞여있을 수 있습니다. Search Assist에는 %1$s서비스 약관%2$s이 적용됩니다."
 
 # smartling.placeholder_format=C
 #. Label on the button for restoring all previous website data.
@@ -16007,7 +15764,7 @@ msgstr "리뷰"
 #. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Rewrite this recipe scaled for a different number of servings."
-msgstr ""
+msgstr "이 레시피를 다른 제공량에 맞게 다시 작성해줘."
 
 # smartling.placeholder_format=C
 msgid "Romania"
@@ -16278,9 +16035,7 @@ msgctxt "Description for Chat History feature with Encrypted Storage option"
 msgid ""
 "Save up to 30 of your most recent chats locally on your device, with the "
 "option for more with Encrypted Storage."
-msgstr ""
-"최근 채팅을 30개까지 기기에 로컬로 저장하며, 암호화된 저장소를 사용하면 더 많"
-"이 저장할 수도 있습니다."
+msgstr "최근 채팅을 30개까지 기기에 로컬로 저장하며, 암호화된 저장소를 사용하면 더 많이 저장할 수도 있습니다."
 
 # smartling.placeholder_format=C
 #. Short text for native DDG browser users explaining how Chat History stores up to 30 of their most recent chats locally on their device.
@@ -16422,9 +16177,7 @@ msgstr "아래로 스크롤하여 %1$s고급 설정 보기%2$s를 클릭하세�
 msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)"
-msgstr ""
-"아래로 스크롤하여 %1$s주소 표시줄에서 검색%2$s을 찾으세요. 그리고 %3$s변"
-"경%4$s(또는 %5$s새로 추가%6$s)을 클릭하세요."
+msgstr "아래로 스크롤하여 %1$s주소 표시줄에서 검색%2$s을 찾으세요. 그리고 %3$s변경%4$s(또는 %5$s새로 추가%6$s)을 클릭하세요."
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
@@ -16432,9 +16185,7 @@ msgstr ""
 msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)."
-msgstr ""
-"아래로 스크롤하여 %1$s주소 표시줄에서 검색%2$s을 찾은 후 %3$s변경%4$s(또는 "
-"%5$s새로 추가%6$s)을 클릭하세요."
+msgstr "아래로 스크롤하여 %1$s주소 표시줄에서 검색%2$s을 찾은 후 %3$s변경%4$s(또는 %5$s새로 추가%6$s)을 클릭하세요."
 
 # smartling.placeholder_format=C
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -16458,9 +16209,7 @@ msgstr "%1$sDuckDuckGo%2$s로 스크롤하여 사용자의 위치를 사용하�
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down to the %sServices%s section and click %sAddress bar%s."
-msgstr ""
-"아래로 스크롤하여 %1$s서비스%2$s 섹션으로 이동한 후 %3$s주소 표시줄%4$s을 클"
-"릭하세요."
+msgstr "아래로 스크롤하여 %1$s서비스%2$s 섹션으로 이동한 후 %3$s주소 표시줄%4$s을 클릭하세요."
 
 # smartling.placeholder_format=C
 #. Rugby match stats
@@ -16508,12 +16257,10 @@ msgid ""
 "(on a wide range of searches). For now, Search Assist is only available in a "
 "subset of English speaking regions."
 msgstr ""
-"Search Assist는 검색 질의에 익명으로 답변을 생성하며, 이를 위해 웹에서 관련 "
-"콘텐츠를 검색한 다음 AI를 사용하여 간단한 답변을 생성합니다. 답변 표시 빈도"
-"는 사용자가 직접 선택할 수 있습니다. 안 함, 요청 시(검색 결과에서 Assist를 클"
-"릭했을 때만), 가끔(관련성이 높은 경우에만 표시), 자주(검색 결과가 광범위할 "
-"때 표시) 중 선택하세요. 현재 Search Assist는 영어를 사용하는 일부 지역에만 제"
-"공됩니다."
+"Search Assist는 검색 질의에 익명으로 답변을 생성하며, 이를 위해 웹에서 관련 콘텐츠를 검색한 다음 AI를 사용하여 간단한 "
+"답변을 생성합니다. 답변 표시 빈도는 사용자가 직접 선택할 수 있습니다. 안 함, 요청 시(검색 결과에서 Assist를 클릭했을 때만), "
+"가끔(관련성이 높은 경우에만 표시), 자주(검색 결과가 광범위할 때 표시) 중 선택하세요. 현재 Search Assist는 영어를 "
+"사용하는 일부 지역에만 제공됩니다."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI) when the answer is not found and the answer is unsourced or with no sources
@@ -16521,8 +16268,8 @@ msgid ""
 "Search Assist couldn't find enough reliable information to generate an "
 "answer for this question. Try another search."
 msgstr ""
-"Search Assist가 이 질문에 대한 답변을 생성하기에 위해 신뢰할 수 있는 정보를 "
-"충분히 찾지 못했습니다. 다른 검색을 시도해 보세요."
+"Search Assist가 이 질문에 대한 답변을 생성하기에 위해 신뢰할 수 있는 정보를 충분히 찾지 못했습니다. 다른 검색을 시도해 "
+"보세요."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -16531,9 +16278,8 @@ msgid ""
 "search queries. To do this, it %sscans the web%s for relevant content and "
 "then uses AI to generate a brief answer based on information found."
 msgstr ""
-"Search Assist는 검색 질의에 대해 익명으로 답변을 생성하는 옵션 기능이며, 이"
-"를 위해 %1$s웹에서 관련 콘텐츠를 스캔%2$s 한 다음 AI를 사용하여 찾은 정보를 "
-"기반으로 간단한 답변을 생성합니다."
+"Search Assist는 검색 질의에 대해 익명으로 답변을 생성하는 옵션 기능이며, 이를 위해 %1$s웹에서 관련 콘텐츠를 스캔%2$s "
+"한 다음 AI를 사용하여 찾은 정보를 기반으로 간단한 답변을 생성합니다."
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/search_box. top header
@@ -16654,8 +16400,8 @@ msgid ""
 "Search other sites with %s shortcuts: a search for ”!w ducks” will search "
 "for “ducks” directly on Wikipedia."
 msgstr ""
-"다른 사이트에서 검색할 때 %1$s 단축 키를 사용하세요. '!w ducks'라고 입력하면 "
-"위키피디아에서 바로 'ducks'를 바로 검색합니다."
+"다른 사이트에서 검색할 때 %1$s 단축 키를 사용하세요. '!w ducks'라고 입력하면 위키피디아에서 바로 'ducks'를 바로 "
+"검색합니다."
 
 # smartling.placeholder_format=C
 #. Placeholder text for the search form when no text has been entered
@@ -16674,18 +16420,15 @@ msgid ""
 "Search privately with our app or extension, add private web search to your "
 "favorite browser, or search directly at %sduckduckgo.com%s."
 msgstr ""
-"DuckDuckGo 앱 또는 확장 프로그램을 사용하여 비공개로 검색하거나, 자주 사용하"
-"는 브라우저에 비공개 웹 검색 기능을 설치하거나, %1$sduckduckgo.com%2$s에서 바"
-"로 검색하세요."
+"DuckDuckGo 앱 또는 확장 프로그램을 사용하여 비공개로 검색하거나, 자주 사용하는 브라우저에 비공개 웹 검색 기능을 설치하거나, "
+"%1$sduckduckgo.com%2$s에서 바로 검색하세요."
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/6LZAoqH.png
 msgctxt "settings"
 msgid ""
 "Search queries are included in URL (if off, searches will use POST requests)"
-msgstr ""
-"검색 쿼리가 URL에 포함됩니다('꺼짐'으로 설정된 경우 검색 시 POST 요청을 사용"
-"합니다)."
+msgstr "검색 쿼리가 URL에 포함됩니다('꺼짐'으로 설정된 경우 검색 시 POST 요청을 사용합니다)."
 
 # smartling.placeholder_format=C
 #. Describes how cookies are used to store user settings privately and securely.
@@ -16697,10 +16440,9 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"검색 설정은 비개인 브라우저 쿠키와 사용자의 브라우저 안에 있는 로컬 공간에 저"
-"장됩니다. 하지만 Cloud Save를 사용하여 클라우드 원격 서버에 설정을 익명으로 "
-"저장할 수도 있습니다. 클라우드에는 사용자의 개인 신원 정보가 저장되지 않으"
-"며, 암호가 브라우저 밖으로 유출되지 않습니다."
+"검색 설정은 비개인 브라우저 쿠키와 사용자의 브라우저 안에 있는 로컬 공간에 저장됩니다. 하지만 Cloud Save를 사용하여 클라우드 "
+"원격 서버에 설정을 익명으로 저장할 수도 있습니다. 클라우드에는 사용자의 개인 신원 정보가 저장되지 않으며, 암호가 브라우저 밖으로 "
+"유출되지 않습니다."
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -16796,9 +16538,7 @@ msgctxt "Description explaining how native users can enable sync"
 msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
-msgstr ""
-"종단간 암호화를 사용해 무제한에 가까운 채팅을 Duck.ai 서버에 안전하게 저장하"
-"고 모든 기기에 접근할 수 있습니다."
+msgstr "종단간 암호화를 사용해 무제한에 가까운 채팅을 Duck.ai 서버에 안전하게 저장하고 모든 기기에 접근할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Text explaining that the Encrypted Storage feature stores the user's chats encrypted on their device.
@@ -16806,9 +16546,7 @@ msgctxt "Description for encrypted storage feature"
 msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
-msgstr ""
-"종단간 암호화를 사용해 무제한에 가까운 채팅을 Duck.ai 서버에 안전하게 저장하"
-"고 모든 기기에 접근할 수 있습니다."
+msgstr "종단간 암호화를 사용해 무제한에 가까운 채팅을 Duck.ai 서버에 안전하게 저장하고 모든 기기에 접근할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -16816,9 +16554,7 @@ msgctxt "Description explaining how native users can enable sync"
 msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your synced devices."
-msgstr ""
-"종단간 암호화를 사용해 무제한에 가까운 채팅을 Duck.ai 서버에 안전하게 저장하"
-"고 모든 동기화된 기기에 접근할 수 있습니다."
+msgstr "종단간 암호화를 사용해 무제한에 가까운 채팅을 Duck.ai 서버에 안전하게 저장하고 모든 동기화된 기기에 접근할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -16826,9 +16562,7 @@ msgctxt "Description explaining how native users can enable sync"
 msgid ""
 "Securely store your chats on our server using end-to-end encryption, and "
 "access them from all your devices."
-msgstr ""
-"종단간 암호화를 사용해 사용자의 채팅을 Duck.ai 서버에 안전하게 저장하고 모든 "
-"기기에 접근할 수 있습니다."
+msgstr "종단간 암호화를 사용해 사용자의 채팅을 Duck.ai 서버에 안전하게 저장하고 모든 기기에 접근할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
@@ -16842,9 +16576,7 @@ msgctxt "Chat history with sync modal list item"
 msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
-msgstr ""
-"DuckDuckGo 서버에 안전하게 저장되며, 종단간 암호화가 적용됩니다. 회원님의 데"
-"이터는 본인 외에 누구도 볼 수 없습니다."
+msgstr "DuckDuckGo 서버에 안전하게 저장되며, 종단간 암호화가 적용됩니다. 회원님의 데이터는 본인 외에 누구도 볼 수 없습니다."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -16988,9 +16720,7 @@ msgstr "Safari 메뉴에서 %1$s'이 웹사이트의 설정'%2$s을 선택하세
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
-msgstr ""
-"%1$s사용자 지정%2$s을 선택하고 입력 창에 %3$shttps://duckduckgo.com%4$s를 입"
-"력하세요."
+msgstr "%1$s사용자 지정%2$s을 선택하고 입력 창에 %3$shttps://duckduckgo.com%4$s를 입력하세요."
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
@@ -17054,18 +16784,14 @@ msgstr "드롭다운 메뉴에서 %1$s추가 기능 관리%2$s를 선택하세�
 #. Tells users where in the settings menu they can change their default search engine.
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sMenu > Settings%s (on Windows)"
-msgstr ""
-"Mac에서는 %1$sOpera > 환경설정%2$s을 선택하고, Windows에서는 %3$s메뉴 > 설"
-"정%4$s을 선택하세요."
+msgstr "Mac에서는 %1$sOpera > 환경설정%2$s을 선택하고, Windows에서는 %3$s메뉴 > 설정%4$s을 선택하세요."
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sOpera > Options%s (on Windows)"
-msgstr ""
-"Mac에서는 %1$sOpera > 환경설정%2$s을 선택하고, Windows에서는 %3$sOpera > 옵"
-"션%4$s을 선택하세요."
+msgstr "Mac에서는 %1$sOpera > 환경설정%2$s을 선택하고, Windows에서는 %3$sOpera > 옵션%4$s을 선택하세요."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -17129,8 +16855,7 @@ msgstr "%1$s설정%2$s을 선택한 다음 %3$s검색 엔진%4$s을 선택하세
 msgid ""
 "Select %sUse this webpage as your only home page%s (or one of the other "
 "options if you prefer)"
-msgstr ""
-"%1$s이 웹페이지를 홈 화면으로 사용%2$s을 선택하세요(다른 옵션도 선택 가능)."
+msgstr "%1$s이 웹페이지를 홈 화면으로 사용%2$s을 선택하세요(다른 옵션도 선택 가능)."
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
@@ -17251,9 +16976,7 @@ msgid ""
 "Sends a prompt to AI models with your messages with instructions on how to "
 "respond. These instructions will apply to all of your conversations going "
 "forward."
-msgstr ""
-"AI 모델에 메시지와 응답 방법에 대한 지침을 프롬프트로 보냅니다. 이 지침은 앞"
-"으로 나와 나누는 모든 대화에 적용됩니다."
+msgstr "AI 모델에 메시지와 응답 방법에 대한 지침을 프롬프트로 보냅니다. 이 지침은 앞으로 나와 나누는 모든 대화에 적용됩니다."
 
 # smartling.placeholder_format=C
 msgid "Senegal"
@@ -17332,7 +17055,7 @@ msgstr "지금 설치"
 #. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
 msgctxt "Encrypted storage setup button shown in native browsers"
 msgid "Set Up Sync & Backup"
-msgstr ""
+msgstr "Sync & Backup 설치"
 
 # smartling.placeholder_format=C
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
@@ -17362,9 +17085,7 @@ msgctxt "Chat history about modal list item"
 msgid ""
 "Set up Sync & Backup after turning on Chat History to keep your chats synced "
 "across devices."
-msgstr ""
-"채팅 기록을 켜고 Sync & Backup을 설정하여 기기 간 채팅을 동기화된 상태로 유지"
-"하세요."
+msgstr "채팅 기록을 켜고 Sync & Backup을 설정하여 기기 간 채팅을 동기화된 상태로 유지하세요."
 
 # smartling.placeholder_format=C
 #. Prompt for the user to indicate their location on a map, to enable more relevant search results.
@@ -17424,9 +17145,7 @@ msgstr "공유"
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "Share DuckDuckGo and help friends take their privacy back!"
-msgstr ""
-"DuckDuckGo를 더 많은 친구들에게 알려서 개인정보를 보호할 수 있도록 도와주세"
-"요!"
+msgstr "DuckDuckGo를 더 많은 친구들에게 알려서 개인정보를 보호할 수 있도록 도와주세요!"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button that opens a feedback modal when clicked.
@@ -17453,8 +17172,8 @@ msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
 msgstr ""
-"관련성을 높이기 위해, 어느 도시에 있는지 AI 모델에 알려주세요. Duck.ai는 사용"
-"자의 정확한 위치를 우리에게나 AI 모델에게나 절대 공개하지 않습니다."
+"관련성을 높이기 위해, 어느 도시에 있는지 AI 모델에 알려주세요. Duck.ai는 사용자의 정확한 위치를 우리에게나 AI 모델에게나 "
+"절대 공개하지 않습니다."
 
 # smartling.placeholder_format=C
 #. Menu option to share feedback about a result
@@ -17519,7 +17238,7 @@ msgstr "긍정적인 피드백 공유"
 msgctxt ""
 "Label beside the share-content switch on the Duck.ai response feedback form"
 msgid "Share this conversation with DuckDuckGo"
-msgstr ""
+msgstr "이 대화를 DuckDuckGo와 공유"
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -17536,8 +17255,7 @@ msgctxt ""
 msgid ""
 "Share your prompt and chat response with DuckDuckGo (required for illegal "
 "and harmful report)"
-msgstr ""
-"DuckDuckGo에 프롬프트 및 채팅 응답 공유하기(불법적이고 유해한 신고에 필요)"
+msgstr "DuckDuckGo에 프롬프트 및 채팅 응답 공유하기(불법적이고 유해한 신고에 필요)"
 
 # smartling.placeholder_format=C
 #. An invitation for users to leave feedback
@@ -17883,17 +17601,15 @@ msgid ""
 "Shows a reminder that searches on DuckDuckGo are always private. Turning "
 "this off hides the reminder and never affects search privacy."
 msgstr ""
-"DuckDuckGo의 모든 검색은 항상 비공개라는 알림을 표시합니다. 이 기능을 끄면 알"
-"림을 숨기며 검색 개인정보에는 영향을 주지 않습니다."
+"DuckDuckGo의 모든 검색은 항상 비공개라는 알림을 표시합니다. 이 기능을 끄면 알림을 숨기며 검색 개인정보에는 영향을 주지 "
+"않습니다."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Shows a reminder that searches on DuckDuckGo are always protected. Turning "
 "this off hides the reminder and never affects search protection."
-msgstr ""
-"DuckDuckGo의 검색은 항상 보호 받는다는 알림을 표시합니다. 이 기능을 끄면 알림"
-"만 감춰지고, 검색 보호에는 영향이 가지 않습니다."
+msgstr "DuckDuckGo의 검색은 항상 보호 받는다는 알림을 표시합니다. 이 기능을 끄면 알림만 감춰지고, 검색 보호에는 영향이 가지 않습니다."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18038,8 +17754,7 @@ msgstr "사이트 이름"
 #. A message saying that site filters are not currently working
 msgctxt "Site filter message"
 msgid "Site search is temporarily unavailable. We are working on a fix."
-msgstr ""
-"사이트 검색을 일시적으로 사용할 수 없습니다. 현재 문제를 해결하고 있습니다."
+msgstr "사이트 검색을 일시적으로 사용할 수 없습니다. 현재 문제를 해결하고 있습니다."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18251,8 +17966,7 @@ msgctxt "Error message when an uploaded image cannot be decoded or processed"
 msgid ""
 "Sorry, the uploaded image couldn't be processed. Please try a different "
 "image or format."
-msgstr ""
-"업로드하신 이미지를 처리할 수 없습니다. 다른 이미지나 형식을 사용해 보세요."
+msgstr "업로드하신 이미지를 처리할 수 없습니다. 다른 이미지나 형식을 사용해 보세요."
 
 # smartling.placeholder_format=C
 #. Body copy shown when a scanned or pasted pairing payload fails schema validation.
@@ -18260,9 +17974,7 @@ msgctxt "Description for the wrong code error screen"
 msgid ""
 "Sorry, this code is invalid. Please make sure the correct code was entered "
 "or scanned."
-msgstr ""
-"죄송합니다. 이 코드는 유효하지 않습니다. 코드를 정확하게 입력했거나 스캔했는"
-"지 확인하세요."
+msgstr "죄송합니다. 이 코드는 유효하지 않습니다. 코드를 정확하게 입력했거나 스캔했는지 확인하세요."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -18276,9 +17988,7 @@ msgctxt "noresults"
 msgid ""
 "Sorry, we ran into an error displaying these results. %sClick here%s to try "
 "again."
-msgstr ""
-"죄송하지만 이 결과를 표시하는 동안 오류가 생겼습니다. 다시 시도하려면 %1$s여"
-"기를 클릭%2$s하세요."
+msgstr "죄송하지만 이 결과를 표시하는 동안 오류가 생겼습니다. 다시 시도하려면 %1$s여기를 클릭%2$s하세요."
 
 # smartling.placeholder_format=C
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
@@ -18338,8 +18048,7 @@ msgstr "원문 지움"
 msgctxt "Error message for summary selection input limit"
 msgid ""
 "Source text is too long to summarize. Try again with a shorter selection."
-msgstr ""
-"원본이 너무 길어서 요약할 수 없습니다. 길이를 줄여서 다시 시도해 보세요."
+msgstr "원본이 너무 길어서 요약할 수 없습니다. 길이를 줄여서 다시 시도해 보세요."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under Interface Settings.in the end. It is a header
@@ -18682,9 +18391,7 @@ msgctxt "Description prompting subscription for higher limits"
 msgid ""
 "Subscribe to DuckDuckGo to unlock higher limits in Duck.ai, or come back "
 "later to create more images."
-msgstr ""
-"DuckDuckGo를 구독해서 Duck.ai 한도를 높이거나, 나중에 돌아와서 이미지를 더 많"
-"이 만들어 보세요."
+msgstr "DuckDuckGo를 구독해서 Duck.ai 한도를 높이거나, 나중에 돌아와서 이미지를 더 많이 만들어 보세요."
 
 # smartling.placeholder_format=C
 #. Description shown to free users who have reached their image generation limit, encouraging them to subscribe.
@@ -18764,19 +18471,19 @@ msgstr "블로그 글 제목 제안"
 #. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Suggest related articles or topics worth exploring next."
-msgstr ""
+msgstr "다음에 탐색할 만한 관련 기사나 주제를 제안해 주세요."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Suggest related articles to explore"
-msgstr ""
+msgstr "탐색할 관련 기사 추천"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Suggest some alternatives to this product."
-msgstr ""
+msgstr "이 제품의 대안을 추천해줘."
 
 # smartling.placeholder_format=C
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
@@ -18793,7 +18500,7 @@ msgstr "추천:"
 #. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Sum up the reviews"
-msgstr ""
+msgstr "후기 요약"
 
 # smartling.placeholder_format=C
 #. A short title for the a message asking the AI to summarize a text.
@@ -18805,85 +18512,85 @@ msgstr "요약"
 #. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize the Q&As"
-msgstr ""
+msgstr "Q&A 요약"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the background and notable work of this person."
-msgstr ""
+msgstr "이 사람의 배경과 주요 활동을 요약해줘."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the key details of this event."
-msgstr ""
+msgstr "이 이벤트에 대한 주요 정보를 요약해줘."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the questions and answers on this page."
-msgstr ""
+msgstr "이 페이지의 질문과 답변을 요약해 주세요."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize their background"
-msgstr ""
+msgstr "이 사람들의 배경 요약"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this book"
-msgstr ""
+msgstr "이 책 요약"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this book."
-msgstr ""
+msgstr "이 책을 요약해줘."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this discussion"
-msgstr ""
+msgstr "이 토론을 요약해 주세요"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this discussion thread."
-msgstr ""
+msgstr "이 토론 타래를 요약해줘."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this page"
-msgstr ""
+msgstr "이 페이지 요약"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this page."
-msgstr ""
+msgstr "이 페이지를 요약해줘."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this video"
-msgstr ""
+msgstr "이 영상 요약"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this video."
-msgstr ""
+msgstr "이 동영상을 요약해 주세요."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize what the reviews say."
-msgstr ""
+msgstr "리뷰 내용을 요약해 주세요."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -19147,13 +18854,11 @@ msgid ""
 msgstr ""
 "동기화 복구 코드\n"
 "\n"
-"복구 코드를 사용하면 여러 장치에서 비밀번호, 자동 입력 데이터 및 Duck.ai 채팅"
-"을 동기화할 수 있으며, 장치에 액세스할 수 없는 경우 동기화된 데이터를 복구할 "
-"수 있습니다.\n"
+"복구 코드를 사용하면 여러 장치에서 비밀번호, 자동 입력 데이터 및 Duck.ai 채팅을 동기화할 수 있으며, 장치에 액세스할 수 없는 "
+"경우 동기화된 데이터를 복구할 수 있습니다.\n"
 "\n"
 "이 정보를 안전하게 보관하세요.\n"
-"이 코드에 액세스할 수 있는 모든 사람이 동기화된 데이터에 액세스할 수 있습니"
-"다.\n"
+"이 코드에 액세스할 수 있는 모든 사람이 동기화된 데이터에 액세스할 수 있습니다.\n"
 "\n"
 "%1$s\n"
 "\n"
@@ -19162,8 +18867,8 @@ msgstr ""
 "2. \"Sync & Backup\"를 선택한 다음, \"동기화된 데이터 복구\"를 선택합니다.\n"
 "3. 위 복구 코드를 복사하여 \"여기에 코드 붙여넣기\"에 붙여넣습니다.\n"
 "\n"
-"Sync & Backup이 활성화된 상태에서 DuckDuckGo 브라우저를 18개월 이상 사용하지 "
-"않으면 서버에서 데이터가 삭제되어 복원할 수 없습니다."
+"Sync & Backup이 활성화된 상태에서 DuckDuckGo 브라우저를 18개월 이상 사용하지 않으면 서버에서 데이터가 삭제되어 "
+"복원할 수 없습니다."
 
 # smartling.placeholder_format=C
 #. Secondary button label on the Sync & Backup intro screen that takes the user to the camera scan screen to pair with another device.
@@ -19209,7 +18914,7 @@ msgstr "시리아"
 #. Text for a button that enables the theme to follow the operating system's color scheme preference.
 msgctxt "System theme button for theme selector"
 msgid "System"
-msgstr ""
+msgstr "시스템"
 
 # smartling.placeholder_format=C
 #. Abbreviation indicating this is the total score for a game
@@ -19243,7 +18948,7 @@ msgstr "타히티어"
 #. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Tailor my resume"
-msgstr ""
+msgstr "이력서 맞춤 작성"
 
 # smartling.placeholder_format=C
 msgid "Taiwan"
@@ -19279,7 +18984,7 @@ msgstr "개인정보를 원하는 대로 관리하세요!"
 msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
-msgstr ""
+msgstr "익명 설문조사를 통해 Duck.ai가 무엇을 개선할 수 있을지 알려주세요."
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -19494,9 +19199,8 @@ msgid ""
 "link is at increased risk of being intercepted by a third party. In rare "
 "cases this includes passwords, or payment details."
 msgstr ""
-"이는 사용자의 기기와 이 링크 뒤의 웹 페이지 사이에 전송되는 정보를 제삼자가 "
-"가로챌 위험이 높아짐을 의미합니다. 드문 경우이지만 비밀번호 또는 결제 세부 정"
-"보가 이에 포함됩니다."
+"이는 사용자의 기기와 이 링크 뒤의 웹 페이지 사이에 전송되는 정보를 제삼자가 가로챌 위험이 높아짐을 의미합니다. 드문 경우이지만 "
+"비밀번호 또는 결제 세부 정보가 이에 포함됩니다."
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -19504,9 +19208,7 @@ msgctxt "cloudsave"
 msgid ""
 "The Cloud Save bookmarklet allows any changes you make to your settings to "
 "automatically save in the cloud."
-msgstr ""
-"Cloud Save 북마클릿을 사용하면 설정에 대한 모든 변경 사항을 클라우드에 자동으"
-"로 저장할 수 있습니다."
+msgstr "Cloud Save 북마클릿을 사용하면 설정에 대한 모든 변경 사항을 클라우드에 자동으로 저장할 수 있습니다."
 
 # smartling.placeholder_format=C
 msgid "The Gambia"
@@ -19535,8 +19237,7 @@ msgctxt "Second paragraph for the Sync & Backup intro screen"
 msgid ""
 "The encryption key is only saved in your browser's local storage, and only "
 "you can access it."
-msgstr ""
-"암호화 키는 브라우저의 로컬 저장소에만 저장되며, 본인만 접근할 수 있습니다."
+msgstr "암호화 키는 브라우저의 로컬 저장소에만 저장되며, 본인만 접근할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider deletes all chat data within 30 days.
@@ -19585,7 +19286,7 @@ msgstr "테마"
 #. Text for the theme selector label that allows users to switch between Light and dark theme.
 msgctxt "Label for the theme selector feature"
 msgid "Theme"
-msgstr ""
+msgstr "테마"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/LpFhb1e.png
@@ -19615,9 +19316,7 @@ msgctxt "Error message when there was an issue saving a chat to the browser"
 msgid ""
 "There was an error saving this chat locally. Please check your browser "
 "settings to make sure local data storage is enabled."
-msgstr ""
-"이 채팅을 로컬에 저장하는 중 오류가 발생했습니다. 로컬 데이터 저장 공간이 활"
-"성화되어 있는지 브라우저 설정에서 확인하세요."
+msgstr "이 채팅을 로컬에 저장하는 중 오류가 발생했습니다. 로컬 데이터 저장 공간이 활성화되어 있는지 브라우저 설정에서 확인하세요."
 
 # smartling.placeholder_format=C
 #. Error modal body line 1.
@@ -19631,8 +19330,7 @@ msgctxt "noresults"
 msgid ""
 "There was still an error displaying the search results. Please wait a few "
 "minutes before you try again."
-msgstr ""
-"검색 결과를 표시하는 중에 오류가 발생했습니다. 몇 분 후 다시 시도해 주세요."
+msgstr "검색 결과를 표시하는 중에 오류가 발생했습니다. 몇 분 후 다시 시도해 주세요."
 
 # smartling.placeholder_format=C
 #. Error message for explore more questions when a retryable error occurs (timeout, network)
@@ -19651,9 +19349,8 @@ msgid ""
 "visit by blocking hidden trackers, encrypting connections where possible, "
 "and by making DuckDuckGo your default search engine."
 msgstr ""
-"이 브라우저 권한은 숨겨진 추적기를 차단하고, 가능한 경우 연결을 암호화하고, "
-"DuckDuckGo를 기본 검색 엔진으로 설정하여 방문하는 웹사이트의 개인정보 보호를 "
-"강화하는 데 적용됩니다."
+"이 브라우저 권한은 숨겨진 추적기를 차단하고, 가능한 경우 연결을 암호화하고, DuckDuckGo를 기본 검색 엔진으로 설정하여 방문하는 "
+"웹사이트의 개인정보 보호를 강화하는 데 적용됩니다."
 
 # smartling.placeholder_format=C
 #. Secondary line under DUCKCHAT_SYNC_PAIRING_ALREADY_SYNCED_TITLE.
@@ -19690,9 +19387,7 @@ msgctxt "AI Chat: Error message for when a model is removed"
 msgid ""
 "This AI model is no longer available. Try starting a new chat with a "
 "different model."
-msgstr ""
-"이 AI 모델은 더 이상 이용할 수 없습니다. 다른 모델로 새로 채팅을 시작해 보세"
-"요."
+msgstr "이 AI 모델은 더 이상 이용할 수 없습니다. 다른 모델로 새로 채팅을 시작해 보세요."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is no longer supported because it has been upgraded to a newest version.
@@ -19700,9 +19395,7 @@ msgctxt "AI Chat: Error message for when a model is deprecated"
 msgid ""
 "This AI model version is no longer supported. Try starting a new chat with "
 "the latest version of this model."
-msgstr ""
-"이 AI 모델 버전은 더 이상 지원되지 않습니다. 이 모델의 최신 버전으로 새 채팅"
-"을 시작해 보세요."
+msgstr "이 AI 모델 버전은 더 이상 지원되지 않습니다. 이 모델의 최신 버전으로 새 채팅을 시작해 보세요."
 
 # smartling.placeholder_format=C
 #. Appears below a type of search results called 'Instant Answers'
@@ -19729,8 +19422,8 @@ msgid ""
 "This conversation was generated with Duck.ai (%s) using %s's %s Model. AI "
 "chats may display inaccurate or offensive information (see %s for more info)."
 msgstr ""
-"이 대화는 %2$s의 %3$s 모델을 사용하여 Duck.ai(%1$s)로 생성되었습니다. AI 채팅"
-"은 부정확하거나 공격적인 정보를 보여줄 수 있습니다(자세한 내용은 %4$s 참조)."
+"이 대화는 %2$s의 %3$s 모델을 사용하여 Duck.ai(%1$s)로 생성되었습니다. AI 채팅은 부정확하거나 공격적인 정보를 보여줄 "
+"수 있습니다(자세한 내용은 %4$s 참조)."
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with multiple AI models in the same chat, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using multiple chat models. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -19740,8 +19433,8 @@ msgid ""
 "models. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
 msgstr ""
-"이 대화는 여러 채팅 모델을 사용하여 Duck.ai(%1$s)로 생성되었습니다. AI 채팅"
-"은 부정확하거나 공격적인 정보를 보여줄 수 있습니다(자세한 내용은 %2$s 참조)."
+"이 대화는 여러 채팅 모델을 사용하여 Duck.ai(%1$s)로 생성되었습니다. AI 채팅은 부정확하거나 공격적인 정보를 보여줄 수 "
+"있습니다(자세한 내용은 %2$s 참조)."
 
 # smartling.placeholder_format=C
 #. When a user exports a transcript of a voice chat they had with the AI. This text goes at the very top of the downloaded file as a header. Placeholders are for links. Example: 'This conversation was generated with Duck.ai voice chat (https://duck.ai). AI may provide inaccurate or offensive information. (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -19750,8 +19443,8 @@ msgid ""
 "This conversation was generated with Duck.ai voice chat (%s). AI may provide "
 "inaccurate or offensive information. (see %s for more info)."
 msgstr ""
-"이 대화는 Duck.ai 음성 채팅(%1$s)으로 생성되었습니다. AI가 부정확하거나 불쾌"
-"한 정보를 제공할 수 있습니다(자세한 내용은 %2$s 참고)."
+"이 대화는 Duck.ai 음성 채팅(%1$s)으로 생성되었습니다. AI가 부정확하거나 불쾌한 정보를 제공할 수 있습니다(자세한 내용은 "
+"%2$s 참고)."
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with DuckDuckGo AI Chat (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/aichat/privacy-terms for more info).'
@@ -19761,9 +19454,8 @@ msgid ""
 "Model. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
 msgstr ""
-"이 대화는 %2$s의 %3$s 모델을 사용하여 DuckDuckGo AI Chat(%1$s)으로 생성되었습"
-"니다. AI 채팅은 부정확하거나 공격적인 정보를 보여줄 수 있습니다(자세한 내용"
-"은 %4$s 참조)."
+"이 대화는 %2$s의 %3$s 모델을 사용하여 DuckDuckGo AI Chat(%1$s)으로 생성되었습니다. AI 채팅은 부정확하거나 "
+"공격적인 정보를 보여줄 수 있습니다(자세한 내용은 %4$s 참조)."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
@@ -19834,16 +19526,14 @@ msgstr "이 이미지를 만들 수 없습니다."
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF"
-msgstr ""
-"이 이미지 유형은 지원되지 않으니 JPG, PNG, WebP, GIF 중 하나로 첨부하세요"
+msgstr "이 이미지 유형은 지원되지 않으니 JPG, PNG, WebP, GIF 중 하나로 첨부하세요"
 
 # smartling.placeholder_format=C
 #. Error message displayed when a file that the user tried to upload is not of a supported format
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF."
-msgstr ""
-"이 이미지 유형은 지원되지 않으니 JPG, PNG, WebP, GIF 중 하나로 첨부하세요."
+msgstr "이 이미지 유형은 지원되지 않으니 JPG, PNG, WebP, GIF 중 하나로 첨부하세요."
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
@@ -19868,9 +19558,7 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "This model provider deletes data associated with this chat within 30 days. "
 "Other model providers follow a zero data retention model."
-msgstr ""
-"이 모델 제공사는 이 채팅과 관련된 데이터를 30일 이내에 삭제합니다. 다른 모델 "
-"제공사는 데이터를 보유하지 않는 모델을 따릅니다."
+msgstr "이 모델 제공사는 이 채팅과 관련된 데이터를 30일 이내에 삭제합니다. 다른 모델 제공사는 데이터를 보유하지 않는 모델을 따릅니다."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers, and that other providers may retain chat data for a limited time instead.
@@ -19878,9 +19566,7 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "This model provider does not store any data associated with this chat. Other "
 "model providers follow a limited data retention model."
-msgstr ""
-"이 모델 제공사는 이 채팅과 관련된 데이터를 저장하지 않습니다. 다른 모델 제공"
-"사는 데이터를 제한적으로 보유하는 모델을 따릅니다."
+msgstr "이 모델 제공사는 이 채팅과 관련된 데이터를 저장하지 않습니다. 다른 모델 제공사는 데이터를 제한적으로 보유하는 모델을 따릅니다."
 
 # smartling.placeholder_format=C
 #. Info that page may refresh during update.
@@ -19916,9 +19602,7 @@ msgctxt "First paragraph for the Sync & Backup intro screen"
 msgid ""
 "This saves your chats with end-to-end encryption on DuckDuckGo's secure "
 "server, which later can be accessed from any browser."
-msgstr ""
-"이렇게 하면 채팅이 DuckDuckGo의 보안 서버에 종단간 암호화로 저장되며, 나중에 "
-"모든 브라우저에서 접근할 수 있습니다."
+msgstr "이렇게 하면 채팅이 DuckDuckGo의 보안 서버에 종단간 암호화로 저장되며, 나중에 모든 브라우저에서 접근할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -19926,9 +19610,7 @@ msgctxt "duckassist"
 msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again."
-msgstr ""
-"이 설정은 브라우저에 저장됩니다. 따라서 duckduckgo.com 브라우저 데이터를 지우"
-"면 AI 지원 답변이 다시 표시될 수 있습니다."
+msgstr "이 설정은 브라우저에 저장됩니다. 따라서 duckduckgo.com 브라우저 데이터를 지우면 AI 지원 답변이 다시 표시될 수 있습니다."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -19938,9 +19620,8 @@ msgid ""
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
 msgstr ""
-"이 설정은 브라우저에 저장됩니다. 따라서 duckduckgo.com 브라우저 데이터를 지우"
-"면 AI 지원 답변이 다시 표시될 수 있습니다. 하지만 AI 지원 답변이 절대 표시되"
-"지 않는 시작 페이지(%1$s)도 있습니다."
+"이 설정은 브라우저에 저장됩니다. 따라서 duckduckgo.com 브라우저 데이터를 지우면 AI 지원 답변이 다시 표시될 수 있습니다. "
+"하지만 AI 지원 답변이 절대 표시되지 않는 시작 페이지(%1$s)도 있습니다."
 
 # smartling.placeholder_format=C
 #. User feedback indicating that a translation is helpful
@@ -19963,17 +19644,13 @@ msgstr "이 번역은 잘못되었습니다."
 # smartling.placeholder_format=C
 #. Label indicating that the video can't be played on the current page, and only on the website that owns the vide. The placeholder is the name of the website that owns the video.
 msgid "This video is not yet able to be watched here. You can watch it on %s."
-msgstr ""
-"아직 현재 페이지에서는 이 동영상을 재생할 수 없습니다. %1$s에서 직접 시청할 "
-"수 있습니다."
+msgstr "아직 현재 페이지에서는 이 동영상을 재생할 수 없습니다. %1$s에서 직접 시청할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr ""
-"이 웹사이트는 사용자를 안전하게 보호하고 통신을 암호화하는 HTTPS 프로토콜을 "
-"사용하지 않고 있습니다."
+msgstr "이 웹사이트는 사용자를 안전하게 보호하고 통신을 암호화하는 HTTPS 프로토콜을 사용하지 않고 있습니다."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -19983,9 +19660,8 @@ msgid ""
 "Sync & Backup. You'll still be able to access your chats in other browsers "
 "connected to Sync & Backup."
 msgstr ""
-"이렇게 하면 이 브라우저에서 Duck.ai 채팅이 모두 삭제되고 Sync & Backup 연결"
-"이 끊깁니다. Sync & Backup에 연결된 다른 브라우저에서는 계속 채팅을 볼 수 있"
-"습니다."
+"이렇게 하면 이 브라우저에서 Duck.ai 채팅이 모두 삭제되고 Sync & Backup 연결이 끊깁니다. Sync & Backup에 "
+"연결된 다른 브라우저에서는 계속 채팅을 볼 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to clear all recentchats, with a warning that this action cannot be undone.
@@ -19993,9 +19669,7 @@ msgctxt "Body text for clear all recent chats confirmation modal"
 msgid ""
 "This will delete all your recent chats, unless they're pinned. This cannot "
 "be undone."
-msgstr ""
-"이렇게 하면 고정된 채팅을 제외한 최근 채팅이 전부 삭제됩니다. 이 작업은 되돌"
-"릴 수 없습니다."
+msgstr "이렇게 하면 고정된 채팅을 제외한 최근 채팅이 전부 삭제됩니다. 이 작업은 되돌릴 수 없습니다."
 
 # smartling.placeholder_format=C
 #. Message explaining what will happen when the user deletes an image.
@@ -20087,9 +19761,7 @@ msgstr "팁"
 
 # smartling.placeholder_format=C
 msgid "Tired of being tracked online? %sWe can help.%s"
-msgstr ""
-"개인 정보를 추적하는 웹사이트가 지긋지긋하시다고요? %1$s저희가 도와드리겠습니"
-"다.%2$s"
+msgstr "개인 정보를 추적하는 웹사이트가 지긋지긋하시다고요? %1$s저희가 도와드리겠습니다.%2$s"
 
 # smartling.placeholder_format=C
 #. This is the name of a user setting
@@ -20134,9 +19806,7 @@ msgctxt "directions"
 msgid ""
 "To print directions:%sGo back to the map.%sSelect the route you want to "
 "print.%sClick the print icon.%s"
-msgstr ""
-"경로를 인쇄하려면 %1$s지도로 돌아가세요.%2$s원하는 경로를 선택하세요.%3$s인"
-"쇄 아이콘을 클릭하세요.%4$s"
+msgstr "경로를 인쇄하려면 %1$s지도로 돌아가세요.%2$s원하는 경로를 선택하세요.%3$s인쇄 아이콘을 클릭하세요.%4$s"
 
 # smartling.placeholder_format=C
 #. Explains where the user can find their recovery code. Figma frame 3703-44420.
@@ -20146,9 +19816,8 @@ msgid ""
 "you first set up Sync. This code may have been saved as a PDF on the device "
 "you originally used to set up Sync."
 msgstr ""
-"동기화된 데이터를 복원하려면 처음 Sync를 설치할 때 저장한 복구 코드가 필요합"
-"니다. 이 코드는 Sync를 설치할 때 원래 사용한 기기에 PDF로 저장되었을 수 있습"
-"니다."
+"동기화된 데이터를 복원하려면 처음 Sync를 설치할 때 저장한 복구 코드가 필요합니다. 이 코드는 Sync를 설치할 때 원래 사용한 "
+"기기에 PDF로 저장되었을 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Body text explaining that the user needs to update their DDG browser before migration can proceed.
@@ -20156,18 +19825,14 @@ msgctxt "duckai_migration"
 msgid ""
 "To transfer your chat history to Duck.ai, please update your DuckDuckGo "
 "browser to the latest version and try again."
-msgstr ""
-"채팅 기록을 Duck.ai로 전송하려면 DuckDuckGo 브라우저를 최신 버전으로 업데이트"
-"하고 다시 시도하세요."
+msgstr "채팅 기록을 Duck.ai로 전송하려면 DuckDuckGo 브라우저를 최신 버전으로 업데이트하고 다시 시도하세요."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
 msgid ""
 "To use dictation, allow your browser to access the microphone in your system "
 "settings."
-msgstr ""
-"받아쓰기를 사용하려면 시스템 설정에서 브라우저가 마이크에 접근할 수 있도록 허"
-"용해 주세요."
+msgstr "받아쓰기를 사용하려면 시스템 설정에서 브라우저가 마이크에 접근할 수 있도록 허용해 주세요."
 
 # smartling.placeholder_format=C
 msgid "Today"
@@ -20356,9 +20021,7 @@ msgctxt "tracker_stats"
 msgid ""
 "Tracking attempts blocked by DuckDuckGo appear here. Keep browsing to see "
 "how many we block."
-msgstr ""
-"DuckDuckGo가 차단한 추적 시도가 여기에 표시됩니다. 얼마나 많은 시도가 차단되"
-"었는지 둘러보세요."
+msgstr "DuckDuckGo가 차단한 추적 시도가 여기에 표시됩니다. 얼마나 많은 시도가 차단되었는지 둘러보세요."
 
 # smartling.placeholder_format=C
 #. Placeholder for when we cannot report any blocked trackers yet
@@ -20405,9 +20068,7 @@ msgctxt "Full sentence for translating text"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr ""
-"'여기에서 가장 가까운 영화관에 어떻게 가나요?'라는 문장을 프랑스어로 번역해 "
-"주세요."
+msgstr "'여기에서 가장 가까운 영화관에 어떻게 가나요?'라는 문장을 프랑스어로 번역해 주세요."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for translating a sentence into another language. Translate the whole sentence and please use target language instead of 'English' and modify the sentence to translate into 'English' instead of 'French'. Example: 'Translate this {target language} sentence into English: “How do I get to the nearest movie theatre?”'
@@ -20415,21 +20076,19 @@ msgctxt "Full sentence for translating text prompt"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr ""
-"'여기에서 가장 가까운 영화관에 어떻게 가나요?'라는 문장을 프랑스어로 번역해 "
-"주세요."
+msgstr "'여기에서 가장 가까운 영화관에 어떻게 가나요?'라는 문장을 프랑스어로 번역해 주세요."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Translate this page"
-msgstr ""
+msgstr "이 페이지 번역"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
 msgctxt "Page suggestion prompt"
 msgid "Translate this page into %s."
-msgstr ""
+msgstr "이 페이지를 %1$s로 번역해줘."
 
 # smartling.placeholder_format=C
 #. Placeholder text for a region that will display translated text.
@@ -20576,7 +20235,7 @@ msgstr "무료 체험"
 #. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
 msgctxt "settings"
 msgid "Try It Now"
-msgstr ""
+msgstr "지금 체험해 보세요"
 
 # smartling.placeholder_format=C
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -20725,9 +20384,7 @@ msgstr "위치를 수동으로 설정하세요."
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Try the %sDuckDuckGo Browser.%s Fast. Free. Private."
-msgstr ""
-"%1$sDuckDuckGo%2$s 브라우저를 사용해 보세요. 빠른 검색. 무료 제공. 개인 정보 "
-"보호."
+msgstr "%1$sDuckDuckGo%2$s 브라우저를 사용해 보세요. 빠른 검색. 무료 제공. 개인 정보 보호."
 
 # smartling.placeholder_format=C
 #. Link to a page where users can download the DuckDuckGo Browser for iOS or Android.
@@ -20819,6 +20476,8 @@ msgid ""
 "Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
+"AI 기능을 해제하고 싶으신가요? %1$sDuckDuckGo No AI%2$s 검색 확장 프로그램을 설치하면 설정을 기억시킬 수 "
+"있습니다. %3$s자세히 알아보세요%4$s"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -20827,6 +20486,8 @@ msgid ""
 "Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
+"AI 기능을 해제하고 하시나요? %1$sDuckDuckGo No AI%2$s 검색 확장 프로그램으로 전환하면 설정을 기억시킬 수 "
+"있습니다. %3$s자세히 알아보세요%4$s"
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -20996,9 +20657,7 @@ msgctxt "settings"
 msgid ""
 "Types out DuckAssist answers as they're generated. Turning this off may "
 "result in a short delay between a search and the answer being displayed."
-msgstr ""
-"DuckAssist 답변이 생성되는 대로 입력합니다. 이 기능을 끄면 검색 시 답변이 표"
-"시되기까지 시간이 조금 지연될 수 있습니다."
+msgstr "DuckAssist 답변이 생성되는 대로 입력합니다. 이 기능을 끄면 검색 시 답변이 표시되기까지 시간이 조금 지연될 수 있습니다."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -21127,30 +20786,24 @@ msgstr "장점과 단점 파악"
 msgid ""
 "Under %sOn startup%s, click %sOpen a specific page%s then click %sSet "
 "Pages%s."
-msgstr ""
-"%1$s시작 페이지%2$s 항목에서 %3$s특정 페이지 열기%4$s를 클릭한 다음 %5$s페이"
-"지 설정%6$s을 클릭하세요."
+msgstr "%1$s시작 페이지%2$s 항목에서 %3$s특정 페이지 열기%4$s를 클릭한 다음 %5$s페이지 설정%6$s을 클릭하세요."
 
 #  Maxthon homepage instruction
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
-msgstr ""
-"%1$s시작 페이지%2$s에서 %3$s홈페이지%4$s를 선택한 다음 https://duckduckgo.com"
-"을 입력하세요."
+msgstr "%1$s시작 페이지%2$s에서 %3$s홈페이지%4$s를 선택한 다음 https://duckduckgo.com을 입력하세요."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sOpen with%s select %sA specific page or pages%s"
-msgstr ""
-"%1$s다음으로 열기%2$s에서 %3$s특정 페이지(또는 여러 페이지)%4$s를 선택하세요."
+msgstr "%1$s다음으로 열기%2$s에서 %3$s특정 페이지(또는 여러 페이지)%4$s를 선택하세요."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
-msgstr ""
-"%1$s시작 페이지 > 홈페이지%2$s에서 https://duckduckgo.com을 입력하세요."
+msgstr "%1$s시작 페이지 > 홈페이지%2$s에서 https://duckduckgo.com을 입력하세요."
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -21160,8 +20813,7 @@ msgstr "%1$s검색 설정%2$s에서 %3$sDuckDuckGo%4$s를 선택하세요."
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch in the address bar with%s select %sAdd New%s"
-msgstr ""
-"%1$s주소창에서 다음을 사용하여 검색%2$s에서 %3$s새로 추가%4$s를 선택하세요."
+msgstr "%1$s주소창에서 다음을 사용하여 검색%2$s에서 %3$s새로 추가%4$s를 선택하세요."
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -21173,8 +20825,7 @@ msgstr "%1$s검색%2$s 섹션에서, %3$s검색 엔진 관리...%4$s를 클릭�
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under On startup select %sOpen a specific page or set of pages%s"
-msgstr ""
-"시작 페이지에서 %1$s특정 페이지 또는 페이지 모음 열기%2$s를 선택하세요."
+msgstr "시작 페이지에서 %1$s특정 페이지 또는 페이지 모음 열기%2$s를 선택하세요."
 
 #  Opera default search engine instruction
 # smartling.placeholder_format=C
@@ -21257,9 +20908,7 @@ msgctxt "Description of the modal to upgrade to Pro"
 msgid ""
 "Unlock %s, higher AI reasoning, and 2x higher usage limits than the Plus "
 "plan by upgrading to Pro."
-msgstr ""
-"Pro로 업그레이드하여 %1$s, 더 높은 AI 추론 및 Plus 요금제보다 2배 더 높은 사"
-"용 한도를 이용하세요."
+msgstr "Pro로 업그레이드하여 %1$s, 더 높은 AI 추론 및 Plus 요금제보다 2배 더 높은 사용 한도를 이용하세요."
 
 # smartling.placeholder_format=C
 #. Title for the subscription promo shown in the SERP sidemenu.
@@ -21392,9 +21041,7 @@ msgctxt "Old app version banner component in Duck.ai"
 msgid ""
 "Update the DuckDuckGo browser to activate your subscription in Duck.ai and "
 "access advanced models"
-msgstr ""
-"DuckDuckGo 브라우저를 업데이트하여 Duck.ai에서 구독을 활성화하고 고급 모델을 "
-"이용하세요."
+msgstr "DuckDuckGo 브라우저를 업데이트하여 Duck.ai에서 구독을 활성화하고 고급 모델을 이용하세요."
 
 # smartling.placeholder_format=C
 #. The placeholder indicates a formatted date (e.g., 'Updated 2 days ago')
@@ -21518,9 +21165,7 @@ msgctxt ""
 msgid ""
 "Upgrade to Pro to unlock 2x higher limits than Plus, or come back later to "
 "create more images."
-msgstr ""
-"Pro로 업그레이드해서 한도를 Plus의 2배로 높이거나, 나중에 돌아와서 이미지를 "
-"더 많이 만들어 보세요."
+msgstr "Pro로 업그레이드해서 한도를 Plus의 2배로 높이거나, 나중에 돌아와서 이미지를 더 많이 만들어 보세요."
 
 # smartling.placeholder_format=C
 #. Upsell message shown in the voice chat limit and duration limit modals for Plus subscribers, encouraging them to upgrade to Pro.
@@ -21578,7 +21223,7 @@ msgstr "우루과이"
 #. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
 msgctxt "Navigation label on the Duck.ai settings page"
 msgid "Usage"
-msgstr ""
+msgstr "사용량"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -21622,8 +21267,8 @@ msgid ""
 "Use ChatGPT, Claude, and other AIs, privately. Protect chats from hackers, "
 "scammers, and companies. Keep info confidential. Free. No account required."
 msgstr ""
-"ChatGPT, Claude 등의 AI를 비공개로 사용하세요. 해커, 사기꾼, 기업으로부터 채"
-"팅을 보호하세요. 정보를 기밀로 유지하세요. 무료로. 계정이 없어도 괜찮습니다."
+"ChatGPT, Claude 등의 AI를 비공개로 사용하세요. 해커, 사기꾼, 기업으로부터 채팅을 보호하세요. 정보를 기밀로 유지하세요. "
+"무료로. 계정이 없어도 괜찮습니다."
 
 # smartling.placeholder_format=C
 #. Header above instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -21664,8 +21309,7 @@ msgstr "Safari에서 사용"
 msgctxt "Description for the recovery section inside Manage"
 msgid ""
 "Use this code to restore your saved chats if you lose access to your devices."
-msgstr ""
-"기기에 접근할 수 없는 경우 이 코드를 사용하여 저장된 채팅을 복원하세요."
+msgstr "기기에 접근할 수 없는 경우 이 코드를 사용하여 저장된 채팅을 복원하세요."
 
 # smartling.placeholder_format=C
 #. Prompt to ask the user if they want to use their approximate location for more accurate results
@@ -21814,9 +21458,7 @@ msgctxt "Ads GDPR, internal use only. Do not change"
 msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Microsoft's ad network"
-msgstr ""
-"광고 보기 시 DuckDuckGo에 의해 개인 정보가 보호됩니다. 광고 클릭은 마이크로소"
-"프트의 광고 네트워크에서 관리합니다."
+msgstr "광고 보기 시 DuckDuckGo에 의해 개인 정보가 보호됩니다. 광고 클릭은 마이크로소프트의 광고 네트워크에서 관리합니다."
 
 # smartling.placeholder_format=C
 #. Information about TripAdvisor ads for DuckDuckGo's users. This appears in a tooltip.
@@ -21824,9 +21466,7 @@ msgctxt "Single Place Hotel Offers Module"
 msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "TripAdvisor's ad network."
-msgstr ""
-"광고 보기 시 DuckDuckGo에 의해 개인 정보가 보호됩니다. 광고 클릭은 "
-"TripAdvisor의 광고 네트워크에서 관리합니다."
+msgstr "광고 보기 시 DuckDuckGo에 의해 개인 정보가 보호됩니다. 광고 클릭은 TripAdvisor의 광고 네트워크에서 관리합니다."
 
 # smartling.placeholder_format=C
 msgid "Virgin Islands"
@@ -21853,9 +21493,7 @@ msgctxt "mobile promotion on desktop"
 msgid ""
 "Visit %sDuckDuckGo.com%s on your tablet or phone and follow the provided "
 "instructions."
-msgstr ""
-"휴대전화 또는 태블릿에서 %1$sDuckDuckGo.com%2$s을 접속한 다음, 제공되는 설명"
-"을 따르세요."
+msgstr "휴대전화 또는 태블릿에서 %1$sDuckDuckGo.com%2$s을 접속한 다음, 제공되는 설명을 따르세요."
 
 # smartling.placeholder_format=C
 #. Primary button to visit Duck.ai.
@@ -21870,8 +21508,8 @@ msgid ""
 "Visit Duck.ai in your other browser and go to %sDuck.ai Settings%s > %sSync "
 "& Backup%s > %sManage%s then select %sSync With Another Device%s."
 msgstr ""
-"다른 브라우저에서 Duck.ai를 열고 %1$sDuck.ai 설정%2$s > %3$sSync & "
-"Backup%4$s > %5$s관리%6$s로 들어가 %7$s다른 기기와 동기화%8$s를 선택하세요."
+"다른 브라우저에서 Duck.ai를 열고 %1$sDuck.ai 설정%2$s > %3$sSync & Backup%4$s > "
+"%5$s관리%6$s로 들어가 %7$s다른 기기와 동기화%8$s를 선택하세요."
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -21881,9 +21519,8 @@ msgid ""
 "On” under Sync & Backup and select “Sync With Another Device”. Or scan the "
 "QR on your Recovery PDF."
 msgstr ""
-"다른 브라우저에서 Duck.ai를 방문하여 Duck.ai 설정을 여세요. Sync & Backup 아"
-"래에 있는 '켜기'를 선택하고 ''다른 기기와 동기화'를 선택하세요. 또는 복구 PDF"
-"에 있는 QR을 스캔하세요."
+"다른 브라우저에서 Duck.ai를 방문하여 Duck.ai 설정을 여세요. Sync & Backup 아래에 있는 '켜기'를 선택하고 "
+"''다른 기기와 동기화'를 선택하세요. 또는 복구 PDF에 있는 QR을 스캔하세요."
 
 # smartling.placeholder_format=C
 #. Shared body copy for every screen in the Sync Another Device flow (QR display, camera scan, camera-unavailable fallback, manual entry). Bold tags wrap navigation breadcrumbs. Render with <Translate /> so the HTML is interpreted; plain `translate()` will trip the html-string warning.
@@ -21893,9 +21530,8 @@ msgid ""
 "ai Settings%s > %sSync & Backup%s > %sManage%s then select %sSync With "
 "Another Device%s."
 msgstr ""
-"다른 브라우저나 DuckDuckGo 앱에서 Duck.ai를 열고 %1$sDuck.ai 설정%2$s > "
-"%3$sSync & Backup%4$s > %5$s관리%6$s로 들어가 %7$s다른 기기와 동기화%8$s를 선"
-"택하세요."
+"다른 브라우저나 DuckDuckGo 앱에서 Duck.ai를 열고 %1$sDuck.ai 설정%2$s > %3$sSync & "
+"Backup%4$s > %5$s관리%6$s로 들어가 %7$s다른 기기와 동기화%8$s를 선택하세요."
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -21905,9 +21541,8 @@ msgid ""
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
 msgstr ""
-"다른 브라우저나 DuckDuckGo 앱에서 Duck.ai를 방문하여 Duck.ai 설정을 여세요. "
-"Sync & Backup 아래에 있는 '켜기'를 선택하고 ''다른 기기와 동기화'를 선택하세"
-"요. 또는 복구 PDF에 있는 QR을 스캔하세요."
+"다른 브라우저나 DuckDuckGo 앱에서 Duck.ai를 방문하여 Duck.ai 설정을 여세요. Sync & Backup 아래에 있는 "
+"'켜기'를 선택하고 ''다른 기기와 동기화'를 선택하세요. 또는 복구 PDF에 있는 QR을 스캔하세요."
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -21959,8 +21594,7 @@ msgstr "음성 채팅이 끝났습니다"
 #. Description in consent disclaimer informing that voice chats with the AI (Artificial Intelligence) are anonymized by us, and are never used to train AI models.
 msgctxt "voice chat"
 msgid "Voice chat is anonymized by us, and never used to train AI models."
-msgstr ""
-"당사는 음성 채팅 내용을 익명화하며, AI 모델 학습에 절대 사용하지 않습니다."
+msgstr "당사는 음성 채팅 내용을 익명화하며, AI 모델 학습에 절대 사용하지 않습니다."
 
 # smartling.placeholder_format=C
 #. Title of the modal shown when the user has reached their daily voice chat limit.
@@ -22024,7 +21658,7 @@ msgstr "웨일즈"
 #. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Walk me through the steps"
-msgstr ""
+msgstr "단계별로 알려주세요"
 
 # smartling.placeholder_format=C
 #. Label for walking directions on a map.
@@ -22103,9 +21737,7 @@ msgstr "Duck Player에서 보기"
 msgid ""
 "Watch in Duck Player to block personalized ads on YouTube and prevent your "
 "viewing activity from influencing YouTube recommendations."
-msgstr ""
-"Duck Player로 영상을 시청하면 YouTube 맞춤 광고가 차단되고 시청 내역에 따라 "
-"YouTube 추천 영상이 달라지지 않습니다."
+msgstr "Duck Player로 영상을 시청하면 YouTube 맞춤 광고가 차단되고 시청 내역에 따라 YouTube 추천 영상이 달라지지 않습니다."
 
 # smartling.placeholder_format=C
 #. A button that takes a user to another site in order to watch a video. The placeholder is the name of the video site. For example: 'Watch on Vimeo'
@@ -22125,9 +21757,8 @@ msgid ""
 "independent company and has no relationship with YouTube, where most videos "
 "are hosted."
 msgstr ""
-"여기서 영상을 시청하면 콘텐츠를 스트리밍해야 하기 때문에 해당 영상을 호스팅하"
-"는 웹사이트에서 사용자를 추적할 수 있습니다. DuckDuckGo는 동영상 대부분을 호"
-"스팅하는 YouTube와 무관한 독립적인 기업입니다."
+"여기서 영상을 시청하면 콘텐츠를 스트리밍해야 하기 때문에 해당 영상을 호스팅하는 웹사이트에서 사용자를 추적할 수 있습니다. "
+"DuckDuckGo는 동영상 대부분을 호스팅하는 YouTube와 무관한 독립적인 기업입니다."
 
 # smartling.placeholder_format=C
 #. Heading for the highlight card explaining anonymized prompt delivery.
@@ -22139,9 +21770,7 @@ msgstr "DuckDuckGo의 익명화"
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
-msgstr ""
-"더 정확한 결과를 보여드리기 위해 %1$s사용자의 위치%2$s를 익명화할 수 있습니"
-"다."
+msgstr "더 정확한 결과를 보여드리기 위해 %1$s사용자의 위치%2$s를 익명화할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
@@ -22153,6 +21782,8 @@ msgid ""
 "please share this conversation with DuckDuckGo so we can investigate and "
 "address the issue."
 msgstr ""
+"문제는 눈에 보여야 고칠 수 있습니다. 유해하거나 불법적인 응답을 신고하려면 저희가 문제를 조사하고 해결할 수 있도록 이대화를 "
+"DuckDuckGo와 공유해 주세요."
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -22164,9 +21795,8 @@ msgid ""
 "please share your prompt and response so we can investigate and address the "
 "issue."
 msgstr ""
-"문제는 눈에 보여야 고칠 수 있습니다. 유해하거나 불법적인 응답이 나온 경우, 저"
-"희가 문제를 조사하고 해결할 수 있도록 사용하신 프롬프트와 응답 내용을 보내서 "
-"신고해 주세요."
+"문제는 눈에 보여야 고칠 수 있습니다. 유해하거나 불법적인 응답이 나온 경우, 저희가 문제를 조사하고 해결할 수 있도록 사용하신 "
+"프롬프트와 응답 내용을 보내서 신고해 주세요."
 
 # smartling.placeholder_format=C
 #. Explains how location service is used to show users search results near their current location.
@@ -22207,9 +21837,8 @@ msgid ""
 "We don't store your personal info. We don't follow you around with ads. We "
 "don't track you. Ever."
 msgstr ""
-"DuckDuckGo는 사용자의 개인정보를 저장하지 않습니다. DuckDuckGo는 사용자를 따"
-"라다니며 광고를 게재하지 않습니다. DuckDuckGo는 사용자를 추적하지 않습니다. "
-"절대."
+"DuckDuckGo는 사용자의 개인정보를 저장하지 않습니다. DuckDuckGo는 사용자를 따라다니며 광고를 게재하지 않습니다. "
+"DuckDuckGo는 사용자를 추적하지 않습니다. 절대."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -22222,9 +21851,7 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what brought you "
 "back today:"
-msgstr ""
-"DuckDuckGo는 사용자를 추적하지 않습니다. 따라서 오늘 다시 방문하게 된 계기를 "
-"알려주시면 도움이 될 것 같습니다."
+msgstr "DuckDuckGo는 사용자를 추적하지 않습니다. 따라서 오늘 다시 방문하게 된 계기를 알려주시면 도움이 될 것 같습니다."
 
 # smartling.placeholder_format=C
 #. Message prompting users to fill out a feedback form.
@@ -22232,9 +21859,7 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what convinced you "
 "to try us out today:"
-msgstr ""
-"DuckDuckGo는 사용자를 추적하지 않습니다. 따라서 오늘 사용해보게 된 계기를 알"
-"려주시면 도움이 될 것 같습니다."
+msgstr "DuckDuckGo는 사용자를 추적하지 않습니다. 따라서 오늘 사용해보게 된 계기를 알려주시면 도움이 될 것 같습니다."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -22245,9 +21870,7 @@ msgstr "DuckDuckGo는 절대로 사용자를 추적하지 않습니다."
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with a Continue button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don't track you. That's our Privacy Policy in a nutshell."
-msgstr ""
-"DuckDuckGo는 사용자를 추적하지 않습니다. 그게 바로 우리의 개인정보 보호정책입"
-"니다."
+msgstr "DuckDuckGo는 사용자를 추적하지 않습니다. 그게 바로 우리의 개인정보 보호정책입니다."
 
 # smartling.placeholder_format=C
 #. Description for the audio identification highlight in the dictation consent modal.
@@ -22276,24 +21899,19 @@ msgid ""
 "We don’t store your search history. We therefore have nothing to sell to "
 "advertisers that track you across the Internet."
 msgstr ""
-"DuckDuckGo는 사용자의 검색 기록을 저장하지 않습니다. 따라서 인터넷을 통해 사"
-"용자를 추적하는 광고주에게 판매할 수 있는 어떠한 정보도 보유하고 있지 않습니"
-"다."
+"DuckDuckGo는 사용자의 검색 기록을 저장하지 않습니다. 따라서 인터넷을 통해 사용자를 추적하는 광고주에게 판매할 수 있는 어떠한 "
+"정보도 보유하고 있지 않습니다."
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don’t track you in or out of private browsing mode."
-msgstr ""
-"DuckDuckGo는 개인정보 보호 모드 사용 여부에 관계없이 절대로 사용자를 추적하"
-"지 않습니다."
+msgstr "DuckDuckGo는 개인정보 보호 모드 사용 여부에 관계없이 절대로 사용자를 추적하지 않습니다."
 
 # smartling.placeholder_format=C
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with an Agree button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don’t track you. That’s our Privacy Policy in a nutshell…"
-msgstr ""
-"DuckDuckGo는 사용자를 추적하지 않습니다. 그게 바로 우리의 개인정보 보호정책입"
-"니다."
+msgstr "DuckDuckGo는 사용자를 추적하지 않습니다. 그게 바로 우리의 개인정보 보호정책입니다."
 
 # smartling.placeholder_format=C
 #. Displayed when the user's voice chat session is ended because of being inactive for too long.
@@ -22307,9 +21925,7 @@ msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
 "We have agreements with all AI providers to ensure your chats aren't used to "
 "train AIs."
-msgstr ""
-"DuckDuckGo는 모든 AI 제공업체와 협약을 맺어 채팅 내용이 AI 학습에 사용되지 않"
-"도록 보장합니다."
+msgstr "DuckDuckGo는 모든 AI 제공업체와 협약을 맺어 채팅 내용이 AI 학습에 사용되지 않도록 보장합니다."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -22333,9 +21949,7 @@ msgstr "연결이 끊겼습니다. 메시지를 다시 보내 보세요."
 msgid ""
 "We make money from %sprivacy-respecting search ads%s, not by exploiting your "
 "data."
-msgstr ""
-"우리는 %1$s프라이버시를 존중하는 검색 광고%2$s로 돈을 벌고, 여러분의 데이터"
-"를 악용하지 않습니다."
+msgstr "우리는 %1$s프라이버시를 존중하는 검색 광고%2$s로 돈을 벌고, 여러분의 데이터를 악용하지 않습니다."
 
 # smartling.placeholder_format=C
 #. Message describing how DuckDuckGo users location access anonymously to provide better search results.
@@ -22343,24 +21957,18 @@ msgctxt "precise_user_location"
 msgid ""
 "We only use your anonymous location to deliver better results, closer to "
 "you. You can always change your mind later."
-msgstr ""
-"익명 위치는 사용자 주변의 더 정확한 결과를 제공하기 위해서만 사용되며, 언제든"
-"지 설정을 변경할 수 있습니다."
+msgstr "익명 위치는 사용자 주변의 더 정확한 결과를 제공하기 위해서만 사용되며, 언제든지 설정을 변경할 수 있습니다."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
-msgstr ""
-"여러분이 익명으로 보내주시는 피드백을 바탕으로 DuckDuckGo를 모두가 사용하기 "
-"좋게 발전시킵니다."
+msgstr "여러분이 익명으로 보내주시는 피드백을 바탕으로 DuckDuckGo를 모두가 사용하기 좋게 발전시킵니다."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We stop anyone from getting your search history, including us."
-msgstr ""
-"여러분의 검색 기록을 그 누구도 수집할 수 없게 차단합니다. 물론 DuckDuckGo도 "
-"포함해서 말이죠."
+msgstr "여러분의 검색 기록을 그 누구도 수집할 수 없게 차단합니다. 물론 DuckDuckGo도 포함해서 말이죠."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -22376,8 +21984,8 @@ msgid ""
 "incorporated at the discretion of %s. Corrections may not show up in results "
 "right away."
 msgstr ""
-"DuckDuckGo는 이러한 의견을 참고하여 서비스를 개선합니다. 보내주신 제안은 %1$s"
-"의 재량에 따라 적용됩니다. 정정 사항이 결과에 바로 나타나지 않을 수 있습니다."
+"DuckDuckGo는 이러한 의견을 참고하여 서비스를 개선합니다. 보내주신 제안은 %1$s의 재량에 따라 적용됩니다. 정정 사항이 결과에 "
+"바로 나타나지 않을 수 있습니다."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -22390,9 +21998,7 @@ msgctxt "noresults"
 msgid ""
 "We're aware of this issue and are currently working to resolve it. If you "
 "continue to see this error, please reach out to %s."
-msgstr ""
-"현재 이 문제를 인지하고 해결책을 모색 중입니다. 이 오류가 계속되면 %1$s에 문"
-"의하세요."
+msgstr "현재 이 문제를 인지하고 해결책을 모색 중입니다. 이 오류가 계속되면 %1$s에 문의하세요."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -22400,9 +22006,7 @@ msgctxt "noresults"
 msgid ""
 "We're aware of this issue and are currently working to resolve it. Sometimes "
 "clearing your browser's cache can help."
-msgstr ""
-"현재 이 문제를 인지하고 해결책을 모색 중입니다. 브라우저 캐시를 삭제하면 문제"
-"가 해결되는 경우도 있습니다."
+msgstr "현재 이 문제를 인지하고 해결책을 모색 중입니다. 브라우저 캐시를 삭제하면 문제가 해결되는 경우도 있습니다."
 
 # smartling.placeholder_format=C
 #. Header for a feedback form for new users.
@@ -22416,9 +22020,7 @@ msgctxt "duckai_migration"
 msgid ""
 "We're sorry for this inconvenience. We’re working hard to make your "
 "experience better."
-msgstr ""
-"불편을 드려서 죄송합니다. 사용자 여러분이 더 쾌적한 경험을 하실 수 있도록 노"
-"력 중입니다."
+msgstr "불편을 드려서 죄송합니다. 사용자 여러분이 더 쾌적한 경험을 하실 수 있도록 노력 중입니다."
 
 # smartling.placeholder_format=C
 #. Body text explaining the service update requires a page reload.
@@ -22426,9 +22028,7 @@ msgctxt "duckai_migration"
 msgid ""
 "We've updated the Duck.ai service. For the change to take effect, we need to "
 "reload the page."
-msgstr ""
-"Duck.ai 서비스를 업데이트했습니다. 변경 사항을 적용하려면 페이지를 새로 고치"
-"세요."
+msgstr "Duck.ai 서비스를 업데이트했습니다. 변경 사항을 적용하려면 페이지를 새로 고치세요."
 
 # smartling.placeholder_format=C
 #. Instant Answer Tab Name
@@ -22530,8 +22130,7 @@ msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "Weekly usage limit reached. You can keep chatting by using your monthly "
 "limit."
-msgstr ""
-"주간 사용 한도에 도달했습니다. 월 한도를 사용하여 채팅을 이어갈 수 있습니다."
+msgstr "주간 사용 한도에 도달했습니다. 월 한도를 사용하여 채팅을 이어갈 수 있습니다."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -22545,8 +22144,8 @@ msgid ""
 "Welcome to Duck.ai! All of your chats here are private, anonymized by us and "
 "not used to train AI models."
 msgstr ""
-"Duck.ai에 오신 걸 환영합니다! 여기서 이루어지는 모든 채팅은 비공개로 진행되"
-"며, DuckDuckGo에 저장되거나 AI 모델 학습에 사용되지 않습니다."
+"Duck.ai에 오신 걸 환영합니다! 여기서 이루어지는 모든 채팅은 비공개로 진행되며, DuckDuckGo에 저장되거나 AI 모델 학습에 "
+"사용되지 않습니다."
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened.
@@ -22555,8 +22154,8 @@ msgid ""
 "Welcome to DuckDuckGo AI Chat! All of your chats here are private, "
 "anonymized by us and not used to train AI models."
 msgstr ""
-"DuckDuckGo AI Chat에 오신 것을 환영합니다! 여기서 이루어지는 모든 채팅은 비공"
-"개로 진행되며, DuckDuckGo에 저장되거나 AI 모델 학습에 사용되지 않습니다."
+"DuckDuckGo AI Chat에 오신 것을 환영합니다! 여기서 이루어지는 모든 채팅은 비공개로 진행되며, DuckDuckGo에 "
+"저장되거나 AI 모델 학습에 사용되지 않습니다."
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened. Example: 'Welcome to DuckDuckGo AI Chat! This chat session is powered by OpenAI’s GPT-3. All of your chats here are private, and are never stored by DuckDuckGo or used to train AI models.'
@@ -22566,9 +22165,8 @@ msgid ""
 "of your chats here are private, and are never stored by DuckDuckGo or used "
 "to train AI models."
 msgstr ""
-"DuckDuckGo AI Chat에 오신 것을 환영합니다! %1$s의 %2$s 모델로 작동하는 채팅 "
-"세션입니다. 여기서 이루어지는 모든 채팅은 비공개로 진행되며, DuckDuckGo에 저"
-"장되거나 AI 모델 학습에 사용되지 않습니다."
+"DuckDuckGo AI Chat에 오신 것을 환영합니다! %1$s의 %2$s 모델로 작동하는 채팅 세션입니다. 여기서 이루어지는 모든 "
+"채팅은 비공개로 진행되며, DuckDuckGo에 저장되거나 AI 모델 학습에 사용되지 않습니다."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -22641,9 +22239,7 @@ msgctxt "duckai_fatal_error"
 msgid ""
 "We’re really sorry, but it seems there was a problem loading Duck.ai. Try "
 "reloading the page."
-msgstr ""
-"정말 죄송하지만 Duck.ai를 불러오는 중 문제가 생긴 것 같습니다. 페이지를 새로"
-"고침해 보세요."
+msgstr "정말 죄송하지만 Duck.ai를 불러오는 중 문제가 생긴 것 같습니다. 페이지를 새로고침해 보세요."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to suggest an AI (Artificial Intelligence) model to be added to the product, and this field is optional.
@@ -22677,9 +22273,7 @@ msgctxt "Full sentence for finding a better word"
 msgid ""
 "What are some options for the word ‘better’ in the context of “We really "
 "need to do better.”"
-msgstr ""
-"“우리 정말 더 잘해야 합니다.”라는 문맥에서 '더 잘'이라는 단어의 대체어를 몇 "
-"개 알려 주세요."
+msgstr "“우리 정말 더 잘해야 합니다.”라는 문맥에서 '더 잘'이라는 단어의 대체어를 몇 개 알려 주세요."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
@@ -22698,107 +22292,106 @@ msgid ""
 "easy to understand for people with or without much AI, or technical, "
 "experience."
 msgstr ""
-"Duck.ai를 사용하려고 할 때 DuckDuckGo 브라우저를 설치하면 어떤 점이 좋나요? "
-"DuckDuckGo 공식 출처만 참고하세요. 답변은 명료하게 섹션을 나누어 작성하고 제"
-"목을 답니다. Duck.ai 통합과 개인정보 보호에 중점을 두고, AI나 기술 관련 경험 "
-"유무에 관계 없이 누구나 이해하기 쉽도록 간단하게 설명하세요."
+"Duck.ai를 사용하려고 할 때 DuckDuckGo 브라우저를 설치하면 어떤 점이 좋나요? DuckDuckGo 공식 출처만 참고하세요. "
+"답변은 명료하게 섹션을 나누어 작성하고 제목을 답니다. Duck.ai 통합과 개인정보 보호에 중점을 두고, AI나 기술 관련 경험 유무에 "
+"관계 없이 누구나 이해하기 쉽도록 간단하게 설명하세요."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the counterarguments?"
-msgstr ""
+msgstr "반대 의견은 무엇인가요?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the hours & location?"
-msgstr ""
+msgstr "시간 & 위치가 어떻게 되나요?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key contributions of this paper?"
-msgstr ""
+msgstr "이 논문의 주요 기여 내용은 무엇인가요?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key contributions?"
-msgstr ""
+msgstr "주요 기여 내용은 무엇인가요?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key details?"
-msgstr ""
+msgstr "주요 정보는 무엇인가요?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key points covered in this video?"
-msgstr ""
+msgstr "이 동영상에서 다루는 주요 내용은 무엇인가요?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key points?"
-msgstr ""
+msgstr "주요 내용은 무엇인가요?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key takeaways from this article?"
-msgstr ""
+msgstr "이 기사의 주요 내용은 무엇인가요?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key takeaways?"
-msgstr ""
+msgstr "핵심 내용이 무엇인가요?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key things I will learn from this course?"
-msgstr ""
+msgstr "이 강의에서 배우게 될 주요 내용은 무엇인가요?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the main counterarguments or criticisms of this?"
-msgstr ""
+msgstr "이에 대한 주요 반론이나 비판은 무엇인가요?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the main questions this page answers?"
-msgstr ""
+msgstr "이 페이지에서 다루는 주요 질문은 무엇인가요?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the must-try dishes here?"
-msgstr ""
+msgstr "여기서 꼭 먹어봐야 할 음식은 무엇인가요?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid ""
 "What are the opening hours, location, and contact details for this place?"
-msgstr ""
+msgstr "이곳의 영업 시간, 위치, 연락처 정보는 어떻게 되나요?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the pros and cons of this product?"
-msgstr ""
+msgstr "이 제품의 장단점은 무엇인가요?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the pros and cons?"
-msgstr ""
+msgstr "장단점은 무엇인가요?"
 
 # smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
@@ -22904,7 +22497,7 @@ msgstr "의학 기사의 문맥에서 '신장'은 무엇을 뜻하나요?"
 #. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What does this answer?"
-msgstr ""
+msgstr "이 답은 무엇을 의미하나요?"
 
 # smartling.placeholder_format=C
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
@@ -22922,7 +22515,7 @@ msgstr "어떤 정보가 서버에 저장되나요?"
 #. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What interview questions might come up for this role?"
-msgstr ""
+msgstr "이 직무와 관련해 어떤 면접 질문이 나올 수 있을까요?"
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -22930,8 +22523,7 @@ msgctxt "cloudsave"
 msgid ""
 "What is the Cloud Save bookmarklet and how does it differ from the URL "
 "parameter bookmarklet?"
-msgstr ""
-"Cloud Save 북마클릿이란 무엇이며 URL 매개변수 북마클릿과 어떻게 다른가요?"
+msgstr "Cloud Save 북마클릿이란 무엇이며 URL 매개변수 북마클릿과 어떻게 다른가요?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for looking up the capital city of Albania.
@@ -22943,7 +22535,7 @@ msgstr "알바니아의 수도는 어디인가요?"
 #. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What is the overall verdict and rating for this?"
-msgstr ""
+msgstr "이에 대한 종합적인 평가와 평점이 어떻게 되나요?"
 
 # smartling.placeholder_format=C
 #. Link to a page with additional information.
@@ -22971,7 +22563,7 @@ msgstr "방문자 리뷰"
 #. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What should I order?"
-msgstr ""
+msgstr "무엇을 주문할까요?"
 
 # smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
@@ -22989,13 +22581,13 @@ msgstr "응답에 어떤 문제가 있었나요? (선택 사항)"
 #. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What will I learn?"
-msgstr ""
+msgstr "무엇을 배우게 되나요?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What will I need?"
-msgstr ""
+msgstr "무엇이 필요한가요?"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -23006,8 +22598,7 @@ msgstr "무엇에 대해 피드백을 주고 싶으세요?"
 #. Explains the benefits of using our custom video player, the Duck Player
 msgid ""
 "What you watch in DuckDuckGo won't influence your recommendations on YouTube."
-msgstr ""
-"DuckDuckGo에서 시청하는 콘텐츠는 YouTube의 추천에 영향을 미치지 않습니다."
+msgstr "DuckDuckGo에서 시청하는 콘텐츠는 YouTube의 추천에 영향을 미치지 않습니다."
 
 # smartling.placeholder_format=C
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
@@ -23019,7 +22610,7 @@ msgstr "업데이트 소식"
 #. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What's the verdict?"
-msgstr ""
+msgstr "결론이 무엇인가요?"
 
 # smartling.placeholder_format=C
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -23032,9 +22623,7 @@ msgctxt "Full sentence for identifying product brands"
 msgid ""
 "When buying an electric guitar for a beginner, what are the top product "
 "brands I should consider?"
-msgstr ""
-"초보자가 연주할 일렉트릭 기타를 살 때 가장 추천할 만한 브랜드에는 무엇이 있나"
-"요?"
+msgstr "초보자가 연주할 일렉트릭 기타를 살 때 가장 추천할 만한 브랜드에는 무엇이 있나요?"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -23075,7 +22664,7 @@ msgstr "어떤 기능이 빠졌나요? (선택 사항)"
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Which features are missing? (optional)"
-msgstr ""
+msgstr "어떤 기능이 빠졌나요? (선택 사항)"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
@@ -23097,13 +22686,13 @@ msgstr "회사 정보"
 #. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Who are the main cast and crew, and what else are they known for?"
-msgstr ""
+msgstr "주요 출연진 및 제작진은 누구이며, 그들의 다른 대표작은 무엇인가요?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Who is this person?"
-msgstr ""
+msgstr "이 사람은 누구인가요?"
 
 # smartling.placeholder_format=C
 #. Header above a collection of privacy-related links.
@@ -23493,9 +23082,7 @@ msgctxt "Disclaimer bellow chat input - desktop"
 msgid ""
 "You are chatting with %s. AI chats may display inaccurate or offensive "
 "information."
-msgstr ""
-"%1$s 모델과 채팅 중입니다. AI 채팅은 부정확하거나 불쾌한 정보를 표시할 수 있"
-"습니다."
+msgstr "%1$s 모델과 채팅 중입니다. AI 채팅은 부정확하거나 불쾌한 정보를 표시할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Provide users with the ability to retry their search on a different search engine. First placeholder will be a link with the text "try your search again" OR "try your search later". Second is a URL to the !bangs page: https://duckduckgo.com/bangs.
@@ -23503,9 +23090,7 @@ msgctxt "noresults"
 msgid ""
 "You can %s or search directly on other search engines from DuckDuckGo using "
 "%s search shortcuts."
-msgstr ""
-"%1$s 또는 %2$s 검색 단축키를 사용하여 DuckDuckGo에서 다른 검색 엔진으로 직접 "
-"검색할 수 있습니다."
+msgstr "%1$s 또는 %2$s 검색 단축키를 사용하여 DuckDuckGo에서 다른 검색 엔진으로 직접 검색할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Text informing the user that they can access DuckDuckGo AI Chat directly at a specific URL. The placeholder %s will be replaced with the link. Example: 'You can access DuckDuckGo AI Chat directly at duck.ai.'
@@ -23518,8 +23103,7 @@ msgstr "%1$s에서 DuckDuckGo AI Chat에 바로 접속할 수 있습니다."
 msgctxt "duckassist"
 msgid ""
 "You can adjust how %s works or turn it off anytime in %sSearch Settings%s."
-msgstr ""
-"%1$s검색 설정%2$s에서 언제든 %3$s 작동 방식을 변경하거나 해제할 수 있습니다."
+msgstr "%1$s검색 설정%2$s에서 언제든 %3$s 작동 방식을 변경하거나 해제할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Assist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate Assist.
@@ -23527,22 +23111,17 @@ msgctxt "duckassist"
 msgid ""
 "You can adjust how Assist works or turn it off anytime in %sSearch "
 "Settings%s."
-msgstr ""
-"%1$s검색 설정%2$s에서 언제든 Assist의 작동 방식을 변경하거나 해제할 수 있습니"
-"다."
+msgstr "%1$s검색 설정%2$s에서 언제든 Assist의 작동 방식을 변경하거나 해제할 수 있습니다."
 
 # smartling.placeholder_format=C
 msgid "You can also use %sDuck.ai%s to answer questions or summarize text."
-msgstr ""
-"%1$sDuck.ai%2$s를 사용해 질문에 대한 답을 찾거나 글을 요약할 수도 있습니다."
+msgstr "%1$sDuck.ai%2$s를 사용해 질문에 대한 답을 찾거나 글을 요약할 수도 있습니다."
 
 # smartling.placeholder_format=C
 msgid ""
 "You can also use %sDuckDuckGo AI Chat%s to answer questions or summarize "
 "text."
-msgstr ""
-"%1$sDuckDuckGo AI Chat%2$s을 사용해 질문에 대한 답을 찾거나 글을 요약할 수도 "
-"있습니다."
+msgstr "%1$sDuckDuckGo AI Chat%2$s을 사용해 질문에 대한 답을 찾거나 글을 요약할 수도 있습니다."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach more text selections than are allowed. Placeholder is the maximum number of text selections. E.g. You can attach up to 5 text selections.
@@ -23555,9 +23134,7 @@ msgstr "텍스트 선택은 %1$s개까지 첨부할 수 있습니다."
 msgid ""
 "You can change how frequently you see Search Assist, or turn it off "
 "entirely, in %sSearch Settings%s."
-msgstr ""
-"%1$sSearch Settings%2$s에서 검색 Assist가 표시되는 빈도를 변경하거나 해제할 "
-"수 있습니다."
+msgstr "%1$sSearch Settings%2$s에서 검색 Assist가 표시되는 빈도를 변경하거나 해제할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
@@ -23571,9 +23148,7 @@ msgctxt "cloudsave"
 msgid ""
 "You can do this by saving your settings under a different passphrase, "
 "optionally deleting the first set."
-msgstr ""
-"다른 암호로 설정을 저장하여 암호를 변경할 수 있으며, 필요한 경우 첫 번째 세트"
-"를 삭제할 수도 있습니다."
+msgstr "다른 암호로 설정을 저장하여 암호를 변경할 수 있으며, 필요한 경우 첫 번째 세트를 삭제할 수도 있습니다."
 
 # smartling.placeholder_format=C
 #. Prefix for filename location sentence.
@@ -23596,8 +23171,7 @@ msgstr "%1$s검색 설정%2$s에서 이 알림을 숨길 수 있습니다."
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
-msgstr ""
-"이제 이 기기에 최근 채팅을 최대 100개 저장할 수 있습니다. 마음껏 채팅하세요!"
+msgstr "이제 이 기기에 최근 채팅을 최대 100개 저장할 수 있습니다. 마음껏 채팅하세요!"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -23653,9 +23227,7 @@ msgctxt "Organic result context menu"
 msgid ""
 "You can only block up to %s sites. To block %s, you'll need to unblock "
 "another site first."
-msgstr ""
-"차단할 수 있는 사이트는 최대 %1$s개입니다. %2$s 사이트를 차단하려면 다른 사이"
-"트 차단을 먼저 해제해야 합니다."
+msgstr "차단할 수 있는 사이트는 최대 %1$s개입니다. %2$s 사이트를 차단하려면 다른 사이트 차단을 먼저 해제해야 합니다."
 
 # smartling.placeholder_format=C
 #. Text explaining the benefits of the cloud save feature.
@@ -23711,9 +23283,7 @@ msgctxt "Description of the post-upgrade success modal"
 msgid ""
 "You now have access to %s, higher AI reasoning, and 2x higher usage limits "
 "than Plus."
-msgstr ""
-"이제 %1$s, 더 뛰어난 AI 추론, Plus보다 2배 높은 사용량 한도를 경험할 수 있습"
-"니다."
+msgstr "이제 %1$s, 더 뛰어난 AI 추론, Plus보다 2배 높은 사용량 한도를 경험할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Description text for the welcome modal displayed after the user subscribes to DuckDuckGo.
@@ -23722,8 +23292,8 @@ msgid ""
 "You now have access to advanced AI models. You can access the VPN and other "
 "DuckDuckGo subscription protections in the DuckDuckGo browser."
 msgstr ""
-"이제 고급 AI 모델을 이용하실 수 있습니다. DuckDuckGo 브라우저에서 VPN과 각종 "
-"DuckDuckGo 구독 보호 기능을 이용할 수 있습니다."
+"이제 고급 AI 모델을 이용하실 수 있습니다. DuckDuckGo 브라우저에서 VPN과 각종 DuckDuckGo 구독 보호 기능을 이용할 "
+"수 있습니다."
 
 # smartling.placeholder_format=C
 #. Welcome message that appears after the DuckDuckGo extension is installed.
@@ -23745,9 +23315,8 @@ msgid ""
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
 msgstr ""
-"이 브라우저에서 저장된 대화에 더 이상 액세스할 수 없습니다. 마지막 30개의 채"
-"팅은 로컬 저장소에 계속 남습니다. 암호화된 서버에서 채팅이 삭제되지는 않습니"
-"다."
+"이 브라우저에서 저장된 대화에 더 이상 액세스할 수 없습니다. 마지막 30개의 채팅은 로컬 저장소에 계속 남습니다. 암호화된 서버에서 "
+"채팅이 삭제되지는 않습니다."
 
 # smartling.placeholder_format=C
 #. Explains that turning off disconnects this browser only; the last 30 chats stay in local storage and the encrypted server backup is not deleted.
@@ -23757,9 +23326,8 @@ msgid ""
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
 msgstr ""
-"이 브라우저에서 저장된 대화에 더 이상 액세스할 수 없습니다. 마지막 30개의 채"
-"팅은 로컬 저장소에 계속 남습니다. 암호화된 서버에서 채팅이 삭제되지는 않습니"
-"다."
+"이 브라우저에서 저장된 대화에 더 이상 액세스할 수 없습니다. 마지막 30개의 채팅은 로컬 저장소에 계속 남습니다. 암호화된 서버에서 "
+"채팅이 삭제되지는 않습니다."
 
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
@@ -23781,8 +23349,8 @@ msgid ""
 "You're now searching privately in Chrome. Use our app instead of Chrome to "
 "browse privately too. It’s already installed and can:"
 msgstr ""
-"이제 Chrome에서 비공개로 검색할 수 있습니다. Chrome 대신 DuckDuckGo 앱도 사용"
-"해 보세요. 이미 설치되어 있으며 다음과 같은 기능이 제공됩니다."
+"이제 Chrome에서 비공개로 검색할 수 있습니다. Chrome 대신 DuckDuckGo 앱도 사용해 보세요. 이미 설치되어 있으며 "
+"다음과 같은 기능이 제공됩니다."
 
 # smartling.placeholder_format=C
 #. Confirmation message that appears after the DuckDuckGo browser extension is installed.
@@ -23794,9 +23362,7 @@ msgstr "이제 개인정보 보호를 받으며 검색할 수 있습니다!"
 msgid ""
 "You're now searching with privacy. %sGet tips to reduce your footprint even "
 "more."
-msgstr ""
-"현재 개인정보 보호 모드로 검색하고 있습니다. %1$s보안을 더욱 강화할 수 있는 "
-"팁을 알아보세요."
+msgstr "현재 개인정보 보호 모드로 검색하고 있습니다. %1$s보안을 더욱 강화할 수 있는 팁을 알아보세요."
 
 # smartling.placeholder_format=C
 #. Title of a notice thanking the user for turning off their adblocker
@@ -23866,9 +23432,8 @@ msgid ""
 "You've run out of Sync & Backup storage for Duck.ai chats with attachments. "
 "Delete the %s oldest chats to resume Sync. Pinned chats will not be deleted."
 msgstr ""
-"첨부 파일이 있는 Duck.ai 채팅의 Sync & Backup 저장 공간이 부족합니다. 동기화"
-"를 재개하려면 가장 오래된 채팅 %1$s개를 삭제하세요. 고정된 채팅은 삭제되지 않"
-"습니다."
+"첨부 파일이 있는 Duck.ai 채팅의 Sync & Backup 저장 공간이 부족합니다. 동기화를 재개하려면 가장 오래된 채팅 "
+"%1$s개를 삭제하세요. 고정된 채팅은 삭제되지 않습니다."
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -23878,9 +23443,8 @@ msgid ""
 "oldest chats with attachments to resume Sync. Pinned chats will not be "
 "deleted."
 msgstr ""
-"Duck.ai 채팅용 Sync & Backup 저장 공간이 소진되었습니다. 동기화를 재개하려면 "
-"첨부 파일이 있는 채팅을 오래된 순으로 %1$s개 삭제하세요. 고정된 채팅은 삭제되"
-"지 않습니다."
+"Duck.ai 채팅용 Sync & Backup 저장 공간이 소진되었습니다. 동기화를 재개하려면 첨부 파일이 있는 채팅을 오래된 순으로 "
+"%1$s개 삭제하세요. 고정된 채팅은 삭제되지 않습니다."
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the sync storage limit.
@@ -23894,8 +23458,8 @@ msgid ""
 "YouTube (owned by Google) does not let you watch videos anonymously. As "
 "such, watching YouTube videos here will be tracked by YouTube/Google."
 msgstr ""
-"YouTube(Google 소유)에서는 익명으로 동영상을 시청할 수 없습니다. 따라서 여기"
-"서 YouTube 동영상을 시청하면 YouTube나 Google의 추적을 받게 됩니다."
+"YouTube(Google 소유)에서는 익명으로 동영상을 시청할 수 없습니다. 따라서 여기서 YouTube 동영상을 시청하면 "
+"YouTube나 Google의 추적을 받게 됩니다."
 
 # smartling.placeholder_format=C
 #. Label for a privacy disclaimer related to YouTube videos
@@ -23939,8 +23503,8 @@ msgid ""
 "disconnected from sync. Your %s most recent chats will be available in local "
 "storage on these browsers:"
 msgstr ""
-"백업이 DuckDuckGo 서버에서 삭제됩니다. 모든 기기의 동기화가 해제됩니다. 다음 "
-"브라우저에서는 최근 채팅 %1$s개가 로컬 저장소에 저장됩니다."
+"백업이 DuckDuckGo 서버에서 삭제됩니다. 모든 기기의 동기화가 해제됩니다. 다음 브라우저에서는 최근 채팅 %1$s개가 로컬 "
+"저장소에 저장됩니다."
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list.
@@ -23950,8 +23514,8 @@ msgid ""
 "disconnected from sync. Your 100 most recent chats will be available in "
 "local storage on these browsers:"
 msgstr ""
-"백업이 DuckDuckGo 서버에서 삭제됩니다. 모든 기기의 동기화가 해제됩니다. 다음 "
-"브라우저에서는 최근 채팅 100개가 로컬 저장소에 저장됩니다."
+"백업이 DuckDuckGo 서버에서 삭제됩니다. 모든 기기의 동기화가 해제됩니다. 다음 브라우저에서는 최근 채팅 100개가 로컬 저장소에 "
+"저장됩니다."
 
 # smartling.placeholder_format=C
 #. List item indicating that a site exclusion filter is currently active for the search
@@ -23975,18 +23539,14 @@ msgctxt "new tab page"
 msgid ""
 "Your browser provides a list of your most-visited sites. DuckDuckGo never "
 "has access to this data."
-msgstr ""
-"가장 많이 방문한 사이트 목록은 사용자의 브라우저에서 제공됩니다. DuckDuckGo"
-"는 절대 이 데이터에 접근할 수 없습니다."
+msgstr "가장 많이 방문한 사이트 목록은 사용자의 브라우저에서 제공됩니다. DuckDuckGo는 절대 이 데이터에 접근할 수 없습니다."
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
 msgid ""
 "Your browser provides the list of most-visited sites. DuckDuckGo never has "
 "access to this data."
-msgstr ""
-"브라우저는 가장 많이 방문한 사이트 목록을 제공합니다. DuckDuckGo는 이 데이터"
-"에 절대 액세스할 수 없습니다."
+msgstr "브라우저는 가장 많이 방문한 사이트 목록을 제공합니다. DuckDuckGo는 이 데이터에 절대 액세스할 수 없습니다."
 
 # smartling.placeholder_format=C
 #. Disclaimer text shown bellow chat input. Example: 'You are chatting with GPT-3. AI chats may display inaccurate or offensive information.'
@@ -23994,9 +23554,7 @@ msgctxt "Disclaimer bellow chat input - desktop"
 msgid ""
 "Your chat with %s is private. AI chats may display inaccurate or offensive "
 "information."
-msgstr ""
-"%1$s 서비스와의 채팅은 비공개입니다. AI 채팅은 부정확하거나 불쾌한 정보를 표"
-"시할 수 있습니다."
+msgstr "%1$s 서비스와의 채팅은 비공개입니다. AI 채팅은 부정확하거나 불쾌한 정보를 표시할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Body copy shown after Sync & Backup is enabled, confirming chats are now syncing.
@@ -24021,36 +23579,28 @@ msgstr "사용자의 채팅은 비공개로 처리되며 AI 모델 훈련에 사
 msgctxt "Active Privacy protection description"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
-msgstr ""
-"내 채팅은 비공개이며 당사는 이 내용을 익명화하고, AI 모델 훈련에 사용하지 않"
-"습니다."
+msgstr "내 채팅은 비공개이며 당사는 이 내용을 익명화하고, AI 모델 훈련에 사용하지 않습니다."
 
 # smartling.placeholder_format=C
 #. Text explaining that user chats are private and not used for AI (Artificial Intelligence) training.
 msgctxt "Body text for privacy protection modal"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
-msgstr ""
-"내 채팅은 비공개이며 당사는 이 내용을 익명화하고, AI 모델 훈련에 사용하지 않"
-"습니다."
+msgstr "내 채팅은 비공개이며 당사는 이 내용을 익명화하고, AI 모델 훈련에 사용하지 않습니다."
 
 # smartling.placeholder_format=C
 #. Text for a menu item that describes the privacy protection feature.
 msgctxt "Menu item description"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
-msgstr ""
-"내 채팅은 비공개이며 당사는 이 내용을 저장하지 않고, AI 모델 훈련에도 사용하"
-"지 않습니다."
+msgstr "내 채팅은 비공개이며 당사는 이 내용을 저장하지 않고, AI 모델 훈련에도 사용하지 않습니다."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the active privacy protection.
 msgctxt "Modal body for privacy"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
-msgstr ""
-"내 채팅은 비공개이며 당사는 이 내용을 저장하지 않고, AI 모델 훈련에도 사용하"
-"지 않습니다."
+msgstr "내 채팅은 비공개이며 당사는 이 내용을 저장하지 않고, AI 모델 훈련에도 사용하지 않습니다."
 
 # smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that chats are stored locally on the user's device.
@@ -24065,8 +23615,8 @@ msgid ""
 "Your chats are still private, anonymized by us, and not used to train AI "
 "models. Follow these steps to keep your chat history."
 msgstr ""
-"내 채팅은 여전히 비공개입니다. Duck.ai는 이 내용을 익명화하고, AI 모델 훈련"
-"에 사용하지 않습니다. 채팅 기록을 보관하는 방법은 다음과 같습니다."
+"내 채팅은 여전히 비공개입니다. Duck.ai는 이 내용을 익명화하고, AI 모델 훈련에 사용하지 않습니다. 채팅 기록을 보관하는 방법은 "
+"다음과 같습니다."
 
 # smartling.placeholder_format=C
 #. Body shown after import completes.
@@ -24105,9 +23655,7 @@ msgctxt "newsletter email collection"
 msgid ""
 "Your email address will not be shared, %sor associated with anonymous "
 "searches. [%sExample message%s]"
-msgstr ""
-"사용자의 이메일은 공유되지 않으며 %1$s비공개 검색에도 사용되지 않습니다. "
-"[%2$s메시지 예시%3$s]"
+msgstr "사용자의 이메일은 공유되지 않으며 %1$s비공개 검색에도 사용되지 않습니다. [%2$s메시지 예시%3$s]"
 
 # smartling.placeholder_format=C
 #. A prompt for the user to provide feedback on the third party map app directions experience
@@ -24150,10 +23698,9 @@ msgid ""
 "browser. We save the settings file using the key as the name. DuckDuckGo "
 "never knows your passphrase."
 msgstr ""
-"사용자의 암호는 %1$sSHA-2%2$s라고 알려진 보안 해시 알고리즘을 사용해 512비트 "
-"키를 생성합니다. 키와 연관된 설정 파일만 브라우저 외부로 전송됩니다. "
-"DuckDuckGo는 해당 키를 파일 이름으로 사용하여 설정 파일을 저장하며, 사용자의 "
-"암호를 절대 알 수 없습니다."
+"사용자의 암호는 %1$sSHA-2%2$s라고 알려진 보안 해시 알고리즘을 사용해 512비트 키를 생성합니다. 키와 연관된 설정 파일만 "
+"브라우저 외부로 전송됩니다. DuckDuckGo는 해당 키를 파일 이름으로 사용하여 설정 파일을 저장하며, 사용자의 암호를 절대 알 수 "
+"없습니다."
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -24168,9 +23715,8 @@ msgid ""
 "personally identifiable metadata, so model providers can't tie your "
 "conversations back to you."
 msgstr ""
-"DuckDuckGo 서버를 통해 프롬프트가 전달되며 개인 정보를 식별할 수 있는 메타데"
-"이터는 제거됩니다. 따라서 모델 제공사는 대화를 특정 사용자에 연결할 수 없습니"
-"다."
+"DuckDuckGo 서버를 통해 프롬프트가 전달되며 개인 정보를 식별할 수 있는 메타데이터는 제거됩니다. 따라서 모델 제공사는 대화를 "
+"특정 사용자에 연결할 수 없습니다."
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -24226,9 +23772,8 @@ msgid ""
 "You’re now searching privately in Chrome. Use our browser instead of Chrome "
 "for more protection. It’s already installed and can:"
 msgstr ""
-"이제 Chrome에서 개인 정보 노출 없이 검색할 수 있습니다. Chrome 대신 "
-"DuckDuckGo 브라우저를 이용해서 더 철저하게 보호받으세요. 이미 설치되어 있으"
-"며 다음 기능이 제공됩니다."
+"이제 Chrome에서 개인 정보 노출 없이 검색할 수 있습니다. Chrome 대신 DuckDuckGo 브라우저를 이용해서 더 철저하게 "
+"보호받으세요. 이미 설치되어 있으며 다음 기능이 제공됩니다."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has exceeded the maximum message size.
@@ -24244,9 +23789,7 @@ msgctxt "Error message for conversation limit"
 msgid ""
 "You’ve reached the maximum chat length in this conversation. Clear this "
 "conversation with the Fire Button to continue."
-msgstr ""
-"이 대화에서 채팅 길이 한도에 도달했습니다. 계속 진행하려면 Fire Button을 눌"
-"러 이 대화를 지우세요."
+msgstr "이 대화에서 채팅 길이 한도에 도달했습니다. 계속 진행하려면 Fire Button을 눌러 이 대화를 지우세요."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -24254,8 +23797,7 @@ msgctxt "Error message for conversation limit"
 msgid ""
 "You’ve reached the maximum chat length in this conversation. Start a new "
 "chat to continue."
-msgstr ""
-"이 대화에서 채팅 길이 한도에 도달했습니다. 계속하려면 새 채팅을 시작해."
+msgstr "이 대화에서 채팅 길이 한도에 도달했습니다. 계속하려면 새 채팅을 시작해."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -24269,9 +23811,7 @@ msgctxt "Error message for user limit"
 msgid ""
 "You’ve reached the maximum number of messages for one day. Please continue "
 "this chat tomorrow."
-msgstr ""
-"하루에 보낼 수 있는 메시지 개수 한도에 도달했습니다. 이 채팅은 내일 계속하세"
-"요."
+msgstr "하루에 보낼 수 있는 메시지 개수 한도에 도달했습니다. 이 채팅은 내일 계속하세요."
 
 # smartling.placeholder_format=C
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
@@ -24573,9 +24113,7 @@ msgstr "공식 웹사이트"
 #. <em>%s</em> is for a hexadecimal color code as <em>#395323</em>, but it has to be safe encoded, and as <em>#</em> seems not safe, <em>%23</em> must be used in place of the sharp symbol, but they are the same for your browser.
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
-msgstr ""
-"또는 원하는 색상 코드를 직접 입력하세요. 예: %1$s (%2$s(은)는 인코딩된 %3$s "
-"문자입니다)"
+msgstr "또는 원하는 색상 코드를 직접 입력하세요. 예: %1$s (%2$s(은)는 인코딩된 %3$s 문자입니다)"
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "

--- a/locales/ko_KR/LC_MESSAGES/duckduckgo.po
+++ b/locales/ko_KR/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: ko_KR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -176,8 +176,9 @@ msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
 msgstr ""
-"%1$s는 Pro를 구독하셔야 이용할 수 있습니다. 이 브라우저에서 DuckDuckGo 구독을 다시 업그레이드하여 채팅을 계속 "
-"이용하거나, Plus 또는 무료 모델로 전환하세요."
+"%1$s는 Pro를 구독하셔야 이용할 수 있습니다. 이 브라우저에서 DuckDuckGo 구독"
+"을 다시 업그레이드하여 채팅을 계속 이용하거나, Plus 또는 무료 모델로 전환하세"
+"요."
 
 # smartling.placeholder_format=C
 #. Text for the disclaimer message that appears when a Plus subscriber tries to use a Pro-only model. %s is replaced with the model name. Example: Claude Opus 4.6 is only available with Pro. Upgrade your DuckDuckGo subscription in this browser again to continue the chat, or switch to a Plus or free model.
@@ -187,8 +188,9 @@ msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
 msgstr ""
-"%1$s는 Pro를 구독하셔야 이용할 수 있습니다. 이 브라우저에서 DuckDuckGo 구독을 다시 업그레이드하여 채팅을 계속 "
-"이용하거나, Plus 또는 무료 모델로 전환하세요."
+"%1$s는 Pro를 구독하셔야 이용할 수 있습니다. 이 브라우저에서 DuckDuckGo 구독"
+"을 다시 업그레이드하여 채팅을 계속 이용하거나, Plus 또는 무료 모델로 전환하세"
+"요."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI (Artificial Intelligence) chat model is temporarily unavailable. Example: 'GPT 4o is only available with a DuckDuckGo subscription.'
@@ -204,8 +206,8 @@ msgid ""
 "subscription in this browser again to continue the chat, or switch to a free "
 "model."
 msgstr ""
-"%1$s 서비스는 DuckDuckGo를 구독하셔야 이용할 수 있습니다. 이 브라우저에서 구독을 다시 활성화해서 채팅을 계속 이용하거나, "
-"무료 모델로 전환하세요."
+"%1$s 서비스는 DuckDuckGo를 구독하셔야 이용할 수 있습니다. 이 브라우저에서 구"
+"독을 다시 활성화해서 채팅을 계속 이용하거나, 무료 모델로 전환하세요."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is temporarily unavailable. Example: 'GPT 3.5 Turbo is temporarily unavailable. Please switch to a different model or try again later.'
@@ -213,7 +215,9 @@ msgctxt "Error message for model unavailability"
 msgid ""
 "%s is temporarily unavailable. Please switch to a different model or try "
 "again later."
-msgstr "%1$s 모델을 일시적으로 사용할 수 없습니다. 다른 모델로 전환하거나 나중에 다시 시도하세요."
+msgstr ""
+"%1$s 모델을 일시적으로 사용할 수 없습니다. 다른 모델로 전환하거나 나중에 다"
+"시 시도하세요."
 
 # smartling.placeholder_format=C
 #. Reddit's "fake internet points". https://support.reddithelp.com/hc/en-us/articles/204511829-What-is-karma
@@ -304,8 +308,8 @@ msgid ""
 "provider can see your prompts or the model’s responses, or save this chat on "
 "their servers."
 msgstr ""
-"%1$s(은)는 신뢰할 수 있는 실행 환경에서 실행됩니다. 즉, 모델 제공자조차도 사용자의 메시지나 모델의 응답을 보거나 서버에 이 "
-"채팅을 저장할 수 없습니다."
+"%1$s(은)는 신뢰할 수 있는 실행 환경에서 실행됩니다. 즉, 모델 제공자조차도 사"
+"용자의 메시지나 모델의 응답을 보거나 서버에 이 채팅을 저장할 수 없습니다."
 
 # smartling.placeholder_format=C
 #. Label shown in the batch selection toolbar when exactly one chat is selected. %s is replaced with 1. Use singular agreement where the language requires it.
@@ -384,7 +388,9 @@ msgctxt ""
 msgid ""
 "%s will be leaving Duck.ai in %s days (%s). After that, you can switch "
 "models to continue this chat."
-msgstr "%1$s 모델은 %2$s일 후(%3$s)에 Duck.ai에서 제거됩니다. 그 후에는 모델을 바꿔서 이 채팅을 계속할 수 있습니다."
+msgstr ""
+"%1$s 모델은 %2$s일 후(%3$s)에 Duck.ai에서 제거됩니다. 그 후에는 모델을 바꿔"
+"서 이 채팅을 계속할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Displayed in a saved chat when its AI model is about to be retired tomorrow. First placeholder is the friendly model name, second placeholder is the removal date formatted in the user's browser locale (e.g., 'June 15, 2026' in en-US). Singular-day form.
@@ -394,7 +400,9 @@ msgctxt ""
 msgid ""
 "%s will be leaving Duck.ai in 1 day (%s). After that, you can switch models "
 "to continue this chat."
-msgstr "%1$s 모델은 %2$s일 후에 Duck.ai에서 제거됩니다. 그 후에는 모델을 바꿔서 이 채팅을 계속할 수 있습니다."
+msgstr ""
+"%1$s 모델은 %2$s일 후에 Duck.ai에서 제거됩니다. 그 후에는 모델을 바꿔서 이 채"
+"팅을 계속할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Shown in a text selection chip when the selection contains multiple words. %s is replaced with the number of words, e.g. '142 words'.
@@ -406,7 +414,9 @@ msgstr "단어 %1$s개"
 #. Instructions on which buttons and options the user has to click in order to add the DuckDuckGo extension to their browser.
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
-msgstr "%1$s추가%2$s를 클릭합니다.%3$s허용%4$s에 체크 표시한 후%5$s 확인%6$s을 클릭합니다.%7$s"
+msgstr ""
+"%1$s추가%2$s를 클릭합니다.%3$s허용%4$s에 체크 표시한 후%5$s 확인%6$s을 클릭합"
+"니다.%7$s"
 
 # Firefox, obsolete
 # smartling.placeholder_format=C
@@ -414,8 +424,8 @@ msgstr "%1$s추가%2$s를 클릭합니다.%3$s허용%4$s에 체크 표시한 후
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAllow%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
 msgstr ""
-"%1$s허용%2$s을 클릭합니다.%3$s추가%4$s를 클릭합니다.%5$s허용%6$s에 %7$s체크 표시한 후 %8$s확인%9$s을 "
-"클릭합니다."
+"%1$s허용%2$s을 클릭합니다.%3$s추가%4$s를 클릭합니다.%5$s허용%6$s에 %7$s체크 "
+"표시한 후 %8$s확인%9$s을 클릭합니다."
 
 # Firefox
 # smartling.placeholder_format=C
@@ -425,8 +435,8 @@ msgid ""
 "%sClick %sContinue To Installation%sClick %sAdd%sCheck %sAllow%s, then click "
 "%sOkay%s"
 msgstr ""
-"%1$s설치 진행하기%2$s를 클릭합니다.%3$s%4$s추가%5$s를 클릭합니다.%6$s허용%7$s에 체크 표시한 후 "
-"%8$s확인%9$s을 클릭합니다."
+"%1$s설치 진행하기%2$s를 클릭합니다.%3$s%4$s추가%5$s를 클릭합니다.%6$s허용%7$s"
+"에 체크 표시한 후 %8$s확인%9$s을 클릭합니다."
 
 # smartling.placeholder_format=C
 #. A button that reloads search results when an error occurs.
@@ -434,7 +444,9 @@ msgctxt "noresults"
 msgid ""
 "%sClick here%s to try again, if you think there should be results for this "
 "search."
-msgstr "이 검색 결과가 표시되어야 한다고 생각되는 경우 %1$s여기%2$s를 클릭해서 다시 시도해 보세요."
+msgstr ""
+"이 검색 결과가 표시되어야 한다고 생각되는 경우 %1$s여기%2$s를 클릭해서 다시 "
+"시도해 보세요."
 
 # smartling.placeholder_format=C
 #. Header for a page with information about sharing DuckDuckGo.
@@ -452,14 +464,16 @@ msgstr "%1$s더 알아보기%2$s."
 #. Link to a page with more information about how anonymous location works.
 msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
-msgstr "%1$sDuckDuckGo가 사용자의 위치 정보를 어떻게 보호하는지 알아보세요%2$s."
+msgstr ""
+"%1$sDuckDuckGo가 사용자의 위치 정보를 어떻게 보호하는지 알아보세요%2$s."
 
 # smartling.placeholder_format=C
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
 msgctxt "Footer text for About Sync modal"
 msgid ""
 "%sLearn more%s about how chats are stored privately on DuckDuckGo's server."
-msgstr "DuckDuckGo 서버에 채팅이 비공개로 저장되는 방식 %1$s자세히 알아보기%2$s"
+msgstr ""
+"DuckDuckGo 서버에 채팅이 비공개로 저장되는 방식 %1$s자세히 알아보기%2$s"
 
 # smartling.placeholder_format=C
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
@@ -477,7 +491,8 @@ msgstr "홈 화면에서 DuckDuckGo 앱 아이콘을 %1$s길게 누릅니다%2$s
 #. A message displayed when there is an error loading content or no results on requery
 msgctxt "Error or no results message"
 msgid "%sOops!%s%sSomething went wrong. Please %srefresh%s and try again."
-msgstr "%1$s이런!%2$s%3$s문제가 발생했습니다. %4$s새로고침%5$s하고 다시 시도하세요."
+msgstr ""
+"%1$s이런!%2$s%3$s문제가 발생했습니다. %4$s새로고침%5$s하고 다시 시도하세요."
 
 # smartling.placeholder_format=C
 #. Tagline in a popover encouraging the user to download the DuckDuckGo browser
@@ -794,14 +809,17 @@ msgstr "6시간 사용 제한에 도달했습니다."
 #. Displayed when the user has reached a fixed 6-hour Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "6-hour usage limit reached. You can continue this chat after %s."
-msgstr "6시간 사용 한도에 도달했습니다. %1$s 이후에 이 채팅을 이어갈 수 있습니다."
+msgstr ""
+"6시간 사용 한도에 도달했습니다. %1$s 이후에 이 채팅을 이어갈 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable 6-hour Duck.ai usage limit and can opt in to continue using the daily limit.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "6-hour usage limit reached. You can keep chatting by using your daily limit."
-msgstr "6시간 사용 한도에 도달했습니다. 일일 한도를 사용해서 채팅을 이어갈 수 있습니다."
+msgstr ""
+"6시간 사용 한도에 도달했습니다. 일일 한도를 사용해서 채팅을 이어갈 수 있습니"
+"다."
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes abbreviation
@@ -854,14 +872,17 @@ msgstr "A"
 msgid ""
 "A network issue is preventing Search Assist from generating an answer. "
 "Please check your connection and try again."
-msgstr "Search Assist가 네트워크 문제로 답변을 생성하지 못하고 있습니다. 연결 상태를 확인하고 다시 시도하세요."
+msgstr ""
+"Search Assist가 네트워크 문제로 답변을 생성하지 못하고 있습니다. 연결 상태를 "
+"확인하고 다시 시도하세요."
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of AI Chat is available and they need to refresh the page.
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of AI Chat is available! Please refresh this page to continue."
-msgstr "새로운 버전의 AI Chat이 나왔습니다! 이 페이지를 새로고침해서 진행하세요."
+msgstr ""
+"새로운 버전의 AI Chat이 나왔습니다! 이 페이지를 새로고침해서 진행하세요."
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of Duck.ai is available and they need to refresh the page.
@@ -906,9 +927,9 @@ msgid ""
 "still access AI Chat when this setting is off by visiting %sduckduckgo.com/"
 "aichat%s."
 msgstr ""
-"AI Chat을 사용하면 외부 AI Chat 모델과 익명으로 대화할 수 있습니다. 이 기능을 끄면 DuckDuckGo Search의 AI "
-"Chat 기능이 숨겨집니다. 이 설정이 꺼져 있어도 %1$sduckduckgo.com/aichat%2$s를 통해 AI Chat을 계속 "
-"이용할 수 있습니다."
+"AI Chat을 사용하면 외부 AI Chat 모델과 익명으로 대화할 수 있습니다. 이 기능"
+"을 끄면 DuckDuckGo Search의 AI Chat 기능이 숨겨집니다. 이 설정이 꺼져 있어도 "
+"%1$sduckduckgo.com/aichat%2$s를 통해 AI Chat을 계속 이용할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -969,9 +990,10 @@ msgid ""
 "questions, which is our private AI-powered chat service that supports chat "
 "models from OpenAI, and Anthropic, and more."
 msgstr ""
-"현재 AI 지원 답변은 직접적인 후속 질문을 지원하지 않습니다. 하지만 후속 질문을 위해 %1$sDuck.ai%2$s를 제안하고 링크를 "
-"제공하는 경우는 많습니다. Duck.ai는 OpenAI와 Anthropic 등의 채팅 모델을 지원하는 DuckDuckGo의 비공개 AI "
-"기반 채팅 서비스입니다."
+"현재 AI 지원 답변은 직접적인 후속 질문을 지원하지 않습니다. 하지만 후속 질문"
+"을 위해 %1$sDuck.ai%2$s를 제안하고 링크를 제공하는 경우는 많습니다. Duck.ai"
+"는 OpenAI와 Anthropic 등의 채팅 모델을 지원하는 DuckDuckGo의 비공개 AI 기반 "
+"채팅 서비스입니다."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has turned off AI features and will no longer see AI-assisted answers.
@@ -1155,7 +1177,9 @@ msgctxt ""
 msgid ""
 "Activate your %s in this browser again to continue the chat, or switch to a "
 "free model."
-msgstr "이 브라우저에서 %1$s을 다시 활성화해서 채팅을 계속 이용하거나, 무료 모델로 전환하세요."
+msgstr ""
+"이 브라우저에서 %1$s을 다시 활성화해서 채팅을 계속 이용하거나, 무료 모델로 전"
+"환하세요."
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an active DuckDuckGo subscription.
@@ -1190,14 +1214,18 @@ msgstr "광고"
 #. An item in the ads tooltip that explains that ad clicks are managed by the ad network and are not used to profile you. The placeholder is the name of the ad network. For example: Microsoft
 msgid ""
 "Ad clicks are managed by %s’s ad network and are not used to profile you."
-msgstr "광고 클릭은 %1$s의 광고 네트워크에서 관리되며 사용자의 정보를 수집하는 데 사용되지 않습니다."
+msgstr ""
+"광고 클릭은 %1$s의 광고 네트워크에서 관리되며 사용자의 정보를 수집하는 데 사"
+"용되지 않습니다."
 
 # smartling.placeholder_format=C
 #. Information that ad clicks are managed by Microsoft.
 msgid ""
 "Ad clicks are managed by Microsoft’s ad network and are not used to profile "
 "you."
-msgstr "광고 클릭은 Microsoft의 광고 네트워크에서 관리되며 사용자의 정보를 수집하는 데 사용되지 않습니다."
+msgstr ""
+"광고 클릭은 Microsoft의 광고 네트워크에서 관리되며 사용자의 정보를 수집하는 "
+"데 사용되지 않습니다."
 
 # smartling.placeholder_format=C
 #. An item in the ads tooltip that explains that ad clicks aren’t used to profile you.
@@ -1247,7 +1275,9 @@ msgstr "DuckDuckGo 확장 프로그램 추가"
 # smartling.placeholder_format=C
 msgid ""
 "Add DuckDuckGo Privacy Essentials to your browser for free with one download:"
-msgstr "다운로드 한 번으로 브라우저에 DuckDuckGo Privacy Essentials를 무료로 추가하세요."
+msgstr ""
+"다운로드 한 번으로 브라우저에 DuckDuckGo Privacy Essentials를 무료로 추가하세"
+"요."
 
 #  IE default search engine instruction
 # smartling.placeholder_format=C
@@ -1402,6 +1432,12 @@ msgid "Address is incorrect"
 msgstr "주소가 올바르지 않습니다."
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Adjust the servings"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. as in multiple advertisements
 msgid "Ads"
 msgstr "광고"
@@ -1483,7 +1519,8 @@ msgstr "다운로드가 완료되고 파일이 열리면 %1$s설치%2$s를 클�
 #. Instructions on how to install the DuckDuckGo browser extension after it downloads.
 msgid ""
 "After it downloads, locate the extension file and double-click it to install"
-msgstr "다운로드가 완료되면 확장 프로그램 파일을 찾아 더블 클릭하여 설치합니다."
+msgstr ""
+"다운로드가 완료되면 확장 프로그램 파일을 찾아 더블 클릭하여 설치합니다."
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an age below a web search result.
@@ -1613,6 +1650,14 @@ msgid "All chats are %sprivate%s"
 msgstr "모든 채팅은 %1$s비공개%2$s입니다"
 
 # smartling.placeholder_format=C
+#. Paragraph in the Privacy & Terms section of the About & Legal page in Duck.ai settings, summarizing how chats are anonymized and are not stored or used to train chat models.
+msgctxt "Privacy & Terms section description on the Duck.ai settings page"
+msgid ""
+"All chats are anonymized by DuckDuckGo, and your conversations are not used "
+"to train chat models by DuckDuckGo or the model providers"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
 msgctxt "Privacy modal header in Duck.ai chat"
 msgid "All chats are private"
@@ -1642,7 +1687,8 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "All model providers are prevented from training their AI on your "
 "conversations."
-msgstr "모든 모델 제공사가 사용자의 대화를 AI에 학습시킬 수 없도록 금지되어 있습니다."
+msgstr ""
+"모든 모델 제공사가 사용자의 대화를 AI에 학습시킬 수 없도록 금지되어 있습니다."
 
 # smartling.placeholder_format=C
 #. Text displayed in the subheader of the modal that allows the user to pick an AI chat model.
@@ -1656,7 +1702,9 @@ msgctxt "Body copy for the anonymized card in the How Duck.ai Works panel"
 msgid ""
 "All personal metadata (for example, your IP address) is removed before "
 "sending a chat to the AI provider."
-msgstr "AI 제공자에 채팅을 보내기 전에 모든 개인 메타데이터(예: IP 주소)가 제거됩니다."
+msgstr ""
+"AI 제공자에 채팅을 보내기 전에 모든 개인 메타데이터(예: IP 주소)가 제거됩니"
+"다."
 
 # smartling.placeholder_format=C
 #. A filter that shows search results from all countries.
@@ -1681,7 +1729,8 @@ msgstr "모든 종류"
 msgctxt "voice chat"
 msgid ""
 "Allow DuckDuckGo microphone access in System Settings to use voice chat."
-msgstr "음성 채팅을 사용하려면 시스템 설정에서 DuckDuckGo 마이크 접근을 허용하세요."
+msgstr ""
+"음성 채팅을 사용하려면 시스템 설정에서 DuckDuckGo 마이크 접근을 허용하세요."
 
 # smartling.placeholder_format=C
 #. Tells users which icon to press in their browser. Part of a list of instructions on how to enable location service.
@@ -1707,15 +1756,17 @@ msgid ""
 "sends AI-generated queries to a search engine with limited data retention. "
 "Prompts and responses with %s still have %szero provider visibility%s."
 msgstr ""
-"%1$s 모델의 웹 검색을 허용하여 관련 프롬프트에 대한 응답을 향상합니다. 데이터 보유가 제한된 검색 엔진에만 AI가 생성한 쿼리를 "
-"보냅니다. %2$s 모델의 프롬프트 및 응답은 계속해서 %3$s제공자에게 전혀 노출되지 않습니다%4$s."
+"%1$s 모델의 웹 검색을 허용하여 관련 프롬프트에 대한 응답을 향상합니다. 데이"
+"터 보유가 제한된 검색 엔진에만 AI가 생성한 쿼리를 보냅니다. %2$s 모델의 프롬"
+"프트 및 응답은 계속해서 %3$s제공자에게 전혀 노출되지 않습니다%4$s."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Allows Cloud Save key to be stored locally on device (required to use Cloud "
 "Save)"
-msgstr "Cloud Save 키가 기기에 로컬로 저장되도록 허용(Cloud Save를 사용하는 데 필요)"
+msgstr ""
+"Cloud Save 키가 기기에 로컬로 저장되도록 허용(Cloud Save를 사용하는 데 필요)"
 
 # smartling.placeholder_format=C
 #. Pending title indicating near completion.
@@ -1852,7 +1903,8 @@ msgctxt "AI Chat description"
 msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
-msgstr "%1$s 및 %2$s, 오픈 소스 %3$s 및 %4$s 같은 인기 AI 모델에 익명으로 접속하세요."
+msgstr ""
+"%1$s 및 %2$s, 오픈 소스 %3$s 및 %4$s 같은 인기 AI 모델에 익명으로 접속하세요."
 
 # smartling.placeholder_format=C
 #. Text with information about Duck.ai and supported AI models, the placeholders list AI models. Example: 'Anonymous access to popular AI models, including GPT, Claude, and open-source Llama and Mistral.'
@@ -1860,13 +1912,21 @@ msgctxt "Duck.ai description"
 msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
-msgstr "%1$s 및 %2$s, 오픈 소스 %3$s 및 %4$s 같은 인기 AI 모델에 익명으로 접속하세요."
+msgstr ""
+"%1$s 및 %2$s, 오픈 소스 %3$s 및 %4$s 같은 인기 AI 모델에 익명으로 접속하세요."
 
 # smartling.placeholder_format=C
 #. Confirmation message after location service is enabled.
 msgctxt "precise_user_location"
 msgid "Anonymous location enabled"
 msgstr "익명 위치 활성화됨"
+
+# smartling.placeholder_format=C
+msgctxt "settings"
+msgid ""
+"Anonymously generates answers for search queries based on web content. "
+"Choose how often you want it to appear, or disable it completely."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -1912,7 +1972,9 @@ msgctxt "Placeholder for additional instructions textarea"
 msgid ""
 "Any additional instructions you want Duck.ai to follow. e.g. Always tell me "
 "facts about ducks"
-msgstr "Duck.ai가 따랐으면 하는 그 밖의 지침이 있으신가요(예: 항상 오리에 대한 정보를 들려줘)?"
+msgstr ""
+"Duck.ai가 따랐으면 하는 그 밖의 지침이 있으신가요(예: 항상 오리에 대한 정보"
+"를 들려줘)?"
 
 # smartling.placeholder_format=C
 #. Shown in video filtering. https://duckduckgo.com/?q=videos+of+cats&iax=videos&ia=videos
@@ -2077,8 +2139,8 @@ msgid ""
 "As per our privacy policy, we do not collect or share any personal "
 "information ourselves. All of this privacy protection happens on your device."
 msgstr ""
-"DuckDuckGo의 개인정보 보호정책에 따라 DuckDuckGo는 어떠한 개인정보도 수집하거나 공유하지 않습니다. 모든 개인정보 보호는 "
-"사용자의 기기에서 이루어집니다."
+"DuckDuckGo의 개인정보 보호정책에 따라 DuckDuckGo는 어떠한 개인정보도 수집하거"
+"나 공유하지 않습니다. 모든 개인정보 보호는 사용자의 기기에서 이루어집니다."
 
 # smartling.placeholder_format=C
 #. A button to ask Duck.ai a question
@@ -2139,6 +2201,12 @@ msgstr "후속 질문 하기"
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse
 msgid "Ask a follow-up with Duck.ai"
 msgstr "Duck.ai로 후속 질문하기"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
+msgctxt "Page suggestion chip label"
+msgid "Ask about this page"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2202,10 +2270,11 @@ msgid ""
 "(shows more frequently on a wider range of searches). For now, AI-assisted "
 "answers are only available in the U.S. (English) region."
 msgstr ""
-"Assist는 일부 검색에 대해 관련 웹 콘텐츠를 요약하여 익명으로 AI 지원 답변을 생성할 수 있습니다. Assist 표시 빈도 선택 "
-"가능: 안 함(검색 결과에서 Assist UI를 완전히 제거), 주문형(Assist 버튼을 클릭할 때만 AI 지원 답변 표시), "
-"가끔(관련성이 높은 경우에만 AI 지원 답변 표시), 자주(광범위한 검색에서 더 자주 표시). 현재 AI 지원 답변은 미국(영어) "
-"지역에서만 이용 가능합니다."
+"Assist는 일부 검색에 대해 관련 웹 콘텐츠를 요약하여 익명으로 AI 지원 답변을 "
+"생성할 수 있습니다. Assist 표시 빈도 선택 가능: 안 함(검색 결과에서 Assist UI"
+"를 완전히 제거), 주문형(Assist 버튼을 클릭할 때만 AI 지원 답변 표시), 가끔(관"
+"련성이 높은 경우에만 AI 지원 답변 표시), 자주(광범위한 검색에서 더 자주 표"
+"시). 현재 AI 지원 답변은 미국(영어) 지역에서만 이용 가능합니다."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2217,9 +2286,10 @@ msgid ""
 "to remember that responses are auto-generated from cited sources and based "
 "on %scrawling the web%s."
 msgstr ""
-"Assist는 검색 질의에 익명으로 AI 지원 답변을 생성하는 검색 결과 옵션 기능이며 웹에서 관련 콘텐츠를 검색한 다음 AI 기반 "
-"자연어 기술을 사용하여, 검색된 관련 정보를 바탕으로 간단한 답변을 생성합니다. 답변은 인용된 출처와 %1$s웹 크롤링%2$s을 기반으로 "
-"자동 생성합니다."
+"Assist는 검색 질의에 익명으로 AI 지원 답변을 생성하는 검색 결과 옵션 기능이"
+"며 웹에서 관련 콘텐츠를 검색한 다음 AI 기반 자연어 기술을 사용하여, 검색된 관"
+"련 정보를 바탕으로 간단한 답변을 생성합니다. 답변은 인용된 출처와 %1$s웹 크롤"
+"링%2$s을 기반으로 자동 생성합니다."
 
 # smartling.placeholder_format=C
 #. Title for the dropdown menu where users select the assistant's role. Example: 'Assistant role: Travel guide'
@@ -2351,13 +2421,17 @@ msgstr "자동 응답"
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid "Auto-generated based on listed sources. May contain inaccuracies."
-msgstr "나열된 자료를 바탕으로 자동 생성된 응답이며 부정확한 내용이 섞여있을 수 있습니다."
+msgstr ""
+"나열된 자료를 바탕으로 자동 생성된 응답이며 부정확한 내용이 섞여있을 수 있습"
+"니다."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid ""
 "Auto-generated based on listed sources. Responses may contain inaccuracies."
-msgstr "나열된 자료를 바탕으로 자동 생성된 응답이며 부정확한 내용이 포함되어 있을 수 있습니다."
+msgstr ""
+"나열된 자료를 바탕으로 자동 생성된 응답이며 부정확한 내용이 포함되어 있을 수 "
+"있습니다."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI) on mobile
@@ -2382,8 +2456,9 @@ msgid ""
 "look up and summarize information in response to some searches. For now, "
 "Assist is only available in English regions."
 msgstr ""
-"관련 검색어에 대한 Assist를 자동으로 표시합니다. Assist는 일부 검색에 대하여 익명으로 정보를 조회하고 요약할 수 있습니다. "
-"현재 Assist 서비스는 영어 사용 지역에서만 제공됩니다."
+"관련 검색어에 대한 Assist를 자동으로 표시합니다. Assist는 일부 검색에 대하여 "
+"익명으로 정보를 조회하고 요약할 수 있습니다. 현재 Assist 서비스는 영어 사용 "
+"지역에서만 제공됩니다."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2392,14 +2467,16 @@ msgid ""
 "anonymously look up and summarize information in response to some searches. "
 "For now, DuckAssist is only available in English regions."
 msgstr ""
-"관련 검색어에 대한 DuckAssist를 자동으로 표시합니다. DuckAssist는 일부 검색에 대하여 익명으로 정보를 조회하고 요약할 "
-"수 있습니다. 현재 DuckAssist 서비스는 영어 사용 지역에서만 제공됩니다."
+"관련 검색어에 대한 DuckAssist를 자동으로 표시합니다. DuckAssist는 일부 검색"
+"에 대하여 익명으로 정보를 조회하고 요약할 수 있습니다. 현재 DuckAssist 서비스"
+"는 영어 사용 지역에서만 제공됩니다."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Autoplay short, silent video previews when you hover over video results."
-msgstr "영상 결과에 마우스를 올리면 짧은 무음 영상 미리 보기가 자동으로 재생됩니다."
+msgstr ""
+"영상 결과에 마우스를 올리면 짧은 무음 영상 미리 보기가 자동으로 재생됩니다."
 
 # smartling.placeholder_format=C
 #. Screen-reader label for the radiogroup of tool options inside the Tools dropdown. Announced when assistive technology enters the group of menuitemradio items.
@@ -2541,6 +2618,12 @@ msgid "Barcode"
 msgstr "바코드"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Based on this page, is this course worth taking?"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Basic"
 msgstr "기본"
@@ -2579,6 +2662,14 @@ msgstr "배트맨"
 msgctxt "Assistant response placeholder"
 msgid "Before continuing..."
 msgstr "계속 진행하기 전에..."
+
+# smartling.placeholder_format=C
+#. Explains that before storing the report, DuckDuckGo will anonymize the conversation by removing PII like names, email addresses, and identifying metadata.
+msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
+msgid ""
+"Before storing this report, DuckDuckGo will anonymize your conversation by "
+"removing PII like names, email addresses, and identifying metadata."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -2897,6 +2988,12 @@ msgid "Break Points Won"
 msgstr "획득한 브레이크 포인트"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Break this down into clear, numbered steps."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
 msgctxt "Weather IA"
 msgid "Breezy"
@@ -2953,16 +3050,18 @@ msgid ""
 "Browse as usual while we add privacy protection. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
 msgstr ""
-"기존과 동일하게 검색하세요. 개인정보는 저희가 보호해 드릴게요. 하나의 %1$s%2$s확장 프로그램%3$s으로 검색 엔진, 추적 차단, "
-"암호화 보호 강화 기능을 이용할 수 있습니다."
+"기존과 동일하게 검색하세요. 개인정보는 저희가 보호해 드릴게요. 하나의 "
+"%1$s%2$s확장 프로그램%3$s으로 검색 엔진, 추적 차단, 암호화 보호 강화 기능을 "
+"이용할 수 있습니다."
 
 # smartling.placeholder_format=C
 msgid ""
 "Browse as usual, and we'll take care of the rest. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
 msgstr ""
-"기존과 동일하게 검색하세요. 검색 기록이 저장되지 않습니다. 하나의 %1$s%2$s확장 프로그램%3$s으로 검색 엔진, 추적 차단, "
-"암호화 보호 강화 기능을 이용할 수 있습니다."
+"기존과 동일하게 검색하세요. 검색 기록이 저장되지 않습니다. 하나의 %1$s%2$s확"
+"장 프로그램%3$s으로 검색 엔진, 추적 차단, 암호화 보호 강화 기능을 이용할 수 "
+"있습니다."
 
 # smartling.placeholder_format=C
 msgid ""
@@ -2970,8 +3069,9 @@ msgid ""
 "search, tracker blocking, and site encryption, all in one download, for "
 "%smajor browsers%s."
 msgstr ""
-"기존과 동일하게 검색하세요. 검색 기록이 저장되지 않습니다. 다운로드 한 번으로 %1$s주요 브라우저%2$s에서 비공개 검색, 추적 "
-"차단, 사이트 암호화 기능을 이용할 수 있습니다."
+"기존과 동일하게 검색하세요. 검색 기록이 저장되지 않습니다. 다운로드 한 번으"
+"로 %1$s주요 브라우저%2$s에서 비공개 검색, 추적 차단, 사이트 암호화 기능을 이"
+"용할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Header for a call to action to browse with the DuckDuckGo browser
@@ -3078,9 +3178,10 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"기본적으로 설정은 비개인 브라우저 쿠키(사용자의 브라우저)에 저장됩니다. 익명 Cloud Save를 사용하여 설정을 보다 영구적으로 "
-"저장할 수 있습니다(클라우드의 원격 서버에 저장). 클라우드에는 사용자의 개인 신원 정보가 저장되지 않으며, 암호 또한 서버에 저장되지 "
-"않습니다."
+"기본적으로 설정은 비개인 브라우저 쿠키(사용자의 브라우저)에 저장됩니다. 익명 "
+"Cloud Save를 사용하여 설정을 보다 영구적으로 저장할 수 있습니다(클라우드의 원"
+"격 서버에 저장). 클라우드에는 사용자의 개인 신원 정보가 저장되지 않으며, 암"
+"호 또한 서버에 저장되지 않습니다."
 
 # smartling.placeholder_format=C
 #. Description for the consent highlight in the dictation consent modal. %s is replaced with a link to the help page.
@@ -3088,8 +3189,8 @@ msgid ""
 "By enabling dictation, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
 msgstr ""
-"받아쓰기를 활성화함으로써, 이 기능을 사용하기 위해 본인의 음성 데이터가 OpenAI로 전송되는 것에 동의합니다. 시작하기 전에 %1$s "
-"페이지를 확인하세요."
+"받아쓰기를 활성화함으로써, 이 기능을 사용하기 위해 본인의 음성 데이터가 "
+"OpenAI로 전송되는 것에 동의합니다. 시작하기 전에 %1$s 페이지를 확인하세요."
 
 # smartling.placeholder_format=C
 #. Description for the 'enable voice chat' section of the voice chat consent modal. Placeholder for the voice chat help page link and text. Example: 'By enabling voice chat, you consent to your voice data being sent to OpenAI for the use of this feature. See our voice chat help page before getting started.'
@@ -3098,8 +3199,8 @@ msgid ""
 "By enabling voice chat, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
 msgstr ""
-"음성 채팅을 활성화함으로써, 이 기능을 사용하기 위해 본인의 음성 데이터가 OpenAI로 전송되는 것에 동의합니다. 시작하기 전에 "
-"%1$s 페이지를 확인하세요."
+"음성 채팅을 활성화함으로써, 이 기능을 사용하기 위해 본인의 음성 데이터가 "
+"OpenAI로 전송되는 것에 동의합니다. 시작하기 전에 %1$s 페이지를 확인하세요."
 
 # smartling.placeholder_format=C
 #. Golf leaderboard: player missed the cut
@@ -3134,7 +3235,8 @@ msgstr "카메룬"
 #. Text for a prompt suggestion for creating a few simple recipes using chicken, broccoli, and rice.
 msgctxt "Full sentence for crafting a recipe"
 msgid "Can you create a few simple recipes using chicken, broccoli, and rice?"
-msgstr "닭고기, 브로콜리, 쌀을 재료로 한 몇 가지 간단한 요리법을 만들 수 있나요?"
+msgstr ""
+"닭고기, 브로콜리, 쌀을 재료로 한 몇 가지 간단한 요리법을 만들 수 있나요?"
 
 # smartling.placeholder_format=C
 msgid "Canada"
@@ -3345,6 +3447,12 @@ msgid "Cast"
 msgstr "캐스트"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Cast & Crew"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
 msgctxt "Tone option label for Casual"
 msgid "Casual"
@@ -3448,7 +3556,9 @@ msgstr "전체 사이트에 적용되는 배경 색상을 변경합니다."
 msgctxt "settings"
 msgid ""
 "Changes the background color of results on hover, modules, and dropdown menus"
-msgstr "검색 결과(마우스 커서를 올렸을 때), 모듈 및 드롭다운 메뉴의 배경 색상을 변경합니다."
+msgstr ""
+"검색 결과(마우스 커서를 올렸을 때), 모듈 및 드롭다운 메뉴의 배경 색상을 변경"
+"합니다."
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/NdpkbY0.png
@@ -3577,8 +3687,9 @@ msgid ""
 "DuckDuckGo Search. However, you can still access Chat when this setting is "
 "off by visiting %shttps://duck.ai%s directly."
 msgstr ""
-"Duck.ai 서비스를 통한 채팅을 사용하면 OpenAI, Anthropic 등의 모델을 지원하는 타사 AI 채팅 모델과 익명으로 대화할 "
-"수 있습니다. 이 설정을 끄면 DuckDuckGo Search에서 채팅 버튼과 링크가 보이지 않습니다. 하지만 이 설정이 꺼져 있어도 "
+"Duck.ai 서비스를 통한 채팅을 사용하면 OpenAI, Anthropic 등의 모델을 지원하는 "
+"타사 AI 채팅 모델과 익명으로 대화할 수 있습니다. 이 설정을 끄면 DuckDuckGo "
+"Search에서 채팅 버튼과 링크가 보이지 않습니다. 하지만 이 설정이 꺼져 있어도 "
 "%1$shttps://duck.ai%2$s에 바로 접속해서 채팅을 이용할 수 있습니다."
 
 # smartling.placeholder_format=C
@@ -3634,14 +3745,18 @@ msgstr "비공개로 채팅하기"
 #. Mobile variant of DUCKCHAT_BROWSER_UPSELL_PROMO_TEXT. Shorter version for the promotional card encouraging third-party browser users to download the DuckDuckGo browser.
 msgctxt "Promotional text (mobile)"
 msgid "Chat privately on any website with Duck.ai built into our free browser."
-msgstr "DuckDuckGo 무료 브라우저에 내장된 Duck.ai로 어떤 웹사이트에서든 비공개로 채팅하세요."
+msgstr ""
+"DuckDuckGo 무료 브라우저에 내장된 Duck.ai로 어떤 웹사이트에서든 비공개로 채팅"
+"하세요."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card encouraging third-party browser users to download the DuckDuckGo browser. Not shown in the DuckDuckGo browser or on Linux.
 msgctxt "Promotional text"
 msgid ""
 "Chat privately on any website with the Duck.ai sidebar in our free browser."
-msgstr "DuckDuckGo 무료 브라우저에서 Duck.ai 사이드바를 통해 어떤 웹사이트에서든 비공개로 채팅하세요."
+msgstr ""
+"DuckDuckGo 무료 브라우저에서 Duck.ai 사이드바를 통해 어떤 웹사이트에서든 비공"
+"개로 채팅하세요."
 
 # smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
@@ -3703,7 +3818,9 @@ msgctxt "Description for Chat History feature"
 msgid ""
 "Chats are stored locally on your device instead of on DuckDuckGo servers or "
 "remote servers. Disabling chat history will delete pinned chats."
-msgstr "채팅은 DuckDuckGo 서버나 원격 서버가 아닌 사용자의 기기 자체에 저장됩니다. 채팅 기록을 비활성화하면 고정된 채팅이 삭제돼."
+msgstr ""
+"채팅은 DuckDuckGo 서버나 원격 서버가 아닌 사용자의 기기 자체에 저장됩니다. 채"
+"팅 기록을 비활성화하면 고정된 채팅이 삭제돼."
 
 # smartling.placeholder_format=C
 #. Text explaining how the Chat History feature stores the user's chats locally to their device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection. Also explains that disabling chat history will delete pinned chats.
@@ -3715,9 +3832,10 @@ msgid ""
 "history will delete pinned chats, and disable the temporary storage of new "
 "prompts and responses."
 msgstr ""
-"채팅은 사용자의 기기에 직접 저장됩니다. 사용자의 인터넷 연결이 끊겼을 때 채팅을 복원할 수 있도록, 전송된 새 프롬프트와 응답을 "
-"암호화하여 DuckDuckGo 서버에 임시로 저장합니다. 채팅 기록을 비활성화하면 고정된 채팅이 삭제되고, 새로운 프롬프트와 응답의 임시 "
-"저장이 중단됩니다."
+"채팅은 사용자의 기기에 직접 저장됩니다. 사용자의 인터넷 연결이 끊겼을 때 채팅"
+"을 복원할 수 있도록, 전송된 새 프롬프트와 응답을 암호화하여 DuckDuckGo 서버"
+"에 임시로 저장합니다. 채팅 기록을 비활성화하면 고정된 채팅이 삭제되고, 새로"
+"운 프롬프트와 응답의 임시 저장이 중단됩니다."
 
 # smartling.placeholder_format=C
 #. Title shown above the body copy in the Duck.ai recent chats IndexedDB unavailable notice.
@@ -3738,7 +3856,9 @@ msgstr "채팅을 안전하게 내려받았습니다"
 msgctxt "Sync file storage inline disclaimer body"
 msgid ""
 "Chats with attachments have stopped syncing. Free up storage to resume Sync."
-msgstr "첨부 파일이 있는 채팅의 동기화가 중단되었습니다. 저장 공간을 확보하면 동기화를 재개할 수 있습니다."
+msgstr ""
+"첨부 파일이 있는 채팅의 동기화가 중단되었습니다. 저장 공간을 확보하면 동기화"
+"를 재개할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Message shown when we have no data from upstream to display
@@ -3791,7 +3911,8 @@ msgstr "철자 검사"
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
 msgctxt "noresults"
 msgid "Check the DuckDuckGo subreddit for updates on this outage."
-msgstr "DuckDuckGo 서브레딧에서 이번 서비스 중단에 대한 최신 소식을 확인하세요."
+msgstr ""
+"DuckDuckGo 서브레딧에서 이번 서비스 중단에 대한 최신 소식을 확인하세요."
 
 # smartling.placeholder_format=C
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
@@ -4071,8 +4192,9 @@ msgid ""
 "Clearing browser data deletes chats. Some browsers may keep recent chats "
 "indefinitely or auto-delete them after 7+ days of no AI Chat use."
 msgstr ""
-"브라우저 데이터를 삭제하면 채팅이 사라집니다. 일부 브라우저는 최근 채팅을 무기한으로 보관하거나, AI Chat을 7일 이상 사용하지 "
-"않으면 자동으로 삭제할 수 있습니다."
+"브라우저 데이터를 삭제하면 채팅이 사라집니다. 일부 브라우저는 최근 채팅을 무"
+"기한으로 보관하거나, AI Chat을 7일 이상 사용하지 않으면 자동으로 삭제할 수 있"
+"습니다."
 
 # smartling.placeholder_format=C
 #. Text explaining what happens to recent chats when browser data is cleared.
@@ -4082,8 +4204,9 @@ msgid ""
 "indefinitely or auto-deleted after 7 days without using Duck.ai, depending "
 "on your browser."
 msgstr ""
-"브라우저 데이터를 삭제하면 최근 채팅이 삭제됩니다. 브라우저에 따라 최근 채팅이 무기한으로 저장될 수도 있고, Duck.ai를 7일 이상 "
-"사용하지 않으면 자동으로 삭제될 수도 있습니다."
+"브라우저 데이터를 삭제하면 최근 채팅이 삭제됩니다. 브라우저에 따라 최근 채팅"
+"이 무기한으로 저장될 수도 있고, Duck.ai를 7일 이상 사용하지 않으면 자동으로 "
+"삭제될 수도 있습니다."
 
 # smartling.placeholder_format=C
 #. Warning message shown on the Block domain success modal. Blocked sites are stored in localStorage which is cleared alongside cookies when users clear browser data. Followed by a linked 'our free browser' text.
@@ -4091,7 +4214,9 @@ msgctxt "settings"
 msgid ""
 "Clearing browser data will reset your blocked sites. Save your block list "
 "permanently in"
-msgstr "브라우저 데이터를 삭제하면 차단된 사이트가 초기화됩니다. 차단 목록을 DuckDuckGo 무료 브라우저에"
+msgstr ""
+"브라우저 데이터를 삭제하면 차단된 사이트가 초기화됩니다. 차단 목록을 "
+"DuckDuckGo 무료 브라우저에"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -4100,8 +4225,9 @@ msgid ""
 "%sDuck.ai%s, our private AI chat service that supports chat models from "
 "OpenAI, Anthropic, and more."
 msgstr ""
-"'더 보기'를 클릭해서 주제를 더 깊이 탐색하고, OpenAI와 Anthropic 등의 채팅 모델을 지원하는 DuckDuckGo의 비공개 "
-"AI 기반 채팅 서비스 %1$sDuck.ai%2$s를 통해 후속 질문을 하세요."
+"'더 보기'를 클릭해서 주제를 더 깊이 탐색하고, OpenAI와 Anthropic 등의 채팅 모"
+"델을 지원하는 DuckDuckGo의 비공개 AI 기반 채팅 서비스 %1$sDuck.ai%2$s를 통해 "
+"후속 질문을 하세요."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4142,7 +4268,9 @@ msgstr "드롭다운 메뉴에서 %1$s검색 설정 변경%2$s을 클릭하세�
 msgid ""
 "Click %sEdit > Preferences%s (on Windows) %sSeaMonkey > Preferences%s (on "
 "Mac)"
-msgstr "Windows에서는 %1$s편집 > 환경설정%2$s을 클릭하고, Mac에서는%3$sSeaMonkey > 환경설정%4$s을 클릭하세요."
+msgstr ""
+"Windows에서는 %1$s편집 > 환경설정%2$s을 클릭하고, Mac에서는%3$sSeaMonkey > 환"
+"경설정%4$s을 클릭하세요."
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -4158,7 +4286,9 @@ msgstr "DuckDuckGo 확장 프로그램을 다운로드하려면 %1$s여기%2$s�
 # smartling.placeholder_format=C
 #. Link to download the DuckDuckGo browser extension.
 msgid "Click %sOpen%s to download and open the DuckDuckGo Safari extension"
-msgstr "%1$s열기%2$s를 클릭해서 DuckDuckGo Safari 확장 프로그램을 다운로드하고 여세요."
+msgstr ""
+"%1$s열기%2$s를 클릭해서 DuckDuckGo Safari 확장 프로그램을 다운로드하고 여세"
+"요."
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -4172,7 +4302,9 @@ msgstr "왼쪽 사이드바에서 %1$s개인정보 및 서비스%2$s를 클릭�
 msgid ""
 "Click %sSafari%s in the top menu (On Windows, click the %sgears icon%s in "
 "the top right)"
-msgstr "상단 메뉴의 %1$sSafari%2$s를 클릭하세요(Windows에서는 오른쪽 상단에 있는 %3$s기어 모양 아이콘%4$s을 클릭하세요)."
+msgstr ""
+"상단 메뉴의 %1$sSafari%2$s를 클릭하세요(Windows에서는 오른쪽 상단에 있는 %3$s"
+"기어 모양 아이콘%4$s을 클릭하세요)."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4201,7 +4333,8 @@ msgstr "%1$s예%2$s를 클릭하세요."
 # smartling.placeholder_format=C
 #. Tells the user where to click to open their browser's settings menu.
 msgid "Click %ssettings/hamburger icon %s on the Chrome toolbar (top right)."
-msgstr "Chrome 툴바(오른쪽 상단)에서 %1$ssettings/hamburger icon%2$s을 클릭하세요."
+msgstr ""
+"Chrome 툴바(오른쪽 상단)에서 %1$ssettings/hamburger icon%2$s을 클릭하세요."
 
 #  Maxthon default search engine instruction
 # smartling.placeholder_format=C
@@ -4263,8 +4396,9 @@ msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Search Settings%s."
 msgstr ""
-"%1$s데이터 삭제하기%2$s를 클릭하거나 누르면 클라우드에서는 데이터가 제거되지만 브라우저에는 남아있습니다. 남아있는 데이터를 "
-"제거하려면 %3$s모든 검색 설정 초기화%4$s를 클릭하거나 누르세요."
+"%1$s데이터 삭제하기%2$s를 클릭하거나 누르면 클라우드에서는 데이터가 제거되지"
+"만 브라우저에는 남아있습니다. 남아있는 데이터를 제거하려면 %3$s모든 검색 설"
+"정 초기화%4$s를 클릭하거나 누르세요."
 
 # smartling.placeholder_format=C
 #. Tells users where to click in order to disable the cloud save feature and delete any data backed-up to the cloud.
@@ -4275,8 +4409,9 @@ msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Settings%s."
 msgstr ""
-"%1$s내 데이터 삭제%2$s를 클릭하거나 누릅니다. 이 작업을 수행하면 클라우드에서는 데이터가 삭제되지만, %3$s모든 설정 "
-"초기화%4$s를 클릭하거나 누를 때까지 브라우저에는 데이터가 남아 있게 됩니다."
+"%1$s내 데이터 삭제%2$s를 클릭하거나 누릅니다. 이 작업을 수행하면 클라우드에서"
+"는 데이터가 삭제되지만, %3$s모든 설정 초기화%4$s를 클릭하거나 누를 때까지 브"
+"라우저에는 데이터가 남아 있게 됩니다."
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -4344,14 +4479,18 @@ msgstr "검색 창에서 드롭다운을 클릭하세요."
 msgid ""
 "Click the dropdown menu beside %sSearch engine used in the address bar%s and "
 "select %sDuckDuckGo%s."
-msgstr "주소 표시줄%2$s에 사용된 %1$s검색 엔진 옆 드롭다운 메뉴를 클릭하고 %3$sDuckDuckGo%4$s를 선택하세요."
+msgstr ""
+"주소 표시줄%2$s에 사용된 %1$s검색 엔진 옆 드롭다운 메뉴를 클릭하고 "
+"%3$sDuckDuckGo%4$s를 선택하세요."
 
 # smartling.placeholder_format=C
 #. First step in a list of steps to take to disable the user's ad blocker
 msgid ""
 "Click the icon of the ad blocker extension. It's usually in the upper right "
 "hand corner of your browser."
-msgstr "광고 차단 확장 프로그램 아이콘을 클릭하세요. 주로 브라우저 오른쪽 상단 모서리에 있습니다."
+msgstr ""
+"광고 차단 확장 프로그램 아이콘을 클릭하세요. 주로 브라우저 오른쪽 상단 모서리"
+"에 있습니다."
 
 #  Safari default search engine instruction
 # smartling.placeholder_format=C
@@ -4539,7 +4678,9 @@ msgctxt "cloudsave"
 msgid ""
 "Cloud Save lets you save your settings more permanently by entering a "
 "passphrase. It is entirely optional."
-msgstr "Cloud Save는 현재 설정을 영구적으로 저장하고 암호를 입력해 간편하게 불러올 수 있는 기능으로, 꼭 사용하실 필요는 없습니다."
+msgstr ""
+"Cloud Save는 현재 설정을 영구적으로 저장하고 암호를 입력해 간편하게 불러올 "
+"수 있는 기능으로, 꼭 사용하실 필요는 없습니다."
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -4898,7 +5039,8 @@ msgstr "복사"
 # smartling.placeholder_format=C
 #. Instructions on how to change the default search engine
 msgid "Copy &amp; paste %sabout:preferences#search%s into the address bar"
-msgstr "주소 표시줄에 %1$sabout:preferences#search%2$s를 복사하여 붙여넣으세요."
+msgstr ""
+"주소 표시줄에 %1$sabout:preferences#search%2$s를 복사하여 붙여넣으세요."
 
 # smartling.placeholder_format=C
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
@@ -5012,6 +5154,12 @@ msgstr "이미지 만들기"
 msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr "이미지 만들기"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Create a shopping list with quantities from this recipe."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed in the input field when starting a new image generation session.
@@ -5268,14 +5416,17 @@ msgstr "일일 한도에 도달했습니다."
 #. Displayed when the user has reached a fixed daily Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Daily usage limit reached. You can continue this chat after %s."
-msgstr "일일 사용 한도에 도달했습니다. %1$s 이후에 이 채팅을 이어갈 수 있습니다."
+msgstr ""
+"일일 사용 한도에 도달했습니다. %1$s 이후에 이 채팅을 이어갈 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable daily Duck.ai usage limit and can opt in to continue using the weekly limit.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "Daily usage limit reached. You can keep chatting by using your weekly limit."
-msgstr "일일 사용 한도에 도달했습니다. 주간 채팅 제한을 이용해서 채팅을 이어갈 수 있습니다."
+msgstr ""
+"일일 사용 한도에 도달했습니다. 주간 채팅 제한을 이용해서 채팅을 이어갈 수 있"
+"습니다."
 
 # smartling.placeholder_format=C
 #. The name of the Danish language
@@ -5642,7 +5793,8 @@ msgstr "Duck.ai 받아쓰기"
 # smartling.placeholder_format=C
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
-msgstr "당사는 받아쓰기 내용을 익명화하며, AI 모델 학습에 절대 사용하지 않습니다."
+msgstr ""
+"당사는 받아쓰기 내용을 익명화하며, AI 모델 학습에 절대 사용하지 않습니다."
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
@@ -5650,11 +5802,18 @@ msgid "Dictation limit reached"
 msgstr "받아쓰기 한도에 도달했습니다"
 
 # smartling.placeholder_format=C
+#. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
+msgid "Dictation temporarily unavailable"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
 "chat in Duck.ai without having to type."
-msgstr "받아쓰기 기능은 OpenAI 모델을 사용하여 음성을 텍스트로 변환하므로, 직접 입력하지 않고도 Duck.ai에서 채팅을 할 수 있습니다."
+msgstr ""
+"받아쓰기 기능은 OpenAI 모델을 사용하여 음성을 텍스트로 변환하므로, 직접 입력"
+"하지 않고도 Duck.ai에서 채팅을 할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. In 0-click box -- link to definition.
@@ -5922,7 +6081,9 @@ msgstr "목록에 DuckDuckGo가 보이지 않으시나요?"
 #. Link to download a file again if the user can't find it on their computer.
 msgctxt "install-extension"
 msgid "Don't see it? %s%s%sClick here to re-download%s"
-msgstr "파일을 찾을 수 없으신가요? %1$s%2$s%3$s여기를 클릭하여 다시 다운로드하세요.%4$s"
+msgstr ""
+"파일을 찾을 수 없으신가요? %1$s%2$s%3$s여기를 클릭하여 다시 다운로드하세요."
+"%4$s"
 
 #  IE < 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -5946,6 +6107,22 @@ msgstr "완료"
 msgctxt "precise_user_location"
 msgid "Done"
 msgstr "완료"
+
+# smartling.placeholder_format=C
+#. Message shown in a modal after DuckDuckGo browser users disable AI features in Settings. The first two placeholders bold noai.duckduckgo.com. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
+"filtered out. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
+"and AI images filtered out. %sLearn more%s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6047,7 +6224,9 @@ msgctxt "Full sentence for writing an email"
 msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for "
 "ceiling fan repair services."
-msgstr "실링 팬 수리 업체에 보낼 견적 요청 이메일 초안을 간결하면서도 상세하게 작성하세요."
+msgstr ""
+"실링 팬 수리 업체에 보낼 견적 요청 이메일 초안을 간결하면서도 상세하게 작성하"
+"세요."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion asking for an email draft to a vendor requesting a quote for home refrigerator repair services.
@@ -6055,7 +6234,21 @@ msgctxt "Full sentence for writing an email"
 msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
-msgstr "가정용 냉장고 수리 업체에 보낼 견적 요청 이메일 초안을 간결하면서도 상세하게 작성하세요."
+msgstr ""
+"가정용 냉장고 수리 업체에 보낼 견적 요청 이메일 초안을 간결하면서도 상세하게 "
+"작성하세요."
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Draft a cover letter"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Draft a cover letter for this job."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -6063,7 +6256,9 @@ msgctxt "Full sentence for drafting a social media post"
 msgid ""
 "Draft a few options for a social media post inviting people to my upcoming "
 "party."
-msgstr "다가오는 파티에 사람들을 초대하기 위해 SNS에 올릴 글을 몇 가지 버전으로 작성하세요."
+msgstr ""
+"다가오는 파티에 사람들을 초대하기 위해 SNS에 올릴 글을 몇 가지 버전으로 작성"
+"하세요."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a few options for a blog post title about strategies to increase team collaboration.
@@ -6071,7 +6266,9 @@ msgctxt "Full sentence for suggesting a blog post title"
 msgid ""
 "Draft a few options for a title of a post I’m writing about strategies to "
 "increase team collaboration."
-msgstr "팀 협업 강화 전략에 대해 내가 쓰고 있는 게시물의 제목을 여러 가지 버전으로 써보세요."
+msgstr ""
+"팀 협업 강화 전략에 대해 내가 쓰고 있는 게시물의 제목을 여러 가지 버전으로 써"
+"보세요."
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for drafting a social media post.
@@ -6197,8 +6394,9 @@ msgid ""
 "content is only included when you attach it, unless you choose to attach "
 "pages automatically in Settings."
 msgstr ""
-"이제 내가 보고있는 페이지에 대해 궁금한 점이 있을 때 Duck.ai가 답해드릴 수 있습니다. 페이지 내용은 사용자가 첨부할 때만 "
-"포함됩니다. 또는 설정에서 페이지 자동 첨부를 선택하세요."
+"이제 내가 보고있는 페이지에 대해 궁금한 점이 있을 때 Duck.ai가 답해드릴 수 있"
+"습니다. 페이지 내용은 사용자가 첨부할 때만 포함됩니다. 또는 설정에서 페이지 "
+"자동 첨부를 선택하세요."
 
 # smartling.placeholder_format=C
 #. Shown in the Duck.ai recent chats list on standalone when the browser API needed to store chats locally is missing or unavailable.
@@ -6208,8 +6406,8 @@ msgid ""
 "Duck.ai can’t access local storage to save your chats. Please check your "
 "browser settings or disable any extensions and try again."
 msgstr ""
-"Duck.ai가 채팅을 저장하기 위해 로컬 저장소에 액세스할 수 없습니다. 브라우저 설정을 확인하거나 확장 프로그램을 비활성화한 후 다시 "
-"시도하세요."
+"Duck.ai가 채팅을 저장하기 위해 로컬 저장소에 액세스할 수 없습니다. 브라우저 "
+"설정을 확인하거나 확장 프로그램을 비활성화한 후 다시 시도하세요."
 
 # smartling.placeholder_format=C
 #. Displayed when the chat service has reached the maximum number of messages for one day.
@@ -6217,13 +6415,25 @@ msgctxt "Error message for service limit"
 msgid ""
 "Duck.ai has reached the maximum number of messages for one day. Please "
 "continue this chat tomorrow."
-msgstr "Duck.ai의 하루 메시지 전송 한도에 도달했습니다. 내일 대화를 이어가세요."
+msgstr ""
+"Duck.ai의 하루 메시지 전송 한도에 도달했습니다. 내일 대화를 이어가세요."
 
 # smartling.placeholder_format=C
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
-msgstr "Duck.ai는 개인정보가 보호되는 무료 브라우저 DuckDuckGo에서 최고 성능을 발휘합니다!"
+msgstr ""
+"Duck.ai는 개인정보가 보호되는 무료 브라우저 DuckDuckGo에서 최고 성능을 발휘합"
+"니다!"
+
+# smartling.placeholder_format=C
+#. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
+msgctxt "About section description on the Duck.ai settings page"
+msgid ""
+"Duck.ai is created by DuckDuckGo. We're an independent online protection "
+"company for anyone who wants to take back control of their personal "
+"information."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
@@ -6237,7 +6447,9 @@ msgctxt "duckai_migration"
 msgid ""
 "Duck.ai is still a DuckDuckGo product, but will now have an easier to "
 "remember home on the web: https://duck.ai"
-msgstr "Duck.ai는 여전히 DuckDuckGo 제품이지만, 웹사이트 주소가 https://duck.ai로 기억하기 쉽게 바뀌었습니다."
+msgstr ""
+"Duck.ai는 여전히 DuckDuckGo 제품이지만, 웹사이트 주소가 https://duck.ai로 기"
+"억하기 쉽게 바뀌었습니다."
 
 # smartling.placeholder_format=C
 #. Headline for domain change notice.
@@ -6251,14 +6463,18 @@ msgctxt "Error message for BOTNET limit."
 msgid ""
 "Duck.ai is temporarily unavailable. If this persists, please email this "
 "anonymous code %s to %s"
-msgstr "Duck.ai를 일시적으로 사용할 수 없습니다. 문제가 지속되면 이 익명 코드(%1$s)를 %2$s 이메일로 보내주세요"
+msgstr ""
+"Duck.ai를 일시적으로 사용할 수 없습니다. 문제가 지속되면 이 익명 코드(%1$s)"
+"를 %2$s 이메일로 보내주세요"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
 msgctxt "Error message for VQD error"
 msgid ""
 "Duck.ai is temporarily unavailable. Please refresh the page and try again."
-msgstr "Duck.ai를 일시적으로 사용할 수 없습니다. 페이지를 새로고침한 후 다시 시도하세요."
+msgstr ""
+"Duck.ai를 일시적으로 사용할 수 없습니다. 페이지를 새로고침한 후 다시 시도하세"
+"요."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -6269,15 +6485,23 @@ msgstr "Duck.ai를 일시적으로 사용할 수 없습니다. 잠시 후 다시
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
+"Duck.ai lets you chat privately with popular AI models. Disabling it hides "
+"Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
+msgstr ""
+
+# smartling.placeholder_format=C
+msgctxt "settings"
+msgid ""
 "Duck.ai lets you have anonymous conversations with 3rd-party AI chat models, "
 "including models from OpenAI, Anthropic, and others. Turning this setting "
 "off will hide Duck.ai buttons and links on DuckDuckGo Search. However, you "
 "can still access Duck.ai when this setting is off by visiting %shttps://duck."
 "ai%s directly."
 msgstr ""
-"Duck.ai를 사용하면 OpenAI, Anthropic 등의 외부 AI 채팅 모델과 익명으로 대화할 수 있습니다. 이 설정을 끄면 "
-"DuckDuckGo Search에서 Duck.ai 버튼과 링크가 보이지 않습니다. 하지만 이 설정이 꺼져 있어도 "
-"%1$shttps://duck.ai%2$s에 바로 접속해서 Duck.ai를 이용할 수 있습니다."
+"Duck.ai를 사용하면 OpenAI, Anthropic 등의 외부 AI 채팅 모델과 익명으로 대화"
+"할 수 있습니다. 이 설정을 끄면 DuckDuckGo Search에서 Duck.ai 버튼과 링크가 보"
+"이지 않습니다. 하지만 이 설정이 꺼져 있어도 %1$shttps://duck.ai%2$s에 바로 접"
+"속해서 Duck.ai를 이용할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
@@ -6291,7 +6515,9 @@ msgctxt "duckai_migration"
 msgid ""
 "Duck.ai might have lost your recent chats. You can still use Duck.ai as "
 "usual."
-msgstr "Duck.ai에서 나의 최근 채팅이 사라졌을 수 있습니다. Duck.ai는 평소처럼 사용하실 수 있습니다."
+msgstr ""
+"Duck.ai에서 나의 최근 채팅이 사라졌을 수 있습니다. Duck.ai는 평소처럼 사용하"
+"실 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
@@ -6322,7 +6548,8 @@ msgstr "Duck.ai가 업그레이드되었습니다!"
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
-msgstr "Duck.ai는 개인정보가 보호되는 무료 DuckDuckGo 앱에서 최고 성능을 발휘합니다!"
+msgstr ""
+"Duck.ai는 개인정보가 보호되는 무료 DuckDuckGo 앱에서 최고 성능을 발휘합니다!"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -6332,8 +6559,9 @@ msgid ""
 "AI chat no sign up, OpenAI, Anthropic, Llama, Mistral, open source AI "
 "models, privacy focused AI, no account AI chat"
 msgstr ""
-"Duck.ai, DuckDuckGo AI, 비공개 AI 챗봇, 무료 AI 채팅, 익명 AI 채팅, 가입 필요 없는 AI 채팅, "
-"OpenAI, Anthropic, Llama, Mistral, 오픈 소스 AI 모델, 프라이버시 중심 AI, 계정 필요 없는 AI 채팅"
+"Duck.ai, DuckDuckGo AI, 비공개 AI 챗봇, 무료 AI 채팅, 익명 AI 채팅, 가입 필"
+"요 없는 AI 채팅, OpenAI, Anthropic, Llama, Mistral, 오픈 소스 AI 모델, 프라이"
+"버시 중심 AI, 계정 필요 없는 AI 채팅"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -6361,9 +6589,11 @@ msgid ""
 "relevant), or Often (shows more frequently on a wider range of searches). "
 "For now, DuckAssist is only available in the U.S. (English) region."
 msgstr ""
-"DuckAssist는 일부 검색에 대하여 익명으로 정보를 조회하고 요약할 수 있습니다. DuckAssist 표시 빈도 선택 가능: 안 "
-"함(검색 결과에서 DuckAssist UI를 완전히 제거), 주문형(Assist 버튼을 클릭할 때만 표시), 가끔(관련성이 높은 경우에만 "
-"표시), 자주(광범위한 검색에서 더 자주 표시). 현재 DuckAssist 서비스는 미국(영어) 지역에서만 제공됩니다."
+"DuckAssist는 일부 검색에 대하여 익명으로 정보를 조회하고 요약할 수 있습니다. "
+"DuckAssist 표시 빈도 선택 가능: 안 함(검색 결과에서 DuckAssist UI를 완전히 제"
+"거), 주문형(Assist 버튼을 클릭할 때만 표시), 가끔(관련성이 높은 경우에만 표"
+"시), 자주(광범위한 검색에서 더 자주 표시). 현재 DuckAssist 서비스는 미국(영"
+"어) 지역에서만 제공됩니다."
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6372,8 +6602,9 @@ msgid ""
 "%sDuckDuckGo AI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI, and Anthropic, and more."
 msgstr ""
-"DuckAssist는 후속 질문에 답변할 수 없지만 OpenAI 및 Anthropic의 채팅 모델을 지원하는 비공개 AI 기반 채팅 "
-"서비스인 %1$sDuckDuckGo AI Chat%2$s도 제공합니다."
+"DuckAssist는 후속 질문에 답변할 수 없지만 OpenAI 및 Anthropic의 채팅 모델을 "
+"지원하는 비공개 AI 기반 채팅 서비스인 %1$sDuckDuckGo AI Chat%2$s도 제공합니"
+"다."
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6382,8 +6613,9 @@ msgid ""
 "DuckDuckGo %sAI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI and Anthropic."
 msgstr ""
-"DuckAssist는 후속 질문에 답변할 수 없지만 OpenAI 및 Anthropic의 채팅 모델을 지원하는 비공개 AI 기반 채팅 "
-"서비스인 DuckDuckGo %1$sAI Chat%2$s도 제공합니다."
+"DuckAssist는 후속 질문에 답변할 수 없지만 OpenAI 및 Anthropic의 채팅 모델을 "
+"지원하는 비공개 AI 기반 채팅 서비스인 DuckDuckGo %1$sAI Chat%2$s도 제공합니"
+"다."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6395,9 +6627,10 @@ msgid ""
 "responses are currently based on Wikipedia and related content and are not "
 "checked for accuracy."
 msgstr ""
-"DuckAssist는 검색 질의에 익명으로 답변을 생성하는 새 기능입니다. Wikipedia와 관련 사이트에서 의미있는 콘텐츠를 검색한 "
-"다음 AI 기반 자연어 기술을 사용하여 해당 정보를 요약하는 방식으로 답변을 생성합니다. 현재 Wikipedia와 관련 내용을 기반으로 "
-"답변을 제공하며 정확성 검사는 하지 않습니다."
+"DuckAssist는 검색 질의에 익명으로 답변을 생성하는 새 기능입니다. Wikipedia와 "
+"관련 사이트에서 의미있는 콘텐츠를 검색한 다음 AI 기반 자연어 기술을 사용하여 "
+"해당 정보를 요약하는 방식으로 답변을 생성합니다. 현재 Wikipedia와 관련 내용"
+"을 기반으로 답변을 제공하며 정확성 검사는 하지 않습니다."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6411,17 +6644,21 @@ msgid ""
 "It’s important to remember that responses are auto-generated from cited "
 "sources and based on %scrawling the web%s."
 msgstr ""
-"DuckAssist는 검색 질의에 익명으로 답변을 생성하는 옵션 기능입니다. 웹에서 관련 콘텐츠를 검색한 다음 AI 기반 자연어 기술을 "
-"사용하여, 검색된 관련 정보를 바탕으로 간단한 답변을 생성합니다. DuckAssist는 응답을 할 때 항상 출처 1~2개를 바로 링크하고 "
-"답변 출처를 인용하기 때문에 사용자가 쉽게 이동하여 더 자세한 정보를 얻을 수 있습니다. 답변은 인용된 출처와 %1$s웹 크롤링%2$s을 "
-"기반으로 자동 생성합니다."
+"DuckAssist는 검색 질의에 익명으로 답변을 생성하는 옵션 기능입니다. 웹에서 관"
+"련 콘텐츠를 검색한 다음 AI 기반 자연어 기술을 사용하여, 검색된 관련 정보를 바"
+"탕으로 간단한 답변을 생성합니다. DuckAssist는 응답을 할 때 항상 출처 1~2개를 "
+"바로 링크하고 답변 출처를 인용하기 때문에 사용자가 쉽게 이동하여 더 자세한 정"
+"보를 얻을 수 있습니다. 답변은 인용된 출처와 %1$s웹 크롤링%2$s을 기반으로 자"
+"동 생성합니다."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid ""
 "DuckAssist responses are auto-generated based on listed sources and not "
 "checked for accuracy."
-msgstr "DuckAssist 응답은 나열된 소스를 기반으로 자동 생성하며 정확성을 확인하지 않습니다."
+msgstr ""
+"DuckAssist 응답은 나열된 소스를 기반으로 자동 생성하며 정확성을 확인하지 않습"
+"니다."
 
 # smartling.placeholder_format=C
 #. Displayed when the chat service has reached the maximum number of messages for one day.
@@ -6429,7 +6666,9 @@ msgctxt "Error message for service limit"
 msgid ""
 "DuckDuckGo AI Chat has reached the maximum number of messages for one day. "
 "Please continue this chat tomorrow."
-msgstr "하루에 보낼 수 있는 DuckDuckGo AI Chat 메시지 개수 한도에 도달했습니다. 이 채팅은 내일 계속하세요."
+msgstr ""
+"하루에 보낼 수 있는 DuckDuckGo AI Chat 메시지 개수 한도에 도달했습니다. 이 채"
+"팅은 내일 계속하세요."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the AI chat service and supported AI models. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -6438,8 +6677,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"DuckDuckGo AI Chat은 현재 %1$s의 %2$s, %3$s의 %4$s 채팅 모델을 지원하는 비공개 AI 기반 채팅 "
-"서비스입니다."
+"DuckDuckGo AI Chat은 현재 %1$s의 %2$s, %3$s의 %4$s 채팅 모델을 지원하는 비공"
+"개 AI 기반 채팅 서비스입니다."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the welcome screen of the onboarding. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -6448,8 +6687,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"DuckDuckGo AI Chat은 현재 %1$s의 %2$s, %3$s의 %4$s 채팅 모델을 지원하는 비공개 AI 기반 채팅 "
-"서비스입니다."
+"DuckDuckGo AI Chat은 현재 %1$s의 %2$s, %3$s의 %4$s 채팅 모델을 지원하는 비공"
+"개 AI 기반 채팅 서비스입니다."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding DuckDuckGo AI Chat.
@@ -6457,7 +6696,9 @@ msgctxt "Disclaimer text at the bottom of the feedback form."
 msgid ""
 "DuckDuckGo AI Chat is in Beta, it may display inaccurate or offensive "
 "information."
-msgstr "DuckDuckGo AI Chat은 베타 버전이므로 부정확하거나 불쾌한 정보가 표시될 수 있습니다."
+msgstr ""
+"DuckDuckGo AI Chat은 베타 버전이므로 부정확하거나 불쾌한 정보가 표시될 수 있"
+"습니다."
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat making it unavailable, and asking the user to send an email with a specific code if the error persists. E.g. 'DuckDuckGo AI Chat is temporarily unavailable. If this persists, please email this anonymous code abcdefg12345 to aichat-error@duckduckgo.com'
@@ -6465,7 +6706,9 @@ msgctxt "Error message for BOTNET limit."
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. If this persists, please "
 "email this anonymous code %s to %s"
-msgstr "DuckDuckGo AI Chat을 일시적으로 사용할 수 없습니다. 문제가 지속되면 이 익명 코드(%1$s)를 %2$s 이메일로 보내주세요"
+msgstr ""
+"DuckDuckGo AI Chat을 일시적으로 사용할 수 없습니다. 문제가 지속되면 이 익명 "
+"코드(%1$s)를 %2$s 이메일로 보내주세요"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -6473,13 +6716,16 @@ msgctxt "Error message for VQD error"
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. Please refresh the page and "
 "try again."
-msgstr "DuckDuckGo AI Chat을 일시적으로 사용할 수 없습니다. 페이지를 새로고침한 후 다시 시도하세요."
+msgstr ""
+"DuckDuckGo AI Chat을 일시적으로 사용할 수 없습니다. 페이지를 새로고침한 후 다"
+"시 시도하세요."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr "DuckDuckGo AI Chat을 일시적으로 사용할 수 없습니다. 잠시 후 다시 시도하세요."
+msgstr ""
+"DuckDuckGo AI Chat을 일시적으로 사용할 수 없습니다. 잠시 후 다시 시도하세요."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -6598,15 +6844,17 @@ msgid ""
 "DuckDuckGo anonymizes these reports by automatically removing PII like "
 "names, email addresses, phone numbers, and identifying metadata."
 msgstr ""
-"DuckDuckGo는 이름, 이메일 주소, 전화번호, 식별 가능한 메타데이터 같은 개인정보(PII)를 자동으로 제거해 이러한 보고서를 "
-"익명화합니다."
+"DuckDuckGo는 이름, 이메일 주소, 전화번호, 식별 가능한 메타데이터 같은 개인정"
+"보(PII)를 자동으로 제거해 이러한 보고서를 익명화합니다."
 
 # smartling.placeholder_format=C
 #. The first %s is the agree button label ('Agree'). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. The leading sentence mirrors the drawer-style inline disclaimer (DUCKCHAT_TOS_INLINE_DISCLAIMER).
 msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid ""
 "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to Duck.ai's %s."
-msgstr "DuckDuckGo는 채팅을 익명으로 처리합니다. %1$s 클릭을 통해 Duck.ai의 %2$s에 동의합니다."
+msgstr ""
+"DuckDuckGo는 채팅을 익명으로 처리합니다. %1$s 클릭을 통해 Duck.ai의 %2$s에 동"
+"의합니다."
 
 # smartling.placeholder_format=C
 #. Shown below the input on the empty state when the user has not yet accepted the terms of service. The first %s is the action button label ('Ask' for chat, 'Create' for image generation). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. Clicking the action button both accepts the terms and submits the prompt.
@@ -6614,7 +6862,9 @@ msgctxt ""
 "Inline terms-of-service disclaimer below chat or image-gen input for new "
 "users"
 msgid "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to our %s."
-msgstr "DuckDuckGo는 채팅을 익명으로 처리합니다. %1$s 클릭을 통해 DuckDuckGo의 %2$s에 동의합니다."
+msgstr ""
+"DuckDuckGo는 채팅을 익명으로 처리합니다. %1$s 클릭을 통해 DuckDuckGo의 %2$s"
+"에 동의합니다."
 
 # smartling.placeholder_format=C
 #. An information popup explaining that we block trackers
@@ -6623,8 +6873,8 @@ msgid ""
 "companies like Google and Facebook, who often try to track you on other "
 "websites."
 msgstr ""
-"DuckDuckGo는 사용자가 방문하는 웹사이트의 추적기를 차단하며, 다른 웹사이트에서 사용자 추적을 시도하는 Google과 "
-"Facebook 등의 추적기도 차단합니다."
+"DuckDuckGo는 사용자가 방문하는 웹사이트의 추적기를 차단하며, 다른 웹사이트에"
+"서 사용자 추적을 시도하는 Google과 Facebook 등의 추적기도 차단합니다."
 
 # smartling.placeholder_format=C
 #. Description of how DuckDuckGo keeps a user's location anonymous while the user searches on a map of their area.
@@ -6636,10 +6886,11 @@ msgid ""
 "away, such that you remain anonymous. %sLearn more about how we designed "
 "this technology to protect your privacy%s."
 msgstr ""
-"DuckDuckGo는 개인정보 보호를 위한 검색 엔진입니다. 위치 기능을 활성화하면 위치 정보는 로컬 기기에만 저장됩니다. 사용자가 "
-"검색을 하면 사용자의 기기는 해당 검색 정보를 DuckDuckGo로 전송하며, DuckDuckGo는 이를 검색 결과를 개선하는 데 사용한 "
-"후 즉시 폐기하여 사용자의 검색 기록을 남기지 않습니다. %1$s개인정보를 보호하기 위해 개발된 DuckDuckGo의 기술에 대해 자세히 "
-"알아보세요%2$s."
+"DuckDuckGo는 개인정보 보호를 위한 검색 엔진입니다. 위치 기능을 활성화하면 위"
+"치 정보는 로컬 기기에만 저장됩니다. 사용자가 검색을 하면 사용자의 기기는 해"
+"당 검색 정보를 DuckDuckGo로 전송하며, DuckDuckGo는 이를 검색 결과를 개선하는 "
+"데 사용한 후 즉시 폐기하여 사용자의 검색 기록을 남기지 않습니다. %1$s개인정보"
+"를 보호하기 위해 개발된 DuckDuckGo의 기술에 대해 자세히 알아보세요%2$s."
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
@@ -6659,8 +6910,8 @@ msgid ""
 "DuckDuckGo only uses your approximate location. That's all we need to "
 "deliver better results, closer to you. %sLearn more%s."
 msgstr ""
-"DuckDuckGo는 사용자의 대략적인 위치만 사용합니다. 이 정보만으로도 충분히 좋은 결과를 제공할 수 있습니다. %1$s자세히 "
-"알아보세요%2$s."
+"DuckDuckGo는 사용자의 대략적인 위치만 사용합니다. 이 정보만으로도 충분히 좋"
+"은 결과를 제공할 수 있습니다. %1$s자세히 알아보세요%2$s."
 
 # smartling.placeholder_format=C
 msgid "DuckDuckGo search"
@@ -6746,8 +6997,9 @@ msgid ""
 "random words from that list, ensuring that the passphrase is at least 18-20 "
 "characters long."
 msgstr ""
-"암호 제안 버튼을 클릭할 때마다 DuckDuckGo는 서버에서 무작위 단어로 조합된 긴 목록을 받습니다. 그러 다음 브라우저에서 목록에 "
-"포함된 4~5개의 무작위 단어를 선택하여 최소 18~20자 이상의 암호를 만듭니다."
+"암호 제안 버튼을 클릭할 때마다 DuckDuckGo는 서버에서 무작위 단어로 조합된 긴 "
+"목록을 받습니다. 그러 다음 브라우저에서 목록에 포함된 4~5개의 무작위 단어를 "
+"선택하여 최소 18~20자 이상의 암호를 만듭니다."
 
 # smartling.placeholder_format=C
 msgctxt "Sports module"
@@ -6942,7 +7194,9 @@ msgstr "웹 검색 활성화"
 msgid ""
 "Enable anonymous location for more accurate results. You can always change "
 "your mind later."
-msgstr "보다 정확한 결과를 얻으려면 익명 위치 기능을 활성화하세요. 언제든지 설정을 변경할 수 있습니다."
+msgstr ""
+"보다 정확한 결과를 얻으려면 익명 위치 기능을 활성화하세요. 언제든지 설정을 변"
+"경할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Title of the dictation privacy consent modal shown on first use.
@@ -6984,7 +7238,9 @@ msgctxt "precise_user_location"
 msgid ""
 "Enabling anonymous location gives more accurate results but still keeps your "
 "searches and exact location private to DuckDuckGo."
-msgstr "익명 위치를 활성화하면 더 정확한 결과를 얻으면서도 사용자의 검색과 정확한 위치는 DuckDuckGo에 공개하지 않을 수 있습니다."
+msgstr ""
+"익명 위치를 활성화하면 더 정확한 결과를 얻으면서도 사용자의 검색과 정확한 위"
+"치는 DuckDuckGo에 공개하지 않을 수 있습니다."
 
 # smartling.placeholder_format=C
 msgid "Encrypt Connections"
@@ -7145,7 +7401,9 @@ msgctxt "cloudsave"
 msgid ""
 "Enter a new passphrase and click/tap %sSave Settings%s. This will save your "
 "data under your new passphrase."
-msgstr "새 암호를 입력하고 %1$s설정 저장%2$s을 클릭하거나 누르세요. 그러면 해당 데이터가 새 암호로 저장됩니다."
+msgstr ""
+"새 암호를 입력하고 %1$s설정 저장%2$s을 클릭하거나 누르세요. 그러면 해당 데이"
+"터가 새 암호로 저장됩니다."
 
 # smartling.placeholder_format=C
 #. Label for the field where a user enters their passphrase.
@@ -7170,7 +7428,9 @@ msgstr "번역할 내용 입력하기"
 #. Instructions for how to change the default search engine.
 msgid ""
 "Enter the following details: %sName%s: DuckDuckGo%s URL%s: %s Alias%s: d%s"
-msgstr "다음 내용을 적어주세요: %1$s이름%2$s: DuckDuckGo%3$s URL%4$s: %5$s 닉네임%6$s: d%7$s"
+msgstr ""
+"다음 내용을 적어주세요: %1$s이름%2$s: DuckDuckGo%3$s URL%4$s: %5$s 닉네"
+"임%6$s: d%7$s"
 
 # smartling.placeholder_format=C
 #. Prompt to enter a destination for driving directions.
@@ -7211,6 +7471,18 @@ msgid "Eritrea"
 msgstr "에리트레아"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Estimate the nutrition"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Estimate the nutritional information for this recipe."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Estonia"
 msgstr "에스토니아"
 
@@ -7244,7 +7516,9 @@ msgstr "지도 확장하기"
 #. Subtitle for the Collaborations promotional card at the bottom of search results. Describes the branded merchandise line. 'Give a duck' is a wordplay on the DuckDuckGo brand name.
 msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
-msgstr "개인 정보 보호를 덕히 중요하게 생각하는 사람들을 위해 전문성을 다해 만들었습니다."
+msgstr ""
+"개인 정보 보호를 덕히 중요하게 생각하는 사람들을 위해 전문성을 다해 만들었습"
+"니다."
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
@@ -7265,11 +7539,59 @@ msgid "Expires in 1 day"
 msgstr "1일 후 만료"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain the accepted answer in simple terms."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
 msgstr "블랙홀의 기본 개념을 고등학교 수준으로 설명해 주세요."
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain the top answer"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this in simple, plain language."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this paper"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this repo"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this research paper in plain language."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this simply"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain what this repository does and how to use it."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label to show if song lyrics contain explicit content
@@ -7446,7 +7768,8 @@ msgstr "피드백이 성공적으로 전송되었습니다."
 msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and improvements."
-msgstr "여러분이 주시는 피드백은 제품 업데이트와 개선에 직접적인 영향을 미칩니다."
+msgstr ""
+"여러분이 주시는 피드백은 제품 업데이트와 개선에 직접적인 영향을 미칩니다."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -7454,7 +7777,9 @@ msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and "
 "improvements. Hopefully we can address the issue you shared too."
-msgstr "여러분이 주시는 피드백은 제품 업데이트와 개선에 직접적인 영향을 미칩니다. 사용자님이 보내주신 문제도 해결하기 위해 노력하겠습니다."
+msgstr ""
+"여러분이 주시는 피드백은 제품 업데이트와 개선에 직접적인 영향을 미칩니다. 사"
+"용자님이 보내주신 문제도 해결하기 위해 노력하겠습니다."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box
@@ -7544,7 +7869,14 @@ msgstr "이미지 검색 결과에서 AI가 생성한 이미지를 걸러냅니�
 msgctxt "settings"
 msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
-msgstr "이미지 검색 결과에서 AI가 생성한 이미지를 걸러냅니다. %1$s자세히 알아보기%2$s"
+msgstr ""
+"이미지 검색 결과에서 AI가 생성한 이미지를 걸러냅니다. %1$s자세히 알아보기%2$s"
+
+# smartling.placeholder_format=C
+msgctxt "settings"
+msgid ""
+"Filters out known AI spam sites from image search results. %sLearn More%s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the final score of a sporting event.
@@ -7585,7 +7917,8 @@ msgstr "다운로드 폴더에서 <b>%1$s</b> 파일을 찾으세요"
 # smartling.placeholder_format=C
 #. Tells users how to change their default search engine to DuckDuckGo.
 msgid "Find DuckDuckGo in the displayed list and click %sMake Default%s"
-msgstr "표시된 목록에서 DuckDuckGo를 찾아 %1$s기본값으로 설정%2$s을 클릭하세요."
+msgstr ""
+"표시된 목록에서 DuckDuckGo를 찾아 %1$s기본값으로 설정%2$s을 클릭하세요."
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for finding a better word.
@@ -7598,6 +7931,12 @@ msgstr "더 나은 단어를 찾아주세요"
 msgctxt "Subtitle for the Web Search tool entry in the Tools dropdown menu"
 msgid "Find current information"
 msgstr "최신 정보 찾기"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Find me alternatives"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button that searches for results closer to the user's current location.
@@ -7616,7 +7955,8 @@ msgstr "여러분과 보다 관련있는 결과를 찾아보세요."
 msgctxt "Precise user location overlay"
 msgid ""
 "Find results near you. %sYour location stays private, secure, and anonymous."
-msgstr "내 주변 결과를 보세요. %1$s내 위치는 익명 비공개로 안전하게 유지됩니다."
+msgstr ""
+"내 주변 결과를 보세요. %1$s내 위치는 익명 비공개로 안전하게 유지됩니다."
 
 # smartling.placeholder_format=C
 #. Loading message shown while generating explore more follow-up questions
@@ -7679,7 +8019,9 @@ msgstr "안개"
 msgid ""
 "Follow the instructions for turning off the ad blocker for DuckDuckGo. You "
 "may have to select a menu option or click a button."
-msgstr "안내에 따라 DuckDuckGo의 광고 차단기를 끄세요. 메뉴 옵션을 선택하거나 버튼을 클릭해야 할 수도 있습니다."
+msgstr ""
+"안내에 따라 DuckDuckGo의 광고 차단기를 끄세요. 메뉴 옵션을 선택하거나 버튼을 "
+"클릭해야 할 수도 있습니다."
 
 # smartling.placeholder_format=C
 #. Privacy reassurance and instructions intro.
@@ -7790,7 +8132,8 @@ msgstr "DuckDuckGo가 익명화하는 무료 비공개 채팅"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr "DuckDuckGo가 익명화하는 무료 비공개 채팅입니다. 계정이 없어도 괜찮습니다."
+msgstr ""
+"DuckDuckGo가 익명화하는 무료 비공개 채팅입니다. 계정이 없어도 괜찮습니다."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -7901,8 +8244,8 @@ msgid ""
 "<strong>Check for Updates...</strong>, then select <strong>Install Update</"
 "strong>."
 msgstr ""
-"Mac의 앱 메뉴 표시줄에서 <strong>DuckDuckGo</strong> &gt; <strong>업데이트 "
-"확인...</strong>을 선택한 후 <strong>업데이트 설치</strong>를 선택합니다."
+"Mac의 앱 메뉴 표시줄에서 <strong>DuckDuckGo</strong> &gt; <strong>업데이트 확"
+"인...</strong>을 선택한 후 <strong>업데이트 설치</strong>를 선택합니다."
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -8068,6 +8411,12 @@ msgstr "이미지 생성"
 #. Text for the button that generates more of an answer from duckassist when the answer has come from a collapsed state
 msgid "Generate More"
 msgstr "더 많이 생성하세요"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Generate a shopping list"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
@@ -8246,7 +8595,9 @@ msgctxt "Description of the modal to upgrade the DuckDuckGo subscription"
 msgid ""
 "Get access to advanced AI models in Duck.ai by subscribing to DuckDuckGo, "
 "which also includes our VPN and other premium privacy protections."
-msgstr "VPN을 비롯한 프리미엄 개인 정보 보호 기능이 제공되는 DuckDuckGo를 구독해 Duck.ai의 고급 AI 모델을 이용하세요."
+msgstr ""
+"VPN을 비롯한 프리미엄 개인 정보 보호 기능이 제공되는 DuckDuckGo를 구독해 "
+"Duck.ai의 고급 AI 모델을 이용하세요."
 
 # smartling.placeholder_format=C
 #. Description for the subscription setting where users can subscribe to DuckDuckGo.
@@ -8256,7 +8607,9 @@ msgctxt ""
 msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
-msgstr "VPN을 비롯한 프리미엄 개인 정보 보호 기능이 제공되는 DuckDuckGo 구독을 통해 Duck.ai의 고급 AI 모델을 이용하세요."
+msgstr ""
+"VPN을 비롯한 프리미엄 개인 정보 보호 기능이 제공되는 DuckDuckGo 구독을 통해 "
+"Duck.ai의 고급 AI 모델을 이용하세요."
 
 # smartling.placeholder_format=C
 #. A button for users to generate an AI generated answer from their query on the duckassist module
@@ -8290,7 +8643,9 @@ msgstr "설정이 사라지지 않도록 DuckDuckGo 브라우저를 이용하세
 # smartling.placeholder_format=C
 msgid ""
 "Get seamless privacy protection on your browser for free with one download:"
-msgstr "다운로드 한 번으로 브라우저에서 무료로 개인정보 보호 기능을 원활하게 이용할 수 있습니다."
+msgstr ""
+"다운로드 한 번으로 브라우저에서 무료로 개인정보 보호 기능을 원활하게 이용할 "
+"수 있습니다."
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo app when clicked
@@ -8355,6 +8710,12 @@ msgid "Give it a Try"
 msgstr "사용해보기기"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Give me a quick background on this person."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
@@ -8366,7 +8727,9 @@ msgctxt "precise_user_location"
 msgid ""
 "Go to %sSettings > Privacy & Security > Location Services%s, and make sure "
 "“Location Services” is turned on."
-msgstr "%1$s설정 > 개인 정보 보호 및 보안 > 위치 서비스%2$s로 이동하여 '위치 서비스'가 켜져 있는지 확인합니다."
+msgstr ""
+"%1$s설정 > 개인 정보 보호 및 보안 > 위치 서비스%2$s로 이동하여 '위치 서비"
+"스'가 켜져 있는지 확인합니다."
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -8374,7 +8737,9 @@ msgctxt "precise_user_location"
 msgid ""
 "Go to %sSettings > Privacy > Permission manager > Location%s and scroll down "
 "to %sDuckDuckGo%s."
-msgstr "%1$s 설정 > 개인 정보 보호 > 권한 관리자 > 위치%2$s에서 화면을 내려 %3$sDuckDuckGo%4$s를 찾습니다."
+msgstr ""
+"%1$s 설정 > 개인 정보 보호 > 권한 관리자 > 위치%2$s에서 화면을 내려 "
+"%3$sDuckDuckGo%4$s를 찾습니다."
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -8797,6 +9162,18 @@ msgid "Help Spread Privacy"
 msgstr "개인정보 보호의 중요성 알리기"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Help me prep for the interview"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Help me tailor my resume for this job."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title of a SERP popup that invites users to take a survey (desktop only)
 msgctxt "User survey popup"
 msgid "Help us improve DuckDuckGo"
@@ -9032,7 +9409,9 @@ msgctxt "settings"
 msgid ""
 "Highlights key facts in Search Assist answers to help you find important "
 "information faster."
-msgstr "중요한 정보를 더 빨리 찾는 데 도움이 되도록 Search Assist 답변의 주요 사실을 강조 표시합니다."
+msgstr ""
+"중요한 정보를 더 빨리 찾는 데 도움이 되도록 Search Assist 답변의 주요 사실을 "
+"강조 표시합니다."
 
 # smartling.placeholder_format=C
 #. The name of the Hindi language
@@ -9059,8 +9438,8 @@ msgid ""
 "Hit %sReturn%s on your keyboard to %ssave DuckDuckGo to the list. %sThen "
 "click %sMake Default%s"
 msgstr ""
-"키보드의 %1$sReturn%2$s 키를 눌러 %3$sDuckDuckGo를 목록에 저장하세요. %4$s그런 다음 %5$s기본값으로 "
-"설정%6$s을 클릭하세요"
+"키보드의 %1$sReturn%2$s 키를 눌러 %3$sDuckDuckGo를 목록에 저장하세요. %4$s그"
+"런 다음 %5$s기본값으로 설정%6$s을 클릭하세요"
 
 # smartling.placeholder_format=C
 #. The name of the Hmong Daw language
@@ -9073,7 +9452,9 @@ msgstr "몽족어"
 msgid ""
 "Hold on! Changing it back will disable the DuckDuckGo extension and you'll "
 "lose our privacy protection."
-msgstr "잠깐만요! 다시 변경하면 DuckDuckGo 확장 기능프로그램이 비활성화되어 개인정보 보호 기능을 사용할 수 없게 됩니다."
+msgstr ""
+"잠깐만요! 다시 변경하면 DuckDuckGo 확장 기능프로그램이 비활성화되어 개인정보 "
+"보호 기능을 사용할 수 없게 됩니다."
 
 # smartling.placeholder_format=C
 #. Heading shown above warning messages in the AI chat, for non-critical issues like unsupported file formats or file size limits. Analogous to 'Oops...' for error messages.
@@ -9122,7 +9503,9 @@ msgstr "더움"
 msgid ""
 "Hotel ad clicks are managed by Tripadvisor’s ad network and are not used to "
 "profile you."
-msgstr "호텔 광고 클릭은 Tripadvisor의 광고 네트워크에서 관리되며 사용자의 정보를 수집하는 데 사용되지 않습니다."
+msgstr ""
+"호텔 광고 클릭은 Tripadvisor의 광고 네트워크에서 관리되며 사용자의 정보를 수"
+"집하는 데 사용되지 않습니다."
 
 # smartling.placeholder_format=C
 #. Refers to hours of operation for a business.
@@ -9304,6 +9687,14 @@ msgid "I Agree"
 msgstr "동의합니다"
 
 # smartling.placeholder_format=C
+#. Text for the button that takes the user to the external DuckDuckGo login subscription page.
+msgctxt ""
+"Text for the I already have a subscription button in the Duck.ai settings "
+"page"
+msgid "I Already Have a Subscription"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for the button that takes the user to the login subscription page.
 msgctxt "Text for the I have a subscription button"
 msgid "I Have a Subscription"
@@ -9376,7 +9767,9 @@ msgctxt "Full sentence for recommending a book"
 msgid ""
 "I like the book Name of the Wind. What are some other good books/series most "
 "like it and why?"
-msgstr "바람의 이름이라는 책을 좋아합니다. 다른 재미있는 책/시리즈에는 무엇이 있으며, 그 이유는 무엇인가요?"
+msgstr ""
+"바람의 이름이라는 책을 좋아합니다. 다른 재미있는 책/시리즈에는 무엇이 있으"
+"며, 그 이유는 무엇인가요?"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the user needs more help or information on how to use the chat.
@@ -9410,7 +9803,9 @@ msgctxt "precise_user_location"
 msgid ""
 "If the browser location remains unavailable, then go to %sSettings > General "
 "> Reset > 'Reset Location & Privacy'%s."
-msgstr "여전히 브라우저 위치를 사용할 수 없는 경우 %1$s설정 > 일반 > 재설정 > 위치 및 개인정보 보호 재설정%2$s으로 이동하세요."
+msgstr ""
+"여전히 브라우저 위치를 사용할 수 없는 경우 %1$s설정 > 일반 > 재설정 > 위치 "
+"및 개인정보 보호 재설정%2$s으로 이동하세요."
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -9420,8 +9815,8 @@ msgid ""
 "> Menu > Settings > Site settings > Location%s, and ensure DuckDuckGo is "
 "allowed location access."
 msgstr ""
-"여전히 브라우저 위치를 사용할 수 없는 경우 브라우저에서 %1$s메뉴 > 설정 > 사이트 설정 > 위치%2$s로 이동하여 "
-"DuckDuckGo의 위치 접근을 허용하세요."
+"여전히 브라우저 위치를 사용할 수 없는 경우 브라우저에서 %1$s메뉴 > 설정 > 사"
+"이트 설정 > 위치%2$s로 이동하여 DuckDuckGo의 위치 접근을 허용하세요."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -9435,7 +9830,9 @@ msgstr "이 오류가 계속되면 %1$s에 문의하세요."
 msgid ""
 "If you don't see %sDuckDuckGo,%s you will need to add it to the list of "
 "%sOther Search Engines%s"
-msgstr "만약 %1$sDuckDuckGo%2$s가 보이지 않는다면 %3$s기타 검색 엔진%4$s 목록에 추가해야 합니다."
+msgstr ""
+"만약 %1$sDuckDuckGo%2$s가 보이지 않는다면 %3$s기타 검색 엔진%4$s 목록에 추가"
+"해야 합니다."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding the AI model providers and links to their support pages. Example: 'If you have concerns about our chat providers or any particular chat response, you can also reach out directly to OpenAI and Anthropic support pages.'
@@ -9443,7 +9840,9 @@ msgctxt "Disclaimer text at the bottom of the feedback form."
 msgid ""
 "If you have concerns about our chat providers or any particular chat "
 "response, you can also reach out directly to %s and %s support pages."
-msgstr "채팅 또는 특정 채팅 응답에 대해 우려되는 부분이 있으면 %1$s 및 %2$s 지원 페이지에 직접 문의하실 수도 있습니다."
+msgstr ""
+"채팅 또는 특정 채팅 응답에 대해 우려되는 부분이 있으면 %1$s 및 %2$s 지원 페이"
+"지에 직접 문의하실 수도 있습니다."
 
 # smartling.placeholder_format=C
 #. Body copy explaining what the recovery code is for and how it can be saved.
@@ -9451,13 +9850,17 @@ msgctxt "Body for the Sync & Backup recovery code screen"
 msgid ""
 "If you lose access to your devices, you will need this code to recover your "
 "saved chats. You can save this code to your device as a text file."
-msgstr "기기에 접근할 수 없게 되었을 때 저장된 채팅을 복구하려면 이 코드가 필요합니다. 이 코드를 기기에 텍스트 파일로 저장할 수 있습니다."
+msgstr ""
+"기기에 접근할 수 없게 되었을 때 저장된 채팅을 복구하려면 이 코드가 필요합니"
+"다. 이 코드를 기기에 텍스트 파일로 저장할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
-msgstr "저희를 계속 지원하고 싶으시다면, %1$sDuckDuckGo를 더 많은 사람들에게 소개해주세요%2$s"
+msgstr ""
+"저희를 계속 지원하고 싶으시다면, %1$sDuckDuckGo를 더 많은 사람들에게 소개해주"
+"세요%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -9466,7 +9869,8 @@ msgstr "저희를 계속 지원하고 싶으시다면, %1$sDuckDuckGo를 더 많
 msgid ""
 "If you want to use DuckDuckGo without JavaScript, please use our %s or %s "
 "versions."
-msgstr "JavaScript 없이 DuckDuckGo를 사용하려면 %1$s 또는 %2$s버전을 사용하세요."
+msgstr ""
+"JavaScript 없이 DuckDuckGo를 사용하려면 %1$s 또는 %2$s버전을 사용하세요."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -9614,8 +10018,8 @@ msgid ""
 "In some older browsers, it's necessary to redirect your clicks through our "
 "server to prevent search leakage. %sLearn more%s."
 msgstr ""
-"일부 이전 버전의 브라우저에서는 검색 결과 유출을 방지하기 위해 클릭한 정보가 서버를 통해 처리되도록 경로 변경이 필요합니다. "
-"%1$s자세히 알아보세요%2$s."
+"일부 이전 버전의 브라우저에서는 검색 결과 유출을 방지하기 위해 클릭한 정보가 "
+"서버를 통해 처리되도록 경로 변경이 필요합니다. %1$s자세히 알아보세요%2$s."
 
 # smartling.placeholder_format=C
 #. Instructions accompanying DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE; tells the user where to use the code on a DuckDuckGo browser.
@@ -9625,7 +10029,9 @@ msgctxt ""
 msgid ""
 "In the DuckDuckGo browser, go to Settings › Sync & Backup, and then “Sync "
 "with another device”."
-msgstr "DuckDuckGo 브라우저에서 설정 > Sync & Backup으로 이동한 다음 “다른 장치와 동기화”로 이동하세요."
+msgstr ""
+"DuckDuckGo 브라우저에서 설정 > Sync & Backup으로 이동한 다음 “다른 장치와 동"
+"기화”로 이동하세요."
 
 #  SeaMonkey default search engine instruction
 # smartling.placeholder_format=C
@@ -9639,7 +10045,9 @@ msgctxt "cloudsave"
 msgid ""
 "In the interest of transparency, this data is not encrypted: You can see "
 "exactly what information we store."
-msgstr "투명성을 위해 이 정보는 암호화되지 않으며, 저장된 정보는 전부 사용자에게 공개됩니다."
+msgstr ""
+"투명성을 위해 이 정보는 암호화되지 않으며, 저장된 정보는 전부 사용자에게 공개"
+"됩니다."
 
 # smartling.placeholder_format=C
 msgid "In the menu at the top select %sTools%s > %sSettings%s"
@@ -9855,6 +10263,12 @@ msgid "Install Mac Browser"
 msgstr "Mac 브라우저 설치"
 
 # smartling.placeholder_format=C
+#. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
+msgctxt "settings"
+msgid "Install Now"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of a button to install the DuckDuckGo app
 msgctxt "Serp footer content"
 msgid "Install Our App"
@@ -9952,10 +10366,42 @@ msgid "Is deleted data really deleted?"
 msgstr "데이터가 정말로 삭제되나요?"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is it worth taking?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this place any good?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"Is this place any good? Summarize its reputation based on reviews and "
+"ratings."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "Is this video helpful?"
 msgstr "이 영상이 유용했나요?"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this worth watching?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Is this worth watching? Give me a spoiler-free take."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -10006,8 +10452,9 @@ msgid ""
 "through Microsoft's Ad Network. Clicks lead directly to merchant landing "
 "pages and unlike ads, DuckDuckGo is not compensated for these results."
 msgstr ""
-"항목은 검색어와의 관련성에 따라 순위가 지정되며 Microsoft의 광고 네트워크를 통해 제공됩니다. 클릭하면 판매자 랜딩 페이지로 바로 "
-"연결되며, 광고와는 달리 DuckDuckGo는 이러한 결과에 대해 수익을 얻지 않습니다."
+"항목은 검색어와의 관련성에 따라 순위가 지정되며 Microsoft의 광고 네트워크를 "
+"통해 제공됩니다. 클릭하면 판매자 랜딩 페이지로 바로 연결되며, 광고와는 달리 "
+"DuckDuckGo는 이러한 결과에 대해 수익을 얻지 않습니다."
 
 # smartling.placeholder_format=C
 #. Text explaining why passphrases use a series of words instead of random numbers and letters.
@@ -10015,7 +10462,8 @@ msgctxt "cloudsave"
 msgid ""
 "It’s easier to remember 4-5 words than 10 random letters and numbers, and "
 "far more secure."
-msgstr "임의의 문자 및 숫자 10개보다 단어 4~5개를 기억하는 것이 훨씬 쉽고 안전합니다."
+msgstr ""
+"임의의 문자 및 숫자 10개보다 단어 4~5개를 기억하는 것이 훨씬 쉽고 안전합니다."
 
 # smartling.placeholder_format=C
 msgid "Ivory Coast"
@@ -10562,6 +11010,12 @@ msgid "Links:"
 msgstr "링크:"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "List the tools, materials, or prerequisites I need for this."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
 msgid "Listen"
 msgstr "듣기"
@@ -10968,6 +11422,12 @@ msgid "Manage blocked sites"
 msgstr "차단된 사이트 관리"
 
 # smartling.placeholder_format=C
+#. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
+msgctxt "setting"
+msgid "Manage in Browser Settings"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to the site exclusion settings page
 msgctxt "Organic result context menu"
 msgid "Manage sites you've blocked"
@@ -11190,7 +11650,8 @@ msgstr "미크로네시아"
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
 msgid ""
 "Microphone access was denied. Please allow microphone access and try again."
-msgstr "마이크 액세스가 거부되었습니다. 마이크 액세스를 허용하고 다시 시도하세요."
+msgstr ""
+"마이크 액세스가 거부되었습니다. 마이크 액세스를 허용하고 다시 시도하세요."
 
 # smartling.placeholder_format=C
 #. The Microsoft brand name.
@@ -11938,8 +12399,10 @@ msgid ""
 "internet connection. Disabling chat history will delete pinned chats, and "
 "disable the temporary storage of new prompts and responses."
 msgstr ""
-"사용자의 인터넷 연결이 끊겼을 때 채팅을 복원할 수 있도록, 전송된 새 프롬프트와 응답을 암호화하여 DuckDuckGo 서버에 임시로 "
-"저장합니다. 채팅 기록을 비활성화하면 고정된 채팅이 삭제되고, 새로운 프롬프트와 응답의 임시 저장이 중단됩니다."
+"사용자의 인터넷 연결이 끊겼을 때 채팅을 복원할 수 있도록, 전송된 새 프롬프트"
+"와 응답을 암호화하여 DuckDuckGo 서버에 임시로 저장합니다. 채팅 기록을 비활성"
+"화하면 고정된 채팅이 삭제되고, 새로운 프롬프트와 응답의 임시 저장이 중단됩니"
+"다."
 
 # smartling.placeholder_format=C
 #. Question in a feedback form.
@@ -12248,7 +12711,8 @@ msgstr "검색 결과가 없습니다."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the recording contains no audible speech.
 msgid "No speech detected. Please try again and speak into your microphone."
-msgstr "음성이 감지되지 않았습니다. 다시 시도해 주세요. 마이크에 대고 말씀해 주세요."
+msgstr ""
+"음성이 감지되지 않았습니다. 다시 시도해 주세요. 마이크에 대고 말씀해 주세요."
 
 # smartling.placeholder_format=C
 #. Button that dismisses a feedback form.
@@ -12754,7 +13218,9 @@ msgstr "요청 시"
 msgid ""
 "On Mac, %sClick Maxthon > Preferences%s, On Windows, %sClick the %s icon > "
 "Settings%s"
-msgstr "Mac에서는 %1$sMaxthon > 환경설정%2$s을 클릭하고, Windows%3$s에서는 %4$s아이콘 > 설정을 클릭하세요.%5$s"
+msgstr ""
+"Mac에서는 %1$sMaxthon > 환경설정%2$s을 클릭하고, Windows%3$s에서는 %4$s아이"
+"콘 > 설정을 클릭하세요.%5$s"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
@@ -12775,7 +13241,9 @@ msgctxt ""
 msgid ""
 "One of the files attached has more pages than we support. Please upload "
 "files with %s pages or fewer."
-msgstr "첨부된 파일 중 하나가 지원 가능한 페이지 수를 초과합니다. %1$s페이지 이하의 파일을 업로드하세요."
+msgstr ""
+"첨부된 파일 중 하나가 지원 가능한 페이지 수를 초과합니다. %1$s페이지 이하의 "
+"파일을 업로드하세요."
 
 # smartling.placeholder_format=C
 #. Response a user can select in a feedback form, indicating that they heard about DuckDuckGo in an online article.
@@ -12801,7 +13269,9 @@ msgctxt "cloudsave"
 msgid ""
 "Only the settings that you have changed. They are detailed on the %sURL "
 "Parameters%s page."
-msgstr "사용자가 변경한 설정만 저장됩니다. 자세한 내용은 %1$sURL 매개 변수%2$s 페이지를 참고하세요."
+msgstr ""
+"사용자가 변경한 설정만 저장됩니다. 자세한 내용은 %1$sURL 매개 변수%2$s 페이지"
+"를 참고하세요."
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers only when the user clicks the Assist button.
@@ -12815,7 +13285,8 @@ msgctxt "translations_module"
 msgid ""
 "Oops! An unexpected error occurred while translating this text. Please try "
 "again later."
-msgstr "이런! 번역 중 예기치 않은 오류가 발생했습니다. 나중에 다시 시도해 주세요."
+msgstr ""
+"이런! 번역 중 예기치 않은 오류가 발생했습니다. 나중에 다시 시도해 주세요."
 
 # smartling.placeholder_format=C
 #. Title shown in a fatal error modal when Duck.ai fails to load.
@@ -13131,7 +13602,9 @@ msgctxt "homepage onboarding"
 msgid ""
 "Other search engines track your searches even when you’re in private "
 "browsing mode. We don’t track you &mdash; period."
-msgstr "다른 검색 엔진은 시크릿 모드에서도 사용자를 추적하지만, DuckDuckGo는 절대로 추적하지 않습니다."
+msgstr ""
+"다른 검색 엔진은 시크릿 모드에서도 사용자를 추적하지만, DuckDuckGo는 절대로 "
+"추적하지 않습니다."
 
 # smartling.placeholder_format=C
 msgctxt "SERP footer content"
@@ -13143,7 +13616,9 @@ msgctxt "homepage onboarding"
 msgid ""
 "Our privacy policy is simple: we don’t collect or share any of your personal "
 "information."
-msgstr "DuckDuckGo의 개인정보 보호정책은 간단합니다. 어떠한 개인 정보도 수집하거나 공유하지 않습니다."
+msgstr ""
+"DuckDuckGo의 개인정보 보호정책은 간단합니다. 어떠한 개인 정보도 수집하거나 공"
+"유하지 않습니다."
 
 # smartling.placeholder_format=C
 msgid ""
@@ -13151,8 +13626,8 @@ msgid ""
 "tracker blocker, encryption enforcer, and more. Available on %siOS & "
 "Android%s."
 msgstr ""
-"DuckDuckGo 모바일용 비공개 브라우저에는 검색 엔진, 추적 차단, 암호화 보호 강화 등의 기능이 탑재되어 있습니다. %1$siOS "
-"및 Android%2$s에서 다운로드하세요."
+"DuckDuckGo 모바일용 비공개 브라우저에는 검색 엔진, 추적 차단, 암호화 보호 강"
+"화 등의 기능이 탑재되어 있습니다. %1$siOS 및 Android%2$s에서 다운로드하세요."
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the information was out of date.
@@ -13404,7 +13879,9 @@ msgctxt "cloudsave"
 msgid ""
 "Passphrases cannot be recovered as we don't associate your IP address, "
 "browser fingerprint, or any other information with the file."
-msgstr "해당 파일에는 사용자의 IP 주소, 브라우저 지문 또는 기타 정보가 연결되어 있지 않기 때문에 암호를 복구할 수 없습니다."
+msgstr ""
+"해당 파일에는 사용자의 IP 주소, 브라우저 지문 또는 기타 정보가 연결되어 있지 "
+"않기 때문에 암호를 복구할 수 없습니다."
 
 # smartling.placeholder_format=C
 #. Label for the section of recent chats that were edited in the past 7 days.
@@ -13598,8 +14075,9 @@ msgid ""
 "answers. To turn them off and hide the Assist button visit %sSearch "
 "Settings%s."
 msgstr ""
-"검색어를 완전한 문장 형태의 질문으로 작성하면 AI 지원 답변이 자동으로 나오고 답변 수준이 높아질 수 있습니다. 이 기능을 끄고 "
-"Assist 버튼을 숨기려면 %1$s검색 설정%2$s으로 들어가세요."
+"검색어를 완전한 문장 형태의 질문으로 작성하면 AI 지원 답변이 자동으로 나오고 "
+"답변 수준이 높아질 수 있습니다. 이 기능을 끄고 Assist 버튼을 숨기려면 %1$s검"
+"색 설정%2$s으로 들어가세요."
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -13608,8 +14086,9 @@ msgid ""
 "DuckAssist more likely to appear and often yields better answers. To adjust "
 "how this feature works, or to turn it off, visit %sDuckAssist Settings%s."
 msgstr ""
-"검색어를 완전한 문장 형태의 질문으로 작성하면 DuckAssist가 나타나고 더 뛰어난 답을 얻을 가능성이 높아집니다. "
-"%1$sDuckAssist 설정%2$s에서 이 기능을 끄거나 작동 방식을 조정할 수 있습니다."
+"검색어를 완전한 문장 형태의 질문으로 작성하면 DuckAssist가 나타나고 더 뛰어"
+"난 답을 얻을 가능성이 높아집니다. %1$sDuckAssist 설정%2$s에서 이 기능을 끄거"
+"나 작동 방식을 조정할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -13619,8 +14098,9 @@ msgid ""
 "answers. To turn it off and hide the Assist button visit %sDuckAssist "
 "Settings%s."
 msgstr ""
-"검색어를 완전한 문장 형태의 질문으로 작성하면, DuckAssist가 자동으로 나오고 더 좋은 답을 얻을 가능성이 높아집니다. 이 기능을 "
-"끄고 Assist 버튼을 감추려면 %1$sDuckAssist 설정%2$s을 방문하세요."
+"검색어를 완전한 문장 형태의 질문으로 작성하면, DuckAssist가 자동으로 나오고 "
+"더 좋은 답을 얻을 가능성이 높아집니다. 이 기능을 끄고 Assist 버튼을 감추려면 "
+"%1$sDuckAssist 설정%2$s을 방문하세요."
 
 # smartling.placeholder_format=C
 #. Button that allows users to manually select a location on a map.
@@ -13652,7 +14132,9 @@ msgctxt "Body copy for the chat card in the How Duck.ai Works panel"
 msgid ""
 "Pick a popular AI to chat with, like GPT-5 mini, Claude Haiku 4.5, Mistral, "
 "etc."
-msgstr "GPT-5 mini, Claude Haiku 4.5, Mistral 등 인기 있는 AI를 선택하여 대화를 나눠보세요."
+msgstr ""
+"GPT-5 mini, Claude Haiku 4.5, Mistral 등 인기 있는 AI를 선택하여 대화를 나눠"
+"보세요."
 
 # smartling.placeholder_format=C
 #. Describes the ability to choose from popular AI models. Pairs with a chat-bubble pictogram.
@@ -13660,7 +14142,9 @@ msgctxt "Body copy for the chat card in the How Duck.ai Works panel"
 msgid ""
 "Pick a popular AI to chat with, like GPT-5 mini, Claude Haiku 4.5, "
 "Mistral, etc."
-msgstr "GPT-5 mini, Claude Haiku 4.5, Mistral 등 인기 있는 AI를 선택하여 대화를 나눠보세요."
+msgstr ""
+"GPT-5 mini, Claude Haiku 4.5, Mistral 등 인기 있는 AI를 선택하여 대화를 나눠"
+"보세요."
 
 # smartling.placeholder_format=C
 #. The description of the third party map app picker, shown on iOS when a user is given an option of which app to navigate to a destination with
@@ -13668,7 +14152,9 @@ msgctxt "Third party map app picker"
 msgid ""
 "Pick a service to navigate to your destination. External apps won’t come "
 "with DuckDuckGo protections."
-msgstr "목적지로 가능 방법을 확인할 서비스를 선택하세요. 외부 앱에서는 DuckDuckGo 보호 기능이 제공되지 않습니다."
+msgstr ""
+"목적지로 가능 방법을 확인할 서비스를 선택하세요. 외부 앱에서는 DuckDuckGo 보"
+"호 기능이 제공되지 않습니다."
 
 # smartling.placeholder_format=C
 #. Label for a list of problems on a feedback form.
@@ -13763,6 +14249,12 @@ msgstr "사람이 검색한 것임을 확인할 수 있도록 다음 과제를  
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
+msgid "Please describe why the chat response is harmful or illegal. (optional)"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
+msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
 msgstr "채팅 응답이 불법적이거나 유해한 이유를 설명해 주세요. (선택 사항)"
 
@@ -13791,8 +14283,18 @@ msgstr "참고: 어떤 모델과든 새 채팅을 시작하면 현재의 채팅 
 msgctxt "Feedback prompt"
 msgid ""
 "Please paste your prompt and the problematic output (with any personal "
+"information removed) and describe why the content is harmful or illegal."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
+msgctxt "Feedback prompt"
+msgid ""
+"Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is illegal or harmful."
-msgstr "해당 프롬프트와 문제가 있는 산출물(개인 정보 제거)을 붙여 넣고, 콘텐츠가 불법이거나 해로운 이유를 설명해 주세요."
+msgstr ""
+"해당 프롬프트와 문제가 있는 산출물(개인 정보 제거)을 붙여 넣고, 콘텐츠가 불법"
+"이거나 해로운 이유를 설명해 주세요."
 
 # smartling.placeholder_format=C
 #. Title on a feedback form.
@@ -13944,7 +14446,9 @@ msgstr "DuckDuckGo를 구독하면 더 많은 프리미엄 기능들도 따라�
 msgid ""
 "Plus, what you watch in Duck Player won’t influence your recommendations on "
 "YouTube."
-msgstr "또한 Duck Player에서 시청하는 콘텐츠는 YouTube의 추천에 영향을 미치지 않습니다."
+msgstr ""
+"또한 Duck Player에서 시청하는 콘텐츠는 YouTube의 추천에 영향을 미치지 않습니"
+"다."
 
 # smartling.placeholder_format=C
 #. A link to the Substack page (https://insideduckduckgo.substack.com/?showWelcome=true)
@@ -14250,6 +14754,12 @@ msgid "Privacy"
 msgstr "개인정보 보호"
 
 # smartling.placeholder_format=C
+#. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
+msgctxt "Section heading on the Duck.ai settings page"
+msgid "Privacy & Terms"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Privacy Blog"
 msgstr "개인정보 보호 블로그"
 
@@ -14318,6 +14828,12 @@ msgstr "개인정보 보호정책 & 이용 약관"
 msgctxt "Copy used to compose link in sentences"
 msgid "Privacy Policy and Terms of Service"
 msgstr "개인정보 보호정책 및 서비스 약관"
+
+# smartling.placeholder_format=C
+#. Text for a button that links to the terms of use and privacy policy page.
+msgctxt "Secondary button text in active privacy modal"
+msgid "Privacy Policy and Terms of Service"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title displayed on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
@@ -14419,7 +14935,8 @@ msgstr "DuckDuckGo는 절대 저장하지 않는 비공개 채팅"
 #. The device location shared is is not logged by us
 msgctxt "precise_user_location"
 msgid "Private to us and secured on your device"
-msgstr "DuckDuckGo에는 정보가 기록되지 않고 사용자의 기기에서 보안이 유지됩니다."
+msgstr ""
+"DuckDuckGo에는 정보가 기록되지 않고 사용자의 기기에서 보안이 유지됩니다."
 
 # smartling.placeholder_format=C
 #. Heading above the group of Pro-tier locked models in the model picker dropdown, when the user is on the Plus tier.
@@ -14491,7 +15008,9 @@ msgstr "재생하기 전에 물어보기"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Prompt me to use my approximate location to get nearby results."
-msgstr "내 대략적인 위치를 사용하여 주변 결과를 표시하라는 메시지가 표시되도록 합니다."
+msgstr ""
+"내 대략적인 위치를 사용하여 주변 결과를 표시하라는 메시지가 표시되도록 합니"
+"다."
 
 # smartling.placeholder_format=C
 #. DuckDuckGo Email Protection removes trackers from emails
@@ -14509,7 +15028,8 @@ msgstr "검색과 인터넷 이용 과정에서 데이터를 보호하세요."
 #. Shown on the Mac and Windows browser promo cards. DuckDuckGo's desktop browser protects your data across search, browsing, and AI chat.
 msgctxt "SERP footer content"
 msgid "Protect your data as you search, browse, and use AI."
-msgstr "검색하고, 인터넷을 이용하고 AI를 사용하는 과정에서 데이터를 보호하세요."
+msgstr ""
+"검색하고, 인터넷을 이용하고 AI를 사용하는 과정에서 데이터를 보호하세요."
 
 # smartling.placeholder_format=C
 #. A title above links to download the DuckDuckGo apps.
@@ -14533,7 +15053,9 @@ msgctxt "Full sentence for critiquing writing"
 msgid ""
 "Provide a few suggestions to make the following text more concise. [Insert "
 "your own text here.]"
-msgstr "다음 글을 더 간결하게 정리하기 위한 제안을 몇 가지 해주세요. [여기에 바로 입력]"
+msgstr ""
+"다음 글을 더 간결하게 정리하기 위한 제안을 몇 가지 해주세요. [여기에 바로 입"
+"력]"
 
 # smartling.placeholder_format=C
 #. In the context of a standings table for NHL (hockey), column title that abbreviates 'Total Points' (the total points of this team)
@@ -14769,7 +15291,9 @@ msgctxt "Description for recent chats feature"
 msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
-msgstr "최근 채팅은 DuckDuckGo 서버나 다른 원격 서버가 아닌 사용자의 기기 자체에 저장됩니다."
+msgstr ""
+"최근 채팅은 DuckDuckGo 서버나 다른 원격 서버가 아닌 사용자의 기기 자체에 저장"
+"됩니다."
 
 # smartling.placeholder_format=C
 #. Text explaining that recent chats are stored locally on the user's device.
@@ -14777,7 +15301,9 @@ msgctxt "Description of where recent chats are stored"
 msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
-msgstr "최근 채팅은 DuckDuckGo 서버나 다른 원격 서버가 아닌 사용자의 기기 자체에 저장됩니다."
+msgstr ""
+"최근 채팅은 DuckDuckGo 서버나 다른 원격 서버가 아닌 사용자의 기기 자체에 저장"
+"됩니다."
 
 # smartling.placeholder_format=C
 #. Text explaining how recent chats are stored locally on the user's device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection.
@@ -14787,8 +15313,9 @@ msgid ""
 "are encrypted and temporarily stored on a DuckDuckGo server after being "
 "sent, to help recover a chat if you lose your internet connection."
 msgstr ""
-"최근 채팅은 사용자의 기기에 직접 저장됩니다. 사용자의 인터넷 연결이 끊겼을 때 채팅을 복원할 수 있도록, 전송된 새 프롬프트와 응답을 "
-"암호화하여 DuckDuckGo 서버에 임시로 저장합니다."
+"최근 채팅은 사용자의 기기에 직접 저장됩니다. 사용자의 인터넷 연결이 끊겼을 "
+"때 채팅을 복원할 수 있도록, 전송된 새 프롬프트와 응답을 암호화하여 "
+"DuckDuckGo 서버에 임시로 저장합니다."
 
 # smartling.placeholder_format=C
 msgctxt "region filter"
@@ -14810,6 +15337,30 @@ msgstr "%1$s%2$s%3$s 레시피"
 msgctxt "Brief for recommending a book"
 msgid "Recommend a book"
 msgstr "책 추천"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar books"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar books."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar movies or shows."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar titles"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
@@ -15021,7 +15572,9 @@ msgstr "Duck.ai를 다시 불러오기"
 msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
-msgstr "안내된 방법을 따르거나 브라우저에서 '새로고침' 또는 'Reload' 버튼을 눌러 DuckDuckGo를 새로고침하세요."
+msgstr ""
+"안내된 방법을 따르거나 브라우저에서 '새로고침' 또는 'Reload' 버튼을 눌러 "
+"DuckDuckGo를 새로고침하세요."
 
 # smartling.placeholder_format=C
 #. checkbox label that allows the user to save the setting
@@ -15110,14 +15663,18 @@ msgctxt "settings"
 msgid ""
 "Removes the \"Ask\" button so answers appear automatically in response to "
 "relevant searches. Cached answers always display automatically."
-msgstr "'Ask' 버튼을 제거하면 관련 검색 시 답변이 자동으로 표시됩니다. 캐시된 답변이 항상 자동으로 표시됩니다."
+msgstr ""
+"'Ask' 버튼을 제거하면 관련 검색 시 답변이 자동으로 표시됩니다. 캐시된 답변이 "
+"항상 자동으로 표시됩니다."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Removes the \"Generate\" button so answers appear automatically in response "
 "to relevant searches. Cached answers always display automatically."
-msgstr "'생성' 버튼을 제거하면 관련 검색 시 답변이 자동으로 표시됩니다. 캐시된 답변이 항상 자동으로 표시됩니다."
+msgstr ""
+"'생성' 버튼을 제거하면 관련 검색 시 답변이 자동으로 표시됩니다. 캐시된 답변"
+"이 항상 자동으로 표시됩니다."
 
 # smartling.placeholder_format=C
 #. Text for a button to rename a chat, as in it will allow the user to change the title of the chat.
@@ -15175,15 +15732,18 @@ msgid ""
 "service. Your anonymous feedback is also shared with %s to help improve "
 "their services."
 msgstr ""
-"보고서는 익명으로 제공되며, 검색 서비스 향상을 위해 DuckDuckGo로 전송됩니다. 사용자님이 익명으로 보내주신 의견은 %1$s "
-"사에도 서비스 개선을 위해 제공됩니다."
+"보고서는 익명으로 제공되며, 검색 서비스 향상을 위해 DuckDuckGo로 전송됩니다. "
+"사용자님이 익명으로 보내주신 의견은 %1$s 사에도 서비스 개선을 위해 제공됩니"
+"다."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "Reports sent to DuckDuckGo are anonymous. Please do not include any personal "
 "or identifying information in your feedback."
-msgstr "DuckDuckGo로 전송되는 보고서는 익명입니다. 피드백에 개인 정보나 식별 정보를 기재하지 마세요."
+msgstr ""
+"DuckDuckGo로 전송되는 보고서는 익명입니다. 피드백에 개인 정보나 식별 정보를 "
+"기재하지 마세요."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -15192,12 +15752,22 @@ msgid ""
 "translate during this page load, and are anonymous. Please do not include "
 "any personal or identifying information in your feedback."
 msgstr ""
-"DuckDuckGo로 전송되는 보고서에는 사용자가 이 페이지를 불러오는 중 번역하도록 요청하는 모든 텍스트가 들어있으며, 이 텍스트는 "
-"익명 상태입니다. 피드백에 개인 정보나 식별 정보를 기재하지 마세요."
+"DuckDuckGo로 전송되는 보고서에는 사용자가 이 페이지를 불러오는 중 번역하도록 "
+"요청하는 모든 텍스트가 들어있으며, 이 텍스트는 익명 상태입니다. 피드백에 개"
+"인 정보나 식별 정보를 기재하지 마세요."
 
 # smartling.placeholder_format=C
 msgid "Republic of Moldova"
 msgstr "몰도바 공화국"
+
+# smartling.placeholder_format=C
+#. Note indicating that sharing the conversation is mandatory when reporting harmful or illegal content. Rendered alongside the standard share label (DUCKCHAT_RESPONSE_FEEDBACK_SHARE_PROMPT_RESPONSE_LABEL), not replacing it.
+msgctxt ""
+"Note shown under the share-content switch label on the Duck.ai response "
+"feedback form when the user has selected Harmful or Illegal as the feedback "
+"reason"
+msgid "Required for harmful or illegal reports"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
@@ -15264,8 +15834,9 @@ msgid ""
 "legal, financial, investment, or other professional advice. AI-assisted "
 "answers are subject to our %sTerms of Service%s."
 msgstr ""
-"응답은 교육 목적으로만 제공되며 의학적, 법률적, 금융적, 투자, 그 밖의 전문적인 조언을 제공하기 위한 것이 아닙니다. AI 지원 "
-"답변에는 %1$s서비스 약관%2$s이 적용됩니다."
+"응답은 교육 목적으로만 제공되며 의학적, 법률적, 금융적, 투자, 그 밖의 전문적"
+"인 조언을 제공하기 위한 것이 아닙니다. AI 지원 답변에는 %1$s서비스 약관%2$s"
+"이 적용됩니다."
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -15274,8 +15845,9 @@ msgid ""
 "legal, financial, investment, or other professional advice. DuckAssist is "
 "subject to our %sTerms of Service%s."
 msgstr ""
-"응답은 교육 목적으로만 제공되며 의학적, 법률적, 금융적, 투자, 그 밖의 전문적인 조언을 제공하기 위한 것이 아닙니다. "
-"DuckAssist에는 %1$s서비스 약관%2$s이 적용됩니다."
+"응답은 교육 목적으로만 제공되며 의학적, 법률적, 금융적, 투자, 그 밖의 전문적"
+"인 조언을 제공하기 위한 것이 아닙니다. DuckAssist에는 %1$s서비스 약관%2$s이 "
+"적용됩니다."
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -15285,8 +15857,10 @@ msgid ""
 "generated based on web content and may contain inaccuracies. Search Assist "
 "is subject to our %sTerms of Service%s."
 msgstr ""
-"응답은 교육 목적으로만 제공되며 의학적, 법률적, 금융적, 투자, 그 밖의 전문적인 조언을 제공하기 위한 것이 아닙니다. 웹 콘텐츠를 "
-"바탕으로 자동 생성된 응답이며 부정확한 내용이 섞여있을 수 있습니다. Search Assist에는 %1$s서비스 약관%2$s이 적용됩니다."
+"응답은 교육 목적으로만 제공되며 의학적, 법률적, 금융적, 투자, 그 밖의 전문적"
+"인 조언을 제공하기 위한 것이 아닙니다. 웹 콘텐츠를 바탕으로 자동 생성된 응답"
+"이며 부정확한 내용이 섞여있을 수 있습니다. Search Assist에는 %1$s서비스 약"
+"관%2$s이 적용됩니다."
 
 # smartling.placeholder_format=C
 #. Label on the button for restoring all previous website data.
@@ -15428,6 +16002,12 @@ msgstr "리뷰"
 msgctxt "maps_places"
 msgid "Reviews"
 msgstr "리뷰"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Rewrite this recipe scaled for a different number of servings."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Romania"
@@ -15698,7 +16278,9 @@ msgctxt "Description for Chat History feature with Encrypted Storage option"
 msgid ""
 "Save up to 30 of your most recent chats locally on your device, with the "
 "option for more with Encrypted Storage."
-msgstr "최근 채팅을 30개까지 기기에 로컬로 저장하며, 암호화된 저장소를 사용하면 더 많이 저장할 수도 있습니다."
+msgstr ""
+"최근 채팅을 30개까지 기기에 로컬로 저장하며, 암호화된 저장소를 사용하면 더 많"
+"이 저장할 수도 있습니다."
 
 # smartling.placeholder_format=C
 #. Short text for native DDG browser users explaining how Chat History stores up to 30 of their most recent chats locally on their device.
@@ -15840,7 +16422,9 @@ msgstr "아래로 스크롤하여 %1$s고급 설정 보기%2$s를 클릭하세�
 msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)"
-msgstr "아래로 스크롤하여 %1$s주소 표시줄에서 검색%2$s을 찾으세요. 그리고 %3$s변경%4$s(또는 %5$s새로 추가%6$s)을 클릭하세요."
+msgstr ""
+"아래로 스크롤하여 %1$s주소 표시줄에서 검색%2$s을 찾으세요. 그리고 %3$s변"
+"경%4$s(또는 %5$s새로 추가%6$s)을 클릭하세요."
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
@@ -15848,7 +16432,9 @@ msgstr "아래로 스크롤하여 %1$s주소 표시줄에서 검색%2$s을 찾�
 msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)."
-msgstr "아래로 스크롤하여 %1$s주소 표시줄에서 검색%2$s을 찾은 후 %3$s변경%4$s(또는 %5$s새로 추가%6$s)을 클릭하세요."
+msgstr ""
+"아래로 스크롤하여 %1$s주소 표시줄에서 검색%2$s을 찾은 후 %3$s변경%4$s(또는 "
+"%5$s새로 추가%6$s)을 클릭하세요."
 
 # smartling.placeholder_format=C
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -15872,7 +16458,9 @@ msgstr "%1$sDuckDuckGo%2$s로 스크롤하여 사용자의 위치를 사용하�
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down to the %sServices%s section and click %sAddress bar%s."
-msgstr "아래로 스크롤하여 %1$s서비스%2$s 섹션으로 이동한 후 %3$s주소 표시줄%4$s을 클릭하세요."
+msgstr ""
+"아래로 스크롤하여 %1$s서비스%2$s 섹션으로 이동한 후 %3$s주소 표시줄%4$s을 클"
+"릭하세요."
 
 # smartling.placeholder_format=C
 #. Rugby match stats
@@ -15920,10 +16508,12 @@ msgid ""
 "(on a wide range of searches). For now, Search Assist is only available in a "
 "subset of English speaking regions."
 msgstr ""
-"Search Assist는 검색 질의에 익명으로 답변을 생성하며, 이를 위해 웹에서 관련 콘텐츠를 검색한 다음 AI를 사용하여 간단한 "
-"답변을 생성합니다. 답변 표시 빈도는 사용자가 직접 선택할 수 있습니다. 안 함, 요청 시(검색 결과에서 Assist를 클릭했을 때만), "
-"가끔(관련성이 높은 경우에만 표시), 자주(검색 결과가 광범위할 때 표시) 중 선택하세요. 현재 Search Assist는 영어를 "
-"사용하는 일부 지역에만 제공됩니다."
+"Search Assist는 검색 질의에 익명으로 답변을 생성하며, 이를 위해 웹에서 관련 "
+"콘텐츠를 검색한 다음 AI를 사용하여 간단한 답변을 생성합니다. 답변 표시 빈도"
+"는 사용자가 직접 선택할 수 있습니다. 안 함, 요청 시(검색 결과에서 Assist를 클"
+"릭했을 때만), 가끔(관련성이 높은 경우에만 표시), 자주(검색 결과가 광범위할 "
+"때 표시) 중 선택하세요. 현재 Search Assist는 영어를 사용하는 일부 지역에만 제"
+"공됩니다."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI) when the answer is not found and the answer is unsourced or with no sources
@@ -15931,8 +16521,8 @@ msgid ""
 "Search Assist couldn't find enough reliable information to generate an "
 "answer for this question. Try another search."
 msgstr ""
-"Search Assist가 이 질문에 대한 답변을 생성하기에 위해 신뢰할 수 있는 정보를 충분히 찾지 못했습니다. 다른 검색을 시도해 "
-"보세요."
+"Search Assist가 이 질문에 대한 답변을 생성하기에 위해 신뢰할 수 있는 정보를 "
+"충분히 찾지 못했습니다. 다른 검색을 시도해 보세요."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -15941,8 +16531,9 @@ msgid ""
 "search queries. To do this, it %sscans the web%s for relevant content and "
 "then uses AI to generate a brief answer based on information found."
 msgstr ""
-"Search Assist는 검색 질의에 대해 익명으로 답변을 생성하는 옵션 기능이며, 이를 위해 %1$s웹에서 관련 콘텐츠를 스캔%2$s "
-"한 다음 AI를 사용하여 찾은 정보를 기반으로 간단한 답변을 생성합니다."
+"Search Assist는 검색 질의에 대해 익명으로 답변을 생성하는 옵션 기능이며, 이"
+"를 위해 %1$s웹에서 관련 콘텐츠를 스캔%2$s 한 다음 AI를 사용하여 찾은 정보를 "
+"기반으로 간단한 답변을 생성합니다."
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/search_box. top header
@@ -16063,8 +16654,8 @@ msgid ""
 "Search other sites with %s shortcuts: a search for ”!w ducks” will search "
 "for “ducks” directly on Wikipedia."
 msgstr ""
-"다른 사이트에서 검색할 때 %1$s 단축 키를 사용하세요. '!w ducks'라고 입력하면 위키피디아에서 바로 'ducks'를 바로 "
-"검색합니다."
+"다른 사이트에서 검색할 때 %1$s 단축 키를 사용하세요. '!w ducks'라고 입력하면 "
+"위키피디아에서 바로 'ducks'를 바로 검색합니다."
 
 # smartling.placeholder_format=C
 #. Placeholder text for the search form when no text has been entered
@@ -16083,15 +16674,18 @@ msgid ""
 "Search privately with our app or extension, add private web search to your "
 "favorite browser, or search directly at %sduckduckgo.com%s."
 msgstr ""
-"DuckDuckGo 앱 또는 확장 프로그램을 사용하여 비공개로 검색하거나, 자주 사용하는 브라우저에 비공개 웹 검색 기능을 설치하거나, "
-"%1$sduckduckgo.com%2$s에서 바로 검색하세요."
+"DuckDuckGo 앱 또는 확장 프로그램을 사용하여 비공개로 검색하거나, 자주 사용하"
+"는 브라우저에 비공개 웹 검색 기능을 설치하거나, %1$sduckduckgo.com%2$s에서 바"
+"로 검색하세요."
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/6LZAoqH.png
 msgctxt "settings"
 msgid ""
 "Search queries are included in URL (if off, searches will use POST requests)"
-msgstr "검색 쿼리가 URL에 포함됩니다('꺼짐'으로 설정된 경우 검색 시 POST 요청을 사용합니다)."
+msgstr ""
+"검색 쿼리가 URL에 포함됩니다('꺼짐'으로 설정된 경우 검색 시 POST 요청을 사용"
+"합니다)."
 
 # smartling.placeholder_format=C
 #. Describes how cookies are used to store user settings privately and securely.
@@ -16103,9 +16697,10 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"검색 설정은 비개인 브라우저 쿠키와 사용자의 브라우저 안에 있는 로컬 공간에 저장됩니다. 하지만 Cloud Save를 사용하여 클라우드 "
-"원격 서버에 설정을 익명으로 저장할 수도 있습니다. 클라우드에는 사용자의 개인 신원 정보가 저장되지 않으며, 암호가 브라우저 밖으로 "
-"유출되지 않습니다."
+"검색 설정은 비개인 브라우저 쿠키와 사용자의 브라우저 안에 있는 로컬 공간에 저"
+"장됩니다. 하지만 Cloud Save를 사용하여 클라우드 원격 서버에 설정을 익명으로 "
+"저장할 수도 있습니다. 클라우드에는 사용자의 개인 신원 정보가 저장되지 않으"
+"며, 암호가 브라우저 밖으로 유출되지 않습니다."
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -16201,7 +16796,9 @@ msgctxt "Description explaining how native users can enable sync"
 msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
-msgstr "종단간 암호화를 사용해 무제한에 가까운 채팅을 Duck.ai 서버에 안전하게 저장하고 모든 기기에 접근할 수 있습니다."
+msgstr ""
+"종단간 암호화를 사용해 무제한에 가까운 채팅을 Duck.ai 서버에 안전하게 저장하"
+"고 모든 기기에 접근할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Text explaining that the Encrypted Storage feature stores the user's chats encrypted on their device.
@@ -16209,7 +16806,9 @@ msgctxt "Description for encrypted storage feature"
 msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
-msgstr "종단간 암호화를 사용해 무제한에 가까운 채팅을 Duck.ai 서버에 안전하게 저장하고 모든 기기에 접근할 수 있습니다."
+msgstr ""
+"종단간 암호화를 사용해 무제한에 가까운 채팅을 Duck.ai 서버에 안전하게 저장하"
+"고 모든 기기에 접근할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -16217,7 +16816,9 @@ msgctxt "Description explaining how native users can enable sync"
 msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your synced devices."
-msgstr "종단간 암호화를 사용해 무제한에 가까운 채팅을 Duck.ai 서버에 안전하게 저장하고 모든 동기화된 기기에 접근할 수 있습니다."
+msgstr ""
+"종단간 암호화를 사용해 무제한에 가까운 채팅을 Duck.ai 서버에 안전하게 저장하"
+"고 모든 동기화된 기기에 접근할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -16225,7 +16826,9 @@ msgctxt "Description explaining how native users can enable sync"
 msgid ""
 "Securely store your chats on our server using end-to-end encryption, and "
 "access them from all your devices."
-msgstr "종단간 암호화를 사용해 사용자의 채팅을 Duck.ai 서버에 안전하게 저장하고 모든 기기에 접근할 수 있습니다."
+msgstr ""
+"종단간 암호화를 사용해 사용자의 채팅을 Duck.ai 서버에 안전하게 저장하고 모든 "
+"기기에 접근할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
@@ -16239,7 +16842,9 @@ msgctxt "Chat history with sync modal list item"
 msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
-msgstr "DuckDuckGo 서버에 안전하게 저장되며, 종단간 암호화가 적용됩니다. 회원님의 데이터는 본인 외에 누구도 볼 수 없습니다."
+msgstr ""
+"DuckDuckGo 서버에 안전하게 저장되며, 종단간 암호화가 적용됩니다. 회원님의 데"
+"이터는 본인 외에 누구도 볼 수 없습니다."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -16383,7 +16988,9 @@ msgstr "Safari 메뉴에서 %1$s'이 웹사이트의 설정'%2$s을 선택하세
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
-msgstr "%1$s사용자 지정%2$s을 선택하고 입력 창에 %3$shttps://duckduckgo.com%4$s를 입력하세요."
+msgstr ""
+"%1$s사용자 지정%2$s을 선택하고 입력 창에 %3$shttps://duckduckgo.com%4$s를 입"
+"력하세요."
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
@@ -16447,14 +17054,18 @@ msgstr "드롭다운 메뉴에서 %1$s추가 기능 관리%2$s를 선택하세�
 #. Tells users where in the settings menu they can change their default search engine.
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sMenu > Settings%s (on Windows)"
-msgstr "Mac에서는 %1$sOpera > 환경설정%2$s을 선택하고, Windows에서는 %3$s메뉴 > 설정%4$s을 선택하세요."
+msgstr ""
+"Mac에서는 %1$sOpera > 환경설정%2$s을 선택하고, Windows에서는 %3$s메뉴 > 설"
+"정%4$s을 선택하세요."
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sOpera > Options%s (on Windows)"
-msgstr "Mac에서는 %1$sOpera > 환경설정%2$s을 선택하고, Windows에서는 %3$sOpera > 옵션%4$s을 선택하세요."
+msgstr ""
+"Mac에서는 %1$sOpera > 환경설정%2$s을 선택하고, Windows에서는 %3$sOpera > 옵"
+"션%4$s을 선택하세요."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -16518,7 +17129,8 @@ msgstr "%1$s설정%2$s을 선택한 다음 %3$s검색 엔진%4$s을 선택하세
 msgid ""
 "Select %sUse this webpage as your only home page%s (or one of the other "
 "options if you prefer)"
-msgstr "%1$s이 웹페이지를 홈 화면으로 사용%2$s을 선택하세요(다른 옵션도 선택 가능)."
+msgstr ""
+"%1$s이 웹페이지를 홈 화면으로 사용%2$s을 선택하세요(다른 옵션도 선택 가능)."
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
@@ -16639,7 +17251,9 @@ msgid ""
 "Sends a prompt to AI models with your messages with instructions on how to "
 "respond. These instructions will apply to all of your conversations going "
 "forward."
-msgstr "AI 모델에 메시지와 응답 방법에 대한 지침을 프롬프트로 보냅니다. 이 지침은 앞으로 나와 나누는 모든 대화에 적용됩니다."
+msgstr ""
+"AI 모델에 메시지와 응답 방법에 대한 지침을 프롬프트로 보냅니다. 이 지침은 앞"
+"으로 나와 나누는 모든 대화에 적용됩니다."
 
 # smartling.placeholder_format=C
 msgid "Senegal"
@@ -16715,6 +17329,12 @@ msgid "Set Up Now"
 msgstr "지금 설치"
 
 # smartling.placeholder_format=C
+#. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
+msgctxt "Encrypted storage setup button shown in native browsers"
+msgid "Set Up Sync & Backup"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
 msgctxt "Title for the Sync & Backup intro screen"
 msgid "Set Up Sync & Backup"
@@ -16742,7 +17362,9 @@ msgctxt "Chat history about modal list item"
 msgid ""
 "Set up Sync & Backup after turning on Chat History to keep your chats synced "
 "across devices."
-msgstr "채팅 기록을 켜고 Sync & Backup을 설정하여 기기 간 채팅을 동기화된 상태로 유지하세요."
+msgstr ""
+"채팅 기록을 켜고 Sync & Backup을 설정하여 기기 간 채팅을 동기화된 상태로 유지"
+"하세요."
 
 # smartling.placeholder_format=C
 #. Prompt for the user to indicate their location on a map, to enable more relevant search results.
@@ -16802,7 +17424,9 @@ msgstr "공유"
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "Share DuckDuckGo and help friends take their privacy back!"
-msgstr "DuckDuckGo를 더 많은 친구들에게 알려서 개인정보를 보호할 수 있도록 도와주세요!"
+msgstr ""
+"DuckDuckGo를 더 많은 친구들에게 알려서 개인정보를 보호할 수 있도록 도와주세"
+"요!"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button that opens a feedback modal when clicked.
@@ -16829,8 +17453,8 @@ msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
 msgstr ""
-"관련성을 높이기 위해, 어느 도시에 있는지 AI 모델에 알려주세요. Duck.ai는 사용자의 정확한 위치를 우리에게나 AI 모델에게나 "
-"절대 공개하지 않습니다."
+"관련성을 높이기 위해, 어느 도시에 있는지 AI 모델에 알려주세요. Duck.ai는 사용"
+"자의 정확한 위치를 우리에게나 AI 모델에게나 절대 공개하지 않습니다."
 
 # smartling.placeholder_format=C
 #. Menu option to share feedback about a result
@@ -16891,6 +17515,13 @@ msgid "Share positive feedback"
 msgstr "긍정적인 피드백 공유"
 
 # smartling.placeholder_format=C
+#. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
+msgctxt ""
+"Label beside the share-content switch on the Duck.ai response feedback form"
+msgid "Share this conversation with DuckDuckGo"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
 msgctxt ""
 "Label beside the share-content switch on the Duck.ai response feedback form"
@@ -16905,7 +17536,8 @@ msgctxt ""
 msgid ""
 "Share your prompt and chat response with DuckDuckGo (required for illegal "
 "and harmful report)"
-msgstr "DuckDuckGo에 프롬프트 및 채팅 응답 공유하기(불법적이고 유해한 신고에 필요)"
+msgstr ""
+"DuckDuckGo에 프롬프트 및 채팅 응답 공유하기(불법적이고 유해한 신고에 필요)"
 
 # smartling.placeholder_format=C
 #. An invitation for users to leave feedback
@@ -17251,15 +17883,17 @@ msgid ""
 "Shows a reminder that searches on DuckDuckGo are always private. Turning "
 "this off hides the reminder and never affects search privacy."
 msgstr ""
-"DuckDuckGo의 모든 검색은 항상 비공개라는 알림을 표시합니다. 이 기능을 끄면 알림을 숨기며 검색 개인정보에는 영향을 주지 "
-"않습니다."
+"DuckDuckGo의 모든 검색은 항상 비공개라는 알림을 표시합니다. 이 기능을 끄면 알"
+"림을 숨기며 검색 개인정보에는 영향을 주지 않습니다."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Shows a reminder that searches on DuckDuckGo are always protected. Turning "
 "this off hides the reminder and never affects search protection."
-msgstr "DuckDuckGo의 검색은 항상 보호 받는다는 알림을 표시합니다. 이 기능을 끄면 알림만 감춰지고, 검색 보호에는 영향이 가지 않습니다."
+msgstr ""
+"DuckDuckGo의 검색은 항상 보호 받는다는 알림을 표시합니다. 이 기능을 끄면 알림"
+"만 감춰지고, 검색 보호에는 영향이 가지 않습니다."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -17404,7 +18038,8 @@ msgstr "사이트 이름"
 #. A message saying that site filters are not currently working
 msgctxt "Site filter message"
 msgid "Site search is temporarily unavailable. We are working on a fix."
-msgstr "사이트 검색을 일시적으로 사용할 수 없습니다. 현재 문제를 해결하고 있습니다."
+msgstr ""
+"사이트 검색을 일시적으로 사용할 수 없습니다. 현재 문제를 해결하고 있습니다."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -17616,7 +18251,8 @@ msgctxt "Error message when an uploaded image cannot be decoded or processed"
 msgid ""
 "Sorry, the uploaded image couldn't be processed. Please try a different "
 "image or format."
-msgstr "업로드하신 이미지를 처리할 수 없습니다. 다른 이미지나 형식을 사용해 보세요."
+msgstr ""
+"업로드하신 이미지를 처리할 수 없습니다. 다른 이미지나 형식을 사용해 보세요."
 
 # smartling.placeholder_format=C
 #. Body copy shown when a scanned or pasted pairing payload fails schema validation.
@@ -17624,7 +18260,9 @@ msgctxt "Description for the wrong code error screen"
 msgid ""
 "Sorry, this code is invalid. Please make sure the correct code was entered "
 "or scanned."
-msgstr "죄송합니다. 이 코드는 유효하지 않습니다. 코드를 정확하게 입력했거나 스캔했는지 확인하세요."
+msgstr ""
+"죄송합니다. 이 코드는 유효하지 않습니다. 코드를 정확하게 입력했거나 스캔했는"
+"지 확인하세요."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -17638,7 +18276,9 @@ msgctxt "noresults"
 msgid ""
 "Sorry, we ran into an error displaying these results. %sClick here%s to try "
 "again."
-msgstr "죄송하지만 이 결과를 표시하는 동안 오류가 생겼습니다. 다시 시도하려면 %1$s여기를 클릭%2$s하세요."
+msgstr ""
+"죄송하지만 이 결과를 표시하는 동안 오류가 생겼습니다. 다시 시도하려면 %1$s여"
+"기를 클릭%2$s하세요."
 
 # smartling.placeholder_format=C
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
@@ -17698,7 +18338,8 @@ msgstr "원문 지움"
 msgctxt "Error message for summary selection input limit"
 msgid ""
 "Source text is too long to summarize. Try again with a shorter selection."
-msgstr "원본이 너무 길어서 요약할 수 없습니다. 길이를 줄여서 다시 시도해 보세요."
+msgstr ""
+"원본이 너무 길어서 요약할 수 없습니다. 길이를 줄여서 다시 시도해 보세요."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under Interface Settings.in the end. It is a header
@@ -18041,7 +18682,9 @@ msgctxt "Description prompting subscription for higher limits"
 msgid ""
 "Subscribe to DuckDuckGo to unlock higher limits in Duck.ai, or come back "
 "later to create more images."
-msgstr "DuckDuckGo를 구독해서 Duck.ai 한도를 높이거나, 나중에 돌아와서 이미지를 더 많이 만들어 보세요."
+msgstr ""
+"DuckDuckGo를 구독해서 Duck.ai 한도를 높이거나, 나중에 돌아와서 이미지를 더 많"
+"이 만들어 보세요."
 
 # smartling.placeholder_format=C
 #. Description shown to free users who have reached their image generation limit, encouraging them to subscribe.
@@ -18118,6 +18761,24 @@ msgid "Suggest a title for a blog post"
 msgstr "블로그 글 제목 제안"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest related articles or topics worth exploring next."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Suggest related articles to explore"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest some alternatives to this product."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
 msgctxt "directions"
 msgid "Suggestions:"
@@ -18129,10 +18790,100 @@ msgid "Suggestions:"
 msgstr "추천:"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Sum up the reviews"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A short title for the a message asking the AI to summarize a text.
 msgctxt "Title for the summarize message"
 msgid "Summarize"
 msgstr "요약"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize the Q&As"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the background and notable work of this person."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the key details of this event."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the questions and answers on this page."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize their background"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this book"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this book."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this discussion"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this discussion thread."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this page"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this page."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this video"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this video."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize what the reviews say."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -18396,11 +19147,13 @@ msgid ""
 msgstr ""
 "동기화 복구 코드\n"
 "\n"
-"복구 코드를 사용하면 여러 장치에서 비밀번호, 자동 입력 데이터 및 Duck.ai 채팅을 동기화할 수 있으며, 장치에 액세스할 수 없는 "
-"경우 동기화된 데이터를 복구할 수 있습니다.\n"
+"복구 코드를 사용하면 여러 장치에서 비밀번호, 자동 입력 데이터 및 Duck.ai 채팅"
+"을 동기화할 수 있으며, 장치에 액세스할 수 없는 경우 동기화된 데이터를 복구할 "
+"수 있습니다.\n"
 "\n"
 "이 정보를 안전하게 보관하세요.\n"
-"이 코드에 액세스할 수 있는 모든 사람이 동기화된 데이터에 액세스할 수 있습니다.\n"
+"이 코드에 액세스할 수 있는 모든 사람이 동기화된 데이터에 액세스할 수 있습니"
+"다.\n"
 "\n"
 "%1$s\n"
 "\n"
@@ -18409,8 +19162,8 @@ msgstr ""
 "2. \"Sync & Backup\"를 선택한 다음, \"동기화된 데이터 복구\"를 선택합니다.\n"
 "3. 위 복구 코드를 복사하여 \"여기에 코드 붙여넣기\"에 붙여넣습니다.\n"
 "\n"
-"Sync & Backup이 활성화된 상태에서 DuckDuckGo 브라우저를 18개월 이상 사용하지 않으면 서버에서 데이터가 삭제되어 "
-"복원할 수 없습니다."
+"Sync & Backup이 활성화된 상태에서 DuckDuckGo 브라우저를 18개월 이상 사용하지 "
+"않으면 서버에서 데이터가 삭제되어 복원할 수 없습니다."
 
 # smartling.placeholder_format=C
 #. Secondary button label on the Sync & Backup intro screen that takes the user to the camera scan screen to pair with another device.
@@ -18453,6 +19206,12 @@ msgid "Syria"
 msgstr "시리아"
 
 # smartling.placeholder_format=C
+#. Text for a button that enables the theme to follow the operating system's color scheme preference.
+msgctxt "System theme button for theme selector"
+msgid "System"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Abbreviation indicating this is the total score for a game
 msgctxt "Sports module"
 msgid "T"
@@ -18479,6 +19238,12 @@ msgstr "TV"
 msgctxt "language_name"
 msgid "Tahitian"
 msgstr "타히티어"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Tailor my resume"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Taiwan"
@@ -18508,6 +19273,13 @@ msgstr "개인정보를 원하는 대로 관리하세요."
 msgctxt "homepage ATB modal"
 msgid "Take control of your personal data!"
 msgstr "개인정보를 원하는 대로 관리하세요!"
+
+# smartling.placeholder_format=C
+#. Description for the Feedback section of the Duck.ai settings page, asking the user to take an anonymous survey to let us know how we can make Duck.ai better.
+msgctxt "Feedback section description on the Duck.ai settings page"
+msgid ""
+"Take this anonymous survey to let us know how we can make Duck.ai better."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -18722,8 +19494,9 @@ msgid ""
 "link is at increased risk of being intercepted by a third party. In rare "
 "cases this includes passwords, or payment details."
 msgstr ""
-"이는 사용자의 기기와 이 링크 뒤의 웹 페이지 사이에 전송되는 정보를 제삼자가 가로챌 위험이 높아짐을 의미합니다. 드문 경우이지만 "
-"비밀번호 또는 결제 세부 정보가 이에 포함됩니다."
+"이는 사용자의 기기와 이 링크 뒤의 웹 페이지 사이에 전송되는 정보를 제삼자가 "
+"가로챌 위험이 높아짐을 의미합니다. 드문 경우이지만 비밀번호 또는 결제 세부 정"
+"보가 이에 포함됩니다."
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -18731,7 +19504,9 @@ msgctxt "cloudsave"
 msgid ""
 "The Cloud Save bookmarklet allows any changes you make to your settings to "
 "automatically save in the cloud."
-msgstr "Cloud Save 북마클릿을 사용하면 설정에 대한 모든 변경 사항을 클라우드에 자동으로 저장할 수 있습니다."
+msgstr ""
+"Cloud Save 북마클릿을 사용하면 설정에 대한 모든 변경 사항을 클라우드에 자동으"
+"로 저장할 수 있습니다."
 
 # smartling.placeholder_format=C
 msgid "The Gambia"
@@ -18760,7 +19535,8 @@ msgctxt "Second paragraph for the Sync & Backup intro screen"
 msgid ""
 "The encryption key is only saved in your browser's local storage, and only "
 "you can access it."
-msgstr "암호화 키는 브라우저의 로컬 저장소에만 저장되며, 본인만 접근할 수 있습니다."
+msgstr ""
+"암호화 키는 브라우저의 로컬 저장소에만 저장되며, 본인만 접근할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider deletes all chat data within 30 days.
@@ -18806,6 +19582,12 @@ msgid "Theme"
 msgstr "테마"
 
 # smartling.placeholder_format=C
+#. Text for the theme selector label that allows users to switch between Light and dark theme.
+msgctxt "Label for the theme selector feature"
+msgid "Theme"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. http://i.imgur.com/LpFhb1e.png
 msgctxt "settings"
 msgid "Theme"
@@ -18833,7 +19615,9 @@ msgctxt "Error message when there was an issue saving a chat to the browser"
 msgid ""
 "There was an error saving this chat locally. Please check your browser "
 "settings to make sure local data storage is enabled."
-msgstr "이 채팅을 로컬에 저장하는 중 오류가 발생했습니다. 로컬 데이터 저장 공간이 활성화되어 있는지 브라우저 설정에서 확인하세요."
+msgstr ""
+"이 채팅을 로컬에 저장하는 중 오류가 발생했습니다. 로컬 데이터 저장 공간이 활"
+"성화되어 있는지 브라우저 설정에서 확인하세요."
 
 # smartling.placeholder_format=C
 #. Error modal body line 1.
@@ -18847,7 +19631,8 @@ msgctxt "noresults"
 msgid ""
 "There was still an error displaying the search results. Please wait a few "
 "minutes before you try again."
-msgstr "검색 결과를 표시하는 중에 오류가 발생했습니다. 몇 분 후 다시 시도해 주세요."
+msgstr ""
+"검색 결과를 표시하는 중에 오류가 발생했습니다. 몇 분 후 다시 시도해 주세요."
 
 # smartling.placeholder_format=C
 #. Error message for explore more questions when a retryable error occurs (timeout, network)
@@ -18866,8 +19651,9 @@ msgid ""
 "visit by blocking hidden trackers, encrypting connections where possible, "
 "and by making DuckDuckGo your default search engine."
 msgstr ""
-"이 브라우저 권한은 숨겨진 추적기를 차단하고, 가능한 경우 연결을 암호화하고, DuckDuckGo를 기본 검색 엔진으로 설정하여 방문하는 "
-"웹사이트의 개인정보 보호를 강화하는 데 적용됩니다."
+"이 브라우저 권한은 숨겨진 추적기를 차단하고, 가능한 경우 연결을 암호화하고, "
+"DuckDuckGo를 기본 검색 엔진으로 설정하여 방문하는 웹사이트의 개인정보 보호를 "
+"강화하는 데 적용됩니다."
 
 # smartling.placeholder_format=C
 #. Secondary line under DUCKCHAT_SYNC_PAIRING_ALREADY_SYNCED_TITLE.
@@ -18904,7 +19690,9 @@ msgctxt "AI Chat: Error message for when a model is removed"
 msgid ""
 "This AI model is no longer available. Try starting a new chat with a "
 "different model."
-msgstr "이 AI 모델은 더 이상 이용할 수 없습니다. 다른 모델로 새로 채팅을 시작해 보세요."
+msgstr ""
+"이 AI 모델은 더 이상 이용할 수 없습니다. 다른 모델로 새로 채팅을 시작해 보세"
+"요."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is no longer supported because it has been upgraded to a newest version.
@@ -18912,7 +19700,9 @@ msgctxt "AI Chat: Error message for when a model is deprecated"
 msgid ""
 "This AI model version is no longer supported. Try starting a new chat with "
 "the latest version of this model."
-msgstr "이 AI 모델 버전은 더 이상 지원되지 않습니다. 이 모델의 최신 버전으로 새 채팅을 시작해 보세요."
+msgstr ""
+"이 AI 모델 버전은 더 이상 지원되지 않습니다. 이 모델의 최신 버전으로 새 채팅"
+"을 시작해 보세요."
 
 # smartling.placeholder_format=C
 #. Appears below a type of search results called 'Instant Answers'
@@ -18939,8 +19729,8 @@ msgid ""
 "This conversation was generated with Duck.ai (%s) using %s's %s Model. AI "
 "chats may display inaccurate or offensive information (see %s for more info)."
 msgstr ""
-"이 대화는 %2$s의 %3$s 모델을 사용하여 Duck.ai(%1$s)로 생성되었습니다. AI 채팅은 부정확하거나 공격적인 정보를 보여줄 "
-"수 있습니다(자세한 내용은 %4$s 참조)."
+"이 대화는 %2$s의 %3$s 모델을 사용하여 Duck.ai(%1$s)로 생성되었습니다. AI 채팅"
+"은 부정확하거나 공격적인 정보를 보여줄 수 있습니다(자세한 내용은 %4$s 참조)."
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with multiple AI models in the same chat, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using multiple chat models. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -18950,8 +19740,8 @@ msgid ""
 "models. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
 msgstr ""
-"이 대화는 여러 채팅 모델을 사용하여 Duck.ai(%1$s)로 생성되었습니다. AI 채팅은 부정확하거나 공격적인 정보를 보여줄 수 "
-"있습니다(자세한 내용은 %2$s 참조)."
+"이 대화는 여러 채팅 모델을 사용하여 Duck.ai(%1$s)로 생성되었습니다. AI 채팅"
+"은 부정확하거나 공격적인 정보를 보여줄 수 있습니다(자세한 내용은 %2$s 참조)."
 
 # smartling.placeholder_format=C
 #. When a user exports a transcript of a voice chat they had with the AI. This text goes at the very top of the downloaded file as a header. Placeholders are for links. Example: 'This conversation was generated with Duck.ai voice chat (https://duck.ai). AI may provide inaccurate or offensive information. (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -18960,8 +19750,8 @@ msgid ""
 "This conversation was generated with Duck.ai voice chat (%s). AI may provide "
 "inaccurate or offensive information. (see %s for more info)."
 msgstr ""
-"이 대화는 Duck.ai 음성 채팅(%1$s)으로 생성되었습니다. AI가 부정확하거나 불쾌한 정보를 제공할 수 있습니다(자세한 내용은 "
-"%2$s 참고)."
+"이 대화는 Duck.ai 음성 채팅(%1$s)으로 생성되었습니다. AI가 부정확하거나 불쾌"
+"한 정보를 제공할 수 있습니다(자세한 내용은 %2$s 참고)."
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with DuckDuckGo AI Chat (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/aichat/privacy-terms for more info).'
@@ -18971,8 +19761,9 @@ msgid ""
 "Model. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
 msgstr ""
-"이 대화는 %2$s의 %3$s 모델을 사용하여 DuckDuckGo AI Chat(%1$s)으로 생성되었습니다. AI 채팅은 부정확하거나 "
-"공격적인 정보를 보여줄 수 있습니다(자세한 내용은 %4$s 참조)."
+"이 대화는 %2$s의 %3$s 모델을 사용하여 DuckDuckGo AI Chat(%1$s)으로 생성되었습"
+"니다. AI 채팅은 부정확하거나 공격적인 정보를 보여줄 수 있습니다(자세한 내용"
+"은 %4$s 참조)."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
@@ -19043,14 +19834,16 @@ msgstr "이 이미지를 만들 수 없습니다."
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF"
-msgstr "이 이미지 유형은 지원되지 않으니 JPG, PNG, WebP, GIF 중 하나로 첨부하세요"
+msgstr ""
+"이 이미지 유형은 지원되지 않으니 JPG, PNG, WebP, GIF 중 하나로 첨부하세요"
 
 # smartling.placeholder_format=C
 #. Error message displayed when a file that the user tried to upload is not of a supported format
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF."
-msgstr "이 이미지 유형은 지원되지 않으니 JPG, PNG, WebP, GIF 중 하나로 첨부하세요."
+msgstr ""
+"이 이미지 유형은 지원되지 않으니 JPG, PNG, WebP, GIF 중 하나로 첨부하세요."
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
@@ -19075,7 +19868,9 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "This model provider deletes data associated with this chat within 30 days. "
 "Other model providers follow a zero data retention model."
-msgstr "이 모델 제공사는 이 채팅과 관련된 데이터를 30일 이내에 삭제합니다. 다른 모델 제공사는 데이터를 보유하지 않는 모델을 따릅니다."
+msgstr ""
+"이 모델 제공사는 이 채팅과 관련된 데이터를 30일 이내에 삭제합니다. 다른 모델 "
+"제공사는 데이터를 보유하지 않는 모델을 따릅니다."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers, and that other providers may retain chat data for a limited time instead.
@@ -19083,7 +19878,9 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "This model provider does not store any data associated with this chat. Other "
 "model providers follow a limited data retention model."
-msgstr "이 모델 제공사는 이 채팅과 관련된 데이터를 저장하지 않습니다. 다른 모델 제공사는 데이터를 제한적으로 보유하는 모델을 따릅니다."
+msgstr ""
+"이 모델 제공사는 이 채팅과 관련된 데이터를 저장하지 않습니다. 다른 모델 제공"
+"사는 데이터를 제한적으로 보유하는 모델을 따릅니다."
 
 # smartling.placeholder_format=C
 #. Info that page may refresh during update.
@@ -19119,7 +19916,9 @@ msgctxt "First paragraph for the Sync & Backup intro screen"
 msgid ""
 "This saves your chats with end-to-end encryption on DuckDuckGo's secure "
 "server, which later can be accessed from any browser."
-msgstr "이렇게 하면 채팅이 DuckDuckGo의 보안 서버에 종단간 암호화로 저장되며, 나중에 모든 브라우저에서 접근할 수 있습니다."
+msgstr ""
+"이렇게 하면 채팅이 DuckDuckGo의 보안 서버에 종단간 암호화로 저장되며, 나중에 "
+"모든 브라우저에서 접근할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -19127,7 +19926,9 @@ msgctxt "duckassist"
 msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again."
-msgstr "이 설정은 브라우저에 저장됩니다. 따라서 duckduckgo.com 브라우저 데이터를 지우면 AI 지원 답변이 다시 표시될 수 있습니다."
+msgstr ""
+"이 설정은 브라우저에 저장됩니다. 따라서 duckduckgo.com 브라우저 데이터를 지우"
+"면 AI 지원 답변이 다시 표시될 수 있습니다."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -19137,8 +19938,9 @@ msgid ""
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
 msgstr ""
-"이 설정은 브라우저에 저장됩니다. 따라서 duckduckgo.com 브라우저 데이터를 지우면 AI 지원 답변이 다시 표시될 수 있습니다. "
-"하지만 AI 지원 답변이 절대 표시되지 않는 시작 페이지(%1$s)도 있습니다."
+"이 설정은 브라우저에 저장됩니다. 따라서 duckduckgo.com 브라우저 데이터를 지우"
+"면 AI 지원 답변이 다시 표시될 수 있습니다. 하지만 AI 지원 답변이 절대 표시되"
+"지 않는 시작 페이지(%1$s)도 있습니다."
 
 # smartling.placeholder_format=C
 #. User feedback indicating that a translation is helpful
@@ -19161,13 +19963,17 @@ msgstr "이 번역은 잘못되었습니다."
 # smartling.placeholder_format=C
 #. Label indicating that the video can't be played on the current page, and only on the website that owns the vide. The placeholder is the name of the website that owns the video.
 msgid "This video is not yet able to be watched here. You can watch it on %s."
-msgstr "아직 현재 페이지에서는 이 동영상을 재생할 수 없습니다. %1$s에서 직접 시청할 수 있습니다."
+msgstr ""
+"아직 현재 페이지에서는 이 동영상을 재생할 수 없습니다. %1$s에서 직접 시청할 "
+"수 있습니다."
 
 # smartling.placeholder_format=C
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr "이 웹사이트는 사용자를 안전하게 보호하고 통신을 암호화하는 HTTPS 프로토콜을 사용하지 않고 있습니다."
+msgstr ""
+"이 웹사이트는 사용자를 안전하게 보호하고 통신을 암호화하는 HTTPS 프로토콜을 "
+"사용하지 않고 있습니다."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -19177,8 +19983,9 @@ msgid ""
 "Sync & Backup. You'll still be able to access your chats in other browsers "
 "connected to Sync & Backup."
 msgstr ""
-"이렇게 하면 이 브라우저에서 Duck.ai 채팅이 모두 삭제되고 Sync & Backup 연결이 끊깁니다. Sync & Backup에 "
-"연결된 다른 브라우저에서는 계속 채팅을 볼 수 있습니다."
+"이렇게 하면 이 브라우저에서 Duck.ai 채팅이 모두 삭제되고 Sync & Backup 연결"
+"이 끊깁니다. Sync & Backup에 연결된 다른 브라우저에서는 계속 채팅을 볼 수 있"
+"습니다."
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to clear all recentchats, with a warning that this action cannot be undone.
@@ -19186,7 +19993,9 @@ msgctxt "Body text for clear all recent chats confirmation modal"
 msgid ""
 "This will delete all your recent chats, unless they're pinned. This cannot "
 "be undone."
-msgstr "이렇게 하면 고정된 채팅을 제외한 최근 채팅이 전부 삭제됩니다. 이 작업은 되돌릴 수 없습니다."
+msgstr ""
+"이렇게 하면 고정된 채팅을 제외한 최근 채팅이 전부 삭제됩니다. 이 작업은 되돌"
+"릴 수 없습니다."
 
 # smartling.placeholder_format=C
 #. Message explaining what will happen when the user deletes an image.
@@ -19278,7 +20087,9 @@ msgstr "팁"
 
 # smartling.placeholder_format=C
 msgid "Tired of being tracked online? %sWe can help.%s"
-msgstr "개인 정보를 추적하는 웹사이트가 지긋지긋하시다고요? %1$s저희가 도와드리겠습니다.%2$s"
+msgstr ""
+"개인 정보를 추적하는 웹사이트가 지긋지긋하시다고요? %1$s저희가 도와드리겠습니"
+"다.%2$s"
 
 # smartling.placeholder_format=C
 #. This is the name of a user setting
@@ -19323,7 +20134,9 @@ msgctxt "directions"
 msgid ""
 "To print directions:%sGo back to the map.%sSelect the route you want to "
 "print.%sClick the print icon.%s"
-msgstr "경로를 인쇄하려면 %1$s지도로 돌아가세요.%2$s원하는 경로를 선택하세요.%3$s인쇄 아이콘을 클릭하세요.%4$s"
+msgstr ""
+"경로를 인쇄하려면 %1$s지도로 돌아가세요.%2$s원하는 경로를 선택하세요.%3$s인"
+"쇄 아이콘을 클릭하세요.%4$s"
 
 # smartling.placeholder_format=C
 #. Explains where the user can find their recovery code. Figma frame 3703-44420.
@@ -19333,8 +20146,9 @@ msgid ""
 "you first set up Sync. This code may have been saved as a PDF on the device "
 "you originally used to set up Sync."
 msgstr ""
-"동기화된 데이터를 복원하려면 처음 Sync를 설치할 때 저장한 복구 코드가 필요합니다. 이 코드는 Sync를 설치할 때 원래 사용한 "
-"기기에 PDF로 저장되었을 수 있습니다."
+"동기화된 데이터를 복원하려면 처음 Sync를 설치할 때 저장한 복구 코드가 필요합"
+"니다. 이 코드는 Sync를 설치할 때 원래 사용한 기기에 PDF로 저장되었을 수 있습"
+"니다."
 
 # smartling.placeholder_format=C
 #. Body text explaining that the user needs to update their DDG browser before migration can proceed.
@@ -19342,14 +20156,18 @@ msgctxt "duckai_migration"
 msgid ""
 "To transfer your chat history to Duck.ai, please update your DuckDuckGo "
 "browser to the latest version and try again."
-msgstr "채팅 기록을 Duck.ai로 전송하려면 DuckDuckGo 브라우저를 최신 버전으로 업데이트하고 다시 시도하세요."
+msgstr ""
+"채팅 기록을 Duck.ai로 전송하려면 DuckDuckGo 브라우저를 최신 버전으로 업데이트"
+"하고 다시 시도하세요."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
 msgid ""
 "To use dictation, allow your browser to access the microphone in your system "
 "settings."
-msgstr "받아쓰기를 사용하려면 시스템 설정에서 브라우저가 마이크에 접근할 수 있도록 허용해 주세요."
+msgstr ""
+"받아쓰기를 사용하려면 시스템 설정에서 브라우저가 마이크에 접근할 수 있도록 허"
+"용해 주세요."
 
 # smartling.placeholder_format=C
 msgid "Today"
@@ -19538,7 +20356,9 @@ msgctxt "tracker_stats"
 msgid ""
 "Tracking attempts blocked by DuckDuckGo appear here. Keep browsing to see "
 "how many we block."
-msgstr "DuckDuckGo가 차단한 추적 시도가 여기에 표시됩니다. 얼마나 많은 시도가 차단되었는지 둘러보세요."
+msgstr ""
+"DuckDuckGo가 차단한 추적 시도가 여기에 표시됩니다. 얼마나 많은 시도가 차단되"
+"었는지 둘러보세요."
 
 # smartling.placeholder_format=C
 #. Placeholder for when we cannot report any blocked trackers yet
@@ -19585,7 +20405,9 @@ msgctxt "Full sentence for translating text"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr "'여기에서 가장 가까운 영화관에 어떻게 가나요?'라는 문장을 프랑스어로 번역해 주세요."
+msgstr ""
+"'여기에서 가장 가까운 영화관에 어떻게 가나요?'라는 문장을 프랑스어로 번역해 "
+"주세요."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for translating a sentence into another language. Translate the whole sentence and please use target language instead of 'English' and modify the sentence to translate into 'English' instead of 'French'. Example: 'Translate this {target language} sentence into English: “How do I get to the nearest movie theatre?”'
@@ -19593,7 +20415,21 @@ msgctxt "Full sentence for translating text prompt"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr "'여기에서 가장 가까운 영화관에 어떻게 가나요?'라는 문장을 프랑스어로 번역해 주세요."
+msgstr ""
+"'여기에서 가장 가까운 영화관에 어떻게 가나요?'라는 문장을 프랑스어로 번역해 "
+"주세요."
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Translate this page"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
+msgctxt "Page suggestion prompt"
+msgid "Translate this page into %s."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder text for a region that will display translated text.
@@ -19735,6 +20571,12 @@ msgstr "다시 시도"
 msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
 msgstr "무료 체험"
+
+# smartling.placeholder_format=C
+#. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
+msgctxt "settings"
+msgid "Try It Now"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -19883,7 +20725,9 @@ msgstr "위치를 수동으로 설정하세요."
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Try the %sDuckDuckGo Browser.%s Fast. Free. Private."
-msgstr "%1$sDuckDuckGo%2$s 브라우저를 사용해 보세요. 빠른 검색. 무료 제공. 개인 정보 보호."
+msgstr ""
+"%1$sDuckDuckGo%2$s 브라우저를 사용해 보세요. 빠른 검색. 무료 제공. 개인 정보 "
+"보호."
 
 # smartling.placeholder_format=C
 #. Link to a page where users can download the DuckDuckGo Browser for iOS or Android.
@@ -19967,6 +20811,22 @@ msgstr "%1$s 시도하기"
 msgctxt "new user poll"
 msgid "Trying DuckDuckGo again"
 msgstr "DuckDuckGo를 다시 사용해 보는 중"
+
+# smartling.placeholder_format=C
+#. Message shown in a modal after supported third-party browser users disable AI features in Settings. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -20136,7 +20996,9 @@ msgctxt "settings"
 msgid ""
 "Types out DuckAssist answers as they're generated. Turning this off may "
 "result in a short delay between a search and the answer being displayed."
-msgstr "DuckAssist 답변이 생성되는 대로 입력합니다. 이 기능을 끄면 검색 시 답변이 표시되기까지 시간이 조금 지연될 수 있습니다."
+msgstr ""
+"DuckAssist 답변이 생성되는 대로 입력합니다. 이 기능을 끄면 검색 시 답변이 표"
+"시되기까지 시간이 조금 지연될 수 있습니다."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -20265,24 +21127,30 @@ msgstr "장점과 단점 파악"
 msgid ""
 "Under %sOn startup%s, click %sOpen a specific page%s then click %sSet "
 "Pages%s."
-msgstr "%1$s시작 페이지%2$s 항목에서 %3$s특정 페이지 열기%4$s를 클릭한 다음 %5$s페이지 설정%6$s을 클릭하세요."
+msgstr ""
+"%1$s시작 페이지%2$s 항목에서 %3$s특정 페이지 열기%4$s를 클릭한 다음 %5$s페이"
+"지 설정%6$s을 클릭하세요."
 
 #  Maxthon homepage instruction
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
-msgstr "%1$s시작 페이지%2$s에서 %3$s홈페이지%4$s를 선택한 다음 https://duckduckgo.com을 입력하세요."
+msgstr ""
+"%1$s시작 페이지%2$s에서 %3$s홈페이지%4$s를 선택한 다음 https://duckduckgo.com"
+"을 입력하세요."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sOpen with%s select %sA specific page or pages%s"
-msgstr "%1$s다음으로 열기%2$s에서 %3$s특정 페이지(또는 여러 페이지)%4$s를 선택하세요."
+msgstr ""
+"%1$s다음으로 열기%2$s에서 %3$s특정 페이지(또는 여러 페이지)%4$s를 선택하세요."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
-msgstr "%1$s시작 페이지 > 홈페이지%2$s에서 https://duckduckgo.com을 입력하세요."
+msgstr ""
+"%1$s시작 페이지 > 홈페이지%2$s에서 https://duckduckgo.com을 입력하세요."
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -20292,7 +21160,8 @@ msgstr "%1$s검색 설정%2$s에서 %3$sDuckDuckGo%4$s를 선택하세요."
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch in the address bar with%s select %sAdd New%s"
-msgstr "%1$s주소창에서 다음을 사용하여 검색%2$s에서 %3$s새로 추가%4$s를 선택하세요."
+msgstr ""
+"%1$s주소창에서 다음을 사용하여 검색%2$s에서 %3$s새로 추가%4$s를 선택하세요."
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -20304,7 +21173,8 @@ msgstr "%1$s검색%2$s 섹션에서, %3$s검색 엔진 관리...%4$s를 클릭�
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under On startup select %sOpen a specific page or set of pages%s"
-msgstr "시작 페이지에서 %1$s특정 페이지 또는 페이지 모음 열기%2$s를 선택하세요."
+msgstr ""
+"시작 페이지에서 %1$s특정 페이지 또는 페이지 모음 열기%2$s를 선택하세요."
 
 #  Opera default search engine instruction
 # smartling.placeholder_format=C
@@ -20387,7 +21257,9 @@ msgctxt "Description of the modal to upgrade to Pro"
 msgid ""
 "Unlock %s, higher AI reasoning, and 2x higher usage limits than the Plus "
 "plan by upgrading to Pro."
-msgstr "Pro로 업그레이드하여 %1$s, 더 높은 AI 추론 및 Plus 요금제보다 2배 더 높은 사용 한도를 이용하세요."
+msgstr ""
+"Pro로 업그레이드하여 %1$s, 더 높은 AI 추론 및 Plus 요금제보다 2배 더 높은 사"
+"용 한도를 이용하세요."
 
 # smartling.placeholder_format=C
 #. Title for the subscription promo shown in the SERP sidemenu.
@@ -20520,7 +21392,9 @@ msgctxt "Old app version banner component in Duck.ai"
 msgid ""
 "Update the DuckDuckGo browser to activate your subscription in Duck.ai and "
 "access advanced models"
-msgstr "DuckDuckGo 브라우저를 업데이트하여 Duck.ai에서 구독을 활성화하고 고급 모델을 이용하세요."
+msgstr ""
+"DuckDuckGo 브라우저를 업데이트하여 Duck.ai에서 구독을 활성화하고 고급 모델을 "
+"이용하세요."
 
 # smartling.placeholder_format=C
 #. The placeholder indicates a formatted date (e.g., 'Updated 2 days ago')
@@ -20644,7 +21518,9 @@ msgctxt ""
 msgid ""
 "Upgrade to Pro to unlock 2x higher limits than Plus, or come back later to "
 "create more images."
-msgstr "Pro로 업그레이드해서 한도를 Plus의 2배로 높이거나, 나중에 돌아와서 이미지를 더 많이 만들어 보세요."
+msgstr ""
+"Pro로 업그레이드해서 한도를 Plus의 2배로 높이거나, 나중에 돌아와서 이미지를 "
+"더 많이 만들어 보세요."
 
 # smartling.placeholder_format=C
 #. Upsell message shown in the voice chat limit and duration limit modals for Plus subscribers, encouraging them to upgrade to Pro.
@@ -20699,6 +21575,12 @@ msgid "Uruguay"
 msgstr "우루과이"
 
 # smartling.placeholder_format=C
+#. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
+msgctxt "Navigation label on the Duck.ai settings page"
+msgid "Usage"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A feedback suggestion
 msgctxt "Feedback prompt"
 msgid "Usage limit"
@@ -20740,8 +21622,8 @@ msgid ""
 "Use ChatGPT, Claude, and other AIs, privately. Protect chats from hackers, "
 "scammers, and companies. Keep info confidential. Free. No account required."
 msgstr ""
-"ChatGPT, Claude 등의 AI를 비공개로 사용하세요. 해커, 사기꾼, 기업으로부터 채팅을 보호하세요. 정보를 기밀로 유지하세요. "
-"무료로. 계정이 없어도 괜찮습니다."
+"ChatGPT, Claude 등의 AI를 비공개로 사용하세요. 해커, 사기꾼, 기업으로부터 채"
+"팅을 보호하세요. 정보를 기밀로 유지하세요. 무료로. 계정이 없어도 괜찮습니다."
 
 # smartling.placeholder_format=C
 #. Header above instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -20782,7 +21664,8 @@ msgstr "Safari에서 사용"
 msgctxt "Description for the recovery section inside Manage"
 msgid ""
 "Use this code to restore your saved chats if you lose access to your devices."
-msgstr "기기에 접근할 수 없는 경우 이 코드를 사용하여 저장된 채팅을 복원하세요."
+msgstr ""
+"기기에 접근할 수 없는 경우 이 코드를 사용하여 저장된 채팅을 복원하세요."
 
 # smartling.placeholder_format=C
 #. Prompt to ask the user if they want to use their approximate location for more accurate results
@@ -20931,7 +21814,9 @@ msgctxt "Ads GDPR, internal use only. Do not change"
 msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Microsoft's ad network"
-msgstr "광고 보기 시 DuckDuckGo에 의해 개인 정보가 보호됩니다. 광고 클릭은 마이크로소프트의 광고 네트워크에서 관리합니다."
+msgstr ""
+"광고 보기 시 DuckDuckGo에 의해 개인 정보가 보호됩니다. 광고 클릭은 마이크로소"
+"프트의 광고 네트워크에서 관리합니다."
 
 # smartling.placeholder_format=C
 #. Information about TripAdvisor ads for DuckDuckGo's users. This appears in a tooltip.
@@ -20939,7 +21824,9 @@ msgctxt "Single Place Hotel Offers Module"
 msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "TripAdvisor's ad network."
-msgstr "광고 보기 시 DuckDuckGo에 의해 개인 정보가 보호됩니다. 광고 클릭은 TripAdvisor의 광고 네트워크에서 관리합니다."
+msgstr ""
+"광고 보기 시 DuckDuckGo에 의해 개인 정보가 보호됩니다. 광고 클릭은 "
+"TripAdvisor의 광고 네트워크에서 관리합니다."
 
 # smartling.placeholder_format=C
 msgid "Virgin Islands"
@@ -20966,7 +21853,9 @@ msgctxt "mobile promotion on desktop"
 msgid ""
 "Visit %sDuckDuckGo.com%s on your tablet or phone and follow the provided "
 "instructions."
-msgstr "휴대전화 또는 태블릿에서 %1$sDuckDuckGo.com%2$s을 접속한 다음, 제공되는 설명을 따르세요."
+msgstr ""
+"휴대전화 또는 태블릿에서 %1$sDuckDuckGo.com%2$s을 접속한 다음, 제공되는 설명"
+"을 따르세요."
 
 # smartling.placeholder_format=C
 #. Primary button to visit Duck.ai.
@@ -20981,8 +21870,8 @@ msgid ""
 "Visit Duck.ai in your other browser and go to %sDuck.ai Settings%s > %sSync "
 "& Backup%s > %sManage%s then select %sSync With Another Device%s."
 msgstr ""
-"다른 브라우저에서 Duck.ai를 열고 %1$sDuck.ai 설정%2$s > %3$sSync & Backup%4$s > "
-"%5$s관리%6$s로 들어가 %7$s다른 기기와 동기화%8$s를 선택하세요."
+"다른 브라우저에서 Duck.ai를 열고 %1$sDuck.ai 설정%2$s > %3$sSync & "
+"Backup%4$s > %5$s관리%6$s로 들어가 %7$s다른 기기와 동기화%8$s를 선택하세요."
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -20992,8 +21881,9 @@ msgid ""
 "On” under Sync & Backup and select “Sync With Another Device”. Or scan the "
 "QR on your Recovery PDF."
 msgstr ""
-"다른 브라우저에서 Duck.ai를 방문하여 Duck.ai 설정을 여세요. Sync & Backup 아래에 있는 '켜기'를 선택하고 "
-"''다른 기기와 동기화'를 선택하세요. 또는 복구 PDF에 있는 QR을 스캔하세요."
+"다른 브라우저에서 Duck.ai를 방문하여 Duck.ai 설정을 여세요. Sync & Backup 아"
+"래에 있는 '켜기'를 선택하고 ''다른 기기와 동기화'를 선택하세요. 또는 복구 PDF"
+"에 있는 QR을 스캔하세요."
 
 # smartling.placeholder_format=C
 #. Shared body copy for every screen in the Sync Another Device flow (QR display, camera scan, camera-unavailable fallback, manual entry). Bold tags wrap navigation breadcrumbs. Render with <Translate /> so the HTML is interpreted; plain `translate()` will trip the html-string warning.
@@ -21003,8 +21893,9 @@ msgid ""
 "ai Settings%s > %sSync & Backup%s > %sManage%s then select %sSync With "
 "Another Device%s."
 msgstr ""
-"다른 브라우저나 DuckDuckGo 앱에서 Duck.ai를 열고 %1$sDuck.ai 설정%2$s > %3$sSync & "
-"Backup%4$s > %5$s관리%6$s로 들어가 %7$s다른 기기와 동기화%8$s를 선택하세요."
+"다른 브라우저나 DuckDuckGo 앱에서 Duck.ai를 열고 %1$sDuck.ai 설정%2$s > "
+"%3$sSync & Backup%4$s > %5$s관리%6$s로 들어가 %7$s다른 기기와 동기화%8$s를 선"
+"택하세요."
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -21014,8 +21905,9 @@ msgid ""
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
 msgstr ""
-"다른 브라우저나 DuckDuckGo 앱에서 Duck.ai를 방문하여 Duck.ai 설정을 여세요. Sync & Backup 아래에 있는 "
-"'켜기'를 선택하고 ''다른 기기와 동기화'를 선택하세요. 또는 복구 PDF에 있는 QR을 스캔하세요."
+"다른 브라우저나 DuckDuckGo 앱에서 Duck.ai를 방문하여 Duck.ai 설정을 여세요. "
+"Sync & Backup 아래에 있는 '켜기'를 선택하고 ''다른 기기와 동기화'를 선택하세"
+"요. 또는 복구 PDF에 있는 QR을 스캔하세요."
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -21067,7 +21959,8 @@ msgstr "음성 채팅이 끝났습니다"
 #. Description in consent disclaimer informing that voice chats with the AI (Artificial Intelligence) are anonymized by us, and are never used to train AI models.
 msgctxt "voice chat"
 msgid "Voice chat is anonymized by us, and never used to train AI models."
-msgstr "당사는 음성 채팅 내용을 익명화하며, AI 모델 학습에 절대 사용하지 않습니다."
+msgstr ""
+"당사는 음성 채팅 내용을 익명화하며, AI 모델 학습에 절대 사용하지 않습니다."
 
 # smartling.placeholder_format=C
 #. Title of the modal shown when the user has reached their daily voice chat limit.
@@ -21126,6 +22019,12 @@ msgstr "위치 대기 중..."
 # smartling.placeholder_format=C
 msgid "Wales"
 msgstr "웨일즈"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Walk me through the steps"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for walking directions on a map.
@@ -21204,7 +22103,9 @@ msgstr "Duck Player에서 보기"
 msgid ""
 "Watch in Duck Player to block personalized ads on YouTube and prevent your "
 "viewing activity from influencing YouTube recommendations."
-msgstr "Duck Player로 영상을 시청하면 YouTube 맞춤 광고가 차단되고 시청 내역에 따라 YouTube 추천 영상이 달라지지 않습니다."
+msgstr ""
+"Duck Player로 영상을 시청하면 YouTube 맞춤 광고가 차단되고 시청 내역에 따라 "
+"YouTube 추천 영상이 달라지지 않습니다."
 
 # smartling.placeholder_format=C
 #. A button that takes a user to another site in order to watch a video. The placeholder is the name of the video site. For example: 'Watch on Vimeo'
@@ -21224,8 +22125,9 @@ msgid ""
 "independent company and has no relationship with YouTube, where most videos "
 "are hosted."
 msgstr ""
-"여기서 영상을 시청하면 콘텐츠를 스트리밍해야 하기 때문에 해당 영상을 호스팅하는 웹사이트에서 사용자를 추적할 수 있습니다. "
-"DuckDuckGo는 동영상 대부분을 호스팅하는 YouTube와 무관한 독립적인 기업입니다."
+"여기서 영상을 시청하면 콘텐츠를 스트리밍해야 하기 때문에 해당 영상을 호스팅하"
+"는 웹사이트에서 사용자를 추적할 수 있습니다. DuckDuckGo는 동영상 대부분을 호"
+"스팅하는 YouTube와 무관한 독립적인 기업입니다."
 
 # smartling.placeholder_format=C
 #. Heading for the highlight card explaining anonymized prompt delivery.
@@ -21237,7 +22139,20 @@ msgstr "DuckDuckGo의 익명화"
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
-msgstr "더 정확한 결과를 보여드리기 위해 %1$s사용자의 위치%2$s를 익명화할 수 있습니다."
+msgstr ""
+"더 정확한 결과를 보여드리기 위해 %1$s사용자의 위치%2$s를 익명화할 수 있습니"
+"다."
+
+# smartling.placeholder_format=C
+#. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
+msgctxt ""
+"Inline warning shown below the share-content toggle when the user selects "
+"Harmful or Illegal but has not enabled sharing"
+msgid ""
+"We can only fix what we can see. To report a harmful or illegal response, "
+"please share this conversation with DuckDuckGo so we can investigate and "
+"address the issue."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -21249,8 +22164,9 @@ msgid ""
 "please share your prompt and response so we can investigate and address the "
 "issue."
 msgstr ""
-"문제는 눈에 보여야 고칠 수 있습니다. 유해하거나 불법적인 응답이 나온 경우, 저희가 문제를 조사하고 해결할 수 있도록 사용하신 "
-"프롬프트와 응답 내용을 보내서 신고해 주세요."
+"문제는 눈에 보여야 고칠 수 있습니다. 유해하거나 불법적인 응답이 나온 경우, 저"
+"희가 문제를 조사하고 해결할 수 있도록 사용하신 프롬프트와 응답 내용을 보내서 "
+"신고해 주세요."
 
 # smartling.placeholder_format=C
 #. Explains how location service is used to show users search results near their current location.
@@ -21291,8 +22207,9 @@ msgid ""
 "We don't store your personal info. We don't follow you around with ads. We "
 "don't track you. Ever."
 msgstr ""
-"DuckDuckGo는 사용자의 개인정보를 저장하지 않습니다. DuckDuckGo는 사용자를 따라다니며 광고를 게재하지 않습니다. "
-"DuckDuckGo는 사용자를 추적하지 않습니다. 절대."
+"DuckDuckGo는 사용자의 개인정보를 저장하지 않습니다. DuckDuckGo는 사용자를 따"
+"라다니며 광고를 게재하지 않습니다. DuckDuckGo는 사용자를 추적하지 않습니다. "
+"절대."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -21305,7 +22222,9 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what brought you "
 "back today:"
-msgstr "DuckDuckGo는 사용자를 추적하지 않습니다. 따라서 오늘 다시 방문하게 된 계기를 알려주시면 도움이 될 것 같습니다."
+msgstr ""
+"DuckDuckGo는 사용자를 추적하지 않습니다. 따라서 오늘 다시 방문하게 된 계기를 "
+"알려주시면 도움이 될 것 같습니다."
 
 # smartling.placeholder_format=C
 #. Message prompting users to fill out a feedback form.
@@ -21313,7 +22232,9 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what convinced you "
 "to try us out today:"
-msgstr "DuckDuckGo는 사용자를 추적하지 않습니다. 따라서 오늘 사용해보게 된 계기를 알려주시면 도움이 될 것 같습니다."
+msgstr ""
+"DuckDuckGo는 사용자를 추적하지 않습니다. 따라서 오늘 사용해보게 된 계기를 알"
+"려주시면 도움이 될 것 같습니다."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -21324,7 +22245,9 @@ msgstr "DuckDuckGo는 절대로 사용자를 추적하지 않습니다."
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with a Continue button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don't track you. That's our Privacy Policy in a nutshell."
-msgstr "DuckDuckGo는 사용자를 추적하지 않습니다. 그게 바로 우리의 개인정보 보호정책입니다."
+msgstr ""
+"DuckDuckGo는 사용자를 추적하지 않습니다. 그게 바로 우리의 개인정보 보호정책입"
+"니다."
 
 # smartling.placeholder_format=C
 #. Description for the audio identification highlight in the dictation consent modal.
@@ -21353,19 +22276,24 @@ msgid ""
 "We don’t store your search history. We therefore have nothing to sell to "
 "advertisers that track you across the Internet."
 msgstr ""
-"DuckDuckGo는 사용자의 검색 기록을 저장하지 않습니다. 따라서 인터넷을 통해 사용자를 추적하는 광고주에게 판매할 수 있는 어떠한 "
-"정보도 보유하고 있지 않습니다."
+"DuckDuckGo는 사용자의 검색 기록을 저장하지 않습니다. 따라서 인터넷을 통해 사"
+"용자를 추적하는 광고주에게 판매할 수 있는 어떠한 정보도 보유하고 있지 않습니"
+"다."
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don’t track you in or out of private browsing mode."
-msgstr "DuckDuckGo는 개인정보 보호 모드 사용 여부에 관계없이 절대로 사용자를 추적하지 않습니다."
+msgstr ""
+"DuckDuckGo는 개인정보 보호 모드 사용 여부에 관계없이 절대로 사용자를 추적하"
+"지 않습니다."
 
 # smartling.placeholder_format=C
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with an Agree button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don’t track you. That’s our Privacy Policy in a nutshell…"
-msgstr "DuckDuckGo는 사용자를 추적하지 않습니다. 그게 바로 우리의 개인정보 보호정책입니다."
+msgstr ""
+"DuckDuckGo는 사용자를 추적하지 않습니다. 그게 바로 우리의 개인정보 보호정책입"
+"니다."
 
 # smartling.placeholder_format=C
 #. Displayed when the user's voice chat session is ended because of being inactive for too long.
@@ -21379,7 +22307,9 @@ msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
 "We have agreements with all AI providers to ensure your chats aren't used to "
 "train AIs."
-msgstr "DuckDuckGo는 모든 AI 제공업체와 협약을 맺어 채팅 내용이 AI 학습에 사용되지 않도록 보장합니다."
+msgstr ""
+"DuckDuckGo는 모든 AI 제공업체와 협약을 맺어 채팅 내용이 AI 학습에 사용되지 않"
+"도록 보장합니다."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -21403,7 +22333,9 @@ msgstr "연결이 끊겼습니다. 메시지를 다시 보내 보세요."
 msgid ""
 "We make money from %sprivacy-respecting search ads%s, not by exploiting your "
 "data."
-msgstr "우리는 %1$s프라이버시를 존중하는 검색 광고%2$s로 돈을 벌고, 여러분의 데이터를 악용하지 않습니다."
+msgstr ""
+"우리는 %1$s프라이버시를 존중하는 검색 광고%2$s로 돈을 벌고, 여러분의 데이터"
+"를 악용하지 않습니다."
 
 # smartling.placeholder_format=C
 #. Message describing how DuckDuckGo users location access anonymously to provide better search results.
@@ -21411,18 +22343,24 @@ msgctxt "precise_user_location"
 msgid ""
 "We only use your anonymous location to deliver better results, closer to "
 "you. You can always change your mind later."
-msgstr "익명 위치는 사용자 주변의 더 정확한 결과를 제공하기 위해서만 사용되며, 언제든지 설정을 변경할 수 있습니다."
+msgstr ""
+"익명 위치는 사용자 주변의 더 정확한 결과를 제공하기 위해서만 사용되며, 언제든"
+"지 설정을 변경할 수 있습니다."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
-msgstr "여러분이 익명으로 보내주시는 피드백을 바탕으로 DuckDuckGo를 모두가 사용하기 좋게 발전시킵니다."
+msgstr ""
+"여러분이 익명으로 보내주시는 피드백을 바탕으로 DuckDuckGo를 모두가 사용하기 "
+"좋게 발전시킵니다."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We stop anyone from getting your search history, including us."
-msgstr "여러분의 검색 기록을 그 누구도 수집할 수 없게 차단합니다. 물론 DuckDuckGo도 포함해서 말이죠."
+msgstr ""
+"여러분의 검색 기록을 그 누구도 수집할 수 없게 차단합니다. 물론 DuckDuckGo도 "
+"포함해서 말이죠."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -21438,8 +22376,8 @@ msgid ""
 "incorporated at the discretion of %s. Corrections may not show up in results "
 "right away."
 msgstr ""
-"DuckDuckGo는 이러한 의견을 참고하여 서비스를 개선합니다. 보내주신 제안은 %1$s의 재량에 따라 적용됩니다. 정정 사항이 결과에 "
-"바로 나타나지 않을 수 있습니다."
+"DuckDuckGo는 이러한 의견을 참고하여 서비스를 개선합니다. 보내주신 제안은 %1$s"
+"의 재량에 따라 적용됩니다. 정정 사항이 결과에 바로 나타나지 않을 수 있습니다."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -21452,7 +22390,9 @@ msgctxt "noresults"
 msgid ""
 "We're aware of this issue and are currently working to resolve it. If you "
 "continue to see this error, please reach out to %s."
-msgstr "현재 이 문제를 인지하고 해결책을 모색 중입니다. 이 오류가 계속되면 %1$s에 문의하세요."
+msgstr ""
+"현재 이 문제를 인지하고 해결책을 모색 중입니다. 이 오류가 계속되면 %1$s에 문"
+"의하세요."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -21460,7 +22400,9 @@ msgctxt "noresults"
 msgid ""
 "We're aware of this issue and are currently working to resolve it. Sometimes "
 "clearing your browser's cache can help."
-msgstr "현재 이 문제를 인지하고 해결책을 모색 중입니다. 브라우저 캐시를 삭제하면 문제가 해결되는 경우도 있습니다."
+msgstr ""
+"현재 이 문제를 인지하고 해결책을 모색 중입니다. 브라우저 캐시를 삭제하면 문제"
+"가 해결되는 경우도 있습니다."
 
 # smartling.placeholder_format=C
 #. Header for a feedback form for new users.
@@ -21474,7 +22416,9 @@ msgctxt "duckai_migration"
 msgid ""
 "We're sorry for this inconvenience. We’re working hard to make your "
 "experience better."
-msgstr "불편을 드려서 죄송합니다. 사용자 여러분이 더 쾌적한 경험을 하실 수 있도록 노력 중입니다."
+msgstr ""
+"불편을 드려서 죄송합니다. 사용자 여러분이 더 쾌적한 경험을 하실 수 있도록 노"
+"력 중입니다."
 
 # smartling.placeholder_format=C
 #. Body text explaining the service update requires a page reload.
@@ -21482,7 +22426,9 @@ msgctxt "duckai_migration"
 msgid ""
 "We've updated the Duck.ai service. For the change to take effect, we need to "
 "reload the page."
-msgstr "Duck.ai 서비스를 업데이트했습니다. 변경 사항을 적용하려면 페이지를 새로 고치세요."
+msgstr ""
+"Duck.ai 서비스를 업데이트했습니다. 변경 사항을 적용하려면 페이지를 새로 고치"
+"세요."
 
 # smartling.placeholder_format=C
 #. Instant Answer Tab Name
@@ -21584,7 +22530,8 @@ msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "Weekly usage limit reached. You can keep chatting by using your monthly "
 "limit."
-msgstr "주간 사용 한도에 도달했습니다. 월 한도를 사용하여 채팅을 이어갈 수 있습니다."
+msgstr ""
+"주간 사용 한도에 도달했습니다. 월 한도를 사용하여 채팅을 이어갈 수 있습니다."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -21598,8 +22545,8 @@ msgid ""
 "Welcome to Duck.ai! All of your chats here are private, anonymized by us and "
 "not used to train AI models."
 msgstr ""
-"Duck.ai에 오신 걸 환영합니다! 여기서 이루어지는 모든 채팅은 비공개로 진행되며, DuckDuckGo에 저장되거나 AI 모델 학습에 "
-"사용되지 않습니다."
+"Duck.ai에 오신 걸 환영합니다! 여기서 이루어지는 모든 채팅은 비공개로 진행되"
+"며, DuckDuckGo에 저장되거나 AI 모델 학습에 사용되지 않습니다."
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened.
@@ -21608,8 +22555,8 @@ msgid ""
 "Welcome to DuckDuckGo AI Chat! All of your chats here are private, "
 "anonymized by us and not used to train AI models."
 msgstr ""
-"DuckDuckGo AI Chat에 오신 것을 환영합니다! 여기서 이루어지는 모든 채팅은 비공개로 진행되며, DuckDuckGo에 "
-"저장되거나 AI 모델 학습에 사용되지 않습니다."
+"DuckDuckGo AI Chat에 오신 것을 환영합니다! 여기서 이루어지는 모든 채팅은 비공"
+"개로 진행되며, DuckDuckGo에 저장되거나 AI 모델 학습에 사용되지 않습니다."
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened. Example: 'Welcome to DuckDuckGo AI Chat! This chat session is powered by OpenAI’s GPT-3. All of your chats here are private, and are never stored by DuckDuckGo or used to train AI models.'
@@ -21619,8 +22566,9 @@ msgid ""
 "of your chats here are private, and are never stored by DuckDuckGo or used "
 "to train AI models."
 msgstr ""
-"DuckDuckGo AI Chat에 오신 것을 환영합니다! %1$s의 %2$s 모델로 작동하는 채팅 세션입니다. 여기서 이루어지는 모든 "
-"채팅은 비공개로 진행되며, DuckDuckGo에 저장되거나 AI 모델 학습에 사용되지 않습니다."
+"DuckDuckGo AI Chat에 오신 것을 환영합니다! %1$s의 %2$s 모델로 작동하는 채팅 "
+"세션입니다. 여기서 이루어지는 모든 채팅은 비공개로 진행되며, DuckDuckGo에 저"
+"장되거나 AI 모델 학습에 사용되지 않습니다."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -21693,7 +22641,9 @@ msgctxt "duckai_fatal_error"
 msgid ""
 "We’re really sorry, but it seems there was a problem loading Duck.ai. Try "
 "reloading the page."
-msgstr "정말 죄송하지만 Duck.ai를 불러오는 중 문제가 생긴 것 같습니다. 페이지를 새로고침해 보세요."
+msgstr ""
+"정말 죄송하지만 Duck.ai를 불러오는 중 문제가 생긴 것 같습니다. 페이지를 새로"
+"고침해 보세요."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to suggest an AI (Artificial Intelligence) model to be added to the product, and this field is optional.
@@ -21727,7 +22677,9 @@ msgctxt "Full sentence for finding a better word"
 msgid ""
 "What are some options for the word ‘better’ in the context of “We really "
 "need to do better.”"
-msgstr "“우리 정말 더 잘해야 합니다.”라는 문맥에서 '더 잘'이라는 단어의 대체어를 몇 개 알려 주세요."
+msgstr ""
+"“우리 정말 더 잘해야 합니다.”라는 문맥에서 '더 잘'이라는 단어의 대체어를 몇 "
+"개 알려 주세요."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
@@ -21746,9 +22698,107 @@ msgid ""
 "easy to understand for people with or without much AI, or technical, "
 "experience."
 msgstr ""
-"Duck.ai를 사용하려고 할 때 DuckDuckGo 브라우저를 설치하면 어떤 점이 좋나요? DuckDuckGo 공식 출처만 참고하세요. "
-"답변은 명료하게 섹션을 나누어 작성하고 제목을 답니다. Duck.ai 통합과 개인정보 보호에 중점을 두고, AI나 기술 관련 경험 유무에 "
-"관계 없이 누구나 이해하기 쉽도록 간단하게 설명하세요."
+"Duck.ai를 사용하려고 할 때 DuckDuckGo 브라우저를 설치하면 어떤 점이 좋나요? "
+"DuckDuckGo 공식 출처만 참고하세요. 답변은 명료하게 섹션을 나누어 작성하고 제"
+"목을 답니다. Duck.ai 통합과 개인정보 보호에 중점을 두고, AI나 기술 관련 경험 "
+"유무에 관계 없이 누구나 이해하기 쉽도록 간단하게 설명하세요."
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the counterarguments?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the hours & location?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key contributions of this paper?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key contributions?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key details?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key points covered in this video?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key points?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key takeaways from this article?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key takeaways?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key things I will learn from this course?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main counterarguments or criticisms of this?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main questions this page answers?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the must-try dishes here?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"What are the opening hours, location, and contact details for this place?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the pros and cons of this product?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the pros and cons?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
@@ -21851,6 +22901,12 @@ msgid "What does atria mean in the context of a medical article?"
 msgstr "의학 기사의 문맥에서 '신장'은 무엇을 뜻하나요?"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What does this answer?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
@@ -21863,18 +22919,31 @@ msgid "What information gets saved?"
 msgstr "어떤 정보가 서버에 저장되나요?"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What interview questions might come up for this role?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
 msgid ""
 "What is the Cloud Save bookmarklet and how does it differ from the URL "
 "parameter bookmarklet?"
-msgstr "Cloud Save 북마클릿이란 무엇이며 URL 매개변수 북마클릿과 어떻게 다른가요?"
+msgstr ""
+"Cloud Save 북마클릿이란 무엇이며 URL 매개변수 북마클릿과 어떻게 다른가요?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for looking up the capital city of Albania.
 msgctxt "Full sentence for looking up basic facts"
 msgid "What is the capital city of Albania?"
 msgstr "알바니아의 수도는 어디인가요?"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What is the overall verdict and rating for this?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to a page with additional information.
@@ -21899,6 +22968,12 @@ msgid "What people say:"
 msgstr "방문자 리뷰"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What should I order?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
 msgctxt "feedback form"
 msgid "What stood out?"
@@ -21911,6 +22986,18 @@ msgid "What was wrong with the response? (optional)"
 msgstr "응답에 어떤 문제가 있었나요? (선택 사항)"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I learn?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I need?"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid "What would you like to provide feedback on?"
 msgstr "무엇에 대해 피드백을 주고 싶으세요?"
@@ -21919,13 +23006,20 @@ msgstr "무엇에 대해 피드백을 주고 싶으세요?"
 #. Explains the benefits of using our custom video player, the Duck Player
 msgid ""
 "What you watch in DuckDuckGo won't influence your recommendations on YouTube."
-msgstr "DuckDuckGo에서 시청하는 콘텐츠는 YouTube의 추천에 영향을 미치지 않습니다."
+msgstr ""
+"DuckDuckGo에서 시청하는 콘텐츠는 YouTube의 추천에 영향을 미치지 않습니다."
 
 # smartling.placeholder_format=C
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
 msgctxt "SERP footer content"
 msgid "What's New"
 msgstr "업데이트 소식"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What's the verdict?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -21938,7 +23032,9 @@ msgctxt "Full sentence for identifying product brands"
 msgid ""
 "When buying an electric guitar for a beginner, what are the top product "
 "brands I should consider?"
-msgstr "초보자가 연주할 일렉트릭 기타를 살 때 가장 추천할 만한 브랜드에는 무엇이 있나요?"
+msgstr ""
+"초보자가 연주할 일렉트릭 기타를 살 때 가장 추천할 만한 브랜드에는 무엇이 있나"
+"요?"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -21976,6 +23072,12 @@ msgid "Which features are missing? (Optional)"
 msgstr "어떤 기능이 빠졌나요? (선택 사항)"
 
 # smartling.placeholder_format=C
+#. An invitation for users to leave feedback
+msgctxt "Feedback prompt"
+msgid "Which features are missing? (optional)"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
 msgid "White"
 msgstr "하얀색"
@@ -21990,6 +23092,18 @@ msgstr "하얀색"
 #. Link to an about us page.
 msgid "Who We Are"
 msgstr "회사 정보"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Who are the main cast and crew, and what else are they known for?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Who is this person?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Header above a collection of privacy-related links.
@@ -22379,7 +23493,9 @@ msgctxt "Disclaimer bellow chat input - desktop"
 msgid ""
 "You are chatting with %s. AI chats may display inaccurate or offensive "
 "information."
-msgstr "%1$s 모델과 채팅 중입니다. AI 채팅은 부정확하거나 불쾌한 정보를 표시할 수 있습니다."
+msgstr ""
+"%1$s 모델과 채팅 중입니다. AI 채팅은 부정확하거나 불쾌한 정보를 표시할 수 있"
+"습니다."
 
 # smartling.placeholder_format=C
 #. Provide users with the ability to retry their search on a different search engine. First placeholder will be a link with the text "try your search again" OR "try your search later". Second is a URL to the !bangs page: https://duckduckgo.com/bangs.
@@ -22387,7 +23503,9 @@ msgctxt "noresults"
 msgid ""
 "You can %s or search directly on other search engines from DuckDuckGo using "
 "%s search shortcuts."
-msgstr "%1$s 또는 %2$s 검색 단축키를 사용하여 DuckDuckGo에서 다른 검색 엔진으로 직접 검색할 수 있습니다."
+msgstr ""
+"%1$s 또는 %2$s 검색 단축키를 사용하여 DuckDuckGo에서 다른 검색 엔진으로 직접 "
+"검색할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Text informing the user that they can access DuckDuckGo AI Chat directly at a specific URL. The placeholder %s will be replaced with the link. Example: 'You can access DuckDuckGo AI Chat directly at duck.ai.'
@@ -22400,7 +23518,8 @@ msgstr "%1$s에서 DuckDuckGo AI Chat에 바로 접속할 수 있습니다."
 msgctxt "duckassist"
 msgid ""
 "You can adjust how %s works or turn it off anytime in %sSearch Settings%s."
-msgstr "%1$s검색 설정%2$s에서 언제든 %3$s 작동 방식을 변경하거나 해제할 수 있습니다."
+msgstr ""
+"%1$s검색 설정%2$s에서 언제든 %3$s 작동 방식을 변경하거나 해제할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Assist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate Assist.
@@ -22408,17 +23527,22 @@ msgctxt "duckassist"
 msgid ""
 "You can adjust how Assist works or turn it off anytime in %sSearch "
 "Settings%s."
-msgstr "%1$s검색 설정%2$s에서 언제든 Assist의 작동 방식을 변경하거나 해제할 수 있습니다."
+msgstr ""
+"%1$s검색 설정%2$s에서 언제든 Assist의 작동 방식을 변경하거나 해제할 수 있습니"
+"다."
 
 # smartling.placeholder_format=C
 msgid "You can also use %sDuck.ai%s to answer questions or summarize text."
-msgstr "%1$sDuck.ai%2$s를 사용해 질문에 대한 답을 찾거나 글을 요약할 수도 있습니다."
+msgstr ""
+"%1$sDuck.ai%2$s를 사용해 질문에 대한 답을 찾거나 글을 요약할 수도 있습니다."
 
 # smartling.placeholder_format=C
 msgid ""
 "You can also use %sDuckDuckGo AI Chat%s to answer questions or summarize "
 "text."
-msgstr "%1$sDuckDuckGo AI Chat%2$s을 사용해 질문에 대한 답을 찾거나 글을 요약할 수도 있습니다."
+msgstr ""
+"%1$sDuckDuckGo AI Chat%2$s을 사용해 질문에 대한 답을 찾거나 글을 요약할 수도 "
+"있습니다."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach more text selections than are allowed. Placeholder is the maximum number of text selections. E.g. You can attach up to 5 text selections.
@@ -22431,7 +23555,9 @@ msgstr "텍스트 선택은 %1$s개까지 첨부할 수 있습니다."
 msgid ""
 "You can change how frequently you see Search Assist, or turn it off "
 "entirely, in %sSearch Settings%s."
-msgstr "%1$sSearch Settings%2$s에서 검색 Assist가 표시되는 빈도를 변경하거나 해제할 수 있습니다."
+msgstr ""
+"%1$sSearch Settings%2$s에서 검색 Assist가 표시되는 빈도를 변경하거나 해제할 "
+"수 있습니다."
 
 # smartling.placeholder_format=C
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
@@ -22445,7 +23571,9 @@ msgctxt "cloudsave"
 msgid ""
 "You can do this by saving your settings under a different passphrase, "
 "optionally deleting the first set."
-msgstr "다른 암호로 설정을 저장하여 암호를 변경할 수 있으며, 필요한 경우 첫 번째 세트를 삭제할 수도 있습니다."
+msgstr ""
+"다른 암호로 설정을 저장하여 암호를 변경할 수 있으며, 필요한 경우 첫 번째 세트"
+"를 삭제할 수도 있습니다."
 
 # smartling.placeholder_format=C
 #. Prefix for filename location sentence.
@@ -22468,7 +23596,8 @@ msgstr "%1$s검색 설정%2$s에서 이 알림을 숨길 수 있습니다."
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
-msgstr "이제 이 기기에 최근 채팅을 최대 100개 저장할 수 있습니다. 마음껏 채팅하세요!"
+msgstr ""
+"이제 이 기기에 최근 채팅을 최대 100개 저장할 수 있습니다. 마음껏 채팅하세요!"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -22524,7 +23653,9 @@ msgctxt "Organic result context menu"
 msgid ""
 "You can only block up to %s sites. To block %s, you'll need to unblock "
 "another site first."
-msgstr "차단할 수 있는 사이트는 최대 %1$s개입니다. %2$s 사이트를 차단하려면 다른 사이트 차단을 먼저 해제해야 합니다."
+msgstr ""
+"차단할 수 있는 사이트는 최대 %1$s개입니다. %2$s 사이트를 차단하려면 다른 사이"
+"트 차단을 먼저 해제해야 합니다."
 
 # smartling.placeholder_format=C
 #. Text explaining the benefits of the cloud save feature.
@@ -22580,7 +23711,9 @@ msgctxt "Description of the post-upgrade success modal"
 msgid ""
 "You now have access to %s, higher AI reasoning, and 2x higher usage limits "
 "than Plus."
-msgstr "이제 %1$s, 더 뛰어난 AI 추론, Plus보다 2배 높은 사용량 한도를 경험할 수 있습니다."
+msgstr ""
+"이제 %1$s, 더 뛰어난 AI 추론, Plus보다 2배 높은 사용량 한도를 경험할 수 있습"
+"니다."
 
 # smartling.placeholder_format=C
 #. Description text for the welcome modal displayed after the user subscribes to DuckDuckGo.
@@ -22589,8 +23722,8 @@ msgid ""
 "You now have access to advanced AI models. You can access the VPN and other "
 "DuckDuckGo subscription protections in the DuckDuckGo browser."
 msgstr ""
-"이제 고급 AI 모델을 이용하실 수 있습니다. DuckDuckGo 브라우저에서 VPN과 각종 DuckDuckGo 구독 보호 기능을 이용할 "
-"수 있습니다."
+"이제 고급 AI 모델을 이용하실 수 있습니다. DuckDuckGo 브라우저에서 VPN과 각종 "
+"DuckDuckGo 구독 보호 기능을 이용할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Welcome message that appears after the DuckDuckGo extension is installed.
@@ -22612,8 +23745,9 @@ msgid ""
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
 msgstr ""
-"이 브라우저에서 저장된 대화에 더 이상 액세스할 수 없습니다. 마지막 30개의 채팅은 로컬 저장소에 계속 남습니다. 암호화된 서버에서 "
-"채팅이 삭제되지는 않습니다."
+"이 브라우저에서 저장된 대화에 더 이상 액세스할 수 없습니다. 마지막 30개의 채"
+"팅은 로컬 저장소에 계속 남습니다. 암호화된 서버에서 채팅이 삭제되지는 않습니"
+"다."
 
 # smartling.placeholder_format=C
 #. Explains that turning off disconnects this browser only; the last 30 chats stay in local storage and the encrypted server backup is not deleted.
@@ -22623,8 +23757,9 @@ msgid ""
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
 msgstr ""
-"이 브라우저에서 저장된 대화에 더 이상 액세스할 수 없습니다. 마지막 30개의 채팅은 로컬 저장소에 계속 남습니다. 암호화된 서버에서 "
-"채팅이 삭제되지는 않습니다."
+"이 브라우저에서 저장된 대화에 더 이상 액세스할 수 없습니다. 마지막 30개의 채"
+"팅은 로컬 저장소에 계속 남습니다. 암호화된 서버에서 채팅이 삭제되지는 않습니"
+"다."
 
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
@@ -22646,8 +23781,8 @@ msgid ""
 "You're now searching privately in Chrome. Use our app instead of Chrome to "
 "browse privately too. It’s already installed and can:"
 msgstr ""
-"이제 Chrome에서 비공개로 검색할 수 있습니다. Chrome 대신 DuckDuckGo 앱도 사용해 보세요. 이미 설치되어 있으며 "
-"다음과 같은 기능이 제공됩니다."
+"이제 Chrome에서 비공개로 검색할 수 있습니다. Chrome 대신 DuckDuckGo 앱도 사용"
+"해 보세요. 이미 설치되어 있으며 다음과 같은 기능이 제공됩니다."
 
 # smartling.placeholder_format=C
 #. Confirmation message that appears after the DuckDuckGo browser extension is installed.
@@ -22659,7 +23794,9 @@ msgstr "이제 개인정보 보호를 받으며 검색할 수 있습니다!"
 msgid ""
 "You're now searching with privacy. %sGet tips to reduce your footprint even "
 "more."
-msgstr "현재 개인정보 보호 모드로 검색하고 있습니다. %1$s보안을 더욱 강화할 수 있는 팁을 알아보세요."
+msgstr ""
+"현재 개인정보 보호 모드로 검색하고 있습니다. %1$s보안을 더욱 강화할 수 있는 "
+"팁을 알아보세요."
 
 # smartling.placeholder_format=C
 #. Title of a notice thanking the user for turning off their adblocker
@@ -22729,8 +23866,9 @@ msgid ""
 "You've run out of Sync & Backup storage for Duck.ai chats with attachments. "
 "Delete the %s oldest chats to resume Sync. Pinned chats will not be deleted."
 msgstr ""
-"첨부 파일이 있는 Duck.ai 채팅의 Sync & Backup 저장 공간이 부족합니다. 동기화를 재개하려면 가장 오래된 채팅 "
-"%1$s개를 삭제하세요. 고정된 채팅은 삭제되지 않습니다."
+"첨부 파일이 있는 Duck.ai 채팅의 Sync & Backup 저장 공간이 부족합니다. 동기화"
+"를 재개하려면 가장 오래된 채팅 %1$s개를 삭제하세요. 고정된 채팅은 삭제되지 않"
+"습니다."
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -22740,8 +23878,9 @@ msgid ""
 "oldest chats with attachments to resume Sync. Pinned chats will not be "
 "deleted."
 msgstr ""
-"Duck.ai 채팅용 Sync & Backup 저장 공간이 소진되었습니다. 동기화를 재개하려면 첨부 파일이 있는 채팅을 오래된 순으로 "
-"%1$s개 삭제하세요. 고정된 채팅은 삭제되지 않습니다."
+"Duck.ai 채팅용 Sync & Backup 저장 공간이 소진되었습니다. 동기화를 재개하려면 "
+"첨부 파일이 있는 채팅을 오래된 순으로 %1$s개 삭제하세요. 고정된 채팅은 삭제되"
+"지 않습니다."
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the sync storage limit.
@@ -22755,8 +23894,8 @@ msgid ""
 "YouTube (owned by Google) does not let you watch videos anonymously. As "
 "such, watching YouTube videos here will be tracked by YouTube/Google."
 msgstr ""
-"YouTube(Google 소유)에서는 익명으로 동영상을 시청할 수 없습니다. 따라서 여기서 YouTube 동영상을 시청하면 "
-"YouTube나 Google의 추적을 받게 됩니다."
+"YouTube(Google 소유)에서는 익명으로 동영상을 시청할 수 없습니다. 따라서 여기"
+"서 YouTube 동영상을 시청하면 YouTube나 Google의 추적을 받게 됩니다."
 
 # smartling.placeholder_format=C
 #. Label for a privacy disclaimer related to YouTube videos
@@ -22800,8 +23939,8 @@ msgid ""
 "disconnected from sync. Your %s most recent chats will be available in local "
 "storage on these browsers:"
 msgstr ""
-"백업이 DuckDuckGo 서버에서 삭제됩니다. 모든 기기의 동기화가 해제됩니다. 다음 브라우저에서는 최근 채팅 %1$s개가 로컬 "
-"저장소에 저장됩니다."
+"백업이 DuckDuckGo 서버에서 삭제됩니다. 모든 기기의 동기화가 해제됩니다. 다음 "
+"브라우저에서는 최근 채팅 %1$s개가 로컬 저장소에 저장됩니다."
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list.
@@ -22811,8 +23950,8 @@ msgid ""
 "disconnected from sync. Your 100 most recent chats will be available in "
 "local storage on these browsers:"
 msgstr ""
-"백업이 DuckDuckGo 서버에서 삭제됩니다. 모든 기기의 동기화가 해제됩니다. 다음 브라우저에서는 최근 채팅 100개가 로컬 저장소에 "
-"저장됩니다."
+"백업이 DuckDuckGo 서버에서 삭제됩니다. 모든 기기의 동기화가 해제됩니다. 다음 "
+"브라우저에서는 최근 채팅 100개가 로컬 저장소에 저장됩니다."
 
 # smartling.placeholder_format=C
 #. List item indicating that a site exclusion filter is currently active for the search
@@ -22836,14 +23975,18 @@ msgctxt "new tab page"
 msgid ""
 "Your browser provides a list of your most-visited sites. DuckDuckGo never "
 "has access to this data."
-msgstr "가장 많이 방문한 사이트 목록은 사용자의 브라우저에서 제공됩니다. DuckDuckGo는 절대 이 데이터에 접근할 수 없습니다."
+msgstr ""
+"가장 많이 방문한 사이트 목록은 사용자의 브라우저에서 제공됩니다. DuckDuckGo"
+"는 절대 이 데이터에 접근할 수 없습니다."
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
 msgid ""
 "Your browser provides the list of most-visited sites. DuckDuckGo never has "
 "access to this data."
-msgstr "브라우저는 가장 많이 방문한 사이트 목록을 제공합니다. DuckDuckGo는 이 데이터에 절대 액세스할 수 없습니다."
+msgstr ""
+"브라우저는 가장 많이 방문한 사이트 목록을 제공합니다. DuckDuckGo는 이 데이터"
+"에 절대 액세스할 수 없습니다."
 
 # smartling.placeholder_format=C
 #. Disclaimer text shown bellow chat input. Example: 'You are chatting with GPT-3. AI chats may display inaccurate or offensive information.'
@@ -22851,7 +23994,9 @@ msgctxt "Disclaimer bellow chat input - desktop"
 msgid ""
 "Your chat with %s is private. AI chats may display inaccurate or offensive "
 "information."
-msgstr "%1$s 서비스와의 채팅은 비공개입니다. AI 채팅은 부정확하거나 불쾌한 정보를 표시할 수 있습니다."
+msgstr ""
+"%1$s 서비스와의 채팅은 비공개입니다. AI 채팅은 부정확하거나 불쾌한 정보를 표"
+"시할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Body copy shown after Sync & Backup is enabled, confirming chats are now syncing.
@@ -22876,28 +24021,36 @@ msgstr "사용자의 채팅은 비공개로 처리되며 AI 모델 훈련에 사
 msgctxt "Active Privacy protection description"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
-msgstr "내 채팅은 비공개이며 당사는 이 내용을 익명화하고, AI 모델 훈련에 사용하지 않습니다."
+msgstr ""
+"내 채팅은 비공개이며 당사는 이 내용을 익명화하고, AI 모델 훈련에 사용하지 않"
+"습니다."
 
 # smartling.placeholder_format=C
 #. Text explaining that user chats are private and not used for AI (Artificial Intelligence) training.
 msgctxt "Body text for privacy protection modal"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
-msgstr "내 채팅은 비공개이며 당사는 이 내용을 익명화하고, AI 모델 훈련에 사용하지 않습니다."
+msgstr ""
+"내 채팅은 비공개이며 당사는 이 내용을 익명화하고, AI 모델 훈련에 사용하지 않"
+"습니다."
 
 # smartling.placeholder_format=C
 #. Text for a menu item that describes the privacy protection feature.
 msgctxt "Menu item description"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
-msgstr "내 채팅은 비공개이며 당사는 이 내용을 저장하지 않고, AI 모델 훈련에도 사용하지 않습니다."
+msgstr ""
+"내 채팅은 비공개이며 당사는 이 내용을 저장하지 않고, AI 모델 훈련에도 사용하"
+"지 않습니다."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the active privacy protection.
 msgctxt "Modal body for privacy"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
-msgstr "내 채팅은 비공개이며 당사는 이 내용을 저장하지 않고, AI 모델 훈련에도 사용하지 않습니다."
+msgstr ""
+"내 채팅은 비공개이며 당사는 이 내용을 저장하지 않고, AI 모델 훈련에도 사용하"
+"지 않습니다."
 
 # smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that chats are stored locally on the user's device.
@@ -22912,8 +24065,8 @@ msgid ""
 "Your chats are still private, anonymized by us, and not used to train AI "
 "models. Follow these steps to keep your chat history."
 msgstr ""
-"내 채팅은 여전히 비공개입니다. Duck.ai는 이 내용을 익명화하고, AI 모델 훈련에 사용하지 않습니다. 채팅 기록을 보관하는 방법은 "
-"다음과 같습니다."
+"내 채팅은 여전히 비공개입니다. Duck.ai는 이 내용을 익명화하고, AI 모델 훈련"
+"에 사용하지 않습니다. 채팅 기록을 보관하는 방법은 다음과 같습니다."
 
 # smartling.placeholder_format=C
 #. Body shown after import completes.
@@ -22952,7 +24105,9 @@ msgctxt "newsletter email collection"
 msgid ""
 "Your email address will not be shared, %sor associated with anonymous "
 "searches. [%sExample message%s]"
-msgstr "사용자의 이메일은 공유되지 않으며 %1$s비공개 검색에도 사용되지 않습니다. [%2$s메시지 예시%3$s]"
+msgstr ""
+"사용자의 이메일은 공유되지 않으며 %1$s비공개 검색에도 사용되지 않습니다. "
+"[%2$s메시지 예시%3$s]"
 
 # smartling.placeholder_format=C
 #. A prompt for the user to provide feedback on the third party map app directions experience
@@ -22995,9 +24150,10 @@ msgid ""
 "browser. We save the settings file using the key as the name. DuckDuckGo "
 "never knows your passphrase."
 msgstr ""
-"사용자의 암호는 %1$sSHA-2%2$s라고 알려진 보안 해시 알고리즘을 사용해 512비트 키를 생성합니다. 키와 연관된 설정 파일만 "
-"브라우저 외부로 전송됩니다. DuckDuckGo는 해당 키를 파일 이름으로 사용하여 설정 파일을 저장하며, 사용자의 암호를 절대 알 수 "
-"없습니다."
+"사용자의 암호는 %1$sSHA-2%2$s라고 알려진 보안 해시 알고리즘을 사용해 512비트 "
+"키를 생성합니다. 키와 연관된 설정 파일만 브라우저 외부로 전송됩니다. "
+"DuckDuckGo는 해당 키를 파일 이름으로 사용하여 설정 파일을 저장하며, 사용자의 "
+"암호를 절대 알 수 없습니다."
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -23012,8 +24168,9 @@ msgid ""
 "personally identifiable metadata, so model providers can't tie your "
 "conversations back to you."
 msgstr ""
-"DuckDuckGo 서버를 통해 프롬프트가 전달되며 개인 정보를 식별할 수 있는 메타데이터는 제거됩니다. 따라서 모델 제공사는 대화를 "
-"특정 사용자에 연결할 수 없습니다."
+"DuckDuckGo 서버를 통해 프롬프트가 전달되며 개인 정보를 식별할 수 있는 메타데"
+"이터는 제거됩니다. 따라서 모델 제공사는 대화를 특정 사용자에 연결할 수 없습니"
+"다."
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -23069,8 +24226,9 @@ msgid ""
 "You’re now searching privately in Chrome. Use our browser instead of Chrome "
 "for more protection. It’s already installed and can:"
 msgstr ""
-"이제 Chrome에서 개인 정보 노출 없이 검색할 수 있습니다. Chrome 대신 DuckDuckGo 브라우저를 이용해서 더 철저하게 "
-"보호받으세요. 이미 설치되어 있으며 다음 기능이 제공됩니다."
+"이제 Chrome에서 개인 정보 노출 없이 검색할 수 있습니다. Chrome 대신 "
+"DuckDuckGo 브라우저를 이용해서 더 철저하게 보호받으세요. 이미 설치되어 있으"
+"며 다음 기능이 제공됩니다."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has exceeded the maximum message size.
@@ -23086,7 +24244,9 @@ msgctxt "Error message for conversation limit"
 msgid ""
 "You’ve reached the maximum chat length in this conversation. Clear this "
 "conversation with the Fire Button to continue."
-msgstr "이 대화에서 채팅 길이 한도에 도달했습니다. 계속 진행하려면 Fire Button을 눌러 이 대화를 지우세요."
+msgstr ""
+"이 대화에서 채팅 길이 한도에 도달했습니다. 계속 진행하려면 Fire Button을 눌"
+"러 이 대화를 지우세요."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -23094,7 +24254,8 @@ msgctxt "Error message for conversation limit"
 msgid ""
 "You’ve reached the maximum chat length in this conversation. Start a new "
 "chat to continue."
-msgstr "이 대화에서 채팅 길이 한도에 도달했습니다. 계속하려면 새 채팅을 시작해."
+msgstr ""
+"이 대화에서 채팅 길이 한도에 도달했습니다. 계속하려면 새 채팅을 시작해."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -23108,7 +24269,9 @@ msgctxt "Error message for user limit"
 msgid ""
 "You’ve reached the maximum number of messages for one day. Please continue "
 "this chat tomorrow."
-msgstr "하루에 보낼 수 있는 메시지 개수 한도에 도달했습니다. 이 채팅은 내일 계속하세요."
+msgstr ""
+"하루에 보낼 수 있는 메시지 개수 한도에 도달했습니다. 이 채팅은 내일 계속하세"
+"요."
 
 # smartling.placeholder_format=C
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
@@ -23410,7 +24573,9 @@ msgstr "공식 웹사이트"
 #. <em>%s</em> is for a hexadecimal color code as <em>#395323</em>, but it has to be safe encoded, and as <em>#</em> seems not safe, <em>%23</em> must be used in place of the sharp symbol, but they are the same for your browser.
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
-msgstr "또는 원하는 색상 코드를 직접 입력하세요. 예: %1$s (%2$s(은)는 인코딩된 %3$s 문자입니다)"
+msgstr ""
+"또는 원하는 색상 코드를 직접 입력하세요. 예: %1$s (%2$s(은)는 인코딩된 %3$s "
+"문자입니다)"
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "

--- a/locales/ku/LC_MESSAGES/duckduckgo.po
+++ b/locales/ku/LC_MESSAGES/duckduckgo.po
@@ -1166,6 +1166,11 @@ msgctxt "feedback form"
 msgid "Address is incorrect"
 msgstr "Navnîşan şaş e"
 
+#. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Adjust the servings"
+msgstr ""
+
 #. as in multiple advertisements
 msgid "Ads"
 msgstr "Reklam"
@@ -1338,6 +1343,13 @@ msgstr ""
 #. Heading shown on the empty chat screen. The text between the two %s markers is displayed inside a clickable privacy button. First %s renders a shield icon, second %s is an invisible end marker. Keep the word 'private' between both %s markers.
 msgctxt "Empty state heading in Duck.ai chat mode"
 msgid "All chats are %sprivate%s"
+msgstr ""
+
+#. Paragraph in the Privacy & Terms section of the About & Legal page in Duck.ai settings, summarizing how chats are anonymized and are not stored or used to train chat models.
+msgctxt "Privacy & Terms section description on the Duck.ai settings page"
+msgid ""
+"All chats are anonymized by DuckDuckGo, and your conversations are not used "
+"to train chat models by DuckDuckGo or the model providers"
 msgstr ""
 
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1553,6 +1565,12 @@ msgstr ""
 msgctxt "precise_user_location"
 msgid "Anonymous location enabled"
 msgstr "Cihê nenas çalak e"
+
+msgctxt "settings"
+msgid ""
+"Anonymously generates answers for search queries based on web content. "
+"Choose how often you want it to appear, or disable it completely."
+msgstr ""
 
 #. Instant Answer tab name
 msgid "Answer"
@@ -1776,6 +1794,11 @@ msgstr ""
 
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse
 msgid "Ask a follow-up with Duck.ai"
+msgstr ""
+
+#. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
+msgctxt "Page suggestion chip label"
+msgid "Ask about this page"
 msgstr ""
 
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2103,6 +2126,11 @@ msgstr ""
 msgid "Barcode"
 msgstr "Barkod"
 
+#. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Based on this page, is this course worth taking?"
+msgstr ""
+
 msgctxt "settings"
 msgid "Basic"
 msgstr "Hêsan"
@@ -2134,6 +2162,13 @@ msgstr ""
 #. Placeholder text displayed while the assistant waits for the user to choose an action.
 msgctxt "Assistant response placeholder"
 msgid "Before continuing..."
+msgstr ""
+
+#. Explains that before storing the report, DuckDuckGo will anonymize the conversation by removing PII like names, email addresses, and identifying metadata.
+msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
+msgid ""
+"Before storing this report, DuckDuckGo will anonymize your conversation by "
+"removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
 #. Label that's displayed next to a past start date below a web search result.
@@ -2392,6 +2427,11 @@ msgstr "Brazîl"
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Break Points Won"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Break this down into clear, numbered steps."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -2764,6 +2804,11 @@ msgstr "Kar"
 #. Text of a button that performs a search for the cast of a particular movie or tv show
 msgctxt "Movie/TV Show Title instant answer"
 msgid "Cast"
+msgstr ""
+
+#. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Cast & Crew"
 msgstr ""
 
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -4131,6 +4176,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Create a shopping list with quantities from this recipe."
+msgstr ""
+
 #. Placeholder text displayed in the input field when starting a new image generation session.
 msgctxt "Placeholder text for the image generation input field"
 msgid "Create an image of a cute duck..."
@@ -4657,6 +4707,10 @@ msgstr ""
 msgid "Dictation limit reached"
 msgstr ""
 
+#. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
+msgid "Dictation temporarily unavailable"
+msgstr ""
+
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
@@ -4901,6 +4955,20 @@ msgctxt "precise_user_location"
 msgid "Done"
 msgstr "Qediya"
 
+#. Message shown in a modal after DuckDuckGo browser users disable AI features in Settings. The first two placeholders bold noai.duckduckgo.com. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
+"filtered out. %sLearn More%s"
+msgstr ""
+
+#. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
+"and AI images filtered out. %sLearn more%s"
+msgstr ""
+
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Double Faults"
@@ -4991,6 +5059,16 @@ msgctxt "Full sentence for writing an email"
 msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
+msgstr ""
+
+#. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Draft a cover letter"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Draft a cover letter for this job."
 msgstr ""
 
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -5130,6 +5208,14 @@ msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
 msgstr ""
 
+#. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
+msgctxt "About section description on the Duck.ai settings page"
+msgid ""
+"Duck.ai is created by DuckDuckGo. We're an independent online protection "
+"company for anyone who wants to take back control of their personal "
+"information."
+msgstr ""
+
 #. Title shown when an update is required before proceeding.
 msgctxt "duckai_migration"
 msgid "Duck.ai is moving domains"
@@ -5163,6 +5249,12 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Duck.ai lets you chat privately with popular AI models. Disabling it hides "
+"Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
 
 msgctxt "settings"
@@ -5945,6 +6037,16 @@ msgstr ""
 msgid "Eritrea"
 msgstr ""
 
+#. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Estimate the nutrition"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Estimate the nutritional information for this recipe."
+msgstr ""
+
 msgid "Estonia"
 msgstr "Estoniya"
 
@@ -5989,10 +6091,50 @@ msgctxt "merchant promotion product ad extension"
 msgid "Expires in 1 day"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain the accepted answer in simple terms."
+msgstr ""
+
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
+msgstr ""
+
+#. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain the top answer"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this in simple, plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this paper"
+msgstr ""
+
+#. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this repo"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this research paper in plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this simply"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain what this repository does and how to use it."
 msgstr ""
 
 #. Label to show if song lyrics contain explicit content
@@ -6223,6 +6365,11 @@ msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
 msgstr ""
 
+msgctxt "settings"
+msgid ""
+"Filters out known AI spam sites from image search results. %sLearn More%s"
+msgstr ""
+
 #. Label for the final score of a sporting event.
 msgid "Final"
 msgstr "Dawî"
@@ -6262,6 +6409,11 @@ msgstr ""
 #. Short description shown below the 'Web Search' label in the Tools dropdown.
 msgctxt "Subtitle for the Web Search tool entry in the Tools dropdown menu"
 msgid "Find current information"
+msgstr ""
+
+#. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Find me alternatives"
 msgstr ""
 
 #. Button that searches for results closer to the user's current location.
@@ -6652,6 +6804,11 @@ msgstr ""
 msgid "Generate More"
 msgstr ""
 
+#. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Generate a shopping list"
+msgstr ""
+
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
 msgid "Generate a short answer from the web"
 msgstr ""
@@ -6888,6 +7045,11 @@ msgstr ""
 #. Text for a button inviting users to give it a try for the Duck.ai product. On click, they're taken to the Duck.ai page.
 msgctxt "Onboarding welcome screen button text"
 msgid "Give it a Try"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Give me a quick background on this person."
 msgstr ""
 
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -7251,6 +7413,16 @@ msgstr "Alîkariya belavkirina DuckDuckGo bike!"
 #. Link to a page with information about sharing DuckDuckGo with friends.
 msgid "Help Spread Privacy"
 msgstr "Alîkariya Belavkirina Taybetiyê bike"
+
+#. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Help me prep for the interview"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Help me tailor my resume for this job."
+msgstr ""
 
 #. Title of a SERP popup that invites users to take a survey (desktop only)
 msgctxt "User survey popup"
@@ -7673,6 +7845,13 @@ msgstr "Bahoz"
 #. Text displayed on the button on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
 msgctxt "Onboarding terms screen button text"
 msgid "I Agree"
+msgstr ""
+
+#. Text for the button that takes the user to the external DuckDuckGo login subscription page.
+msgctxt ""
+"Text for the I already have a subscription button in the Duck.ai settings "
+"page"
+msgid "I Already Have a Subscription"
 msgstr ""
 
 #. Text for the button that takes the user to the login subscription page.
@@ -8142,6 +8321,11 @@ msgctxt "Sidemenu browser promo"
 msgid "Install Mac Browser"
 msgstr ""
 
+#. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
+msgctxt "settings"
+msgid "Install Now"
+msgstr ""
+
 #. Text of a button to install the DuckDuckGo app
 msgctxt "Serp footer content"
 msgid "Install Our App"
@@ -8221,10 +8405,37 @@ msgctxt "cloudsave"
 msgid "Is deleted data really deleted?"
 msgstr "Daneyên jêbirî bi rastî têne jêbirin?"
 
+#. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is it worth taking?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this place any good?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"Is this place any good? Summarize its reputation based on reviews and "
+"ratings."
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "Is this video helpful?"
 msgstr "Ev vîdyo alîkar bû?"
+
+#. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this worth watching?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Is this worth watching? Give me a spoiler-free take."
+msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
 msgctxt "Weather IA"
@@ -8727,6 +8938,11 @@ msgstr "Curenivîsa Girêdanê:"
 msgid "Links:"
 msgstr "Girêdan:"
 
+#. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "List the tools, materials, or prerequisites I need for this."
+msgstr ""
+
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
 msgid "Listen"
 msgstr "Guhdarkirin"
@@ -9061,6 +9277,11 @@ msgstr ""
 #. Label for linke navigating to site exclusion feature on Settings page
 msgctxt "Exclusion message manage sites button"
 msgid "Manage blocked sites"
+msgstr ""
+
+#. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
+msgctxt "setting"
+msgid "Manage in Browser Settings"
 msgstr ""
 
 #. Link to the site exclusion settings page
@@ -11375,6 +11596,11 @@ msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
+msgid "Please describe why the chat response is harmful or illegal. (optional)"
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
+msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
 msgstr ""
 
@@ -11393,6 +11619,13 @@ msgctxt "Modal disclaimer text"
 msgid ""
 "Please note: starting a new chat with any model will delete your current "
 "chat session."
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
+msgctxt "Feedback prompt"
+msgid ""
+"Please paste your prompt and the problematic output (with any personal "
+"information removed) and describe why the content is harmful or illegal."
 msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -11777,6 +12010,11 @@ msgctxt "settings"
 msgid "Privacy"
 msgstr "Taybetî"
 
+#. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
+msgctxt "Section heading on the Duck.ai settings page"
+msgid "Privacy & Terms"
+msgstr ""
+
 msgid "Privacy Blog"
 msgstr "Bloga Tayebetiyê"
 
@@ -11830,6 +12068,11 @@ msgstr ""
 
 #. Text used in other strings to link to the Privacy Policy and Terms of Service content.
 msgctxt "Copy used to compose link in sentences"
+msgid "Privacy Policy and Terms of Service"
+msgstr ""
+
+#. Text for a button that links to the terms of use and privacy policy page.
+msgctxt "Secondary button text in active privacy modal"
 msgid "Privacy Policy and Terms of Service"
 msgstr ""
 
@@ -12240,6 +12483,26 @@ msgctxt "Brief for recommending a book"
 msgid "Recommend a book"
 msgstr ""
 
+#. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar books"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar books."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar movies or shows."
+msgstr ""
+
+#. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar titles"
+msgstr ""
+
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
 msgid "Recording failed. Please try again."
 msgstr ""
@@ -12564,6 +12827,14 @@ msgstr ""
 msgid "Republic of Moldova"
 msgstr ""
 
+#. Note indicating that sharing the conversation is mandatory when reporting harmful or illegal content. Rendered alongside the standard share label (DUCKCHAT_RESPONSE_FEEDBACK_SHARE_PROMPT_RESPONSE_LABEL), not replacing it.
+msgctxt ""
+"Note shown under the share-content switch label on the Duck.ai response "
+"feedback form when the user has selected Harmful or Illegal as the feedback "
+"reason"
+msgid "Required for harmful or illegal reports"
+msgstr ""
+
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
 msgctxt "Description for extended reasoning mode in Duck.ai"
 msgid "Researches before responding"
@@ -12750,6 +13021,11 @@ msgstr "Nirxandin"
 msgctxt "maps_places"
 msgid "Reviews"
 msgstr "Nirxandin"
+
+#. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Rewrite this recipe scaled for a different number of servings."
+msgstr ""
 
 msgid "Romania"
 msgstr "Romaniya"
@@ -13801,6 +14077,11 @@ msgctxt "Setup button for native sync flow"
 msgid "Set Up Now"
 msgstr ""
 
+#. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
+msgctxt "Encrypted storage setup button shown in native browsers"
+msgid "Set Up Sync & Backup"
+msgstr ""
+
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
 msgctxt "Title for the Sync & Backup intro screen"
 msgid "Set Up Sync & Backup"
@@ -13945,6 +14226,12 @@ msgstr ""
 msgctxt "feedback form"
 msgid "Share positive feedback"
 msgstr "Paşragihandinê erênî parve bike"
+
+#. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
+msgctxt ""
+"Label beside the share-content switch on the Duck.ai response feedback form"
+msgid "Share this conversation with DuckDuckGo"
+msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
 msgctxt ""
@@ -14962,6 +15249,21 @@ msgctxt "Brief for suggesting a blog post title"
 msgid "Suggest a title for a blog post"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest related articles or topics worth exploring next."
+msgstr ""
+
+#. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Suggest related articles to explore"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest some alternatives to this product."
+msgstr ""
+
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
 msgctxt "directions"
 msgid "Suggestions:"
@@ -14971,9 +15273,84 @@ msgctxt "noresults"
 msgid "Suggestions:"
 msgstr "Pêşniyarî:"
 
+#. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Sum up the reviews"
+msgstr ""
+
 #. A short title for the a message asking the AI to summarize a text.
 msgctxt "Title for the summarize message"
 msgid "Summarize"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize the Q&As"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the background and notable work of this person."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the key details of this event."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the questions and answers on this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize their background"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this book"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this book."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this discussion"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this discussion thread."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this video"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this video."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize what the reviews say."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -15228,6 +15605,11 @@ msgstr ""
 msgid "Syria"
 msgstr ""
 
+#. Text for a button that enables the theme to follow the operating system's color scheme preference.
+msgctxt "System theme button for theme selector"
+msgid "System"
+msgstr ""
+
 #. Abbreviation indicating this is the total score for a game
 msgctxt "Sports module"
 msgid "T"
@@ -15251,6 +15633,11 @@ msgctxt "language_name"
 msgid "Tahitian"
 msgstr "Tahîtî"
 
+#. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Tailor my resume"
+msgstr ""
+
 msgid "Taiwan"
 msgstr "Taywan"
 
@@ -15273,6 +15660,12 @@ msgstr "Daneyên xwe yên taybet kontrol bike"
 msgctxt "homepage ATB modal"
 msgid "Take control of your personal data!"
 msgstr "Daneyên xwe yên taybet kontrol bike!"
+
+#. Description for the Feedback section of the Duck.ai settings page, asking the user to take an anonymous survey to let us know how we can make Duck.ai better.
+msgctxt "Feedback section description on the Duck.ai settings page"
+msgid ""
+"Take this anonymous survey to let us know how we can make Duck.ai better."
+msgstr ""
 
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
 msgctxt "Description for reasoning mode in Duck.ai"
@@ -15521,6 +15914,11 @@ msgstr ""
 #. https://duck.co/media/files/theme.png
 msgid "Theme"
 msgstr "Rûkar"
+
+#. Text for the theme selector label that allows users to switch between Light and dark theme.
+msgctxt "Label for the theme selector feature"
+msgid "Theme"
+msgstr ""
 
 #. http://i.imgur.com/LpFhb1e.png
 msgctxt "settings"
@@ -16181,6 +16579,16 @@ msgid ""
 "movie theatre?”"
 msgstr ""
 
+#. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Translate this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
+msgctxt "Page suggestion prompt"
+msgid "Translate this page into %s."
+msgstr ""
+
 #. Placeholder text for a region that will display translated text.
 msgctxt "translations_module"
 msgid "Translation"
@@ -16295,6 +16703,11 @@ msgstr ""
 #. Call-to-action button for the subscription promo in the SERP sidemenu.
 msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
+msgstr ""
+
+#. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
+msgctxt "settings"
+msgid "Try It Now"
 msgstr ""
 
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -16489,6 +16902,20 @@ msgstr ":%s bicerbîne"
 msgctxt "new user poll"
 msgid "Trying DuckDuckGo again"
 msgstr "DuckDuckGo dîsa bicerbîne"
+
+#. Message shown in a modal after supported third-party browser users disable AI features in Settings. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+#. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
 
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
 msgctxt "Assistant response placeholder"
@@ -17096,6 +17523,11 @@ msgstr "Urdûyî"
 msgid "Uruguay"
 msgstr "Urugway"
 
+#. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
+msgctxt "Navigation label on the Duck.ai settings page"
+msgid "Usage"
+msgstr ""
+
 #. A feedback suggestion
 msgctxt "Feedback prompt"
 msgid "Usage limit"
@@ -17448,6 +17880,11 @@ msgstr "Li benda cihê ye..."
 msgid "Wales"
 msgstr "Wêlz"
 
+#. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Walk me through the steps"
+msgstr ""
+
 #. Label for walking directions on a map.
 msgctxt "directions"
 msgid "Walking"
@@ -17544,6 +17981,16 @@ msgstr ""
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
+msgstr ""
+
+#. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
+msgctxt ""
+"Inline warning shown below the share-content toggle when the user selects "
+"Harmful or Illegal but has not enabled sharing"
+msgid ""
+"We can only fix what we can see. To report a harmful or illegal response, "
+"please share this conversation with DuckDuckGo so we can investigate and "
+"address the issue."
 msgstr ""
 
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -17981,6 +18428,87 @@ msgid ""
 "experience."
 msgstr ""
 
+#. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the counterarguments?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the hours & location?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key contributions of this paper?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key contributions?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key details?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key points covered in this video?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key points?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key takeaways from this article?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key takeaways?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key things I will learn from this course?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main counterarguments or criticisms of this?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main questions this page answers?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the must-try dishes here?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"What are the opening hours, location, and contact details for this place?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the pros and cons of this product?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the pros and cons?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
 msgctxt "feedback form"
 msgid "What bothered you most?"
@@ -18064,6 +18592,11 @@ msgctxt "Full sentence for defining a term"
 msgid "What does atria mean in the context of a medical article?"
 msgstr ""
 
+#. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What does this answer?"
+msgstr ""
+
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
@@ -18073,6 +18606,11 @@ msgstr ""
 msgctxt "cloudsave"
 msgid "What information gets saved?"
 msgstr "Çi zanyarî hate tomarkirin"
+
+#. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What interview questions might come up for this role?"
+msgstr ""
 
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
@@ -18086,6 +18624,11 @@ msgstr ""
 #. Text for a prompt suggestion for looking up the capital city of Albania.
 msgctxt "Full sentence for looking up basic facts"
 msgid "What is the capital city of Albania?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What is the overall verdict and rating for this?"
 msgstr ""
 
 #. Link to a page with additional information.
@@ -18106,6 +18649,11 @@ msgctxt "maps_places"
 msgid "What people say:"
 msgstr "Mirov çi dibêjin:"
 
+#. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What should I order?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
 msgctxt "feedback form"
 msgid "What stood out?"
@@ -18114,6 +18662,16 @@ msgstr ""
 #. Question on a feedback form for a negative feedback response.
 msgctxt "feedback form"
 msgid "What was wrong with the response? (optional)"
+msgstr ""
+
+#. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I learn?"
+msgstr ""
+
+#. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I need?"
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -18128,6 +18686,11 @@ msgstr ""
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
 msgctxt "SERP footer content"
 msgid "What's New"
+msgstr ""
+
+#. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What's the verdict?"
 msgstr ""
 
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -18169,6 +18732,11 @@ msgctxt "Feedback prompt"
 msgid "Which features are missing? (Optional)"
 msgstr ""
 
+#. An invitation for users to leave feedback
+msgctxt "Feedback prompt"
+msgid "Which features are missing? (optional)"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
 msgid "White"
 msgstr "Spî"
@@ -18181,6 +18749,16 @@ msgstr "Spî"
 #. Link to an about us page.
 msgid "Who We Are"
 msgstr "Em Kî Ne"
+
+#. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Who are the main cast and crew, and what else are they known for?"
+msgstr ""
+
+#. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Who is this person?"
+msgstr ""
 
 #. Header above a collection of privacy-related links.
 msgid "Why Privacy"

--- a/locales/kw_GB/LC_MESSAGES/duckduckgo.po
+++ b/locales/kw_GB/LC_MESSAGES/duckduckgo.po
@@ -1160,6 +1160,11 @@ msgctxt "feedback form"
 msgid "Address is incorrect"
 msgstr ""
 
+#. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Adjust the servings"
+msgstr ""
+
 #. as in multiple advertisements
 msgid "Ads"
 msgstr ""
@@ -1331,6 +1336,13 @@ msgstr ""
 #. Heading shown on the empty chat screen. The text between the two %s markers is displayed inside a clickable privacy button. First %s renders a shield icon, second %s is an invisible end marker. Keep the word 'private' between both %s markers.
 msgctxt "Empty state heading in Duck.ai chat mode"
 msgid "All chats are %sprivate%s"
+msgstr ""
+
+#. Paragraph in the Privacy & Terms section of the About & Legal page in Duck.ai settings, summarizing how chats are anonymized and are not stored or used to train chat models.
+msgctxt "Privacy & Terms section description on the Duck.ai settings page"
+msgid ""
+"All chats are anonymized by DuckDuckGo, and your conversations are not used "
+"to train chat models by DuckDuckGo or the model providers"
 msgstr ""
 
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1543,6 +1555,12 @@ msgstr ""
 #. Confirmation message after location service is enabled.
 msgctxt "precise_user_location"
 msgid "Anonymous location enabled"
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Anonymously generates answers for search queries based on web content. "
+"Choose how often you want it to appear, or disable it completely."
 msgstr ""
 
 #. Instant Answer tab name
@@ -1765,6 +1783,11 @@ msgstr ""
 
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse
 msgid "Ask a follow-up with Duck.ai"
+msgstr ""
+
+#. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
+msgctxt "Page suggestion chip label"
+msgid "Ask about this page"
 msgstr ""
 
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2089,6 +2112,11 @@ msgstr ""
 msgid "Barcode"
 msgstr "Barrgod"
 
+#. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Based on this page, is this course worth taking?"
+msgstr ""
+
 msgctxt "settings"
 msgid "Basic"
 msgstr ""
@@ -2120,6 +2148,13 @@ msgstr ""
 #. Placeholder text displayed while the assistant waits for the user to choose an action.
 msgctxt "Assistant response placeholder"
 msgid "Before continuing..."
+msgstr ""
+
+#. Explains that before storing the report, DuckDuckGo will anonymize the conversation by removing PII like names, email addresses, and identifying metadata.
+msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
+msgid ""
+"Before storing this report, DuckDuckGo will anonymize your conversation by "
+"removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
 #. Label that's displayed next to a past start date below a web search result.
@@ -2378,6 +2413,11 @@ msgstr ""
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Break Points Won"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Break this down into clear, numbered steps."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -2737,6 +2777,11 @@ msgstr ""
 #. Text of a button that performs a search for the cast of a particular movie or tv show
 msgctxt "Movie/TV Show Title instant answer"
 msgid "Cast"
+msgstr ""
+
+#. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Cast & Crew"
 msgstr ""
 
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -4086,6 +4131,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Create a shopping list with quantities from this recipe."
+msgstr ""
+
 #. Placeholder text displayed in the input field when starting a new image generation session.
 msgctxt "Placeholder text for the image generation input field"
 msgid "Create an image of a cute duck..."
@@ -4612,6 +4662,10 @@ msgstr ""
 msgid "Dictation limit reached"
 msgstr ""
 
+#. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
+msgid "Dictation temporarily unavailable"
+msgstr ""
+
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
@@ -4856,6 +4910,20 @@ msgctxt "precise_user_location"
 msgid "Done"
 msgstr ""
 
+#. Message shown in a modal after DuckDuckGo browser users disable AI features in Settings. The first two placeholders bold noai.duckduckgo.com. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
+"filtered out. %sLearn More%s"
+msgstr ""
+
+#. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
+"and AI images filtered out. %sLearn more%s"
+msgstr ""
+
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Double Faults"
@@ -4946,6 +5014,16 @@ msgctxt "Full sentence for writing an email"
 msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
+msgstr ""
+
+#. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Draft a cover letter"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Draft a cover letter for this job."
 msgstr ""
 
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -5085,6 +5163,14 @@ msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
 msgstr ""
 
+#. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
+msgctxt "About section description on the Duck.ai settings page"
+msgid ""
+"Duck.ai is created by DuckDuckGo. We're an independent online protection "
+"company for anyone who wants to take back control of their personal "
+"information."
+msgstr ""
+
 #. Title shown when an update is required before proceeding.
 msgctxt "duckai_migration"
 msgid "Duck.ai is moving domains"
@@ -5118,6 +5204,12 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Duck.ai lets you chat privately with popular AI models. Disabling it hides "
+"Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
 
 msgctxt "settings"
@@ -5883,6 +5975,16 @@ msgstr ""
 msgid "Eritrea"
 msgstr ""
 
+#. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Estimate the nutrition"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Estimate the nutritional information for this recipe."
+msgstr ""
+
 msgid "Estonia"
 msgstr ""
 
@@ -5927,10 +6029,50 @@ msgctxt "merchant promotion product ad extension"
 msgid "Expires in 1 day"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain the accepted answer in simple terms."
+msgstr ""
+
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
+msgstr ""
+
+#. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain the top answer"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this in simple, plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this paper"
+msgstr ""
+
+#. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this repo"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this research paper in plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this simply"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain what this repository does and how to use it."
 msgstr ""
 
 #. Label to show if song lyrics contain explicit content
@@ -6159,6 +6301,11 @@ msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
 msgstr ""
 
+msgctxt "settings"
+msgid ""
+"Filters out known AI spam sites from image search results. %sLearn More%s"
+msgstr ""
+
 #. Label for the final score of a sporting event.
 msgid "Final"
 msgstr ""
@@ -6198,6 +6345,11 @@ msgstr ""
 #. Short description shown below the 'Web Search' label in the Tools dropdown.
 msgctxt "Subtitle for the Web Search tool entry in the Tools dropdown menu"
 msgid "Find current information"
+msgstr ""
+
+#. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Find me alternatives"
 msgstr ""
 
 #. Button that searches for results closer to the user's current location.
@@ -6588,6 +6740,11 @@ msgstr ""
 msgid "Generate More"
 msgstr ""
 
+#. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Generate a shopping list"
+msgstr ""
+
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
 msgid "Generate a short answer from the web"
 msgstr ""
@@ -6822,6 +6979,11 @@ msgstr ""
 #. Text for a button inviting users to give it a try for the Duck.ai product. On click, they're taken to the Duck.ai page.
 msgctxt "Onboarding welcome screen button text"
 msgid "Give it a Try"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Give me a quick background on this person."
 msgstr ""
 
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -7184,6 +7346,16 @@ msgstr ""
 
 #. Link to a page with information about sharing DuckDuckGo with friends.
 msgid "Help Spread Privacy"
+msgstr ""
+
+#. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Help me prep for the interview"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Help me tailor my resume for this job."
 msgstr ""
 
 #. Title of a SERP popup that invites users to take a survey (desktop only)
@@ -7603,6 +7775,13 @@ msgstr ""
 #. Text displayed on the button on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
 msgctxt "Onboarding terms screen button text"
 msgid "I Agree"
+msgstr ""
+
+#. Text for the button that takes the user to the external DuckDuckGo login subscription page.
+msgctxt ""
+"Text for the I already have a subscription button in the Duck.ai settings "
+"page"
+msgid "I Already Have a Subscription"
 msgstr ""
 
 #. Text for the button that takes the user to the login subscription page.
@@ -8055,6 +8234,11 @@ msgctxt "Sidemenu browser promo"
 msgid "Install Mac Browser"
 msgstr ""
 
+#. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
+msgctxt "settings"
+msgid "Install Now"
+msgstr ""
+
 #. Text of a button to install the DuckDuckGo app
 msgctxt "Serp footer content"
 msgid "Install Our App"
@@ -8134,9 +8318,36 @@ msgctxt "cloudsave"
 msgid "Is deleted data really deleted?"
 msgstr ""
 
+#. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is it worth taking?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this place any good?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"Is this place any good? Summarize its reputation based on reviews and "
+"ratings."
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "Is this video helpful?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this worth watching?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Is this worth watching? Give me a spoiler-free take."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -8633,6 +8844,11 @@ msgstr "Kevren font:"
 msgid "Links:"
 msgstr "Gorgevrennow:"
 
+#. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "List the tools, materials, or prerequisites I need for this."
+msgstr ""
+
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
 msgid "Listen"
 msgstr "Goslowes"
@@ -8965,6 +9181,11 @@ msgstr ""
 #. Label for linke navigating to site exclusion feature on Settings page
 msgctxt "Exclusion message manage sites button"
 msgid "Manage blocked sites"
+msgstr ""
+
+#. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
+msgctxt "setting"
+msgid "Manage in Browser Settings"
 msgstr ""
 
 #. Link to the site exclusion settings page
@@ -11262,6 +11483,11 @@ msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
+msgid "Please describe why the chat response is harmful or illegal. (optional)"
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
+msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
 msgstr ""
 
@@ -11280,6 +11506,13 @@ msgctxt "Modal disclaimer text"
 msgid ""
 "Please note: starting a new chat with any model will delete your current "
 "chat session."
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
+msgctxt "Feedback prompt"
+msgid ""
+"Please paste your prompt and the problematic output (with any personal "
+"information removed) and describe why the content is harmful or illegal."
 msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -11664,6 +11897,11 @@ msgctxt "settings"
 msgid "Privacy"
 msgstr "Privetter"
 
+#. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
+msgctxt "Section heading on the Duck.ai settings page"
+msgid "Privacy & Terms"
+msgstr ""
+
 msgid "Privacy Blog"
 msgstr ""
 
@@ -11717,6 +11955,11 @@ msgstr ""
 
 #. Text used in other strings to link to the Privacy Policy and Terms of Service content.
 msgctxt "Copy used to compose link in sentences"
+msgid "Privacy Policy and Terms of Service"
+msgstr ""
+
+#. Text for a button that links to the terms of use and privacy policy page.
+msgctxt "Secondary button text in active privacy modal"
 msgid "Privacy Policy and Terms of Service"
 msgstr ""
 
@@ -12125,6 +12368,26 @@ msgctxt "Brief for recommending a book"
 msgid "Recommend a book"
 msgstr ""
 
+#. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar books"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar books."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar movies or shows."
+msgstr ""
+
+#. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar titles"
+msgstr ""
+
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
 msgid "Recording failed. Please try again."
 msgstr ""
@@ -12444,6 +12707,14 @@ msgstr ""
 msgid "Republic of Moldova"
 msgstr ""
 
+#. Note indicating that sharing the conversation is mandatory when reporting harmful or illegal content. Rendered alongside the standard share label (DUCKCHAT_RESPONSE_FEEDBACK_SHARE_PROMPT_RESPONSE_LABEL), not replacing it.
+msgctxt ""
+"Note shown under the share-content switch label on the Duck.ai response "
+"feedback form when the user has selected Harmful or Illegal as the feedback "
+"reason"
+msgid "Required for harmful or illegal reports"
+msgstr ""
+
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
 msgctxt "Description for extended reasoning mode in Duck.ai"
 msgid "Researches before responding"
@@ -12629,6 +12900,11 @@ msgstr "Dashwithransow"
 #. Label above a list of customer reviews of a business.
 msgctxt "maps_places"
 msgid "Reviews"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Rewrite this recipe scaled for a different number of servings."
 msgstr ""
 
 msgid "Romania"
@@ -13664,6 +13940,11 @@ msgctxt "Setup button for native sync flow"
 msgid "Set Up Now"
 msgstr ""
 
+#. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
+msgctxt "Encrypted storage setup button shown in native browsers"
+msgid "Set Up Sync & Backup"
+msgstr ""
+
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
 msgctxt "Title for the Sync & Backup intro screen"
 msgid "Set Up Sync & Backup"
@@ -13806,6 +14087,12 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
+msgctxt ""
+"Label beside the share-content switch on the Duck.ai response feedback form"
+msgid "Share this conversation with DuckDuckGo"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -14820,6 +15107,21 @@ msgctxt "Brief for suggesting a blog post title"
 msgid "Suggest a title for a blog post"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest related articles or topics worth exploring next."
+msgstr ""
+
+#. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Suggest related articles to explore"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest some alternatives to this product."
+msgstr ""
+
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
 msgctxt "directions"
 msgid "Suggestions:"
@@ -14829,9 +15131,84 @@ msgctxt "noresults"
 msgid "Suggestions:"
 msgstr ""
 
+#. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Sum up the reviews"
+msgstr ""
+
 #. A short title for the a message asking the AI to summarize a text.
 msgctxt "Title for the summarize message"
 msgid "Summarize"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize the Q&As"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the background and notable work of this person."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the key details of this event."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the questions and answers on this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize their background"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this book"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this book."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this discussion"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this discussion thread."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this video"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this video."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize what the reviews say."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -15086,6 +15463,11 @@ msgstr ""
 msgid "Syria"
 msgstr ""
 
+#. Text for a button that enables the theme to follow the operating system's color scheme preference.
+msgctxt "System theme button for theme selector"
+msgid "System"
+msgstr ""
+
 #. Abbreviation indicating this is the total score for a game
 msgctxt "Sports module"
 msgid "T"
@@ -15109,6 +15491,11 @@ msgctxt "language_name"
 msgid "Tahitian"
 msgstr ""
 
+#. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Tailor my resume"
+msgstr ""
+
 msgid "Taiwan"
 msgstr ""
 
@@ -15130,6 +15517,12 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "Take control of your personal data!"
+msgstr ""
+
+#. Description for the Feedback section of the Duck.ai settings page, asking the user to take an anonymous survey to let us know how we can make Duck.ai better.
+msgctxt "Feedback section description on the Duck.ai settings page"
+msgid ""
+"Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
 
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -15374,6 +15767,11 @@ msgstr ""
 #. https://duck.co/media/files/theme.png
 msgid "Theme"
 msgstr "Thema"
+
+#. Text for the theme selector label that allows users to switch between Light and dark theme.
+msgctxt "Label for the theme selector feature"
+msgid "Theme"
+msgstr ""
 
 #. http://i.imgur.com/LpFhb1e.png
 msgctxt "settings"
@@ -16025,6 +16423,16 @@ msgid ""
 "movie theatre?”"
 msgstr ""
 
+#. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Translate this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
+msgctxt "Page suggestion prompt"
+msgid "Translate this page into %s."
+msgstr ""
+
 #. Placeholder text for a region that will display translated text.
 msgctxt "translations_module"
 msgid "Translation"
@@ -16139,6 +16547,11 @@ msgstr ""
 #. Call-to-action button for the subscription promo in the SERP sidemenu.
 msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
+msgstr ""
+
+#. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
+msgctxt "settings"
+msgid "Try It Now"
 msgstr ""
 
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -16332,6 +16745,20 @@ msgstr "Assaya: %s"
 #. Response a user can select in a feedback form, indicating that they're trying DuckDuckGo again.
 msgctxt "new user poll"
 msgid "Trying DuckDuckGo again"
+msgstr ""
+
+#. Message shown in a modal after supported third-party browser users disable AI features in Settings. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+#. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
 msgstr ""
 
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -16932,6 +17359,11 @@ msgstr ""
 msgid "Uruguay"
 msgstr ""
 
+#. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
+msgctxt "Navigation label on the Duck.ai settings page"
+msgid "Usage"
+msgstr ""
+
 #. A feedback suggestion
 msgctxt "Feedback prompt"
 msgid "Usage limit"
@@ -17280,6 +17712,11 @@ msgstr ""
 msgid "Wales"
 msgstr ""
 
+#. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Walk me through the steps"
+msgstr ""
+
 #. Label for walking directions on a map.
 msgctxt "directions"
 msgid "Walking"
@@ -17370,6 +17807,16 @@ msgstr ""
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
+msgstr ""
+
+#. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
+msgctxt ""
+"Inline warning shown below the share-content toggle when the user selects "
+"Harmful or Illegal but has not enabled sharing"
+msgid ""
+"We can only fix what we can see. To report a harmful or illegal response, "
+"please share this conversation with DuckDuckGo so we can investigate and "
+"address the issue."
 msgstr ""
 
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -17789,6 +18236,87 @@ msgid ""
 "experience."
 msgstr ""
 
+#. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the counterarguments?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the hours & location?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key contributions of this paper?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key contributions?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key details?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key points covered in this video?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key points?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key takeaways from this article?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key takeaways?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key things I will learn from this course?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main counterarguments or criticisms of this?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main questions this page answers?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the must-try dishes here?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"What are the opening hours, location, and contact details for this place?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the pros and cons of this product?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the pros and cons?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
 msgctxt "feedback form"
 msgid "What bothered you most?"
@@ -17872,6 +18400,11 @@ msgctxt "Full sentence for defining a term"
 msgid "What does atria mean in the context of a medical article?"
 msgstr ""
 
+#. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What does this answer?"
+msgstr ""
+
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
@@ -17880,6 +18413,11 @@ msgstr ""
 #. Header above a list of types of information that gets saved by the cloud save feature.
 msgctxt "cloudsave"
 msgid "What information gets saved?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What interview questions might come up for this role?"
 msgstr ""
 
 #. Text explaining how the cloud save feature works.
@@ -17892,6 +18430,11 @@ msgstr ""
 #. Text for a prompt suggestion for looking up the capital city of Albania.
 msgctxt "Full sentence for looking up basic facts"
 msgid "What is the capital city of Albania?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What is the overall verdict and rating for this?"
 msgstr ""
 
 #. Link to a page with additional information.
@@ -17912,6 +18455,11 @@ msgctxt "maps_places"
 msgid "What people say:"
 msgstr ""
 
+#. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What should I order?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
 msgctxt "feedback form"
 msgid "What stood out?"
@@ -17920,6 +18468,16 @@ msgstr ""
 #. Question on a feedback form for a negative feedback response.
 msgctxt "feedback form"
 msgid "What was wrong with the response? (optional)"
+msgstr ""
+
+#. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I learn?"
+msgstr ""
+
+#. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I need?"
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -17934,6 +18492,11 @@ msgstr ""
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
 msgctxt "SERP footer content"
 msgid "What's New"
+msgstr ""
+
+#. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What's the verdict?"
 msgstr ""
 
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -17975,6 +18538,11 @@ msgctxt "Feedback prompt"
 msgid "Which features are missing? (Optional)"
 msgstr ""
 
+#. An invitation for users to leave feedback
+msgctxt "Feedback prompt"
+msgid "Which features are missing? (optional)"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
 msgid "White"
 msgstr "Gwynn"
@@ -17986,6 +18554,16 @@ msgstr ""
 
 #. Link to an about us page.
 msgid "Who We Are"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Who are the main cast and crew, and what else are they known for?"
+msgstr ""
+
+#. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Who is this person?"
 msgstr ""
 
 #. Header above a collection of privacy-related links.

--- a/locales/ky_KG/LC_MESSAGES/duckduckgo.po
+++ b/locales/ky_KG/LC_MESSAGES/duckduckgo.po
@@ -1159,6 +1159,11 @@ msgctxt "feedback form"
 msgid "Address is incorrect"
 msgstr ""
 
+#. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Adjust the servings"
+msgstr ""
+
 #. as in multiple advertisements
 msgid "Ads"
 msgstr ""
@@ -1330,6 +1335,13 @@ msgstr ""
 #. Heading shown on the empty chat screen. The text between the two %s markers is displayed inside a clickable privacy button. First %s renders a shield icon, second %s is an invisible end marker. Keep the word 'private' between both %s markers.
 msgctxt "Empty state heading in Duck.ai chat mode"
 msgid "All chats are %sprivate%s"
+msgstr ""
+
+#. Paragraph in the Privacy & Terms section of the About & Legal page in Duck.ai settings, summarizing how chats are anonymized and are not stored or used to train chat models.
+msgctxt "Privacy & Terms section description on the Duck.ai settings page"
+msgid ""
+"All chats are anonymized by DuckDuckGo, and your conversations are not used "
+"to train chat models by DuckDuckGo or the model providers"
 msgstr ""
 
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1542,6 +1554,12 @@ msgstr ""
 #. Confirmation message after location service is enabled.
 msgctxt "precise_user_location"
 msgid "Anonymous location enabled"
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Anonymously generates answers for search queries based on web content. "
+"Choose how often you want it to appear, or disable it completely."
 msgstr ""
 
 #. Instant Answer tab name
@@ -1764,6 +1782,11 @@ msgstr ""
 
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse
 msgid "Ask a follow-up with Duck.ai"
+msgstr ""
+
+#. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
+msgctxt "Page suggestion chip label"
+msgid "Ask about this page"
 msgstr ""
 
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2088,6 +2111,11 @@ msgstr ""
 msgid "Barcode"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Based on this page, is this course worth taking?"
+msgstr ""
+
 msgctxt "settings"
 msgid "Basic"
 msgstr ""
@@ -2119,6 +2147,13 @@ msgstr ""
 #. Placeholder text displayed while the assistant waits for the user to choose an action.
 msgctxt "Assistant response placeholder"
 msgid "Before continuing..."
+msgstr ""
+
+#. Explains that before storing the report, DuckDuckGo will anonymize the conversation by removing PII like names, email addresses, and identifying metadata.
+msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
+msgid ""
+"Before storing this report, DuckDuckGo will anonymize your conversation by "
+"removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
 #. Label that's displayed next to a past start date below a web search result.
@@ -2377,6 +2412,11 @@ msgstr ""
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Break Points Won"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Break this down into clear, numbered steps."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -2736,6 +2776,11 @@ msgstr ""
 #. Text of a button that performs a search for the cast of a particular movie or tv show
 msgctxt "Movie/TV Show Title instant answer"
 msgid "Cast"
+msgstr ""
+
+#. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Cast & Crew"
 msgstr ""
 
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -4085,6 +4130,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Create a shopping list with quantities from this recipe."
+msgstr ""
+
 #. Placeholder text displayed in the input field when starting a new image generation session.
 msgctxt "Placeholder text for the image generation input field"
 msgid "Create an image of a cute duck..."
@@ -4611,6 +4661,10 @@ msgstr ""
 msgid "Dictation limit reached"
 msgstr ""
 
+#. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
+msgid "Dictation temporarily unavailable"
+msgstr ""
+
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
@@ -4855,6 +4909,20 @@ msgctxt "precise_user_location"
 msgid "Done"
 msgstr ""
 
+#. Message shown in a modal after DuckDuckGo browser users disable AI features in Settings. The first two placeholders bold noai.duckduckgo.com. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
+"filtered out. %sLearn More%s"
+msgstr ""
+
+#. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
+"and AI images filtered out. %sLearn more%s"
+msgstr ""
+
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Double Faults"
@@ -4945,6 +5013,16 @@ msgctxt "Full sentence for writing an email"
 msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
+msgstr ""
+
+#. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Draft a cover letter"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Draft a cover letter for this job."
 msgstr ""
 
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -5084,6 +5162,14 @@ msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
 msgstr ""
 
+#. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
+msgctxt "About section description on the Duck.ai settings page"
+msgid ""
+"Duck.ai is created by DuckDuckGo. We're an independent online protection "
+"company for anyone who wants to take back control of their personal "
+"information."
+msgstr ""
+
 #. Title shown when an update is required before proceeding.
 msgctxt "duckai_migration"
 msgid "Duck.ai is moving domains"
@@ -5117,6 +5203,12 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Duck.ai lets you chat privately with popular AI models. Disabling it hides "
+"Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
 
 msgctxt "settings"
@@ -5882,6 +5974,16 @@ msgstr ""
 msgid "Eritrea"
 msgstr ""
 
+#. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Estimate the nutrition"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Estimate the nutritional information for this recipe."
+msgstr ""
+
 msgid "Estonia"
 msgstr ""
 
@@ -5926,10 +6028,50 @@ msgctxt "merchant promotion product ad extension"
 msgid "Expires in 1 day"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain the accepted answer in simple terms."
+msgstr ""
+
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
+msgstr ""
+
+#. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain the top answer"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this in simple, plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this paper"
+msgstr ""
+
+#. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this repo"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this research paper in plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this simply"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain what this repository does and how to use it."
 msgstr ""
 
 #. Label to show if song lyrics contain explicit content
@@ -6158,6 +6300,11 @@ msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
 msgstr ""
 
+msgctxt "settings"
+msgid ""
+"Filters out known AI spam sites from image search results. %sLearn More%s"
+msgstr ""
+
 #. Label for the final score of a sporting event.
 msgid "Final"
 msgstr ""
@@ -6197,6 +6344,11 @@ msgstr ""
 #. Short description shown below the 'Web Search' label in the Tools dropdown.
 msgctxt "Subtitle for the Web Search tool entry in the Tools dropdown menu"
 msgid "Find current information"
+msgstr ""
+
+#. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Find me alternatives"
 msgstr ""
 
 #. Button that searches for results closer to the user's current location.
@@ -6587,6 +6739,11 @@ msgstr ""
 msgid "Generate More"
 msgstr ""
 
+#. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Generate a shopping list"
+msgstr ""
+
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
 msgid "Generate a short answer from the web"
 msgstr ""
@@ -6821,6 +6978,11 @@ msgstr ""
 #. Text for a button inviting users to give it a try for the Duck.ai product. On click, they're taken to the Duck.ai page.
 msgctxt "Onboarding welcome screen button text"
 msgid "Give it a Try"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Give me a quick background on this person."
 msgstr ""
 
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -7183,6 +7345,16 @@ msgstr ""
 
 #. Link to a page with information about sharing DuckDuckGo with friends.
 msgid "Help Spread Privacy"
+msgstr ""
+
+#. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Help me prep for the interview"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Help me tailor my resume for this job."
 msgstr ""
 
 #. Title of a SERP popup that invites users to take a survey (desktop only)
@@ -7602,6 +7774,13 @@ msgstr ""
 #. Text displayed on the button on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
 msgctxt "Onboarding terms screen button text"
 msgid "I Agree"
+msgstr ""
+
+#. Text for the button that takes the user to the external DuckDuckGo login subscription page.
+msgctxt ""
+"Text for the I already have a subscription button in the Duck.ai settings "
+"page"
+msgid "I Already Have a Subscription"
 msgstr ""
 
 #. Text for the button that takes the user to the login subscription page.
@@ -8052,6 +8231,11 @@ msgctxt "Sidemenu browser promo"
 msgid "Install Mac Browser"
 msgstr ""
 
+#. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
+msgctxt "settings"
+msgid "Install Now"
+msgstr ""
+
 #. Text of a button to install the DuckDuckGo app
 msgctxt "Serp footer content"
 msgid "Install Our App"
@@ -8131,9 +8315,36 @@ msgctxt "cloudsave"
 msgid "Is deleted data really deleted?"
 msgstr "Өчүрүлгөн маалыматтар, чын эле үчтүбү?"
 
+#. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is it worth taking?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this place any good?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"Is this place any good? Summarize its reputation based on reviews and "
+"ratings."
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "Is this video helpful?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this worth watching?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Is this worth watching? Give me a spoiler-free take."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -8630,6 +8841,11 @@ msgstr "Шилтеменин ариби:"
 msgid "Links:"
 msgstr "Шилтемелери:"
 
+#. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "List the tools, materials, or prerequisites I need for this."
+msgstr ""
+
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
 msgid "Listen"
 msgstr "Угуу"
@@ -8962,6 +9178,11 @@ msgstr ""
 #. Label for linke navigating to site exclusion feature on Settings page
 msgctxt "Exclusion message manage sites button"
 msgid "Manage blocked sites"
+msgstr ""
+
+#. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
+msgctxt "setting"
+msgid "Manage in Browser Settings"
 msgstr ""
 
 #. Link to the site exclusion settings page
@@ -11259,6 +11480,11 @@ msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
+msgid "Please describe why the chat response is harmful or illegal. (optional)"
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
+msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
 msgstr ""
 
@@ -11277,6 +11503,13 @@ msgctxt "Modal disclaimer text"
 msgid ""
 "Please note: starting a new chat with any model will delete your current "
 "chat session."
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
+msgctxt "Feedback prompt"
+msgid ""
+"Please paste your prompt and the problematic output (with any personal "
+"information removed) and describe why the content is harmful or illegal."
 msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -11661,6 +11894,11 @@ msgctxt "settings"
 msgid "Privacy"
 msgstr ""
 
+#. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
+msgctxt "Section heading on the Duck.ai settings page"
+msgid "Privacy & Terms"
+msgstr ""
+
 msgid "Privacy Blog"
 msgstr ""
 
@@ -11714,6 +11952,11 @@ msgstr ""
 
 #. Text used in other strings to link to the Privacy Policy and Terms of Service content.
 msgctxt "Copy used to compose link in sentences"
+msgid "Privacy Policy and Terms of Service"
+msgstr ""
+
+#. Text for a button that links to the terms of use and privacy policy page.
+msgctxt "Secondary button text in active privacy modal"
 msgid "Privacy Policy and Terms of Service"
 msgstr ""
 
@@ -12122,6 +12365,26 @@ msgctxt "Brief for recommending a book"
 msgid "Recommend a book"
 msgstr ""
 
+#. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar books"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar books."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar movies or shows."
+msgstr ""
+
+#. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar titles"
+msgstr ""
+
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
 msgid "Recording failed. Please try again."
 msgstr ""
@@ -12441,6 +12704,14 @@ msgstr ""
 msgid "Republic of Moldova"
 msgstr ""
 
+#. Note indicating that sharing the conversation is mandatory when reporting harmful or illegal content. Rendered alongside the standard share label (DUCKCHAT_RESPONSE_FEEDBACK_SHARE_PROMPT_RESPONSE_LABEL), not replacing it.
+msgctxt ""
+"Note shown under the share-content switch label on the Duck.ai response "
+"feedback form when the user has selected Harmful or Illegal as the feedback "
+"reason"
+msgid "Required for harmful or illegal reports"
+msgstr ""
+
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
 msgctxt "Description for extended reasoning mode in Duck.ai"
 msgid "Researches before responding"
@@ -12626,6 +12897,11 @@ msgstr "Пикирлер"
 #. Label above a list of customer reviews of a business.
 msgctxt "maps_places"
 msgid "Reviews"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Rewrite this recipe scaled for a different number of servings."
 msgstr ""
 
 msgid "Romania"
@@ -13661,6 +13937,11 @@ msgctxt "Setup button for native sync flow"
 msgid "Set Up Now"
 msgstr ""
 
+#. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
+msgctxt "Encrypted storage setup button shown in native browsers"
+msgid "Set Up Sync & Backup"
+msgstr ""
+
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
 msgctxt "Title for the Sync & Backup intro screen"
 msgid "Set Up Sync & Backup"
@@ -13803,6 +14084,12 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
+msgctxt ""
+"Label beside the share-content switch on the Duck.ai response feedback form"
+msgid "Share this conversation with DuckDuckGo"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -14817,6 +15104,21 @@ msgctxt "Brief for suggesting a blog post title"
 msgid "Suggest a title for a blog post"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest related articles or topics worth exploring next."
+msgstr ""
+
+#. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Suggest related articles to explore"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest some alternatives to this product."
+msgstr ""
+
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
 msgctxt "directions"
 msgid "Suggestions:"
@@ -14826,9 +15128,84 @@ msgctxt "noresults"
 msgid "Suggestions:"
 msgstr ""
 
+#. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Sum up the reviews"
+msgstr ""
+
 #. A short title for the a message asking the AI to summarize a text.
 msgctxt "Title for the summarize message"
 msgid "Summarize"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize the Q&As"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the background and notable work of this person."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the key details of this event."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the questions and answers on this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize their background"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this book"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this book."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this discussion"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this discussion thread."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this video"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this video."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize what the reviews say."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -15083,6 +15460,11 @@ msgstr ""
 msgid "Syria"
 msgstr ""
 
+#. Text for a button that enables the theme to follow the operating system's color scheme preference.
+msgctxt "System theme button for theme selector"
+msgid "System"
+msgstr ""
+
 #. Abbreviation indicating this is the total score for a game
 msgctxt "Sports module"
 msgid "T"
@@ -15106,6 +15488,11 @@ msgctxt "language_name"
 msgid "Tahitian"
 msgstr ""
 
+#. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Tailor my resume"
+msgstr ""
+
 msgid "Taiwan"
 msgstr ""
 
@@ -15127,6 +15514,12 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "Take control of your personal data!"
+msgstr ""
+
+#. Description for the Feedback section of the Duck.ai settings page, asking the user to take an anonymous survey to let us know how we can make Duck.ai better.
+msgctxt "Feedback section description on the Duck.ai settings page"
+msgid ""
+"Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
 
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -15369,6 +15762,11 @@ msgstr ""
 
 #. Title for the theme menu:
 #. https://duck.co/media/files/theme.png
+msgid "Theme"
+msgstr ""
+
+#. Text for the theme selector label that allows users to switch between Light and dark theme.
+msgctxt "Label for the theme selector feature"
 msgid "Theme"
 msgstr ""
 
@@ -16022,6 +16420,16 @@ msgid ""
 "movie theatre?”"
 msgstr ""
 
+#. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Translate this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
+msgctxt "Page suggestion prompt"
+msgid "Translate this page into %s."
+msgstr ""
+
 #. Placeholder text for a region that will display translated text.
 msgctxt "translations_module"
 msgid "Translation"
@@ -16136,6 +16544,11 @@ msgstr ""
 #. Call-to-action button for the subscription promo in the SERP sidemenu.
 msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
+msgstr ""
+
+#. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
+msgctxt "settings"
+msgid "Try It Now"
 msgstr ""
 
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -16329,6 +16742,20 @@ msgstr ""
 #. Response a user can select in a feedback form, indicating that they're trying DuckDuckGo again.
 msgctxt "new user poll"
 msgid "Trying DuckDuckGo again"
+msgstr ""
+
+#. Message shown in a modal after supported third-party browser users disable AI features in Settings. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+#. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
 msgstr ""
 
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -16929,6 +17356,11 @@ msgstr ""
 msgid "Uruguay"
 msgstr ""
 
+#. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
+msgctxt "Navigation label on the Duck.ai settings page"
+msgid "Usage"
+msgstr ""
+
 #. A feedback suggestion
 msgctxt "Feedback prompt"
 msgid "Usage limit"
@@ -17277,6 +17709,11 @@ msgstr ""
 msgid "Wales"
 msgstr ""
 
+#. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Walk me through the steps"
+msgstr ""
+
 #. Label for walking directions on a map.
 msgctxt "directions"
 msgid "Walking"
@@ -17367,6 +17804,16 @@ msgstr ""
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
+msgstr ""
+
+#. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
+msgctxt ""
+"Inline warning shown below the share-content toggle when the user selects "
+"Harmful or Illegal but has not enabled sharing"
+msgid ""
+"We can only fix what we can see. To report a harmful or illegal response, "
+"please share this conversation with DuckDuckGo so we can investigate and "
+"address the issue."
 msgstr ""
 
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -17786,6 +18233,87 @@ msgid ""
 "experience."
 msgstr ""
 
+#. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the counterarguments?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the hours & location?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key contributions of this paper?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key contributions?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key details?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key points covered in this video?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key points?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key takeaways from this article?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key takeaways?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key things I will learn from this course?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main counterarguments or criticisms of this?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main questions this page answers?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the must-try dishes here?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"What are the opening hours, location, and contact details for this place?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the pros and cons of this product?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the pros and cons?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
 msgctxt "feedback form"
 msgid "What bothered you most?"
@@ -17869,6 +18397,11 @@ msgctxt "Full sentence for defining a term"
 msgid "What does atria mean in the context of a medical article?"
 msgstr ""
 
+#. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What does this answer?"
+msgstr ""
+
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
@@ -17877,6 +18410,11 @@ msgstr ""
 #. Header above a list of types of information that gets saved by the cloud save feature.
 msgctxt "cloudsave"
 msgid "What information gets saved?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What interview questions might come up for this role?"
 msgstr ""
 
 #. Text explaining how the cloud save feature works.
@@ -17889,6 +18427,11 @@ msgstr ""
 #. Text for a prompt suggestion for looking up the capital city of Albania.
 msgctxt "Full sentence for looking up basic facts"
 msgid "What is the capital city of Albania?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What is the overall verdict and rating for this?"
 msgstr ""
 
 #. Link to a page with additional information.
@@ -17909,6 +18452,11 @@ msgctxt "maps_places"
 msgid "What people say:"
 msgstr ""
 
+#. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What should I order?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
 msgctxt "feedback form"
 msgid "What stood out?"
@@ -17917,6 +18465,16 @@ msgstr ""
 #. Question on a feedback form for a negative feedback response.
 msgctxt "feedback form"
 msgid "What was wrong with the response? (optional)"
+msgstr ""
+
+#. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I learn?"
+msgstr ""
+
+#. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I need?"
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -17931,6 +18489,11 @@ msgstr ""
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
 msgctxt "SERP footer content"
 msgid "What's New"
+msgstr ""
+
+#. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What's the verdict?"
 msgstr ""
 
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -17972,6 +18535,11 @@ msgctxt "Feedback prompt"
 msgid "Which features are missing? (Optional)"
 msgstr ""
 
+#. An invitation for users to leave feedback
+msgctxt "Feedback prompt"
+msgid "Which features are missing? (optional)"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
 msgid "White"
 msgstr "Ак"
@@ -17983,6 +18551,16 @@ msgstr ""
 
 #. Link to an about us page.
 msgid "Who We Are"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Who are the main cast and crew, and what else are they known for?"
+msgstr ""
+
+#. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Who is this person?"
 msgstr ""
 
 #. Header above a collection of privacy-related links.

--- a/locales/ln_CD/LC_MESSAGES/duckduckgo.po
+++ b/locales/ln_CD/LC_MESSAGES/duckduckgo.po
@@ -1160,6 +1160,11 @@ msgctxt "feedback form"
 msgid "Address is incorrect"
 msgstr ""
 
+#. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Adjust the servings"
+msgstr ""
+
 #. as in multiple advertisements
 msgid "Ads"
 msgstr ""
@@ -1331,6 +1336,13 @@ msgstr ""
 #. Heading shown on the empty chat screen. The text between the two %s markers is displayed inside a clickable privacy button. First %s renders a shield icon, second %s is an invisible end marker. Keep the word 'private' between both %s markers.
 msgctxt "Empty state heading in Duck.ai chat mode"
 msgid "All chats are %sprivate%s"
+msgstr ""
+
+#. Paragraph in the Privacy & Terms section of the About & Legal page in Duck.ai settings, summarizing how chats are anonymized and are not stored or used to train chat models.
+msgctxt "Privacy & Terms section description on the Duck.ai settings page"
+msgid ""
+"All chats are anonymized by DuckDuckGo, and your conversations are not used "
+"to train chat models by DuckDuckGo or the model providers"
 msgstr ""
 
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1543,6 +1555,12 @@ msgstr ""
 #. Confirmation message after location service is enabled.
 msgctxt "precise_user_location"
 msgid "Anonymous location enabled"
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Anonymously generates answers for search queries based on web content. "
+"Choose how often you want it to appear, or disable it completely."
 msgstr ""
 
 #. Instant Answer tab name
@@ -1765,6 +1783,11 @@ msgstr ""
 
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse
 msgid "Ask a follow-up with Duck.ai"
+msgstr ""
+
+#. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
+msgctxt "Page suggestion chip label"
+msgid "Ask about this page"
 msgstr ""
 
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2089,6 +2112,11 @@ msgstr ""
 msgid "Barcode"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Based on this page, is this course worth taking?"
+msgstr ""
+
 msgctxt "settings"
 msgid "Basic"
 msgstr ""
@@ -2120,6 +2148,13 @@ msgstr ""
 #. Placeholder text displayed while the assistant waits for the user to choose an action.
 msgctxt "Assistant response placeholder"
 msgid "Before continuing..."
+msgstr ""
+
+#. Explains that before storing the report, DuckDuckGo will anonymize the conversation by removing PII like names, email addresses, and identifying metadata.
+msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
+msgid ""
+"Before storing this report, DuckDuckGo will anonymize your conversation by "
+"removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
 #. Label that's displayed next to a past start date below a web search result.
@@ -2378,6 +2413,11 @@ msgstr ""
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Break Points Won"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Break this down into clear, numbered steps."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -2737,6 +2777,11 @@ msgstr ""
 #. Text of a button that performs a search for the cast of a particular movie or tv show
 msgctxt "Movie/TV Show Title instant answer"
 msgid "Cast"
+msgstr ""
+
+#. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Cast & Crew"
 msgstr ""
 
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -4086,6 +4131,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Create a shopping list with quantities from this recipe."
+msgstr ""
+
 #. Placeholder text displayed in the input field when starting a new image generation session.
 msgctxt "Placeholder text for the image generation input field"
 msgid "Create an image of a cute duck..."
@@ -4612,6 +4662,10 @@ msgstr ""
 msgid "Dictation limit reached"
 msgstr ""
 
+#. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
+msgid "Dictation temporarily unavailable"
+msgstr ""
+
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
@@ -4856,6 +4910,20 @@ msgctxt "precise_user_location"
 msgid "Done"
 msgstr ""
 
+#. Message shown in a modal after DuckDuckGo browser users disable AI features in Settings. The first two placeholders bold noai.duckduckgo.com. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
+"filtered out. %sLearn More%s"
+msgstr ""
+
+#. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
+"and AI images filtered out. %sLearn more%s"
+msgstr ""
+
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Double Faults"
@@ -4946,6 +5014,16 @@ msgctxt "Full sentence for writing an email"
 msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
+msgstr ""
+
+#. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Draft a cover letter"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Draft a cover letter for this job."
 msgstr ""
 
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -5085,6 +5163,14 @@ msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
 msgstr ""
 
+#. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
+msgctxt "About section description on the Duck.ai settings page"
+msgid ""
+"Duck.ai is created by DuckDuckGo. We're an independent online protection "
+"company for anyone who wants to take back control of their personal "
+"information."
+msgstr ""
+
 #. Title shown when an update is required before proceeding.
 msgctxt "duckai_migration"
 msgid "Duck.ai is moving domains"
@@ -5118,6 +5204,12 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Duck.ai lets you chat privately with popular AI models. Disabling it hides "
+"Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
 
 msgctxt "settings"
@@ -5883,6 +5975,16 @@ msgstr ""
 msgid "Eritrea"
 msgstr ""
 
+#. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Estimate the nutrition"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Estimate the nutritional information for this recipe."
+msgstr ""
+
 msgid "Estonia"
 msgstr ""
 
@@ -5927,10 +6029,50 @@ msgctxt "merchant promotion product ad extension"
 msgid "Expires in 1 day"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain the accepted answer in simple terms."
+msgstr ""
+
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
+msgstr ""
+
+#. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain the top answer"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this in simple, plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this paper"
+msgstr ""
+
+#. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this repo"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this research paper in plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this simply"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain what this repository does and how to use it."
 msgstr ""
 
 #. Label to show if song lyrics contain explicit content
@@ -6159,6 +6301,11 @@ msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
 msgstr ""
 
+msgctxt "settings"
+msgid ""
+"Filters out known AI spam sites from image search results. %sLearn More%s"
+msgstr ""
+
 #. Label for the final score of a sporting event.
 msgid "Final"
 msgstr ""
@@ -6198,6 +6345,11 @@ msgstr ""
 #. Short description shown below the 'Web Search' label in the Tools dropdown.
 msgctxt "Subtitle for the Web Search tool entry in the Tools dropdown menu"
 msgid "Find current information"
+msgstr ""
+
+#. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Find me alternatives"
 msgstr ""
 
 #. Button that searches for results closer to the user's current location.
@@ -6588,6 +6740,11 @@ msgstr ""
 msgid "Generate More"
 msgstr ""
 
+#. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Generate a shopping list"
+msgstr ""
+
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
 msgid "Generate a short answer from the web"
 msgstr ""
@@ -6822,6 +6979,11 @@ msgstr ""
 #. Text for a button inviting users to give it a try for the Duck.ai product. On click, they're taken to the Duck.ai page.
 msgctxt "Onboarding welcome screen button text"
 msgid "Give it a Try"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Give me a quick background on this person."
 msgstr ""
 
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -7184,6 +7346,16 @@ msgstr ""
 
 #. Link to a page with information about sharing DuckDuckGo with friends.
 msgid "Help Spread Privacy"
+msgstr ""
+
+#. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Help me prep for the interview"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Help me tailor my resume for this job."
 msgstr ""
 
 #. Title of a SERP popup that invites users to take a survey (desktop only)
@@ -7603,6 +7775,13 @@ msgstr ""
 #. Text displayed on the button on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
 msgctxt "Onboarding terms screen button text"
 msgid "I Agree"
+msgstr ""
+
+#. Text for the button that takes the user to the external DuckDuckGo login subscription page.
+msgctxt ""
+"Text for the I already have a subscription button in the Duck.ai settings "
+"page"
+msgid "I Already Have a Subscription"
 msgstr ""
 
 #. Text for the button that takes the user to the login subscription page.
@@ -8053,6 +8232,11 @@ msgctxt "Sidemenu browser promo"
 msgid "Install Mac Browser"
 msgstr ""
 
+#. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
+msgctxt "settings"
+msgid "Install Now"
+msgstr ""
+
 #. Text of a button to install the DuckDuckGo app
 msgctxt "Serp footer content"
 msgid "Install Our App"
@@ -8132,9 +8316,36 @@ msgctxt "cloudsave"
 msgid "Is deleted data really deleted?"
 msgstr ""
 
+#. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is it worth taking?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this place any good?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"Is this place any good? Summarize its reputation based on reviews and "
+"ratings."
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "Is this video helpful?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this worth watching?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Is this worth watching? Give me a spoiler-free take."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -8631,6 +8842,11 @@ msgstr ""
 msgid "Links:"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "List the tools, materials, or prerequisites I need for this."
+msgstr ""
+
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
 msgid "Listen"
 msgstr "Koyóka"
@@ -8963,6 +9179,11 @@ msgstr ""
 #. Label for linke navigating to site exclusion feature on Settings page
 msgctxt "Exclusion message manage sites button"
 msgid "Manage blocked sites"
+msgstr ""
+
+#. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
+msgctxt "setting"
+msgid "Manage in Browser Settings"
 msgstr ""
 
 #. Link to the site exclusion settings page
@@ -11260,6 +11481,11 @@ msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
+msgid "Please describe why the chat response is harmful or illegal. (optional)"
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
+msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
 msgstr ""
 
@@ -11278,6 +11504,13 @@ msgctxt "Modal disclaimer text"
 msgid ""
 "Please note: starting a new chat with any model will delete your current "
 "chat session."
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
+msgctxt "Feedback prompt"
+msgid ""
+"Please paste your prompt and the problematic output (with any personal "
+"information removed) and describe why the content is harmful or illegal."
 msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -11662,6 +11895,11 @@ msgctxt "settings"
 msgid "Privacy"
 msgstr ""
 
+#. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
+msgctxt "Section heading on the Duck.ai settings page"
+msgid "Privacy & Terms"
+msgstr ""
+
 msgid "Privacy Blog"
 msgstr ""
 
@@ -11715,6 +11953,11 @@ msgstr ""
 
 #. Text used in other strings to link to the Privacy Policy and Terms of Service content.
 msgctxt "Copy used to compose link in sentences"
+msgid "Privacy Policy and Terms of Service"
+msgstr ""
+
+#. Text for a button that links to the terms of use and privacy policy page.
+msgctxt "Secondary button text in active privacy modal"
 msgid "Privacy Policy and Terms of Service"
 msgstr ""
 
@@ -12123,6 +12366,26 @@ msgctxt "Brief for recommending a book"
 msgid "Recommend a book"
 msgstr ""
 
+#. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar books"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar books."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar movies or shows."
+msgstr ""
+
+#. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar titles"
+msgstr ""
+
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
 msgid "Recording failed. Please try again."
 msgstr ""
@@ -12442,6 +12705,14 @@ msgstr ""
 msgid "Republic of Moldova"
 msgstr ""
 
+#. Note indicating that sharing the conversation is mandatory when reporting harmful or illegal content. Rendered alongside the standard share label (DUCKCHAT_RESPONSE_FEEDBACK_SHARE_PROMPT_RESPONSE_LABEL), not replacing it.
+msgctxt ""
+"Note shown under the share-content switch label on the Duck.ai response "
+"feedback form when the user has selected Harmful or Illegal as the feedback "
+"reason"
+msgid "Required for harmful or illegal reports"
+msgstr ""
+
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
 msgctxt "Description for extended reasoning mode in Duck.ai"
 msgid "Researches before responding"
@@ -12627,6 +12898,11 @@ msgstr "Makákólí"
 #. Label above a list of customer reviews of a business.
 msgctxt "maps_places"
 msgid "Reviews"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Rewrite this recipe scaled for a different number of servings."
 msgstr ""
 
 msgid "Romania"
@@ -13662,6 +13938,11 @@ msgctxt "Setup button for native sync flow"
 msgid "Set Up Now"
 msgstr ""
 
+#. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
+msgctxt "Encrypted storage setup button shown in native browsers"
+msgid "Set Up Sync & Backup"
+msgstr ""
+
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
 msgctxt "Title for the Sync & Backup intro screen"
 msgid "Set Up Sync & Backup"
@@ -13804,6 +14085,12 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
+msgctxt ""
+"Label beside the share-content switch on the Duck.ai response feedback form"
+msgid "Share this conversation with DuckDuckGo"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -14818,6 +15105,21 @@ msgctxt "Brief for suggesting a blog post title"
 msgid "Suggest a title for a blog post"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest related articles or topics worth exploring next."
+msgstr ""
+
+#. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Suggest related articles to explore"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest some alternatives to this product."
+msgstr ""
+
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
 msgctxt "directions"
 msgid "Suggestions:"
@@ -14827,9 +15129,84 @@ msgctxt "noresults"
 msgid "Suggestions:"
 msgstr ""
 
+#. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Sum up the reviews"
+msgstr ""
+
 #. A short title for the a message asking the AI to summarize a text.
 msgctxt "Title for the summarize message"
 msgid "Summarize"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize the Q&As"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the background and notable work of this person."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the key details of this event."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the questions and answers on this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize their background"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this book"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this book."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this discussion"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this discussion thread."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this video"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this video."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize what the reviews say."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -15084,6 +15461,11 @@ msgstr ""
 msgid "Syria"
 msgstr ""
 
+#. Text for a button that enables the theme to follow the operating system's color scheme preference.
+msgctxt "System theme button for theme selector"
+msgid "System"
+msgstr ""
+
 #. Abbreviation indicating this is the total score for a game
 msgctxt "Sports module"
 msgid "T"
@@ -15107,6 +15489,11 @@ msgctxt "language_name"
 msgid "Tahitian"
 msgstr ""
 
+#. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Tailor my resume"
+msgstr ""
+
 msgid "Taiwan"
 msgstr ""
 
@@ -15128,6 +15515,12 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "Take control of your personal data!"
+msgstr ""
+
+#. Description for the Feedback section of the Duck.ai settings page, asking the user to take an anonymous survey to let us know how we can make Duck.ai better.
+msgctxt "Feedback section description on the Duck.ai settings page"
+msgid ""
+"Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
 
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -15370,6 +15763,11 @@ msgstr ""
 
 #. Title for the theme menu:
 #. https://duck.co/media/files/theme.png
+msgid "Theme"
+msgstr ""
+
+#. Text for the theme selector label that allows users to switch between Light and dark theme.
+msgctxt "Label for the theme selector feature"
 msgid "Theme"
 msgstr ""
 
@@ -16023,6 +16421,16 @@ msgid ""
 "movie theatre?”"
 msgstr ""
 
+#. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Translate this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
+msgctxt "Page suggestion prompt"
+msgid "Translate this page into %s."
+msgstr ""
+
 #. Placeholder text for a region that will display translated text.
 msgctxt "translations_module"
 msgid "Translation"
@@ -16137,6 +16545,11 @@ msgstr ""
 #. Call-to-action button for the subscription promo in the SERP sidemenu.
 msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
+msgstr ""
+
+#. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
+msgctxt "settings"
+msgid "Try It Now"
 msgstr ""
 
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -16330,6 +16743,20 @@ msgstr "Komeka: %s"
 #. Response a user can select in a feedback form, indicating that they're trying DuckDuckGo again.
 msgctxt "new user poll"
 msgid "Trying DuckDuckGo again"
+msgstr ""
+
+#. Message shown in a modal after supported third-party browser users disable AI features in Settings. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+#. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
 msgstr ""
 
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -16930,6 +17357,11 @@ msgstr ""
 msgid "Uruguay"
 msgstr ""
 
+#. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
+msgctxt "Navigation label on the Duck.ai settings page"
+msgid "Usage"
+msgstr ""
+
 #. A feedback suggestion
 msgctxt "Feedback prompt"
 msgid "Usage limit"
@@ -17278,6 +17710,11 @@ msgstr ""
 msgid "Wales"
 msgstr ""
 
+#. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Walk me through the steps"
+msgstr ""
+
 #. Label for walking directions on a map.
 msgctxt "directions"
 msgid "Walking"
@@ -17368,6 +17805,16 @@ msgstr ""
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
+msgstr ""
+
+#. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
+msgctxt ""
+"Inline warning shown below the share-content toggle when the user selects "
+"Harmful or Illegal but has not enabled sharing"
+msgid ""
+"We can only fix what we can see. To report a harmful or illegal response, "
+"please share this conversation with DuckDuckGo so we can investigate and "
+"address the issue."
 msgstr ""
 
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -17787,6 +18234,87 @@ msgid ""
 "experience."
 msgstr ""
 
+#. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the counterarguments?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the hours & location?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key contributions of this paper?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key contributions?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key details?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key points covered in this video?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key points?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key takeaways from this article?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key takeaways?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key things I will learn from this course?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main counterarguments or criticisms of this?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main questions this page answers?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the must-try dishes here?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"What are the opening hours, location, and contact details for this place?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the pros and cons of this product?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the pros and cons?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
 msgctxt "feedback form"
 msgid "What bothered you most?"
@@ -17870,6 +18398,11 @@ msgctxt "Full sentence for defining a term"
 msgid "What does atria mean in the context of a medical article?"
 msgstr ""
 
+#. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What does this answer?"
+msgstr ""
+
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
@@ -17878,6 +18411,11 @@ msgstr ""
 #. Header above a list of types of information that gets saved by the cloud save feature.
 msgctxt "cloudsave"
 msgid "What information gets saved?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What interview questions might come up for this role?"
 msgstr ""
 
 #. Text explaining how the cloud save feature works.
@@ -17890,6 +18428,11 @@ msgstr ""
 #. Text for a prompt suggestion for looking up the capital city of Albania.
 msgctxt "Full sentence for looking up basic facts"
 msgid "What is the capital city of Albania?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What is the overall verdict and rating for this?"
 msgstr ""
 
 #. Link to a page with additional information.
@@ -17910,6 +18453,11 @@ msgctxt "maps_places"
 msgid "What people say:"
 msgstr ""
 
+#. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What should I order?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
 msgctxt "feedback form"
 msgid "What stood out?"
@@ -17918,6 +18466,16 @@ msgstr ""
 #. Question on a feedback form for a negative feedback response.
 msgctxt "feedback form"
 msgid "What was wrong with the response? (optional)"
+msgstr ""
+
+#. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I learn?"
+msgstr ""
+
+#. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I need?"
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -17932,6 +18490,11 @@ msgstr ""
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
 msgctxt "SERP footer content"
 msgid "What's New"
+msgstr ""
+
+#. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What's the verdict?"
 msgstr ""
 
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -17973,6 +18536,11 @@ msgctxt "Feedback prompt"
 msgid "Which features are missing? (Optional)"
 msgstr ""
 
+#. An invitation for users to leave feedback
+msgctxt "Feedback prompt"
+msgid "Which features are missing? (optional)"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
 msgid "White"
 msgstr ""
@@ -17984,6 +18552,16 @@ msgstr ""
 
 #. Link to an about us page.
 msgid "Who We Are"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Who are the main cast and crew, and what else are they known for?"
+msgstr ""
+
+#. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Who is this person?"
 msgstr ""
 
 #. Header above a collection of privacy-related links.

--- a/locales/lt_LT/LC_MESSAGES/duckduckgo.po
+++ b/locales/lt_LT/LC_MESSAGES/duckduckgo.po
@@ -2,16 +2,15 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: lt_LT\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
-"(n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 
 # smartling.gettext_line_width = normalized : 79
 # smartling.placeholder_format=C
@@ -482,8 +481,7 @@ msgstr ""
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "%sLearn more%s about how chats are stored privately on your device."
-msgstr ""
-"%1$sSužinok daugiau%2$s, kaip pokalbiai saugomi privačiai tavo įrenginyje."
+msgstr "%1$sSužinok daugiau%2$s, kaip pokalbiai saugomi privačiai tavo įrenginyje."
 
 # smartling.placeholder_format=C
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
@@ -885,16 +883,14 @@ msgstr ""
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of AI Chat is available! Please refresh this page to continue."
-msgstr ""
-"Pasirodė nauja „AI Chat“ versija! Jei nori tęsti, atnaujink šį puslapį."
+msgstr "Pasirodė nauja „AI Chat“ versija! Jei nori tęsti, atnaujink šį puslapį."
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of Duck.ai is available and they need to refresh the page.
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of Duck.ai is available! Please refresh this page to continue."
-msgstr ""
-"Pasirodė nauja „Duck.ai“ versija! Jei norite tęsti, atnaujinkite šį puslapį."
+msgstr "Pasirodė nauja „Duck.ai“ versija! Jei norite tęsti, atnaujinkite šį puslapį."
 
 # smartling.placeholder_format=C
 #. Shown when the Duck.ai desktop app has been open a long time and a newer version exists.
@@ -1442,7 +1438,7 @@ msgstr "Adresas neteisingas"
 #. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Adjust the servings"
-msgstr ""
+msgstr "Pakeisk porcijų skaičių"
 
 # smartling.placeholder_format=C
 #. as in multiple advertisements
@@ -1526,8 +1522,7 @@ msgstr "Kai atsisiųsi ir atidarysi, spustelėk %1$sĮdiegti%2$s"
 #. Instructions on how to install the DuckDuckGo browser extension after it downloads.
 msgid ""
 "After it downloads, locate the extension file and double-click it to install"
-msgstr ""
-"Kai atsisiųsi, surask plėtinio failą ir du kartus jį spustelėk, kad įdiegtum"
+msgstr "Kai atsisiųsi, surask plėtinio failą ir du kartus jį spustelėk, kad įdiegtum"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an age below a web search result.
@@ -1663,6 +1658,8 @@ msgid ""
 "All chats are anonymized by DuckDuckGo, and your conversations are not used "
 "to train chat models by DuckDuckGo or the model providers"
 msgstr ""
+"„DuckDuckGo“ nuasmenina visus pokalbius, o tavo pokalbių „DuckDuckGo“ ar "
+"modelių teikėjai nenaudoja pokalbių modeliams mokyti"
 
 # smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1755,8 +1752,7 @@ msgstr "Leisti privatumo paisančius skelbimus"
 # smartling.placeholder_format=C
 #. Title in a dialog informing the user how to disable their ad blocker for DuckDuckGo
 msgid "Allow privacy-respecting ads on DuckDuckGo Private Search"
-msgstr ""
-"Leisti privatumo paisančius skelbimus „DuckDuckGo Private Search“ paieškoje"
+msgstr "Leisti privatumo paisančius skelbimus „DuckDuckGo Private Search“ paieškoje"
 
 # smartling.placeholder_format=C
 #. Description explaining privacy implications of enabling web search on encrypted models. The first two placeholders are the full model name (e.g. 'gpt-oss 120B'). The third and fourth placeholders wrap a clickable link reading 'zero provider visibility' that opens the privacy modal, please keep those around the link text in your translation. An example full sentence would be: Allows gpt-oss 120B to search the web to improve responses to relevant prompts. Only sends AI-generated queries to a search engine with limited data retention. Prompts and responses with gpt-oss 120B still have zero provider visibility.
@@ -1808,8 +1804,7 @@ msgstr "Jau sinchronizuota."
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Also search privately on your iPad, iPhone, or Android!"
-msgstr ""
-"Taip pat ieškok privačiai savo „iPad“, „iPhone“ arba „Android“ įrenginyje!"
+msgstr "Taip pat ieškok privačiai savo „iPad“, „iPhone“ arba „Android“ įrenginyje!"
 
 # smartling.placeholder_format=C
 #. Keyboard shortcut for Duck.ai
@@ -1942,6 +1937,8 @@ msgid ""
 "Anonymously generates answers for search queries based on web content. "
 "Choose how often you want it to appear, or disable it completely."
 msgstr ""
+"Anonimiškai generuoja atsakymus į paieškos užklausas pagal interneto turinį. "
+"Pasirink, kaip dažnai nori tai matyti, arba visiškai išjunk."
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -2225,7 +2222,7 @@ msgstr "Užduok tolesnį klausimą „Duck.ai“"
 #. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
 msgctxt "Page suggestion chip label"
 msgid "Ask about this page"
-msgstr ""
+msgstr "Klausk apie šį puslapį"
 
 # smartling.placeholder_format=C
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2445,8 +2442,7 @@ msgstr "Automatinis atsakymas"
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid "Auto-generated based on listed sources. May contain inaccuracies."
-msgstr ""
-"Automatiškai generuojama pagal išvardytus šaltinius. Gali būti netikslumų."
+msgstr "Automatiškai generuojama pagal išvardytus šaltinius. Gali būti netikslumų."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
@@ -2645,7 +2641,7 @@ msgstr "Brūkšninis kodas"
 #. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Based on this page, is this course worth taking?"
-msgstr ""
+msgstr "Sprendžiant iš šio puslapio, ar verta rinktis šį kursą?"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2694,6 +2690,9 @@ msgid ""
 "Before storing this report, DuckDuckGo will anonymize your conversation by "
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
+"Prieš išsaugodama šią ataskaitą, „DuckDuckGo“ nuasmenins jūsų pokalbį "
+"pašalindama asmenį identifikuojančią informaciją, pvz., vardus, el. pašto "
+"adresus ir identifikuojančius metaduomenis."
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -3015,7 +3014,7 @@ msgstr "Laimėti „break point“ taškai"
 #. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Break this down into clear, numbered steps."
-msgstr ""
+msgstr "Išskaidyk tai į aiškius, sunumeruotus žingsnius."
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -3475,7 +3474,7 @@ msgstr "Aktoriai"
 #. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Cast & Crew"
-msgstr ""
+msgstr "Aktoriai ir kūrybinė grupė"
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -3581,8 +3580,7 @@ msgstr "Pakeičia fono spalvą visoje svetainėje"
 msgctxt "settings"
 msgid ""
 "Changes the background color of results on hover, modules, and dropdown menus"
-msgstr ""
-"Pakeičia žymeklio, modulių ir išskleidžiamųjų meniu rezultatų fono spalvą"
+msgstr "Pakeičia žymeklio, modulių ir išskleidžiamųjų meniu rezultatų fono spalvą"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/NdpkbY0.png
@@ -4324,8 +4322,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click %sPrivacy and Services%s in the left sidebar."
-msgstr ""
-"Dešiniojoje šoninėje juostoje spustelėk %1$sPrivatumas ir Paslaugos%2$s."
+msgstr "Dešiniojoje šoninėje juostoje spustelėk %1$sPrivatumas ir Paslaugos%2$s."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -4352,8 +4349,7 @@ msgstr "Išskleidžiamajame meniu spustelėk %1$sNustatymai%2$s."
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
-msgstr ""
-"Spustelėk %1$sNaudoti dabartinius puslapius%2$s, tada %3$s– „Gerai%4$s."
+msgstr "Spustelėk %1$sNaudoti dabartinius puslapius%2$s, tada %3$s– „Gerai%4$s."
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -4420,8 +4416,7 @@ msgstr "Paieškos juostoje spustelėk %1$sdidinamąjį stiklą%2$s"
 # smartling.placeholder_format=C
 #. Tells users what icon to click in their browser to change their default search engine.
 msgid "Click on the magnifying glass in the search box at the top right"
-msgstr ""
-"Viršuje dešinėje esančiame paieškos langelyje spustelėk didinamąjį stiklą"
+msgstr "Viršuje dešinėje esančiame paieškos langelyje spustelėk didinamąjį stiklą"
 
 # smartling.placeholder_format=C
 #. Tells users where to click in order to disable the cloud save feature and delete any data backed-up to the cloud.
@@ -5073,8 +5068,7 @@ msgstr "Kopijuoti"
 # smartling.placeholder_format=C
 #. Instructions on how to change the default search engine
 msgid "Copy &amp; paste %sabout:preferences#search%s into the address bar"
-msgstr ""
-"Nukopijuok ir įklijuok %1$sabout:preferences#search%2$s į adreso juostą"
+msgstr "Nukopijuok ir įklijuok %1$sabout:preferences#search%2$s į adreso juostą"
 
 # smartling.placeholder_format=C
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
@@ -5193,7 +5187,7 @@ msgstr "Kurti vaizdą"
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
-msgstr ""
+msgstr "Sudaryk pirkinių sąrašą ir nurodyk šio recepto kiekius."
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed in the input field when starting a new image generation session.
@@ -5826,8 +5820,7 @@ msgstr "Diktavimas „Duck.ai“"
 # smartling.placeholder_format=C
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
-msgstr ""
-"Diktavimą mes anonimizuojame ir niekada nenaudojame DI modeliams mokyti."
+msgstr "Diktavimą mes anonimizuojame ir niekada nenaudojame DI modeliams mokyti."
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
@@ -5837,7 +5830,7 @@ msgstr "Pasiekei diktavimo ribą"
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
 msgid "Dictation temporarily unavailable"
-msgstr ""
+msgstr "Diktavimas laikinai nepasiekiamas"
 
 # smartling.placeholder_format=C
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
@@ -6146,6 +6139,8 @@ msgid ""
 "Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
 "filtered out. %sLearn More%s"
 msgstr ""
+"Nenori DI? %1$snoai.duckduckgo.com%2$s nesiūlo jokių DI funkcijų ir "
+"išfiltruoja DI vaizdus. %3$sSužinok daugiau%4$s"
 
 # smartling.placeholder_format=C
 #. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
@@ -6154,6 +6149,8 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
+"Nenori DI? Apsilankyk %1$snoai.duckduckgo.com%2$s kad ieškotum be DI "
+"funkcijų, o DI vaizdai būtų išfiltruoti. %3$sSužinok daugiau%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6273,13 +6270,13 @@ msgstr ""
 #. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Draft a cover letter"
-msgstr ""
+msgstr "Parenk motyvacinį laišką"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Draft a cover letter for this job."
-msgstr ""
+msgstr "Parenk motyvacinį laišką šioms pareigoms."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -6469,6 +6466,9 @@ msgid ""
 "company for anyone who wants to take back control of their personal "
 "information."
 msgstr ""
+"„Duck.ai“ sukūrė „DuckDuckGo“. Esame nepriklausoma apsaugos internete įmonė, "
+"padedanti visiems, norintiems susigrąžinti savo asmeninės informacijos "
+"kontrolę."
 
 # smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
@@ -6523,6 +6523,9 @@ msgid ""
 "Duck.ai lets you chat privately with popular AI models. Disabling it hides "
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
+"Naudodamas „Duck.ai“ gali privačiai kalbėtis su populiariais DI modeliais. "
+"Išjungus šią funkciją, paslepiami „Duck.ai“ mygtukai ir nuorodos, tačiau "
+"%1$sduck.ai%2$s vis tiek gali pasiekti tiesiogiai."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6725,8 +6728,8 @@ msgid ""
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
 "„DuckDuckGo AI Chat“ yra privati dirbtiniu intelektu pagrįsta pokalbių "
-"paslauga, kuri šiuo metu palaiko pokalbių modelius „%1$s“ „%2$s“ ir "
-"„%3$s“ „%4$s“."
+"paslauga, kuri šiuo metu palaiko pokalbių modelius „%1$s“ „%2$s“ ir „%3$s“ "
+"„%4$s“."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the welcome screen of the onboarding. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -6736,8 +6739,8 @@ msgid ""
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
 "„DuckDuckGo AI Chat“ yra privati dirbtiniu intelektu pagrįsta pokalbių "
-"paslauga, kuri šiuo metu palaiko pokalbių modelius „%1$s“ „%2$s“ ir "
-"„%3$s“ „%4$s“."
+"paslauga, kuri šiuo metu palaiko pokalbių modelius „%1$s“ „%2$s“ ir „%3$s“ "
+"„%4$s“."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding DuckDuckGo AI Chat.
@@ -6773,8 +6776,7 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr ""
-"„DuckDuckGo DI Chat“ laikinai nepasiekiamas. Bandykite dar kartą vėliau."
+msgstr "„DuckDuckGo DI Chat“ laikinai nepasiekiamas. Bandykite dar kartą vėliau."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -6903,8 +6905,8 @@ msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid ""
 "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to Duck.ai's %s."
 msgstr ""
-"„DuckDuckGo“ anonimina tavo pokalbius. Jei spusteli „%1$s“, sutinki su „Duck."
-"ai“ %2$s."
+"„DuckDuckGo“ anonimina tavo pokalbius. Jei spusteli „%1$s“, sutinki su "
+"„Duck.ai“ %2$s."
 
 # smartling.placeholder_format=C
 #. Shown below the input on the empty state when the user has not yet accepted the terms of service. The first %s is the action button label ('Ask' for chat, 'Create' for image generation). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. Clicking the action button both accepts the terms and submits the prompt.
@@ -7049,9 +7051,9 @@ msgid ""
 "characters long."
 msgstr ""
 "Kiekvieną kartą, kai paprašai pasiūlyti slaptafrazę, naudojame didelį "
-"atsitiktinių žodžių sąrašą iš „DuckDuckGo“ serverių. Naršyklėje parenkame 4–"
-"5 atsitiktinius žodžius iš sąrašo užtikrindami, kad slaptafrazė būtų bent 18–"
-"20 simbolių ilgio."
+"atsitiktinių žodžių sąrašą iš „DuckDuckGo“ serverių. Naršyklėje parenkame "
+"4–5 atsitiktinius žodžius iš sąrašo užtikrindami, kad slaptafrazė būtų bent "
+"18–20 simbolių ilgio."
 
 # smartling.placeholder_format=C
 msgctxt "Sports module"
@@ -7372,15 +7374,13 @@ msgstr "Ar tau patinka „Duck.ai“?"
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure %s'Allow'%s is selected for the 'Location' setting."
-msgstr ""
-"Įsitikink, kad pasirinkta nustatymo „Vieta“ parinktis %1$s„Leisti“%2$s."
+msgstr "Įsitikink, kad pasirinkta nustatymo „Vieta“ parinktis %1$s„Leisti“%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location Services' is %senabled%s."
-msgstr ""
-"Įsitikink, kad parinktis „Buvimo vietos nustatymo paslaugos“ %1$sįjungta%2$s."
+msgstr "Įsitikink, kad parinktis „Buvimo vietos nustatymo paslaugos“ %1$sįjungta%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
@@ -7522,8 +7522,7 @@ msgstr "Pusiaujo Gvinėja"
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Erase your browsing data in a flash with our %sFire Button%s"
-msgstr ""
-"Naršymo duomenis ištrinkite akimirksniu naudodami mūsų %1$s„Fire Button“%2$s"
+msgstr "Naršymo duomenis ištrinkite akimirksniu naudodami mūsų %1$s„Fire Button“%2$s"
 
 # smartling.placeholder_format=C
 msgid "Eritrea"
@@ -7533,13 +7532,13 @@ msgstr "Eritrėja"
 #. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Estimate the nutrition"
-msgstr ""
+msgstr "Apskaičiuok maistinę vertę"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Estimate the nutritional information for this recipe."
-msgstr ""
+msgstr "Apskaičiuok šio recepto maistinę vertę."
 
 # smartling.placeholder_format=C
 msgid "Estonia"
@@ -7599,57 +7598,56 @@ msgstr "Galiojimas baigiasi po 1 dienos"
 #. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain the accepted answer in simple terms."
-msgstr ""
+msgstr "Paprastais žodžiais paaiškink priimtą atsakymą."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
-msgstr ""
-"Paaiškink pagrindines juodųjų skylių sąvokas vidurinės mokyklos lygmeniu."
+msgstr "Paaiškink pagrindines juodųjų skylių sąvokas vidurinės mokyklos lygmeniu."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain the top answer"
-msgstr ""
+msgstr "Paaiškink populiariausią atsakymą"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain this in simple, plain language."
-msgstr ""
+msgstr "Paaiškink tai paprasta, suprantama kalba."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain this paper"
-msgstr ""
+msgstr "Paaiškink šį mokslinį darbą"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain this repo"
-msgstr ""
+msgstr "Paaiškink šią saugyklą"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain this research paper in plain language."
-msgstr ""
+msgstr "Paaiškink šį mokslinį darbą paprasta kalba."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain this simply"
-msgstr ""
+msgstr "Paaiškink tai paprastai"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain what this repository does and how to use it."
-msgstr ""
+msgstr "Paaiškink, kam skirta ši saugykla ir kaip ja naudotis."
 
 # smartling.placeholder_format=C
 #. Label to show if song lyrics contain explicit content
@@ -7673,8 +7671,7 @@ msgstr "Suaugusiesiems skirti dainų tekstai"
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
-msgstr ""
-"Susipažinkite su naujausiais „DuckDuckGo“ produktų ir funkcijų atnaujinimais."
+msgstr "Susipažinkite su naujausiais „DuckDuckGo“ produktų ir funkcijų atnaujinimais."
 
 # smartling.placeholder_format=C
 #. Links to a page that provides a list of DuckDuckGo product updates
@@ -7847,8 +7844,7 @@ msgstr ""
 msgid ""
 "Feel free to adjust the settings below. Then, just copy and paste the code "
 "into your website."
-msgstr ""
-"Keisk savo nustatymus žemiau. Tada, tiesiog nukopijuok kodą į savo svetainę."
+msgstr "Keisk savo nustatymus žemiau. Tada, tiesiog nukopijuok kodą į savo svetainę."
 
 # smartling.placeholder_format=C
 msgid "Fiji"
@@ -7940,6 +7936,8 @@ msgctxt "settings"
 msgid ""
 "Filters out known AI spam sites from image search results. %sLearn More%s"
 msgstr ""
+"Iš vaizdų paieškos rezultatų išfiltruoja žinomas šlamštą platinančias DI "
+"svetaines. %1$sSužinok daugiau%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the final score of a sporting event.
@@ -7968,8 +7966,7 @@ msgstr "Finansų konsultantas"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Find %sDuckDuckGo%s and click%sMake default%s"
-msgstr ""
-"Surask %1$sDuckDuckGo%2$s ir spustelėk%3$sNustatyti kaip numatytąjį%4$s"
+msgstr "Surask %1$sDuckDuckGo%2$s ir spustelėk%3$sNustatyti kaip numatytąjį%4$s"
 
 # smartling.placeholder_format=C
 #. Sentence shown after export, includes a placeholder for one or more filenames with bold formatting for the filename(s).
@@ -8001,7 +7998,7 @@ msgstr "Naujausios informacijos paieška"
 #. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Find me alternatives"
-msgstr ""
+msgstr "Rask alternatyvų"
 
 # smartling.placeholder_format=C
 #. Button that searches for results closer to the user's current location.
@@ -8093,8 +8090,7 @@ msgstr ""
 #. Privacy reassurance and instructions intro.
 msgctxt "duckai_migration"
 msgid "Follow these steps to move your chats to the new Duck.ai"
-msgstr ""
-"Atlik šiuos veiksmus, kad perkeltum pokalbius į naująją „Duck.ai“ versiją"
+msgstr "Atlik šiuos veiksmus, kad perkeltum pokalbius į naująją „Duck.ai“ versiją"
 
 # smartling.placeholder_format=C
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse on mobile
@@ -8199,8 +8195,7 @@ msgstr "Nemokami ir privatūs pokalbiai, kuriuos anonimizuojame"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr ""
-"Nemokami ir privatūs pokalbiai, kuriuos anonimizuojame. Paskyros nereikia."
+msgstr "Nemokami ir privatūs pokalbiai, kuriuos anonimizuojame. Paskyros nereikia."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -8486,7 +8481,7 @@ msgstr "Generuoti daugiau"
 #. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Generate a shopping list"
-msgstr ""
+msgstr "Sudaryk pirkinių sąrašą"
 
 # smartling.placeholder_format=C
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
@@ -8651,8 +8646,7 @@ msgstr "Pradėti"
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the Privacy Pro subscription.
 msgctxt "SERP footer content"
 msgid "Get a VPN + two more protections in one easy subscription."
-msgstr ""
-"Gaukite VPN ir dar dvi apsaugos priemones iš vienos paprastos prenumeratos."
+msgstr "Gaukite VPN ir dar dvi apsaugos priemones iš vienos paprastos prenumeratos."
 
 # smartling.placeholder_format=C
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
@@ -8711,14 +8705,12 @@ msgstr "Reikia pagalbos dėl kompiuterio"
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
 msgctxt "Browser Promo Popover"
 msgid "Get our browser to never lose your settings."
-msgstr ""
-"Atsisiųsk ir naudok mūsų naršyklę, kad niekada neprarastum savo nustatymų."
+msgstr "Atsisiųsk ir naudok mūsų naršyklę, kad niekada neprarastum savo nustatymų."
 
 # smartling.placeholder_format=C
 msgid ""
 "Get seamless privacy protection on your browser for free with one download:"
-msgstr ""
-"Vienu atsisiuntimu nemokamai gauk sklandžią privatumo apsaugą naršyklėje:"
+msgstr "Vienu atsisiuntimu nemokamai gauk sklandžią privatumo apsaugą naršyklėje:"
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo app when clicked
@@ -8786,7 +8778,7 @@ msgstr "Išbandyk"
 #. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Give me a quick background on this person."
-msgstr ""
+msgstr "Pateik trumpą informaciją apie šį asmenį."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9239,13 +9231,13 @@ msgstr "Padėk Skleisti Žinią Apie Privatumą"
 #. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Help me prep for the interview"
-msgstr ""
+msgstr "Padėk pasiruošti darbo pokalbiui"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Help me tailor my resume for this job."
-msgstr ""
+msgstr "Padėk pritaikyti mano gyvenimo aprašymą šioms pareigoms."
 
 # smartling.placeholder_format=C
 #. Title of a SERP popup that invites users to take a survey (desktop only)
@@ -9770,7 +9762,7 @@ msgctxt ""
 "Text for the I already have a subscription button in the Duck.ai settings "
 "page"
 msgid "I Already Have a Subscription"
-msgstr ""
+msgstr "Jau turiu prenumeratą"
 
 # smartling.placeholder_format=C
 #. Text for the button that takes the user to the login subscription page.
@@ -9853,8 +9845,7 @@ msgstr ""
 #. Option for feedback when the user needs more help or information on how to use the chat.
 msgctxt "Feedback option for difficulty in using chat"
 msgid "I need more help/info on how to use Chat"
-msgstr ""
-"Man reikia daugiau pagalbos / informacijos apie tai, kaip naudotis pokalbiu"
+msgstr "Man reikia daugiau pagalbos / informacijos apie tai, kaip naudotis pokalbiu"
 
 # smartling.placeholder_format=C
 msgid "IR Iran"
@@ -10087,8 +10078,7 @@ msgstr "Pagerink argumentus"
 msgctxt "settings"
 msgid ""
 "Improves result legibility with updated URL format, placement, and color"
-msgstr ""
-"Pagerina rezultato skaitomumą atnaujintu URL formatu, išdėstymu ir spalva"
+msgstr "Pagerina rezultato skaitomumą atnaujintu URL formatu, išdėstymu ir spalva"
 
 # smartling.placeholder_format=C
 #. A label that appears in front of the name of a company that DuckDuckGo has partnered with. For example, 'In partnership with Wikipedia'
@@ -10351,7 +10341,7 @@ msgstr "Įdiekite „Mac“ naršyklę"
 #. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
 msgctxt "settings"
 msgid "Install Now"
-msgstr ""
+msgstr "Įdiegti dabar"
 
 # smartling.placeholder_format=C
 #. Text of a button to install the DuckDuckGo app
@@ -10454,13 +10444,13 @@ msgstr "Ar ištrinti duomenys yra iš tiesų pašalinami?"
 #. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Is it worth taking?"
-msgstr ""
+msgstr "Ar verta rinktis?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Is this place any good?"
-msgstr ""
+msgstr "Ar ši vieta verta dėmesio?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
@@ -10469,6 +10459,8 @@ msgid ""
 "Is this place any good? Summarize its reputation based on reviews and "
 "ratings."
 msgstr ""
+"Ar ši vieta verta dėmesio? Apibendrink jos reputaciją pagal atsiliepimus ir "
+"įvertinimus."
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -10480,13 +10472,13 @@ msgstr "Ar šis vaizdo įrašas naudingas?"
 #. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Is this worth watching?"
-msgstr ""
+msgstr "Ar verta tai žiūrėti?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Is this worth watching? Give me a spoiler-free take."
-msgstr ""
+msgstr "Ar verta tai žiūrėti? Pateik apžvalgą be siužeto detalių."
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -10518,8 +10510,7 @@ msgstr "Ji greita, nemokama ir užtikrina dar daugiau apsaugos internete."
 msgctxt "settings"
 msgid ""
 "It's okay to (very infrequently) ask me about my experience using DuckDuckGo"
-msgstr ""
-"Leidžiu (labai retai) manęs klausti apie naudojimosi „DuckDuckGo“ patirtį"
+msgstr "Leidžiu (labai retai) manęs klausti apie naudojimosi „DuckDuckGo“ patirtį"
 
 # smartling.placeholder_format=C
 #. The name of the Italian language
@@ -11101,7 +11092,7 @@ msgstr "Nuorodos:"
 #. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
-msgstr ""
+msgstr "Išvardyk įrankius, medžiagas ar išankstines sąlygas, kurių tam prireiks."
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -11212,8 +11203,7 @@ msgstr "Įkeliama daugiau vaizdų slenkant"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Loads more results in Images, Videos, and Shopping when scrolling"
-msgstr ""
-"Slenkant įkeliama daugiau Vaizdų, Vaizdo Įrašų ir Apsipirkimo rezultatų"
+msgstr "Slenkant įkeliama daugiau Vaizdų, Vaizdo Įrašų ir Apsipirkimo rezultatų"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/WTkvs9I.png
@@ -11514,7 +11504,7 @@ msgstr "Tvarkyti užblokuotas svetaines"
 #. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
 msgctxt "setting"
 msgid "Manage in Browser Settings"
-msgstr ""
+msgstr "Tvarkyti naršyklės nuostatose"
 
 # smartling.placeholder_format=C
 #. Link to the site exclusion settings page
@@ -13270,8 +13260,7 @@ msgstr "Omanas"
 #. http://i.imgur.com/zQWKLIm.png
 msgctxt "settings"
 msgid "Omits objectionable (mostly adult) material"
-msgstr ""
-"Praleidžiami nepageidaujami (daugiausia tik suaugusiesiems skirti) rezultatai"
+msgstr "Praleidžiami nepageidaujami (daugiausia tik suaugusiesiems skirti) rezultatai"
 
 # smartling.placeholder_format=C
 msgid "On"
@@ -13428,8 +13417,7 @@ msgstr "Atidaryti %1$s svetainę"
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open %sLocation%s, and ensure location is %senabled%s"
-msgstr ""
-"Atidarykite %1$sVieta%2$s ir įsitikinkite, kad vieta yra %3$sįjungta%4$s"
+msgstr "Atidarykite %1$sVieta%2$s ir įsitikinkite, kad vieta yra %3$sįjungta%4$s"
 
 #  Chrome/Firefox on Android/iOS
 # smartling.placeholder_format=C
@@ -13592,8 +13580,7 @@ msgstr "Atidaryti skydelį „Kaip veikia Duck.ai“"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open the Safari menu and select %sSettings for DuckDuckGo...%s"
-msgstr ""
-"Atidarykite „Safari“ meniu ir pasirinkite %1$s„DuckDuckGo“ nustatymai...%2$s"
+msgstr "Atidarykite „Safari“ meniu ir pasirinkite %1$s„DuckDuckGo“ nustatymai...%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the time a business opens. For example: 'Opens at 10am'
@@ -14350,13 +14337,14 @@ msgstr "Atlik šią užduotį, kad patvirtintum, jog šią paiešką atliko žmo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is harmful or illegal. (optional)"
 msgstr ""
+"Aprašykite, kodėl atsakymas pokalbyje yra žalingas ar neteisėtas. "
+"(neprivaloma)"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
-msgstr ""
-"Aprašyk, kodėl šis pokalbio atsakymas neteisėtas ar žalingas. (Neprivaloma)"
+msgstr "Aprašyk, kodėl šis pokalbio atsakymas neteisėtas ar žalingas. (Neprivaloma)"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to enter their passphrase.
@@ -14387,6 +14375,9 @@ msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is harmful or illegal."
 msgstr ""
+"Įklijuokite savo užklausą ir probleminį atsakymą (pašalinę bet kokią "
+"asmeninę informaciją) ir aprašykite, kodėl šis turinys yra žalingas ar "
+"neteisėtas."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -14541,8 +14532,7 @@ msgstr "Luktelk..."
 #. Tagline for the subscription promo shown in the SERP sidemenu.
 msgctxt "Sidemenu subscription promo"
 msgid "Plus more premium features with a DuckDuckGo subscription."
-msgstr ""
-"„Plus“ – daugiau aukščiausios kokybės funkcijų su „DuckDuckGo“ prenumerata."
+msgstr "„Plus“ – daugiau aukščiausios kokybės funkcijų su „DuckDuckGo“ prenumerata."
 
 # smartling.placeholder_format=C
 #. A description to provide more detail on what Duck Player does (Duck Player is DDG's feature to watch youtube videos more privately)
@@ -14860,7 +14850,7 @@ msgstr "Privatumas"
 #. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
 msgctxt "Section heading on the Duck.ai settings page"
 msgid "Privacy & Terms"
-msgstr ""
+msgstr "Privatumas ir sąlygos"
 
 # smartling.placeholder_format=C
 msgid "Privacy Blog"
@@ -14936,7 +14926,7 @@ msgstr "Privatumo politika ir paslaugų teikimo sąlygos"
 #. Text for a button that links to the terms of use and privacy policy page.
 msgctxt "Secondary button text in active privacy modal"
 msgid "Privacy Policy and Terms of Service"
-msgstr ""
+msgstr "Privatumo politika ir paslaugų teikimo sąlygos"
 
 # smartling.placeholder_format=C
 #. Title displayed on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
@@ -15110,8 +15100,7 @@ msgstr "Paraginti mane"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Prompt me to use my approximate location to get nearby results."
-msgstr ""
-"Paraginti mane naudoti apytikslę vietą, kad gaučiau tikslesnių rezultatų."
+msgstr "Paraginti mane naudoti apytikslę vietą, kad gaučiau tikslesnių rezultatų."
 
 # smartling.placeholder_format=C
 #. DuckDuckGo Email Protection removes trackers from emails
@@ -15442,25 +15431,25 @@ msgstr "Rekomenduok knygą"
 #. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Recommend similar books"
-msgstr ""
+msgstr "Rekomenduok panašių knygų"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Recommend similar books."
-msgstr ""
+msgstr "Rekomenduok panašių knygų."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Recommend similar movies or shows."
-msgstr ""
+msgstr "Rekomenduok panašių filmų ar serialų."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Recommend similar titles"
-msgstr ""
+msgstr "Rekomenduok panašių kūrinių"
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
@@ -15873,7 +15862,7 @@ msgctxt ""
 "feedback form when the user has selected Harmful or Illegal as the feedback "
 "reason"
 msgid "Required for harmful or illegal reports"
-msgstr ""
+msgstr "Būtina pranešant apie žalingą ar neteisėtą turinį"
 
 # smartling.placeholder_format=C
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
@@ -16113,7 +16102,7 @@ msgstr "Atsiliepimai"
 #. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Rewrite this recipe scaled for a different number of servings."
-msgstr ""
+msgstr "Perrašyk šį receptą pritaikydamas jį kitam porcijų skaičiui."
 
 # smartling.placeholder_format=C
 msgid "Romania"
@@ -16560,8 +16549,7 @@ msgstr "Slink žemyn ir sąraše rask %1$ssavo naršyklę%2$s."
 #. Tells users which setting to change to enable location service.
 msgctxt "precise_user_location"
 msgid "Scroll down to %sDuckDuckGo%s and allow it to use your location."
-msgstr ""
-"Slinkite žemyn iki %1$sDuckDuckGo%2$s ir leiskite jai naudoti jūsų vietovę."
+msgstr "Slinkite žemyn iki %1$sDuckDuckGo%2$s ir leiskite jai naudoti jūsų vietovę."
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -16940,8 +16928,8 @@ msgid ""
 "Securely store your chats on our server using end-to-end encryption, and "
 "access them from all your devices."
 msgstr ""
-"Saugok savo susirašinėjimus mūsų serveryje su ištisiniu (angl. <em>end-to-"
-"end</em>) šifravimu ir pasiek juos bet kuriame įrenginyje."
+"Saugok savo susirašinėjimus mūsų serveryje su ištisiniu (angl. "
+"<em>end-to-end</em>) šifravimu ir pasiek juos bet kuriame įrenginyje."
 
 # smartling.placeholder_format=C
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
@@ -17102,27 +17090,24 @@ msgstr "„Safari“ meniu pasirink %1$s„Šios svetainės nustatymas...“%2$s
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
 msgstr ""
-"Pasirink %1$sPasirinktinis%2$s ir įvesties laukelyje įvesk %3$shttps://"
-"duckduckgo.com%4$s"
+"Pasirink %1$sPasirinktinis%2$s ir įvesties laukelyje įvesk "
+"%3$shttps://duckduckgo.com%4$s"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
-msgstr ""
-"Pasirink %1$s„DuckDuckGo“%2$s ir spustelėk %3$sPridėti kaip numatytąją%4$s!"
+msgstr "Pasirink %1$s„DuckDuckGo“%2$s ir spustelėk %3$sPridėti kaip numatytąją%4$s!"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s"
-msgstr ""
-"Pasirink %1$s„DuckDuckGo“%2$s ir spustelėk %3$sNustatyti kaip numatytąją%4$s"
+msgstr "Pasirink %1$s„DuckDuckGo“%2$s ir spustelėk %3$sNustatyti kaip numatytąją%4$s"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s."
-msgstr ""
-"Pasirink %1$s„DuckDuckGo“%2$s ir spustelėk %3$sNustatyti kaip numatytąją%4$s."
+msgstr "Pasirink %1$s„DuckDuckGo“%2$s ir spustelėk %3$sNustatyti kaip numatytąją%4$s."
 
 #  Firefox 33
 # smartling.placeholder_format=C
@@ -17136,8 +17121,7 @@ msgstr ""
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %sDuckDuckGo%s in the list and %sallow%s location access"
-msgstr ""
-"Sąraše pasirinkite %1$sDuckDuckGo%2$s ir %3$sleiskite%4$s pasiekti vietą"
+msgstr "Sąraše pasirinkite %1$sDuckDuckGo%2$s ir %3$sleiskite%4$s pasiekti vietą"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -17149,8 +17133,7 @@ msgstr "Paieškos teikėjų sąraše pasirink %1$s„DuckDuckGo“%2$s"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s under the%sDefault Search Engine%s section"
-msgstr ""
-"Pasirink %1$s„DuckDuckGo“%2$s skiltyje%3$sNumatytoji Paieškos Sistema%4$s"
+msgstr "Pasirink %1$s„DuckDuckGo“%2$s skiltyje%3$sNumatytoji Paieškos Sistema%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user were in the settings menu they can change their default search engine.
@@ -17161,8 +17144,7 @@ msgstr "Pasirink %1$s„DuckDuckGo“%2$s!"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Select %sEdit Search Engines...%sin the dropdown"
-msgstr ""
-"Išskleidžiamajame meniu pasirink %1$sRedaguoti Paieškos Sistemas...%2$s"
+msgstr "Išskleidžiamajame meniu pasirink %1$sRedaguoti Paieškos Sistemas...%2$s"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -17236,8 +17218,7 @@ msgstr "Pasirink %1$sNustatymai%2$s, tuomet %3$sIšplėstiniai nustatymai%4$s"
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sDefault search engine%s"
-msgstr ""
-"Pasirink %1$sNustatymai%2$s, tuomet %3$sNumatytoji paieškos sistema%4$s"
+msgstr "Pasirink %1$sNustatymai%2$s, tuomet %3$sNumatytoji paieškos sistema%4$s"
 
 #  Chrome/Firefox on Android
 # smartling.placeholder_format=C
@@ -17259,8 +17240,7 @@ msgstr ""
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %syour browser%s in the list and %sallow%s location access"
-msgstr ""
-"Sąraše pasirinkite %1$ssavo naršyklę%2$s ir %3$sleiskite%4$s vietos prieigą"
+msgstr "Sąraše pasirinkite %1$ssavo naršyklę%2$s ir %3$sleiskite%4$s vietos prieigą"
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the modal for deleting all recent chats, that allows the user to select the chats to delete.
@@ -17332,8 +17312,7 @@ msgstr "Pažymėtas tekstas iš %1$s"
 #. Displayed when the user's text selection exceeds the maximum message size for AI tools (summary, translation, etc.).
 msgctxt "Error message for selection input limit"
 msgid "Selected text is too long. Try again with a shorter selection."
-msgstr ""
-"Pasirinktas tekstas per ilgas. Bandykite dar kartą su trumpesniu pasirinkimu."
+msgstr "Pasirinktas tekstas per ilgas. Bandykite dar kartą su trumpesniu pasirinkimu."
 
 # smartling.placeholder_format=C
 #. Label for the semi-finals knockout stage in e.g. the soccer World Cup
@@ -17457,7 +17436,7 @@ msgstr "Nustatyk dabar"
 #. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
 msgctxt "Encrypted storage setup button shown in native browsers"
 msgid "Set Up Sync & Backup"
-msgstr ""
+msgstr "Nustatyti „Sync & Backup“"
 
 # smartling.placeholder_format=C
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
@@ -17645,7 +17624,7 @@ msgstr "Bendrinti teigiamus atsiliepimus"
 msgctxt ""
 "Label beside the share-content switch on the Duck.ai response feedback form"
 msgid "Share this conversation with DuckDuckGo"
-msgstr ""
+msgstr "Bendrinti šį pokalbį su „DuckDuckGo“"
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -17784,8 +17763,7 @@ msgstr "Rodyti „DuckAssist“ <sup>BETA</sup>"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show DuckAssist more often. (You can also completely %sturn it off%s.)"
-msgstr ""
-"Rodykite „DuckAssist“ dažniau. (Taip pat galite visiškai %1$sišjungti%2$s.)"
+msgstr "Rodykite „DuckAssist“ dažniau. (Taip pat galite visiškai %1$sišjungti%2$s.)"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
@@ -18032,8 +18010,7 @@ msgstr "Rodomos horizontalios linijos ties rezultatų puslapio lūžiais"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows links to instructions for how to add DuckDuckGo to your browser"
-msgstr ""
-"Rodo nuorodas į instrukcijas, kaip pridėti „DuckDuckGo“ prie savo naršyklės"
+msgstr "Rodo nuorodas į instrukcijas, kaip pridėti „DuckDuckGo“ prie savo naršyklės"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers more frequently.
@@ -18100,8 +18077,7 @@ msgstr "Rodomas sveikinamasis pranešimas paieškos rezultatų viršuje"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message to EU Android preference menu users"
-msgstr ""
-"Rodomas sveikinamasis pranešimas ES „Android“ nuostatų meniu naudotojams"
+msgstr "Rodomas sveikinamasis pranešimas ES „Android“ nuostatų meniu naudotojams"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers sometimes.
@@ -18423,8 +18399,7 @@ msgstr ""
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr ""
-"Atsiprašome, negalėjome pateikti tavo atsiliepimo. Bandyk dar kartą vėliau."
+msgstr "Atsiprašome, negalėjome pateikti tavo atsiliepimo. Bandyk dar kartą vėliau."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -18687,15 +18662,13 @@ msgstr ""
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletters."
-msgstr ""
-"Apsisaugok ir gauk informacijos užsisakęs mūsų privatumo naujienlaiškius."
+msgstr "Apsisaugok ir gauk informacijos užsisakęs mūsų privatumo naujienlaiškius."
 
 # smartling.placeholder_format=C
 #. Text on the page where users can subscribe to DuckDuckGo's privacy newsletter
 msgctxt "showcase_newsletter"
 msgid "Stay protected and informed with our privacy newsletters."
-msgstr ""
-"Apsisaugok ir gauk informacijos užsisakęs mūsų privatumo naujienlaiškius."
+msgstr "Apsisaugok ir gauk informacijos užsisakęs mūsų privatumo naujienlaiškius."
 
 # smartling.placeholder_format=C
 #. Loading message shown when image generation is taking longer than usual.
@@ -18733,14 +18706,12 @@ msgstr "Sustabdyti generavimą"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop hidden trackers lurking on other websites."
-msgstr ""
-"Užkirsk kelią paslėptoms stebėjimo priemonėms, slypinčioms kitose svetainėse."
+msgstr "Užkirsk kelią paslėptoms stebėjimo priemonėms, slypinčioms kitose svetainėse."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop most hidden trackers lurking on other websites."
-msgstr ""
-"Sustabdyk daugumą paslėptų stebėjimo priemonių, slypinčių kitose svetainėse."
+msgstr "Sustabdyk daugumą paslėptų stebėjimo priemonių, slypinčių kitose svetainėse."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18913,19 +18884,19 @@ msgstr "Pasiūlyk tinklaraščio įrašo pavadinimą"
 #. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Suggest related articles or topics worth exploring next."
-msgstr ""
+msgstr "Pasiūlyk susijusių straipsnių ar temų, kuriomis verta pasidomėti toliau."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Suggest related articles to explore"
-msgstr ""
+msgstr "Pasiūlyk susijusių straipsnių, kuriais verta pasidomėti"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Suggest some alternatives to this product."
-msgstr ""
+msgstr "Pasiūlyk kelias alternatyvas šiam produktui."
 
 # smartling.placeholder_format=C
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
@@ -18942,7 +18913,7 @@ msgstr "Pasiūlymai:"
 #. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Sum up the reviews"
-msgstr ""
+msgstr "Apibendrink atsiliepimus"
 
 # smartling.placeholder_format=C
 #. A short title for the a message asking the AI to summarize a text.
@@ -18954,85 +18925,85 @@ msgstr "Apibendrinti"
 #. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize the Q&As"
-msgstr ""
+msgstr "Apibendrink klausimus ir atsakymus"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the background and notable work of this person."
-msgstr ""
+msgstr "Apibendrink šio asmens biografiją ir svarbiausius darbus."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the key details of this event."
-msgstr ""
+msgstr "Apibendrink pagrindines šio renginio detales."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the questions and answers on this page."
-msgstr ""
+msgstr "Apibendrink šiame puslapyje esančius klausimus ir atsakymus."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize their background"
-msgstr ""
+msgstr "Apibendrink šio asmens biografiją"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this book"
-msgstr ""
+msgstr "Apibendrink šią knygą"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this book."
-msgstr ""
+msgstr "Apibendrink šią knygą."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this discussion"
-msgstr ""
+msgstr "Apibendrink šią diskusiją"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this discussion thread."
-msgstr ""
+msgstr "Apibendrink šią diskusijų giją."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this page"
-msgstr ""
+msgstr "Apibendrink šį puslapį"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this page."
-msgstr ""
+msgstr "Apibendrink šį puslapį."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this video"
-msgstr ""
+msgstr "Apibendrink šį vaizdo įrašą"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this video."
-msgstr ""
+msgstr "Apibendrink šį vaizdo įrašą."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize what the reviews say."
-msgstr ""
+msgstr "Apibendrink, kas rašoma atsiliepimuose."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -19363,7 +19334,7 @@ msgstr "Sirija"
 #. Text for a button that enables the theme to follow the operating system's color scheme preference.
 msgctxt "System theme button for theme selector"
 msgid "System"
-msgstr ""
+msgstr "Sistema"
 
 # smartling.placeholder_format=C
 #. Abbreviation indicating this is the total score for a game
@@ -19397,7 +19368,7 @@ msgstr "Taitiečių"
 #. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Tailor my resume"
-msgstr ""
+msgstr "Pritaikyk mano gyvenimo aprašymą"
 
 # smartling.placeholder_format=C
 msgid "Taiwan"
@@ -19434,6 +19405,8 @@ msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
+"Dalyvauk šioje anoniminėje apklausoje ir pranešk, kaip galime patobulinti "
+"„Duck.ai“."
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -19745,7 +19718,7 @@ msgstr "Tema"
 #. Text for the theme selector label that allows users to switch between Light and dark theme.
 msgctxt "Label for the theme selector feature"
 msgid "Theme"
-msgstr ""
+msgstr "Tema"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/LpFhb1e.png
@@ -20590,13 +20563,13 @@ msgstr ""
 #. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Translate this page"
-msgstr ""
+msgstr "Išversk šį puslapį"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
 msgctxt "Page suggestion prompt"
 msgid "Translate this page into %s."
-msgstr ""
+msgstr "Išversk šį puslapį į %1$s."
 
 # smartling.placeholder_format=C
 #. Placeholder text for a region that will display translated text.
@@ -20698,8 +20671,7 @@ msgstr "Pabandyk %1$s, kad daugiau nematytum tokių pranešimų."
 #. Text for a promotional card that encourages users to try the encrypted AI model whose inference runs in a confidential environment so the model provider cannot access user data. %s is replaced with the model's full display name (e.g. 'GPT-OSS 120B').
 msgctxt "Promotional text for encrypted AI model"
 msgid "Try %s, our first model with zero provider visibility."
-msgstr ""
-"Išbandyk %1$s – mūsų pirmąjį modelį be jokio matomumo paslaugų teikėjui."
+msgstr "Išbandyk %1$s – mūsų pirmąjį modelį be jokio matomumo paslaugų teikėjui."
 
 # smartling.placeholder_format=C
 msgid "Try %sDuck.ai%s, our private AI chat service:"
@@ -20744,7 +20716,7 @@ msgstr "Išbandyk nemokamai"
 #. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
 msgctxt "settings"
 msgid "Try It Now"
-msgstr ""
+msgstr "Išbandyk dabar"
 
 # smartling.placeholder_format=C
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -20847,8 +20819,7 @@ msgstr "Išbandyti nemokamai"
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
-msgstr ""
-"Išbandyk nemokamai! Saugus VPN, pažangus ir privatus DI, ir dar daugiau."
+msgstr "Išbandyk nemokamai! Saugus VPN, pažangus ir privatus DI, ir dar daugiau."
 
 # smartling.placeholder_format=C
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -20875,8 +20846,7 @@ msgstr "Išbandyk mūsų naršyklę,"
 # smartling.placeholder_format=C
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
-msgstr ""
-"Išbandyk mūsų pradžios puslapį, kuriame niekada nerodomi šie pranešimai:"
+msgstr "Išbandyk mūsų pradžios puslapį, kuriame niekada nerodomi šie pranešimai:"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with different words to get more results.
@@ -20993,6 +20963,8 @@ msgid ""
 "Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
+"Nori išjungti DI funkcijas? Įdiek paieškos plėtinį %1$s„DuckDuckGo No "
+"AI“%2$s, kad įsimintum savo nuostatas. %3$sSužinok daugiau%4$s"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -21001,6 +20973,8 @@ msgid ""
 "Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
+"Nori išjungti DI funkcijas? Pereik prie paieškos plėtinio %1$s„DuckDuckGo No "
+"AI“%2$s, kad įsimintum savo nuostatas. %3$sSužinok daugiau%4$s"
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -21107,8 +21081,7 @@ msgstr "Norėdami gauti tikslesnius rezultatus, įjunkite %1$sTiksli vieta%2$s"
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
-msgstr ""
-"Įjunkite „Duck Player“, kad galėtumėte žiūrėti „YouTube“ be tikslinių reklamų"
+msgstr "Įjunkite „Duck Player“, kad galėtumėte žiūrėti „YouTube“ be tikslinių reklamų"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service.
@@ -21120,8 +21093,7 @@ msgstr "Kad rezultatai būtų tikslesni, įjunkite nustatymą „Tiksli vietovė
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on “Use precise location” for more accurate results."
-msgstr ""
-"Kad rezultatai būtų tikslesni, įjunkite nustatymą „Naudoti tikslią vietovę“."
+msgstr "Kad rezultatai būtų tikslesni, įjunkite nustatymą „Naudoti tikslią vietovę“."
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Create Image' label in the Tools dropdown.
@@ -21326,8 +21298,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
-msgstr ""
-"Laukelyje %1$sPALEISTIS > Pradžios puslapis%2$s įvesk: https://duckduckgo.com"
+msgstr "Laukelyje %1$sPALEISTIS > Pradžios puslapis%2$s įvesk: https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -21337,15 +21308,13 @@ msgstr "Laukelyje %1$sPaieškos nustatymai%2$s pasirink %3$s„DuckDuckGo“%4$s
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch in the address bar with%s select %sAdd New%s"
-msgstr ""
-"Laukelyje %1$sIeškoti adreso juostoje su%2$s pasirink %3$sPridėti naują%4$s"
+msgstr "Laukelyje %1$sIeškoti adreso juostoje su%2$s pasirink %3$sPridėti naują%4$s"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
-msgstr ""
-"Skiltyje %1$sIeškoti%2$s spustelėk %3$sValdyti paieškos sistemas...%4$s"
+msgstr "Skiltyje %1$sIeškoti%2$s spustelėk %3$sValdyti paieškos sistemas...%4$s"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -21496,8 +21465,7 @@ msgctxt ""
 "Text shown in the subscription promo card, with a trailing call-to-action "
 "link."
 msgid "Unlock more capable AI models with a DuckDuckGo subscription. %s"
-msgstr ""
-"Gauk prieigą prie galingesnių DI modelių su „DuckDuckGo“ prenumerata. %1$s"
+msgstr "Gauk prieigą prie galingesnių DI modelių su „DuckDuckGo“ prenumerata. %1$s"
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to unmute the microphone.
@@ -21764,7 +21732,7 @@ msgstr "Urugvajus"
 #. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
 msgctxt "Navigation label on the Duck.ai settings page"
 msgid "Usage"
-msgstr ""
+msgstr "Naudojimas"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -22156,8 +22124,7 @@ msgstr "Balso pokalbis baigtas"
 #. Description in consent disclaimer informing that voice chats with the AI (Artificial Intelligence) are anonymized by us, and are never used to train AI models.
 msgctxt "voice chat"
 msgid "Voice chat is anonymized by us, and never used to train AI models."
-msgstr ""
-"Balso pokalbius nuasmeniname ir niekada nenaudojame DI modeliams mokyti."
+msgstr "Balso pokalbius nuasmeniname ir niekada nenaudojame DI modeliams mokyti."
 
 # smartling.placeholder_format=C
 #. Title of the modal shown when the user has reached their daily voice chat limit.
@@ -22221,7 +22188,7 @@ msgstr "Velsas"
 #. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Walk me through the steps"
-msgstr ""
+msgstr "Paaiškink man žingsnius"
 
 # smartling.placeholder_format=C
 #. Label for walking directions on a map.
@@ -22352,6 +22319,9 @@ msgid ""
 "please share this conversation with DuckDuckGo so we can investigate and "
 "address the issue."
 msgstr ""
+"Galime ištaisyti tik tai, ką matome. Norėdami pranešti apie žalingą ar "
+"neteisėtą atsakymą, bendrinkite šį pokalbį su „DuckDuckGo“, kad galėtume "
+"ištirti ir išspręsti problemą."
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -22380,8 +22350,7 @@ msgstr ""
 msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
-msgstr ""
-"Negalime perskaityti pridėtų failų, nes bent vienas iš jų yra užšifruotas."
+msgstr "Negalime perskaityti pridėtų failų, nes bent vienas iš jų yra užšifruotas."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -22483,8 +22452,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don’t track you in or out of private browsing mode."
-msgstr ""
-"Nestebime tavęs, kai naudojiesi arba nesinaudoji privačiu naršymo režimu."
+msgstr "Nestebime tavęs, kai naudojiesi arba nesinaudoji privačiu naršymo režimu."
 
 # smartling.placeholder_format=C
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with an Agree button is shown below.
@@ -22764,9 +22732,9 @@ msgid ""
 "of your chats here are private, and are never stored by DuckDuckGo or used "
 "to train AI models."
 msgstr ""
-"Sveiki, čia – „DuckDuckGo AI Chat“! Šią pokalbių sesiją teikia "
-"„%1$s“ „%2$s“. Visi jūsų pokalbiai čia yra privatūs ir „DuckDuckGo“ jų "
-"niekada nesaugo ir nenaudoja DI modeliams mokyti."
+"Sveiki, čia – „DuckDuckGo AI Chat“! Šią pokalbių sesiją teikia „%1$s“ "
+"„%2$s“. Visi jūsų pokalbiai čia yra privatūs ir „DuckDuckGo“ jų niekada "
+"nesaugo ir nenaudoja DI modeliams mokyti."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -22780,8 +22748,7 @@ msgstr ""
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai, it's time to import your chats"
-msgstr ""
-"Sveikiname išbandžius naująją „Duck.ai“ versiją, laikas importuoti pokalbius"
+msgstr "Sveikiname išbandžius naująją „Duck.ai“ versiją, laikas importuoti pokalbius"
 
 # smartling.placeholder_format=C
 #. Welcome message for new DuckDuckGo users.
@@ -22872,8 +22839,7 @@ msgstr "Į kokius veiksnius reikia atsižvelgti perkant kompiuterio monitorių?"
 #. Text for a prompt suggestion for asking about must-see attractions in Paris for a first-time visitor.
 msgctxt "Full sentence for planning a trip"
 msgid "What are some must-see attractions in Paris for a first-time visitor?"
-msgstr ""
-"Kokias lankytinas vietas Paryžiuje būtina pamatyti lankantis pirmą kartą?"
+msgstr "Kokias lankytinas vietas Paryžiuje būtina pamatyti lankantis pirmą kartą?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for finding options for the word 'better' in a specific context.
@@ -22913,98 +22879,98 @@ msgstr ""
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the counterarguments?"
-msgstr ""
+msgstr "Kokie kontrargumentai?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the hours & location?"
-msgstr ""
+msgstr "Koks darbo laikas ir vieta?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key contributions of this paper?"
-msgstr ""
+msgstr "Koks pagrindinis šio mokslinio darbo indėlis?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key contributions?"
-msgstr ""
+msgstr "Koks pagrindinis indėlis?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key details?"
-msgstr ""
+msgstr "Kokios pagrindinės detalės?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key points covered in this video?"
-msgstr ""
+msgstr "Kokie pagrindiniai šio vaizdo įrašo aspektai?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key points?"
-msgstr ""
+msgstr "Kokie pagrindiniai aspektai?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key takeaways from this article?"
-msgstr ""
+msgstr "Kokie pagrindiniai šio straipsnio akcentai?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key takeaways?"
-msgstr ""
+msgstr "Kokie pagrindiniai akcentai?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key things I will learn from this course?"
-msgstr ""
+msgstr "Kokie pagrindiniai dalykai, kurių išmoksiu šiame kurse?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the main counterarguments or criticisms of this?"
-msgstr ""
+msgstr "Kokie pagrindiniai to kontrargumentai ar kritika?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the main questions this page answers?"
-msgstr ""
+msgstr "Į kokius pagrindinius klausimus atsako šis puslapis?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the must-try dishes here?"
-msgstr ""
+msgstr "Kokių patiekalų čia būtina paragauti?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid ""
 "What are the opening hours, location, and contact details for this place?"
-msgstr ""
+msgstr "Koks šios vietos darbo laikas, adresas ir kontaktiniai duomenys?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the pros and cons of this product?"
-msgstr ""
+msgstr "Kokie šio produkto pranašumai ir trūkumai?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the pros and cons?"
-msgstr ""
+msgstr "Kokie pranašumai ir trūkumai?"
 
 # smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
@@ -23110,7 +23076,7 @@ msgstr "Ką reiškia atrija medicinos straipsnio kontekste?"
 #. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What does this answer?"
-msgstr ""
+msgstr "Į ką tai atsako?"
 
 # smartling.placeholder_format=C
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
@@ -23128,7 +23094,7 @@ msgstr "Kokia informacija yra išsaugoma?"
 #. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What interview questions might come up for this role?"
-msgstr ""
+msgstr "Kokių darbo pokalbio klausimų galima sulaukti pretenduojant į šias pareigas?"
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -23150,7 +23116,7 @@ msgstr "Kokia yra Albanijos sostinė?"
 #. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What is the overall verdict and rating for this?"
-msgstr ""
+msgstr "Koks bendras verdiktas ir įvertinimas?"
 
 # smartling.placeholder_format=C
 #. Link to a page with additional information.
@@ -23178,7 +23144,7 @@ msgstr "Ką sako žmonės:"
 #. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What should I order?"
-msgstr ""
+msgstr "Ką užsisakyti?"
 
 # smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
@@ -23196,13 +23162,13 @@ msgstr "Kas atsakyme buvo ne taip? (neprivaloma)"
 #. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What will I learn?"
-msgstr ""
+msgstr "Ko išmoksiu?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What will I need?"
-msgstr ""
+msgstr "Ko prireiks?"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -23213,8 +23179,7 @@ msgstr "Apie ką norėtum pateikti atsiliepimą?"
 #. Explains the benefits of using our custom video player, the Duck Player
 msgid ""
 "What you watch in DuckDuckGo won't influence your recommendations on YouTube."
-msgstr ""
-"Tai, ką žiūrite „DuckDuckGo“, neturės įtakos jūsų rekomendacijoms „YouTube“."
+msgstr "Tai, ką žiūrite „DuckDuckGo“, neturės įtakos jūsų rekomendacijoms „YouTube“."
 
 # smartling.placeholder_format=C
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
@@ -23226,7 +23191,7 @@ msgstr "Kas naujo"
 #. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What's the verdict?"
-msgstr ""
+msgstr "Koks verdiktas?"
 
 # smartling.placeholder_format=C
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -23284,7 +23249,7 @@ msgstr "Kokios funkcijos trūksta? (Pasirinktinai)"
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Which features are missing? (optional)"
-msgstr ""
+msgstr "Kokių funkcijų trūksta? (neprivaloma)"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
@@ -23306,13 +23271,13 @@ msgstr "Kas Mes"
 #. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Who are the main cast and crew, and what else are they known for?"
-msgstr ""
+msgstr "Kas sudaro pagrindinę aktorių ir kūrybinę grupę ir kuo jie dar žinomi?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Who is this person?"
-msgstr ""
+msgstr "Kas šis asmuo?"
 
 # smartling.placeholder_format=C
 #. Header above a collection of privacy-related links.
@@ -23683,8 +23648,7 @@ msgstr "Taip, naujas naudotojas!"
 msgctxt "cloudsave"
 msgid ""
 "Yes, we throw away data when you’re done with it, and it cannot be recovered."
-msgstr ""
-"Taip, mes pašaliname duomenis, kai baigi naudotis, ir jų nebegalima atkurti."
+msgstr "Taip, mes pašaliname duomenis, kai baigi naudotis, ir jų nebegalima atkurti."
 
 # smartling.placeholder_format=C
 #. Option for the filter-by-date search.
@@ -24053,8 +24017,7 @@ msgctxt "Error message for user limit"
 msgid ""
 "You've reached the maximum number of messages for the moment. Please try "
 "again later."
-msgstr ""
-"Šiuo metu pasiekėte maksimalų pranešimų skaičių. Bandykite dar kartą vėliau."
+msgstr "Šiuo metu pasiekėte maksimalų pranešimų skaičių. Bandykite dar kartą vėliau."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -24242,16 +24205,14 @@ msgstr ""
 msgctxt "Active Privacy protection description"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
-msgstr ""
-"Jūsų pokalbiai yra privatūs, anonimizuoti ir nenaudojami DI modeliams mokyti."
+msgstr "Jūsų pokalbiai yra privatūs, anonimizuoti ir nenaudojami DI modeliams mokyti."
 
 # smartling.placeholder_format=C
 #. Text explaining that user chats are private and not used for AI (Artificial Intelligence) training.
 msgctxt "Body text for privacy protection modal"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
-msgstr ""
-"Jūsų pokalbiai yra privatūs, anonimizuoti ir nenaudojami DI modeliams mokyti."
+msgstr "Jūsų pokalbiai yra privatūs, anonimizuoti ir nenaudojami DI modeliams mokyti."
 
 # smartling.placeholder_format=C
 #. Text for a menu item that describes the privacy protection feature.
@@ -24584,8 +24545,7 @@ msgstr "sukurta %1$s"
 #. Trust line shown at the bottom of the explainer panel, summarizing DuckDuckGo's reputation for online protection.
 msgctxt "Footer banner text in the How Duck.ai Works panel"
 msgid "by DuckDuckGo — online protection trusted by millions every day."
-msgstr ""
-"kūrėjas „DuckDuckGo“ – interneto apsauga, kuria kasdien pasitiki milijonai."
+msgstr "kūrėjas „DuckDuckGo“ – interneto apsauga, kuria kasdien pasitiki milijonai."
 
 # smartling.placeholder_format=C
 #. An abreviated unit of time indicating an age, e.g. "2d"

--- a/locales/lt_LT/LC_MESSAGES/duckduckgo.po
+++ b/locales/lt_LT/LC_MESSAGES/duckduckgo.po
@@ -2,15 +2,16 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: lt_LT\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"(n%100<10 || n%100>=20) ? 1 : 2;\n"
 
 # smartling.gettext_line_width = normalized : 79
 # smartling.placeholder_format=C
@@ -481,7 +482,8 @@ msgstr ""
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "%sLearn more%s about how chats are stored privately on your device."
-msgstr "%1$sSužinok daugiau%2$s, kaip pokalbiai saugomi privačiai tavo įrenginyje."
+msgstr ""
+"%1$sSužinok daugiau%2$s, kaip pokalbiai saugomi privačiai tavo įrenginyje."
 
 # smartling.placeholder_format=C
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
@@ -883,14 +885,16 @@ msgstr ""
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of AI Chat is available! Please refresh this page to continue."
-msgstr "Pasirodė nauja „AI Chat“ versija! Jei nori tęsti, atnaujink šį puslapį."
+msgstr ""
+"Pasirodė nauja „AI Chat“ versija! Jei nori tęsti, atnaujink šį puslapį."
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of Duck.ai is available and they need to refresh the page.
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of Duck.ai is available! Please refresh this page to continue."
-msgstr "Pasirodė nauja „Duck.ai“ versija! Jei norite tęsti, atnaujinkite šį puslapį."
+msgstr ""
+"Pasirodė nauja „Duck.ai“ versija! Jei norite tęsti, atnaujinkite šį puslapį."
 
 # smartling.placeholder_format=C
 #. Shown when the Duck.ai desktop app has been open a long time and a newer version exists.
@@ -1435,6 +1439,12 @@ msgid "Address is incorrect"
 msgstr "Adresas neteisingas"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Adjust the servings"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. as in multiple advertisements
 msgid "Ads"
 msgstr "Reklamos"
@@ -1516,7 +1526,8 @@ msgstr "Kai atsisiųsi ir atidarysi, spustelėk %1$sĮdiegti%2$s"
 #. Instructions on how to install the DuckDuckGo browser extension after it downloads.
 msgid ""
 "After it downloads, locate the extension file and double-click it to install"
-msgstr "Kai atsisiųsi, surask plėtinio failą ir du kartus jį spustelėk, kad įdiegtum"
+msgstr ""
+"Kai atsisiųsi, surask plėtinio failą ir du kartus jį spustelėk, kad įdiegtum"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an age below a web search result.
@@ -1646,6 +1657,14 @@ msgid "All chats are %sprivate%s"
 msgstr "Visi pokalbiai — %1$sprivatūs%2$s"
 
 # smartling.placeholder_format=C
+#. Paragraph in the Privacy & Terms section of the About & Legal page in Duck.ai settings, summarizing how chats are anonymized and are not stored or used to train chat models.
+msgctxt "Privacy & Terms section description on the Duck.ai settings page"
+msgid ""
+"All chats are anonymized by DuckDuckGo, and your conversations are not used "
+"to train chat models by DuckDuckGo or the model providers"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
 msgctxt "Privacy modal header in Duck.ai chat"
 msgid "All chats are private"
@@ -1736,7 +1755,8 @@ msgstr "Leisti privatumo paisančius skelbimus"
 # smartling.placeholder_format=C
 #. Title in a dialog informing the user how to disable their ad blocker for DuckDuckGo
 msgid "Allow privacy-respecting ads on DuckDuckGo Private Search"
-msgstr "Leisti privatumo paisančius skelbimus „DuckDuckGo Private Search“ paieškoje"
+msgstr ""
+"Leisti privatumo paisančius skelbimus „DuckDuckGo Private Search“ paieškoje"
 
 # smartling.placeholder_format=C
 #. Description explaining privacy implications of enabling web search on encrypted models. The first two placeholders are the full model name (e.g. 'gpt-oss 120B'). The third and fourth placeholders wrap a clickable link reading 'zero provider visibility' that opens the privacy modal, please keep those around the link text in your translation. An example full sentence would be: Allows gpt-oss 120B to search the web to improve responses to relevant prompts. Only sends AI-generated queries to a search engine with limited data retention. Prompts and responses with gpt-oss 120B still have zero provider visibility.
@@ -1788,7 +1808,8 @@ msgstr "Jau sinchronizuota."
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Also search privately on your iPad, iPhone, or Android!"
-msgstr "Taip pat ieškok privačiai savo „iPad“, „iPhone“ arba „Android“ įrenginyje!"
+msgstr ""
+"Taip pat ieškok privačiai savo „iPad“, „iPhone“ arba „Android“ įrenginyje!"
 
 # smartling.placeholder_format=C
 #. Keyboard shortcut for Duck.ai
@@ -1914,6 +1935,13 @@ msgstr ""
 msgctxt "precise_user_location"
 msgid "Anonymous location enabled"
 msgstr "Įjungta anoniminė vieta"
+
+# smartling.placeholder_format=C
+msgctxt "settings"
+msgid ""
+"Anonymously generates answers for search queries based on web content. "
+"Choose how often you want it to appear, or disable it completely."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -2194,6 +2222,12 @@ msgid "Ask a follow-up with Duck.ai"
 msgstr "Užduok tolesnį klausimą „Duck.ai“"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
+msgctxt "Page suggestion chip label"
+msgid "Ask about this page"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
 msgctxt "Title for the page context onboarding modal"
 msgid "Ask about this page"
@@ -2411,7 +2445,8 @@ msgstr "Automatinis atsakymas"
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid "Auto-generated based on listed sources. May contain inaccuracies."
-msgstr "Automatiškai generuojama pagal išvardytus šaltinius. Gali būti netikslumų."
+msgstr ""
+"Automatiškai generuojama pagal išvardytus šaltinius. Gali būti netikslumų."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
@@ -2607,6 +2642,12 @@ msgid "Barcode"
 msgstr "Brūkšninis kodas"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Based on this page, is this course worth taking?"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Basic"
 msgstr "Pagrindinė"
@@ -2645,6 +2686,14 @@ msgstr "Mušėjas"
 msgctxt "Assistant response placeholder"
 msgid "Before continuing..."
 msgstr "Prieš tęsiant…"
+
+# smartling.placeholder_format=C
+#. Explains that before storing the report, DuckDuckGo will anonymize the conversation by removing PII like names, email addresses, and identifying metadata.
+msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
+msgid ""
+"Before storing this report, DuckDuckGo will anonymize your conversation by "
+"removing PII like names, email addresses, and identifying metadata."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -2961,6 +3010,12 @@ msgstr "Brazilija"
 msgctxt "Sports module"
 msgid "Break Points Won"
 msgstr "Laimėti „break point“ taškai"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Break this down into clear, numbered steps."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -3417,6 +3472,12 @@ msgid "Cast"
 msgstr "Aktoriai"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Cast & Crew"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
 msgctxt "Tone option label for Casual"
 msgid "Casual"
@@ -3520,7 +3581,8 @@ msgstr "Pakeičia fono spalvą visoje svetainėje"
 msgctxt "settings"
 msgid ""
 "Changes the background color of results on hover, modules, and dropdown menus"
-msgstr "Pakeičia žymeklio, modulių ir išskleidžiamųjų meniu rezultatų fono spalvą"
+msgstr ""
+"Pakeičia žymeklio, modulių ir išskleidžiamųjų meniu rezultatų fono spalvą"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/NdpkbY0.png
@@ -4262,7 +4324,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click %sPrivacy and Services%s in the left sidebar."
-msgstr "Dešiniojoje šoninėje juostoje spustelėk %1$sPrivatumas ir Paslaugos%2$s."
+msgstr ""
+"Dešiniojoje šoninėje juostoje spustelėk %1$sPrivatumas ir Paslaugos%2$s."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -4289,7 +4352,8 @@ msgstr "Išskleidžiamajame meniu spustelėk %1$sNustatymai%2$s."
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
-msgstr "Spustelėk %1$sNaudoti dabartinius puslapius%2$s, tada %3$s– „Gerai%4$s."
+msgstr ""
+"Spustelėk %1$sNaudoti dabartinius puslapius%2$s, tada %3$s– „Gerai%4$s."
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -4356,7 +4420,8 @@ msgstr "Paieškos juostoje spustelėk %1$sdidinamąjį stiklą%2$s"
 # smartling.placeholder_format=C
 #. Tells users what icon to click in their browser to change their default search engine.
 msgid "Click on the magnifying glass in the search box at the top right"
-msgstr "Viršuje dešinėje esančiame paieškos langelyje spustelėk didinamąjį stiklą"
+msgstr ""
+"Viršuje dešinėje esančiame paieškos langelyje spustelėk didinamąjį stiklą"
 
 # smartling.placeholder_format=C
 #. Tells users where to click in order to disable the cloud save feature and delete any data backed-up to the cloud.
@@ -5008,7 +5073,8 @@ msgstr "Kopijuoti"
 # smartling.placeholder_format=C
 #. Instructions on how to change the default search engine
 msgid "Copy &amp; paste %sabout:preferences#search%s into the address bar"
-msgstr "Nukopijuok ir įklijuok %1$sabout:preferences#search%2$s į adreso juostą"
+msgstr ""
+"Nukopijuok ir įklijuok %1$sabout:preferences#search%2$s į adreso juostą"
 
 # smartling.placeholder_format=C
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
@@ -5122,6 +5188,12 @@ msgstr "Kurti vaizdą"
 msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr "Kurti vaizdą"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Create a shopping list with quantities from this recipe."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed in the input field when starting a new image generation session.
@@ -5754,12 +5826,18 @@ msgstr "Diktavimas „Duck.ai“"
 # smartling.placeholder_format=C
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
-msgstr "Diktavimą mes anonimizuojame ir niekada nenaudojame DI modeliams mokyti."
+msgstr ""
+"Diktavimą mes anonimizuojame ir niekada nenaudojame DI modeliams mokyti."
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
 msgid "Dictation limit reached"
 msgstr "Pasiekei diktavimo ribą"
+
+# smartling.placeholder_format=C
+#. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
+msgid "Dictation temporarily unavailable"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
@@ -6062,6 +6140,22 @@ msgid "Done"
 msgstr "Atlikta"
 
 # smartling.placeholder_format=C
+#. Message shown in a modal after DuckDuckGo browser users disable AI features in Settings. The first two placeholders bold noai.duckduckgo.com. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
+"filtered out. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
+"and AI images filtered out. %sLearn more%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Double Faults"
@@ -6174,6 +6268,18 @@ msgid ""
 msgstr ""
 "Parenk glaustą ir išsamų el. laišką pardavėjui, kuriame prašoma pateikti "
 "namų šaldytuvo remonto paslaugų kainą."
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Draft a cover letter"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Draft a cover letter for this job."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -6356,6 +6462,15 @@ msgstr ""
 "naršyklėje!"
 
 # smartling.placeholder_format=C
+#. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
+msgctxt "About section description on the Duck.ai settings page"
+msgid ""
+"Duck.ai is created by DuckDuckGo. We're an independent online protection "
+"company for anyone who wants to take back control of their personal "
+"information."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
 msgctxt "duckai_migration"
 msgid "Duck.ai is moving domains"
@@ -6401,6 +6516,13 @@ msgstr ""
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
 msgstr "„Duck.ai“ laikinai nepasiekiamas. Bandykite dar kartą vėliau."
+
+# smartling.placeholder_format=C
+msgctxt "settings"
+msgid ""
+"Duck.ai lets you chat privately with popular AI models. Disabling it hides "
+"Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6603,8 +6725,8 @@ msgid ""
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
 "„DuckDuckGo AI Chat“ yra privati dirbtiniu intelektu pagrįsta pokalbių "
-"paslauga, kuri šiuo metu palaiko pokalbių modelius „%1$s“ „%2$s“ ir „%3$s“ "
-"„%4$s“."
+"paslauga, kuri šiuo metu palaiko pokalbių modelius „%1$s“ „%2$s“ ir "
+"„%3$s“ „%4$s“."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the welcome screen of the onboarding. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -6614,8 +6736,8 @@ msgid ""
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
 "„DuckDuckGo AI Chat“ yra privati dirbtiniu intelektu pagrįsta pokalbių "
-"paslauga, kuri šiuo metu palaiko pokalbių modelius „%1$s“ „%2$s“ ir „%3$s“ "
-"„%4$s“."
+"paslauga, kuri šiuo metu palaiko pokalbių modelius „%1$s“ „%2$s“ ir "
+"„%3$s“ „%4$s“."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding DuckDuckGo AI Chat.
@@ -6651,7 +6773,8 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr "„DuckDuckGo DI Chat“ laikinai nepasiekiamas. Bandykite dar kartą vėliau."
+msgstr ""
+"„DuckDuckGo DI Chat“ laikinai nepasiekiamas. Bandykite dar kartą vėliau."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -6780,8 +6903,8 @@ msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid ""
 "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to Duck.ai's %s."
 msgstr ""
-"„DuckDuckGo“ anonimina tavo pokalbius. Jei spusteli „%1$s“, sutinki su "
-"„Duck.ai“ %2$s."
+"„DuckDuckGo“ anonimina tavo pokalbius. Jei spusteli „%1$s“, sutinki su „Duck."
+"ai“ %2$s."
 
 # smartling.placeholder_format=C
 #. Shown below the input on the empty state when the user has not yet accepted the terms of service. The first %s is the action button label ('Ask' for chat, 'Create' for image generation). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. Clicking the action button both accepts the terms and submits the prompt.
@@ -6926,9 +7049,9 @@ msgid ""
 "characters long."
 msgstr ""
 "Kiekvieną kartą, kai paprašai pasiūlyti slaptafrazę, naudojame didelį "
-"atsitiktinių žodžių sąrašą iš „DuckDuckGo“ serverių. Naršyklėje parenkame "
-"4–5 atsitiktinius žodžius iš sąrašo užtikrindami, kad slaptafrazė būtų bent "
-"18–20 simbolių ilgio."
+"atsitiktinių žodžių sąrašą iš „DuckDuckGo“ serverių. Naršyklėje parenkame 4–"
+"5 atsitiktinius žodžius iš sąrašo užtikrindami, kad slaptafrazė būtų bent 18–"
+"20 simbolių ilgio."
 
 # smartling.placeholder_format=C
 msgctxt "Sports module"
@@ -7249,13 +7372,15 @@ msgstr "Ar tau patinka „Duck.ai“?"
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure %s'Allow'%s is selected for the 'Location' setting."
-msgstr "Įsitikink, kad pasirinkta nustatymo „Vieta“ parinktis %1$s„Leisti“%2$s."
+msgstr ""
+"Įsitikink, kad pasirinkta nustatymo „Vieta“ parinktis %1$s„Leisti“%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location Services' is %senabled%s."
-msgstr "Įsitikink, kad parinktis „Buvimo vietos nustatymo paslaugos“ %1$sįjungta%2$s."
+msgstr ""
+"Įsitikink, kad parinktis „Buvimo vietos nustatymo paslaugos“ %1$sįjungta%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
@@ -7397,11 +7522,24 @@ msgstr "Pusiaujo Gvinėja"
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Erase your browsing data in a flash with our %sFire Button%s"
-msgstr "Naršymo duomenis ištrinkite akimirksniu naudodami mūsų %1$s„Fire Button“%2$s"
+msgstr ""
+"Naršymo duomenis ištrinkite akimirksniu naudodami mūsų %1$s„Fire Button“%2$s"
 
 # smartling.placeholder_format=C
 msgid "Eritrea"
 msgstr "Eritrėja"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Estimate the nutrition"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Estimate the nutritional information for this recipe."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Estonia"
@@ -7458,11 +7596,60 @@ msgid "Expires in 1 day"
 msgstr "Galiojimas baigiasi po 1 dienos"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain the accepted answer in simple terms."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
-msgstr "Paaiškink pagrindines juodųjų skylių sąvokas vidurinės mokyklos lygmeniu."
+msgstr ""
+"Paaiškink pagrindines juodųjų skylių sąvokas vidurinės mokyklos lygmeniu."
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain the top answer"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this in simple, plain language."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this paper"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this repo"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this research paper in plain language."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this simply"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain what this repository does and how to use it."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label to show if song lyrics contain explicit content
@@ -7486,7 +7673,8 @@ msgstr "Suaugusiesiems skirti dainų tekstai"
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
-msgstr "Susipažinkite su naujausiais „DuckDuckGo“ produktų ir funkcijų atnaujinimais."
+msgstr ""
+"Susipažinkite su naujausiais „DuckDuckGo“ produktų ir funkcijų atnaujinimais."
 
 # smartling.placeholder_format=C
 #. Links to a page that provides a list of DuckDuckGo product updates
@@ -7659,7 +7847,8 @@ msgstr ""
 msgid ""
 "Feel free to adjust the settings below. Then, just copy and paste the code "
 "into your website."
-msgstr "Keisk savo nustatymus žemiau. Tada, tiesiog nukopijuok kodą į savo svetainę."
+msgstr ""
+"Keisk savo nustatymus žemiau. Tada, tiesiog nukopijuok kodą į savo svetainę."
 
 # smartling.placeholder_format=C
 msgid "Fiji"
@@ -7747,6 +7936,12 @@ msgstr ""
 "daugiau%2$s"
 
 # smartling.placeholder_format=C
+msgctxt "settings"
+msgid ""
+"Filters out known AI spam sites from image search results. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the final score of a sporting event.
 msgid "Final"
 msgstr "Galutinis"
@@ -7773,7 +7968,8 @@ msgstr "Finansų konsultantas"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Find %sDuckDuckGo%s and click%sMake default%s"
-msgstr "Surask %1$sDuckDuckGo%2$s ir spustelėk%3$sNustatyti kaip numatytąjį%4$s"
+msgstr ""
+"Surask %1$sDuckDuckGo%2$s ir spustelėk%3$sNustatyti kaip numatytąjį%4$s"
 
 # smartling.placeholder_format=C
 #. Sentence shown after export, includes a placeholder for one or more filenames with bold formatting for the filename(s).
@@ -7800,6 +7996,12 @@ msgstr "Rask geresnį žodį"
 msgctxt "Subtitle for the Web Search tool entry in the Tools dropdown menu"
 msgid "Find current information"
 msgstr "Naujausios informacijos paieška"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Find me alternatives"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button that searches for results closer to the user's current location.
@@ -7891,7 +8093,8 @@ msgstr ""
 #. Privacy reassurance and instructions intro.
 msgctxt "duckai_migration"
 msgid "Follow these steps to move your chats to the new Duck.ai"
-msgstr "Atlik šiuos veiksmus, kad perkeltum pokalbius į naująją „Duck.ai“ versiją"
+msgstr ""
+"Atlik šiuos veiksmus, kad perkeltum pokalbius į naująją „Duck.ai“ versiją"
 
 # smartling.placeholder_format=C
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse on mobile
@@ -7996,7 +8199,8 @@ msgstr "Nemokami ir privatūs pokalbiai, kuriuos anonimizuojame"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr "Nemokami ir privatūs pokalbiai, kuriuos anonimizuojame. Paskyros nereikia."
+msgstr ""
+"Nemokami ir privatūs pokalbiai, kuriuos anonimizuojame. Paskyros nereikia."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -8279,6 +8483,12 @@ msgid "Generate More"
 msgstr "Generuoti daugiau"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Generate a shopping list"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
 msgid "Generate a short answer from the web"
 msgstr "Trumpo atsakymo iš žiniatinklio generavimas"
@@ -8441,7 +8651,8 @@ msgstr "Pradėti"
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the Privacy Pro subscription.
 msgctxt "SERP footer content"
 msgid "Get a VPN + two more protections in one easy subscription."
-msgstr "Gaukite VPN ir dar dvi apsaugos priemones iš vienos paprastos prenumeratos."
+msgstr ""
+"Gaukite VPN ir dar dvi apsaugos priemones iš vienos paprastos prenumeratos."
 
 # smartling.placeholder_format=C
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
@@ -8500,12 +8711,14 @@ msgstr "Reikia pagalbos dėl kompiuterio"
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
 msgctxt "Browser Promo Popover"
 msgid "Get our browser to never lose your settings."
-msgstr "Atsisiųsk ir naudok mūsų naršyklę, kad niekada neprarastum savo nustatymų."
+msgstr ""
+"Atsisiųsk ir naudok mūsų naršyklę, kad niekada neprarastum savo nustatymų."
 
 # smartling.placeholder_format=C
 msgid ""
 "Get seamless privacy protection on your browser for free with one download:"
-msgstr "Vienu atsisiuntimu nemokamai gauk sklandžią privatumo apsaugą naršyklėje:"
+msgstr ""
+"Vienu atsisiuntimu nemokamai gauk sklandžią privatumo apsaugą naršyklėje:"
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo app when clicked
@@ -8568,6 +8781,12 @@ msgstr "Išbandyk"
 msgctxt "Onboarding welcome screen button text"
 msgid "Give it a Try"
 msgstr "Išbandyk"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Give me a quick background on this person."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9015,6 +9234,18 @@ msgstr "Padėk Skleisti Žinią Apie „DuckDuckGo“!"
 #. Link to a page with information about sharing DuckDuckGo with friends.
 msgid "Help Spread Privacy"
 msgstr "Padėk Skleisti Žinią Apie Privatumą"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Help me prep for the interview"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Help me tailor my resume for this job."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title of a SERP popup that invites users to take a survey (desktop only)
@@ -9534,6 +9765,14 @@ msgid "I Agree"
 msgstr "Sutinku"
 
 # smartling.placeholder_format=C
+#. Text for the button that takes the user to the external DuckDuckGo login subscription page.
+msgctxt ""
+"Text for the I already have a subscription button in the Duck.ai settings "
+"page"
+msgid "I Already Have a Subscription"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for the button that takes the user to the login subscription page.
 msgctxt "Text for the I have a subscription button"
 msgid "I Have a Subscription"
@@ -9614,7 +9853,8 @@ msgstr ""
 #. Option for feedback when the user needs more help or information on how to use the chat.
 msgctxt "Feedback option for difficulty in using chat"
 msgid "I need more help/info on how to use Chat"
-msgstr "Man reikia daugiau pagalbos / informacijos apie tai, kaip naudotis pokalbiu"
+msgstr ""
+"Man reikia daugiau pagalbos / informacijos apie tai, kaip naudotis pokalbiu"
 
 # smartling.placeholder_format=C
 msgid "IR Iran"
@@ -9847,7 +10087,8 @@ msgstr "Pagerink argumentus"
 msgctxt "settings"
 msgid ""
 "Improves result legibility with updated URL format, placement, and color"
-msgstr "Pagerina rezultato skaitomumą atnaujintu URL formatu, išdėstymu ir spalva"
+msgstr ""
+"Pagerina rezultato skaitomumą atnaujintu URL formatu, išdėstymu ir spalva"
 
 # smartling.placeholder_format=C
 #. A label that appears in front of the name of a company that DuckDuckGo has partnered with. For example, 'In partnership with Wikipedia'
@@ -10107,6 +10348,12 @@ msgid "Install Mac Browser"
 msgstr "Įdiekite „Mac“ naršyklę"
 
 # smartling.placeholder_format=C
+#. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
+msgctxt "settings"
+msgid "Install Now"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of a button to install the DuckDuckGo app
 msgctxt "Serp footer content"
 msgid "Install Our App"
@@ -10204,10 +10451,42 @@ msgid "Is deleted data really deleted?"
 msgstr "Ar ištrinti duomenys yra iš tiesų pašalinami?"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is it worth taking?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this place any good?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"Is this place any good? Summarize its reputation based on reviews and "
+"ratings."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "Is this video helpful?"
 msgstr "Ar šis vaizdo įrašas naudingas?"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this worth watching?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Is this worth watching? Give me a spoiler-free take."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -10239,7 +10518,8 @@ msgstr "Ji greita, nemokama ir užtikrina dar daugiau apsaugos internete."
 msgctxt "settings"
 msgid ""
 "It's okay to (very infrequently) ask me about my experience using DuckDuckGo"
-msgstr "Leidžiu (labai retai) manęs klausti apie naudojimosi „DuckDuckGo“ patirtį"
+msgstr ""
+"Leidžiu (labai retai) manęs klausti apie naudojimosi „DuckDuckGo“ patirtį"
 
 # smartling.placeholder_format=C
 #. The name of the Italian language
@@ -10818,6 +11098,12 @@ msgid "Links:"
 msgstr "Nuorodos:"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "List the tools, materials, or prerequisites I need for this."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
 msgid "Listen"
 msgstr "Klausyti"
@@ -10926,7 +11212,8 @@ msgstr "Įkeliama daugiau vaizdų slenkant"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Loads more results in Images, Videos, and Shopping when scrolling"
-msgstr "Slenkant įkeliama daugiau Vaizdų, Vaizdo Įrašų ir Apsipirkimo rezultatų"
+msgstr ""
+"Slenkant įkeliama daugiau Vaizdų, Vaizdo Įrašų ir Apsipirkimo rezultatų"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/WTkvs9I.png
@@ -11222,6 +11509,12 @@ msgstr "Tvarkyti prenumeratą"
 msgctxt "Exclusion message manage sites button"
 msgid "Manage blocked sites"
 msgstr "Tvarkyti užblokuotas svetaines"
+
+# smartling.placeholder_format=C
+#. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
+msgctxt "setting"
+msgid "Manage in Browser Settings"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to the site exclusion settings page
@@ -12977,7 +13270,8 @@ msgstr "Omanas"
 #. http://i.imgur.com/zQWKLIm.png
 msgctxt "settings"
 msgid "Omits objectionable (mostly adult) material"
-msgstr "Praleidžiami nepageidaujami (daugiausia tik suaugusiesiems skirti) rezultatai"
+msgstr ""
+"Praleidžiami nepageidaujami (daugiausia tik suaugusiesiems skirti) rezultatai"
 
 # smartling.placeholder_format=C
 msgid "On"
@@ -13134,7 +13428,8 @@ msgstr "Atidaryti %1$s svetainę"
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open %sLocation%s, and ensure location is %senabled%s"
-msgstr "Atidarykite %1$sVieta%2$s ir įsitikinkite, kad vieta yra %3$sįjungta%4$s"
+msgstr ""
+"Atidarykite %1$sVieta%2$s ir įsitikinkite, kad vieta yra %3$sįjungta%4$s"
 
 #  Chrome/Firefox on Android/iOS
 # smartling.placeholder_format=C
@@ -13297,7 +13592,8 @@ msgstr "Atidaryti skydelį „Kaip veikia Duck.ai“"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open the Safari menu and select %sSettings for DuckDuckGo...%s"
-msgstr "Atidarykite „Safari“ meniu ir pasirinkite %1$s„DuckDuckGo“ nustatymai...%2$s"
+msgstr ""
+"Atidarykite „Safari“ meniu ir pasirinkite %1$s„DuckDuckGo“ nustatymai...%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the time a business opens. For example: 'Opens at 10am'
@@ -14052,8 +14348,15 @@ msgstr "Atlik šią užduotį, kad patvirtintum, jog šią paiešką atliko žmo
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
+msgid "Please describe why the chat response is harmful or illegal. (optional)"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
+msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
-msgstr "Aprašyk, kodėl šis pokalbio atsakymas neteisėtas ar žalingas. (Neprivaloma)"
+msgstr ""
+"Aprašyk, kodėl šis pokalbio atsakymas neteisėtas ar žalingas. (Neprivaloma)"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to enter their passphrase.
@@ -14076,6 +14379,14 @@ msgid ""
 msgstr ""
 "Atkreipkite dėmesį: pradėjus naują pokalbį su bet kuriuo modeliu, dabartinė "
 "pokalbių sesija bus ištrinta."
+
+# smartling.placeholder_format=C
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
+msgctxt "Feedback prompt"
+msgid ""
+"Please paste your prompt and the problematic output (with any personal "
+"information removed) and describe why the content is harmful or illegal."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -14230,7 +14541,8 @@ msgstr "Luktelk..."
 #. Tagline for the subscription promo shown in the SERP sidemenu.
 msgctxt "Sidemenu subscription promo"
 msgid "Plus more premium features with a DuckDuckGo subscription."
-msgstr "„Plus“ – daugiau aukščiausios kokybės funkcijų su „DuckDuckGo“ prenumerata."
+msgstr ""
+"„Plus“ – daugiau aukščiausios kokybės funkcijų su „DuckDuckGo“ prenumerata."
 
 # smartling.placeholder_format=C
 #. A description to provide more detail on what Duck Player does (Duck Player is DDG's feature to watch youtube videos more privately)
@@ -14545,6 +14857,12 @@ msgid "Privacy"
 msgstr "Privatumas"
 
 # smartling.placeholder_format=C
+#. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
+msgctxt "Section heading on the Duck.ai settings page"
+msgid "Privacy & Terms"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Privacy Blog"
 msgstr "Privatumo Tinklaraštis"
 
@@ -14613,6 +14931,12 @@ msgstr "Privatumo politika ir naudojimo sąlygos"
 msgctxt "Copy used to compose link in sentences"
 msgid "Privacy Policy and Terms of Service"
 msgstr "Privatumo politika ir paslaugų teikimo sąlygos"
+
+# smartling.placeholder_format=C
+#. Text for a button that links to the terms of use and privacy policy page.
+msgctxt "Secondary button text in active privacy modal"
+msgid "Privacy Policy and Terms of Service"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title displayed on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
@@ -14786,7 +15110,8 @@ msgstr "Paraginti mane"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Prompt me to use my approximate location to get nearby results."
-msgstr "Paraginti mane naudoti apytikslę vietą, kad gaučiau tikslesnių rezultatų."
+msgstr ""
+"Paraginti mane naudoti apytikslę vietą, kad gaučiau tikslesnių rezultatų."
 
 # smartling.placeholder_format=C
 #. DuckDuckGo Email Protection removes trackers from emails
@@ -15112,6 +15437,30 @@ msgstr "%1$s%2$s%3$s receptai"
 msgctxt "Brief for recommending a book"
 msgid "Recommend a book"
 msgstr "Rekomenduok knygą"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar books"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar books."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar movies or shows."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar titles"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
@@ -15518,6 +15867,15 @@ msgid "Republic of Moldova"
 msgstr "Moldovos Respublika"
 
 # smartling.placeholder_format=C
+#. Note indicating that sharing the conversation is mandatory when reporting harmful or illegal content. Rendered alongside the standard share label (DUCKCHAT_RESPONSE_FEEDBACK_SHARE_PROMPT_RESPONSE_LABEL), not replacing it.
+msgctxt ""
+"Note shown under the share-content switch label on the Duck.ai response "
+"feedback form when the user has selected Harmful or Illegal as the feedback "
+"reason"
+msgid "Required for harmful or illegal reports"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
 msgctxt "Description for extended reasoning mode in Duck.ai"
 msgid "Researches before responding"
@@ -15750,6 +16108,12 @@ msgstr "Atsiliepimai"
 msgctxt "maps_places"
 msgid "Reviews"
 msgstr "Atsiliepimai"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Rewrite this recipe scaled for a different number of servings."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Romania"
@@ -16196,7 +16560,8 @@ msgstr "Slink žemyn ir sąraše rask %1$ssavo naršyklę%2$s."
 #. Tells users which setting to change to enable location service.
 msgctxt "precise_user_location"
 msgid "Scroll down to %sDuckDuckGo%s and allow it to use your location."
-msgstr "Slinkite žemyn iki %1$sDuckDuckGo%2$s ir leiskite jai naudoti jūsų vietovę."
+msgstr ""
+"Slinkite žemyn iki %1$sDuckDuckGo%2$s ir leiskite jai naudoti jūsų vietovę."
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -16575,8 +16940,8 @@ msgid ""
 "Securely store your chats on our server using end-to-end encryption, and "
 "access them from all your devices."
 msgstr ""
-"Saugok savo susirašinėjimus mūsų serveryje su ištisiniu (angl. "
-"<em>end-to-end</em>) šifravimu ir pasiek juos bet kuriame įrenginyje."
+"Saugok savo susirašinėjimus mūsų serveryje su ištisiniu (angl. <em>end-to-"
+"end</em>) šifravimu ir pasiek juos bet kuriame įrenginyje."
 
 # smartling.placeholder_format=C
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
@@ -16737,24 +17102,27 @@ msgstr "„Safari“ meniu pasirink %1$s„Šios svetainės nustatymas...“%2$s
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
 msgstr ""
-"Pasirink %1$sPasirinktinis%2$s ir įvesties laukelyje įvesk "
-"%3$shttps://duckduckgo.com%4$s"
+"Pasirink %1$sPasirinktinis%2$s ir įvesties laukelyje įvesk %3$shttps://"
+"duckduckgo.com%4$s"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
-msgstr "Pasirink %1$s„DuckDuckGo“%2$s ir spustelėk %3$sPridėti kaip numatytąją%4$s!"
+msgstr ""
+"Pasirink %1$s„DuckDuckGo“%2$s ir spustelėk %3$sPridėti kaip numatytąją%4$s!"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s"
-msgstr "Pasirink %1$s„DuckDuckGo“%2$s ir spustelėk %3$sNustatyti kaip numatytąją%4$s"
+msgstr ""
+"Pasirink %1$s„DuckDuckGo“%2$s ir spustelėk %3$sNustatyti kaip numatytąją%4$s"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s."
-msgstr "Pasirink %1$s„DuckDuckGo“%2$s ir spustelėk %3$sNustatyti kaip numatytąją%4$s."
+msgstr ""
+"Pasirink %1$s„DuckDuckGo“%2$s ir spustelėk %3$sNustatyti kaip numatytąją%4$s."
 
 #  Firefox 33
 # smartling.placeholder_format=C
@@ -16768,7 +17136,8 @@ msgstr ""
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %sDuckDuckGo%s in the list and %sallow%s location access"
-msgstr "Sąraše pasirinkite %1$sDuckDuckGo%2$s ir %3$sleiskite%4$s pasiekti vietą"
+msgstr ""
+"Sąraše pasirinkite %1$sDuckDuckGo%2$s ir %3$sleiskite%4$s pasiekti vietą"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -16780,7 +17149,8 @@ msgstr "Paieškos teikėjų sąraše pasirink %1$s„DuckDuckGo“%2$s"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s under the%sDefault Search Engine%s section"
-msgstr "Pasirink %1$s„DuckDuckGo“%2$s skiltyje%3$sNumatytoji Paieškos Sistema%4$s"
+msgstr ""
+"Pasirink %1$s„DuckDuckGo“%2$s skiltyje%3$sNumatytoji Paieškos Sistema%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user were in the settings menu they can change their default search engine.
@@ -16791,7 +17161,8 @@ msgstr "Pasirink %1$s„DuckDuckGo“%2$s!"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Select %sEdit Search Engines...%sin the dropdown"
-msgstr "Išskleidžiamajame meniu pasirink %1$sRedaguoti Paieškos Sistemas...%2$s"
+msgstr ""
+"Išskleidžiamajame meniu pasirink %1$sRedaguoti Paieškos Sistemas...%2$s"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -16865,7 +17236,8 @@ msgstr "Pasirink %1$sNustatymai%2$s, tuomet %3$sIšplėstiniai nustatymai%4$s"
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sDefault search engine%s"
-msgstr "Pasirink %1$sNustatymai%2$s, tuomet %3$sNumatytoji paieškos sistema%4$s"
+msgstr ""
+"Pasirink %1$sNustatymai%2$s, tuomet %3$sNumatytoji paieškos sistema%4$s"
 
 #  Chrome/Firefox on Android
 # smartling.placeholder_format=C
@@ -16887,7 +17259,8 @@ msgstr ""
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %syour browser%s in the list and %sallow%s location access"
-msgstr "Sąraše pasirinkite %1$ssavo naršyklę%2$s ir %3$sleiskite%4$s vietos prieigą"
+msgstr ""
+"Sąraše pasirinkite %1$ssavo naršyklę%2$s ir %3$sleiskite%4$s vietos prieigą"
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the modal for deleting all recent chats, that allows the user to select the chats to delete.
@@ -16959,7 +17332,8 @@ msgstr "Pažymėtas tekstas iš %1$s"
 #. Displayed when the user's text selection exceeds the maximum message size for AI tools (summary, translation, etc.).
 msgctxt "Error message for selection input limit"
 msgid "Selected text is too long. Try again with a shorter selection."
-msgstr "Pasirinktas tekstas per ilgas. Bandykite dar kartą su trumpesniu pasirinkimu."
+msgstr ""
+"Pasirinktas tekstas per ilgas. Bandykite dar kartą su trumpesniu pasirinkimu."
 
 # smartling.placeholder_format=C
 #. Label for the semi-finals knockout stage in e.g. the soccer World Cup
@@ -17078,6 +17452,12 @@ msgstr "Nustatyti dabar"
 msgctxt "Setup button for native sync flow"
 msgid "Set Up Now"
 msgstr "Nustatyk dabar"
+
+# smartling.placeholder_format=C
+#. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
+msgctxt "Encrypted storage setup button shown in native browsers"
+msgid "Set Up Sync & Backup"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
@@ -17261,6 +17641,13 @@ msgid "Share positive feedback"
 msgstr "Bendrinti teigiamus atsiliepimus"
 
 # smartling.placeholder_format=C
+#. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
+msgctxt ""
+"Label beside the share-content switch on the Duck.ai response feedback form"
+msgid "Share this conversation with DuckDuckGo"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
 msgctxt ""
 "Label beside the share-content switch on the Duck.ai response feedback form"
@@ -17397,7 +17784,8 @@ msgstr "Rodyti „DuckAssist“ <sup>BETA</sup>"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show DuckAssist more often. (You can also completely %sturn it off%s.)"
-msgstr "Rodykite „DuckAssist“ dažniau. (Taip pat galite visiškai %1$sišjungti%2$s.)"
+msgstr ""
+"Rodykite „DuckAssist“ dažniau. (Taip pat galite visiškai %1$sišjungti%2$s.)"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
@@ -17644,7 +18032,8 @@ msgstr "Rodomos horizontalios linijos ties rezultatų puslapio lūžiais"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows links to instructions for how to add DuckDuckGo to your browser"
-msgstr "Rodo nuorodas į instrukcijas, kaip pridėti „DuckDuckGo“ prie savo naršyklės"
+msgstr ""
+"Rodo nuorodas į instrukcijas, kaip pridėti „DuckDuckGo“ prie savo naršyklės"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers more frequently.
@@ -17711,7 +18100,8 @@ msgstr "Rodomas sveikinamasis pranešimas paieškos rezultatų viršuje"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message to EU Android preference menu users"
-msgstr "Rodomas sveikinamasis pranešimas ES „Android“ nuostatų meniu naudotojams"
+msgstr ""
+"Rodomas sveikinamasis pranešimas ES „Android“ nuostatų meniu naudotojams"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers sometimes.
@@ -18033,7 +18423,8 @@ msgstr ""
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr "Atsiprašome, negalėjome pateikti tavo atsiliepimo. Bandyk dar kartą vėliau."
+msgstr ""
+"Atsiprašome, negalėjome pateikti tavo atsiliepimo. Bandyk dar kartą vėliau."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -18296,13 +18687,15 @@ msgstr ""
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletters."
-msgstr "Apsisaugok ir gauk informacijos užsisakęs mūsų privatumo naujienlaiškius."
+msgstr ""
+"Apsisaugok ir gauk informacijos užsisakęs mūsų privatumo naujienlaiškius."
 
 # smartling.placeholder_format=C
 #. Text on the page where users can subscribe to DuckDuckGo's privacy newsletter
 msgctxt "showcase_newsletter"
 msgid "Stay protected and informed with our privacy newsletters."
-msgstr "Apsisaugok ir gauk informacijos užsisakęs mūsų privatumo naujienlaiškius."
+msgstr ""
+"Apsisaugok ir gauk informacijos užsisakęs mūsų privatumo naujienlaiškius."
 
 # smartling.placeholder_format=C
 #. Loading message shown when image generation is taking longer than usual.
@@ -18340,12 +18733,14 @@ msgstr "Sustabdyti generavimą"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop hidden trackers lurking on other websites."
-msgstr "Užkirsk kelią paslėptoms stebėjimo priemonėms, slypinčioms kitose svetainėse."
+msgstr ""
+"Užkirsk kelią paslėptoms stebėjimo priemonėms, slypinčioms kitose svetainėse."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop most hidden trackers lurking on other websites."
-msgstr "Sustabdyk daugumą paslėptų stebėjimo priemonių, slypinčių kitose svetainėse."
+msgstr ""
+"Sustabdyk daugumą paslėptų stebėjimo priemonių, slypinčių kitose svetainėse."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18515,6 +18910,24 @@ msgid "Suggest a title for a blog post"
 msgstr "Pasiūlyk tinklaraščio įrašo pavadinimą"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest related articles or topics worth exploring next."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Suggest related articles to explore"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest some alternatives to this product."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
 msgctxt "directions"
 msgid "Suggestions:"
@@ -18526,10 +18939,100 @@ msgid "Suggestions:"
 msgstr "Pasiūlymai:"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Sum up the reviews"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A short title for the a message asking the AI to summarize a text.
 msgctxt "Title for the summarize message"
 msgid "Summarize"
 msgstr "Apibendrinti"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize the Q&As"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the background and notable work of this person."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the key details of this event."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the questions and answers on this page."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize their background"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this book"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this book."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this discussion"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this discussion thread."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this page"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this page."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this video"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this video."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize what the reviews say."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -18857,6 +19360,12 @@ msgid "Syria"
 msgstr "Sirija"
 
 # smartling.placeholder_format=C
+#. Text for a button that enables the theme to follow the operating system's color scheme preference.
+msgctxt "System theme button for theme selector"
+msgid "System"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Abbreviation indicating this is the total score for a game
 msgctxt "Sports module"
 msgid "T"
@@ -18883,6 +19392,12 @@ msgstr "TV"
 msgctxt "language_name"
 msgid "Tahitian"
 msgstr "Taitiečių"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Tailor my resume"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Taiwan"
@@ -18912,6 +19427,13 @@ msgstr "Kontroliuok savo asmens duomenis"
 msgctxt "homepage ATB modal"
 msgid "Take control of your personal data!"
 msgstr "Kontroliuok savo asmenins duomenis!"
+
+# smartling.placeholder_format=C
+#. Description for the Feedback section of the Duck.ai settings page, asking the user to take an anonymous survey to let us know how we can make Duck.ai better.
+msgctxt "Feedback section description on the Duck.ai settings page"
+msgid ""
+"Take this anonymous survey to let us know how we can make Duck.ai better."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -19218,6 +19740,12 @@ msgstr "Serveris susidūrė su klaida ir negalėjo įvykdyti užklausos."
 #. https://duck.co/media/files/theme.png
 msgid "Theme"
 msgstr "Tema"
+
+# smartling.placeholder_format=C
+#. Text for the theme selector label that allows users to switch between Light and dark theme.
+msgctxt "Label for the theme selector feature"
+msgid "Theme"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/LpFhb1e.png
@@ -20059,6 +20587,18 @@ msgstr ""
 "kino teatrą?“"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Translate this page"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
+msgctxt "Page suggestion prompt"
+msgid "Translate this page into %s."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text for a region that will display translated text.
 msgctxt "translations_module"
 msgid "Translation"
@@ -20158,7 +20698,8 @@ msgstr "Pabandyk %1$s, kad daugiau nematytum tokių pranešimų."
 #. Text for a promotional card that encourages users to try the encrypted AI model whose inference runs in a confidential environment so the model provider cannot access user data. %s is replaced with the model's full display name (e.g. 'GPT-OSS 120B').
 msgctxt "Promotional text for encrypted AI model"
 msgid "Try %s, our first model with zero provider visibility."
-msgstr "Išbandyk %1$s – mūsų pirmąjį modelį be jokio matomumo paslaugų teikėjui."
+msgstr ""
+"Išbandyk %1$s – mūsų pirmąjį modelį be jokio matomumo paslaugų teikėjui."
 
 # smartling.placeholder_format=C
 msgid "Try %sDuck.ai%s, our private AI chat service:"
@@ -20198,6 +20739,12 @@ msgstr "Bandyti Dar Kartą"
 msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
 msgstr "Išbandyk nemokamai"
+
+# smartling.placeholder_format=C
+#. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
+msgctxt "settings"
+msgid "Try It Now"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -20300,7 +20847,8 @@ msgstr "Išbandyti nemokamai"
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
-msgstr "Išbandyk nemokamai! Saugus VPN, pažangus ir privatus DI, ir dar daugiau."
+msgstr ""
+"Išbandyk nemokamai! Saugus VPN, pažangus ir privatus DI, ir dar daugiau."
 
 # smartling.placeholder_format=C
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -20327,7 +20875,8 @@ msgstr "Išbandyk mūsų naršyklę,"
 # smartling.placeholder_format=C
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
-msgstr "Išbandyk mūsų pradžios puslapį, kuriame niekada nerodomi šie pranešimai:"
+msgstr ""
+"Išbandyk mūsų pradžios puslapį, kuriame niekada nerodomi šie pranešimai:"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with different words to get more results.
@@ -20438,6 +20987,22 @@ msgid "Trying DuckDuckGo again"
 msgstr "„DuckDuckGo“ bandymas iš naujo"
 
 # smartling.placeholder_format=C
+#. Message shown in a modal after supported third-party browser users disable AI features in Settings. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
 msgctxt "Assistant response placeholder"
 msgid "Trying with %s"
@@ -20542,7 +21107,8 @@ msgstr "Norėdami gauti tikslesnius rezultatus, įjunkite %1$sTiksli vieta%2$s"
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
-msgstr "Įjunkite „Duck Player“, kad galėtumėte žiūrėti „YouTube“ be tikslinių reklamų"
+msgstr ""
+"Įjunkite „Duck Player“, kad galėtumėte žiūrėti „YouTube“ be tikslinių reklamų"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service.
@@ -20554,7 +21120,8 @@ msgstr "Kad rezultatai būtų tikslesni, įjunkite nustatymą „Tiksli vietovė
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on “Use precise location” for more accurate results."
-msgstr "Kad rezultatai būtų tikslesni, įjunkite nustatymą „Naudoti tikslią vietovę“."
+msgstr ""
+"Kad rezultatai būtų tikslesni, įjunkite nustatymą „Naudoti tikslią vietovę“."
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Create Image' label in the Tools dropdown.
@@ -20759,7 +21326,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
-msgstr "Laukelyje %1$sPALEISTIS > Pradžios puslapis%2$s įvesk: https://duckduckgo.com"
+msgstr ""
+"Laukelyje %1$sPALEISTIS > Pradžios puslapis%2$s įvesk: https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -20769,13 +21337,15 @@ msgstr "Laukelyje %1$sPaieškos nustatymai%2$s pasirink %3$s„DuckDuckGo“%4$s
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch in the address bar with%s select %sAdd New%s"
-msgstr "Laukelyje %1$sIeškoti adreso juostoje su%2$s pasirink %3$sPridėti naują%4$s"
+msgstr ""
+"Laukelyje %1$sIeškoti adreso juostoje su%2$s pasirink %3$sPridėti naują%4$s"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
-msgstr "Skiltyje %1$sIeškoti%2$s spustelėk %3$sValdyti paieškos sistemas...%4$s"
+msgstr ""
+"Skiltyje %1$sIeškoti%2$s spustelėk %3$sValdyti paieškos sistemas...%4$s"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -20926,7 +21496,8 @@ msgctxt ""
 "Text shown in the subscription promo card, with a trailing call-to-action "
 "link."
 msgid "Unlock more capable AI models with a DuckDuckGo subscription. %s"
-msgstr "Gauk prieigą prie galingesnių DI modelių su „DuckDuckGo“ prenumerata. %1$s"
+msgstr ""
+"Gauk prieigą prie galingesnių DI modelių su „DuckDuckGo“ prenumerata. %1$s"
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to unmute the microphone.
@@ -21188,6 +21759,12 @@ msgstr "Urdu"
 # smartling.placeholder_format=C
 msgid "Uruguay"
 msgstr "Urugvajus"
+
+# smartling.placeholder_format=C
+#. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
+msgctxt "Navigation label on the Duck.ai settings page"
+msgid "Usage"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -21579,7 +22156,8 @@ msgstr "Balso pokalbis baigtas"
 #. Description in consent disclaimer informing that voice chats with the AI (Artificial Intelligence) are anonymized by us, and are never used to train AI models.
 msgctxt "voice chat"
 msgid "Voice chat is anonymized by us, and never used to train AI models."
-msgstr "Balso pokalbius nuasmeniname ir niekada nenaudojame DI modeliams mokyti."
+msgstr ""
+"Balso pokalbius nuasmeniname ir niekada nenaudojame DI modeliams mokyti."
 
 # smartling.placeholder_format=C
 #. Title of the modal shown when the user has reached their daily voice chat limit.
@@ -21638,6 +22216,12 @@ msgstr "Laukiama Vietos..."
 # smartling.placeholder_format=C
 msgid "Wales"
 msgstr "Velsas"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Walk me through the steps"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for walking directions on a map.
@@ -21759,6 +22343,17 @@ msgstr ""
 "tikslesnius rezultatus."
 
 # smartling.placeholder_format=C
+#. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
+msgctxt ""
+"Inline warning shown below the share-content toggle when the user selects "
+"Harmful or Illegal but has not enabled sharing"
+msgid ""
+"We can only fix what we can see. To report a harmful or illegal response, "
+"please share this conversation with DuckDuckGo so we can investigate and "
+"address the issue."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
 msgctxt ""
 "Inline warning shown below the share-content toggle when the user selects "
@@ -21785,7 +22380,8 @@ msgstr ""
 msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
-msgstr "Negalime perskaityti pridėtų failų, nes bent vienas iš jų yra užšifruotas."
+msgstr ""
+"Negalime perskaityti pridėtų failų, nes bent vienas iš jų yra užšifruotas."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -21887,7 +22483,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don’t track you in or out of private browsing mode."
-msgstr "Nestebime tavęs, kai naudojiesi arba nesinaudoji privačiu naršymo režimu."
+msgstr ""
+"Nestebime tavęs, kai naudojiesi arba nesinaudoji privačiu naršymo režimu."
 
 # smartling.placeholder_format=C
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with an Agree button is shown below.
@@ -22167,9 +22764,9 @@ msgid ""
 "of your chats here are private, and are never stored by DuckDuckGo or used "
 "to train AI models."
 msgstr ""
-"Sveiki, čia – „DuckDuckGo AI Chat“! Šią pokalbių sesiją teikia „%1$s“ "
-"„%2$s“. Visi jūsų pokalbiai čia yra privatūs ir „DuckDuckGo“ jų niekada "
-"nesaugo ir nenaudoja DI modeliams mokyti."
+"Sveiki, čia – „DuckDuckGo AI Chat“! Šią pokalbių sesiją teikia "
+"„%1$s“ „%2$s“. Visi jūsų pokalbiai čia yra privatūs ir „DuckDuckGo“ jų "
+"niekada nesaugo ir nenaudoja DI modeliams mokyti."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -22183,7 +22780,8 @@ msgstr ""
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai, it's time to import your chats"
-msgstr "Sveikiname išbandžius naująją „Duck.ai“ versiją, laikas importuoti pokalbius"
+msgstr ""
+"Sveikiname išbandžius naująją „Duck.ai“ versiją, laikas importuoti pokalbius"
 
 # smartling.placeholder_format=C
 #. Welcome message for new DuckDuckGo users.
@@ -22274,7 +22872,8 @@ msgstr "Į kokius veiksnius reikia atsižvelgti perkant kompiuterio monitorių?"
 #. Text for a prompt suggestion for asking about must-see attractions in Paris for a first-time visitor.
 msgctxt "Full sentence for planning a trip"
 msgid "What are some must-see attractions in Paris for a first-time visitor?"
-msgstr "Kokias lankytinas vietas Paryžiuje būtina pamatyti lankantis pirmą kartą?"
+msgstr ""
+"Kokias lankytinas vietas Paryžiuje būtina pamatyti lankantis pirmą kartą?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for finding options for the word 'better' in a specific context.
@@ -22309,6 +22908,103 @@ msgstr ""
 "integracijai ir privatumo apsaugai. Rašyk gana trumpai, paprastai ir taip, "
 "kad būtų lengva suprasti net ir tiems, kurie neturi daug DI ar techninės "
 "patirties."
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the counterarguments?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the hours & location?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key contributions of this paper?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key contributions?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key details?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key points covered in this video?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key points?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key takeaways from this article?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key takeaways?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key things I will learn from this course?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main counterarguments or criticisms of this?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main questions this page answers?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the must-try dishes here?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"What are the opening hours, location, and contact details for this place?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the pros and cons of this product?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the pros and cons?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
@@ -22411,6 +23107,12 @@ msgid "What does atria mean in the context of a medical article?"
 msgstr "Ką reiškia atrija medicinos straipsnio kontekste?"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What does this answer?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
@@ -22421,6 +23123,12 @@ msgstr "Kokią funkciją norėtum, kad pridėtume? (neprivaloma)"
 msgctxt "cloudsave"
 msgid "What information gets saved?"
 msgstr "Kokia informacija yra išsaugoma?"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What interview questions might come up for this role?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -22437,6 +23145,12 @@ msgstr ""
 msgctxt "Full sentence for looking up basic facts"
 msgid "What is the capital city of Albania?"
 msgstr "Kokia yra Albanijos sostinė?"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What is the overall verdict and rating for this?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to a page with additional information.
@@ -22461,6 +23175,12 @@ msgid "What people say:"
 msgstr "Ką sako žmonės:"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What should I order?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
 msgctxt "feedback form"
 msgid "What stood out?"
@@ -22473,6 +23193,18 @@ msgid "What was wrong with the response? (optional)"
 msgstr "Kas atsakyme buvo ne taip? (neprivaloma)"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I learn?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I need?"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid "What would you like to provide feedback on?"
 msgstr "Apie ką norėtum pateikti atsiliepimą?"
@@ -22481,13 +23213,20 @@ msgstr "Apie ką norėtum pateikti atsiliepimą?"
 #. Explains the benefits of using our custom video player, the Duck Player
 msgid ""
 "What you watch in DuckDuckGo won't influence your recommendations on YouTube."
-msgstr "Tai, ką žiūrite „DuckDuckGo“, neturės įtakos jūsų rekomendacijoms „YouTube“."
+msgstr ""
+"Tai, ką žiūrite „DuckDuckGo“, neturės įtakos jūsų rekomendacijoms „YouTube“."
 
 # smartling.placeholder_format=C
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
 msgctxt "SERP footer content"
 msgid "What's New"
 msgstr "Kas naujo"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What's the verdict?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -22542,6 +23281,12 @@ msgid "Which features are missing? (Optional)"
 msgstr "Kokios funkcijos trūksta? (Pasirinktinai)"
 
 # smartling.placeholder_format=C
+#. An invitation for users to leave feedback
+msgctxt "Feedback prompt"
+msgid "Which features are missing? (optional)"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
 msgid "White"
 msgstr "Balta"
@@ -22556,6 +23301,18 @@ msgstr "Balta"
 #. Link to an about us page.
 msgid "Who We Are"
 msgstr "Kas Mes"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Who are the main cast and crew, and what else are they known for?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Who is this person?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Header above a collection of privacy-related links.
@@ -22926,7 +23683,8 @@ msgstr "Taip, naujas naudotojas!"
 msgctxt "cloudsave"
 msgid ""
 "Yes, we throw away data when you’re done with it, and it cannot be recovered."
-msgstr "Taip, mes pašaliname duomenis, kai baigi naudotis, ir jų nebegalima atkurti."
+msgstr ""
+"Taip, mes pašaliname duomenis, kai baigi naudotis, ir jų nebegalima atkurti."
 
 # smartling.placeholder_format=C
 #. Option for the filter-by-date search.
@@ -23295,7 +24053,8 @@ msgctxt "Error message for user limit"
 msgid ""
 "You've reached the maximum number of messages for the moment. Please try "
 "again later."
-msgstr "Šiuo metu pasiekėte maksimalų pranešimų skaičių. Bandykite dar kartą vėliau."
+msgstr ""
+"Šiuo metu pasiekėte maksimalų pranešimų skaičių. Bandykite dar kartą vėliau."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -23483,14 +24242,16 @@ msgstr ""
 msgctxt "Active Privacy protection description"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
-msgstr "Jūsų pokalbiai yra privatūs, anonimizuoti ir nenaudojami DI modeliams mokyti."
+msgstr ""
+"Jūsų pokalbiai yra privatūs, anonimizuoti ir nenaudojami DI modeliams mokyti."
 
 # smartling.placeholder_format=C
 #. Text explaining that user chats are private and not used for AI (Artificial Intelligence) training.
 msgctxt "Body text for privacy protection modal"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
-msgstr "Jūsų pokalbiai yra privatūs, anonimizuoti ir nenaudojami DI modeliams mokyti."
+msgstr ""
+"Jūsų pokalbiai yra privatūs, anonimizuoti ir nenaudojami DI modeliams mokyti."
 
 # smartling.placeholder_format=C
 #. Text for a menu item that describes the privacy protection feature.
@@ -23823,7 +24584,8 @@ msgstr "sukurta %1$s"
 #. Trust line shown at the bottom of the explainer panel, summarizing DuckDuckGo's reputation for online protection.
 msgctxt "Footer banner text in the How Duck.ai Works panel"
 msgid "by DuckDuckGo — online protection trusted by millions every day."
-msgstr "kūrėjas „DuckDuckGo“ – interneto apsauga, kuria kasdien pasitiki milijonai."
+msgstr ""
+"kūrėjas „DuckDuckGo“ – interneto apsauga, kuria kasdien pasitiki milijonai."
 
 # smartling.placeholder_format=C
 #. An abreviated unit of time indicating an age, e.g. "2d"

--- a/locales/lv_LV/LC_MESSAGES/duckduckgo.po
+++ b/locales/lv_LV/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: lv_LV\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -887,16 +887,14 @@ msgstr ""
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of AI Chat is available! Please refresh this page to continue."
-msgstr ""
-"Ir pieejama jauna AI Chat versija! Lūdzu, atsvaidzini šo lapu, lai turpinātu."
+msgstr "Ir pieejama jauna AI Chat versija! Lūdzu, atsvaidzini šo lapu, lai turpinātu."
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of Duck.ai is available and they need to refresh the page.
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of Duck.ai is available! Please refresh this page to continue."
-msgstr ""
-"Ir pieejama jauna Duck.ai versija! Lai turpinātu, lūdzu, atsvaidzini šo lapu."
+msgstr "Ir pieejama jauna Duck.ai versija! Lai turpinātu, lūdzu, atsvaidzini šo lapu."
 
 # smartling.placeholder_format=C
 #. Shown when the Duck.ai desktop app has been open a long time and a newer version exists.
@@ -1444,7 +1442,7 @@ msgstr "Adrese ir nepareiza"
 #. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Adjust the servings"
-msgstr ""
+msgstr "Pielāgo porciju skaitu"
 
 # smartling.placeholder_format=C
 #. as in multiple advertisements
@@ -1651,8 +1649,7 @@ msgstr "Visas tērzēšanas sarunas ir %1$s"
 #. Disclaimer text shown below chat input. %s is replaced with a clickable underlined 'private' link that opens the privacy protection modal.
 msgctxt "Disclaimer below chat input in Duck.ai"
 msgid "All chats are %s. AI can make mistakes."
-msgstr ""
-"Visas tērzēšanas sarunas ir %1$s. Mākslīgais intelekts var pieļaut kļūdas."
+msgstr "Visas tērzēšanas sarunas ir %1$s. Mākslīgais intelekts var pieļaut kļūdas."
 
 # smartling.placeholder_format=C
 #. Heading shown on the empty chat screen. The text between the two %s markers is displayed inside a clickable privacy button. First %s renders a shield icon, second %s is an invisible end marker. Keep the word 'private' between both %s markers.
@@ -1667,6 +1664,8 @@ msgid ""
 "All chats are anonymized by DuckDuckGo, and your conversations are not used "
 "to train chat models by DuckDuckGo or the model providers"
 msgstr ""
+"DuckDuckGo anonimizē visas sarunas, un ne DuckDuckGo, ne modeļu "
+"nodrošinātāji tavas sarunas neizmanto tērzēšanas modeļu apmācībai"
 
 # smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1944,6 +1943,8 @@ msgid ""
 "Anonymously generates answers for search queries based on web content. "
 "Choose how often you want it to appear, or disable it completely."
 msgstr ""
+"Anonīmi ģenerē atbildes uz meklēšanas vaicājumiem, pamatojoties uz tīmekļa "
+"saturu. Izvēlies, cik bieži vēlies to redzēt, vai atspējo to pavisam."
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -2090,8 +2091,7 @@ msgstr "Vai tu joprojām esi tur?"
 msgctxt "Body text for clear all chats confirmation modal"
 msgid ""
 "Are you sure you want to clear all of your chats? This cannot be undone."
-msgstr ""
-"Vai tiešām vēlies notīrīt visas tērzēšanas sarunas? Šo darbību nevar atsaukt."
+msgstr "Vai tiešām vēlies notīrīt visas tērzēšanas sarunas? Šo darbību nevar atsaukt."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that asks the user if they want to clear the conversation.
@@ -2103,8 +2103,7 @@ msgstr "Vai tiešām vēlies notīrīt šo sarunu un sākt jaunu?"
 #. Text asking the user to confirm if they want to delete their current chat, explaining that this action cannot be undone.
 msgctxt "Body text for delete chat confirmation modal"
 msgid "Are you sure you want to delete this chat? This cannot be undone."
-msgstr ""
-"Vai tiešām vēlies izdzēst šo tērzēšanas sarunu? Šo darbību nevar atsaukt."
+msgstr "Vai tiešām vēlies izdzēst šo tērzēšanas sarunu? Šo darbību nevar atsaukt."
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to disable chat history, with a warning that it will also delete currently saved chats including pinned chats.
@@ -2230,7 +2229,7 @@ msgstr "Lūgt turpinājumu, izmantojot Duck.ai"
 #. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
 msgctxt "Page suggestion chip label"
 msgid "Ask about this page"
-msgstr ""
+msgstr "Jautā par šo lapu"
 
 # smartling.placeholder_format=C
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2652,7 +2651,7 @@ msgstr "Svītrkods"
 #. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Based on this page, is this course worth taking?"
-msgstr ""
+msgstr "Vai, spriežot pēc šīs lapas, šo kursu ir vērts apgūt?"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2701,6 +2700,8 @@ msgid ""
 "Before storing this report, DuckDuckGo will anonymize your conversation by "
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
+"Pirms šī ziņojuma saglabāšanas DuckDuckGo anonimizēs tavu sarunu, noņemot "
+"tādus personas datus kā vārdus, e-pasta adreses un identificējošus metadatus."
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -3022,7 +3023,7 @@ msgstr "Uzvarētie breikpunkti"
 #. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Break this down into clear, numbered steps."
-msgstr ""
+msgstr "Sadali to skaidros, numurētos soļos."
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -3267,8 +3268,7 @@ msgstr "Kamerūna"
 #. Text for a prompt suggestion for creating a few simple recipes using chicken, broccoli, and rice.
 msgctxt "Full sentence for crafting a recipe"
 msgid "Can you create a few simple recipes using chicken, broccoli, and rice?"
-msgstr ""
-"Vai vari izveidot dažas vienkāršas receptes ar vistu, brokoļiem un rīsiem?"
+msgstr "Vai vari izveidot dažas vienkāršas receptes ar vistu, brokoļiem un rīsiem?"
 
 # smartling.placeholder_format=C
 msgid "Canada"
@@ -3482,7 +3482,7 @@ msgstr "Dalībnieki"
 #. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Cast & Crew"
-msgstr ""
+msgstr "Lomu atveidotāji un veidotāji"
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -3588,8 +3588,7 @@ msgstr "Maina fona krāsu visā vietnē"
 msgctxt "settings"
 msgid ""
 "Changes the background color of results on hover, modules, and dropdown menus"
-msgstr ""
-"Maina rezultātu fona krāsu zem kursora, moduļos un nolaižamajās izvēlnēs"
+msgstr "Maina rezultātu fona krāsu zem kursora, moduļos un nolaižamajās izvēlnēs"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/NdpkbY0.png
@@ -3722,8 +3721,8 @@ msgstr ""
 "ar trešo pušu mākslīgā intelekta tērzēšanas modeļiem, kas atbalsta OpenAI, "
 "Anthropic un citus rīkus. Izslēdzot šo iestatījumu tiks paslēptas tērzēšanas "
 "pogas un saites DuckDuckGo Search platformā. Taču tu joprojām vari piekļūt "
-"tērzēšanai, ja šis iestatījums ir izslēgts, apmeklējot %1$shttps://duck."
-"ai%2$s tieši."
+"tērzēšanai, ja šis iestatījums ir izslēgts, apmeklējot "
+"%1$shttps://duck.ai%2$s tieši."
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -4298,8 +4297,7 @@ msgstr "Nospied %1$sAtļaut%2$s, pēc tam %3$sPievienot%4$s."
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Click %sChange Search Settings%s in the drop down"
-msgstr ""
-"Nolaižamajā izvēlnē noklikšķini uz %1$sMainīt meklēšanas iestatījumus%2$s"
+msgstr "Nolaižamajā izvēlnē noklikšķini uz %1$sMainīt meklēšanas iestatījumus%2$s"
 
 #  SeaMonkey default search engine instruction
 # smartling.placeholder_format=C
@@ -4400,8 +4398,7 @@ msgstr "Sānjoslā noklikšķini uz %1$sPārlūks%2$s"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click on %sChange Search Settings%s in the dropdown menu"
-msgstr ""
-"Nolaižamajā izvēlnē noklikšķini uz %1$sMainīt meklēšanas iestatījumus%2$s"
+msgstr "Nolaižamajā izvēlnē noklikšķini uz %1$sMainīt meklēšanas iestatījumus%2$s"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -4421,8 +4418,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click on the %sTools icon%s in the top-right of the browser"
-msgstr ""
-"Pārlūkprogrammas augšējā labajā stūrī noklikšķini uz %1$sRīku ikonas%2$s"
+msgstr "Pārlūkprogrammas augšējā labajā stūrī noklikšķini uz %1$sRīku ikonas%2$s"
 
 #  Firefox default search engine instruction
 # smartling.placeholder_format=C
@@ -4551,8 +4547,7 @@ msgstr "Noklikšķini uz palielināmā stikla ikonas meklēšanas lodziņā"
 #. Tells users what icon to click in order to make DuckDuckGo the default engine in their browser.
 msgid ""
 "Click the magnifying glass in the search box (at the top of the browser)"
-msgstr ""
-"Noklikšķini uz palielināmā stikla meklēšanas lodziņā (parlūka augšdaļā)"
+msgstr "Noklikšķini uz palielināmā stikla meklēšanas lodziņā (parlūka augšdaļā)"
 
 #  IE default search engine instruction
 # smartling.placeholder_format=C
@@ -5158,8 +5153,7 @@ msgstr "Kostarika"
 #. Inline error shown on the recovery code screen when exportSyncSettings rejects.
 msgctxt "Error message when the recovery code fails to generate"
 msgid "Couldn't load your recovery code. Please close this and try again."
-msgstr ""
-"Nevarēja ielādēt tavu atkopšanas kodu. Lūdzu, aizver šo un mēģini vēlreiz."
+msgstr "Nevarēja ielādēt tavu atkopšanas kodu. Lūdzu, aizver šo un mēģini vēlreiz."
 
 # smartling.placeholder_format=C
 #. Pairs with a Retry button. Shown after two consecutive failed attempts to load the device list.
@@ -5208,7 +5202,7 @@ msgstr "Izveidot attēlu"
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
-msgstr ""
+msgstr "Izveido iepirkumu sarakstu ar daudzumiem no šīs receptes."
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed in the input field when starting a new image generation session.
@@ -5857,7 +5851,7 @@ msgstr "Sasniegts diktēšanas ierobežojums"
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
 msgid "Dictation temporarily unavailable"
-msgstr ""
+msgstr "Diktēšana uz laiku nav pieejama"
 
 # smartling.placeholder_format=C
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
@@ -5946,8 +5940,7 @@ msgstr "Atspējot un atvienot"
 #. Title of a modal that asks the user if they want to turn off chat history and disconnect from Sync & Backup.
 msgctxt "Modal header for disabling chat history and disconnecting sync"
 msgid "Disable chat history and disconnect from Sync & Backup?"
-msgstr ""
-"Vai atspējot tērzēšanas vēsturi un pārtraukt savienojumu ar Sync & Backup?"
+msgstr "Vai atspējot tērzēšanas vēsturi un pārtraukt savienojumu ar Sync & Backup?"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to turn off the chat history feature.
@@ -6135,8 +6128,7 @@ msgstr "Neredzi DuckDuckGo sarakstā?"
 #. Link to download a file again if the user can't find it on their computer.
 msgctxt "install-extension"
 msgid "Don't see it? %s%s%sClick here to re-download%s"
-msgstr ""
-"Neredzi to? %1$s%2$s%3$sNoklikšķini šeit, lai lejupielādētu vēlreiz%4$s"
+msgstr "Neredzi to? %1$s%2$s%3$sNoklikšķini šeit, lai lejupielādētu vēlreiz%4$s"
 
 #  IE < 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -6168,6 +6160,8 @@ msgid ""
 "Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
 "filtered out. %sLearn More%s"
 msgstr ""
+"Nevēlies mākslīgo intelektu? %1$snoai.duckduckgo.com%2$s nepiedāvā MI "
+"funkcijas, un MI attēli tiek izfiltrēti. %3$sUzzināt vairāk%4$s"
 
 # smartling.placeholder_format=C
 #. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
@@ -6176,6 +6170,9 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
+"Nevēlies mākslīgo intelektu? Apmeklē %1$snoai.duckduckgo.com%2$s, lai "
+"meklētu bez MI funkcijām un ar izfiltrētiem MI attēliem. %3$sUzzināt "
+"vairāk%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6295,13 +6292,13 @@ msgstr ""
 #. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Draft a cover letter"
-msgstr ""
+msgstr "Sagatavo pieteikuma vēstuli"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Draft a cover letter for this job."
-msgstr ""
+msgstr "Sagatavo pieteikuma vēstuli šai vakancei."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -6489,6 +6486,9 @@ msgid ""
 "company for anyone who wants to take back control of their personal "
 "information."
 msgstr ""
+"Duck.ai veidotāji ir DuckDuckGo. Mēs esam neatkarīgs uzņēmums tiešsaistes "
+"aizsardzībai ikvienam, kurš vēlas būt noteicējs pār savu personisko "
+"informāciju."
 
 # smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
@@ -6527,8 +6527,7 @@ msgstr ""
 msgctxt "Error message for VQD error"
 msgid ""
 "Duck.ai is temporarily unavailable. Please refresh the page and try again."
-msgstr ""
-"Duck.ai uz laiku nav pieejams. Lūdzu, atsvaidzini lapu un mēģini vēlreiz."
+msgstr "Duck.ai uz laiku nav pieejams. Lūdzu, atsvaidzini lapu un mēģini vēlreiz."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -6542,6 +6541,9 @@ msgid ""
 "Duck.ai lets you chat privately with popular AI models. Disabling it hides "
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
+"Duck.ai ļauj tev privāti tērzēt ar populāriem MI modeļiem. Atspējošana "
+"paslēpj Duck.ai pogas un saites, taču tu joprojām vari apmeklēt "
+"%1$sduck.ai%2$s tieši."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6605,8 +6607,7 @@ msgstr "Duck.ai atjaunināts!"
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
-msgstr ""
-"Duck.ai vislabāk darbojas mūsu privātajā un bezmaksas DuckDuckGo lietotnē!"
+msgstr "Duck.ai vislabāk darbojas mūsu privātajā un bezmaksas DuckDuckGo lietotnē!"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -7134,8 +7135,7 @@ msgstr "Rediģē attēlu..."
 msgctxt "Info text for the editing message feature"
 msgid ""
 "Editing your message will remove the response below and generate a new one."
-msgstr ""
-"Rediģējot savu ziņu, tiks dzēsta zemāk esošā atbilde un izveidota jauna."
+msgstr "Rediģējot savu ziņu, tiks dzēsta zemāk esošā atbilde un izveidota jauna."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of an editor in its responses.
@@ -7451,15 +7451,13 @@ msgstr ""
 #. Tells how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed location access"
-msgstr ""
-"Pārliecinies, vai pārlūkprogrammai ir atļauta piekļuve atrašanās vietai"
+msgstr "Pārliecinies, vai pārlūkprogrammai ir atļauta piekļuve atrašanās vietai"
 
 # smartling.placeholder_format=C
 #. Tells how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed location access."
-msgstr ""
-"Pārliecinies, vai pārlūkprogrammai ir atļauta piekļuve atrašanās vietai."
+msgstr "Pārliecinies, vai pārlūkprogrammai ir atļauta piekļuve atrašanās vietai."
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -7547,8 +7545,7 @@ msgstr "Ekvatoriālā Gvineja"
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Erase your browsing data in a flash with our %sFire Button%s"
-msgstr ""
-"Ātri izdzēs savus pārlūkošanas datus, izmantojot mūsu %1$sFire Button%2$s"
+msgstr "Ātri izdzēs savus pārlūkošanas datus, izmantojot mūsu %1$sFire Button%2$s"
 
 # smartling.placeholder_format=C
 msgid "Eritrea"
@@ -7558,13 +7555,13 @@ msgstr "Eritreja"
 #. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Estimate the nutrition"
-msgstr ""
+msgstr "Aprēķini uzturvērtību"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Estimate the nutritional information for this recipe."
-msgstr ""
+msgstr "Aprēķini šīs receptes uzturvērtību."
 
 # smartling.placeholder_format=C
 msgid "Estonia"
@@ -7624,57 +7621,56 @@ msgstr "Derīguma termiņš beigsies pēc 1 dienas"
 #. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain the accepted answer in simple terms."
-msgstr ""
+msgstr "Izskaidro pieņemto atbildi vienkāršā valodā."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
-msgstr ""
-"Paskaidro man pamatjēdzienus par melnajiem caurumiem vidusskolas līmenī."
+msgstr "Paskaidro man pamatjēdzienus par melnajiem caurumiem vidusskolas līmenī."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain the top answer"
-msgstr ""
+msgstr "Izskaidro labāko atbildi"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain this in simple, plain language."
-msgstr ""
+msgstr "Paskaidro to vienkāršā, saprotamā valodā."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain this paper"
-msgstr ""
+msgstr "Izskaidro šo rakstu"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain this repo"
-msgstr ""
+msgstr "Izskaidro šo repozitoriju"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain this research paper in plain language."
-msgstr ""
+msgstr "Izskaidro šo pētniecisko darbu vienkāršā valodā."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain this simply"
-msgstr ""
+msgstr "Izskaidro to vienkārši"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain what this repository does and how to use it."
-msgstr ""
+msgstr "Paskaidro, ko šis repozitorijs dara un kā to izmantot."
 
 # smartling.placeholder_format=C
 #. Label to show if song lyrics contain explicit content
@@ -7851,8 +7847,7 @@ msgstr "Atsauksme sekmīgi iesniegta"
 msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and improvements."
-msgstr ""
-"Tavas atsauksmes tieši ietekmē mūsu produktu atjauninājumus un uzlabojumus."
+msgstr "Tavas atsauksmes tieši ietekmē mūsu produktu atjauninājumus un uzlabojumus."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -7963,6 +7958,8 @@ msgctxt "settings"
 msgid ""
 "Filters out known AI spam sites from image search results. %sLearn More%s"
 msgstr ""
+"Izfiltrē zināmas mākslīgā intelekta spama vietnes no attēlu meklēšanas "
+"rezultātiem. %1$sUzzināt vairāk%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the final score of a sporting event.
@@ -7991,8 +7988,7 @@ msgstr "Finanšu konsultants"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Find %sDuckDuckGo%s and click%sMake default%s"
-msgstr ""
-"Atrodi %1$sDuckDuckGo%2$s un noklikšķini uz%3$sPadarīt par noklusējumu%4$s"
+msgstr "Atrodi %1$sDuckDuckGo%2$s un noklikšķini uz%3$sPadarīt par noklusējumu%4$s"
 
 # smartling.placeholder_format=C
 #. Sentence shown after export, includes a placeholder for one or more filenames with bold formatting for the filename(s).
@@ -8024,7 +8020,7 @@ msgstr "Atrodi aktuālo informāciju"
 #. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Find me alternatives"
-msgstr ""
+msgstr "Atrodi man alternatīvas"
 
 # smartling.placeholder_format=C
 #. Button that searches for results closer to the user's current location.
@@ -8337,9 +8333,9 @@ msgid ""
 "strong>."
 msgstr ""
 "Mac datorā lietotnes izvēlnes joslā izvēlies <strong>DuckDuckGo</strong> "
-"&gt; <strong>Check for Updates...</strong> (&quot;Meklēt atjauninājumus..."
-"&quot;) un tad <strong>Install Update</strong> (&quot;Instalēt "
-"atjauninājumu&quot;)."
+"&gt; <strong>Check for Updates...</strong> (&quot;Meklēt "
+"atjauninājumus...&quot;) un tad <strong>Install Update</strong> "
+"(&quot;Instalēt atjauninājumu&quot;)."
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -8510,7 +8506,7 @@ msgstr "Ģenerēt vairāk"
 #. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Generate a shopping list"
-msgstr ""
+msgstr "Ģenerē iepirkumu sarakstu"
 
 # smartling.placeholder_format=C
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
@@ -8809,14 +8805,13 @@ msgstr "Izmēģini"
 #. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Give me a quick background on this person."
-msgstr ""
+msgstr "Sniedz man īsu informāciju par šo cilvēku."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
-msgstr ""
-"Atver sadaļas %1$sPrivātums un drošība > Atrašanās vietas pakalpojumi%2$s"
+msgstr "Atver sadaļas %1$sPrivātums un drošība > Atrašanās vietas pakalpojumi%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9263,13 +9258,13 @@ msgstr "Palīdzi izplatīt privātumu"
 #. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Help me prep for the interview"
-msgstr ""
+msgstr "Palīdzi man sagatavoties intervijai"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Help me tailor my resume for this job."
-msgstr ""
+msgstr "Palīdzi man pielāgot savu CV šai vakancei."
 
 # smartling.placeholder_format=C
 #. Title of a SERP popup that invites users to take a survey (desktop only)
@@ -9471,8 +9466,8 @@ msgstr "Slēp savu e-pasta adresi"
 msgctxt "settings"
 msgid "Hides search term from being shown in browser tab/history"
 msgstr ""
-"Nodrošina, ka meklētais vienums netiek parādīts pārlūkprogrammas cilnē/"
-"vēsturē"
+"Nodrošina, ka meklētais vienums netiek parādīts pārlūkprogrammas "
+"cilnē/vēsturē"
 
 # smartling.placeholder_format=C
 #. The highest stock price in a day
@@ -9720,8 +9715,7 @@ msgstr "Cik daudz tu vēlies, lai parādītos MI atbalstītas atbildes?"
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
 msgctxt "Duck.ai settings usage section"
 msgid "How much of your daily and weekly limits you've used so far."
-msgstr ""
-"Cik daudz no saviem dienas un nedēļas limitiem tu esi līdz šim izmantojis."
+msgstr "Cik daudz no saviem dienas un nedēļas limitiem tu esi līdz šim izmantojis."
 
 # smartling.placeholder_format=C
 #. A header for the feedback form in the assist negative feedback flow. The user is being asked to update how often they want AI-assisted answers to appear.
@@ -9795,7 +9789,7 @@ msgctxt ""
 "Text for the I already have a subscription button in the Duck.ai settings "
 "page"
 msgid "I Already Have a Subscription"
-msgstr ""
+msgstr "Man jau ir abonements"
 
 # smartling.placeholder_format=C
 #. Text for the button that takes the user to the login subscription page.
@@ -9878,8 +9872,7 @@ msgstr ""
 #. Option for feedback when the user needs more help or information on how to use the chat.
 msgctxt "Feedback option for difficulty in using chat"
 msgid "I need more help/info on how to use Chat"
-msgstr ""
-"Man ir nepieciešama papildu palīdzība/informācija par tērzēšanas izmantošanu"
+msgstr "Man ir nepieciešama papildu palīdzība/informācija par tērzēšanas izmantošanu"
 
 # smartling.placeholder_format=C
 msgid "IR Iran"
@@ -9966,8 +9959,7 @@ msgstr ""
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
-msgstr ""
-"Ja tu tiešām vēlies mūs atbalstīt, %1$spalīdzi popularizēt DuckDuckGo%2$s"
+msgstr "Ja tu tiešām vēlies mūs atbalstīt, %1$spalīdzi popularizēt DuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -9985,8 +9977,7 @@ msgstr ""
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "If you want, select Home Page next to New windows and New tabs (open with)."
-msgstr ""
-"Ja vēlies, nospied Sākuma lapu pie Jauna loga un Jaunas cilnes (atvērt ar)."
+msgstr "Ja vēlies, nospied Sākuma lapu pie Jauna loga un Jaunas cilnes (atvērt ar)."
 
 # smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that adds an image to the AI chat message being composed.
@@ -10379,7 +10370,7 @@ msgstr "Instalēt Mac pārlūkprogrammu"
 #. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
 msgctxt "settings"
 msgid "Install Now"
-msgstr ""
+msgstr "Instalēt tūlīt"
 
 # smartling.placeholder_format=C
 #. Text of a button to install the DuckDuckGo app
@@ -10482,13 +10473,13 @@ msgstr "Vai dzēstie dati tiešām ir dzēsti?"
 #. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Is it worth taking?"
-msgstr ""
+msgstr "Vai ir vērts to ņemt?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Is this place any good?"
-msgstr ""
+msgstr "Vai šī vieta ir laba?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
@@ -10497,6 +10488,8 @@ msgid ""
 "Is this place any good? Summarize its reputation based on reviews and "
 "ratings."
 msgstr ""
+"Vai šī vieta ir laba? Apkopo tās reputāciju, pamatojoties uz atsauksmēm un "
+"vērtējumiem."
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -10508,13 +10501,15 @@ msgstr "Vai šis video ir noderīgs?"
 #. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Is this worth watching?"
-msgstr ""
+msgstr "Vai to ir vērts skatīties?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Is this worth watching? Give me a spoiler-free take."
 msgstr ""
+"Vai to ir vērts skatīties? Sniedz man pārskatu, neatklājot sižeta "
+"pavērsienus."
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -10540,8 +10535,7 @@ msgstr "Tas varētu aizņemt dažas minūtes"
 #. Body text of a card that promotes installing the DuckDuckGo desktop browser.
 msgctxt "new tab page"
 msgid "It's fast, free, and gives you even more online protection."
-msgstr ""
-"Tas ir ātrs, bezmaksas un sniedz tev vēl lielāku aizsardzību tiešsaistē."
+msgstr "Tas ir ātrs, bezmaksas un sniedz tev vēl lielāku aizsardzību tiešsaistē."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -11130,6 +11124,8 @@ msgstr "Saites:"
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
 msgstr ""
+"Uzskaiti rīkus, materiālus vai priekšnosacījumus, kas man tam ir "
+"nepieciešami."
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -11543,7 +11539,7 @@ msgstr "Bloķēto vietņu pārvaldība"
 #. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
 msgctxt "setting"
 msgid "Manage in Browser Settings"
-msgstr ""
+msgstr "Pārvaldīt pārlūka iestatījumos"
 
 # smartling.placeholder_format=C
 #. Link to the site exclusion settings page
@@ -11995,8 +11991,7 @@ msgstr "Tu esi sasniedzis mēneša limitu"
 #. Displayed when the user has reached a fixed monthly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Monthly usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Sasniegts mēneša lietošanas limits. Tu varēsi turpināt šo tērzēšanu pēc %1$s."
+msgstr "Sasniegts mēneša lietošanas limits. Tu varēsi turpināt šo tērzēšanu pēc %1$s."
 
 # smartling.placeholder_format=C
 #. Used to point to additional social networking profiles (in results).
@@ -12862,8 +12857,7 @@ msgstr "Tikai meklēšana – bez izsekošanas un mērķētas reklāmas!"
 #. Refers to how web searches on DuckDuckGo aren't tracked.
 msgctxt "homepage onboarding"
 msgid "No tracking, no ad targeting, just searching."
-msgstr ""
-"Tikai meklēšana, bez izsekošanas, bez reklāmas mērķauditorijas atlases."
+msgstr "Tikai meklēšana, bez izsekošanas, bez reklāmas mērķauditorijas atlases."
 
 # smartling.placeholder_format=C
 #. Indicates that there were no search results for a user's search. The placeholder is the user's search term. For example: 'No videos found for 'bad dogs''
@@ -13483,8 +13477,7 @@ msgstr "Atver %1$sIestatījumi%2$s"
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open 'Location', and ensure location is %senabled%s."
-msgstr ""
-"Atver opciju “Atrašanās vieta” un pārliecinies, ka tā ir %1$siespējota%2$s."
+msgstr "Atver opciju “Atrašanās vieta” un pārliecinies, ka tā ir %1$siespējota%2$s."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -14366,8 +14359,7 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this prompt was made by a "
 "human."
-msgstr ""
-"Lūdzu, izpildi uzdevumu, lai apstiprinātu, ka šo vaicājumu veic cilvēks."
+msgstr "Lūdzu, izpildi uzdevumu, lai apstiprinātu, ka šo vaicājumu veic cilvēks."
 
 # smartling.placeholder_format=C
 #. Bot challenge explanation
@@ -14375,14 +14367,15 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this search was made by a "
 "human."
-msgstr ""
-"Lūdzu, izpildi šo uzdevumu, lai apstiprinātu, ka meklēšanu veic cilvēks."
+msgstr "Lūdzu, izpildi šo uzdevumu, lai apstiprinātu, ka meklēšanu veic cilvēks."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is harmful or illegal. (optional)"
 msgstr ""
+"Lūdzu, apraksti, kāpēc šī tērzēšanas atbilde ir kaitīga vai nelikumīga. "
+"(Neobligāti)"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
@@ -14421,6 +14414,9 @@ msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is harmful or illegal."
 msgstr ""
+"Lūdzu, nokopē un ielīmē savu uzvedni un problemātisko rezultātu (vispirms "
+"izdzēšot personisku informāciju, ja tāda ir) un apraksti, kāpēc šis saturs "
+"ir kaitīgs vai nelikumīgs."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -14582,8 +14578,7 @@ msgstr "Plus vēl citas premium funkcijas ar DuckDuckGo abonementu."
 msgid ""
 "Plus, what you watch in Duck Player won’t influence your recommendations on "
 "YouTube."
-msgstr ""
-"Turklāt tas, ko tu skaties Duck Player, neietekmē tavus ieteikumus YouTube."
+msgstr "Turklāt tas, ko tu skaties Duck Player, neietekmē tavus ieteikumus YouTube."
 
 # smartling.placeholder_format=C
 #. A link to the Substack page (https://insideduckduckgo.substack.com/?showWelcome=true)
@@ -14892,7 +14887,7 @@ msgstr "Privātums"
 #. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
 msgctxt "Section heading on the Duck.ai settings page"
 msgid "Privacy & Terms"
-msgstr ""
+msgstr "Privātums un noteikumi"
 
 # smartling.placeholder_format=C
 msgid "Privacy Blog"
@@ -14968,7 +14963,7 @@ msgstr "Privātuma politika un Pakalpojumu sniegšanas noteikumi"
 #. Text for a button that links to the terms of use and privacy policy page.
 msgctxt "Secondary button text in active privacy modal"
 msgid "Privacy Policy and Terms of Service"
-msgstr ""
+msgstr "Privātuma politika un pakalpojumu sniegšanas noteikumi"
 
 # smartling.placeholder_format=C
 #. Title displayed on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
@@ -15162,8 +15157,7 @@ msgstr "Aizsargā savus datus meklēšanas un pārlūkošanas laikā."
 #. Shown on the Mac and Windows browser promo cards. DuckDuckGo's desktop browser protects your data across search, browsing, and AI chat.
 msgctxt "SERP footer content"
 msgid "Protect your data as you search, browse, and use AI."
-msgstr ""
-"Aizsargā savus datus, meklējot, pārlūkojot un izmantojot mākslīgo intelektu."
+msgstr "Aizsargā savus datus, meklējot, pārlūkojot un izmantojot mākslīgo intelektu."
 
 # smartling.placeholder_format=C
 #. A title above links to download the DuckDuckGo apps.
@@ -15477,25 +15471,25 @@ msgstr "Iesaki kādu grāmatu"
 #. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Recommend similar books"
-msgstr ""
+msgstr "Iesaki līdzīgas grāmatas"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Recommend similar books."
-msgstr ""
+msgstr "Iesaki līdzīgas grāmatas."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Recommend similar movies or shows."
-msgstr ""
+msgstr "Iesaki līdzīgas filmas vai seriālus."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Recommend similar titles"
-msgstr ""
+msgstr "Iesaki līdzīgus darbus"
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
@@ -15721,8 +15715,7 @@ msgstr "Atcerēties manu izvēli"
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings
 msgid "Remember my choice (this can be changed in %s%s%sSettings%s)"
-msgstr ""
-"Atcerēties manu izvēli (to var mainīt sadaļā %1$s%2$s%3$sIestatījumi%4$s)"
+msgstr "Atcerēties manu izvēli (to var mainīt sadaļā %1$s%2$s%3$sIestatījumi%4$s)"
 
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
@@ -15907,7 +15900,7 @@ msgctxt ""
 "feedback form when the user has selected Harmful or Illegal as the feedback "
 "reason"
 msgid "Required for harmful or illegal reports"
-msgstr ""
+msgstr "Obligāti ziņojumiem par kaitīgu vai nelikumīgu saturu"
 
 # smartling.placeholder_format=C
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
@@ -16151,7 +16144,7 @@ msgstr "Atsauksmes"
 #. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Rewrite this recipe scaled for a different number of servings."
-msgstr ""
+msgstr "Pārraksti šo recepti, pielāgojot to citam porciju skaitam."
 
 # smartling.placeholder_format=C
 msgid "Romania"
@@ -16598,8 +16591,7 @@ msgstr "Ritini uz leju un sarakstā atrodi %1$ssavu pārlūkprogrammu%2$s."
 #. Tells users which setting to change to enable location service.
 msgctxt "precise_user_location"
 msgid "Scroll down to %sDuckDuckGo%s and allow it to use your location."
-msgstr ""
-"Ritini uz leju līdz %1$sDuckDuckGo%2$s un ļauj izmantot savu atrašanās vietu."
+msgstr "Ritini uz leju līdz %1$sDuckDuckGo%2$s un ļauj izmantot savu atrašanās vietu."
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -17105,8 +17097,7 @@ msgstr "Apskati dažus no mūsu pēdējiem atjauninājumiem"
 #. Link to a page with more information about how user settings are stored in a URL.
 msgctxt "settings"
 msgid "See the %sURL Parameter Reference page%s for more details."
-msgstr ""
-"Apskati %1$sURL parametru uzziņas lapa%2$s, lai iegūtu vairāk informācijas."
+msgstr "Apskati %1$sURL parametru uzziņas lapa%2$s, lai iegūtu vairāk informācijas."
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the context menu of a chat in chat history, that allows the user to select the chat and begin batch selection mode.
@@ -17140,20 +17131,18 @@ msgstr "Safari izvēlnē atlasi %1$s“Šīs vietnes iestatījumi...”%2$s."
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
 msgstr ""
-"Atlasi %1$sPielāgots%2$s un ievades laukā raksti %3$shttps://duckduckgo."
-"com%4$s"
+"Atlasi %1$sPielāgots%2$s un ievades laukā raksti "
+"%3$shttps://duckduckgo.com%4$s"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
-msgstr ""
-"Atlasi %1$sDuckDuckGo%2$s un noklikšķini uz %3$sPievienot kā noklusējumu%4$s!"
+msgstr "Atlasi %1$sDuckDuckGo%2$s un noklikšķini uz %3$sPievienot kā noklusējumu%4$s!"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s"
-msgstr ""
-"Atlasi %1$sDuckDuckGo%2$s un noklikšķini uz %3$sIestatīt kā noklusējumu%4$s"
+msgstr "Atlasi %1$sDuckDuckGo%2$s un noklikšķini uz %3$sIestatīt kā noklusējumu%4$s"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
@@ -17165,8 +17154,7 @@ msgstr "Atlasi %1$sDuckDuckGo%2$s un nospied %3$sIestatīt kā noklusējumu%4$s.
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Select %sDuckDuckGo%s in the Default Search Engine drop down"
-msgstr ""
-"Noklusējuma meklētājprogrammas nolaižamajā izvēlnē atlasi %1$sDuckDuckGo%2$s"
+msgstr "Noklusējuma meklētājprogrammas nolaižamajā izvēlnē atlasi %1$sDuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
@@ -17186,8 +17174,7 @@ msgstr "Meklēšanas pakalpojumu sniedzēju sarakstā atlasi %1$sDuckDuckGo%2$s"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s under the%sDefault Search Engine%s section"
-msgstr ""
-"Sadaļā%3$sNoklusējuma meklētājprogramma%4$s izvēlies %1$sDuckDuckGo%2$s"
+msgstr "Sadaļā%3$sNoklusējuma meklētājprogramma%4$s izvēlies %1$sDuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. Tells the user were in the settings menu they can change their default search engine.
@@ -17220,8 +17207,7 @@ msgstr ""
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sOpera > Options%s (on Windows)"
-msgstr ""
-"Atver %1$sOpera > Preferences%2$s (Mac) vai %3$sOpera > Opcijas%4$s (Windows)"
+msgstr "Atver %1$sOpera > Preferences%2$s (Mac) vai %3$sOpera > Opcijas%4$s (Windows)"
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -17493,7 +17479,7 @@ msgstr "Iestati tagad"
 #. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
 msgctxt "Encrypted storage setup button shown in native browsers"
 msgid "Set Up Sync & Backup"
-msgstr ""
+msgstr "Iestati Sync & Backup"
 
 # smartling.placeholder_format=C
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
@@ -17681,7 +17667,7 @@ msgstr "Sniegt pozitīvu atsauksmi"
 msgctxt ""
 "Label beside the share-content switch on the Duck.ai response feedback form"
 msgid "Share this conversation with DuckDuckGo"
-msgstr ""
+msgstr "Kopīgot šo sarunu ar DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -18066,8 +18052,7 @@ msgstr "Parāda horizontālas līnijas rezultātu lapu pārtraukumos"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows links to instructions for how to add DuckDuckGo to your browser"
-msgstr ""
-"Parāda saites uz instrukcijām, kā pievienot DuckDuckGo savai pārlūkprogrammai"
+msgstr "Parāda saites uz instrukcijām, kā pievienot DuckDuckGo savai pārlūkprogrammai"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers more frequently.
@@ -18088,8 +18073,7 @@ msgstr "Ik pa laikam rāda atgādinājumus par DuckDuckGo pievienošanu pārlūk
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr ""
-"Ik pa laikam rāda atgādinājumus par DuckDuckGo pievienošanu tavām ierīcēm"
+msgstr "Ik pa laikam rāda atgādinājumus par DuckDuckGo pievienošanu tavām ierīcēm"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18351,15 +18335,13 @@ msgstr "Kaut kas notika nepareizi"
 #. Error message indicating that the user's settings weren't able to be saved.
 msgctxt "cloudsave"
 msgid "Something went wrong saving to the server, please try again."
-msgstr ""
-"Kaut kas nogāja greizi, mēģinot saglabāt serverī, lūdzu, mēģini vēlreiz."
+msgstr "Kaut kas nogāja greizi, mēģinot saglabāt serverī, lūdzu, mēģini vēlreiz."
 
 # smartling.placeholder_format=C
 #. Body copy displayed under the Set Up Now button when the sync setup call fails.
 msgctxt "Generic error shown when sync setup fails"
 msgid "Something went wrong while enabling Sync & Backup. Please try again."
-msgstr ""
-"Kaut kas nogāja greizi, iespējojot Sync & Backup. Lūdzu, mēģini vēlreiz."
+msgstr "Kaut kas nogāja greizi, iespējojot Sync & Backup. Lūdzu, mēģini vēlreiz."
 
 # smartling.placeholder_format=C
 #. Displayed when the voice chat session ends with an unknown error.
@@ -18440,8 +18422,8 @@ msgstr ""
 msgid ""
 "Sorry, we couldn't generate a richer answer. You can try asking Duck.ai."
 msgstr ""
-"Atvaino, mēs nevarējām sniegt plašāku atbildi. Tu vari mēģināt jautāt Duck."
-"ai."
+"Atvaino, mēs nevarējām sniegt plašāku atbildi. Tu vari mēģināt jautāt "
+"Duck.ai."
 
 # smartling.placeholder_format=C
 #. Inform the users that "something" went wrong and that they could try to refresh the page to resolve the error. Placeholders are for markup, please ignore.
@@ -18457,8 +18439,7 @@ msgstr ""
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr ""
-"Diemžēl mums neizdevās iesniegt tavu atsauksmi. Lūdzu, mēģini vēlreiz vēlāk."
+msgstr "Diemžēl mums neizdevās iesniegt tavu atsauksmi. Lūdzu, mēģini vēlreiz vēlāk."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -18713,22 +18694,19 @@ msgstr "Paliec DuckDuckGo platformā"
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletter."
-msgstr ""
-"Lasi mūsu privātuma informatīvos ziņojumus savai drošībai un informētībai."
+msgstr "Lasi mūsu privātuma informatīvos ziņojumus savai drošībai un informētībai."
 
 # smartling.placeholder_format=C
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletters."
-msgstr ""
-"Lasi mūsu privātuma informatīvos ziņojumus savai drošībai un informētībai."
+msgstr "Lasi mūsu privātuma informatīvos ziņojumus savai drošībai un informētībai."
 
 # smartling.placeholder_format=C
 #. Text on the page where users can subscribe to DuckDuckGo's privacy newsletter
 msgctxt "showcase_newsletter"
 msgid "Stay protected and informed with our privacy newsletters."
-msgstr ""
-"Lasi mūsu privātuma informatīvos ziņojumus savai drošībai un informētībai."
+msgstr "Lasi mūsu privātuma informatīvos ziņojumus savai drošībai un informētībai."
 
 # smartling.placeholder_format=C
 #. Loading message shown when image generation is taking longer than usual.
@@ -18930,8 +18908,7 @@ msgctxt "Full sentence for composing a card"
 msgid ""
 "Suggest a phrase to write on a get-well card for someone recovering from a "
 "surgery?"
-msgstr ""
-"Iesaki frāzi, ko uzrakstīt uz kartītes kādam, kurš atveseļojas pēc operācijas"
+msgstr "Iesaki frāzi, ko uzrakstīt uz kartītes kādam, kurš atveseļojas pēc operācijas"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for asking for a suggestion of a blog post title.
@@ -18943,19 +18920,19 @@ msgstr "Iesaki nosaukumu bloga ierakstam"
 #. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Suggest related articles or topics worth exploring next."
-msgstr ""
+msgstr "Iesaki saistītus rakstus vai tēmas, ko vērts izpētīt tālāk."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Suggest related articles to explore"
-msgstr ""
+msgstr "Iesaki saistītus rakstus, ko apskatīt"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Suggest some alternatives to this product."
-msgstr ""
+msgstr "Iesaki dažas alternatīvas šai precei."
 
 # smartling.placeholder_format=C
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
@@ -18972,7 +18949,7 @@ msgstr "Ieteikumi:"
 #. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Sum up the reviews"
-msgstr ""
+msgstr "Apkopo atsauksmes"
 
 # smartling.placeholder_format=C
 #. A short title for the a message asking the AI to summarize a text.
@@ -18984,85 +18961,85 @@ msgstr "Apkopotājs"
 #. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize the Q&As"
-msgstr ""
+msgstr "Apkopo jautājumus un atbildes"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the background and notable work of this person."
-msgstr ""
+msgstr "Apkopo šī cilvēka biogrāfiju un ievērojamākos darbus."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the key details of this event."
-msgstr ""
+msgstr "Apkopo šī notikuma galveno informāciju."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the questions and answers on this page."
-msgstr ""
+msgstr "Apkopo jautājumus un atbildes šajā lapā."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize their background"
-msgstr ""
+msgstr "Apkopo informāciju"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this book"
-msgstr ""
+msgstr "Apkopo šo grāmatu"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this book."
-msgstr ""
+msgstr "Apkopo šo grāmatu."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this discussion"
-msgstr ""
+msgstr "Apkopot šo diskusiju"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this discussion thread."
-msgstr ""
+msgstr "Apkopo šo diskusiju pavedienu."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this page"
-msgstr ""
+msgstr "Apkopot šo lapu"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this page."
-msgstr ""
+msgstr "Apkopo šo lapu."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this video"
-msgstr ""
+msgstr "Apkopo šo video"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this video."
-msgstr ""
+msgstr "Apkopo šo video."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize what the reviews say."
-msgstr ""
+msgstr "Apkopo atsauksmēs teikto."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -19392,7 +19369,7 @@ msgstr "Sīrija"
 #. Text for a button that enables the theme to follow the operating system's color scheme preference.
 msgctxt "System theme button for theme selector"
 msgid "System"
-msgstr ""
+msgstr "Sistēma"
 
 # smartling.placeholder_format=C
 #. Abbreviation indicating this is the total score for a game
@@ -19426,7 +19403,7 @@ msgstr "Taitiešu"
 #. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Tailor my resume"
-msgstr ""
+msgstr "Pielāgo manu CV"
 
 # smartling.placeholder_format=C
 msgid "Taiwan"
@@ -19462,7 +19439,7 @@ msgstr "Esi noteicējs pār saviem personīgajiem datiem!"
 msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
-msgstr ""
+msgstr "Aizpildi šo anonīmo aptauju, lai mēs uzzinātu, kā varam uzlabot Duck.ai."
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -19773,7 +19750,7 @@ msgstr "Motīvs"
 #. Text for the theme selector label that allows users to switch between Light and dark theme.
 msgctxt "Label for the theme selector feature"
 msgid "Theme"
-msgstr ""
+msgstr "Dizains"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/LpFhb1e.png
@@ -20428,8 +20405,7 @@ msgstr "Pārāk daudz reklāmu"
 #. Displayed when the user has sent too many requests in a short period of time.
 msgctxt "Error message for rate limit"
 msgid "Too many requests. Please take a short break and try again."
-msgstr ""
-"Pārāk daudz pieprasījumu. Lūdzu, paņem nelielu pārtraukumu un mēģini vēlreiz."
+msgstr "Pārāk daudz pieprasījumu. Lūdzu, paņem nelielu pārtraukumu un mēģini vēlreiz."
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -20621,13 +20597,13 @@ msgstr ""
 #. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Translate this page"
-msgstr ""
+msgstr "Tulkot šo lapu"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
 msgctxt "Page suggestion prompt"
 msgid "Translate this page into %s."
-msgstr ""
+msgstr "Tulko šo lapu – %1$s."
 
 # smartling.placeholder_format=C
 #. Placeholder text for a region that will display translated text.
@@ -20774,7 +20750,7 @@ msgstr "Izmēģini bez maksas"
 #. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
 msgctxt "settings"
 msgid "Try It Now"
-msgstr ""
+msgstr "Izmēģināt tūlīt"
 
 # smartling.placeholder_format=C
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -20840,8 +20816,7 @@ msgstr ""
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
 msgctxt "precise_user_location"
 msgid "Try enabling anonymous location for more accurate results."
-msgstr ""
-"Lai iegūtu precīzākus rezultātus, pamēģini iespējot anonīmu atrašanās vietu."
+msgstr "Lai iegūtu precīzākus rezultātus, pamēģini iespējot anonīmu atrašanās vietu."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the screen of the onboarding where the user picks a chat model.
@@ -21020,6 +20995,9 @@ msgid ""
 "Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
+"Mēģini atspējot mākslīgā intelekta funkcijas? Instalē %1$sDuckDuckGo No "
+"AI%2$s meklēšanas paplašinājumu, lai saglabātu savus iestatījumus. "
+"%3$sUzzināt vairāk%4$s"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -21028,6 +21006,9 @@ msgid ""
 "Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
+"Mēģini atspējot mākslīgā intelekta funkcijas? Pārslēdzies uz %1$sDuckDuckGo "
+"No AI%2$s meklēšanas paplašinājumu, lai saglabātu savus iestatījumus. "
+"%3$sUzzināt vairāk%4$s"
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -21148,8 +21129,7 @@ msgstr "Lai iegūtu precīzākus rezultātus, ieslēdz “Precīza atrašanās v
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on “Use precise location” for more accurate results."
-msgstr ""
-"Lai iegūtu precīzākus rezultātus, ieslēdz “Izmantot precīzu atrašanās vietu”."
+msgstr "Lai iegūtu precīzākus rezultātus, ieslēdz “Izmantot precīzu atrašanās vietu”."
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Create Image' label in the Tools dropdown.
@@ -21300,8 +21280,7 @@ msgstr "Nevar iesniegt atsauksmi"
 #. Message shown to the user when the voice chat failed to establish a connection, and they should try again later.
 msgctxt "voice chat"
 msgid "Unable to connect to voice chat, please try again later."
-msgstr ""
-"Nevar izveidot savienojumu ar balss tērzēšanu. Lūdzu, vēlāk mēģini vēlreiz. "
+msgstr "Nevar izveidot savienojumu ar balss tērzēšanu. Lūdzu, vēlāk mēģini vēlreiz. "
 
 # smartling.placeholder_format=C
 #. Message shown to the user when there was an issue connecting to their microphone.
@@ -21342,8 +21321,8 @@ msgstr ""
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
 msgstr ""
-"Sadaļā %1$sPie palaišanas%2$s atlasi %3$sMājaslapa%4$s un ievadi: https://"
-"duckduckgo.com"
+"Sadaļā %1$sPie palaišanas%2$s atlasi %3$sMājaslapa%4$s un ievadi: "
+"https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -21369,15 +21348,13 @@ msgstr "Zem %1$sMeklēt adreses joslā ar%2$s nospied %3$sPievienot jaunu%4$s"
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
-msgstr ""
-"Zem %1$sMeklēt%2$s sekcijas nospied %3$sPārvaldīt meklējumprogrammas...%4$s"
+msgstr "Zem %1$sMeklēt%2$s sekcijas nospied %3$sPārvaldīt meklējumprogrammas...%4$s"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under On startup select %sOpen a specific page or set of pages%s"
-msgstr ""
-"Sadaļā \"Pie palaišanas\" atlasi %1$sAtvērt noteiktu lapu vai lapu kopu%2$s"
+msgstr "Sadaļā \"Pie palaišanas\" atlasi %1$sAtvērt noteiktu lapu vai lapu kopu%2$s"
 
 #  Opera default search engine instruction
 # smartling.placeholder_format=C
@@ -21485,8 +21462,7 @@ msgstr "Atbloķē ar DuckDuckGo abonementu"
 msgctxt "voice chat limit modal"
 msgid ""
 "Unlock advanced AI models and higher limits with a DuckDuckGo Subscription"
-msgstr ""
-"Atbloķē uzlabotus MI modeļus un augstākas robežas ar DuckDuckGo abonementu"
+msgstr "Atbloķē uzlabotus MI modeļus un augstākas robežas ar DuckDuckGo abonementu"
 
 # smartling.placeholder_format=C
 #. Text informing the user that advanced AI models can be unlocked with a subscription. The variable is used to insert a link that opens the subscription modal. Example: Unlock advanced AI models with a DuckDuckGo subscription.
@@ -21788,7 +21764,7 @@ msgstr "Urugvaja"
 #. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
 msgctxt "Navigation label on the Duck.ai settings page"
 msgid "Usage"
-msgstr ""
+msgstr "Lietojums"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -21883,8 +21859,7 @@ msgstr ""
 #. Prompt to ask the user if they want to use their approximate location for more accurate results
 msgctxt "DuckChat location prompt"
 msgid "Use your approximate location for more accurate results?"
-msgstr ""
-"Vai izmantot aptuveno atrašanās vietu, lai iegūtu precīzākus rezultātus?"
+msgstr "Vai izmantot aptuveno atrašanās vietu, lai iegūtu precīzākus rezultātus?"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes before every user message in the downloaded file, indicating which message it is out of the total number of messages. Example: 'User prompt 3 of 5'
@@ -22123,8 +22098,8 @@ msgid ""
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
 msgstr ""
-"Apmeklē Duck.ai citā pārlūkprogrammā vai DuckDuckGo lietotnē un atver Duck."
-"ai iestatījumus. Sadaļā “Sync & Backup” izvēlies “Ieslēgt” un tad "
+"Apmeklē Duck.ai citā pārlūkprogrammā vai DuckDuckGo lietotnē un atver "
+"Duck.ai iestatījumus. Sadaļā “Sync & Backup” izvēlies “Ieslēgt” un tad "
 "“Sinhronizēt ar citu ierīci”. Vai arī noskenē kvadrātkodu savā atkopšanas "
 "PDF failā."
 
@@ -22244,7 +22219,7 @@ msgstr "Velsa"
 #. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Walk me through the steps"
-msgstr ""
+msgstr "Paskaidro man soli pa solim"
 
 # smartling.placeholder_format=C
 #. Label for walking directions on a map.
@@ -22375,6 +22350,9 @@ msgid ""
 "please share this conversation with DuckDuckGo so we can investigate and "
 "address the issue."
 msgstr ""
+"Mēs varam labot tikai to, ko redzam. Lai ziņotu par kaitīgu vai nelikumīgu "
+"atbildi, lūdzu, kopīgo šo sarunu ar DuckDuckGo, lai mēs varētu izmeklēt un "
+"risināt šo problēmu."
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -22403,8 +22381,7 @@ msgstr ""
 msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
-msgstr ""
-"Mēs nevaram nolasīt pievienotos failus, jo vismaz viens no tiem ir šifrēts."
+msgstr "Mēs nevaram nolasīt pievienotos failus, jo vismaz viens no tiem ir šifrēts."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -22420,8 +22397,7 @@ msgstr "Mēs neglabājam lietotājvārdus un personu identificējošu informāci
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don't store your personal info or track you. Ever."
-msgstr ""
-"Mēs neuzglabājam tavu personisko informāciju un neizsekojam tevi. Nekad."
+msgstr "Mēs neuzglabājam tavu personisko informāciju un neizsekojam tevi. Nekad."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -22544,8 +22520,7 @@ msgstr "Mēs zaudējām savienojumu, lūdzu, vēlāk mēģini vēlreiz."
 #. We store chats for 15 minutes in the BE. If the user tries to fetch it after the 15 minutes elapsed or if we had an issue saving it we show them this error message so they can re-submit their prompt.
 msgctxt "AI Chat: Error message for unsaved or expired chats saved in sync"
 msgid "We lost the connection. Please try sending your message again."
-msgstr ""
-"Mēs pazaudējām savienojumu. Lūdzu, mēģini nosūtīt savu ziņojumu vēlreiz."
+msgstr "Mēs pazaudējām savienojumu. Lūdzu, mēģini nosūtīt savu ziņojumu vēlreiz."
 
 # smartling.placeholder_format=C
 #. Message asking the user to disable their ad blocker, with a link to how our ads don't track you. The placeholders are for the start and end tags of that link (e.g. <a href="%">, </a>)
@@ -22577,8 +22552,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We stop anyone from getting your search history, including us."
-msgstr ""
-"Mēs neļaujam nevienam piekļūt tavai meklēšanas vēsturei – to nevaram arī mēs."
+msgstr "Mēs neļaujam nevienam piekļūt tavai meklēšanas vēsturei – to nevaram arī mēs."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -22797,8 +22771,7 @@ msgstr ""
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai! You can now import your downloaded chats."
-msgstr ""
-"Laipni lūdzam jaunajā Duck.ai! Tagad vari importēt lejupielādētās sarakstes."
+msgstr "Laipni lūdzam jaunajā Duck.ai! Tagad vari importēt lejupielādētās sarakstes."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -22937,98 +22910,98 @@ msgstr ""
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the counterarguments?"
-msgstr ""
+msgstr "Kādi ir pretargumenti?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the hours & location?"
-msgstr ""
+msgstr "Kāds ir darba laiks un atrašanās vieta?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key contributions of this paper?"
-msgstr ""
+msgstr "Kādi ir šī raksta galvenie ieguldījumi?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key contributions?"
-msgstr ""
+msgstr "Kādi ir galvenie ieguldījumi?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key details?"
-msgstr ""
+msgstr "Kādas ir galvenās detaļas?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key points covered in this video?"
-msgstr ""
+msgstr "Kādi ir galvenie punkti, kas apskatīti šajā video?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key points?"
-msgstr ""
+msgstr "Kādi ir galvenie punkti?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key takeaways from this article?"
-msgstr ""
+msgstr "Kādi ir galvenie šī raksta secinājumi?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key takeaways?"
-msgstr ""
+msgstr "Kādi ir galvenie secinājumi?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key things I will learn from this course?"
-msgstr ""
+msgstr "Kādas ir galvenās lietas, ko es apgūšu šajā kursā?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the main counterarguments or criticisms of this?"
-msgstr ""
+msgstr "Kādi ir galvenie pretargumenti vai kritika?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the main questions this page answers?"
-msgstr ""
+msgstr "Uz kādiem galvenajiem jautājumiem šī lapa sniedz atbildes?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the must-try dishes here?"
-msgstr ""
+msgstr "Kādus ēdienus šeit noteikti ir vērts nogaršot?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid ""
 "What are the opening hours, location, and contact details for this place?"
-msgstr ""
+msgstr "Kāds ir šīs vietas darba laiks, atrašanās vieta un kontaktinformācija?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the pros and cons of this product?"
-msgstr ""
+msgstr "Kādi ir šī produkta plusi un mīnusi?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the pros and cons?"
-msgstr ""
+msgstr "Kādi ir plusi un mīnusi?"
 
 # smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
@@ -23134,7 +23107,7 @@ msgstr "Ko nozīmē \"atria\" medicīniska raksta kontekstā?"
 #. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What does this answer?"
-msgstr ""
+msgstr "Ko tas atbild?"
 
 # smartling.placeholder_format=C
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
@@ -23152,7 +23125,7 @@ msgstr "Kāda informācija tiek saglabāta?"
 #. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What interview questions might come up for this role?"
-msgstr ""
+msgstr "Kādi intervijas jautājumi varētu tikt uzdoti šajā vakancē?"
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -23174,7 +23147,7 @@ msgstr "Kas ir Albānijas galvaspilsēta?"
 #. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What is the overall verdict and rating for this?"
-msgstr ""
+msgstr "Kāds ir kopējais viedoklis un vērtējums par šo?"
 
 # smartling.placeholder_format=C
 #. Link to a page with additional information.
@@ -23202,7 +23175,7 @@ msgstr "Ko saka citi:"
 #. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What should I order?"
-msgstr ""
+msgstr "Ko man pasūtīt?"
 
 # smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
@@ -23220,13 +23193,13 @@ msgstr "Kas bija nepareizi ar atbildi? (Neobligāti)"
 #. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What will I learn?"
-msgstr ""
+msgstr "Ko es uzzināšu?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What will I need?"
-msgstr ""
+msgstr "Kas man būs nepieciešams?"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -23237,8 +23210,7 @@ msgstr "Par ko tu vēlētos sniegt atsauksmes?"
 #. Explains the benefits of using our custom video player, the Duck Player
 msgid ""
 "What you watch in DuckDuckGo won't influence your recommendations on YouTube."
-msgstr ""
-"Tas, ko skaties DuckDuckGo, neietekmēs tavus ieteikumus pakalpojumā YouTube."
+msgstr "Tas, ko skaties DuckDuckGo, neietekmēs tavus ieteikumus pakalpojumā YouTube."
 
 # smartling.placeholder_format=C
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
@@ -23250,7 +23222,7 @@ msgstr "Kas jauns"
 #. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What's the verdict?"
-msgstr ""
+msgstr "Kāds ir vērtējums?"
 
 # smartling.placeholder_format=C
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -23306,7 +23278,7 @@ msgstr "Kādas funkcijas trūkst? (Neobligāti)"
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Which features are missing? (optional)"
-msgstr ""
+msgstr "Kādas funkcijas trūkst? (Neobligāti)"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
@@ -23328,13 +23300,13 @@ msgstr "Kas mēs esam"
 #. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Who are the main cast and crew, and what else are they known for?"
-msgstr ""
+msgstr "Kas ir galvenie aktieri un filmēšanas grupa, un ar ko vēl viņi ir pazīstami?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Who is this person?"
-msgstr ""
+msgstr "Kas ir šī persona?"
 
 # smartling.placeholder_format=C
 #. Header above a collection of privacy-related links.
@@ -23705,8 +23677,7 @@ msgstr "Jā, jauns lietotājs!"
 msgctxt "cloudsave"
 msgid ""
 "Yes, we throw away data when you’re done with it, and it cannot be recovered."
-msgstr ""
-"Jā, mēs izmetam datus, kad tu beidz ar tiem darboties, un tos nevar atgūt."
+msgstr "Jā, mēs izmetam datus, kad tu beidz ar tiem darboties, un tos nevar atgūt."
 
 # smartling.placeholder_format=C
 #. Option for the filter-by-date search.
@@ -23830,8 +23801,7 @@ msgstr "Šo atgādinājumu varat paslēpt sadaļā %1$sMeklēšanas iestatījumi
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
-msgstr ""
-"Tagad šajā ierīcē vari saglabāt līdz pat 100 tērzēšanas sarunām. Tērzē!"
+msgstr "Tagad šajā ierīcē vari saglabāt līdz pat 100 tērzēšanas sarunām. Tērzē!"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -23998,8 +23968,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
 msgid "You won't see this message again unless you clear your browser data."
-msgstr ""
-"Tu vairs neredzēsi šo ziņojumu, ja vien nenotīrīsi pārlūkprogrammas datus."
+msgstr "Tu vairs neredzēsi šo ziņojumu, ja vien nenotīrīsi pārlūkprogrammas datus."
 
 # smartling.placeholder_format=C
 #. The second paragraph of a pop up where we explain how to update the browser manually.
@@ -24096,8 +24065,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
 msgid "You've reached your dictation usage limit. Try again later."
-msgstr ""
-"Tu esi sasniedzis diktēšanas lietošanas ierobežojumu. Mēģini vēlreiz vēlāk."
+msgstr "Tu esi sasniedzis diktēšanas lietošanas ierobežojumu. Mēģini vēlreiz vēlāk."
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -24258,8 +24226,7 @@ msgstr ""
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never used to train AI models"
-msgstr ""
-"Tava tērzēšana ir privāta, un tā nekad netiek izmantota MI modeļu apmācībai"
+msgstr "Tava tērzēšana ir privāta, un tā nekad netiek izmantota MI modeļu apmācībai"
 
 # smartling.placeholder_format=C
 #. Text for a description of the active privacy protection for DuckDuckGo's AI Chat feature.
@@ -24530,8 +24497,7 @@ msgstr ""
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
 msgctxt "voice chat limit modal"
 msgid "You’ve reached the voice chat limit for now. Please try again later."
-msgstr ""
-"Tu esi sasniedzis balss tērzēšanas ierobežojumu. Lūdzu, vēlāk mēģini vēlreiz."
+msgstr "Tu esi sasniedzis balss tērzēšanas ierobežojumu. Lūdzu, vēlāk mēģini vēlreiz."
 
 # smartling.placeholder_format=C
 #. The name of the Yucatec Maya language
@@ -24829,8 +24795,7 @@ msgstr "oficiālā vietne"
 #. <em>%s</em> is for a hexadecimal color code as <em>#395323</em>, but it has to be safe encoded, and as <em>#</em> seems not safe, <em>%23</em> must be used in place of the sharp symbol, but they are the same for your browser.
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
-msgstr ""
-"vai uzraksti krāsas kodu pats, piemēram, %1$s (%2$s ir %3$s zīmes kods)."
+msgstr "vai uzraksti krāsas kodu pats, piemēram, %1$s (%2$s ir %3$s zīmes kods)."
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "

--- a/locales/lv_LV/LC_MESSAGES/duckduckgo.po
+++ b/locales/lv_LV/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: lv_LV\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -887,14 +887,16 @@ msgstr ""
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of AI Chat is available! Please refresh this page to continue."
-msgstr "Ir pieejama jauna AI Chat versija! Lūdzu, atsvaidzini šo lapu, lai turpinātu."
+msgstr ""
+"Ir pieejama jauna AI Chat versija! Lūdzu, atsvaidzini šo lapu, lai turpinātu."
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of Duck.ai is available and they need to refresh the page.
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of Duck.ai is available! Please refresh this page to continue."
-msgstr "Ir pieejama jauna Duck.ai versija! Lai turpinātu, lūdzu, atsvaidzini šo lapu."
+msgstr ""
+"Ir pieejama jauna Duck.ai versija! Lai turpinātu, lūdzu, atsvaidzini šo lapu."
 
 # smartling.placeholder_format=C
 #. Shown when the Duck.ai desktop app has been open a long time and a newer version exists.
@@ -1439,6 +1441,12 @@ msgid "Address is incorrect"
 msgstr "Adrese ir nepareiza"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Adjust the servings"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. as in multiple advertisements
 msgid "Ads"
 msgstr "Reklāmas"
@@ -1643,13 +1651,22 @@ msgstr "Visas tērzēšanas sarunas ir %1$s"
 #. Disclaimer text shown below chat input. %s is replaced with a clickable underlined 'private' link that opens the privacy protection modal.
 msgctxt "Disclaimer below chat input in Duck.ai"
 msgid "All chats are %s. AI can make mistakes."
-msgstr "Visas tērzēšanas sarunas ir %1$s. Mākslīgais intelekts var pieļaut kļūdas."
+msgstr ""
+"Visas tērzēšanas sarunas ir %1$s. Mākslīgais intelekts var pieļaut kļūdas."
 
 # smartling.placeholder_format=C
 #. Heading shown on the empty chat screen. The text between the two %s markers is displayed inside a clickable privacy button. First %s renders a shield icon, second %s is an invisible end marker. Keep the word 'private' between both %s markers.
 msgctxt "Empty state heading in Duck.ai chat mode"
 msgid "All chats are %sprivate%s"
 msgstr "Visas tērzēšanas sarunas ir %1$sprivātas%2$s"
+
+# smartling.placeholder_format=C
+#. Paragraph in the Privacy & Terms section of the About & Legal page in Duck.ai settings, summarizing how chats are anonymized and are not stored or used to train chat models.
+msgctxt "Privacy & Terms section description on the Duck.ai settings page"
+msgid ""
+"All chats are anonymized by DuckDuckGo, and your conversations are not used "
+"to train chat models by DuckDuckGo or the model providers"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1922,6 +1939,13 @@ msgid "Anonymous location enabled"
 msgstr "Ir iespējota anonīma atrašanās vieta"
 
 # smartling.placeholder_format=C
+msgctxt "settings"
+msgid ""
+"Anonymously generates answers for search queries based on web content. "
+"Choose how often you want it to appear, or disable it completely."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Instant Answer tab name
 msgid "Answer"
 msgstr "Atbilde"
@@ -2066,7 +2090,8 @@ msgstr "Vai tu joprojām esi tur?"
 msgctxt "Body text for clear all chats confirmation modal"
 msgid ""
 "Are you sure you want to clear all of your chats? This cannot be undone."
-msgstr "Vai tiešām vēlies notīrīt visas tērzēšanas sarunas? Šo darbību nevar atsaukt."
+msgstr ""
+"Vai tiešām vēlies notīrīt visas tērzēšanas sarunas? Šo darbību nevar atsaukt."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that asks the user if they want to clear the conversation.
@@ -2078,7 +2103,8 @@ msgstr "Vai tiešām vēlies notīrīt šo sarunu un sākt jaunu?"
 #. Text asking the user to confirm if they want to delete their current chat, explaining that this action cannot be undone.
 msgctxt "Body text for delete chat confirmation modal"
 msgid "Are you sure you want to delete this chat? This cannot be undone."
-msgstr "Vai tiešām vēlies izdzēst šo tērzēšanas sarunu? Šo darbību nevar atsaukt."
+msgstr ""
+"Vai tiešām vēlies izdzēst šo tērzēšanas sarunu? Šo darbību nevar atsaukt."
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to disable chat history, with a warning that it will also delete currently saved chats including pinned chats.
@@ -2199,6 +2225,12 @@ msgstr "Uzdod papildjautājumu"
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse
 msgid "Ask a follow-up with Duck.ai"
 msgstr "Lūgt turpinājumu, izmantojot Duck.ai"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
+msgctxt "Page suggestion chip label"
+msgid "Ask about this page"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2617,6 +2649,12 @@ msgid "Barcode"
 msgstr "Svītrkods"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Based on this page, is this course worth taking?"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Basic"
 msgstr "Pamata"
@@ -2655,6 +2693,14 @@ msgstr "Sitējs"
 msgctxt "Assistant response placeholder"
 msgid "Before continuing..."
 msgstr "Pirms turpināt..."
+
+# smartling.placeholder_format=C
+#. Explains that before storing the report, DuckDuckGo will anonymize the conversation by removing PII like names, email addresses, and identifying metadata.
+msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
+msgid ""
+"Before storing this report, DuckDuckGo will anonymize your conversation by "
+"removing PII like names, email addresses, and identifying metadata."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -2973,6 +3019,12 @@ msgid "Break Points Won"
 msgstr "Uzvarētie breikpunkti"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Break this down into clear, numbered steps."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
 msgctxt "Weather IA"
 msgid "Breezy"
@@ -3215,7 +3267,8 @@ msgstr "Kamerūna"
 #. Text for a prompt suggestion for creating a few simple recipes using chicken, broccoli, and rice.
 msgctxt "Full sentence for crafting a recipe"
 msgid "Can you create a few simple recipes using chicken, broccoli, and rice?"
-msgstr "Vai vari izveidot dažas vienkāršas receptes ar vistu, brokoļiem un rīsiem?"
+msgstr ""
+"Vai vari izveidot dažas vienkāršas receptes ar vistu, brokoļiem un rīsiem?"
 
 # smartling.placeholder_format=C
 msgid "Canada"
@@ -3426,6 +3479,12 @@ msgid "Cast"
 msgstr "Dalībnieki"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Cast & Crew"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
 msgctxt "Tone option label for Casual"
 msgid "Casual"
@@ -3529,7 +3588,8 @@ msgstr "Maina fona krāsu visā vietnē"
 msgctxt "settings"
 msgid ""
 "Changes the background color of results on hover, modules, and dropdown menus"
-msgstr "Maina rezultātu fona krāsu zem kursora, moduļos un nolaižamajās izvēlnēs"
+msgstr ""
+"Maina rezultātu fona krāsu zem kursora, moduļos un nolaižamajās izvēlnēs"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/NdpkbY0.png
@@ -3662,8 +3722,8 @@ msgstr ""
 "ar trešo pušu mākslīgā intelekta tērzēšanas modeļiem, kas atbalsta OpenAI, "
 "Anthropic un citus rīkus. Izslēdzot šo iestatījumu tiks paslēptas tērzēšanas "
 "pogas un saites DuckDuckGo Search platformā. Taču tu joprojām vari piekļūt "
-"tērzēšanai, ja šis iestatījums ir izslēgts, apmeklējot "
-"%1$shttps://duck.ai%2$s tieši."
+"tērzēšanai, ja šis iestatījums ir izslēgts, apmeklējot %1$shttps://duck."
+"ai%2$s tieši."
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -4238,7 +4298,8 @@ msgstr "Nospied %1$sAtļaut%2$s, pēc tam %3$sPievienot%4$s."
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Click %sChange Search Settings%s in the drop down"
-msgstr "Nolaižamajā izvēlnē noklikšķini uz %1$sMainīt meklēšanas iestatījumus%2$s"
+msgstr ""
+"Nolaižamajā izvēlnē noklikšķini uz %1$sMainīt meklēšanas iestatījumus%2$s"
 
 #  SeaMonkey default search engine instruction
 # smartling.placeholder_format=C
@@ -4339,7 +4400,8 @@ msgstr "Sānjoslā noklikšķini uz %1$sPārlūks%2$s"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click on %sChange Search Settings%s in the dropdown menu"
-msgstr "Nolaižamajā izvēlnē noklikšķini uz %1$sMainīt meklēšanas iestatījumus%2$s"
+msgstr ""
+"Nolaižamajā izvēlnē noklikšķini uz %1$sMainīt meklēšanas iestatījumus%2$s"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -4359,7 +4421,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click on the %sTools icon%s in the top-right of the browser"
-msgstr "Pārlūkprogrammas augšējā labajā stūrī noklikšķini uz %1$sRīku ikonas%2$s"
+msgstr ""
+"Pārlūkprogrammas augšējā labajā stūrī noklikšķini uz %1$sRīku ikonas%2$s"
 
 #  Firefox default search engine instruction
 # smartling.placeholder_format=C
@@ -4488,7 +4551,8 @@ msgstr "Noklikšķini uz palielināmā stikla ikonas meklēšanas lodziņā"
 #. Tells users what icon to click in order to make DuckDuckGo the default engine in their browser.
 msgid ""
 "Click the magnifying glass in the search box (at the top of the browser)"
-msgstr "Noklikšķini uz palielināmā stikla meklēšanas lodziņā (parlūka augšdaļā)"
+msgstr ""
+"Noklikšķini uz palielināmā stikla meklēšanas lodziņā (parlūka augšdaļā)"
 
 #  IE default search engine instruction
 # smartling.placeholder_format=C
@@ -5094,7 +5158,8 @@ msgstr "Kostarika"
 #. Inline error shown on the recovery code screen when exportSyncSettings rejects.
 msgctxt "Error message when the recovery code fails to generate"
 msgid "Couldn't load your recovery code. Please close this and try again."
-msgstr "Nevarēja ielādēt tavu atkopšanas kodu. Lūdzu, aizver šo un mēģini vēlreiz."
+msgstr ""
+"Nevarēja ielādēt tavu atkopšanas kodu. Lūdzu, aizver šo un mēģini vēlreiz."
 
 # smartling.placeholder_format=C
 #. Pairs with a Retry button. Shown after two consecutive failed attempts to load the device list.
@@ -5138,6 +5203,12 @@ msgstr "Izveidot attēlu"
 msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr "Izveidot attēlu"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Create a shopping list with quantities from this recipe."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed in the input field when starting a new image generation session.
@@ -5784,6 +5855,11 @@ msgid "Dictation limit reached"
 msgstr "Sasniegts diktēšanas ierobežojums"
 
 # smartling.placeholder_format=C
+#. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
+msgid "Dictation temporarily unavailable"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
@@ -5870,7 +5946,8 @@ msgstr "Atspējot un atvienot"
 #. Title of a modal that asks the user if they want to turn off chat history and disconnect from Sync & Backup.
 msgctxt "Modal header for disabling chat history and disconnecting sync"
 msgid "Disable chat history and disconnect from Sync & Backup?"
-msgstr "Vai atspējot tērzēšanas vēsturi un pārtraukt savienojumu ar Sync & Backup?"
+msgstr ""
+"Vai atspējot tērzēšanas vēsturi un pārtraukt savienojumu ar Sync & Backup?"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to turn off the chat history feature.
@@ -6058,7 +6135,8 @@ msgstr "Neredzi DuckDuckGo sarakstā?"
 #. Link to download a file again if the user can't find it on their computer.
 msgctxt "install-extension"
 msgid "Don't see it? %s%s%sClick here to re-download%s"
-msgstr "Neredzi to? %1$s%2$s%3$sNoklikšķini šeit, lai lejupielādētu vēlreiz%4$s"
+msgstr ""
+"Neredzi to? %1$s%2$s%3$sNoklikšķini šeit, lai lejupielādētu vēlreiz%4$s"
 
 #  IE < 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -6082,6 +6160,22 @@ msgstr "Gatavs"
 msgctxt "precise_user_location"
 msgid "Done"
 msgstr "Gatavs"
+
+# smartling.placeholder_format=C
+#. Message shown in a modal after DuckDuckGo browser users disable AI features in Settings. The first two placeholders bold noai.duckduckgo.com. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
+"filtered out. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
+"and AI images filtered out. %sLearn more%s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6196,6 +6290,18 @@ msgid ""
 msgstr ""
 "Sagatavo kodolīgu un detalizētu e-pasta vēstuli pārdevējam, pieprasot mājas "
 "ledusskapja remonta pakalpojumu cenu piedāvājumu."
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Draft a cover letter"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Draft a cover letter for this job."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -6376,6 +6482,15 @@ msgstr ""
 "pārlūkprogrammā!"
 
 # smartling.placeholder_format=C
+#. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
+msgctxt "About section description on the Duck.ai settings page"
+msgid ""
+"Duck.ai is created by DuckDuckGo. We're an independent online protection "
+"company for anyone who wants to take back control of their personal "
+"information."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
 msgctxt "duckai_migration"
 msgid "Duck.ai is moving domains"
@@ -6412,13 +6527,21 @@ msgstr ""
 msgctxt "Error message for VQD error"
 msgid ""
 "Duck.ai is temporarily unavailable. Please refresh the page and try again."
-msgstr "Duck.ai uz laiku nav pieejams. Lūdzu, atsvaidzini lapu un mēģini vēlreiz."
+msgstr ""
+"Duck.ai uz laiku nav pieejams. Lūdzu, atsvaidzini lapu un mēģini vēlreiz."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
 msgstr "Duck.ai uz laiku nav pieejams. Lūdzu, mēģini vēlreiz vēlāk."
+
+# smartling.placeholder_format=C
+msgctxt "settings"
+msgid ""
+"Duck.ai lets you chat privately with popular AI models. Disabling it hides "
+"Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6482,7 +6605,8 @@ msgstr "Duck.ai atjaunināts!"
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
-msgstr "Duck.ai vislabāk darbojas mūsu privātajā un bezmaksas DuckDuckGo lietotnē!"
+msgstr ""
+"Duck.ai vislabāk darbojas mūsu privātajā un bezmaksas DuckDuckGo lietotnē!"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -7010,7 +7134,8 @@ msgstr "Rediģē attēlu..."
 msgctxt "Info text for the editing message feature"
 msgid ""
 "Editing your message will remove the response below and generate a new one."
-msgstr "Rediģējot savu ziņu, tiks dzēsta zemāk esošā atbilde un izveidota jauna."
+msgstr ""
+"Rediģējot savu ziņu, tiks dzēsta zemāk esošā atbilde un izveidota jauna."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of an editor in its responses.
@@ -7326,13 +7451,15 @@ msgstr ""
 #. Tells how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed location access"
-msgstr "Pārliecinies, vai pārlūkprogrammai ir atļauta piekļuve atrašanās vietai"
+msgstr ""
+"Pārliecinies, vai pārlūkprogrammai ir atļauta piekļuve atrašanās vietai"
 
 # smartling.placeholder_format=C
 #. Tells how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed location access."
-msgstr "Pārliecinies, vai pārlūkprogrammai ir atļauta piekļuve atrašanās vietai."
+msgstr ""
+"Pārliecinies, vai pārlūkprogrammai ir atļauta piekļuve atrašanās vietai."
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -7420,11 +7547,24 @@ msgstr "Ekvatoriālā Gvineja"
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Erase your browsing data in a flash with our %sFire Button%s"
-msgstr "Ātri izdzēs savus pārlūkošanas datus, izmantojot mūsu %1$sFire Button%2$s"
+msgstr ""
+"Ātri izdzēs savus pārlūkošanas datus, izmantojot mūsu %1$sFire Button%2$s"
 
 # smartling.placeholder_format=C
 msgid "Eritrea"
 msgstr "Eritreja"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Estimate the nutrition"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Estimate the nutritional information for this recipe."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Estonia"
@@ -7481,11 +7621,60 @@ msgid "Expires in 1 day"
 msgstr "Derīguma termiņš beigsies pēc 1 dienas"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain the accepted answer in simple terms."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
-msgstr "Paskaidro man pamatjēdzienus par melnajiem caurumiem vidusskolas līmenī."
+msgstr ""
+"Paskaidro man pamatjēdzienus par melnajiem caurumiem vidusskolas līmenī."
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain the top answer"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this in simple, plain language."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this paper"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this repo"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this research paper in plain language."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this simply"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain what this repository does and how to use it."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label to show if song lyrics contain explicit content
@@ -7662,7 +7851,8 @@ msgstr "Atsauksme sekmīgi iesniegta"
 msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and improvements."
-msgstr "Tavas atsauksmes tieši ietekmē mūsu produktu atjauninājumus un uzlabojumus."
+msgstr ""
+"Tavas atsauksmes tieši ietekmē mūsu produktu atjauninājumus un uzlabojumus."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -7769,6 +7959,12 @@ msgstr ""
 "vairāk%2$s"
 
 # smartling.placeholder_format=C
+msgctxt "settings"
+msgid ""
+"Filters out known AI spam sites from image search results. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the final score of a sporting event.
 msgid "Final"
 msgstr "Pēdējais"
@@ -7795,7 +7991,8 @@ msgstr "Finanšu konsultants"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Find %sDuckDuckGo%s and click%sMake default%s"
-msgstr "Atrodi %1$sDuckDuckGo%2$s un noklikšķini uz%3$sPadarīt par noklusējumu%4$s"
+msgstr ""
+"Atrodi %1$sDuckDuckGo%2$s un noklikšķini uz%3$sPadarīt par noklusējumu%4$s"
 
 # smartling.placeholder_format=C
 #. Sentence shown after export, includes a placeholder for one or more filenames with bold formatting for the filename(s).
@@ -7822,6 +8019,12 @@ msgstr "Atrodi labāku vārdu"
 msgctxt "Subtitle for the Web Search tool entry in the Tools dropdown menu"
 msgid "Find current information"
 msgstr "Atrodi aktuālo informāciju"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Find me alternatives"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button that searches for results closer to the user's current location.
@@ -8134,9 +8337,9 @@ msgid ""
 "strong>."
 msgstr ""
 "Mac datorā lietotnes izvēlnes joslā izvēlies <strong>DuckDuckGo</strong> "
-"&gt; <strong>Check for Updates...</strong> (&quot;Meklēt "
-"atjauninājumus...&quot;) un tad <strong>Install Update</strong> "
-"(&quot;Instalēt atjauninājumu&quot;)."
+"&gt; <strong>Check for Updates...</strong> (&quot;Meklēt atjauninājumus..."
+"&quot;) un tad <strong>Install Update</strong> (&quot;Instalēt "
+"atjauninājumu&quot;)."
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -8302,6 +8505,12 @@ msgstr "Ģenerēt attēlu"
 #. Text for the button that generates more of an answer from duckassist when the answer has come from a collapsed state
 msgid "Generate More"
 msgstr "Ģenerēt vairāk"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Generate a shopping list"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
@@ -8597,10 +8806,17 @@ msgid "Give it a Try"
 msgstr "Izmēģini"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Give me a quick background on this person."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
-msgstr "Atver sadaļas %1$sPrivātums un drošība > Atrašanās vietas pakalpojumi%2$s"
+msgstr ""
+"Atver sadaļas %1$sPrivātums un drošība > Atrašanās vietas pakalpojumi%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9044,6 +9260,18 @@ msgid "Help Spread Privacy"
 msgstr "Palīdzi izplatīt privātumu"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Help me prep for the interview"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Help me tailor my resume for this job."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title of a SERP popup that invites users to take a survey (desktop only)
 msgctxt "User survey popup"
 msgid "Help us improve DuckDuckGo"
@@ -9243,8 +9471,8 @@ msgstr "Slēp savu e-pasta adresi"
 msgctxt "settings"
 msgid "Hides search term from being shown in browser tab/history"
 msgstr ""
-"Nodrošina, ka meklētais vienums netiek parādīts pārlūkprogrammas "
-"cilnē/vēsturē"
+"Nodrošina, ka meklētais vienums netiek parādīts pārlūkprogrammas cilnē/"
+"vēsturē"
 
 # smartling.placeholder_format=C
 #. The highest stock price in a day
@@ -9492,7 +9720,8 @@ msgstr "Cik daudz tu vēlies, lai parādītos MI atbalstītas atbildes?"
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
 msgctxt "Duck.ai settings usage section"
 msgid "How much of your daily and weekly limits you've used so far."
-msgstr "Cik daudz no saviem dienas un nedēļas limitiem tu esi līdz šim izmantojis."
+msgstr ""
+"Cik daudz no saviem dienas un nedēļas limitiem tu esi līdz šim izmantojis."
 
 # smartling.placeholder_format=C
 #. A header for the feedback form in the assist negative feedback flow. The user is being asked to update how often they want AI-assisted answers to appear.
@@ -9559,6 +9788,14 @@ msgstr "Viesuļvētra"
 msgctxt "Onboarding terms screen button text"
 msgid "I Agree"
 msgstr "Piekrītu"
+
+# smartling.placeholder_format=C
+#. Text for the button that takes the user to the external DuckDuckGo login subscription page.
+msgctxt ""
+"Text for the I already have a subscription button in the Duck.ai settings "
+"page"
+msgid "I Already Have a Subscription"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the button that takes the user to the login subscription page.
@@ -9641,7 +9878,8 @@ msgstr ""
 #. Option for feedback when the user needs more help or information on how to use the chat.
 msgctxt "Feedback option for difficulty in using chat"
 msgid "I need more help/info on how to use Chat"
-msgstr "Man ir nepieciešama papildu palīdzība/informācija par tērzēšanas izmantošanu"
+msgstr ""
+"Man ir nepieciešama papildu palīdzība/informācija par tērzēšanas izmantošanu"
 
 # smartling.placeholder_format=C
 msgid "IR Iran"
@@ -9728,7 +9966,8 @@ msgstr ""
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
-msgstr "Ja tu tiešām vēlies mūs atbalstīt, %1$spalīdzi popularizēt DuckDuckGo%2$s"
+msgstr ""
+"Ja tu tiešām vēlies mūs atbalstīt, %1$spalīdzi popularizēt DuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -9746,7 +9985,8 @@ msgstr ""
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "If you want, select Home Page next to New windows and New tabs (open with)."
-msgstr "Ja vēlies, nospied Sākuma lapu pie Jauna loga un Jaunas cilnes (atvērt ar)."
+msgstr ""
+"Ja vēlies, nospied Sākuma lapu pie Jauna loga un Jaunas cilnes (atvērt ar)."
 
 # smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that adds an image to the AI chat message being composed.
@@ -10136,6 +10376,12 @@ msgid "Install Mac Browser"
 msgstr "Instalēt Mac pārlūkprogrammu"
 
 # smartling.placeholder_format=C
+#. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
+msgctxt "settings"
+msgid "Install Now"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of a button to install the DuckDuckGo app
 msgctxt "Serp footer content"
 msgid "Install Our App"
@@ -10233,10 +10479,42 @@ msgid "Is deleted data really deleted?"
 msgstr "Vai dzēstie dati tiešām ir dzēsti?"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is it worth taking?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this place any good?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"Is this place any good? Summarize its reputation based on reviews and "
+"ratings."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "Is this video helpful?"
 msgstr "Vai šis video ir noderīgs?"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this worth watching?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Is this worth watching? Give me a spoiler-free take."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -10262,7 +10540,8 @@ msgstr "Tas varētu aizņemt dažas minūtes"
 #. Body text of a card that promotes installing the DuckDuckGo desktop browser.
 msgctxt "new tab page"
 msgid "It's fast, free, and gives you even more online protection."
-msgstr "Tas ir ātrs, bezmaksas un sniedz tev vēl lielāku aizsardzību tiešsaistē."
+msgstr ""
+"Tas ir ātrs, bezmaksas un sniedz tev vēl lielāku aizsardzību tiešsaistē."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -10847,6 +11126,12 @@ msgid "Links:"
 msgstr "Saites:"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "List the tools, materials, or prerequisites I need for this."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
 msgid "Listen"
 msgstr "Klausīties"
@@ -11253,6 +11538,12 @@ msgstr "Pārvaldīt savu abonementu"
 msgctxt "Exclusion message manage sites button"
 msgid "Manage blocked sites"
 msgstr "Bloķēto vietņu pārvaldība"
+
+# smartling.placeholder_format=C
+#. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
+msgctxt "setting"
+msgid "Manage in Browser Settings"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to the site exclusion settings page
@@ -11704,7 +11995,8 @@ msgstr "Tu esi sasniedzis mēneša limitu"
 #. Displayed when the user has reached a fixed monthly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Monthly usage limit reached. You can continue this chat after %s."
-msgstr "Sasniegts mēneša lietošanas limits. Tu varēsi turpināt šo tērzēšanu pēc %1$s."
+msgstr ""
+"Sasniegts mēneša lietošanas limits. Tu varēsi turpināt šo tērzēšanu pēc %1$s."
 
 # smartling.placeholder_format=C
 #. Used to point to additional social networking profiles (in results).
@@ -12570,7 +12862,8 @@ msgstr "Tikai meklēšana – bez izsekošanas un mērķētas reklāmas!"
 #. Refers to how web searches on DuckDuckGo aren't tracked.
 msgctxt "homepage onboarding"
 msgid "No tracking, no ad targeting, just searching."
-msgstr "Tikai meklēšana, bez izsekošanas, bez reklāmas mērķauditorijas atlases."
+msgstr ""
+"Tikai meklēšana, bez izsekošanas, bez reklāmas mērķauditorijas atlases."
 
 # smartling.placeholder_format=C
 #. Indicates that there were no search results for a user's search. The placeholder is the user's search term. For example: 'No videos found for 'bad dogs''
@@ -13190,7 +13483,8 @@ msgstr "Atver %1$sIestatījumi%2$s"
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open 'Location', and ensure location is %senabled%s."
-msgstr "Atver opciju “Atrašanās vieta” un pārliecinies, ka tā ir %1$siespējota%2$s."
+msgstr ""
+"Atver opciju “Atrašanās vieta” un pārliecinies, ka tā ir %1$siespējota%2$s."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -14072,7 +14366,8 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this prompt was made by a "
 "human."
-msgstr "Lūdzu, izpildi uzdevumu, lai apstiprinātu, ka šo vaicājumu veic cilvēks."
+msgstr ""
+"Lūdzu, izpildi uzdevumu, lai apstiprinātu, ka šo vaicājumu veic cilvēks."
 
 # smartling.placeholder_format=C
 #. Bot challenge explanation
@@ -14080,7 +14375,14 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this search was made by a "
 "human."
-msgstr "Lūdzu, izpildi šo uzdevumu, lai apstiprinātu, ka meklēšanu veic cilvēks."
+msgstr ""
+"Lūdzu, izpildi šo uzdevumu, lai apstiprinātu, ka meklēšanu veic cilvēks."
+
+# smartling.placeholder_format=C
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
+msgctxt "Feedback prompt"
+msgid "Please describe why the chat response is harmful or illegal. (optional)"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
@@ -14111,6 +14413,14 @@ msgid ""
 msgstr ""
 "Lūdzu, ņem vērā: uzsākot jaunu tērzēšanu ar jebkuru modeli, tava pašreizējā "
 "tērzēšanas sesija tiks dzēsta."
+
+# smartling.placeholder_format=C
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
+msgctxt "Feedback prompt"
+msgid ""
+"Please paste your prompt and the problematic output (with any personal "
+"information removed) and describe why the content is harmful or illegal."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -14272,7 +14582,8 @@ msgstr "Plus vēl citas premium funkcijas ar DuckDuckGo abonementu."
 msgid ""
 "Plus, what you watch in Duck Player won’t influence your recommendations on "
 "YouTube."
-msgstr "Turklāt tas, ko tu skaties Duck Player, neietekmē tavus ieteikumus YouTube."
+msgstr ""
+"Turklāt tas, ko tu skaties Duck Player, neietekmē tavus ieteikumus YouTube."
 
 # smartling.placeholder_format=C
 #. A link to the Substack page (https://insideduckduckgo.substack.com/?showWelcome=true)
@@ -14578,6 +14889,12 @@ msgid "Privacy"
 msgstr "Privātums"
 
 # smartling.placeholder_format=C
+#. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
+msgctxt "Section heading on the Duck.ai settings page"
+msgid "Privacy & Terms"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Privacy Blog"
 msgstr "Privātuma blogs"
 
@@ -14646,6 +14963,12 @@ msgstr "Privātuma politika un Lietošanas noteikumi"
 msgctxt "Copy used to compose link in sentences"
 msgid "Privacy Policy and Terms of Service"
 msgstr "Privātuma politika un Pakalpojumu sniegšanas noteikumi"
+
+# smartling.placeholder_format=C
+#. Text for a button that links to the terms of use and privacy policy page.
+msgctxt "Secondary button text in active privacy modal"
+msgid "Privacy Policy and Terms of Service"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title displayed on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
@@ -14839,7 +15162,8 @@ msgstr "Aizsargā savus datus meklēšanas un pārlūkošanas laikā."
 #. Shown on the Mac and Windows browser promo cards. DuckDuckGo's desktop browser protects your data across search, browsing, and AI chat.
 msgctxt "SERP footer content"
 msgid "Protect your data as you search, browse, and use AI."
-msgstr "Aizsargā savus datus, meklējot, pārlūkojot un izmantojot mākslīgo intelektu."
+msgstr ""
+"Aizsargā savus datus, meklējot, pārlūkojot un izmantojot mākslīgo intelektu."
 
 # smartling.placeholder_format=C
 #. A title above links to download the DuckDuckGo apps.
@@ -15150,6 +15474,30 @@ msgid "Recommend a book"
 msgstr "Iesaki kādu grāmatu"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar books"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar books."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar movies or shows."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar titles"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
 msgid "Recording failed. Please try again."
 msgstr "Ierakstīšana neizdevās. Lūdzu, mēģini vēlreiz."
@@ -15373,7 +15721,8 @@ msgstr "Atcerēties manu izvēli"
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings
 msgid "Remember my choice (this can be changed in %s%s%sSettings%s)"
-msgstr "Atcerēties manu izvēli (to var mainīt sadaļā %1$s%2$s%3$sIestatījumi%4$s)"
+msgstr ""
+"Atcerēties manu izvēli (to var mainīt sadaļā %1$s%2$s%3$sIestatījumi%4$s)"
 
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
@@ -15550,6 +15899,15 @@ msgstr ""
 # smartling.placeholder_format=C
 msgid "Republic of Moldova"
 msgstr "Moldova"
+
+# smartling.placeholder_format=C
+#. Note indicating that sharing the conversation is mandatory when reporting harmful or illegal content. Rendered alongside the standard share label (DUCKCHAT_RESPONSE_FEEDBACK_SHARE_PROMPT_RESPONSE_LABEL), not replacing it.
+msgctxt ""
+"Note shown under the share-content switch label on the Duck.ai response "
+"feedback form when the user has selected Harmful or Illegal as the feedback "
+"reason"
+msgid "Required for harmful or illegal reports"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
@@ -15788,6 +16146,12 @@ msgstr "Atsauksmes"
 msgctxt "maps_places"
 msgid "Reviews"
 msgstr "Atsauksmes"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Rewrite this recipe scaled for a different number of servings."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Romania"
@@ -16234,7 +16598,8 @@ msgstr "Ritini uz leju un sarakstā atrodi %1$ssavu pārlūkprogrammu%2$s."
 #. Tells users which setting to change to enable location service.
 msgctxt "precise_user_location"
 msgid "Scroll down to %sDuckDuckGo%s and allow it to use your location."
-msgstr "Ritini uz leju līdz %1$sDuckDuckGo%2$s un ļauj izmantot savu atrašanās vietu."
+msgstr ""
+"Ritini uz leju līdz %1$sDuckDuckGo%2$s un ļauj izmantot savu atrašanās vietu."
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -16740,7 +17105,8 @@ msgstr "Apskati dažus no mūsu pēdējiem atjauninājumiem"
 #. Link to a page with more information about how user settings are stored in a URL.
 msgctxt "settings"
 msgid "See the %sURL Parameter Reference page%s for more details."
-msgstr "Apskati %1$sURL parametru uzziņas lapa%2$s, lai iegūtu vairāk informācijas."
+msgstr ""
+"Apskati %1$sURL parametru uzziņas lapa%2$s, lai iegūtu vairāk informācijas."
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the context menu of a chat in chat history, that allows the user to select the chat and begin batch selection mode.
@@ -16774,18 +17140,20 @@ msgstr "Safari izvēlnē atlasi %1$s“Šīs vietnes iestatījumi...”%2$s."
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
 msgstr ""
-"Atlasi %1$sPielāgots%2$s un ievades laukā raksti "
-"%3$shttps://duckduckgo.com%4$s"
+"Atlasi %1$sPielāgots%2$s un ievades laukā raksti %3$shttps://duckduckgo."
+"com%4$s"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
-msgstr "Atlasi %1$sDuckDuckGo%2$s un noklikšķini uz %3$sPievienot kā noklusējumu%4$s!"
+msgstr ""
+"Atlasi %1$sDuckDuckGo%2$s un noklikšķini uz %3$sPievienot kā noklusējumu%4$s!"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s"
-msgstr "Atlasi %1$sDuckDuckGo%2$s un noklikšķini uz %3$sIestatīt kā noklusējumu%4$s"
+msgstr ""
+"Atlasi %1$sDuckDuckGo%2$s un noklikšķini uz %3$sIestatīt kā noklusējumu%4$s"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
@@ -16797,7 +17165,8 @@ msgstr "Atlasi %1$sDuckDuckGo%2$s un nospied %3$sIestatīt kā noklusējumu%4$s.
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Select %sDuckDuckGo%s in the Default Search Engine drop down"
-msgstr "Noklusējuma meklētājprogrammas nolaižamajā izvēlnē atlasi %1$sDuckDuckGo%2$s"
+msgstr ""
+"Noklusējuma meklētājprogrammas nolaižamajā izvēlnē atlasi %1$sDuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
@@ -16817,7 +17186,8 @@ msgstr "Meklēšanas pakalpojumu sniedzēju sarakstā atlasi %1$sDuckDuckGo%2$s"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s under the%sDefault Search Engine%s section"
-msgstr "Sadaļā%3$sNoklusējuma meklētājprogramma%4$s izvēlies %1$sDuckDuckGo%2$s"
+msgstr ""
+"Sadaļā%3$sNoklusējuma meklētājprogramma%4$s izvēlies %1$sDuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. Tells the user were in the settings menu they can change their default search engine.
@@ -16850,7 +17220,8 @@ msgstr ""
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sOpera > Options%s (on Windows)"
-msgstr "Atver %1$sOpera > Preferences%2$s (Mac) vai %3$sOpera > Opcijas%4$s (Windows)"
+msgstr ""
+"Atver %1$sOpera > Preferences%2$s (Mac) vai %3$sOpera > Opcijas%4$s (Windows)"
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -17119,6 +17490,12 @@ msgid "Set Up Now"
 msgstr "Iestati tagad"
 
 # smartling.placeholder_format=C
+#. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
+msgctxt "Encrypted storage setup button shown in native browsers"
+msgid "Set Up Sync & Backup"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
 msgctxt "Title for the Sync & Backup intro screen"
 msgid "Set Up Sync & Backup"
@@ -17298,6 +17675,13 @@ msgstr "Kopīgo lapas URL"
 msgctxt "feedback form"
 msgid "Share positive feedback"
 msgstr "Sniegt pozitīvu atsauksmi"
+
+# smartling.placeholder_format=C
+#. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
+msgctxt ""
+"Label beside the share-content switch on the Duck.ai response feedback form"
+msgid "Share this conversation with DuckDuckGo"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -17682,7 +18066,8 @@ msgstr "Parāda horizontālas līnijas rezultātu lapu pārtraukumos"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows links to instructions for how to add DuckDuckGo to your browser"
-msgstr "Parāda saites uz instrukcijām, kā pievienot DuckDuckGo savai pārlūkprogrammai"
+msgstr ""
+"Parāda saites uz instrukcijām, kā pievienot DuckDuckGo savai pārlūkprogrammai"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers more frequently.
@@ -17703,7 +18088,8 @@ msgstr "Ik pa laikam rāda atgādinājumus par DuckDuckGo pievienošanu pārlūk
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr "Ik pa laikam rāda atgādinājumus par DuckDuckGo pievienošanu tavām ierīcēm"
+msgstr ""
+"Ik pa laikam rāda atgādinājumus par DuckDuckGo pievienošanu tavām ierīcēm"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -17965,13 +18351,15 @@ msgstr "Kaut kas notika nepareizi"
 #. Error message indicating that the user's settings weren't able to be saved.
 msgctxt "cloudsave"
 msgid "Something went wrong saving to the server, please try again."
-msgstr "Kaut kas nogāja greizi, mēģinot saglabāt serverī, lūdzu, mēģini vēlreiz."
+msgstr ""
+"Kaut kas nogāja greizi, mēģinot saglabāt serverī, lūdzu, mēģini vēlreiz."
 
 # smartling.placeholder_format=C
 #. Body copy displayed under the Set Up Now button when the sync setup call fails.
 msgctxt "Generic error shown when sync setup fails"
 msgid "Something went wrong while enabling Sync & Backup. Please try again."
-msgstr "Kaut kas nogāja greizi, iespējojot Sync & Backup. Lūdzu, mēģini vēlreiz."
+msgstr ""
+"Kaut kas nogāja greizi, iespējojot Sync & Backup. Lūdzu, mēģini vēlreiz."
 
 # smartling.placeholder_format=C
 #. Displayed when the voice chat session ends with an unknown error.
@@ -18052,8 +18440,8 @@ msgstr ""
 msgid ""
 "Sorry, we couldn't generate a richer answer. You can try asking Duck.ai."
 msgstr ""
-"Atvaino, mēs nevarējām sniegt plašāku atbildi. Tu vari mēģināt jautāt "
-"Duck.ai."
+"Atvaino, mēs nevarējām sniegt plašāku atbildi. Tu vari mēģināt jautāt Duck."
+"ai."
 
 # smartling.placeholder_format=C
 #. Inform the users that "something" went wrong and that they could try to refresh the page to resolve the error. Placeholders are for markup, please ignore.
@@ -18069,7 +18457,8 @@ msgstr ""
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr "Diemžēl mums neizdevās iesniegt tavu atsauksmi. Lūdzu, mēģini vēlreiz vēlāk."
+msgstr ""
+"Diemžēl mums neizdevās iesniegt tavu atsauksmi. Lūdzu, mēģini vēlreiz vēlāk."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -18324,19 +18713,22 @@ msgstr "Paliec DuckDuckGo platformā"
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletter."
-msgstr "Lasi mūsu privātuma informatīvos ziņojumus savai drošībai un informētībai."
+msgstr ""
+"Lasi mūsu privātuma informatīvos ziņojumus savai drošībai un informētībai."
 
 # smartling.placeholder_format=C
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletters."
-msgstr "Lasi mūsu privātuma informatīvos ziņojumus savai drošībai un informētībai."
+msgstr ""
+"Lasi mūsu privātuma informatīvos ziņojumus savai drošībai un informētībai."
 
 # smartling.placeholder_format=C
 #. Text on the page where users can subscribe to DuckDuckGo's privacy newsletter
 msgctxt "showcase_newsletter"
 msgid "Stay protected and informed with our privacy newsletters."
-msgstr "Lasi mūsu privātuma informatīvos ziņojumus savai drošībai un informētībai."
+msgstr ""
+"Lasi mūsu privātuma informatīvos ziņojumus savai drošībai un informētībai."
 
 # smartling.placeholder_format=C
 #. Loading message shown when image generation is taking longer than usual.
@@ -18538,13 +18930,32 @@ msgctxt "Full sentence for composing a card"
 msgid ""
 "Suggest a phrase to write on a get-well card for someone recovering from a "
 "surgery?"
-msgstr "Iesaki frāzi, ko uzrakstīt uz kartītes kādam, kurš atveseļojas pēc operācijas"
+msgstr ""
+"Iesaki frāzi, ko uzrakstīt uz kartītes kādam, kurš atveseļojas pēc operācijas"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for asking for a suggestion of a blog post title.
 msgctxt "Brief for suggesting a blog post title"
 msgid "Suggest a title for a blog post"
 msgstr "Iesaki nosaukumu bloga ierakstam"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest related articles or topics worth exploring next."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Suggest related articles to explore"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest some alternatives to this product."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
@@ -18558,10 +18969,100 @@ msgid "Suggestions:"
 msgstr "Ieteikumi:"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Sum up the reviews"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A short title for the a message asking the AI to summarize a text.
 msgctxt "Title for the summarize message"
 msgid "Summarize"
 msgstr "Apkopotājs"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize the Q&As"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the background and notable work of this person."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the key details of this event."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the questions and answers on this page."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize their background"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this book"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this book."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this discussion"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this discussion thread."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this page"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this page."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this video"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this video."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize what the reviews say."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -18888,6 +19389,12 @@ msgid "Syria"
 msgstr "Sīrija"
 
 # smartling.placeholder_format=C
+#. Text for a button that enables the theme to follow the operating system's color scheme preference.
+msgctxt "System theme button for theme selector"
+msgid "System"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Abbreviation indicating this is the total score for a game
 msgctxt "Sports module"
 msgid "T"
@@ -18914,6 +19421,12 @@ msgstr "TV"
 msgctxt "language_name"
 msgid "Tahitian"
 msgstr "Taitiešu"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Tailor my resume"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Taiwan"
@@ -18943,6 +19456,13 @@ msgstr "Esi noteicējs pār saviem personīgajiem datiem"
 msgctxt "homepage ATB modal"
 msgid "Take control of your personal data!"
 msgstr "Esi noteicējs pār saviem personīgajiem datiem!"
+
+# smartling.placeholder_format=C
+#. Description for the Feedback section of the Duck.ai settings page, asking the user to take an anonymous survey to let us know how we can make Duck.ai better.
+msgctxt "Feedback section description on the Duck.ai settings page"
+msgid ""
+"Take this anonymous survey to let us know how we can make Duck.ai better."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -19248,6 +19768,12 @@ msgstr "Radās servera kļūda, tāpēc mēs nevarējām pabeigt tavu pieprasīj
 #. https://duck.co/media/files/theme.png
 msgid "Theme"
 msgstr "Motīvs"
+
+# smartling.placeholder_format=C
+#. Text for the theme selector label that allows users to switch between Light and dark theme.
+msgctxt "Label for the theme selector feature"
+msgid "Theme"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/LpFhb1e.png
@@ -19902,7 +20428,8 @@ msgstr "Pārāk daudz reklāmu"
 #. Displayed when the user has sent too many requests in a short period of time.
 msgctxt "Error message for rate limit"
 msgid "Too many requests. Please take a short break and try again."
-msgstr "Pārāk daudz pieprasījumu. Lūdzu, paņem nelielu pārtraukumu un mēģini vēlreiz."
+msgstr ""
+"Pārāk daudz pieprasījumu. Lūdzu, paņem nelielu pārtraukumu un mēģini vēlreiz."
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -20091,6 +20618,18 @@ msgstr ""
 "kinoteātrim?”"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Translate this page"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
+msgctxt "Page suggestion prompt"
+msgid "Translate this page into %s."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text for a region that will display translated text.
 msgctxt "translations_module"
 msgid "Translation"
@@ -20232,6 +20771,12 @@ msgid "Try Free"
 msgstr "Izmēģini bez maksas"
 
 # smartling.placeholder_format=C
+#. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
+msgctxt "settings"
+msgid "Try It Now"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
 msgctxt "Promotional CTA for new AI models"
 msgid "Try Now"
@@ -20295,7 +20840,8 @@ msgstr ""
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
 msgctxt "precise_user_location"
 msgid "Try enabling anonymous location for more accurate results."
-msgstr "Lai iegūtu precīzākus rezultātus, pamēģini iespējot anonīmu atrašanās vietu."
+msgstr ""
+"Lai iegūtu precīzākus rezultātus, pamēģini iespējot anonīmu atrašanās vietu."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the screen of the onboarding where the user picks a chat model.
@@ -20468,6 +21014,22 @@ msgid "Trying DuckDuckGo again"
 msgstr "Vēlreiz izmēģinu DuckDuckGo"
 
 # smartling.placeholder_format=C
+#. Message shown in a modal after supported third-party browser users disable AI features in Settings. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
 msgctxt "Assistant response placeholder"
 msgid "Trying with %s"
@@ -20586,7 +21148,8 @@ msgstr "Lai iegūtu precīzākus rezultātus, ieslēdz “Precīza atrašanās v
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on “Use precise location” for more accurate results."
-msgstr "Lai iegūtu precīzākus rezultātus, ieslēdz “Izmantot precīzu atrašanās vietu”."
+msgstr ""
+"Lai iegūtu precīzākus rezultātus, ieslēdz “Izmantot precīzu atrašanās vietu”."
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Create Image' label in the Tools dropdown.
@@ -20737,7 +21300,8 @@ msgstr "Nevar iesniegt atsauksmi"
 #. Message shown to the user when the voice chat failed to establish a connection, and they should try again later.
 msgctxt "voice chat"
 msgid "Unable to connect to voice chat, please try again later."
-msgstr "Nevar izveidot savienojumu ar balss tērzēšanu. Lūdzu, vēlāk mēģini vēlreiz. "
+msgstr ""
+"Nevar izveidot savienojumu ar balss tērzēšanu. Lūdzu, vēlāk mēģini vēlreiz. "
 
 # smartling.placeholder_format=C
 #. Message shown to the user when there was an issue connecting to their microphone.
@@ -20778,8 +21342,8 @@ msgstr ""
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
 msgstr ""
-"Sadaļā %1$sPie palaišanas%2$s atlasi %3$sMājaslapa%4$s un ievadi: "
-"https://duckduckgo.com"
+"Sadaļā %1$sPie palaišanas%2$s atlasi %3$sMājaslapa%4$s un ievadi: https://"
+"duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -20805,13 +21369,15 @@ msgstr "Zem %1$sMeklēt adreses joslā ar%2$s nospied %3$sPievienot jaunu%4$s"
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
-msgstr "Zem %1$sMeklēt%2$s sekcijas nospied %3$sPārvaldīt meklējumprogrammas...%4$s"
+msgstr ""
+"Zem %1$sMeklēt%2$s sekcijas nospied %3$sPārvaldīt meklējumprogrammas...%4$s"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under On startup select %sOpen a specific page or set of pages%s"
-msgstr "Sadaļā \"Pie palaišanas\" atlasi %1$sAtvērt noteiktu lapu vai lapu kopu%2$s"
+msgstr ""
+"Sadaļā \"Pie palaišanas\" atlasi %1$sAtvērt noteiktu lapu vai lapu kopu%2$s"
 
 #  Opera default search engine instruction
 # smartling.placeholder_format=C
@@ -20919,7 +21485,8 @@ msgstr "Atbloķē ar DuckDuckGo abonementu"
 msgctxt "voice chat limit modal"
 msgid ""
 "Unlock advanced AI models and higher limits with a DuckDuckGo Subscription"
-msgstr "Atbloķē uzlabotus MI modeļus un augstākas robežas ar DuckDuckGo abonementu"
+msgstr ""
+"Atbloķē uzlabotus MI modeļus un augstākas robežas ar DuckDuckGo abonementu"
 
 # smartling.placeholder_format=C
 #. Text informing the user that advanced AI models can be unlocked with a subscription. The variable is used to insert a link that opens the subscription modal. Example: Unlock advanced AI models with a DuckDuckGo subscription.
@@ -21218,6 +21785,12 @@ msgid "Uruguay"
 msgstr "Urugvaja"
 
 # smartling.placeholder_format=C
+#. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
+msgctxt "Navigation label on the Duck.ai settings page"
+msgid "Usage"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A feedback suggestion
 msgctxt "Feedback prompt"
 msgid "Usage limit"
@@ -21310,7 +21883,8 @@ msgstr ""
 #. Prompt to ask the user if they want to use their approximate location for more accurate results
 msgctxt "DuckChat location prompt"
 msgid "Use your approximate location for more accurate results?"
-msgstr "Vai izmantot aptuveno atrašanās vietu, lai iegūtu precīzākus rezultātus?"
+msgstr ""
+"Vai izmantot aptuveno atrašanās vietu, lai iegūtu precīzākus rezultātus?"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes before every user message in the downloaded file, indicating which message it is out of the total number of messages. Example: 'User prompt 3 of 5'
@@ -21549,8 +22123,8 @@ msgid ""
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
 msgstr ""
-"Apmeklē Duck.ai citā pārlūkprogrammā vai DuckDuckGo lietotnē un atver "
-"Duck.ai iestatījumus. Sadaļā “Sync & Backup” izvēlies “Ieslēgt” un tad "
+"Apmeklē Duck.ai citā pārlūkprogrammā vai DuckDuckGo lietotnē un atver Duck."
+"ai iestatījumus. Sadaļā “Sync & Backup” izvēlies “Ieslēgt” un tad "
 "“Sinhronizēt ar citu ierīci”. Vai arī noskenē kvadrātkodu savā atkopšanas "
 "PDF failā."
 
@@ -21665,6 +22239,12 @@ msgstr "Gaida atrašanās vietu..."
 # smartling.placeholder_format=C
 msgid "Wales"
 msgstr "Velsa"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Walk me through the steps"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for walking directions on a map.
@@ -21786,6 +22366,17 @@ msgstr ""
 "rezultātus."
 
 # smartling.placeholder_format=C
+#. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
+msgctxt ""
+"Inline warning shown below the share-content toggle when the user selects "
+"Harmful or Illegal but has not enabled sharing"
+msgid ""
+"We can only fix what we can see. To report a harmful or illegal response, "
+"please share this conversation with DuckDuckGo so we can investigate and "
+"address the issue."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
 msgctxt ""
 "Inline warning shown below the share-content toggle when the user selects "
@@ -21812,7 +22403,8 @@ msgstr ""
 msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
-msgstr "Mēs nevaram nolasīt pievienotos failus, jo vismaz viens no tiem ir šifrēts."
+msgstr ""
+"Mēs nevaram nolasīt pievienotos failus, jo vismaz viens no tiem ir šifrēts."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -21828,7 +22420,8 @@ msgstr "Mēs neglabājam lietotājvārdus un personu identificējošu informāci
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don't store your personal info or track you. Ever."
-msgstr "Mēs neuzglabājam tavu personisko informāciju un neizsekojam tevi. Nekad."
+msgstr ""
+"Mēs neuzglabājam tavu personisko informāciju un neizsekojam tevi. Nekad."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -21951,7 +22544,8 @@ msgstr "Mēs zaudējām savienojumu, lūdzu, vēlāk mēģini vēlreiz."
 #. We store chats for 15 minutes in the BE. If the user tries to fetch it after the 15 minutes elapsed or if we had an issue saving it we show them this error message so they can re-submit their prompt.
 msgctxt "AI Chat: Error message for unsaved or expired chats saved in sync"
 msgid "We lost the connection. Please try sending your message again."
-msgstr "Mēs pazaudējām savienojumu. Lūdzu, mēģini nosūtīt savu ziņojumu vēlreiz."
+msgstr ""
+"Mēs pazaudējām savienojumu. Lūdzu, mēģini nosūtīt savu ziņojumu vēlreiz."
 
 # smartling.placeholder_format=C
 #. Message asking the user to disable their ad blocker, with a link to how our ads don't track you. The placeholders are for the start and end tags of that link (e.g. <a href="%">, </a>)
@@ -21983,7 +22577,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We stop anyone from getting your search history, including us."
-msgstr "Mēs neļaujam nevienam piekļūt tavai meklēšanas vēsturei – to nevaram arī mēs."
+msgstr ""
+"Mēs neļaujam nevienam piekļūt tavai meklēšanas vēsturei – to nevaram arī mēs."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -22202,7 +22797,8 @@ msgstr ""
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai! You can now import your downloaded chats."
-msgstr "Laipni lūdzam jaunajā Duck.ai! Tagad vari importēt lejupielādētās sarakstes."
+msgstr ""
+"Laipni lūdzam jaunajā Duck.ai! Tagad vari importēt lejupielādētās sarakstes."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -22338,6 +22934,103 @@ msgstr ""
 "mākslīgā intelekta vai tehniskas pieredzes."
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the counterarguments?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the hours & location?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key contributions of this paper?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key contributions?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key details?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key points covered in this video?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key points?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key takeaways from this article?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key takeaways?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key things I will learn from this course?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main counterarguments or criticisms of this?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main questions this page answers?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the must-try dishes here?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"What are the opening hours, location, and contact details for this place?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the pros and cons of this product?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the pros and cons?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
 msgctxt "feedback form"
 msgid "What bothered you most?"
@@ -22438,6 +23131,12 @@ msgid "What does atria mean in the context of a medical article?"
 msgstr "Ko nozīmē \"atria\" medicīniska raksta kontekstā?"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What does this answer?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
@@ -22448,6 +23147,12 @@ msgstr "Kādu funkciju tu vēlētos, lai mēs pievienotu? (pēc izvēles)"
 msgctxt "cloudsave"
 msgid "What information gets saved?"
 msgstr "Kāda informācija tiek saglabāta?"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What interview questions might come up for this role?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -22464,6 +23169,12 @@ msgstr ""
 msgctxt "Full sentence for looking up basic facts"
 msgid "What is the capital city of Albania?"
 msgstr "Kas ir Albānijas galvaspilsēta?"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What is the overall verdict and rating for this?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to a page with additional information.
@@ -22488,6 +23199,12 @@ msgid "What people say:"
 msgstr "Ko saka citi:"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What should I order?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
 msgctxt "feedback form"
 msgid "What stood out?"
@@ -22500,6 +23217,18 @@ msgid "What was wrong with the response? (optional)"
 msgstr "Kas bija nepareizi ar atbildi? (Neobligāti)"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I learn?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I need?"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid "What would you like to provide feedback on?"
 msgstr "Par ko tu vēlētos sniegt atsauksmes?"
@@ -22508,13 +23237,20 @@ msgstr "Par ko tu vēlētos sniegt atsauksmes?"
 #. Explains the benefits of using our custom video player, the Duck Player
 msgid ""
 "What you watch in DuckDuckGo won't influence your recommendations on YouTube."
-msgstr "Tas, ko skaties DuckDuckGo, neietekmēs tavus ieteikumus pakalpojumā YouTube."
+msgstr ""
+"Tas, ko skaties DuckDuckGo, neietekmēs tavus ieteikumus pakalpojumā YouTube."
 
 # smartling.placeholder_format=C
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
 msgctxt "SERP footer content"
 msgid "What's New"
 msgstr "Kas jauns"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What's the verdict?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -22567,6 +23303,12 @@ msgid "Which features are missing? (Optional)"
 msgstr "Kādas funkcijas trūkst? (Neobligāti)"
 
 # smartling.placeholder_format=C
+#. An invitation for users to leave feedback
+msgctxt "Feedback prompt"
+msgid "Which features are missing? (optional)"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
 msgid "White"
 msgstr "Balts"
@@ -22581,6 +23323,18 @@ msgstr "Balts"
 #. Link to an about us page.
 msgid "Who We Are"
 msgstr "Kas mēs esam"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Who are the main cast and crew, and what else are they known for?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Who is this person?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Header above a collection of privacy-related links.
@@ -22951,7 +23705,8 @@ msgstr "Jā, jauns lietotājs!"
 msgctxt "cloudsave"
 msgid ""
 "Yes, we throw away data when you’re done with it, and it cannot be recovered."
-msgstr "Jā, mēs izmetam datus, kad tu beidz ar tiem darboties, un tos nevar atgūt."
+msgstr ""
+"Jā, mēs izmetam datus, kad tu beidz ar tiem darboties, un tos nevar atgūt."
 
 # smartling.placeholder_format=C
 #. Option for the filter-by-date search.
@@ -23075,7 +23830,8 @@ msgstr "Šo atgādinājumu varat paslēpt sadaļā %1$sMeklēšanas iestatījumi
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
-msgstr "Tagad šajā ierīcē vari saglabāt līdz pat 100 tērzēšanas sarunām. Tērzē!"
+msgstr ""
+"Tagad šajā ierīcē vari saglabāt līdz pat 100 tērzēšanas sarunām. Tērzē!"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -23242,7 +23998,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
 msgid "You won't see this message again unless you clear your browser data."
-msgstr "Tu vairs neredzēsi šo ziņojumu, ja vien nenotīrīsi pārlūkprogrammas datus."
+msgstr ""
+"Tu vairs neredzēsi šo ziņojumu, ja vien nenotīrīsi pārlūkprogrammas datus."
 
 # smartling.placeholder_format=C
 #. The second paragraph of a pop up where we explain how to update the browser manually.
@@ -23339,7 +24096,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
 msgid "You've reached your dictation usage limit. Try again later."
-msgstr "Tu esi sasniedzis diktēšanas lietošanas ierobežojumu. Mēģini vēlreiz vēlāk."
+msgstr ""
+"Tu esi sasniedzis diktēšanas lietošanas ierobežojumu. Mēģini vēlreiz vēlāk."
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -23500,7 +24258,8 @@ msgstr ""
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never used to train AI models"
-msgstr "Tava tērzēšana ir privāta, un tā nekad netiek izmantota MI modeļu apmācībai"
+msgstr ""
+"Tava tērzēšana ir privāta, un tā nekad netiek izmantota MI modeļu apmācībai"
 
 # smartling.placeholder_format=C
 #. Text for a description of the active privacy protection for DuckDuckGo's AI Chat feature.
@@ -23771,7 +24530,8 @@ msgstr ""
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
 msgctxt "voice chat limit modal"
 msgid "You’ve reached the voice chat limit for now. Please try again later."
-msgstr "Tu esi sasniedzis balss tērzēšanas ierobežojumu. Lūdzu, vēlāk mēģini vēlreiz."
+msgstr ""
+"Tu esi sasniedzis balss tērzēšanas ierobežojumu. Lūdzu, vēlāk mēģini vēlreiz."
 
 # smartling.placeholder_format=C
 #. The name of the Yucatec Maya language
@@ -24069,7 +24829,8 @@ msgstr "oficiālā vietne"
 #. <em>%s</em> is for a hexadecimal color code as <em>#395323</em>, but it has to be safe encoded, and as <em>#</em> seems not safe, <em>%23</em> must be used in place of the sharp symbol, but they are the same for your browser.
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
-msgstr "vai uzraksti krāsas kodu pats, piemēram, %1$s (%2$s ir %3$s zīmes kods)."
+msgstr ""
+"vai uzraksti krāsas kodu pats, piemēram, %1$s (%2$s ir %3$s zīmes kods)."
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "

--- a/locales/lv_LV/LC_MESSAGES/duckduckgo.po
+++ b/locales/lv_LV/LC_MESSAGES/duckduckgo.po
@@ -19750,7 +19750,7 @@ msgstr "Motīvs"
 #. Text for the theme selector label that allows users to switch between Light and dark theme.
 msgctxt "Label for the theme selector feature"
 msgid "Theme"
-msgstr "Dizains"
+msgstr "Motīvs"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/LpFhb1e.png

--- a/locales/ml_IN/LC_MESSAGES/duckduckgo.po
+++ b/locales/ml_IN/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: ml_IN\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -176,8 +176,9 @@ msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
 msgstr ""
-"Pro-യുടെ ഒപ്പം മാത്രമേ %1$s ലഭ്യമാകൂ. ചാറ്റ് തുടരാൻ ഈ ബ്രൗസറിൽ നിങ്ങളുടെ DuckDuckGo "
-"സബ്‌സ്‌ക്രിപ്‌ഷൻ വീണ്ടും അപ്‌ഗ്രേഡ് ചെയ്യുക, അല്ലെങ്കിൽ Plus അല്ലെങ്കിൽ സൗജന്യ മോഡലിലേക്ക് മാറുക."
+"Pro-യുടെ ഒപ്പം മാത്രമേ %1$s ലഭ്യമാകൂ. ചാറ്റ് തുടരാൻ ഈ ബ്രൗസറിൽ നിങ്ങളുടെ "
+"DuckDuckGo സബ്‌സ്‌ക്രിപ്‌ഷൻ വീണ്ടും അപ്‌ഗ്രേഡ് ചെയ്യുക, അല്ലെങ്കിൽ Plus "
+"അല്ലെങ്കിൽ സൗജന്യ മോഡലിലേക്ക് മാറുക."
 
 # smartling.placeholder_format=C
 #. Text for the disclaimer message that appears when a Plus subscriber tries to use a Pro-only model. %s is replaced with the model name. Example: Claude Opus 4.6 is only available with Pro. Upgrade your DuckDuckGo subscription in this browser again to continue the chat, or switch to a Plus or free model.
@@ -187,8 +188,9 @@ msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
 msgstr ""
-"Pro-യുടെ ഒപ്പം മാത്രമേ %1$s ലഭ്യമാകൂ. ചാറ്റ് തുടരാൻ ഈ ബ്രൗസറിൽ നിങ്ങളുടെ DuckDuckGo "
-"സബ്‌സ്‌ക്രിപ്‌ഷൻ വീണ്ടും അപ്‌ഗ്രേഡ് ചെയ്യുക, അല്ലെങ്കിൽ Plus അല്ലെങ്കിൽ സൗജന്യ മോഡലിലേക്ക് മാറുക."
+"Pro-യുടെ ഒപ്പം മാത്രമേ %1$s ലഭ്യമാകൂ. ചാറ്റ് തുടരാൻ ഈ ബ്രൗസറിൽ നിങ്ങളുടെ "
+"DuckDuckGo സബ്‌സ്‌ക്രിപ്‌ഷൻ വീണ്ടും അപ്‌ഗ്രേഡ് ചെയ്യുക, അല്ലെങ്കിൽ Plus "
+"അല്ലെങ്കിൽ സൗജന്യ മോഡലിലേക്ക് മാറുക."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI (Artificial Intelligence) chat model is temporarily unavailable. Example: 'GPT 4o is only available with a DuckDuckGo subscription.'
@@ -204,8 +206,9 @@ msgid ""
 "subscription in this browser again to continue the chat, or switch to a free "
 "model."
 msgstr ""
-"%1$s DuckDuckGo സബ്‌സ്‌ക്രിപ്‌ഷനോടൊപ്പം മാത്രമേ ലഭ്യമാകൂ. ഈ ബ്രൗസറിൽ ചാറ്റ് തുടരാൻ, നിങ്ങളുടെ "
-"സബ്സ്ക്രിപ്ഷൻ വീണ്ടും സജീവമാക്കുക, അല്ലെങ്കിൽ ഒരു സൗജന്യ മോഡലിലേക്ക് മാറുക."
+"%1$s DuckDuckGo സബ്‌സ്‌ക്രിപ്‌ഷനോടൊപ്പം മാത്രമേ ലഭ്യമാകൂ. ഈ ബ്രൗസറിൽ ചാറ്റ് "
+"തുടരാൻ, നിങ്ങളുടെ സബ്സ്ക്രിപ്ഷൻ വീണ്ടും സജീവമാക്കുക, അല്ലെങ്കിൽ ഒരു സൗജന്യ "
+"മോഡലിലേക്ക് മാറുക."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is temporarily unavailable. Example: 'GPT 3.5 Turbo is temporarily unavailable. Please switch to a different model or try again later.'
@@ -214,8 +217,8 @@ msgid ""
 "%s is temporarily unavailable. Please switch to a different model or try "
 "again later."
 msgstr ""
-"%1$s താൽക്കാലികമായി ലഭ്യമല്ല. ദയവായി മറ്റൊരു മോഡലിലേക്ക് മാറുക അല്ലെങ്കിൽ പിന്നീട് വീണ്ടും "
-"ശ്രമിക്കുക."
+"%1$s താൽക്കാലികമായി ലഭ്യമല്ല. ദയവായി മറ്റൊരു മോഡലിലേക്ക് മാറുക അല്ലെങ്കിൽ "
+"പിന്നീട് വീണ്ടും ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Reddit's "fake internet points". https://support.reddithelp.com/hc/en-us/articles/204511829-What-is-karma
@@ -306,9 +309,9 @@ msgid ""
 "provider can see your prompts or the model’s responses, or save this chat on "
 "their servers."
 msgstr ""
-"%1$s ഒരു വിശ്വസനീയമായ നിർവഹണ അന്തരീക്ഷത്തിൽ പ്രവർത്തിക്കുന്നു. മോഡൽ ദാതാവിന് പോലും "
-"നിങ്ങളുടെ പ്രോംപ്റ്റുകളോ മോഡലിന്റെ പ്രതികരണങ്ങളോ കാണാനോ ഈ ചാറ്റ് അവരുടെ സെർവറുകളിൽ "
-"സംരക്ഷിക്കാനോ കഴിയില്ല എന്നാണ്."
+"%1$s ഒരു വിശ്വസനീയമായ നിർവഹണ അന്തരീക്ഷത്തിൽ പ്രവർത്തിക്കുന്നു. മോഡൽ ദാതാവിന് "
+"പോലും നിങ്ങളുടെ പ്രോംപ്റ്റുകളോ മോഡലിന്റെ പ്രതികരണങ്ങളോ കാണാനോ ഈ ചാറ്റ് "
+"അവരുടെ സെർവറുകളിൽ സംരക്ഷിക്കാനോ കഴിയില്ല എന്നാണ്."
 
 # smartling.placeholder_format=C
 #. Label shown in the batch selection toolbar when exactly one chat is selected. %s is replaced with 1. Use singular agreement where the language requires it.
@@ -388,8 +391,8 @@ msgid ""
 "%s will be leaving Duck.ai in %s days (%s). After that, you can switch "
 "models to continue this chat."
 msgstr ""
-"%1$s %2$s ദിവസങ്ങൾക്കുള്ളിൽ (%3$s) Duck.ai ഉപേക്ഷിച്ച് പോകും. അതിനുശേഷം, ഈ ചാറ്റ് "
-"തുടരുന്നതിന് നിങ്ങൾക്ക് മോഡലുകൾ മാറ്റാം."
+"%1$s %2$s ദിവസങ്ങൾക്കുള്ളിൽ (%3$s) Duck.ai ഉപേക്ഷിച്ച് പോകും. അതിനുശേഷം, ഈ "
+"ചാറ്റ് തുടരുന്നതിന് നിങ്ങൾക്ക് മോഡലുകൾ മാറ്റാം."
 
 # smartling.placeholder_format=C
 #. Displayed in a saved chat when its AI model is about to be retired tomorrow. First placeholder is the friendly model name, second placeholder is the removal date formatted in the user's browser locale (e.g., 'June 15, 2026' in en-US). Singular-day form.
@@ -400,8 +403,8 @@ msgid ""
 "%s will be leaving Duck.ai in 1 day (%s). After that, you can switch models "
 "to continue this chat."
 msgstr ""
-"%1$s 1 ദിവസം കൊണ്ട് Duck.ai വിടുന്നതായിരിക്കും (%2$s). അതിനുശേഷം, ഈ ചാറ്റ് തുടരുന്നതിന് "
-"നിങ്ങൾക്ക് മോഡലുകൾ മാറ്റാം."
+"%1$s 1 ദിവസം കൊണ്ട് Duck.ai വിടുന്നതായിരിക്കും (%2$s). അതിനുശേഷം, ഈ ചാറ്റ് "
+"തുടരുന്നതിന് നിങ്ങൾക്ക് മോഡലുകൾ മാറ്റാം."
 
 # smartling.placeholder_format=C
 #. Shown in a text selection chip when the selection contains multiple words. %s is replaced with the number of words, e.g. '142 words'.
@@ -414,8 +417,8 @@ msgstr "%1$s വാക്കുകൾ"
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
 msgstr ""
-"%1$s%2$sചേർക്കുക%3$s ക്ലിക്ക് ചെയ്യുക %4$sഅനുവദിക്കുക%5$s ചെക്ക് ചെയ്യുക, തുടർന്ന് "
-"%6$sശരി%7$s ക്ലിക്ക് ചെയ്യുക"
+"%1$s%2$sചേർക്കുക%3$s ക്ലിക്ക് ചെയ്യുക %4$sഅനുവദിക്കുക%5$s ചെക്ക് ചെയ്യുക, "
+"തുടർന്ന് %6$sശരി%7$s ക്ലിക്ക് ചെയ്യുക"
 
 # Firefox, obsolete
 # smartling.placeholder_format=C
@@ -423,8 +426,8 @@ msgstr ""
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAllow%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
 msgstr ""
-"%1$s%2$sഅനുവദിക്കുക%3$s ക്ലിക്ക് ചെയ്യുക%4$sചേർക്കുക%5$s ക്ലിക്ക് ചെയ്യുക%6$sഅനുവദിക്കുക%7$s "
-"ശരിയിടുക, തുടർന്ന് %8$sശരി%9$s ക്ലിക്ക് ചെയ്യുക"
+"%1$s%2$sഅനുവദിക്കുക%3$s ക്ലിക്ക് ചെയ്യുക%4$sചേർക്കുക%5$s ക്ലിക്ക് "
+"ചെയ്യുക%6$sഅനുവദിക്കുക%7$s ശരിയിടുക, തുടർന്ന് %8$sശരി%9$s ക്ലിക്ക് ചെയ്യുക"
 
 # Firefox
 # smartling.placeholder_format=C
@@ -434,8 +437,9 @@ msgid ""
 "%sClick %sContinue To Installation%sClick %sAdd%sCheck %sAllow%s, then click "
 "%sOkay%s"
 msgstr ""
-"%1$s%2$sഇൻസ്റ്റാളേഷനിലേക്ക് തുടരുക%3$s ക്ലിക്ക് ചെയ്യുക %4$sചേർക്കുക%5$s ക്ലിക്ക് "
-"ചെയ്യുക%6$sഅനുവദിക്കുക%7$s അടയാളപ്പെടുത്തുക, തുടർന്ന് %8$sശരി%9$s ക്ലിക്ക് ചെയ്യുക"
+"%1$s%2$sഇൻസ്റ്റാളേഷനിലേക്ക് തുടരുക%3$s ക്ലിക്ക് ചെയ്യുക %4$sചേർക്കുക%5$s "
+"ക്ലിക്ക് ചെയ്യുക%6$sഅനുവദിക്കുക%7$s അടയാളപ്പെടുത്തുക, തുടർന്ന് %8$sശരി%9$s "
+"ക്ലിക്ക് ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. A button that reloads search results when an error occurs.
@@ -444,8 +448,8 @@ msgid ""
 "%sClick here%s to try again, if you think there should be results for this "
 "search."
 msgstr ""
-"വീണ്ടും ശ്രമിക്കാൻ %1$sഇവിടെ അമർത്തുക%2$s, ഈ തിരയലിന് ഫലങ്ങൾ ഉണ്ടായിരിക്കണമെന്ന് നിങ്ങൾ "
-"കരുതുന്നുണ്ടെങ്കിൽ."
+"വീണ്ടും ശ്രമിക്കാൻ %1$sഇവിടെ അമർത്തുക%2$s, ഈ തിരയലിന് ഫലങ്ങൾ "
+"ഉണ്ടായിരിക്കണമെന്ന് നിങ്ങൾ കരുതുന്നുണ്ടെങ്കിൽ."
 
 # smartling.placeholder_format=C
 #. Header for a page with information about sharing DuckDuckGo.
@@ -464,7 +468,8 @@ msgstr "%1$sകൂടുതലറിയുക%2$s ."
 msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
 msgstr ""
-"%1$sനിങ്ങളുടെ ലൊക്കേഷൻ ഞങ്ങൾ സ്വകാര്യമായി സൂക്ഷിക്കുന്നത് എങ്ങനെയെന്ന് മനസ്സിലാക്കുക%2$s."
+"%1$sനിങ്ങളുടെ ലൊക്കേഷൻ ഞങ്ങൾ സ്വകാര്യമായി സൂക്ഷിക്കുന്നത് എങ്ങനെയെന്ന് "
+"മനസ്സിലാക്കുക%2$s."
 
 # smartling.placeholder_format=C
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
@@ -472,16 +477,16 @@ msgctxt "Footer text for About Sync modal"
 msgid ""
 "%sLearn more%s about how chats are stored privately on DuckDuckGo's server."
 msgstr ""
-"DuckDuckGo-യുടെ സെർവറിൽ ചാറ്റുകൾ എങ്ങനെ സ്വകാര്യമായി സൂക്ഷിക്കപ്പെടുന്നു എന്നതിനെക്കുറിച്ച് "
-"%1$sകൂടുതൽ അറിയുക%2$s."
+"DuckDuckGo-യുടെ സെർവറിൽ ചാറ്റുകൾ എങ്ങനെ സ്വകാര്യമായി സൂക്ഷിക്കപ്പെടുന്നു "
+"എന്നതിനെക്കുറിച്ച് %1$sകൂടുതൽ അറിയുക%2$s."
 
 # smartling.placeholder_format=C
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "%sLearn more%s about how chats are stored privately on your device."
 msgstr ""
-"ചാറ്റുകൾ നിങ്ങളുടെ ഉപകരണത്തിൽ എങ്ങനെ സ്വകാര്യമായി സൂക്ഷിക്കപ്പെടുന്നു എന്നതിനെക്കുറിച്ച് "
-"%1$sകൂടുതൽ അറിയുക%2$s."
+"ചാറ്റുകൾ നിങ്ങളുടെ ഉപകരണത്തിൽ എങ്ങനെ സ്വകാര്യമായി സൂക്ഷിക്കപ്പെടുന്നു "
+"എന്നതിനെക്കുറിച്ച് %1$sകൂടുതൽ അറിയുക%2$s."
 
 # smartling.placeholder_format=C
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
@@ -494,7 +499,8 @@ msgstr "ഹോം സ്ക്രീനിൽ DuckDuckGo ആപ്പ് ഐക�
 msgctxt "Error or no results message"
 msgid "%sOops!%s%sSomething went wrong. Please %srefresh%s and try again."
 msgstr ""
-"%1$sക്ഷമിക്കണം!%2$s%3$sഎന്തോ കുഴപ്പം സംഭവിച്ചു. ദയവായി %4$sപുതുക്കി%5$s വീണ്ടും ശ്രമിക്കുക."
+"%1$sക്ഷമിക്കണം!%2$s%3$sഎന്തോ കുഴപ്പം സംഭവിച്ചു. ദയവായി %4$sപുതുക്കി%5$s "
+"വീണ്ടും ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Tagline in a popover encouraging the user to download the DuckDuckGo browser
@@ -818,7 +824,9 @@ msgstr "6 മണിക്കൂർ ഉപയോഗ പരിധി കഴിഞ�
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "6-hour usage limit reached. You can keep chatting by using your daily limit."
-msgstr "6 മണിക്കൂർ ഉപയോഗ പരിധി കഴിഞ്ഞു. നിങ്ങളുടെ ദൈനംദിന പരിധി ഉപയോഗിച്ച് ചാറ്റ് തുടരാം."
+msgstr ""
+"6 മണിക്കൂർ ഉപയോഗ പരിധി കഴിഞ്ഞു. നിങ്ങളുടെ ദൈനംദിന പരിധി ഉപയോഗിച്ച് ചാറ്റ് "
+"തുടരാം."
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes abbreviation
@@ -872,8 +880,8 @@ msgid ""
 "A network issue is preventing Search Assist from generating an answer. "
 "Please check your connection and try again."
 msgstr ""
-"ഒരു നെറ്റ്‌വർക്ക് പ്രശ്‌നം Search Assist ഉത്തരം സൃഷ്ടിക്കുന്നതിനെ തടയുന്നു. നിങ്ങളുടെ കണക്ഷൻ "
-"പരിശോധിച്ച് വീണ്ടും ശ്രമിക്കുക."
+"ഒരു നെറ്റ്‌വർക്ക് പ്രശ്‌നം Search Assist ഉത്തരം സൃഷ്ടിക്കുന്നതിനെ തടയുന്നു. "
+"നിങ്ങളുടെ കണക്ഷൻ പരിശോധിച്ച് വീണ്ടും ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of AI Chat is available and they need to refresh the page.
@@ -925,10 +933,10 @@ msgid ""
 "still access AI Chat when this setting is off by visiting %sduckduckgo.com/"
 "aichat%s."
 msgstr ""
-"3കക്ഷി AI Chat മോഡലുകളുമായി അജ്ഞാത സംഭാഷണങ്ങൾ നടത്താൻ AI Chat നിങ്ങളെ അനുവദിക്കുന്നു. ഇത് "
-"ഓഫാക്കുന്നത് DuckDuckGo Search-ലെ AI Chat സവിശേഷത മറയ്ക്കും. %1$sduckduckgo.com/"
-"aichat%2$s സന്ദർശിച്ച് ഈ ക്രമീകരണം ഓഫ് ചെയ്യുമ്പോഴും നിങ്ങൾക്ക് AI Chat ആക്സസ് ചെയ്യാൻ "
-"കഴിയും."
+"3കക്ഷി AI Chat മോഡലുകളുമായി അജ്ഞാത സംഭാഷണങ്ങൾ നടത്താൻ AI Chat നിങ്ങളെ "
+"അനുവദിക്കുന്നു. ഇത് ഓഫാക്കുന്നത് DuckDuckGo Search-ലെ AI Chat സവിശേഷത "
+"മറയ്ക്കും. %1$sduckduckgo.com/aichat%2$s സന്ദർശിച്ച് ഈ ക്രമീകരണം ഓഫ് "
+"ചെയ്യുമ്പോഴും നിങ്ങൾക്ക് AI Chat ആക്സസ് ചെയ്യാൻ കഴിയും."
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -989,10 +997,11 @@ msgid ""
 "questions, which is our private AI-powered chat service that supports chat "
 "models from OpenAI, and Anthropic, and more."
 msgstr ""
-"AI- സഹായത്തോടെയുള്ള ഉത്തരങ്ങൾ നിലവിൽ ഫോളോ-അപ്പ് ചോദ്യങ്ങളെ നേരിട്ട് പിന്തുണയ്ക്കുന്നില്ല. "
-"എന്നിരുന്നാലും, ഞങ്ങൾ ഫോളോ-അപ്പ് ചോദ്യങ്ങൾക്കായി %1$sDuck.ai%2$s വാഗ്ദാനം ചെയ്യുകയും "
-"പലപ്പോഴും ലിങ്ക് ചെയ്യുകയും ചെയ്യുന്നു, ഇത് OpenAI, Anthropic തുടങ്ങിയവയിൽ നിന്നുള്ള ചാറ്റ് "
-"മോഡലുകളെ പിന്തുണയ്ക്കുന്ന ഞങ്ങളുടെ സ്വകാര്യ AI-പിന്തുണയുള്ള ചാറ്റ് സേവനമാണ്."
+"AI- സഹായത്തോടെയുള്ള ഉത്തരങ്ങൾ നിലവിൽ ഫോളോ-അപ്പ് ചോദ്യങ്ങളെ നേരിട്ട് "
+"പിന്തുണയ്ക്കുന്നില്ല. എന്നിരുന്നാലും, ഞങ്ങൾ ഫോളോ-അപ്പ് ചോദ്യങ്ങൾക്കായി "
+"%1$sDuck.ai%2$s വാഗ്ദാനം ചെയ്യുകയും പലപ്പോഴും ലിങ്ക് ചെയ്യുകയും ചെയ്യുന്നു, "
+"ഇത് OpenAI, Anthropic തുടങ്ങിയവയിൽ നിന്നുള്ള ചാറ്റ് മോഡലുകളെ "
+"പിന്തുണയ്ക്കുന്ന ഞങ്ങളുടെ സ്വകാര്യ AI-പിന്തുണയുള്ള ചാറ്റ് സേവനമാണ്."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has turned off AI features and will no longer see AI-assisted answers.
@@ -1177,8 +1186,8 @@ msgid ""
 "Activate your %s in this browser again to continue the chat, or switch to a "
 "free model."
 msgstr ""
-"ചാറ്റ് തുടരാൻ നിങ്ങളുടെ %1$s ഈ ബ്രൗസറിൽ വീണ്ടും സജീവമാക്കുക, അല്ലെങ്കിൽ ഒരു സൗജന്യ "
-"മോഡലിലേക്ക് മാറുക."
+"ചാറ്റ് തുടരാൻ നിങ്ങളുടെ %1$s ഈ ബ്രൗസറിൽ വീണ്ടും സജീവമാക്കുക, അല്ലെങ്കിൽ ഒരു "
+"സൗജന്യ മോഡലിലേക്ക് മാറുക."
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an active DuckDuckGo subscription.
@@ -1214,8 +1223,8 @@ msgstr "പരസ്യം"
 msgid ""
 "Ad clicks are managed by %s’s ad network and are not used to profile you."
 msgstr ""
-"%1$s-ൻ്റെ പരസ്യ നെറ്റ്വർക്കുകൾ ആണ് പരസ്യ ക്ലിക്കുകൾ കൈകാര്യം ചെയ്യുന്നത്, അവ നിങ്ങളെ "
-"തിരിച്ചറിയാൻ ഉപയോഗിക്കപ്പെടാറില്ല."
+"%1$s-ൻ്റെ പരസ്യ നെറ്റ്വർക്കുകൾ ആണ് പരസ്യ ക്ലിക്കുകൾ കൈകാര്യം ചെയ്യുന്നത്, അവ "
+"നിങ്ങളെ തിരിച്ചറിയാൻ ഉപയോഗിക്കപ്പെടാറില്ല."
 
 # smartling.placeholder_format=C
 #. Information that ad clicks are managed by Microsoft.
@@ -1223,8 +1232,8 @@ msgid ""
 "Ad clicks are managed by Microsoft’s ad network and are not used to profile "
 "you."
 msgstr ""
-"പരസ്യ ക്ലിക്കുകൾ നിയന്ത്രിക്കുന്നത് Microsoft-ന്റെ പരസ്യ ശൃംഖലയാണ്, നിങ്ങളെ പ്രൊഫൈൽ "
-"ചെയ്യുന്നതിനായി അവ ഉപയോഗിക്കപ്പെടുന്നില്ല."
+"പരസ്യ ക്ലിക്കുകൾ നിയന്ത്രിക്കുന്നത് Microsoft-ന്റെ പരസ്യ ശൃംഖലയാണ്, നിങ്ങളെ "
+"പ്രൊഫൈൽ ചെയ്യുന്നതിനായി അവ ഉപയോഗിക്കപ്പെടുന്നില്ല."
 
 # smartling.placeholder_format=C
 #. An item in the ads tooltip that explains that ad clicks aren’t used to profile you.
@@ -1275,8 +1284,8 @@ msgstr "DuckDuckGo എക്സ്റ്റൻഷൻ ചേർക്കുക"
 msgid ""
 "Add DuckDuckGo Privacy Essentials to your browser for free with one download:"
 msgstr ""
-"ഒരു ഡൗൺ ലോഡിനൊപ്പം സൗജന്യമായി നിങ്ങളുടെ ബ്രൗസറിലേക്ക് DuckDuckGo Privacy Essentials "
-"ചേർക്കുക:"
+"ഒരു ഡൗൺ ലോഡിനൊപ്പം സൗജന്യമായി നിങ്ങളുടെ ബ്രൗസറിലേക്ക് DuckDuckGo Privacy "
+"Essentials ചേർക്കുക:"
 
 #  IE default search engine instruction
 # smartling.placeholder_format=C
@@ -1434,7 +1443,7 @@ msgstr "വിലാസം തെറ്റാണ്"
 #. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Adjust the servings"
-msgstr ""
+msgstr "സെർവിംഗുകൾ ക്രമീകരിക്കുക"
 
 # smartling.placeholder_format=C
 #. as in multiple advertisements
@@ -1512,15 +1521,17 @@ msgstr "ആഫ്രികാൻസ്"
 # smartling.placeholder_format=C
 #. Instructions on how to install the DuckDuckGo browser extension after it downloads.
 msgid "After it downloads and opens, click %sInstall%s"
-msgstr "ഇത് ഡൗൺലോഡ് ചെയ്ത് തുറന്ന ശേഷം %1$sഇൻസ്റ്റാൾ ചെയ്യുക%2$s എന്നതിൽ ക്ലിക്ക് ചെയ്യുക"
+msgstr ""
+"ഇത് ഡൗൺലോഡ് ചെയ്ത് തുറന്ന ശേഷം %1$sഇൻസ്റ്റാൾ ചെയ്യുക%2$s എന്നതിൽ ക്ലിക്ക് "
+"ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. Instructions on how to install the DuckDuckGo browser extension after it downloads.
 msgid ""
 "After it downloads, locate the extension file and double-click it to install"
 msgstr ""
-"അത് ഡൗൺലോഡ് ചെയ്ത ശേഷം, എക്സ്റ്റൻഷൻ ഫയൽ കണ്ടെത്തി, ഇൻസ്റ്റാൾ ചെയ്യാൻ അത് ഡബിൾ ക്ലിക്ക് "
-"ചെയ്യുക"
+"അത് ഡൗൺലോഡ് ചെയ്ത ശേഷം, എക്സ്റ്റൻഷൻ ഫയൽ കണ്ടെത്തി, ഇൻസ്റ്റാൾ ചെയ്യാൻ അത് "
+"ഡബിൾ ക്ലിക്ക് ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an age below a web search result.
@@ -1656,6 +1667,9 @@ msgid ""
 "All chats are anonymized by DuckDuckGo, and your conversations are not used "
 "to train chat models by DuckDuckGo or the model providers"
 msgstr ""
+"എല്ലാ ചാറ്റുകളും DuckDuckGo അജ്ഞാതമാക്കുന്നു, കൂടാതെ നിങ്ങളുടെ സംഭാഷണങ്ങൾ "
+"DuckDuckGo അല്ലെങ്കിൽ മോഡൽ ദാതാക്കൾ ചാറ്റ് മോഡലുകളെ പരിശീലിപ്പിക്കാൻ "
+"ഉപയോഗിക്കുന്നില്ല"
 
 # smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1688,8 +1702,8 @@ msgid ""
 "All model providers are prevented from training their AI on your "
 "conversations."
 msgstr ""
-"നിങ്ങളുടെ സംഭാഷണങ്ങൾ ഉപയോഗിച്ച് അവരുടെ AI പരിശീലിപ്പിക്കാൻ എല്ലാ മോഡൽ ദാതാക്കളെയും "
-"അനുവദിക്കില്ല."
+"നിങ്ങളുടെ സംഭാഷണങ്ങൾ ഉപയോഗിച്ച് അവരുടെ AI പരിശീലിപ്പിക്കാൻ എല്ലാ മോഡൽ "
+"ദാതാക്കളെയും അനുവദിക്കില്ല."
 
 # smartling.placeholder_format=C
 #. Text displayed in the subheader of the modal that allows the user to pick an AI chat model.
@@ -1704,8 +1718,8 @@ msgid ""
 "All personal metadata (for example, your IP address) is removed before "
 "sending a chat to the AI provider."
 msgstr ""
-"AI ദാതാവിന് ഒരു ചാറ്റ് അയയ്ക്കുന്നതിന് മുമ്പ് എല്ലാ വ്യക്തിഗത മെറ്റാഡാറ്റയും (ഉദാഹരണത്തിന്, "
-"നിങ്ങളുടെ IP വിലാസം) നീക്കംചെയ്യപ്പെടുന്നു."
+"AI ദാതാവിന് ഒരു ചാറ്റ് അയയ്ക്കുന്നതിന് മുമ്പ് എല്ലാ വ്യക്തിഗത മെറ്റാഡാറ്റയും "
+"(ഉദാഹരണത്തിന്, നിങ്ങളുടെ IP വിലാസം) നീക്കംചെയ്യപ്പെടുന്നു."
 
 # smartling.placeholder_format=C
 #. A filter that shows search results from all countries.
@@ -1731,7 +1745,8 @@ msgctxt "voice chat"
 msgid ""
 "Allow DuckDuckGo microphone access in System Settings to use voice chat."
 msgstr ""
-"വോയ്സ് ചാറ്റ് ഉപയോഗിക്കാൻ സിസ്റ്റം ക്രമീകരണങ്ങളിൽ DuckDuckGo മൈക്രോഫോൺ ആക്സസ് അനുവദിക്കുക."
+"വോയ്സ് ചാറ്റ് ഉപയോഗിക്കാൻ സിസ്റ്റം ക്രമീകരണങ്ങളിൽ DuckDuckGo മൈക്രോഫോൺ "
+"ആക്സസ് അനുവദിക്കുക."
 
 # smartling.placeholder_format=C
 #. Tells users which icon to press in their browser. Part of a list of instructions on how to enable location service.
@@ -1757,10 +1772,11 @@ msgid ""
 "sends AI-generated queries to a search engine with limited data retention. "
 "Prompts and responses with %s still have %szero provider visibility%s."
 msgstr ""
-"പ്രസക്തമായ പ്രോംപ്റ്റുകൾക്കുള്ള പ്രതികരണങ്ങൾ മെച്ചപ്പെടുത്താൻ വെബിൽ തിരയാൻ %1$s-നെ "
-"അനുവദിക്കുന്നു. പരിമിതമായ ഡാറ്റ നിലനിർത്തൽ ഉള്ള ഒരു സെർച്ച് എഞ്ചിനിലേക്ക് മാത്രമേ AI സൃഷ്ടിച്ച "
-"ചോദ്യങ്ങൾ അയയ്ക്കൂ. %2$s ഉള്ള പ്രോംപ്റ്റുകൾക്കും പ്രതികരണങ്ങൾക്കും ഇപ്പോഴും %3$sദാതാവിന്റെ "
-"ദൃശ്യപരത പൂജ്യം ആണ്%4$s."
+"പ്രസക്തമായ പ്രോംപ്റ്റുകൾക്കുള്ള പ്രതികരണങ്ങൾ മെച്ചപ്പെടുത്താൻ വെബിൽ തിരയാൻ "
+"%1$s-നെ അനുവദിക്കുന്നു. പരിമിതമായ ഡാറ്റ നിലനിർത്തൽ ഉള്ള ഒരു സെർച്ച് "
+"എഞ്ചിനിലേക്ക് മാത്രമേ AI സൃഷ്ടിച്ച ചോദ്യങ്ങൾ അയയ്ക്കൂ. %2$s ഉള്ള "
+"പ്രോംപ്റ്റുകൾക്കും പ്രതികരണങ്ങൾക്കും ഇപ്പോഴും %3$sദാതാവിന്റെ ദൃശ്യപരത പൂജ്യം "
+"ആണ്%4$s."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -1907,8 +1923,8 @@ msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
 msgstr ""
-"%1$s, %2$s, കൂടാതെ ഓപ്പൺ സോഴ്സ് %3$s, %4$s ഉൾപ്പെടെയുള്ള ജനപ്രിയ AI മോഡലുകളിലേക്കുള്ള "
-"അജ്ഞാത ആക്സസ്."
+"%1$s, %2$s, കൂടാതെ ഓപ്പൺ സോഴ്സ് %3$s, %4$s ഉൾപ്പെടെയുള്ള ജനപ്രിയ AI "
+"മോഡലുകളിലേക്കുള്ള അജ്ഞാത ആക്സസ്."
 
 # smartling.placeholder_format=C
 #. Text with information about Duck.ai and supported AI models, the placeholders list AI models. Example: 'Anonymous access to popular AI models, including GPT, Claude, and open-source Llama and Mistral.'
@@ -1917,8 +1933,8 @@ msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
 msgstr ""
-"%1$s, %2$s, കൂടാതെ ഓപ്പൺ സോഴ്സ് %3$s, %4$s ഉൾപ്പെടെയുള്ള ജനപ്രിയ AI മോഡലുകളിലേക്കുള്ള "
-"അജ്ഞാത ആക്സസ്."
+"%1$s, %2$s, കൂടാതെ ഓപ്പൺ സോഴ്സ് %3$s, %4$s ഉൾപ്പെടെയുള്ള ജനപ്രിയ AI "
+"മോഡലുകളിലേക്കുള്ള അജ്ഞാത ആക്സസ്."
 
 # smartling.placeholder_format=C
 #. Confirmation message after location service is enabled.
@@ -1932,6 +1948,9 @@ msgid ""
 "Anonymously generates answers for search queries based on web content. "
 "Choose how often you want it to appear, or disable it completely."
 msgstr ""
+"വെബ് ഉള്ളടക്കത്തെ അടിസ്ഥാനമാക്കി തിരയൽ അന്വേഷണങ്ങൾക്ക് അജ്ഞാതമായി ഉത്തരങ്ങൾ "
+"സൃഷ്ടിക്കുന്നു. ഇത് എത്ര തവണ പ്രത്യക്ഷപ്പെടണമെന്ന് തിരഞ്ഞെടുക്കുക, "
+"അല്ലെങ്കിൽ പൂർണ്ണമായും പ്രവർത്തനരഹിതമാക്കുക."
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -2099,8 +2118,8 @@ msgid ""
 "Are you sure you want to disable history? This will delete all chats, "
 "including pinned chats."
 msgstr ""
-"ചരിത്രം പ്രവർത്തനരഹിതമാക്കണമെന്ന് നിങ്ങൾക്ക് ഉറപ്പാണോ? ഇത് പിൻ ചെയ്ത ചാറ്റുകൾ ഉൾപ്പെടെ എല്ലാ "
-"ചാറ്റുകളും ഇല്ലാതാക്കും."
+"ചരിത്രം പ്രവർത്തനരഹിതമാക്കണമെന്ന് നിങ്ങൾക്ക് ഉറപ്പാണോ? ഇത് പിൻ ചെയ്ത "
+"ചാറ്റുകൾ ഉൾപ്പെടെ എല്ലാ ചാറ്റുകളും ഇല്ലാതാക്കും."
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to disable recent chats, with a warning that it will also delete currently saved chats.
@@ -2109,8 +2128,8 @@ msgid ""
 "Are you sure you want to disable recent chats? This will also delete any "
 "recent chats that are currently saved."
 msgstr ""
-"സമീപകാല ചാറ്റുകൾ പ്രവർത്തനരഹിതമാക്കണമെന്ന് നിങ്ങൾക്ക് ഉറപ്പാണോ? നിലവിൽ സേവ് ചെയ്ത സമീപകാല "
-"ചാറ്റുകളും ഇത് ഇല്ലാതാക്കും."
+"സമീപകാല ചാറ്റുകൾ പ്രവർത്തനരഹിതമാക്കണമെന്ന് നിങ്ങൾക്ക് ഉറപ്പാണോ? നിലവിൽ സേവ് "
+"ചെയ്ത സമീപകാല ചാറ്റുകളും ഇത് ഇല്ലാതാക്കും."
 
 # smartling.placeholder_format=C
 #. Question asking user if they want to share the URL of the page they were on when giving feedback
@@ -2148,8 +2167,9 @@ msgid ""
 "As per our privacy policy, we do not collect or share any personal "
 "information ourselves. All of this privacy protection happens on your device."
 msgstr ""
-"ഞങ്ങളുടെ സ്വകാര്യത നയം അനുസരിച്ച്, ഞങ്ങൾ നിങ്ങളുടെ വ്യക്തിഗത വിവരങ്ങൾ ഒന്നും ശേഖരിക്കുകയോ "
-"പങ്കുവയ്ക്കുകയോ ചെയ്യില്ല. ഈ സ്വകാര്യതാ പരിരക്ഷ എല്ലാം നിങ്ങളുടെ ഉപകരണത്തിൽ സംഭവിക്കുന്നു."
+"ഞങ്ങളുടെ സ്വകാര്യത നയം അനുസരിച്ച്, ഞങ്ങൾ നിങ്ങളുടെ വ്യക്തിഗത വിവരങ്ങൾ ഒന്നും "
+"ശേഖരിക്കുകയോ പങ്കുവയ്ക്കുകയോ ചെയ്യില്ല. ഈ സ്വകാര്യതാ പരിരക്ഷ എല്ലാം "
+"നിങ്ങളുടെ ഉപകരണത്തിൽ സംഭവിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. A button to ask Duck.ai a question
@@ -2215,7 +2235,7 @@ msgstr "Duck.ai-യിൽ ഒരു ഫോളോ-അപ്പ് ചോദിക
 #. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
 msgctxt "Page suggestion chip label"
 msgid "Ask about this page"
-msgstr ""
+msgstr "ഈ പേജിനെക്കുറിച്ച് ചോദിക്കുക"
 
 # smartling.placeholder_format=C
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2279,13 +2299,15 @@ msgid ""
 "(shows more frequently on a wider range of searches). For now, AI-assisted "
 "answers are only available in the U.S. (English) region."
 msgstr ""
-"പ്രസക്തമായ വെബ് ഉള്ളടക്കം സംഗ്രഹിച്ച് ചില തിരയലുകൾക്ക് AI സഹായത്തോടെ ഉത്തരങ്ങൾ അജ്ഞാതമായി "
-"സൃഷ്ടിക്കാൻ Assist-ന് കഴിയും. Assist എത്ര തവണ പ്രത്യക്ഷപ്പെടണമെന്ന് നിങ്ങൾക്ക് തിരഞ്ഞെടുക്കാം: "
-"ഒരിക്കലും ഇല്ല (തിരയൽ ഫലങ്ങളിൽ നിന്ന് Assist UI പൂർണ്ണമായും നീക്കം ചെയ്യുന്നു), ആവശ്യാനുസരണം "
-"(നിങ്ങൾ Assist ബട്ടൺ ക്ലിക്ക് ചെയ്താൽ മാത്രമേ AI സഹായിക്കുന്ന ഉത്തരങ്ങൾ കാണിക്കൂ), ചിലപ്പോൾ "
-"(വളരെ പ്രസക്തമാകുമ്പോൾ മാത്രമേ AI സഹായിക്കുന്ന ഉത്തരങ്ങൾ കാണിക്കൂ), ഇടയ്ക്കിടെ (വിശാലമായ "
-"തിരയൽ ശ്രേണികളിൽ കൂടുതൽ പതിവായി കാണിക്കുന്നു). ഇപ്പോൾ, AI സഹായിക്കുന്ന ഉത്തരങ്ങൾ യു.എസ്. "
-"(ഇംഗ്ലീഷ്) മേഖലയിൽ മാത്രമേ ലഭ്യമാകൂ."
+"പ്രസക്തമായ വെബ് ഉള്ളടക്കം സംഗ്രഹിച്ച് ചില തിരയലുകൾക്ക് AI സഹായത്തോടെ "
+"ഉത്തരങ്ങൾ അജ്ഞാതമായി സൃഷ്ടിക്കാൻ Assist-ന് കഴിയും. Assist എത്ര തവണ "
+"പ്രത്യക്ഷപ്പെടണമെന്ന് നിങ്ങൾക്ക് തിരഞ്ഞെടുക്കാം: ഒരിക്കലും ഇല്ല (തിരയൽ "
+"ഫലങ്ങളിൽ നിന്ന് Assist UI പൂർണ്ണമായും നീക്കം ചെയ്യുന്നു), ആവശ്യാനുസരണം "
+"(നിങ്ങൾ Assist ബട്ടൺ ക്ലിക്ക് ചെയ്താൽ മാത്രമേ AI സഹായിക്കുന്ന ഉത്തരങ്ങൾ "
+"കാണിക്കൂ), ചിലപ്പോൾ (വളരെ പ്രസക്തമാകുമ്പോൾ മാത്രമേ AI സഹായിക്കുന്ന ഉത്തരങ്ങൾ "
+"കാണിക്കൂ), ഇടയ്ക്കിടെ (വിശാലമായ തിരയൽ ശ്രേണികളിൽ കൂടുതൽ പതിവായി "
+"കാണിക്കുന്നു). ഇപ്പോൾ, AI സഹായിക്കുന്ന ഉത്തരങ്ങൾ യു.എസ്. (ഇംഗ്ലീഷ്) മേഖലയിൽ "
+"മാത്രമേ ലഭ്യമാകൂ."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2297,13 +2319,14 @@ msgid ""
 "to remember that responses are auto-generated from cited sources and based "
 "on %scrawling the web%s."
 msgstr ""
-"ഞങ്ങളുടെ തിരയൽ ഫലങ്ങളിലെ ഒരു ഓപ്ഷണൽ സവിശേഷതയാണ് Assist, അതിന് തിരയൽ അന്വേഷണങ്ങൾക്ക് "
-"അജ്ഞാതമായി AI സഹായത്തോടെയുള്ള ഉത്തരങ്ങൾ സൃഷ്ടിക്കാൻ കഴിയും. ഇത് ചെയ്യുന്നതിന്, പ്രസക്തമായ "
-"ഉള്ളടക്കത്തിനായി ഇത് വെബ് സ്കാൻ ചെയ്യുകയും തുടർന്ന് കണ്ടെത്തിയ പ്രസക്തമായ വിവരങ്ങളെ "
-"അടിസ്ഥാനമാക്കി ഒരു ഹ്രസ്വമായ ഉത്തരം സൃഷ്ടിക്കുന്നതിന് AI- പിന്തുണയ്ക്കുന്ന സ്വഭാവിക ഭാഷ "
-"സാങ്കേതികവിദ്യ ഉപയോഗിക്കുകയും ചെയ്യുന്നു. ഉദ്ധരിച്ച ഉറവിടങ്ങളിൽ നിന്ന് പ്രതികരണങ്ങൾ സ്വയം "
-"സൃഷ്ടിക്കപ്പെട്ടതാണെന്നും%2$s വെബ് ക്രൗളിങ്ങിനെ %1$sഅടിസ്ഥാനമാക്കിയുള്ളതാണെന്നും ഓർമ്മിക്കേണ്ടത് "
-"പ്രധാനമാണ്."
+"ഞങ്ങളുടെ തിരയൽ ഫലങ്ങളിലെ ഒരു ഓപ്ഷണൽ സവിശേഷതയാണ് Assist, അതിന് തിരയൽ "
+"അന്വേഷണങ്ങൾക്ക് അജ്ഞാതമായി AI സഹായത്തോടെയുള്ള ഉത്തരങ്ങൾ സൃഷ്ടിക്കാൻ കഴിയും. "
+"ഇത് ചെയ്യുന്നതിന്, പ്രസക്തമായ ഉള്ളടക്കത്തിനായി ഇത് വെബ് സ്കാൻ ചെയ്യുകയും "
+"തുടർന്ന് കണ്ടെത്തിയ പ്രസക്തമായ വിവരങ്ങളെ അടിസ്ഥാനമാക്കി ഒരു ഹ്രസ്വമായ ഉത്തരം "
+"സൃഷ്ടിക്കുന്നതിന് AI- പിന്തുണയ്ക്കുന്ന സ്വഭാവിക ഭാഷ സാങ്കേതികവിദ്യ "
+"ഉപയോഗിക്കുകയും ചെയ്യുന്നു. ഉദ്ധരിച്ച ഉറവിടങ്ങളിൽ നിന്ന് പ്രതികരണങ്ങൾ സ്വയം "
+"സൃഷ്ടിക്കപ്പെട്ടതാണെന്നും%2$s വെബ് ക്രൗളിങ്ങിനെ "
+"%1$sഅടിസ്ഥാനമാക്കിയുള്ളതാണെന്നും ഓർമ്മിക്കേണ്ടത് പ്രധാനമാണ്."
 
 # smartling.placeholder_format=C
 #. Title for the dropdown menu where users select the assistant's role. Example: 'Assistant role: Travel guide'
@@ -2436,15 +2459,16 @@ msgstr "സ്വയമേവയുള്ള-ഉത്തരം"
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid "Auto-generated based on listed sources. May contain inaccuracies."
 msgstr ""
-"ലിസ്റ്റ് ചെയ്ത ഉറവിടങ്ങളെ അടിസ്ഥാനമാക്കി യാന്ത്രികമായി സൃഷ്ടിച്ചത്. അപാകതകൾ അടങ്ങിയിരിക്കാം."
+"ലിസ്റ്റ് ചെയ്ത ഉറവിടങ്ങളെ അടിസ്ഥാനമാക്കി യാന്ത്രികമായി സൃഷ്ടിച്ചത്. അപാകതകൾ "
+"അടങ്ങിയിരിക്കാം."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid ""
 "Auto-generated based on listed sources. Responses may contain inaccuracies."
 msgstr ""
-"ലിസ്റ്റ് ചെയ്ത ഉറവിടങ്ങളെ അടിസ്ഥാനമാക്കി യാന്ത്രികമായി സൃഷ്ടിച്ചത്. പ്രതികരണങ്ങളിൽ അപാകതകൾ "
-"അടങ്ങിയിരിക്കാം."
+"ലിസ്റ്റ് ചെയ്ത ഉറവിടങ്ങളെ അടിസ്ഥാനമാക്കി യാന്ത്രികമായി സൃഷ്ടിച്ചത്. "
+"പ്രതികരണങ്ങളിൽ അപാകതകൾ അടങ്ങിയിരിക്കാം."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI) on mobile
@@ -2469,9 +2493,9 @@ msgid ""
 "look up and summarize information in response to some searches. For now, "
 "Assist is only available in English regions."
 msgstr ""
-"പ്രസക്തമായ തിരയലുകൾക്കായി സ്വയമേവ Assist കാണിക്കുന്നു. Assist-ന് അജ്ഞാതമായി തിരയാനും ചില "
-"സെർച്ചുകൾക്ക് മറുപടിയായി വിവരങ്ങൾ സംഗ്രഹിക്കാനും കഴിയും. ഇപ്പോൾ, ഇംഗ്ലീഷ് പ്രദേശങ്ങളിൽ "
-"മാത്രമേ Assist ലഭ്യമാകൂ."
+"പ്രസക്തമായ തിരയലുകൾക്കായി സ്വയമേവ Assist കാണിക്കുന്നു. Assist-ന് അജ്ഞാതമായി "
+"തിരയാനും ചില സെർച്ചുകൾക്ക് മറുപടിയായി വിവരങ്ങൾ സംഗ്രഹിക്കാനും കഴിയും. "
+"ഇപ്പോൾ, ഇംഗ്ലീഷ് പ്രദേശങ്ങളിൽ മാത്രമേ Assist ലഭ്യമാകൂ."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2480,16 +2504,17 @@ msgid ""
 "anonymously look up and summarize information in response to some searches. "
 "For now, DuckAssist is only available in English regions."
 msgstr ""
-"പ്രസക്തമായ തിരയലുകൾക്കായി സ്വയമേവ DuckAssist കാണിക്കുന്നു. DuckAssist-ന് അജ്ഞാതമായി "
-"തിരയാനും ചില തിരയലുകൾക്ക് മറുപടിയായി വിവരങ്ങൾ സംഗ്രഹിക്കാനും കഴിയും. ഇപ്പോൾ, ഇംഗ്ലീഷ് "
-"പ്രദേശങ്ങളിൽ മാത്രമേ DuckAssist ലഭ്യമാകൂ."
+"പ്രസക്തമായ തിരയലുകൾക്കായി സ്വയമേവ DuckAssist കാണിക്കുന്നു. DuckAssist-ന് "
+"അജ്ഞാതമായി തിരയാനും ചില തിരയലുകൾക്ക് മറുപടിയായി വിവരങ്ങൾ സംഗ്രഹിക്കാനും "
+"കഴിയും. ഇപ്പോൾ, ഇംഗ്ലീഷ് പ്രദേശങ്ങളിൽ മാത്രമേ DuckAssist ലഭ്യമാകൂ."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Autoplay short, silent video previews when you hover over video results."
 msgstr ""
-"വീഡിയോ ഫലങ്ങളിൽ ഹോവർ ചെയ്യുമ്പോൾ ചെറുതും നിശബ്‌ദവുമായ വീഡിയോ പ്രിവ്യൂകൾ സ്വയമേവ പ്ലേ ചെയ്യുക."
+"വീഡിയോ ഫലങ്ങളിൽ ഹോവർ ചെയ്യുമ്പോൾ ചെറുതും നിശബ്‌ദവുമായ വീഡിയോ പ്രിവ്യൂകൾ "
+"സ്വയമേവ പ്ലേ ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Screen-reader label for the radiogroup of tool options inside the Tools dropdown. Announced when assistive technology enters the group of menuitemradio items.
@@ -2515,7 +2540,9 @@ msgstr "ശരാശരി വോളിയം"
 #. Warning text shown below the chat input when the user has attached files, advising them not to upload files from untrusted sources.
 msgctxt "Disclaimer below chat input in Duck.ai when files are attached"
 msgid "Avoid uploading files from sources you don't trust."
-msgstr "നിങ്ങൾ വിശ്വസിക്കാത്ത ഉറവിടങ്ങളിൽ നിന്ന് ഫയലുകൾ അപ്‌ലോഡ് ചെയ്യുന്നത് ഒഴിവാക്കുക."
+msgstr ""
+"നിങ്ങൾ വിശ്വസിക്കാത്ത ഉറവിടങ്ങളിൽ നിന്ന് ഫയലുകൾ അപ്‌ലോഡ് ചെയ്യുന്നത് "
+"ഒഴിവാക്കുക."
 
 # smartling.placeholder_format=C
 #. Indicates the Win-Loss record of a team when playing away
@@ -2634,7 +2661,7 @@ msgstr "ബാർകോഡ്"
 #. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Based on this page, is this course worth taking?"
-msgstr ""
+msgstr "ഈ പേജിനെ അടിസ്ഥാനമാക്കി, ഈ കോഴ്സ് എടുക്കുന്നത് പ്രയോജനകരമാണോ?"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2683,6 +2710,9 @@ msgid ""
 "Before storing this report, DuckDuckGo will anonymize your conversation by "
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
+"ഈ റിപ്പോർട്ട് സൂക്ഷിക്കുന്നതിന് മുമ്പ്, പേരുകൾ, ഇമെയിൽ വിലാസങ്ങൾ, "
+"തിരിച്ചറിയൽ മെറ്റാഡാറ്റ എന്നിവ പോലുള്ള PII നീക്കം ചെയ്തുകൊണ്ട് DuckDuckGo "
+"നിങ്ങളുടെ സംഭാഷണം അജ്ഞാതമാക്കും."
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -3004,7 +3034,7 @@ msgstr "നേടിയ ബ്രേക്ക് പോയിന്റുകൾ"
 #. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Break this down into clear, numbered steps."
-msgstr ""
+msgstr "ഇത് വ്യക്തമായ, നമ്പറുകളുള്ള ഘട്ടങ്ങളായി വിഭജിക്കുക."
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -3063,18 +3093,18 @@ msgid ""
 "Browse as usual while we add privacy protection. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
 msgstr ""
-"ഞങ്ങൾ സ്വകാര്യത പരിരക്ഷണം ചേർക്കുമ്പോൾ പതിവുപോലെ ബ്രൗസ് ചെയ്യുക. ഞങ്ങളുടെ തിരയൽ എഞ്ചിൻ, "
-"ട്രാക്കർ ബ്ലോക്കർ, എൻക്രിപ്ഷൻ എൻഫോഴ്സർ എന്നിവ ഒറ്റ %1$s%2$s വിപുലീകരണത്തിലേക്ക്%3$s ഞങ്ങൾ "
-"ഒരുമിച്ചുചേർത്തു."
+"ഞങ്ങൾ സ്വകാര്യത പരിരക്ഷണം ചേർക്കുമ്പോൾ പതിവുപോലെ ബ്രൗസ് ചെയ്യുക. ഞങ്ങളുടെ "
+"തിരയൽ എഞ്ചിൻ, ട്രാക്കർ ബ്ലോക്കർ, എൻക്രിപ്ഷൻ എൻഫോഴ്സർ എന്നിവ ഒറ്റ %1$s%2$s "
+"വിപുലീകരണത്തിലേക്ക്%3$s ഞങ്ങൾ ഒരുമിച്ചുചേർത്തു."
 
 # smartling.placeholder_format=C
 msgid ""
 "Browse as usual, and we'll take care of the rest. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
 msgstr ""
-"സാധാരണപോലെ ബ്രൗസ് ചെയ്യുക, ബാക്കി കാര്യങ്ങൾ ഞങ്ങൾ നോക്കിക്കൊള്ളാം. ഞങ്ങളുടെ തിരയൽ എഞ്ചിൻ, "
-"ട്രാക്കർ ബ്ലോക്കർ, എൻക്രിപ്ഷൻ എൻഫോഴ്സർ എന്നിവ ഒറ്റ %1$s%2$s വിപുലീകരണത്തിലേക്ക്%3$s ഞങ്ങൾ "
-"ഒരുമിച്ചുചേർത്തു."
+"സാധാരണപോലെ ബ്രൗസ് ചെയ്യുക, ബാക്കി കാര്യങ്ങൾ ഞങ്ങൾ നോക്കിക്കൊള്ളാം. ഞങ്ങളുടെ "
+"തിരയൽ എഞ്ചിൻ, ട്രാക്കർ ബ്ലോക്കർ, എൻക്രിപ്ഷൻ എൻഫോഴ്സർ എന്നിവ ഒറ്റ %1$s%2$s "
+"വിപുലീകരണത്തിലേക്ക്%3$s ഞങ്ങൾ ഒരുമിച്ചുചേർത്തു."
 
 # smartling.placeholder_format=C
 msgid ""
@@ -3082,9 +3112,9 @@ msgid ""
 "search, tracker blocking, and site encryption, all in one download, for "
 "%smajor browsers%s."
 msgstr ""
-"സാധാരണപോലെ ബ്രൗസ് ചെയ്യുക, ബാക്കി കാര്യങ്ങൾ ഞങ്ങൾ നോക്കിക്കൊള്ളാം. %1$sപ്രധാന "
-"ബ്രൗസറുകൾക്കായുള്ള%2$s private search, ട്രാക്കർ ബ്ലോക്കിംഗ്, സൈറ്റ് എൻക്രിപ്ഷൻ എന്നിവ "
-"മൊത്തത്തിൽ ഒറ്റ ഡൗൺലോഡിൽ നേടുക."
+"സാധാരണപോലെ ബ്രൗസ് ചെയ്യുക, ബാക്കി കാര്യങ്ങൾ ഞങ്ങൾ നോക്കിക്കൊള്ളാം. "
+"%1$sപ്രധാന ബ്രൗസറുകൾക്കായുള്ള%2$s private search, ട്രാക്കർ ബ്ലോക്കിംഗ്, "
+"സൈറ്റ് എൻക്രിപ്ഷൻ എന്നിവ മൊത്തത്തിൽ ഒറ്റ ഡൗൺലോഡിൽ നേടുക."
 
 # smartling.placeholder_format=C
 #. Header for a call to action to browse with the DuckDuckGo browser
@@ -3170,7 +3200,9 @@ msgstr "'%1$s' ക്ലിക്ക് ചെയ്യുക വഴി, നി�
 msgctxt ""
 "Copy stating agreement to Duck.ai Privacy Policy and Terms of Service."
 msgid "By clicking “%s,” you accept Duck.ai’s %s and %s."
-msgstr "“%1$s” ക്ലിക്ക് ചെയ്യുന്നതിലൂടെ നീ Duck.ai-യുടെ %2$s ഉം %3$s ഉം അംഗീകരിക്കുന്നു."
+msgstr ""
+"“%1$s” ക്ലിക്ക് ചെയ്യുന്നതിലൂടെ നീ Duck.ai-യുടെ %2$s ഉം %3$s ഉം "
+"അംഗീകരിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Text stating agreement to Duck.ai Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'By clicking “Agree and Continue,” you accept Duck.ai’s Privacy Policy and Terms of Service.'
@@ -3191,10 +3223,11 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"സ്വതവേ, വ്യക്തിഗതമല്ലാത്ത ബ്രൗസർ കുക്കികളിലാണ് (നിങ്ങളുടെ ബ്രൗസറിൽ), ക്രമീകരണം "
-"സൂക്ഷിച്ചിരിക്കുന്നത്. നിങ്ങളുടെ ക്രമീകരണം കൂടുതൽ സ്ഥിരമായ ഒരു വിധത്തിൽ സംഭരിക്കാൻ (ക്ലൗഡിലെ "
-"ഒരു റിമോട്ട് സെർവറിൽ), നിങ്ങൾക്ക് അജ്ഞാത Cloud Save ഉപയോഗിക്കാൻ കഴിയും. വ്യക്തിപരമായി "
-"തിരിച്ചറിയാൻ കഴിയുന്ന വിവരങ്ങളൊന്നും ക്ലൗഡിൽ സംഭരിക്കില്ല, നിങ്ങളുടെ പാസ്‌ഫ്രെയ്സ് ഒരിക്കലും "
+"സ്വതവേ, വ്യക്തിഗതമല്ലാത്ത ബ്രൗസർ കുക്കികളിലാണ് (നിങ്ങളുടെ ബ്രൗസറിൽ), "
+"ക്രമീകരണം സൂക്ഷിച്ചിരിക്കുന്നത്. നിങ്ങളുടെ ക്രമീകരണം കൂടുതൽ സ്ഥിരമായ ഒരു "
+"വിധത്തിൽ സംഭരിക്കാൻ (ക്ലൗഡിലെ ഒരു റിമോട്ട് സെർവറിൽ), നിങ്ങൾക്ക് അജ്ഞാത "
+"Cloud Save ഉപയോഗിക്കാൻ കഴിയും. വ്യക്തിപരമായി തിരിച്ചറിയാൻ കഴിയുന്ന "
+"വിവരങ്ങളൊന്നും ക്ലൗഡിൽ സംഭരിക്കില്ല, നിങ്ങളുടെ പാസ്‌ഫ്രെയ്സ് ഒരിക്കലും "
 "നിങ്ങളുടെ ബ്രൗസറിൽ നിന്ന് പുറത്തുപോകില്ല."
 
 # smartling.placeholder_format=C
@@ -3203,8 +3236,9 @@ msgid ""
 "By enabling dictation, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
 msgstr ""
-"ഡിക്ടേഷന്‍ പ്രവര്‍ത്തനക്ഷമമാക്കുന്നതിലൂടെ, ഈ സവിശേഷത ഉപയോഗിക്കുന്നതിനായി നിങ്ങളുടെ ശബ്ദ ഡാറ്റ "
-"OpenAI-ലേക്ക് അയയ്ക്കുന്നതിന് നിങ്ങൾ സമ്മതം നൽകുന്നു. ആരംഭിക്കുന്നതിന് മുമ്പ് ഞങ്ങളുടെ %1$s കാണൂ."
+"ഡിക്ടേഷന്‍ പ്രവര്‍ത്തനക്ഷമമാക്കുന്നതിലൂടെ, ഈ സവിശേഷത ഉപയോഗിക്കുന്നതിനായി "
+"നിങ്ങളുടെ ശബ്ദ ഡാറ്റ OpenAI-ലേക്ക് അയയ്ക്കുന്നതിന് നിങ്ങൾ സമ്മതം നൽകുന്നു. "
+"ആരംഭിക്കുന്നതിന് മുമ്പ് ഞങ്ങളുടെ %1$s കാണൂ."
 
 # smartling.placeholder_format=C
 #. Description for the 'enable voice chat' section of the voice chat consent modal. Placeholder for the voice chat help page link and text. Example: 'By enabling voice chat, you consent to your voice data being sent to OpenAI for the use of this feature. See our voice chat help page before getting started.'
@@ -3213,9 +3247,9 @@ msgid ""
 "By enabling voice chat, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
 msgstr ""
-"വോയ്സ് ചാറ്റ് പ്രവർത്തനക്ഷമമാക്കുന്നതിലൂടെ, ഈ സവിശേഷത ഉപയോഗിക്കുന്നതിനായി നിങ്ങളുടെ വോയ്സ് "
-"ഡാറ്റ OpenAI-ലേക്ക് അയയ്ക്കുന്നതിന് നിങ്ങൾ സമ്മതം നൽകുന്നു. ആരംഭിക്കുന്നതിന് മുമ്പ് ഞങ്ങളുടെ %1$s "
-"കാണൂ."
+"വോയ്സ് ചാറ്റ് പ്രവർത്തനക്ഷമമാക്കുന്നതിലൂടെ, ഈ സവിശേഷത ഉപയോഗിക്കുന്നതിനായി "
+"നിങ്ങളുടെ വോയ്സ് ഡാറ്റ OpenAI-ലേക്ക് അയയ്ക്കുന്നതിന് നിങ്ങൾ സമ്മതം നൽകുന്നു. "
+"ആരംഭിക്കുന്നതിന് മുമ്പ് ഞങ്ങളുടെ %1$s കാണൂ."
 
 # smartling.placeholder_format=C
 #. Golf leaderboard: player missed the cut
@@ -3251,8 +3285,8 @@ msgstr "കാമറൂൺ"
 msgctxt "Full sentence for crafting a recipe"
 msgid "Can you create a few simple recipes using chicken, broccoli, and rice?"
 msgstr ""
-"കോഴിയിറച്ചി, ബ്രോക്കോളി, അരി എന്നിവ ഉപയോഗിച്ച് നിങ്ങൾക്ക് ഏതാനും ലളിതമായ പാചകക്കുറിപ്പുകൾ "
-"സൃഷ്ടിക്കാൻ കഴിയുമോ?"
+"കോഴിയിറച്ചി, ബ്രോക്കോളി, അരി എന്നിവ ഉപയോഗിച്ച് നിങ്ങൾക്ക് ഏതാനും ലളിതമായ "
+"പാചകക്കുറിപ്പുകൾ സൃഷ്ടിക്കാൻ കഴിയുമോ?"
 
 # smartling.placeholder_format=C
 msgid "Canada"
@@ -3466,7 +3500,7 @@ msgstr "കാസ്റ്റ്"
 #. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Cast & Crew"
-msgstr ""
+msgstr "അഭിനേതാക്കളും അണിയറപ്രവർത്തകരും"
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -3554,7 +3588,8 @@ msgstr "ഫലങ്ങളുടെ URL-കൾ എങ്ങനെ പ്രദ�
 msgctxt "settings"
 msgid "Changes how the header is displayed and its behavior as you scroll"
 msgstr ""
-"നിങ്ങൾ സ്ക്രോൾ ചെയ്യുമ്പോൾ ശീർഷകം എങ്ങനെ പ്രദർശിപ്പിക്കുന്നു എന്നതും അതിന്റെ പെരുമാറ്റവും മാറുന്നു"
+"നിങ്ങൾ സ്ക്രോൾ ചെയ്യുമ്പോൾ ശീർഷകം എങ്ങനെ പ്രദർശിപ്പിക്കുന്നു എന്നതും അതിന്റെ "
+"പെരുമാറ്റവും മാറുന്നു"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/mcZdcaF.png
@@ -3573,13 +3608,17 @@ msgstr "മുഴുവൻ സൈറ്റിലും പശ്ചാത്ത�
 msgctxt "settings"
 msgid ""
 "Changes the background color of results on hover, modules, and dropdown menus"
-msgstr "ഹോവർ, മൊഡ്യൂളുകൾ, ഡ്രോപ്പ്ഡൗൺ മെനുകൾ എന്നിവയിലെ ഫലങ്ങളുടെ പശ്ചാത്തല നിറം മാറ്റുന്നു"
+msgstr ""
+"ഹോവർ, മൊഡ്യൂളുകൾ, ഡ്രോപ്പ്ഡൗൺ മെനുകൾ എന്നിവയിലെ ഫലങ്ങളുടെ പശ്ചാത്തല നിറം "
+"മാറ്റുന്നു"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/NdpkbY0.png
 msgctxt "settings"
 msgid "Changes the background color when hovering over a result"
-msgstr "ഫലങ്ങളുടെ മുകളില്‍ കൂടി മൗസ് ചലിപ്പിക്കുമ്പോള്‍ പശ്ചാത്തലത്തിന്റെ നിറം മാറ്റുന്നു"
+msgstr ""
+"ഫലങ്ങളുടെ മുകളില്‍ കൂടി മൗസ് ചലിപ്പിക്കുമ്പോള്‍ പശ്ചാത്തലത്തിന്റെ നിറം "
+"മാറ്റുന്നു"
 
 # smartling.placeholder_format=C
 #. Description of a setting managing the color of search result snippet text.
@@ -3702,10 +3741,11 @@ msgid ""
 "DuckDuckGo Search. However, you can still access Chat when this setting is "
 "off by visiting %shttps://duck.ai%s directly."
 msgstr ""
-"നിങ്ങൾക്ക് മൂന്നാം കക്ഷി AI ചാറ്റ് മോഡലുകളുമായി അജ്ഞാത സംഭാഷണങ്ങൾ നടത്താൻ ചാറ്റ് (Duck.ai "
-"സേവനം വഴി) നിങ്ങളെ അനുവദിക്കുന്നു, ഇത് OpenAI, Anthropic തുടങ്ങിയ മോഡലുകളെ പിന്തുണയ്ക്കുന്നു. "
-"ഈ ക്രമീകരണം ഓഫാക്കുന്നത് DuckDuckGo Search-ൽ ചാറ്റ് ബട്ടണുകളും ലിങ്കുകളും മറയ്ക്കും. "
-"എന്നിരുന്നാലും, %1$shttps://duck.ai%2$s സന്ദർശിച്ച് ഈ ക്രമീകരണം ഓഫ് ആയിരിക്കുമ്പോഴും "
+"നിങ്ങൾക്ക് മൂന്നാം കക്ഷി AI ചാറ്റ് മോഡലുകളുമായി അജ്ഞാത സംഭാഷണങ്ങൾ നടത്താൻ "
+"ചാറ്റ് (Duck.ai സേവനം വഴി) നിങ്ങളെ അനുവദിക്കുന്നു, ഇത് OpenAI, Anthropic "
+"തുടങ്ങിയ മോഡലുകളെ പിന്തുണയ്ക്കുന്നു. ഈ ക്രമീകരണം ഓഫാക്കുന്നത് DuckDuckGo "
+"Search-ൽ ചാറ്റ് ബട്ടണുകളും ലിങ്കുകളും മറയ്ക്കും. എന്നിരുന്നാലും, "
+"%1$shttps://duck.ai%2$s സന്ദർശിച്ച് ഈ ക്രമീകരണം ഓഫ് ആയിരിക്കുമ്പോഴും "
 "നിങ്ങൾക്ക് ചാറ്റ് ആക്സസ് ചെയ്യാൻ കഴിയും. നേരിട്ട്."
 
 # smartling.placeholder_format=C
@@ -3762,8 +3802,8 @@ msgstr "സ്വകാര്യമായി ചാറ്റ് ചെയ്യ�
 msgctxt "Promotional text (mobile)"
 msgid "Chat privately on any website with Duck.ai built into our free browser."
 msgstr ""
-"ഞങ്ങളുടെ സൗജന്യ ബ്രൗസറിൽ തന്നെയുള്ള Duck.ai ഉപയോഗിച്ച് ഏത് വെബ്‌സൈറ്റിലും സ്വകാര്യമായി ചാറ്റ് "
-"ചെയ്യുക."
+"ഞങ്ങളുടെ സൗജന്യ ബ്രൗസറിൽ തന്നെയുള്ള Duck.ai ഉപയോഗിച്ച് ഏത് വെബ്‌സൈറ്റിലും "
+"സ്വകാര്യമായി ചാറ്റ് ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card encouraging third-party browser users to download the DuckDuckGo browser. Not shown in the DuckDuckGo browser or on Linux.
@@ -3771,8 +3811,8 @@ msgctxt "Promotional text"
 msgid ""
 "Chat privately on any website with the Duck.ai sidebar in our free browser."
 msgstr ""
-"ഞങ്ങളുടെ സൗജന്യ ബ്രൗസറിലെ Duck.ai സൈഡ്‌ബാർ ഉപയോഗിച്ച് ഏത് വെബ്‌സൈറ്റിലും സ്വകാര്യമായി ചാറ്റ് "
-"ചെയ്യുക."
+"ഞങ്ങളുടെ സൗജന്യ ബ്രൗസറിലെ Duck.ai സൈഡ്‌ബാർ ഉപയോഗിച്ച് ഏത് വെബ്‌സൈറ്റിലും "
+"സ്വകാര്യമായി ചാറ്റ് ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
@@ -3835,9 +3875,9 @@ msgid ""
 "Chats are stored locally on your device instead of on DuckDuckGo servers or "
 "remote servers. Disabling chat history will delete pinned chats."
 msgstr ""
-"ചാറ്റുകൾ DuckDuckGo സെർവറുകളിലോ വിദൂര സെർവറുകളിലോ സംഭരിക്കുന്നതിന് പകരം നിങ്ങളുടെ "
-"ഉപകരണത്തിൽ പ്രാദേശികമായി സംഭരിക്കുന്നു. ചാറ്റ് ചരിത്രം പ്രവർത്തനരഹിതമാക്കുന്നത് പിൻ ചെയ്ത "
-"ചാറ്റുകൾ നീക്കം ചെയ്യും."
+"ചാറ്റുകൾ DuckDuckGo സെർവറുകളിലോ വിദൂര സെർവറുകളിലോ സംഭരിക്കുന്നതിന് പകരം "
+"നിങ്ങളുടെ ഉപകരണത്തിൽ പ്രാദേശികമായി സംഭരിക്കുന്നു. ചാറ്റ് ചരിത്രം "
+"പ്രവർത്തനരഹിതമാക്കുന്നത് പിൻ ചെയ്ത ചാറ്റുകൾ നീക്കം ചെയ്യും."
 
 # smartling.placeholder_format=C
 #. Text explaining how the Chat History feature stores the user's chats locally to their device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection. Also explains that disabling chat history will delete pinned chats.
@@ -3849,11 +3889,13 @@ msgid ""
 "history will delete pinned chats, and disable the temporary storage of new "
 "prompts and responses."
 msgstr ""
-"ചാറ്റുകൾ നിങ്ങളുടെ ഉപകരണത്തിൽ തന്നെ സംഭരിക്കപ്പെടുന്നു. പുതിയ പ്രോംപ്റ്റുകളും പ്രതികരണങ്ങളും "
-"അയച്ചതിനുശേഷം എൻക്രിപ്റ്റ് ചെയ്ത് താൽക്കാലികമായി ഒരു DuckDuckGo സെർവറിൽ സംഭരിക്കും, ഇത് "
-"നിങ്ങളുടെ ഇന്റർനെറ്റ് കണക്ഷൻ നഷ്ടപ്പെട്ടാൽ ഒരു ചാറ്റ് വീണ്ടെടുക്കാൻ സഹായിക്കും. ചാറ്റ് ചരിത്രം "
-"പ്രവർത്തനരഹിതമാക്കുന്നത് പിൻ ചെയ്‌ത ചാറ്റുകൾ ഇല്ലാതാക്കുകയും പുതിയ പ്രോംപ്റ്റുകളുടെയും "
-"പ്രതികരണങ്ങളുടെയും താൽക്കാലിക സ്റ്റോറേജ് പ്രവർത്തനരഹിതമാക്കുകയും ചെയ്യും."
+"ചാറ്റുകൾ നിങ്ങളുടെ ഉപകരണത്തിൽ തന്നെ സംഭരിക്കപ്പെടുന്നു. പുതിയ "
+"പ്രോംപ്റ്റുകളും പ്രതികരണങ്ങളും അയച്ചതിനുശേഷം എൻക്രിപ്റ്റ് ചെയ്ത് "
+"താൽക്കാലികമായി ഒരു DuckDuckGo സെർവറിൽ സംഭരിക്കും, ഇത് നിങ്ങളുടെ ഇന്റർനെറ്റ് "
+"കണക്ഷൻ നഷ്ടപ്പെട്ടാൽ ഒരു ചാറ്റ് വീണ്ടെടുക്കാൻ സഹായിക്കും. ചാറ്റ് ചരിത്രം "
+"പ്രവർത്തനരഹിതമാക്കുന്നത് പിൻ ചെയ്‌ത ചാറ്റുകൾ ഇല്ലാതാക്കുകയും പുതിയ "
+"പ്രോംപ്റ്റുകളുടെയും പ്രതികരണങ്ങളുടെയും താൽക്കാലിക സ്റ്റോറേജ് "
+"പ്രവർത്തനരഹിതമാക്കുകയും ചെയ്യും."
 
 # smartling.placeholder_format=C
 #. Title shown above the body copy in the Duck.ai recent chats IndexedDB unavailable notice.
@@ -3875,8 +3917,8 @@ msgctxt "Sync file storage inline disclaimer body"
 msgid ""
 "Chats with attachments have stopped syncing. Free up storage to resume Sync."
 msgstr ""
-"അറ്റാച്ചുമെന്റുകളുള്ള ചാറ്റുകൾ സമന്വയിപ്പിക്കുന്നത് നിർത്തിയിരിക്കുന്നു. സമന്വയം പുനരാരംഭിക്കാൻ "
-"സംഭരണ സ്ഥലം ശൂന്യമാക്കുക."
+"അറ്റാച്ചുമെന്റുകളുള്ള ചാറ്റുകൾ സമന്വയിപ്പിക്കുന്നത് നിർത്തിയിരിക്കുന്നു. "
+"സമന്വയം പുനരാരംഭിക്കാൻ സംഭരണ സ്ഥലം ശൂന്യമാക്കുക."
 
 # smartling.placeholder_format=C
 #. Message shown when we have no data from upstream to display
@@ -3929,7 +3971,9 @@ msgstr "സ്പെല്ലിംഗ് പരിശോധിക്കുക"
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
 msgctxt "noresults"
 msgid "Check the DuckDuckGo subreddit for updates on this outage."
-msgstr "ഈ തടസ്സത്തിനെക്കുറിച്ചുള്ള അപ്ഡേറ്റുകൾക്കായി DuckDuckGo സബ് റെഡ്ഡിറ്റ് പരിശോധിക്കുക."
+msgstr ""
+"ഈ തടസ്സത്തിനെക്കുറിച്ചുള്ള അപ്ഡേറ്റുകൾക്കായി DuckDuckGo സബ് റെഡ്ഡിറ്റ് "
+"പരിശോധിക്കുക."
 
 # smartling.placeholder_format=C
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
@@ -3994,7 +4038,9 @@ msgstr "%1$s , %2$s എന്നിവ ഉൾപ്പെടെ AI മോഡല�
 # smartling.placeholder_format=C
 #. As in 'Choose to keep DuckDuckGo as your default search engine'. Placeholders are for markup, you can ignore them.
 msgid "Choose %skeep it%s to continue protecting your privacy."
-msgstr "നിങ്ങളുടെ സ്വകാര്യത പരിരക്ഷിക്കുന്നത് തുടരാൻ %1$sനിലനിർത്തുക%2$s തിരഞ്ഞെടുക്കുക."
+msgstr ""
+"നിങ്ങളുടെ സ്വകാര്യത പരിരക്ഷിക്കുന്നത് തുടരാൻ %1$sനിലനിർത്തുക%2$s "
+"തിരഞ്ഞെടുക്കുക."
 
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
@@ -4029,8 +4075,8 @@ msgctxt "settings"
 msgid ""
 "Choose which app to use when you need directions for a location search result"
 msgstr ""
-"നിങ്ങൾക്ക് ഒരു ലൊക്കേഷൻ തിരയൽ ഫലത്തിനായി നിർദ്ദേശങ്ങൾ ആവശ്യമുള്ളപ്പോൾ ഏത് ആപ്പ് "
-"ഉപയോഗിക്കണമെന്ന് തിരഞ്ഞെടുക്കുക"
+"നിങ്ങൾക്ക് ഒരു ലൊക്കേഷൻ തിരയൽ ഫലത്തിനായി നിർദ്ദേശങ്ങൾ ആവശ്യമുള്ളപ്പോൾ ഏത് "
+"ആപ്പ് ഉപയോഗിക്കണമെന്ന് തിരഞ്ഞെടുക്കുക"
 
 # smartling.placeholder_format=C
 #. Accessible label for the citations popover dialog in Duck.ai chat responses.
@@ -4211,9 +4257,9 @@ msgid ""
 "Clearing browser data deletes chats. Some browsers may keep recent chats "
 "indefinitely or auto-delete them after 7+ days of no AI Chat use."
 msgstr ""
-"ബ്രൗസർ ഡാറ്റ മായ്ക്കുന്നത് ചാറ്റുകൾ ഇല്ലാതാക്കും. ചില ബ്രൗസറുകൾ അടുത്തിടെ നടന്ന ചാറ്റുകൾ "
-"അനിശ്ചിതകാലം സൂക്ഷിക്കുകയോ AI Chat ഉപയോഗം ഇല്ലാത്ത 7 ദിവസങ്ങൾക്ക് ശേഷം യാന്ത്രികമായി "
-"ഇല്ലാതാക്കുകയോ ചെയ്തേക്കാം."
+"ബ്രൗസർ ഡാറ്റ മായ്ക്കുന്നത് ചാറ്റുകൾ ഇല്ലാതാക്കും. ചില ബ്രൗസറുകൾ അടുത്തിടെ "
+"നടന്ന ചാറ്റുകൾ അനിശ്ചിതകാലം സൂക്ഷിക്കുകയോ AI Chat ഉപയോഗം ഇല്ലാത്ത 7 "
+"ദിവസങ്ങൾക്ക് ശേഷം യാന്ത്രികമായി ഇല്ലാതാക്കുകയോ ചെയ്തേക്കാം."
 
 # smartling.placeholder_format=C
 #. Text explaining what happens to recent chats when browser data is cleared.
@@ -4223,9 +4269,10 @@ msgid ""
 "indefinitely or auto-deleted after 7 days without using Duck.ai, depending "
 "on your browser."
 msgstr ""
-"ബ്രൗസർ ഡാറ്റ മായ്ക്കുന്നത് സമീപകാല ചാറ്റുകൾ ഇല്ലാതാക്കും. സമീപകാല ചാറ്റുകൾ Duck.ai "
-"ഉപയോഗിക്കാതെ 7 ദിവസത്തിനുശേഷം അനിശ്ചിതകാലം സൂക്ഷിക്കപ്പെടുകയോ യാന്ത്രികമായി ഇല്ലാതാക്കുകയോ "
-"ചെയ്യാം. നിങ്ങളുടെ ബ്രൗസറിനെ ആശ്രയിച്ചിരിക്കുന്നു."
+"ബ്രൗസർ ഡാറ്റ മായ്ക്കുന്നത് സമീപകാല ചാറ്റുകൾ ഇല്ലാതാക്കും. സമീപകാല ചാറ്റുകൾ "
+"Duck.ai ഉപയോഗിക്കാതെ 7 ദിവസത്തിനുശേഷം അനിശ്ചിതകാലം സൂക്ഷിക്കപ്പെടുകയോ "
+"യാന്ത്രികമായി ഇല്ലാതാക്കുകയോ ചെയ്യാം. നിങ്ങളുടെ ബ്രൗസറിനെ "
+"ആശ്രയിച്ചിരിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Warning message shown on the Block domain success modal. Blocked sites are stored in localStorage which is cleared alongside cookies when users clear browser data. Followed by a linked 'our free browser' text.
@@ -4234,8 +4281,8 @@ msgid ""
 "Clearing browser data will reset your blocked sites. Save your block list "
 "permanently in"
 msgstr ""
-"ബ്രൗസർ ഡാറ്റ മായ്ക്കുന്നത് നിങ്ങൾ തടഞ്ഞ സൈറ്റുകളെ റീസെറ്റ് ചെയ്യും. നിങ്ങളുടെ ബ്ലോക്ക് ലിസ്റ്റ് "
-"ശാശ്വതമായി ഞങ്ങളുടെ സൗജന്യ"
+"ബ്രൗസർ ഡാറ്റ മായ്ക്കുന്നത് നിങ്ങൾ തടഞ്ഞ സൈറ്റുകളെ റീസെറ്റ് ചെയ്യും. "
+"നിങ്ങളുടെ ബ്ലോക്ക് ലിസ്റ്റ് ശാശ്വതമായി ഞങ്ങളുടെ സൗജന്യ"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -4244,9 +4291,10 @@ msgid ""
 "%sDuck.ai%s, our private AI chat service that supports chat models from "
 "OpenAI, Anthropic, and more."
 msgstr ""
-"ഒരു വിഷയത്തിൽ കൂടുതൽ ആഴത്തിൽ പോകാൻ \"കൂടുതൽ\" ക്ലിക്ക് ചെയ്യുക, കൂടാതെ %1$sDuck.ai%2$s "
-"വഴി ഫോളോ-അപ്പ് ചോദ്യങ്ങൾ ചോദിക്കൂ OpenAI, Anthropic എന്നിവയിൽ നിന്നുള്ള ചാറ്റ് മോഡലുകളെ "
-"പിന്തുണയ്ക്കുന്ന ഞങ്ങളുടെ സ്വകാര്യ AI ചാറ്റ് സേവനം."
+"ഒരു വിഷയത്തിൽ കൂടുതൽ ആഴത്തിൽ പോകാൻ \"കൂടുതൽ\" ക്ലിക്ക് ചെയ്യുക, കൂടാതെ "
+"%1$sDuck.ai%2$s വഴി ഫോളോ-അപ്പ് ചോദ്യങ്ങൾ ചോദിക്കൂ OpenAI, Anthropic "
+"എന്നിവയിൽ നിന്നുള്ള ചാറ്റ് മോഡലുകളെ പിന്തുണയ്ക്കുന്ന ഞങ്ങളുടെ സ്വകാര്യ AI "
+"ചാറ്റ് സേവനം."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4305,7 +4353,9 @@ msgstr "DuckDuckGo എക്സ്റ്റൻഷൻ ഡൗൺലോഡ് ച�
 # smartling.placeholder_format=C
 #. Link to download the DuckDuckGo browser extension.
 msgid "Click %sOpen%s to download and open the DuckDuckGo Safari extension"
-msgstr "DuckDuckGo Safari എക്സ്റ്റൻഷൻ ഡൗൺലോഡ് ചെയ്യാൻ %1$sതുറക്കുക%2$s ക്ലിക്ക് ചെയ്യുക"
+msgstr ""
+"DuckDuckGo Safari എക്സ്റ്റൻഷൻ ഡൗൺലോഡ് ചെയ്യാൻ %1$sതുറക്കുക%2$s ക്ലിക്ക് "
+"ചെയ്യുക"
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -4322,8 +4372,8 @@ msgid ""
 "Click %sSafari%s in the top menu (On Windows, click the %sgears icon%s in "
 "the top right)"
 msgstr ""
-"മുകളിലെ മെനുവിലെ %1$sSafari%2$s ക്ലിക്ക് ചെയ്യുക (Windows-ൽ, മുകളിൽ വലതുവശത്തുള്ള "
-"%3$sഗിയേഴ്സ് ഐക്കൺ%4$s ക്ലിക്ക് ചെയ്യുക)"
+"മുകളിലെ മെനുവിലെ %1$sSafari%2$s ക്ലിക്ക് ചെയ്യുക (Windows-ൽ, മുകളിൽ "
+"വലതുവശത്തുള്ള %3$sഗിയേഴ്സ് ഐക്കൺ%4$s ക്ലിക്ക് ചെയ്യുക)"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4341,7 +4391,8 @@ msgstr "ഡ്രോപ്പ്ഡൗണിൽ %1$sക്രമീകരണം%
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
 msgstr ""
-"%1$sനിലവിലുള്ള പേജുകൾ ഉപയോഗിക്കുക%2$s ക്ലിക്ക് ചെയ്യുക, തുടർന്ന് %3$sശരി ക്ലിക്ക് ചെയ്യുക%4$s."
+"%1$sനിലവിലുള്ള പേജുകൾ ഉപയോഗിക്കുക%2$s ക്ലിക്ക് ചെയ്യുക, തുടർന്ന് %3$sശരി "
+"ക്ലിക്ക് ചെയ്യുക%4$s."
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -4354,7 +4405,8 @@ msgstr "%1$sഉവ്വ്%2$s ക്ലിക്ക് ചെയ്യുക"
 #. Tells the user where to click to open their browser's settings menu.
 msgid "Click %ssettings/hamburger icon %s on the Chrome toolbar (top right)."
 msgstr ""
-"(മുകളിൽ വലത്), Chrome ടൂൾബാറിലെ %1$sക്രമീകരണം/ഹാംബർഗർ ഐക്കൺ %2$s ക്ലിക്ക് ചെയ്യുക."
+"(മുകളിൽ വലത്), Chrome ടൂൾബാറിലെ %1$sക്രമീകരണം/ഹാംബർഗർ ഐക്കൺ %2$s ക്ലിക്ക് "
+"ചെയ്യുക."
 
 #  Maxthon default search engine instruction
 # smartling.placeholder_format=C
@@ -4416,9 +4468,10 @@ msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Search Settings%s."
 msgstr ""
-"%1$sഎൻ്റെ ഡാറ്റ ഇല്ലാതാക്കുക%2$s ക്ലിക്ക് ചെയ്യുക അല്ലെങ്കിൽ ടാപ്പ് ചെയ്യുക. ഇത് ക്ലൗഡിൽ നിന്ന് "
-"ഡാറ്റ നീക്കംചെയ്യുന്നു, എന്നാൽ നിങ്ങൾ %3$sഎല്ലാ തിരയൽ ക്രമീകരണവും പുനഃക്രമീകരിക്കുക%4$s "
-"ക്ലിക്ക്/ടാപ്പ് ചെയ്യുന്നതുവരെ ഇത് നിങ്ങളുടെ ബ്രൗസറിൽ തുടരും."
+"%1$sഎൻ്റെ ഡാറ്റ ഇല്ലാതാക്കുക%2$s ക്ലിക്ക് ചെയ്യുക അല്ലെങ്കിൽ ടാപ്പ് ചെയ്യുക. "
+"ഇത് ക്ലൗഡിൽ നിന്ന് ഡാറ്റ നീക്കംചെയ്യുന്നു, എന്നാൽ നിങ്ങൾ %3$sഎല്ലാ തിരയൽ "
+"ക്രമീകരണവും പുനഃക്രമീകരിക്കുക%4$s ക്ലിക്ക്/ടാപ്പ് ചെയ്യുന്നതുവരെ ഇത് "
+"നിങ്ങളുടെ ബ്രൗസറിൽ തുടരും."
 
 # smartling.placeholder_format=C
 #. Tells users where to click in order to disable the cloud save feature and delete any data backed-up to the cloud.
@@ -4429,9 +4482,10 @@ msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Settings%s."
 msgstr ""
-"%1$sഎന്റെ ഡാറ്റ ഇല്ലാതാക്കുക%2$s ക്ലിക്ക് ചെയ്യുക അല്ലെങ്കിൽ ടാപ്പ് ചെയ്യുക. ഇത് ക്ലൗഡിൽ നിന്ന് "
-"ഡാറ്റ നീക്കംചെയ്യുന്നു, എന്നാൽ നിങ്ങൾ %3$sഎല്ലാ ക്രമീകരണവും പുനഃക്രമീകരിക്കുക%4$s ക്ലിക്ക്/"
-"ടാപ്പ് ചെയ്യുന്നതുവരെ ഇത് നിങ്ങളുടെ ബ്രൗസറിൽ തുടരും."
+"%1$sഎന്റെ ഡാറ്റ ഇല്ലാതാക്കുക%2$s ക്ലിക്ക് ചെയ്യുക അല്ലെങ്കിൽ ടാപ്പ് ചെയ്യുക. "
+"ഇത് ക്ലൗഡിൽ നിന്ന് ഡാറ്റ നീക്കംചെയ്യുന്നു, എന്നാൽ നിങ്ങൾ %3$sഎല്ലാ "
+"ക്രമീകരണവും പുനഃക്രമീകരിക്കുക%4$s ക്ലിക്ക്/ടാപ്പ് ചെയ്യുന്നതുവരെ ഇത് "
+"നിങ്ങളുടെ ബ്രൗസറിൽ തുടരും."
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -4500,8 +4554,8 @@ msgid ""
 "Click the dropdown menu beside %sSearch engine used in the address bar%s and "
 "select %sDuckDuckGo%s."
 msgstr ""
-"%1$sവിലാസ ബാറിൽ ഉപയോഗിച്ചിരിക്കുന്ന തിരയൽ എഞ്ചിന്%2$s സമീപമുള്ള ഡ്രോപ്പ്ഡൗൺ മെനുവിൽ "
-"ക്ലിക്ക് ചെയ്ത്, %3$sDuckDuckGo%4$s തിരഞ്ഞെടുക്കുക."
+"%1$sവിലാസ ബാറിൽ ഉപയോഗിച്ചിരിക്കുന്ന തിരയൽ എഞ്ചിന്%2$s സമീപമുള്ള ഡ്രോപ്പ്ഡൗൺ "
+"മെനുവിൽ ക്ലിക്ക് ചെയ്ത്, %3$sDuckDuckGo%4$s തിരഞ്ഞെടുക്കുക."
 
 # smartling.placeholder_format=C
 #. First step in a list of steps to take to disable the user's ad blocker
@@ -4509,8 +4563,8 @@ msgid ""
 "Click the icon of the ad blocker extension. It's usually in the upper right "
 "hand corner of your browser."
 msgstr ""
-"Ad blocker എക്സ്റ്റൻഷന്റെ ഐക്കണിൽ ക്ലിക്ക് ചെയ്യുക. ഇത് സാധാരണയായി നിങ്ങളുടെ ബ്രൗസറിന്റെ "
-"മുകളിൽ വലത് കോണിലായിരിക്കും."
+"Ad blocker എക്സ്റ്റൻഷന്റെ ഐക്കണിൽ ക്ലിക്ക് ചെയ്യുക. ഇത് സാധാരണയായി നിങ്ങളുടെ "
+"ബ്രൗസറിന്റെ മുകളിൽ വലത് കോണിലായിരിക്കും."
 
 #  Safari default search engine instruction
 # smartling.placeholder_format=C
@@ -4699,8 +4753,8 @@ msgid ""
 "Cloud Save lets you save your settings more permanently by entering a "
 "passphrase. It is entirely optional."
 msgstr ""
-"Cloud Save പാസ്‌ഫ്രെയ്സ് നൽകുക വഴി നിങ്ങളുടെ ക്രമീകരണം സ്ഥിരമായി സംരക്ഷിക്കാൻ അനുവദിക്കും. "
-"ഇത് തീർത്തും ഓപ്ഷണല്‍ ആണ്."
+"Cloud Save പാസ്‌ഫ്രെയ്സ് നൽകുക വഴി നിങ്ങളുടെ ക്രമീകരണം സ്ഥിരമായി "
+"സംരക്ഷിക്കാൻ അനുവദിക്കും. ഇത് തീർത്തും ഓപ്ഷണല്‍ ആണ്."
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -5129,7 +5183,9 @@ msgstr "കോസ്റ്റാ റിക്ക"
 #. Inline error shown on the recovery code screen when exportSyncSettings rejects.
 msgctxt "Error message when the recovery code fails to generate"
 msgid "Couldn't load your recovery code. Please close this and try again."
-msgstr "നിങ്ങളുടെ റിക്കവറി കോഡ് ലോഡ് ചെയ്യാൻ കഴിഞ്ഞില്ല. ദയവായി ഇത് അടച്ച് വീണ്ടും ശ്രമിക്കു."
+msgstr ""
+"നിങ്ങളുടെ റിക്കവറി കോഡ് ലോഡ് ചെയ്യാൻ കഴിഞ്ഞില്ല. ദയവായി ഇത് അടച്ച് വീണ്ടും "
+"ശ്രമിക്കു."
 
 # smartling.placeholder_format=C
 #. Pairs with a Retry button. Shown after two consecutive failed attempts to load the device list.
@@ -5178,7 +5234,7 @@ msgstr "ചിത്രം സൃഷ്ടിക്കുക"
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
-msgstr ""
+msgstr "ഈ പാചകക്കുറിപ്പിൽ നിന്നുള്ള അളവുകൾ സഹിതം ഒരു ഷോപ്പിംഗ് ലിസ്റ്റ് തയ്യാറാക്കുക."
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed in the input field when starting a new image generation session.
@@ -5442,7 +5498,9 @@ msgstr "ദൈനംദിന ഉപയോഗ പരിധി കവിഞ്ഞ
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "Daily usage limit reached. You can keep chatting by using your weekly limit."
-msgstr "ദൈനംദിന ഉപയോഗ പരിധി കവിഞ്ഞു. നിങ്ങൾക്ക് പ്രതിവാര പരിധി ഉപയോഗിച്ച് ചാറ്റ് തുടരാം."
+msgstr ""
+"ദൈനംദിന ഉപയോഗ പരിധി കവിഞ്ഞു. നിങ്ങൾക്ക് പ്രതിവാര പരിധി ഉപയോഗിച്ച് ചാറ്റ് "
+"തുടരാം."
 
 # smartling.placeholder_format=C
 #. The name of the Danish language
@@ -5700,7 +5758,9 @@ msgstr "സംഭരണ സ്ഥലം ശൂന്യമാക്കാൻ ഏ
 #. Title shown when user has reached the file storage sync quota (5GB).
 msgctxt "Sync file storage limit modal title"
 msgid "Delete oldest chats with attachments to free up storage?"
-msgstr "സ്റ്റോറേജ് ഒഴിവാക്കാൻ അറ്റാച്ച്മെന്റുകളുള്ള ഏറ്റവും പഴയ ചാറ്റുകൾ ഇല്ലാതാക്കണോ?"
+msgstr ""
+"സ്റ്റോറേജ് ഒഴിവാക്കാൻ അറ്റാച്ച്മെന്റുകളുള്ള ഏറ്റവും പഴയ ചാറ്റുകൾ "
+"ഇല്ലാതാക്കണോ?"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to delete all recent chats.
@@ -5810,8 +5870,8 @@ msgstr "Duck.ai-യിലെ ഡിക്റ്റേഷൻ"
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
 msgstr ""
-"ഡിക്റ്റേഷൻ നമ്മൾ അജ്ഞാതമാക്കിയിരിക്കുന്നു, മാത്രമല്ല AI മോഡലുകളെ പരിശീലിപ്പിക്കാൻ ഒരിക്കലും "
-"ഉപയോഗിക്കാറില്ല."
+"ഡിക്റ്റേഷൻ നമ്മൾ അജ്ഞാതമാക്കിയിരിക്കുന്നു, മാത്രമല്ല AI മോഡലുകളെ "
+"പരിശീലിപ്പിക്കാൻ ഒരിക്കലും ഉപയോഗിക്കാറില്ല."
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
@@ -5821,7 +5881,7 @@ msgstr "ഡിക്റ്റേഷൻ പരിധിയിൽ എത്തി"
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
 msgid "Dictation temporarily unavailable"
-msgstr ""
+msgstr "ഡിക്റ്റേഷൻ താൽക്കാലികമായി ലഭ്യമല്ല"
 
 # smartling.placeholder_format=C
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
@@ -5829,8 +5889,9 @@ msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
 "chat in Duck.ai without having to type."
 msgstr ""
-"നിങ്ങളുടെ സംസാരം ടെക്സ്റ്റാക്കി മാറ്റുന്നതിനായി ഡിക്റ്റേഷൻ ഒരു OpenAI മോഡൽ ഉപയോഗിക്കുന്നു, "
-"അതിനാൽ നിങ്ങൾക്ക് ടൈപ്പ് ചെയ്യാതെ തന്നെ Duck.ai-യിൽ ചാറ്റ് ചെയ്യാൻ സാധിക്കും."
+"നിങ്ങളുടെ സംസാരം ടെക്സ്റ്റാക്കി മാറ്റുന്നതിനായി ഡിക്റ്റേഷൻ ഒരു OpenAI മോഡൽ "
+"ഉപയോഗിക്കുന്നു, അതിനാൽ നിങ്ങൾക്ക് ടൈപ്പ് ചെയ്യാതെ തന്നെ Duck.ai-യിൽ ചാറ്റ് "
+"ചെയ്യാൻ സാധിക്കും."
 
 # smartling.placeholder_format=C
 #. In 0-click box -- link to definition.
@@ -6098,7 +6159,9 @@ msgstr "പട്ടികയിൽ DuckDuckGo കാണുന്നില്ല
 #. Link to download a file again if the user can't find it on their computer.
 msgctxt "install-extension"
 msgid "Don't see it? %s%s%sClick here to re-download%s"
-msgstr "അത് കാണുന്നില്ലേ? %1$s%2$s%3$sവീണ്ടും ഡൗൺലോഡ് ചെയ്യാൻ ഇവിടെ ക്ലിക്ക് ചെയ്യുക%4$s"
+msgstr ""
+"അത് കാണുന്നില്ലേ? %1$s%2$s%3$sവീണ്ടും ഡൗൺലോഡ് ചെയ്യാൻ ഇവിടെ ക്ലിക്ക് "
+"ചെയ്യുക%4$s"
 
 #  IE < 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -6130,6 +6193,8 @@ msgid ""
 "Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
 "filtered out. %sLearn More%s"
 msgstr ""
+"AI വേണ്ടേ? %1$snoai.duckduckgo.com%2$s AI ഫീച്ചറുകളൊന്നും നൽകുന്നില്ല, AI "
+"ചിത്രങ്ങൾ ഫിൽട്ടർ ചെയ്ത് ഒഴിവാക്കിയിരിക്കുന്നു. %3$sകൂടുതലറിയുക%4$s"
 
 # smartling.placeholder_format=C
 #. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
@@ -6138,6 +6203,8 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
+"AI വേണ്ടേ? %1$snoai.duckduckgo.com%2$s സന്ദർശിക്കുക AI സവിശേഷതകളില്ലാതെ, AI "
+"ചിത്രങ്ങൾ ഫിൽട്ടർ ചെയ്ത് ഒഴിവാക്കിയ നിലയിൽ തിരയാൻ. %3$sകൂടുതൽ അറിയുക%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6240,8 +6307,8 @@ msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for "
 "ceiling fan repair services."
 msgstr ""
-"സീലിംഗ് ഫാൻ അറ്റകുറ്റപ്പണി സേവനങ്ങൾക്കായി ഒരു ക്വൊട്ടേഷൻ അഭ്യർത്ഥിച്ച് ഒരു വെണ്ടറിന് "
-"സംക്ഷിപ്തവും വിശദവുമായ ഒരു ഇമെയിൽ തയ്യാറാക്കുക."
+"സീലിംഗ് ഫാൻ അറ്റകുറ്റപ്പണി സേവനങ്ങൾക്കായി ഒരു ക്വൊട്ടേഷൻ അഭ്യർത്ഥിച്ച് ഒരു "
+"വെണ്ടറിന് സംക്ഷിപ്തവും വിശദവുമായ ഒരു ഇമെയിൽ തയ്യാറാക്കുക."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion asking for an email draft to a vendor requesting a quote for home refrigerator repair services.
@@ -6250,20 +6317,20 @@ msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
 msgstr ""
-"വീട്ടിലെ റഫ്രിജറേറ്റർ അറ്റകുറ്റപ്പണി സേവനങ്ങൾക്കായി ഒരു ക്വൊട്ടേഷൻ അഭ്യർത്ഥിച്ച് ഒരു വെണ്ടർക്ക് "
-"സംക്ഷിപ്തവും വിശദവുമായ ഒരു ഇമെയിൽ തയ്യാറാക്കുക."
+"വീട്ടിലെ റഫ്രിജറേറ്റർ അറ്റകുറ്റപ്പണി സേവനങ്ങൾക്കായി ഒരു ക്വൊട്ടേഷൻ "
+"അഭ്യർത്ഥിച്ച് ഒരു വെണ്ടർക്ക് സംക്ഷിപ്തവും വിശദവുമായ ഒരു ഇമെയിൽ തയ്യാറാക്കുക."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Draft a cover letter"
-msgstr ""
+msgstr "ഒരു കവർ ലെറ്റർ തയ്യാറാക്കുക"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Draft a cover letter for this job."
-msgstr ""
+msgstr "ഈ ജോലിക്കായി ഒരു കവർ ലെറ്റർ തയ്യാറാക്കുക."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -6272,8 +6339,8 @@ msgid ""
 "Draft a few options for a social media post inviting people to my upcoming "
 "party."
 msgstr ""
-"എന്റെ വരാനിരിക്കുന്ന പാർട്ടിയിലേക്ക് ആളുകളെ ക്ഷണിക്കുന്ന ഒരു സോഷ്യൽ മീഡിയ പോസ്റ്റിന് കുറച്ച് "
-"ഓപ്ഷനുകൾ ഡ്രാഫ്റ്റ് ചെയ്യുക."
+"എന്റെ വരാനിരിക്കുന്ന പാർട്ടിയിലേക്ക് ആളുകളെ ക്ഷണിക്കുന്ന ഒരു സോഷ്യൽ മീഡിയ "
+"പോസ്റ്റിന് കുറച്ച് ഓപ്ഷനുകൾ ഡ്രാഫ്റ്റ് ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a few options for a blog post title about strategies to increase team collaboration.
@@ -6282,8 +6349,8 @@ msgid ""
 "Draft a few options for a title of a post I’m writing about strategies to "
 "increase team collaboration."
 msgstr ""
-"ടീം സഹകരണം വർദ്ധിപ്പിക്കുന്നതിനുള്ള തന്ത്രങ്ങളെക്കുറിച്ച് ഞാൻ എഴുതുന്ന ഒരു പോസ്റ്റിന്റെ "
-"തലക്കെട്ടിനായി കുറച്ച് ഓപ്ഷനുകൾ തയ്യാറാക്കുക."
+"ടീം സഹകരണം വർദ്ധിപ്പിക്കുന്നതിനുള്ള തന്ത്രങ്ങളെക്കുറിച്ച് ഞാൻ എഴുതുന്ന ഒരു "
+"പോസ്റ്റിന്റെ തലക്കെട്ടിനായി കുറച്ച് ഓപ്ഷനുകൾ തയ്യാറാക്കുക."
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for drafting a social media post.
@@ -6353,7 +6420,9 @@ msgstr "നിങ്ങളുടെ ഫോട്ടോകളോ PDF ഫയലു
 # smartling.placeholder_format=C
 #. A title explaining what Duck Player (DDG's feature to watch youtube videos more privately) does
 msgid "Duck Player lets you watch YouTube without targeted ads"
-msgstr "ലക്ഷ്യമിട്ടുള്ള പരസ്യങ്ങളില്ലാതെ YouTube കാണാൻ Duck Player നിങ്ങളെ അനുവദിക്കുന്നു"
+msgstr ""
+"ലക്ഷ്യമിട്ടുള്ള പരസ്യങ്ങളില്ലാതെ YouTube കാണാൻ Duck Player നിങ്ങളെ "
+"അനുവദിക്കുന്നു"
 
 # smartling.placeholder_format=C
 #. This is the DDG version of "Google it", meaning "search it".
@@ -6409,9 +6478,10 @@ msgid ""
 "content is only included when you attach it, unless you choose to attach "
 "pages automatically in Settings."
 msgstr ""
-"നിങ്ങൾ കാണുന്ന പേജിനെക്കുറിച്ചുള്ള ചോദ്യങ്ങൾക്ക് ഇപ്പോൾ Duck.ai-യ്ക്ക് ഉത്തരം നൽകാൻ "
-"സഹായിക്കാനാവും. ക്രമീകരണങ്ങളിൽ പേജുകൾ സ്വയമേവ അറ്റാച്ച് ചെയ്യാൻ നിങ്ങൾ "
-"തിരഞ്ഞെടുക്കുന്നില്ലെങ്കിൽ മാത്രമേ അത് അറ്റാച്ചുചെയ്യുമ്പോൾ പേജ് ഉള്ളടക്കം ഉൾപ്പെടുത്തൂ."
+"നിങ്ങൾ കാണുന്ന പേജിനെക്കുറിച്ചുള്ള ചോദ്യങ്ങൾക്ക് ഇപ്പോൾ Duck.ai-യ്ക്ക് "
+"ഉത്തരം നൽകാൻ സഹായിക്കാനാവും. ക്രമീകരണങ്ങളിൽ പേജുകൾ സ്വയമേവ അറ്റാച്ച് ചെയ്യാൻ "
+"നിങ്ങൾ തിരഞ്ഞെടുക്കുന്നില്ലെങ്കിൽ മാത്രമേ അത് അറ്റാച്ചുചെയ്യുമ്പോൾ പേജ് "
+"ഉള്ളടക്കം ഉൾപ്പെടുത്തൂ."
 
 # smartling.placeholder_format=C
 #. Shown in the Duck.ai recent chats list on standalone when the browser API needed to store chats locally is missing or unavailable.
@@ -6421,9 +6491,9 @@ msgid ""
 "Duck.ai can’t access local storage to save your chats. Please check your "
 "browser settings or disable any extensions and try again."
 msgstr ""
-"നിങ്ങളുടെ ചാറ്റുകൾ സംരക്ഷിക്കാനായി Duck.ai-ക്ക് ലോക്കൽ സ്റ്റോറേജ് ആക്‌സസ് ചെയ്യാൻ കഴിയില്ല. "
-"നിങ്ങളുടെ ബ്രൗസർ ക്രമീകരണങ്ങൾ പരിശോധിക്കുകയോ ഏതെങ്കിലും എക്സ്റ്റൻഷനുകൾ പ്രവർത്തനരഹിതമാക്കുകയോ "
-"ചെയ്ത് വീണ്ടും ശ്രമിക്കുക."
+"നിങ്ങളുടെ ചാറ്റുകൾ സംരക്ഷിക്കാനായി Duck.ai-ക്ക് ലോക്കൽ സ്റ്റോറേജ് ആക്‌സസ് "
+"ചെയ്യാൻ കഴിയില്ല. നിങ്ങളുടെ ബ്രൗസർ ക്രമീകരണങ്ങൾ പരിശോധിക്കുകയോ ഏതെങ്കിലും "
+"എക്സ്റ്റൻഷനുകൾ പ്രവർത്തനരഹിതമാക്കുകയോ ചെയ്ത് വീണ്ടും ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Displayed when the chat service has reached the maximum number of messages for one day.
@@ -6432,14 +6502,16 @@ msgid ""
 "Duck.ai has reached the maximum number of messages for one day. Please "
 "continue this chat tomorrow."
 msgstr ""
-"ഒരു ദിവസത്തേക്കുള്ള പരമാവധി സന്ദേശങ്ങളുടെ എണ്ണത്തിൽ Duck.ai എത്തിച്ചേർന്നു. ദയവായി നാളെ ഈ "
-"ചാറ്റ് തുടരുക."
+"ഒരു ദിവസത്തേക്കുള്ള പരമാവധി സന്ദേശങ്ങളുടെ എണ്ണത്തിൽ Duck.ai എത്തിച്ചേർന്നു. "
+"ദയവായി നാളെ ഈ ചാറ്റ് തുടരുക."
 
 # smartling.placeholder_format=C
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
-msgstr "ഞങ്ങളുടെ സ്വകാര്യവും സൗജന്യവുമായ DuckDuckGo ബ്രൗസറിൽ Duck.ai ആണ് ഏറ്റവും മികച്ചത്!"
+msgstr ""
+"ഞങ്ങളുടെ സ്വകാര്യവും സൗജന്യവുമായ DuckDuckGo ബ്രൗസറിൽ Duck.ai ആണ് ഏറ്റവും "
+"മികച്ചത്!"
 
 # smartling.placeholder_format=C
 #. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
@@ -6449,6 +6521,9 @@ msgid ""
 "company for anyone who wants to take back control of their personal "
 "information."
 msgstr ""
+"Duck.ai നിർമ്മിച്ചത് DuckDuckGo ആണ്. തങ്ങളുടെ സ്വകാര്യ വിവരങ്ങളുടെ "
+"നിയന്ത്രണം തിരികെ നേടാൻ ആഗ്രഹിക്കുന്ന ഏതൊരാൾക്കും വേണ്ടിയുള്ള ഒരു സ്വതന്ത്ര "
+"ഓൺലൈൻ സംരക്ഷണ കമ്പനിയാണ് ഞങ്ങൾ."
 
 # smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
@@ -6463,8 +6538,8 @@ msgid ""
 "Duck.ai is still a DuckDuckGo product, but will now have an easier to "
 "remember home on the web: https://duck.ai"
 msgstr ""
-"Duck.ai ഇപ്പോഴും ഒരു DuckDuckGo ഉൽപ്പന്നമാണ്, പക്ഷേ ഇനി വെബിൽ ഓർമ്മിക്കാൻ എളുപ്പമുള്ള ഒരു "
-"വിലാസം ലഭിക്കും: https://duck.ai"
+"Duck.ai ഇപ്പോഴും ഒരു DuckDuckGo ഉൽപ്പന്നമാണ്, പക്ഷേ ഇനി വെബിൽ ഓർമ്മിക്കാൻ "
+"എളുപ്പമുള്ള ഒരു വിലാസം ലഭിക്കും: https://duck.ai"
 
 # smartling.placeholder_format=C
 #. Headline for domain change notice.
@@ -6479,8 +6554,8 @@ msgid ""
 "Duck.ai is temporarily unavailable. If this persists, please email this "
 "anonymous code %s to %s"
 msgstr ""
-"Duck.ai താൽക്കാലികമായി ലഭ്യമല്ല. ഇത് നിലനിൽക്കുകയാണെങ്കിൽ, ദയവായി ഈ %1$s അജ്ഞാത കോഡ് "
-"%2$s എന്നതിലേക്ക് ഇമെയിൽ ചെയ്യുക"
+"Duck.ai താൽക്കാലികമായി ലഭ്യമല്ല. ഇത് നിലനിൽക്കുകയാണെങ്കിൽ, ദയവായി ഈ %1$s "
+"അജ്ഞാത കോഡ് %2$s എന്നതിലേക്ക് ഇമെയിൽ ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -6501,6 +6576,9 @@ msgid ""
 "Duck.ai lets you chat privately with popular AI models. Disabling it hides "
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
+"ജനപ്രിയ AI മോഡലുകളുമായി സ്വകാര്യമായി ചാറ്റ് ചെയ്യാൻ Duck.ai നിങ്ങളെ "
+"അനുവദിക്കുന്നു. ഇത് പ്രവർത്തനരഹിതമാക്കുന്നത് Duck.ai ബട്ടണുകളും ലിങ്കുകളും "
+"മറയ്ക്കും, എന്നാൽ നിങ്ങൾക്ക് ഇപ്പോഴും %1$sduck.ai%2$s സന്ദർശിക്കാം നേരിട്ട്."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6511,11 +6589,12 @@ msgid ""
 "can still access Duck.ai when this setting is off by visiting %shttps://duck."
 "ai%s directly."
 msgstr ""
-"OpenAI, Anthropic, കൂടാതെ മറ്റുള്ളവയിൽ നിന്നുമുള്ള മോഡലുകൾ ഉൾപ്പെടെ മൂന്നാം കക്ഷി AI ചാറ്റ് "
-"മോഡലുകളുമായി അജ്ഞാത സംഭാഷണങ്ങൾ നടത്താൻ Duck.ai നിങ്ങളെ അനുവദിക്കുന്നു. ഈ ക്രമീകരണം "
-"ഓഫാക്കുന്നത് DuckDuckGo Search-ലെ Duck.ai ബട്ടണുകളും ലിങ്കുകളും മറയ്ക്കും. എന്നിരുന്നാലും, ഈ "
-"ക്രമീകരണം ഓഫ് ആയിരിക്കുമ്പോൾ %1$shttps://duck.ai%2$s സന്ദർശിച്ച് നിങ്ങൾക്ക് Duck.ai "
-"ആക്സസ് ചെയ്യാൻ കഴിയും. നേരിട്ട്."
+"OpenAI, Anthropic, കൂടാതെ മറ്റുള്ളവയിൽ നിന്നുമുള്ള മോഡലുകൾ ഉൾപ്പെടെ മൂന്നാം "
+"കക്ഷി AI ചാറ്റ് മോഡലുകളുമായി അജ്ഞാത സംഭാഷണങ്ങൾ നടത്താൻ Duck.ai നിങ്ങളെ "
+"അനുവദിക്കുന്നു. ഈ ക്രമീകരണം ഓഫാക്കുന്നത് DuckDuckGo Search-ലെ Duck.ai "
+"ബട്ടണുകളും ലിങ്കുകളും മറയ്ക്കും. എന്നിരുന്നാലും, ഈ ക്രമീകരണം ഓഫ് "
+"ആയിരിക്കുമ്പോൾ %1$shttps://duck.ai%2$s സന്ദർശിച്ച് നിങ്ങൾക്ക് Duck.ai ആക്സസ് "
+"ചെയ്യാൻ കഴിയും. നേരിട്ട്."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
@@ -6530,15 +6609,16 @@ msgid ""
 "Duck.ai might have lost your recent chats. You can still use Duck.ai as "
 "usual."
 msgstr ""
-"Duck.ai-ക്ക് നിങ്ങളുടെ അടുത്തിടെ നടന്ന ചാറ്റുകൾ നഷ്ടപ്പെട്ടിരിക്കാം. നിങ്ങൾക്ക് ഇപ്പോഴും "
-"പതിവുപോലെ Duck.ai ഉപയോഗിക്കാം."
+"Duck.ai-ക്ക് നിങ്ങളുടെ അടുത്തിടെ നടന്ന ചാറ്റുകൾ നഷ്ടപ്പെട്ടിരിക്കാം. "
+"നിങ്ങൾക്ക് ഇപ്പോഴും പതിവുപോലെ Duck.ai ഉപയോഗിക്കാം."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
 msgctxt "Promotional text for PDF upload feature"
 msgid "Duck.ai now can read and analyze PDFs. Give it a try!"
 msgstr ""
-"Duck.ai-ക്ക് ഇപ്പോൾ PDF-കൾ വായിക്കാനും വിശകലനം ചെയ്യാനും കഴിയും. ഒന്ന് പരീക്ഷിച്ചു നോക്കൂ!"
+"Duck.ai-ക്ക് ഇപ്പോൾ PDF-കൾ വായിക്കാനും വിശകലനം ചെയ്യാനും കഴിയും. ഒന്ന് "
+"പരീക്ഷിച്ചു നോക്കൂ!"
 
 # smartling.placeholder_format=C
 #. Disclaimer text shown above the chat input only when coming from a DuckAssist grounded response into ungrounded models.
@@ -6546,8 +6626,8 @@ msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
 msgstr ""
-"Duck.ai പ്രതികരണങ്ങൾ പ്രത്യേക ഉറവിടങ്ങളെ അടിസ്ഥാനമാക്കിയുള്ളതല്ല, അല്ലെങ്കിൽ കൃത്യതയ്ക്കായി "
-"പരിശോധിച്ചിട്ടുമില്ല."
+"Duck.ai പ്രതികരണങ്ങൾ പ്രത്യേക ഉറവിടങ്ങളെ അടിസ്ഥാനമാക്കിയുള്ളതല്ല, അല്ലെങ്കിൽ "
+"കൃത്യതയ്ക്കായി പരിശോധിച്ചിട്ടുമില്ല."
 
 # smartling.placeholder_format=C
 #. Title shown when native app needs to reload for service update.
@@ -6566,8 +6646,8 @@ msgstr "Duck.ai അപ്ഗ്രേഡ് ചെയ്തു!"
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
 msgstr ""
-"Duck.ai ഏറ്റവും മികച്ച രീതിയിൽ പ്രവർത്തിക്കുന്നത് ഞങ്ങളുടെ സ്വകാര്യവും സൗജന്യവുമായ "
-"DuckDuckGo ആപ്പിലാണ്!"
+"Duck.ai ഏറ്റവും മികച്ച രീതിയിൽ പ്രവർത്തിക്കുന്നത് ഞങ്ങളുടെ സ്വകാര്യവും "
+"സൗജന്യവുമായ DuckDuckGo ആപ്പിലാണ്!"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -6577,9 +6657,10 @@ msgid ""
 "AI chat no sign up, OpenAI, Anthropic, Llama, Mistral, open source AI "
 "models, privacy focused AI, no account AI chat"
 msgstr ""
-"Duck.ai, DuckDuckGo AI, സ്വകാര്യ AI ചാറ്റ്ബോട്ട്, സൗജന്യ AI ചാറ്റ്, അജ്ഞാത AI ചാറ്റ്, "
-"സൈൻ അപ്പ് ആവശ്യമില്ലാത്ത AI ചാറ്റ്, OpenAI, ആന്ത്രോപിക്, ലാമ, മിസ്ട്രൽ, ഓപ്പൺ സോഴ്‌സ് AI "
-"മോഡലുകൾ, സ്വകാര്യത കേന്ദ്രീകരിച്ചുള്ള AI, അക്കൗണ്ടില്ലാത്ത AI ചാറ്റ്"
+"Duck.ai, DuckDuckGo AI, സ്വകാര്യ AI ചാറ്റ്ബോട്ട്, സൗജന്യ AI ചാറ്റ്, അജ്ഞാത "
+"AI ചാറ്റ്, സൈൻ അപ്പ് ആവശ്യമില്ലാത്ത AI ചാറ്റ്, OpenAI, ആന്ത്രോപിക്, ലാമ, "
+"മിസ്ട്രൽ, ഓപ്പൺ സോഴ്‌സ് AI മോഡലുകൾ, സ്വകാര്യത കേന്ദ്രീകരിച്ചുള്ള AI, "
+"അക്കൗണ്ടില്ലാത്ത AI ചാറ്റ്"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -6607,11 +6688,12 @@ msgid ""
 "relevant), or Often (shows more frequently on a wider range of searches). "
 "For now, DuckAssist is only available in the U.S. (English) region."
 msgstr ""
-"DuckAssist-ന് അജ്ഞാതമായി തിരയാനും ചില search-കൾക്ക് മറുപടിയായി വിവരങ്ങൾ സംഗ്രഹിക്കാനും "
-"കഴിയും. DuckAssist എത്ര തവണ ദൃശ്യമാകാൻ ആഗ്രഹിക്കുന്നുവെന്ന് നിങ്ങൾക്ക് തിരഞ്ഞെടുക്കാം: "
-"ഒരിക്കലുമില്ല (Search ഫലങ്ങളിൽ നിന്ന് DuckAssist UI പൂർണ്ണമായും നീക്കംചെയ്യുന്നു), ഓൺ-"
-"ഡിമാൻഡ് (നിങ്ങൾ അസിസ്റ്റ് ബട്ടൺ ക്ലിക്ക് ചെയ്താൽ മാത്രം കാണിക്കുന്നു), ചിലപ്പോൾ (വളരെ "
-"പ്രസക്തമാകുമ്പോൾ മാത്രം കാണിക്കുക), ഇടയ്ക്കിടെ (വിശാലമായ Search-കളിൽ കൂടുതൽ പതിവായി "
+"DuckAssist-ന് അജ്ഞാതമായി തിരയാനും ചില search-കൾക്ക് മറുപടിയായി വിവരങ്ങൾ "
+"സംഗ്രഹിക്കാനും കഴിയും. DuckAssist എത്ര തവണ ദൃശ്യമാകാൻ ആഗ്രഹിക്കുന്നുവെന്ന് "
+"നിങ്ങൾക്ക് തിരഞ്ഞെടുക്കാം: ഒരിക്കലുമില്ല (Search ഫലങ്ങളിൽ നിന്ന് DuckAssist "
+"UI പൂർണ്ണമായും നീക്കംചെയ്യുന്നു), ഓൺ-ഡിമാൻഡ് (നിങ്ങൾ അസിസ്റ്റ് ബട്ടൺ "
+"ക്ലിക്ക് ചെയ്താൽ മാത്രം കാണിക്കുന്നു), ചിലപ്പോൾ (വളരെ പ്രസക്തമാകുമ്പോൾ "
+"മാത്രം കാണിക്കുക), ഇടയ്ക്കിടെ (വിശാലമായ Search-കളിൽ കൂടുതൽ പതിവായി "
 "കാണിക്കുന്നു). ഇപ്പോൾ, DuckAssist യുഎസ് (ഇംഗ്ലീഷ്) മേഖലയിൽ മാത്രമേ ലഭ്യമാകൂ."
 
 # smartling.placeholder_format=C
@@ -6621,9 +6703,10 @@ msgid ""
 "%sDuckDuckGo AI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI, and Anthropic, and more."
 msgstr ""
-"DuckAssist-ന് ഫോളോ-അപ്പ് ചോദ്യങ്ങൾക്ക് ഉത്തരം നൽകാൻ കഴിയില്ല, എന്നിരുന്നാലും, ഞങ്ങൾ "
-"%1$sDuckDuckGo AI Chat%2$s വാഗ്ദാനം ചെയ്യുന്നു, ഇത് OpenAI, Anthropic തുടങ്ങിയവയിൽ "
-"നിന്നുള്ള ചാറ്റ് മോഡലുകളെ പിന്തുണയ്ക്കുന്ന ഒരു സ്വകാര്യ AI-പിന്തുണയുള്ള ചാറ്റ് സേവനമാണ്."
+"DuckAssist-ന് ഫോളോ-അപ്പ് ചോദ്യങ്ങൾക്ക് ഉത്തരം നൽകാൻ കഴിയില്ല, "
+"എന്നിരുന്നാലും, ഞങ്ങൾ %1$sDuckDuckGo AI Chat%2$s വാഗ്ദാനം ചെയ്യുന്നു, ഇത് "
+"OpenAI, Anthropic തുടങ്ങിയവയിൽ നിന്നുള്ള ചാറ്റ് മോഡലുകളെ പിന്തുണയ്ക്കുന്ന "
+"ഒരു സ്വകാര്യ AI-പിന്തുണയുള്ള ചാറ്റ് സേവനമാണ്."
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6632,9 +6715,10 @@ msgid ""
 "DuckDuckGo %sAI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI and Anthropic."
 msgstr ""
-"DuckAssist-ന് ഫോളോ-അപ്പ് ചോദ്യങ്ങൾക്ക് ഉത്തരം നൽകാൻ കഴിയില്ല, എന്നിരുന്നാലും, ഞങ്ങൾ "
-"DuckDuckGo %1$sAI Chat%2$s എന്നിവയും വാഗ്ദാനം ചെയ്യുന്നു, ഇത് OpenAI, Anthropic "
-"എന്നിവയിൽ നിന്നുള്ള ചാറ്റ് മോഡലുകളെ പിന്തുണയ്ക്കുന്ന ഒരു സ്വകാര്യ AI-പിന്തുണയുള്ള ചാറ്റ് സേവനമാണ്."
+"DuckAssist-ന് ഫോളോ-അപ്പ് ചോദ്യങ്ങൾക്ക് ഉത്തരം നൽകാൻ കഴിയില്ല, "
+"എന്നിരുന്നാലും, ഞങ്ങൾ DuckDuckGo %1$sAI Chat%2$s എന്നിവയും വാഗ്ദാനം "
+"ചെയ്യുന്നു, ഇത് OpenAI, Anthropic എന്നിവയിൽ നിന്നുള്ള ചാറ്റ് മോഡലുകളെ "
+"പിന്തുണയ്ക്കുന്ന ഒരു സ്വകാര്യ AI-പിന്തുണയുള്ള ചാറ്റ് സേവനമാണ്."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6646,12 +6730,13 @@ msgid ""
 "responses are currently based on Wikipedia and related content and are not "
 "checked for accuracy."
 msgstr ""
-"ഞങ്ങളുടെ തിരയൽ ഫലങ്ങളിലെ ഒരു പുതിയ സവിശേഷതയാണ് DuckAssist, അതിന് തിരയൽ അന്വേഷണങ്ങൾക്ക് "
-"അജ്ഞാതമായി ഉത്തരങ്ങൾ സൃഷ്ടിക്കാൻ കഴിയും. ഇതിനായി, പ്രസക്തമായ ഉള്ളടക്കത്തിനായി "
-"വിക്കിപീഡിയയെയും അനുബന്ധ സൈറ്റുകളെയും സ്കാൻ ചെയ്യുകയും തുടർന്ന് ആ വിവരങ്ങളുടെ സംഗ്രഹം "
-"സൃഷ്ടിക്കാൻ AI-പിന്തുണയുള്ള സ്വാഭാവിക ഭാഷാ സാങ്കേതികവിദ്യ ഉപയോഗിക്കുകയും ചെയ്യുന്നു. അതിന്റെ "
-"പ്രതികരണങ്ങൾ നിലവിൽ വിക്കിപീഡിയയെയും അനുബന്ധ ഉള്ളടക്കത്തെയും അടിസ്ഥാനമാക്കിയുള്ളതാണെന്നും "
-"കൃത്യത പരിശോധിച്ചിട്ടില്ലെന്നതും ശ്രദ്ധിക്കുക."
+"ഞങ്ങളുടെ തിരയൽ ഫലങ്ങളിലെ ഒരു പുതിയ സവിശേഷതയാണ് DuckAssist, അതിന് തിരയൽ "
+"അന്വേഷണങ്ങൾക്ക് അജ്ഞാതമായി ഉത്തരങ്ങൾ സൃഷ്ടിക്കാൻ കഴിയും. ഇതിനായി, പ്രസക്തമായ "
+"ഉള്ളടക്കത്തിനായി വിക്കിപീഡിയയെയും അനുബന്ധ സൈറ്റുകളെയും സ്കാൻ ചെയ്യുകയും "
+"തുടർന്ന് ആ വിവരങ്ങളുടെ സംഗ്രഹം സൃഷ്ടിക്കാൻ AI-പിന്തുണയുള്ള സ്വാഭാവിക ഭാഷാ "
+"സാങ്കേതികവിദ്യ ഉപയോഗിക്കുകയും ചെയ്യുന്നു. അതിന്റെ പ്രതികരണങ്ങൾ നിലവിൽ "
+"വിക്കിപീഡിയയെയും അനുബന്ധ ഉള്ളടക്കത്തെയും അടിസ്ഥാനമാക്കിയുള്ളതാണെന്നും കൃത്യത "
+"പരിശോധിച്ചിട്ടില്ലെന്നതും ശ്രദ്ധിക്കുക."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6665,14 +6750,16 @@ msgid ""
 "It’s important to remember that responses are auto-generated from cited "
 "sources and based on %scrawling the web%s."
 msgstr ""
-"ഞങ്ങളുടെ തിരയൽ ഫലങ്ങളിലെ ഒരു പുതിയ ഓപ്ഷണൽ സവിശേഷതയാണ് DuckAssist, അതിന് തിരയൽ "
-"അന്വേഷണങ്ങൾക്ക് അജ്ഞാതമായി ഉത്തരങ്ങൾ സൃഷ്ടിക്കാൻ കഴിയും. ഇത് ചെയ്യുന്നതിന്, പ്രസക്തമായ "
-"ഉള്ളടക്കത്തിനായി ഇത് വെബ് സ്കാൻ ചെയ്യുകയും തുടർന്ന് കണ്ടെത്തിയ പ്രസക്തമായ വിവരങ്ങളെ "
-"അടിസ്ഥാനമാക്കി ഒരു ഹ്രസ്വമായ ഉത്തരം സൃഷ്ടിക്കുന്നതിന് AI- പിന്തുണയ്ക്കുന്ന സ്വഭാവിക ഭാഷ "
-"സാങ്കേതികവിദ്യ ഉപയോഗിക്കുകയും ചെയ്യുന്നു. DuckAssist പ്രതികരണങ്ങൾ എല്ലായ്പ്പോഴും ഒന്നോ രണ്ടോ "
-"ഉറവിടങ്ങളിലേക്ക് നേരിട്ട് ലിങ്ക് ചെയ്യുന്നു, ഉത്തരം എവിടെ നിന്ന് വന്നുവെന്ന് ഉദ്ധരിക്കുന്നു, അതിനാൽ "
-"നിങ്ങൾക്ക് എളുപ്പത്തിൽ കൂടുതൽ വിശദമായ വിവരങ്ങൾ നേടാനാവും. ഉദ്ധരിച്ച ഉറവിടങ്ങളിൽ നിന്ന് "
-"പ്രതികരണങ്ങൾ സ്വയം സൃഷ്ടിക്കപ്പെട്ടതാണെന്നും%2$s വെബ് ക്രൗളിങ്ങിനെ "
+"ഞങ്ങളുടെ തിരയൽ ഫലങ്ങളിലെ ഒരു പുതിയ ഓപ്ഷണൽ സവിശേഷതയാണ് DuckAssist, അതിന് "
+"തിരയൽ അന്വേഷണങ്ങൾക്ക് അജ്ഞാതമായി ഉത്തരങ്ങൾ സൃഷ്ടിക്കാൻ കഴിയും. ഇത് "
+"ചെയ്യുന്നതിന്, പ്രസക്തമായ ഉള്ളടക്കത്തിനായി ഇത് വെബ് സ്കാൻ ചെയ്യുകയും "
+"തുടർന്ന് കണ്ടെത്തിയ പ്രസക്തമായ വിവരങ്ങളെ അടിസ്ഥാനമാക്കി ഒരു ഹ്രസ്വമായ ഉത്തരം "
+"സൃഷ്ടിക്കുന്നതിന് AI- പിന്തുണയ്ക്കുന്ന സ്വഭാവിക ഭാഷ സാങ്കേതികവിദ്യ "
+"ഉപയോഗിക്കുകയും ചെയ്യുന്നു. DuckAssist പ്രതികരണങ്ങൾ എല്ലായ്പ്പോഴും ഒന്നോ "
+"രണ്ടോ ഉറവിടങ്ങളിലേക്ക് നേരിട്ട് ലിങ്ക് ചെയ്യുന്നു, ഉത്തരം എവിടെ നിന്ന് "
+"വന്നുവെന്ന് ഉദ്ധരിക്കുന്നു, അതിനാൽ നിങ്ങൾക്ക് എളുപ്പത്തിൽ കൂടുതൽ വിശദമായ "
+"വിവരങ്ങൾ നേടാനാവും. ഉദ്ധരിച്ച ഉറവിടങ്ങളിൽ നിന്ന് പ്രതികരണങ്ങൾ സ്വയം "
+"സൃഷ്ടിക്കപ്പെട്ടതാണെന്നും%2$s വെബ് ക്രൗളിങ്ങിനെ "
 "%1$sഅടിസ്ഥാനമാക്കിയുള്ളതാണെന്നും ഓർമ്മിക്കേണ്ടത് പ്രധാനമാണ്."
 
 # smartling.placeholder_format=C
@@ -6691,8 +6778,8 @@ msgid ""
 "DuckDuckGo AI Chat has reached the maximum number of messages for one day. "
 "Please continue this chat tomorrow."
 msgstr ""
-"DuckDuckGo AI Chat ഒരു ദിവസത്തേക്ക് പരമാവധി മെസേജുകള് എത്തിയിട്ടുണ്ട്. ദയവായി നാളെ ഈ "
-"ചാറ്റ് തുടരുക."
+"DuckDuckGo AI Chat ഒരു ദിവസത്തേക്ക് പരമാവധി മെസേജുകള് എത്തിയിട്ടുണ്ട്. "
+"ദയവായി നാളെ ഈ ചാറ്റ് തുടരുക."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the AI chat service and supported AI models. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -6701,8 +6788,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"നിലവിൽ %1$sന്റെ %2$s, %3$sന്റെ %4$s ചാറ്റ് മോഡലുകളെ പിന്തുണയ്ക്കുന്ന ഒരു സ്വകാര്യ AI "
-"പ്രവർത്തിപ്പിക്കുന്ന ചാറ്റ് സേവനമാണ് DuckDuckGo AI Chat."
+"നിലവിൽ %1$sന്റെ %2$s, %3$sന്റെ %4$s ചാറ്റ് മോഡലുകളെ പിന്തുണയ്ക്കുന്ന ഒരു "
+"സ്വകാര്യ AI പ്രവർത്തിപ്പിക്കുന്ന ചാറ്റ് സേവനമാണ് DuckDuckGo AI Chat."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the welcome screen of the onboarding. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -6711,8 +6798,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"നിലവിൽ %1$sന്റെ %2$s, %3$sന്റെ %4$s ചാറ്റ് മോഡലുകളെ പിന്തുണയ്ക്കുന്ന ഒരു സ്വകാര്യ AI "
-"പ്രവർത്തിപ്പിക്കുന്ന ചാറ്റ് സേവനമാണ് DuckDuckGo AI Chat."
+"നിലവിൽ %1$sന്റെ %2$s, %3$sന്റെ %4$s ചാറ്റ് മോഡലുകളെ പിന്തുണയ്ക്കുന്ന ഒരു "
+"സ്വകാര്യ AI പ്രവർത്തിപ്പിക്കുന്ന ചാറ്റ് സേവനമാണ് DuckDuckGo AI Chat."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding DuckDuckGo AI Chat.
@@ -6721,8 +6808,8 @@ msgid ""
 "DuckDuckGo AI Chat is in Beta, it may display inaccurate or offensive "
 "information."
 msgstr ""
-"DuckDuckGo AI Chat ബീറ്റയിലാണുള്ളത്, ഇത് കൃത്യമല്ലാത്തതോ കുറ്റകരമായതോ ആയ വിവരങ്ങൾ "
-"പ്രദർശിപ്പിച്ചേക്കാം."
+"DuckDuckGo AI Chat ബീറ്റയിലാണുള്ളത്, ഇത് കൃത്യമല്ലാത്തതോ കുറ്റകരമായതോ ആയ "
+"വിവരങ്ങൾ പ്രദർശിപ്പിച്ചേക്കാം."
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat making it unavailable, and asking the user to send an email with a specific code if the error persists. E.g. 'DuckDuckGo AI Chat is temporarily unavailable. If this persists, please email this anonymous code abcdefg12345 to aichat-error@duckduckgo.com'
@@ -6731,8 +6818,8 @@ msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. If this persists, please "
 "email this anonymous code %s to %s"
 msgstr ""
-"DuckDuckGo AI Chat താൽക്കാലികമായി ലഭ്യമല്ല. ഇത് നിലനിൽക്കുകയാണെങ്കിൽ, ദയവായി ഈ "
-"അജ്ഞാത കോഡ് %1$s %2$s എന്നതിലേക്ക് ഇമെയിൽ ചെയ്യുക"
+"DuckDuckGo AI Chat താൽക്കാലികമായി ലഭ്യമല്ല. ഇത് നിലനിൽക്കുകയാണെങ്കിൽ, ദയവായി "
+"ഈ അജ്ഞാത കോഡ് %1$s %2$s എന്നതിലേക്ക് ഇമെയിൽ ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -6865,8 +6952,9 @@ msgid ""
 "DuckDuckGo anonymizes these reports by automatically removing PII like "
 "names, email addresses, phone numbers, and identifying metadata."
 msgstr ""
-"പേരുകൾ, ഇമെയിൽ വിലാസങ്ങൾ, ഫോൺ നമ്പറുകൾ, തിരിച്ചറിയൽ മെറ്റാഡാറ്റ എന്നിവ പോലുള്ള PII "
-"സ്വയമേവ നീക്കം ചെയ്തുകൊണ്ട് DuckDuckGo ഈ റിപ്പോർട്ടുകൾ അജ്ഞാതമാക്കുന്നു."
+"പേരുകൾ, ഇമെയിൽ വിലാസങ്ങൾ, ഫോൺ നമ്പറുകൾ, തിരിച്ചറിയൽ മെറ്റാഡാറ്റ എന്നിവ "
+"പോലുള്ള PII സ്വയമേവ നീക്കം ചെയ്തുകൊണ്ട് DuckDuckGo ഈ റിപ്പോർട്ടുകൾ "
+"അജ്ഞാതമാക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. The first %s is the agree button label ('Agree'). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. The leading sentence mirrors the drawer-style inline disclaimer (DUCKCHAT_TOS_INLINE_DISCLAIMER).
@@ -6874,8 +6962,8 @@ msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid ""
 "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to Duck.ai's %s."
 msgstr ""
-"DuckDuckGo നിങ്ങളുടെ ചാറ്റുകൾ അജ്ഞാതമാക്കുന്നു. '%1$s' ക്ലിക്ക് ചെയ്യുക വഴി, നിങ്ങൾ Duck.ai-"
-"യുടെ %2$s സമ്മതിക്കുന്നു."
+"DuckDuckGo നിങ്ങളുടെ ചാറ്റുകൾ അജ്ഞാതമാക്കുന്നു. '%1$s' ക്ലിക്ക് ചെയ്യുക വഴി, "
+"നിങ്ങൾ Duck.ai-യുടെ %2$s സമ്മതിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Shown below the input on the empty state when the user has not yet accepted the terms of service. The first %s is the action button label ('Ask' for chat, 'Create' for image generation). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. Clicking the action button both accepts the terms and submits the prompt.
@@ -6884,8 +6972,8 @@ msgctxt ""
 "users"
 msgid "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to our %s."
 msgstr ""
-"DuckDuckGo നിങ്ങളുടെ ചാറ്റുകൾ അജ്ഞാതമാക്കുന്നു. '%1$s' ക്ലിക്ക് ചെയ്യുക വഴി, നിങ്ങൾ ഞങ്ങളുടെ "
-"%2$s-നെ അംഗീകരിക്കുന്നു."
+"DuckDuckGo നിങ്ങളുടെ ചാറ്റുകൾ അജ്ഞാതമാക്കുന്നു. '%1$s' ക്ലിക്ക് ചെയ്യുക വഴി, "
+"നിങ്ങൾ ഞങ്ങളുടെ %2$s-നെ അംഗീകരിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. An information popup explaining that we block trackers
@@ -6894,9 +6982,9 @@ msgid ""
 "companies like Google and Facebook, who often try to track you on other "
 "websites."
 msgstr ""
-"മറ്റ് വെബ്‌സൈറ്റുകളിൽ ഇടയ്ക്കിടെ നിങ്ങളെ ട്രാക്ക് ചെയ്യാൻ ശ്രമിക്കുന്ന Google, Facebook പോലുള്ള "
-"കമ്പനികളിൽ നിന്നുള്ള ട്രാക്കറുകൾ ഉൾപ്പെടെ, നിങ്ങൾ സന്ദർശിക്കുന്ന വെബ്‌സൈറ്റുകളിലെ ട്രാക്കറുകളെ "
-"DuckDuckGo തടയുന്നു."
+"മറ്റ് വെബ്‌സൈറ്റുകളിൽ ഇടയ്ക്കിടെ നിങ്ങളെ ട്രാക്ക് ചെയ്യാൻ ശ്രമിക്കുന്ന "
+"Google, Facebook പോലുള്ള കമ്പനികളിൽ നിന്നുള്ള ട്രാക്കറുകൾ ഉൾപ്പെടെ, നിങ്ങൾ "
+"സന്ദർശിക്കുന്ന വെബ്‌സൈറ്റുകളിലെ ട്രാക്കറുകളെ DuckDuckGo തടയുന്നു."
 
 # smartling.placeholder_format=C
 #. Description of how DuckDuckGo keeps a user's location anonymous while the user searches on a map of their area.
@@ -6908,12 +6996,13 @@ msgid ""
 "away, such that you remain anonymous. %sLearn more about how we designed "
 "this technology to protect your privacy%s."
 msgstr ""
-"ഡിസൈൻ പ്രകാരം DuckDuckGo സ്വകാര്യമാണ്. നിങ്ങൾ ലൊക്കേഷൻ പ്രവർത്തനക്ഷമമാക്കുമ്പോൾ, നിങ്ങളുടെ "
-"ലോക്കൽ ഉപകരണത്തിൽ മാത്രം അത് സംഭരിക്കപ്പെടുന്നു. നിങ്ങൾ തിരയുമ്പോൾ, നിങ്ങളുടെ ഉപകരണം അത് "
-"ഞങ്ങൾക്ക് അയയ്ക്കുന്നു, ആ തിരയലിനായുള്ള ഫലങ്ങൾ മെച്ചപ്പെടുത്തുന്നതിന് ഞങ്ങൾ അത് ഉപയോഗിക്കുന്നു, "
-"തുടർന്ന് നിങ്ങൾ അജ്ഞാതമായി തുടരുന്ന തരത്തിൽ ഞങ്ങൾ അത് ഉടനടി ഉപേക്ഷിച്ചുകളയുന്നു. %1$sനിങ്ങളുടെ "
-"സ്വകാര്യത പരിരക്ഷിക്കുന്നതിന് ഞങ്ങൾ ഈ സാങ്കേതികവിദ്യ രൂപകൽപ്പന ചെയ്തത് എങ്ങനെയെന്ന് കൂടുതൽ "
-"അറിയുക%2$s."
+"ഡിസൈൻ പ്രകാരം DuckDuckGo സ്വകാര്യമാണ്. നിങ്ങൾ ലൊക്കേഷൻ "
+"പ്രവർത്തനക്ഷമമാക്കുമ്പോൾ, നിങ്ങളുടെ ലോക്കൽ ഉപകരണത്തിൽ മാത്രം അത് "
+"സംഭരിക്കപ്പെടുന്നു. നിങ്ങൾ തിരയുമ്പോൾ, നിങ്ങളുടെ ഉപകരണം അത് ഞങ്ങൾക്ക് "
+"അയയ്ക്കുന്നു, ആ തിരയലിനായുള്ള ഫലങ്ങൾ മെച്ചപ്പെടുത്തുന്നതിന് ഞങ്ങൾ അത് "
+"ഉപയോഗിക്കുന്നു, തുടർന്ന് നിങ്ങൾ അജ്ഞാതമായി തുടരുന്ന തരത്തിൽ ഞങ്ങൾ അത് ഉടനടി "
+"ഉപേക്ഷിച്ചുകളയുന്നു. %1$sനിങ്ങളുടെ സ്വകാര്യത പരിരക്ഷിക്കുന്നതിന് ഞങ്ങൾ ഈ "
+"സാങ്കേതികവിദ്യ രൂപകൽപ്പന ചെയ്തത് എങ്ങനെയെന്ന് കൂടുതൽ അറിയുക%2$s."
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
@@ -6933,8 +7022,9 @@ msgid ""
 "DuckDuckGo only uses your approximate location. That's all we need to "
 "deliver better results, closer to you. %sLearn more%s."
 msgstr ""
-"നിങ്ങളുടെ ഏകദേശ ലൊക്കേഷൻ മാത്രമേ DuckDuckGo ഉപയോഗിക്കുകയുള്ളൂ. നിങ്ങൾക്ക് കൂടുതൽ ബന്ധമുള്ള, "
-"മികച്ച ഫലങ്ങൾ നൽകാൻ ഞങ്ങൾ ചെയ്യേണ്ടത് അതുമാത്രമാണ്. %1$sകൂടുതൽ അറിയുക%2$s."
+"നിങ്ങളുടെ ഏകദേശ ലൊക്കേഷൻ മാത്രമേ DuckDuckGo ഉപയോഗിക്കുകയുള്ളൂ. നിങ്ങൾക്ക് "
+"കൂടുതൽ ബന്ധമുള്ള, മികച്ച ഫലങ്ങൾ നൽകാൻ ഞങ്ങൾ ചെയ്യേണ്ടത് അതുമാത്രമാണ്. "
+"%1$sകൂടുതൽ അറിയുക%2$s."
 
 # smartling.placeholder_format=C
 msgid "DuckDuckGo search"
@@ -7020,10 +7110,11 @@ msgid ""
 "random words from that list, ensuring that the passphrase is at least 18-20 "
 "characters long."
 msgstr ""
-"ഓരോ തവണയും നിങ്ങൾ ഒരു പാസ്‌ഫ്രെയ്സ് നിർദേശം ആവശ്യപ്പെടുമ്പോൾ, DuckDuckGo സെർവറുകളിൽ നിന്ന് "
-"ക്രമരഹിതമായ പദങ്ങളുടെ ഒരു നീണ്ട പട്ടിക ഞങ്ങൾക്ക് ലഭിക്കും. പിന്നീട്, ബ്രൗസറിൽ, ആ പട്ടികയിൽ "
-"നിന്നും ഞങ്ങൾ 4-5 ക്രമരഹിതമായ പദങ്ങൾ തിരഞ്ഞെടുത്തുകൊണ്ട്, പാസ്‌ഫ്രെയ്സിന് കുറഞ്ഞത് 18-20 "
-"അക്ഷരങ്ങളെങ്കിലും ദൈർഘ്യമുണ്ടെന്ന് ഉറപ്പാക്കുന്നു."
+"ഓരോ തവണയും നിങ്ങൾ ഒരു പാസ്‌ഫ്രെയ്സ് നിർദേശം ആവശ്യപ്പെടുമ്പോൾ, DuckDuckGo "
+"സെർവറുകളിൽ നിന്ന് ക്രമരഹിതമായ പദങ്ങളുടെ ഒരു നീണ്ട പട്ടിക ഞങ്ങൾക്ക് ലഭിക്കും. "
+"പിന്നീട്, ബ്രൗസറിൽ, ആ പട്ടികയിൽ നിന്നും ഞങ്ങൾ 4-5 ക്രമരഹിതമായ പദങ്ങൾ "
+"തിരഞ്ഞെടുത്തുകൊണ്ട്, പാസ്‌ഫ്രെയ്സിന് കുറഞ്ഞത് 18-20 അക്ഷരങ്ങളെങ്കിലും "
+"ദൈർഘ്യമുണ്ടെന്ന് ഉറപ്പാക്കുന്നു."
 
 # smartling.placeholder_format=C
 msgctxt "Sports module"
@@ -7088,8 +7179,8 @@ msgctxt "Info text for the editing message feature"
 msgid ""
 "Editing your message will remove the response below and generate a new one."
 msgstr ""
-"നിങ്ങളുടെ സന്ദേശം എഡിറ്റ് ചെയ്യുന്നത് ചുവടെയുള്ള പ്രതികരണം നീക്കംചെയ്യുകയും പുതിയത് സൃഷ്ടിക്കുകയും "
-"ചെയ്യും."
+"നിങ്ങളുടെ സന്ദേശം എഡിറ്റ് ചെയ്യുന്നത് ചുവടെയുള്ള പ്രതികരണം നീക്കംചെയ്യുകയും "
+"പുതിയത് സൃഷ്ടിക്കുകയും ചെയ്യും."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of an editor in its responses.
@@ -7150,7 +7241,9 @@ msgstr "AI സവിശേഷതകൾ പ്രവർത്തനക്ഷമ�
 #. Text explaining how to enable the cloud save feature.
 msgctxt "cloudsave"
 msgid "Enable Cloud Save by entering your existing passphrase."
-msgstr "നിങ്ങളുടെ നിലവിലുള്ള പാസ്‌ഫ്രെയ്സ് ഉപയോഗിച്ച് Cloud Save പ്രവർത്തനക്ഷമമാക്കുക."
+msgstr ""
+"നിങ്ങളുടെ നിലവിലുള്ള പാസ്‌ഫ്രെയ്സ് ഉപയോഗിച്ച് Cloud Save "
+"പ്രവർത്തനക്ഷമമാക്കുക."
 
 # smartling.placeholder_format=C
 #. Primary button text in the dictation privacy consent modal to enable dictation.
@@ -7221,8 +7314,8 @@ msgid ""
 "Enable anonymous location for more accurate results. You can always change "
 "your mind later."
 msgstr ""
-"കൂടുതൽ കൃത്യമായ ഫലങ്ങൾക്കായി അജ്ഞാത ലൊക്കേഷൻ പ്രവർത്തനക്ഷമമാക്കുക. പിന്നീട് എപ്പോൾ "
-"വേണമെങ്കിലും നിങ്ങളുടെ മനസ്സ് മാറ്റാൻ കഴിയും."
+"കൂടുതൽ കൃത്യമായ ഫലങ്ങൾക്കായി അജ്ഞാത ലൊക്കേഷൻ പ്രവർത്തനക്ഷമമാക്കുക. പിന്നീട് "
+"എപ്പോൾ വേണമെങ്കിലും നിങ്ങളുടെ മനസ്സ് മാറ്റാൻ കഴിയും."
 
 # smartling.placeholder_format=C
 #. Title of the dictation privacy consent modal shown on first use.
@@ -7267,8 +7360,9 @@ msgid ""
 "Enabling anonymous location gives more accurate results but still keeps your "
 "searches and exact location private to DuckDuckGo."
 msgstr ""
-"അജ്ഞാത ലൊക്കേഷൻ പ്രവർത്തനക്ഷമമാക്കുന്നത് കൂടുതൽ കൃത്യമായ ഫലങ്ങൾ നൽകുന്നു, പക്ഷേ അപ്പോഴും നിങ്ങളുടെ "
-"തിരയലുകളും കൃത്യമായ ലൊക്കേഷനും DuckDuckGo-യിലേക്ക് സ്വകാര്യമായി സൂക്ഷിക്കുന്നു."
+"അജ്ഞാത ലൊക്കേഷൻ പ്രവർത്തനക്ഷമമാക്കുന്നത് കൂടുതൽ കൃത്യമായ ഫലങ്ങൾ നൽകുന്നു, "
+"പക്ഷേ അപ്പോഴും നിങ്ങളുടെ തിരയലുകളും കൃത്യമായ ലൊക്കേഷനും DuckDuckGo-യിലേക്ക് "
+"സ്വകാര്യമായി സൂക്ഷിക്കുന്നു."
 
 # smartling.placeholder_format=C
 msgid "Encrypt Connections"
@@ -7345,7 +7439,8 @@ msgstr "Duck.ai ആസ്വദിക്കുകയാണോ?"
 msgctxt "precise_user_location"
 msgid "Ensure %s'Allow'%s is selected for the 'Location' setting."
 msgstr ""
-"'ലൊക്കേഷൻ' ക്രമീകരണത്തിനായി %1$s'അനുവദിക്കുക'%2$s തിരഞ്ഞെടുത്തിട്ടുണ്ടെന്ന് ഉറപ്പാക്കുക."
+"'ലൊക്കേഷൻ' ക്രമീകരണത്തിനായി %1$s'അനുവദിക്കുക'%2$s തിരഞ്ഞെടുത്തിട്ടുണ്ടെന്ന് "
+"ഉറപ്പാക്കുക."
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
@@ -7431,8 +7526,8 @@ msgid ""
 "Enter a new passphrase and click/tap %sSave Settings%s. This will save your "
 "data under your new passphrase."
 msgstr ""
-"ഒരു പുതിയ പാസ്‌ഫ്രെയ്സ് നൽകിയിട്ട്, %1$sക്രമീകരണം സംരക്ഷിക്കുക%2$s ക്ലിക്ക് ചെയ്യുക. ഇത് "
-"നിങ്ങളുടെ പുതിയ പാസ്‌ഫ്രെയ്സിന് കീഴിൽ ഡാറ്റ രക്ഷിക്കും."
+"ഒരു പുതിയ പാസ്‌ഫ്രെയ്സ് നൽകിയിട്ട്, %1$sക്രമീകരണം സംരക്ഷിക്കുക%2$s ക്ലിക്ക് "
+"ചെയ്യുക. ഇത് നിങ്ങളുടെ പുതിയ പാസ്‌ഫ്രെയ്സിന് കീഴിൽ ഡാറ്റ രക്ഷിക്കും."
 
 # smartling.placeholder_format=C
 #. Label for the field where a user enters their passphrase.
@@ -7458,8 +7553,8 @@ msgstr "ടെക്‌സ്റ്റ് നൽകുക"
 msgid ""
 "Enter the following details: %sName%s: DuckDuckGo%s URL%s: %s Alias%s: d%s"
 msgstr ""
-"ഇനിപ്പറയുന്ന വിശദാംശങ്ങൾ നൽകുക: %1$s പേര് %2$s: DuckDuckGo%3$sURL%4$s: %5$sഅപരനാമം "
-"%6$s: ഡി%7$s"
+"ഇനിപ്പറയുന്ന വിശദാംശങ്ങൾ നൽകുക: %1$s പേര് %2$s: DuckDuckGo%3$sURL%4$s: "
+"%5$sഅപരനാമം %6$s: ഡി%7$s"
 
 # smartling.placeholder_format=C
 #. Prompt to enter a destination for driving directions.
@@ -7494,7 +7589,8 @@ msgstr "ഇക്വറ്റോറിയൽ ഗിനിയ"
 msgctxt "Browser Promo Popover"
 msgid "Erase your browsing data in a flash with our %sFire Button%s"
 msgstr ""
-"ഞങ്ങളുടെ Fire Button ഉപയോഗിച്ച് ഒറ്റ ഫ്ലാഷിൽ നിങ്ങളുടെ ബ്രൗസിംഗ് ഡാറ്റ മായ്ക്കുക %1$s%2$s"
+"ഞങ്ങളുടെ Fire Button ഉപയോഗിച്ച് ഒറ്റ ഫ്ലാഷിൽ നിങ്ങളുടെ ബ്രൗസിംഗ് ഡാറ്റ "
+"മായ്ക്കുക %1$s%2$s"
 
 # smartling.placeholder_format=C
 msgid "Eritrea"
@@ -7504,13 +7600,13 @@ msgstr "എറിത്രിയ"
 #. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Estimate the nutrition"
-msgstr ""
+msgstr "പോഷണം കണക്കാക്കുക"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Estimate the nutritional information for this recipe."
-msgstr ""
+msgstr "ഈ പാചകക്കുറിപ്പിനായുള്ള പോഷക വിവരങ്ങൾ കണക്കാക്കുക."
 
 # smartling.placeholder_format=C
 msgid "Estonia"
@@ -7546,7 +7642,9 @@ msgstr "മാപ്പ് വികസിപ്പിക്കുക"
 #. Subtitle for the Collaborations promotional card at the bottom of search results. Describes the branded merchandise line. 'Give a duck' is a wordplay on the DuckDuckGo brand name.
 msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
-msgstr "സ്വകാര്യതയെ ശരിക്കും ശ്രദ്ധിക്കുന്നവർക്കായി വിദഗ്ദ്ധമായി രൂപകൽപ്പന ചെയ്ത ഉൽപ്പന്നങ്ങൾ."
+msgstr ""
+"സ്വകാര്യതയെ ശരിക്കും ശ്രദ്ധിക്കുന്നവർക്കായി വിദഗ്ദ്ധമായി രൂപകൽപ്പന ചെയ്ത "
+"ഉൽപ്പന്നങ്ങൾ."
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
@@ -7570,7 +7668,7 @@ msgstr "1 ദിവസത്തിനുള്ളിൽ കാലഹരണപ്
 #. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain the accepted answer in simple terms."
-msgstr ""
+msgstr "അംഗീകരിച്ച ഉത്തരം ലളിതമായ വാക്കുകളിൽ വിശദീകരിക്കുക."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
@@ -7583,43 +7681,45 @@ msgstr "ഹൈസ്കൂൾ തലത്തിൽ തമോദ്വാരങ�
 #. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain the top answer"
-msgstr ""
+msgstr "ഏറ്റവും മികച്ച ഉത്തരം വിശദീകരിക്കുക"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain this in simple, plain language."
-msgstr ""
+msgstr "ഇത് ലളിതവും വ്യക്തവുമായ ഭാഷയിൽ വിശദീകരിക്കുക."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain this paper"
-msgstr ""
+msgstr "ഈ പ്രബന്ധം വിശദീകരിക്കുക"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain this repo"
-msgstr ""
+msgstr "ഈ റിപ്പോ വിശദീകരിക്കുക"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain this research paper in plain language."
-msgstr ""
+msgstr "ഈ ഗവേഷണ പ്രബന്ധം ലളിതമായ ഭാഷയിൽ വിശദീകരിക്കുക."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain this simply"
-msgstr ""
+msgstr "ഇത് ലളിതമായി വിശദീകരിക്കുക"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain what this repository does and how to use it."
 msgstr ""
+"ഈ റിപ്പോസിറ്ററി എന്താണ് ചെയ്യുന്നതെന്നും അത് എങ്ങനെ ഉപയോഗിക്കണമെന്നും "
+"വിശദീകരിക്കുക."
 
 # smartling.placeholder_format=C
 #. Label to show if song lyrics contain explicit content
@@ -7797,8 +7897,8 @@ msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and improvements."
 msgstr ""
-"നിങ്ങളുടെ ഫീഡ്ബാക്ക് ഞങ്ങളുടെ ഉൽപ്പന്ന അപ്ഡേറ്റുകളെയും മെച്ചപ്പെടുത്തലുകളെയും നേരിട്ട് "
-"സ്വാധീനിക്കുന്നു."
+"നിങ്ങളുടെ ഫീഡ്ബാക്ക് ഞങ്ങളുടെ ഉൽപ്പന്ന അപ്ഡേറ്റുകളെയും "
+"മെച്ചപ്പെടുത്തലുകളെയും നേരിട്ട് സ്വാധീനിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -7807,8 +7907,9 @@ msgid ""
 "Feedback like yours directly influences our product updates and "
 "improvements. Hopefully we can address the issue you shared too."
 msgstr ""
-"നിങ്ങളുടേത് പോലുള്ള ഫീഡ്ബാക്ക് ഞങ്ങളുടെ ഉൽപ്പന്ന അപ്ഡേറ്റുകളെയും മെച്ചപ്പെടുത്തലുകളെയും നേരിട്ട് "
-"സ്വാധീനിക്കുന്നു. നിങ്ങൾ പങ്കിട്ട പ്രശ്നവും പരിഹരിക്കാൻ ഞങ്ങൾക്ക് കഴിയുമെന്ന് പ്രതീക്ഷിക്കുന്നു."
+"നിങ്ങളുടേത് പോലുള്ള ഫീഡ്ബാക്ക് ഞങ്ങളുടെ ഉൽപ്പന്ന അപ്ഡേറ്റുകളെയും "
+"മെച്ചപ്പെടുത്തലുകളെയും നേരിട്ട് സ്വാധീനിക്കുന്നു. നിങ്ങൾ പങ്കിട്ട പ്രശ്നവും "
+"പരിഹരിക്കാൻ ഞങ്ങൾക്ക് കഴിയുമെന്ന് പ്രതീക്ഷിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box
@@ -7816,8 +7917,8 @@ msgid ""
 "Feel free to adjust the settings below. Then, just copy and paste the code "
 "into your website."
 msgstr ""
-"ഇഷ്ട പ്രകാരം താഴെയുള്ള ക്രമീകരണം ക്രമപ്പെടുത്തുക. തുടർന്ന് കോഡ് താങ്കളുടെ സൈറ്റിലേക്കു പകർത്തി "
-"ഒട്ടിക്കുക"
+"ഇഷ്ട പ്രകാരം താഴെയുള്ള ക്രമീകരണം ക്രമപ്പെടുത്തുക. തുടർന്ന് കോഡ് താങ്കളുടെ "
+"സൈറ്റിലേക്കു പകർത്തി ഒട്ടിക്കുക"
 
 # smartling.placeholder_format=C
 msgid "Fiji"
@@ -7901,14 +8002,16 @@ msgctxt "settings"
 msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
 msgstr ""
-"AI ഉപയോഗിച്ച് നിർമ്മിച്ച ചിത്രങ്ങൾ, ചിത്രങ്ങൾ തിരയുന്നതിൻ്റെ ഫലത്തിൽ നിന്ന് ഫിൽട്ടർ ചെയ്ത് "
-"ഒഴിവാക്കുന്നു. %1$sകൂടുതലറിയുക%2$s"
+"AI ഉപയോഗിച്ച് നിർമ്മിച്ച ചിത്രങ്ങൾ, ചിത്രങ്ങൾ തിരയുന്നതിൻ്റെ ഫലത്തിൽ നിന്ന് "
+"ഫിൽട്ടർ ചെയ്ത് ഒഴിവാക്കുന്നു. %1$sകൂടുതലറിയുക%2$s"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Filters out known AI spam sites from image search results. %sLearn More%s"
 msgstr ""
+"ഇമേജ് തിരയൽ ഫലങ്ങളിൽ നിന്ന് അറിയപ്പെടുന്ന AI സ്പാം സൈറ്റുകൾ ഒഴിവാക്കുന്നു. "
+"%1$sകൂടുതലറിയുക%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the final score of a sporting event.
@@ -7950,7 +8053,8 @@ msgstr "<b>%1$s</b> നിങ്ങളുടെ ഡൗൺലോഡുകൾ ഫ�
 #. Tells users how to change their default search engine to DuckDuckGo.
 msgid "Find DuckDuckGo in the displayed list and click %sMake Default%s"
 msgstr ""
-"പ്രദർശിപ്പിച്ച പട്ടികയിൽ DuckDuckGo കണ്ടെത്തി %1$sഡിഫോൾട്ട് ആക്കുക%2$s എന്നത് ക്ലിക്ക് ചെയ്യുക"
+"പ്രദർശിപ്പിച്ച പട്ടികയിൽ DuckDuckGo കണ്ടെത്തി %1$sഡിഫോൾട്ട് ആക്കുക%2$s "
+"എന്നത് ക്ലിക്ക് ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for finding a better word.
@@ -7968,7 +8072,7 @@ msgstr "നിലവിലെ വിവരങ്ങൾ കണ്ടെത്ത�
 #. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Find me alternatives"
-msgstr ""
+msgstr "എനിക്ക് മറ്റുവഴികൾ കണ്ടെത്തുക"
 
 # smartling.placeholder_format=C
 #. Button that searches for results closer to the user's current location.
@@ -7988,8 +8092,8 @@ msgctxt "Precise user location overlay"
 msgid ""
 "Find results near you. %sYour location stays private, secure, and anonymous."
 msgstr ""
-"നിങ്ങളോട് അടുത്തുള്ള ഫലങ്ങൾ കണ്ടെത്തുക. %1$sനിങ്ങളുടെ ലൊക്കേഷൻ സ്വകാര്യവും സുരക്ഷിതവും "
-"അജ്ഞാതവുമാണ്."
+"നിങ്ങളോട് അടുത്തുള്ള ഫലങ്ങൾ കണ്ടെത്തുക. %1$sനിങ്ങളുടെ ലൊക്കേഷൻ സ്വകാര്യവും "
+"സുരക്ഷിതവും അജ്ഞാതവുമാണ്."
 
 # smartling.placeholder_format=C
 #. Loading message shown while generating explore more follow-up questions
@@ -8053,8 +8157,9 @@ msgid ""
 "Follow the instructions for turning off the ad blocker for DuckDuckGo. You "
 "may have to select a menu option or click a button."
 msgstr ""
-"DuckDuckGo-യ്ക്കായി Ad blocker ഓഫാക്കാൻ നിർദ്ദേശങ്ങൾ പിന്തുടരുക. നിങ്ങൾ ഒരു മെനു ഓപ്ഷൻ "
-"തിരഞ്ഞെടുക്കുകയോ ഒരു ബട്ടൺ ക്ലിക്ക് ചെയ്യുകയോ ചെയ്യേണ്ടി വന്നേക്കാം."
+"DuckDuckGo-യ്ക്കായി Ad blocker ഓഫാക്കാൻ നിർദ്ദേശങ്ങൾ പിന്തുടരുക. നിങ്ങൾ ഒരു "
+"മെനു ഓപ്ഷൻ തിരഞ്ഞെടുക്കുകയോ ഒരു ബട്ടൺ ക്ലിക്ക് ചെയ്യുകയോ ചെയ്യേണ്ടി "
+"വന്നേക്കാം."
 
 # smartling.placeholder_format=C
 #. Privacy reassurance and instructions intro.
@@ -8165,7 +8270,9 @@ msgstr "സൗജന്യവും സ്വകാര്യവുമായ ച�
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr "സൗജന്യവും സ്വകാര്യവുമായ ചാറ്റുകൾ, ഞങ്ങൾ അജ്ഞാതമാക്കിയിരിക്കുന്നു. അക്കൗണ്ട് ആവശ്യമില്ല."
+msgstr ""
+"സൗജന്യവും സ്വകാര്യവുമായ ചാറ്റുകൾ, ഞങ്ങൾ അജ്ഞാതമാക്കിയിരിക്കുന്നു. അക്കൗണ്ട് "
+"ആവശ്യമില്ല."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -8195,7 +8302,9 @@ msgstr "പങ്കിടലും വാണിജ്യപരമായി ഉ�
 #. Description text explaining how to free up sync storage. Pinned chats are chats the user has explicitly marked to keep.
 msgctxt "Sync limit modal description"
 msgid "Free up space by deleting your chats. Pinned chats will not be deleted."
-msgstr "നിങ്ങളുടെ ചാറ്റുകൾ ഇല്ലാതാക്കി സ്ഥലം ശൂന്യമാക്കുക. പിൻ ചെയ്ത ചാറ്റുകൾ ഇല്ലാതാക്കില്ല."
+msgstr ""
+"നിങ്ങളുടെ ചാറ്റുകൾ ഇല്ലാതാക്കി സ്ഥലം ശൂന്യമാക്കുക. പിൻ ചെയ്ത ചാറ്റുകൾ "
+"ഇല്ലാതാക്കില്ല."
 
 # smartling.placeholder_format=C
 #. Indicates that this streaming service is free to watch but shows ads
@@ -8276,9 +8385,9 @@ msgid ""
 "<strong>Check for Updates...</strong>, then select <strong>Install Update</"
 "strong>."
 msgstr ""
-"Mac-ലെ ആപ്പ് മെനു ബാറിൽ നിന്ന്, <strong>DuckDuckGo</strong> &gt; <strong>അപ്ഡേറ്റുകൾ "
-"പരിശോധിക്കുക...</strong>, തുടർന്ന് <strong>അപ്ഡേറ്റ് ഇൻസ്റ്റാൾ ചെയ്യുക</strong> "
-"തിരഞ്ഞെടുക്കുക."
+"Mac-ലെ ആപ്പ് മെനു ബാറിൽ നിന്ന്, <strong>DuckDuckGo</strong> &gt; "
+"<strong>അപ്ഡേറ്റുകൾ പരിശോധിക്കുക...</strong>, തുടർന്ന് <strong>അപ്ഡേറ്റ് "
+"ഇൻസ്റ്റാൾ ചെയ്യുക</strong> തിരഞ്ഞെടുക്കുക."
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -8449,7 +8558,7 @@ msgstr "കൂടുതൽ സൃഷ്ടിക്കുക"
 #. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Generate a shopping list"
-msgstr ""
+msgstr "ഒരു ഷോപ്പിംഗ് ലിസ്റ്റ് സൃഷ്ടിക്കുക"
 
 # smartling.placeholder_format=C
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
@@ -8629,8 +8738,9 @@ msgid ""
 "Get access to advanced AI models in Duck.ai by subscribing to DuckDuckGo, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"ഞങ്ങളുടെ VPN-ഉം മറ്റ് പ്രീമിയം സ്വകാര്യതാ പരിരക്ഷകളും ഉൾപ്പെടുന്ന DuckDuckGo-യിലേക്ക് "
-"സബ്സ്ക്രൈബ് ചെയ്തുകൊണ്ട് Duck.ai-ലെ നൂതന AI മോഡലുകളിലേക്ക് ആക്സസ് നേടുക."
+"ഞങ്ങളുടെ VPN-ഉം മറ്റ് പ്രീമിയം സ്വകാര്യതാ പരിരക്ഷകളും ഉൾപ്പെടുന്ന "
+"DuckDuckGo-യിലേക്ക് സബ്സ്ക്രൈബ് ചെയ്തുകൊണ്ട് Duck.ai-ലെ നൂതന AI "
+"മോഡലുകളിലേക്ക് ആക്സസ് നേടുക."
 
 # smartling.placeholder_format=C
 #. Description for the subscription setting where users can subscribe to DuckDuckGo.
@@ -8641,8 +8751,8 @@ msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"ഞങ്ങളുടെ VPN-ഉം മറ്റ് പ്രീമിയം സ്വകാര്യതാ പരിരക്ഷകളും ഉൾപ്പെടുന്ന DuckDuckGo സബ്സ്ക്രിപ്ഷൻ "
-"ഉപയോഗിച്ച് Duck.ai-ലെ നൂതന AI മോഡലുകളിലേക്ക് ആക്സസ് നേടുക."
+"ഞങ്ങളുടെ VPN-ഉം മറ്റ് പ്രീമിയം സ്വകാര്യതാ പരിരക്ഷകളും ഉൾപ്പെടുന്ന DuckDuckGo "
+"സബ്സ്ക്രിപ്ഷൻ ഉപയോഗിച്ച് Duck.ai-ലെ നൂതന AI മോഡലുകളിലേക്ക് ആക്സസ് നേടുക."
 
 # smartling.placeholder_format=C
 #. A button for users to generate an AI generated answer from their query on the duckassist module
@@ -8677,7 +8787,8 @@ msgstr "നിങ്ങളുടെ ക്രമീകരണങ്ങൾ ഒര�
 msgid ""
 "Get seamless privacy protection on your browser for free with one download:"
 msgstr ""
-"ഒറ്റ ഡൗൺലോഡിൽ നിങ്ങളുടെ ബ്രൗസറിൽ തടസ്സമില്ലാത്ത സ്വകാര്യതാ പരിരക്ഷ സൗജന്യമായി നേടുക:"
+"ഒറ്റ ഡൗൺലോഡിൽ നിങ്ങളുടെ ബ്രൗസറിൽ തടസ്സമില്ലാത്ത സ്വകാര്യതാ പരിരക്ഷ "
+"സൗജന്യമായി നേടുക:"
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo app when clicked
@@ -8745,7 +8856,7 @@ msgstr "ഒന്ന് പരീക്ഷിച്ചു നോക്കൂ"
 #. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Give me a quick background on this person."
-msgstr ""
+msgstr "ഈ വ്യക്തിയെക്കുറിച്ച് എനിക്കൊരു ചെറിയ പശ്ചാത്തലം നൽകുക."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -8760,8 +8871,8 @@ msgid ""
 "Go to %sSettings > Privacy & Security > Location Services%s, and make sure "
 "“Location Services” is turned on."
 msgstr ""
-"%1$sക്രമീകരണം > സ്വകാര്യതയും സുരക്ഷയും > ലൊക്കേഷൻ സേവനങ്ങൾ%2$sഎന്നതിലേക്ക് പോയി "
-"\"ലൊക്കേഷൻ സേവനങ്ങൾ\" ഓണാക്കിയിട്ടുണ്ടെന്ന് ഉറപ്പാക്കുക."
+"%1$sക്രമീകരണം > സ്വകാര്യതയും സുരക്ഷയും > ലൊക്കേഷൻ സേവനങ്ങൾ%2$sഎന്നതിലേക്ക് "
+"പോയി \"ലൊക്കേഷൻ സേവനങ്ങൾ\" ഓണാക്കിയിട്ടുണ്ടെന്ന് ഉറപ്പാക്കുക."
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -9015,7 +9126,9 @@ msgstr "ഗ്വാട്ടിമാല"
 #. Text for a prompt suggestion for guiding through the basic steps of replacing a window wiper.
 msgctxt "Full sentence for learning a new skill"
 msgid "Guide me through the basic steps of replacing a window wiper."
-msgstr "ഒരു വിൻഡോ വൈപ്പർ മാറ്റിസ്ഥാപിക്കുന്നതിനുള്ള അടിസ്ഥാന ഘട്ടങ്ങളിലൂടെ എന്നെ നയിക്കുക."
+msgstr ""
+"ഒരു വിൻഡോ വൈപ്പർ മാറ്റിസ്ഥാപിക്കുന്നതിനുള്ള അടിസ്ഥാന ഘട്ടങ്ങളിലൂടെ എന്നെ "
+"നയിക്കുക."
 
 # smartling.placeholder_format=C
 msgid "Guinea"
@@ -9197,13 +9310,13 @@ msgstr "സ്വകാര്യത വ്യാപിപ്പിക്കാ�
 #. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Help me prep for the interview"
-msgstr ""
+msgstr "ഇന്റർവ്യൂവിനായി തയ്യാറെടുക്കാൻ എന്നെ സഹായിക്കുക"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Help me tailor my resume for this job."
-msgstr ""
+msgstr "ഈ ജോലിക്കായി എന്റെ റെസ്യൂമെ ഇണങ്ങുന്നതാക്കാൻ എന്നെ സഹായിക്കൂ."
 
 # smartling.placeholder_format=C
 #. Title of a SERP popup that invites users to take a survey (desktop only)
@@ -9215,7 +9328,9 @@ msgstr "DuckDuckGo മെച്ചപ്പെടുത്താൻ ഞങ്ങ
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Help us improve DuckDuckGo searches with your feedback"
-msgstr "നിങ്ങളുടെ ഫീഡ്ബാക്ക് ഉപയോഗിച്ച് DuckDuckGo തിരയലുകൾ മെച്ചപ്പെടുത്താൻ ഞങ്ങളെ സഹായിക്കൂ"
+msgstr ""
+"നിങ്ങളുടെ ഫീഡ്ബാക്ക് ഉപയോഗിച്ച് DuckDuckGo തിരയലുകൾ മെച്ചപ്പെടുത്താൻ ഞങ്ങളെ "
+"സഹായിക്കൂ"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -9273,7 +9388,9 @@ msgstr "Duck ഭാഗത്ത് ചേരാൻ നിങ്ങളുടെ �
 #. Text description for the Spread card in the SERP footer
 msgctxt "footer_card"
 msgid "Help your friends and family take back their privacy!"
-msgstr "നിങ്ങളുടെ സുഹൃത്തുക്കളെയും കുടുംബാംഗങ്ങളെയും അവരുടെ സ്വകാര്യത വീണ്ടെടുക്കാൻ സഹായിക്കൂ!"
+msgstr ""
+"നിങ്ങളുടെ സുഹൃത്തുക്കളെയും കുടുംബാംഗങ്ങളെയും അവരുടെ സ്വകാര്യത വീണ്ടെടുക്കാൻ "
+"സഹായിക്കൂ!"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -9442,8 +9559,8 @@ msgid ""
 "Highlights key facts in Search Assist answers to help you find important "
 "information faster."
 msgstr ""
-"പ്രധാനപ്പെട്ട വിവരങ്ങൾ വേഗത്തിൽ കണ്ടെത്താൻ നിങ്ങളെ സഹായിക്കുന്നതിന് Search Assist "
-"ഉത്തരങ്ങളിൽ പ്രധാന വസ്തുതകൾ എടുത്തുകാണിക്കുന്നു."
+"പ്രധാനപ്പെട്ട വിവരങ്ങൾ വേഗത്തിൽ കണ്ടെത്താൻ നിങ്ങളെ സഹായിക്കുന്നതിന് Search "
+"Assist ഉത്തരങ്ങളിൽ പ്രധാന വസ്തുതകൾ എടുത്തുകാണിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. The name of the Hindi language
@@ -9470,8 +9587,9 @@ msgid ""
 "Hit %sReturn%s on your keyboard to %ssave DuckDuckGo to the list. %sThen "
 "click %sMake Default%s"
 msgstr ""
-"DuckDuckGo പട്ടികയിലേക്ക് %3$sസംരക്ഷിക്കാൻ നിങ്ങളുടെ കീബോർഡിൽ %1$sമടങ്ങുക%2$s "
-"അമർത്തുക. %4$sതുടർന്ന് %5$sഡിഫോൾട്ട് ആക്കുക%6$s എന്നത് ക്ലിക്ക് ചെയ്യുക"
+"DuckDuckGo പട്ടികയിലേക്ക് %3$sസംരക്ഷിക്കാൻ നിങ്ങളുടെ കീബോർഡിൽ "
+"%1$sമടങ്ങുക%2$s അമർത്തുക. %4$sതുടർന്ന് %5$sഡിഫോൾട്ട് ആക്കുക%6$s എന്നത് "
+"ക്ലിക്ക് ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. The name of the Hmong Daw language
@@ -9485,8 +9603,8 @@ msgid ""
 "Hold on! Changing it back will disable the DuckDuckGo extension and you'll "
 "lose our privacy protection."
 msgstr ""
-"ഹോൾഡ് ഓൺ! ഇത് തിരികെ മാറ്റുന്നത് DuckDuckGo വിപുലീകരണം പ്രവർത്തനരഹിതമാക്കും, നിങ്ങൾക്ക് "
-"ഞങ്ങളുടെ സ്വകാര്യതാ പരിരക്ഷണം നഷ്‌ടമാകും."
+"ഹോൾഡ് ഓൺ! ഇത് തിരികെ മാറ്റുന്നത് DuckDuckGo വിപുലീകരണം പ്രവർത്തനരഹിതമാക്കും, "
+"നിങ്ങൾക്ക് ഞങ്ങളുടെ സ്വകാര്യതാ പരിരക്ഷണം നഷ്‌ടമാകും."
 
 # smartling.placeholder_format=C
 #. Heading shown above warning messages in the AI chat, for non-critical issues like unsupported file formats or file size limits. Analogous to 'Oops...' for error messages.
@@ -9536,8 +9654,8 @@ msgid ""
 "Hotel ad clicks are managed by Tripadvisor’s ad network and are not used to "
 "profile you."
 msgstr ""
-"ഹോട്ടൽ പരസ്യ ക്ലിക്കുകൾ കൈകാര്യം ചെയ്യുന്നത് ട്രിപ്പ് അഡ്വൈസറിന്റെ പരസ്യ ശൃംഖലയാണ്, നിങ്ങളെ "
-"പ്രൊഫൈൽ ചെയ്യുന്നതിനായി അവ ഉപയോഗിക്കപ്പെടുന്നില്ല."
+"ഹോട്ടൽ പരസ്യ ക്ലിക്കുകൾ കൈകാര്യം ചെയ്യുന്നത് ട്രിപ്പ് അഡ്വൈസറിന്റെ പരസ്യ "
+"ശൃംഖലയാണ്, നിങ്ങളെ പ്രൊഫൈൽ ചെയ്യുന്നതിനായി അവ ഉപയോഗിക്കപ്പെടുന്നില്ല."
 
 # smartling.placeholder_format=C
 #. Refers to hours of operation for a business.
@@ -9646,7 +9764,9 @@ msgstr "ഇത് എങ്ങനെ പ്രവർത്തിക്കുന�
 #. Header for the assist settings modal where the user can choose how often they want AI-assisted answers to appear.
 msgctxt "duckassist"
 msgid "How much do you want AI-assisted answers to appear?"
-msgstr "നിങ്ങൾ എത്രത്തോളം AI- സഹായത്തോടെയുള്ള ഉത്തരങ്ങൾ ദൃശ്യമാകണമെന്നാണ് ആഗ്രഹിക്കുന്നത്?"
+msgstr ""
+"നിങ്ങൾ എത്രത്തോളം AI- സഹായത്തോടെയുള്ള ഉത്തരങ്ങൾ ദൃശ്യമാകണമെന്നാണ് "
+"ആഗ്രഹിക്കുന്നത്?"
 
 # smartling.placeholder_format=C
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
@@ -9679,8 +9799,8 @@ msgid ""
 "How should I tactfully approach a colleague about their constant pencil "
 "tapping and what should I say?"
 msgstr ""
-"അവരുടെ നിരന്തരമായ പെൻസിൽ ടാപ്പിംഗിനെക്കുറിച്ച് ഒരു സഹപ്രവർത്തകനെ എങ്ങനെ തന്ത്രപൂർവ്വം "
-"സമീപിക്കണം, ഞാൻ എന്താണ് പറയേണ്ടത്?"
+"അവരുടെ നിരന്തരമായ പെൻസിൽ ടാപ്പിംഗിനെക്കുറിച്ച് ഒരു സഹപ്രവർത്തകനെ എങ്ങനെ "
+"തന്ത്രപൂർവ്വം സമീപിക്കണം, ഞാൻ എന്താണ് പറയേണ്ടത്?"
 
 # smartling.placeholder_format=C
 #. The title for a feedback prompt that includes thumbs up and thumbs down buttons
@@ -9726,7 +9846,7 @@ msgctxt ""
 "Text for the I already have a subscription button in the Duck.ai settings "
 "page"
 msgid "I Already Have a Subscription"
-msgstr ""
+msgstr "എനിക്ക് ഇതിനകം സബ്സ്ക്രിപ്ഷൻ ഉണ്ട്"
 
 # smartling.placeholder_format=C
 #. Text for the button that takes the user to the login subscription page.
@@ -9787,7 +9907,9 @@ msgstr "കൂടുതൽ വിൽപ്പനക്കാരിൽ നിന�
 #. Header above text explaining that passwords can't be recovered.
 msgctxt "cloudsave"
 msgid "I forgot my passphrase. Can you recover it?"
-msgstr "എന്റെ പാസ്‌ഫ്രെയ്സ് മറന്നു പോയി, നിങ്ങള്‍ക്ക് അത് വീണ്ടെടുക്കുവാന്‍ സാധിക്കുമോ?"
+msgstr ""
+"എന്റെ പാസ്‌ഫ്രെയ്സ് മറന്നു പോയി, നിങ്ങള്‍ക്ക് അത് വീണ്ടെടുക്കുവാന്‍ "
+"സാധിക്കുമോ?"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the user hits a chat limit.
@@ -9802,14 +9924,16 @@ msgid ""
 "I like the book Name of the Wind. What are some other good books/series most "
 "like it and why?"
 msgstr ""
-"കാറ്റിൻ്റെ പേര് എന്ന പുസ്തകം എനിക്കിഷ്ടമാണ്. മറ്റു ചില നല്ല പുസ്തകങ്ങൾ/പരമ്പരകൾ ഏതൊക്കെയാണ് "
-"ഏറ്റവും ഇഷ്ടപ്പെടുന്നത്, എന്തുകൊണ്ട്?"
+"കാറ്റിൻ്റെ പേര് എന്ന പുസ്തകം എനിക്കിഷ്ടമാണ്. മറ്റു ചില നല്ല "
+"പുസ്തകങ്ങൾ/പരമ്പരകൾ ഏതൊക്കെയാണ് ഏറ്റവും ഇഷ്ടപ്പെടുന്നത്, എന്തുകൊണ്ട്?"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the user needs more help or information on how to use the chat.
 msgctxt "Feedback option for difficulty in using chat"
 msgid "I need more help/info on how to use Chat"
-msgstr "ചാറ്റ് എങ്ങനെ ഉപയോഗിക്കാം എന്നതിനെക്കുറിച്ചുള്ള കൂടുതൽ സഹായം/വിവരങ്ങൾ എനിക്ക് ആവശ്യമാണ്"
+msgstr ""
+"ചാറ്റ് എങ്ങനെ ഉപയോഗിക്കാം എന്നതിനെക്കുറിച്ചുള്ള കൂടുതൽ സഹായം/വിവരങ്ങൾ "
+"എനിക്ക് ആവശ്യമാണ്"
 
 # smartling.placeholder_format=C
 msgid "IR Iran"
@@ -9838,8 +9962,9 @@ msgid ""
 "If the browser location remains unavailable, then go to %sSettings > General "
 "> Reset > 'Reset Location & Privacy'%s."
 msgstr ""
-"ബ്രൗസർ ലൊക്കേഷൻ തുടർന്നും ലഭ്യമല്ലെങ്കിൽ, %1$sക്രമീകരണം > പൊതുവായത് > പുനഃക്രമീകരിക്കുക > "
-"'ലൊക്കേഷനും സ്വകാര്യതയും പുനഃക്രമീകരിക്കുക'%2$s എന്നതിലേക്ക് പോകുക."
+"ബ്രൗസർ ലൊക്കേഷൻ തുടർന്നും ലഭ്യമല്ലെങ്കിൽ, %1$sക്രമീകരണം > പൊതുവായത് > "
+"പുനഃക്രമീകരിക്കുക > 'ലൊക്കേഷനും സ്വകാര്യതയും പുനഃക്രമീകരിക്കുക'%2$s "
+"എന്നതിലേക്ക് പോകുക."
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -9849,9 +9974,9 @@ msgid ""
 "> Menu > Settings > Site settings > Location%s, and ensure DuckDuckGo is "
 "allowed location access."
 msgstr ""
-"ബ്രൗസർ ലൊക്കേഷൻ തുടർന്നും ലഭ്യമല്ലെങ്കിൽ, നിങ്ങളുടെ ബ്രൗസറിൽ ഇതിലേക്ക് പോകുക %1$s⋮ > മെനു > "
-"ക്രമീകരണം > സൈറ്റ് ക്രമീകരണം > ലൊക്കേഷൻ%2$s, തുടർന്ന് DuckDuckGo-യ്ക്ക് ലൊക്കേഷൻ ആക്സസ് "
-"അനുവദനീയമാണെന്ന് ഉറപ്പാക്കുക."
+"ബ്രൗസർ ലൊക്കേഷൻ തുടർന്നും ലഭ്യമല്ലെങ്കിൽ, നിങ്ങളുടെ ബ്രൗസറിൽ ഇതിലേക്ക് പോകുക "
+"%1$s⋮ > മെനു > ക്രമീകരണം > സൈറ്റ് ക്രമീകരണം > ലൊക്കേഷൻ%2$s, തുടർന്ന് "
+"DuckDuckGo-യ്ക്ക് ലൊക്കേഷൻ ആക്സസ് അനുവദനീയമാണെന്ന് ഉറപ്പാക്കുക."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -9866,8 +9991,8 @@ msgid ""
 "If you don't see %sDuckDuckGo,%s you will need to add it to the list of "
 "%sOther Search Engines%s"
 msgstr ""
-"നിങ്ങൾ %1$sDuckDuckGo%2$s കാണുന്നില്ലെങ്കിൽ നിങ്ങൾ അത് %3$sമറ്റ് തിരയൽ എഞ്ചിനുകളുടെ%4$s "
-"പട്ടികയിലേക്ക് ചേർക്കേണ്ടതുണ്ട്"
+"നിങ്ങൾ %1$sDuckDuckGo%2$s കാണുന്നില്ലെങ്കിൽ നിങ്ങൾ അത് %3$sമറ്റ് തിരയൽ "
+"എഞ്ചിനുകളുടെ%4$s പട്ടികയിലേക്ക് ചേർക്കേണ്ടതുണ്ട്"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding the AI model providers and links to their support pages. Example: 'If you have concerns about our chat providers or any particular chat response, you can also reach out directly to OpenAI and Anthropic support pages.'
@@ -9876,8 +10001,9 @@ msgid ""
 "If you have concerns about our chat providers or any particular chat "
 "response, you can also reach out directly to %s and %s support pages."
 msgstr ""
-"ഞങ്ങളുടെ ചാറ്റ് ദാതാക്കളെക്കുറിച്ചോ ഏതെങ്കിലും പ്രത്യേക ചാറ്റ് പ്രതികരണത്തെക്കുറിച്ചോ നിങ്ങൾക്ക് "
-"ആശങ്കയുണ്ടെങ്കിൽ, നിങ്ങൾക്ക് നേരിട്ട് %1$s, %2$s പിന്തുണാ പേജുകളിലേക്കും ബന്ധപ്പെടാം."
+"ഞങ്ങളുടെ ചാറ്റ് ദാതാക്കളെക്കുറിച്ചോ ഏതെങ്കിലും പ്രത്യേക ചാറ്റ് "
+"പ്രതികരണത്തെക്കുറിച്ചോ നിങ്ങൾക്ക് ആശങ്കയുണ്ടെങ്കിൽ, നിങ്ങൾക്ക് നേരിട്ട് "
+"%1$s, %2$s പിന്തുണാ പേജുകളിലേക്കും ബന്ധപ്പെടാം."
 
 # smartling.placeholder_format=C
 #. Body copy explaining what the recovery code is for and how it can be saved.
@@ -9886,16 +10012,17 @@ msgid ""
 "If you lose access to your devices, you will need this code to recover your "
 "saved chats. You can save this code to your device as a text file."
 msgstr ""
-"നിങ്ങളുടെ ഉപകരണങ്ങളിലേക്കുള്ള ആക്‌സസ് നഷ്‌ടപ്പെട്ടാൽ, നിങ്ങളുടെ സംരക്ഷിച്ച ചാറ്റുകൾ വീണ്ടെടുക്കാൻ "
-"ഈ കോഡ് ആവശ്യമായി വരും. ഈ കോഡ് നിങ്ങളുടെ ഉപകരണത്തിൽ ഒരു ടെക്സ്റ്റ് ഫയലായി സംരക്ഷിക്കാം."
+"നിങ്ങളുടെ ഉപകരണങ്ങളിലേക്കുള്ള ആക്‌സസ് നഷ്‌ടപ്പെട്ടാൽ, നിങ്ങളുടെ സംരക്ഷിച്ച "
+"ചാറ്റുകൾ വീണ്ടെടുക്കാൻ ഈ കോഡ് ആവശ്യമായി വരും. ഈ കോഡ് നിങ്ങളുടെ ഉപകരണത്തിൽ "
+"ഒരു ടെക്സ്റ്റ് ഫയലായി സംരക്ഷിക്കാം."
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
 msgstr ""
-"നിങ്ങൾ ഇപ്പോഴും ഞങ്ങളെ പിന്തുണയ്ക്കാൻ ആഗ്രഹിക്കുന്നുണ്ടെങ്കിൽ, %1$sDuckDuckGo "
-"പ്രചരിപ്പിക്കുന്നതിനായി സഹായിക്കുക%2$s"
+"നിങ്ങൾ ഇപ്പോഴും ഞങ്ങളെ പിന്തുണയ്ക്കാൻ ആഗ്രഹിക്കുന്നുണ്ടെങ്കിൽ, "
+"%1$sDuckDuckGo പ്രചരിപ്പിക്കുന്നതിനായി സഹായിക്കുക%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -9905,8 +10032,8 @@ msgid ""
 "If you want to use DuckDuckGo without JavaScript, please use our %s or %s "
 "versions."
 msgstr ""
-"JavaScript ഇല്ലാതെ DuckDuckGo ഉപയോഗിക്കാൻ താൽപ്പര്യപ്പെടുന്നെങ്കിൽ, ഞങ്ങളുടെ %1$s "
-"അല്ലെങ്കിൽ %2$s പതിപ്പുകൾ ഉപയോഗിക്കുക."
+"JavaScript ഇല്ലാതെ DuckDuckGo ഉപയോഗിക്കാൻ താൽപ്പര്യപ്പെടുന്നെങ്കിൽ, ഞങ്ങളുടെ "
+"%1$s അല്ലെങ്കിൽ %2$s പതിപ്പുകൾ ഉപയോഗിക്കുക."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -9914,8 +10041,8 @@ msgstr ""
 msgid ""
 "If you want, select Home Page next to New windows and New tabs (open with)."
 msgstr ""
-"നിങ്ങൾ ആഗ്രഹിക്കുന്നെങ്കിൽ, അടുത്ത പുതിയ ജാലകങ്ങൾക്കും പുതിയ ടാബുകൾക്കും അടുത്തുള്ള ഹോം പേജ് "
-"തിരഞ്ഞെടുക്കുക (ഇതിൽ തുറക്കുക)."
+"നിങ്ങൾ ആഗ്രഹിക്കുന്നെങ്കിൽ, അടുത്ത പുതിയ ജാലകങ്ങൾക്കും പുതിയ ടാബുകൾക്കും "
+"അടുത്തുള്ള ഹോം പേജ് തിരഞ്ഞെടുക്കുക (ഇതിൽ തുറക്കുക)."
 
 # smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that adds an image to the AI chat message being composed.
@@ -10044,8 +10171,8 @@ msgctxt "settings"
 msgid ""
 "Improves result legibility with updated URL format, placement, and color"
 msgstr ""
-"അപ്‌ഡേറ്റ് ചെയ്‌ത URL ഫോർമാറ്റ്, പ്ലേസ്‌മെന്റ്, നിറം എന്നിവ ഉപയോഗിച്ച് ഫലത്തിന്റെ വ്യക്തത "
-"മെച്ചപ്പെടുത്തുന്നു"
+"അപ്‌ഡേറ്റ് ചെയ്‌ത URL ഫോർമാറ്റ്, പ്ലേസ്‌മെന്റ്, നിറം എന്നിവ ഉപയോഗിച്ച് "
+"ഫലത്തിന്റെ വ്യക്തത മെച്ചപ്പെടുത്തുന്നു"
 
 # smartling.placeholder_format=C
 #. A label that appears in front of the name of a company that DuckDuckGo has partnered with. For example, 'In partnership with Wikipedia'
@@ -10058,8 +10185,8 @@ msgid ""
 "In some older browsers, it's necessary to redirect your clicks through our "
 "server to prevent search leakage. %sLearn more%s."
 msgstr ""
-"ചില പഴയ ബ്രൗസറുകളിൽ തിരയൽ ചോർച്ച തടയുന്നതിന് ഞങ്ങളുടെ സെർവറിലൂടെ നിങ്ങളുടെ ക്ലിക്കുകൾ "
-"റീഡയറക്റ്റ് ചെയ്യേണ്ടത് ആവശ്യമാണ്. %1$sകൂടുതൽ അറിയുക%2$s."
+"ചില പഴയ ബ്രൗസറുകളിൽ തിരയൽ ചോർച്ച തടയുന്നതിന് ഞങ്ങളുടെ സെർവറിലൂടെ നിങ്ങളുടെ "
+"ക്ലിക്കുകൾ റീഡയറക്റ്റ് ചെയ്യേണ്ടത് ആവശ്യമാണ്. %1$sകൂടുതൽ അറിയുക%2$s."
 
 # smartling.placeholder_format=C
 #. Instructions accompanying DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE; tells the user where to use the code on a DuckDuckGo browser.
@@ -10070,8 +10197,8 @@ msgid ""
 "In the DuckDuckGo browser, go to Settings › Sync & Backup, and then “Sync "
 "with another device”."
 msgstr ""
-"DuckDuckGo ബ്രൗസറിൽ, ക്രമീകരണങ്ങൾ › Sync & Backup എന്നതിലേക്ക് പോയി, തുടർന്ന് \"മറ്റൊരു "
-"ഉപകരണവുമായി സമന്വയിപ്പിക്കുക\" തിരഞ്ഞെടുക്കുക."
+"DuckDuckGo ബ്രൗസറിൽ, ക്രമീകരണങ്ങൾ › Sync & Backup എന്നതിലേക്ക് പോയി, "
+"തുടർന്ന് \"മറ്റൊരു ഉപകരണവുമായി സമന്വയിപ്പിക്കുക\" തിരഞ്ഞെടുക്കുക."
 
 #  SeaMonkey default search engine instruction
 # smartling.placeholder_format=C
@@ -10086,8 +10213,9 @@ msgid ""
 "In the interest of transparency, this data is not encrypted: You can see "
 "exactly what information we store."
 msgstr ""
-"സുതാര്യതയ്ക്കു വേണ്ടി ഈ ഡാറ്റകള്‍ എൻക്രിപ്റ്റ് ചെയ്തിട്ടില്ല: ഏതു തരം വിവരങ്ങളാണ് ഞങ്ങള്‍ ശേഖരിക്കുക "
-"എന്നത് നിങ്ങൾക്ക് വ്യക്തമായി പരിശോധിക്കാവുന്നതാണ്."
+"സുതാര്യതയ്ക്കു വേണ്ടി ഈ ഡാറ്റകള്‍ എൻക്രിപ്റ്റ് ചെയ്തിട്ടില്ല: ഏതു തരം "
+"വിവരങ്ങളാണ് ഞങ്ങള്‍ ശേഖരിക്കുക എന്നത് നിങ്ങൾക്ക് വ്യക്തമായി "
+"പരിശോധിക്കാവുന്നതാണ്."
 
 # smartling.placeholder_format=C
 msgid "In the menu at the top select %sTools%s > %sSettings%s"
@@ -10306,7 +10434,7 @@ msgstr "Mac ബ്രൗസർ ഇൻസ്റ്റാൾ ചെയ്യുക
 #. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
 msgctxt "settings"
 msgid "Install Now"
-msgstr ""
+msgstr "ഇപ്പോൾ ഇൻസ്റ്റാൾ ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. Text of a button to install the DuckDuckGo app
@@ -10409,13 +10537,13 @@ msgstr "ഇല്ലാതാക്കിയ വിവരങ്ങൾ ശരി�
 #. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Is it worth taking?"
-msgstr ""
+msgstr "ഇത് എടുക്കുന്നതിൽ അർത്ഥമുണ്ടോ?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Is this place any good?"
-msgstr ""
+msgstr "ഈ സ്ഥലം നല്ലതാണോ?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
@@ -10424,6 +10552,8 @@ msgid ""
 "Is this place any good? Summarize its reputation based on reviews and "
 "ratings."
 msgstr ""
+"ഈ സ്ഥലം നല്ലതാണോ? അവലോകനങ്ങളെയും റേറ്റിംഗുകളെയും അടിസ്ഥാനമാക്കി ഇതിന്റെ "
+"പ്രശസ്തി സംഗ്രഹിക്കുക."
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -10435,13 +10565,13 @@ msgstr "ഈ വീഡിയോ സഹായകമാണോ?"
 #. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Is this worth watching?"
-msgstr ""
+msgstr "ഇത് കാണാൻ തക്ക മൂല്യമുള്ളതാണോ?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Is this worth watching? Give me a spoiler-free take."
-msgstr ""
+msgstr "ഇത് കാണാൻ തക്ക മൂല്യമുള്ളതാണോ? സ്പോയിലറുകൾ ഇല്ലാത്ത ഒരു അഭിപ്രായം പറയൂ."
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -10467,15 +10597,17 @@ msgstr "ഇതിന് ഏതാനും നിമിഷങ്ങൾ എടു
 #. Body text of a card that promotes installing the DuckDuckGo desktop browser.
 msgctxt "new tab page"
 msgid "It's fast, free, and gives you even more online protection."
-msgstr "ഇത് വേഗതയേറിയതും സൗജന്യവുമാണ്, കൂടാതെ നിങ്ങൾക്ക് കൂടുതൽ ഓൺലൈൻ സുരക്ഷയും നൽകുന്നു."
+msgstr ""
+"ഇത് വേഗതയേറിയതും സൗജന്യവുമാണ്, കൂടാതെ നിങ്ങൾക്ക് കൂടുതൽ ഓൺലൈൻ സുരക്ഷയും "
+"നൽകുന്നു."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "It's okay to (very infrequently) ask me about my experience using DuckDuckGo"
 msgstr ""
-"DuckDuckGo ഉപയോഗിച്ച എന്റെ അനുഭവത്തെക്കുറിച്ച് എന്നോട് (വളരെ അപൂർവമായി) ചോദിക്കുന്നതിൽ "
-"കുഴപ്പമില്ല"
+"DuckDuckGo ഉപയോഗിച്ച എന്റെ അനുഭവത്തെക്കുറിച്ച് എന്നോട് (വളരെ അപൂർവമായി) "
+"ചോദിക്കുന്നതിൽ കുഴപ്പമില്ല"
 
 # smartling.placeholder_format=C
 #. The name of the Italian language
@@ -10494,10 +10626,10 @@ msgid ""
 "through Microsoft's Ad Network. Clicks lead directly to merchant landing "
 "pages and unlike ads, DuckDuckGo is not compensated for these results."
 msgstr ""
-"ഇനങ്ങൾ നിങ്ങളുടെ തിരയൽ പദങ്ങളുടെ പ്രസക്തിയെ അടിസ്ഥാനമാക്കി റാങ്ക് ചെയ്ത്, Microsoft-ന്റെ "
-"പരസ്യ നെറ്റ്‌വർക്ക് വഴി ഡെലിവറി ചെയ്യുന്നു. ക്ലിക്കുകൾ നേരിട്ട് മർച്ചന്റ് ലാൻഡിംഗ് പേജുകളിലേക്ക് "
-"നയിക്കുന്നു, പരസ്യങ്ങളിൽ നിന്ന് വ്യത്യസ്തമായി ഈ ഫലങ്ങൾക്കായി DuckDuckGo-യ്ക്ക് പ്രതിഫലം "
-"ലഭിക്കുന്നില്ല."
+"ഇനങ്ങൾ നിങ്ങളുടെ തിരയൽ പദങ്ങളുടെ പ്രസക്തിയെ അടിസ്ഥാനമാക്കി റാങ്ക് ചെയ്ത്, "
+"Microsoft-ന്റെ പരസ്യ നെറ്റ്‌വർക്ക് വഴി ഡെലിവറി ചെയ്യുന്നു. ക്ലിക്കുകൾ "
+"നേരിട്ട് മർച്ചന്റ് ലാൻഡിംഗ് പേജുകളിലേക്ക് നയിക്കുന്നു, പരസ്യങ്ങളിൽ നിന്ന് "
+"വ്യത്യസ്തമായി ഈ ഫലങ്ങൾക്കായി DuckDuckGo-യ്ക്ക് പ്രതിഫലം ലഭിക്കുന്നില്ല."
 
 # smartling.placeholder_format=C
 #. Text explaining why passphrases use a series of words instead of random numbers and letters.
@@ -10506,8 +10638,8 @@ msgid ""
 "It’s easier to remember 4-5 words than 10 random letters and numbers, and "
 "far more secure."
 msgstr ""
-"10 ക്രമരഹിത പദങ്ങളും സംഖ്യകളും ഓര്‍മിക്കുന്നതിനെക്കാൾ എളുപ്പമാണ് 4-5 വാക്കുകൾ ഓർമിക്കുവാൻ, "
-"വളരെ അധികം സുരക്ഷിതവും."
+"10 ക്രമരഹിത പദങ്ങളും സംഖ്യകളും ഓര്‍മിക്കുന്നതിനെക്കാൾ എളുപ്പമാണ് 4-5 "
+"വാക്കുകൾ ഓർമിക്കുവാൻ, വളരെ അധികം സുരക്ഷിതവും."
 
 # smartling.placeholder_format=C
 msgid "Ivory Coast"
@@ -10874,7 +11006,9 @@ msgstr "DuckDuckGo ക്രമീകരണങ്ങൾ എങ്ങനെ ക�
 #. Description of a page with more information about how anonymous location works.
 msgctxt "precise_user_location"
 msgid "Learn how we keep your location private"
-msgstr "നിങ്ങളുടെ ലൊക്കേഷൻ ഞങ്ങൾ സ്വകാര്യമായി സൂക്ഷിക്കുന്നത് എങ്ങനെയെന്ന് മനസ്സിലാക്കുക"
+msgstr ""
+"നിങ്ങളുടെ ലൊക്കേഷൻ ഞങ്ങൾ സ്വകാര്യമായി സൂക്ഷിക്കുന്നത് എങ്ങനെയെന്ന് "
+"മനസ്സിലാക്കുക"
 
 # smartling.placeholder_format=C
 #. Link text in the Usage section of Duck.ai settings that opens a help page explaining Duck.ai usage limits.
@@ -10916,7 +11050,9 @@ msgstr "ഇത് എങ്ങനെ പ്രവർത്തിക്കുന�
 # smartling.placeholder_format=C
 msgctxt "SERP footer content"
 msgid "Learn why reducing online tracking is important."
-msgstr "ഓൺലൈൻ ട്രാക്കിംഗ് കുറയ്ക്കുന്നത് പ്രധാനമായിരിക്കുന്നത് എന്തുകൊണ്ടാണെന്ന് അറിയുക."
+msgstr ""
+"ഓൺലൈൻ ട്രാക്കിംഗ് കുറയ്ക്കുന്നത് പ്രധാനമായിരിക്കുന്നത് എന്തുകൊണ്ടാണെന്ന് "
+"അറിയുക."
 
 # smartling.placeholder_format=C
 #. A link that takes users to a page where they can learn more about the dangers of online tracking.
@@ -11029,7 +11165,9 @@ msgstr "ഈ ചാറ്റിനായി പരിമിതമായ ഡാറ
 #. Description of a setting managing the length of search result snippet text.
 msgctxt "settings"
 msgid "Limits the amount of descriptive content shown for results"
-msgstr "ഫലങ്ങൾക്കായി കാണിക്കുന്ന വിവരണാത്മക ഉള്ളടക്കത്തിന്റെ അളവ് പരിമിതപ്പെടുത്തുന്നു"
+msgstr ""
+"ഫലങ്ങൾക്കായി കാണിക്കുന്ന വിവരണാത്മക ഉള്ളടക്കത്തിന്റെ അളവ് "
+"പരിമിതപ്പെടുത്തുന്നു"
 
 # smartling.placeholder_format=C
 #. i.e. a type of image comprised of lines without gradiations in shade or hue
@@ -11058,6 +11196,8 @@ msgstr "ലിങ്കുകൾ:"
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
 msgstr ""
+"ഇതിന് എനിക്ക് ആവശ്യമായ ഉപകരണങ്ങൾ, സാമഗ്രികൾ, അല്ലെങ്കിൽ മുൻകൂർ ആവശ്യകതകൾ "
+"ലിസ്റ്റ് ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -11169,7 +11309,8 @@ msgstr "സ്ക്രോൾ ചെയ്യുമ്പോൾ കൂടുത�
 msgctxt "settings"
 msgid "Loads more results in Images, Videos, and Shopping when scrolling"
 msgstr ""
-"സ്ക്രോൾ ചെയ്യുമ്പോൾ ഇമേജുകൾ, വീഡിയോകൾ, ഷോപ്പിംഗ് എന്നിവയിൽ കൂടുതൽ ഫലങ്ങൾ ലോഡ് ചെയ്യുന്നു"
+"സ്ക്രോൾ ചെയ്യുമ്പോൾ ഇമേജുകൾ, വീഡിയോകൾ, ഷോപ്പിംഗ് എന്നിവയിൽ കൂടുതൽ ഫലങ്ങൾ "
+"ലോഡ് ചെയ്യുന്നു"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/WTkvs9I.png
@@ -11350,7 +11491,8 @@ msgstr "എല്ലാ വാക്കുകളും അക്ഷരത്ത�
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Make sure to check %s\"Make this my default search provider\"%s"
 msgstr ""
-"%1$s\"ഇതിനെ എന്റെ ഡിഫോൾട്ട് തിരയല്‍ ദാതാവാക്കുക\"%2$s എന്നത് തിരഞ്ഞെടുത്തുവെന്ന് ഉറപ്പാക്കുക"
+"%1$s\"ഇതിനെ എന്റെ ഡിഫോൾട്ട് തിരയല്‍ ദാതാവാക്കുക\"%2$s എന്നത് "
+"തിരഞ്ഞെടുത്തുവെന്ന് ഉറപ്പാക്കുക"
 
 # smartling.placeholder_format=C
 #. Message prompting users to check the spelling of their search term.
@@ -11471,7 +11613,7 @@ msgstr "ബ്ലോക്ക് ചെയ്ത സൈറ്റുകൾ കൈ
 #. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
 msgctxt "setting"
 msgid "Manage in Browser Settings"
-msgstr ""
+msgstr "ബ്രൗസർ ക്രമീകരണങ്ങളിൽ നിയന്ത്രിക്കുക"
 
 # smartling.placeholder_format=C
 #. Link to the site exclusion settings page
@@ -11696,7 +11838,9 @@ msgstr "മൈക്രോനേഷ്യ"
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
 msgid ""
 "Microphone access was denied. Please allow microphone access and try again."
-msgstr "മൈക്രോഫോൺ പ്രവേശനം നിഷേധിച്ചു. മൈക്രോഫോൺ ആക്‌സസ് അനുവദിച്ച് വീണ്ടും ശ്രമിക്കുക."
+msgstr ""
+"മൈക്രോഫോൺ പ്രവേശനം നിഷേധിച്ചു. മൈക്രോഫോൺ ആക്‌സസ് അനുവദിച്ച് വീണ്ടും "
+"ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. The Microsoft brand name.
@@ -12444,10 +12588,11 @@ msgid ""
 "internet connection. Disabling chat history will delete pinned chats, and "
 "disable the temporary storage of new prompts and responses."
 msgstr ""
-"പുതിയ പ്രോംപ്റ്റുകളും പ്രതികരണങ്ങളും അയച്ചതിനുശേഷം എൻക്രിപ്റ്റ് ചെയ്ത് താൽക്കാലികമായി ഒരു "
-"DuckDuckGo സെർവറിൽ സംഭരിക്കും, ഇത് നിങ്ങളുടെ ഇന്റർനെറ്റ് കണക്ഷൻ നഷ്ടപ്പെട്ടാൽ ഒരു ചാറ്റ് "
-"വീണ്ടെടുക്കാൻ സഹായിക്കും. ചാറ്റ് ചരിത്രം പ്രവർത്തനരഹിതമാക്കുന്നത് പിൻ ചെയ്‌ത ചാറ്റുകൾ "
-"ഇല്ലാതാക്കുകയും പുതിയ പ്രോംപ്റ്റുകളുടെയും പ്രതികരണങ്ങളുടെയും താൽക്കാലിക സ്റ്റോറേജ് "
+"പുതിയ പ്രോംപ്റ്റുകളും പ്രതികരണങ്ങളും അയച്ചതിനുശേഷം എൻക്രിപ്റ്റ് ചെയ്ത് "
+"താൽക്കാലികമായി ഒരു DuckDuckGo സെർവറിൽ സംഭരിക്കും, ഇത് നിങ്ങളുടെ ഇന്റർനെറ്റ് "
+"കണക്ഷൻ നഷ്ടപ്പെട്ടാൽ ഒരു ചാറ്റ് വീണ്ടെടുക്കാൻ സഹായിക്കും. ചാറ്റ് ചരിത്രം "
+"പ്രവർത്തനരഹിതമാക്കുന്നത് പിൻ ചെയ്‌ത ചാറ്റുകൾ ഇല്ലാതാക്കുകയും പുതിയ "
+"പ്രോംപ്റ്റുകളുടെയും പ്രതികരണങ്ങളുടെയും താൽക്കാലിക സ്റ്റോറേജ് "
 "പ്രവർത്തനരഹിതമാക്കുകയും ചെയ്യും."
 
 # smartling.placeholder_format=C
@@ -13287,8 +13432,9 @@ msgid ""
 "One of the files attached has more pages than we support. Please upload "
 "files with %s pages or fewer."
 msgstr ""
-"അറ്റാച്ച് ചെയ്തിരിക്കുന്ന ഫയലുകളിൽ ഒന്നിൽ ഞങ്ങൾ പിന്തുണയ്ക്കുന്നതിനേക്കാൾ കൂടുതൽ പേജുകളുണ്ട്. %1$s "
-"അല്ലെങ്കിൽ അതിൽ കുറവ് പേജുകളുള്ള ഫയലുകൾ അപ്‌ലോഡ് ചെയ്യുക."
+"അറ്റാച്ച് ചെയ്തിരിക്കുന്ന ഫയലുകളിൽ ഒന്നിൽ ഞങ്ങൾ പിന്തുണയ്ക്കുന്നതിനേക്കാൾ "
+"കൂടുതൽ പേജുകളുണ്ട്. %1$s അല്ലെങ്കിൽ അതിൽ കുറവ് പേജുകളുള്ള ഫയലുകൾ അപ്‌ലോഡ് "
+"ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Response a user can select in a feedback form, indicating that they heard about DuckDuckGo in an online article.
@@ -13331,8 +13477,8 @@ msgid ""
 "Oops! An unexpected error occurred while translating this text. Please try "
 "again later."
 msgstr ""
-"ക്ഷമിക്കണം! ഈ ടെക്‌സ്റ്റ് വിവർത്തനം ചെയ്യുന്ന സമയത്ത് ഒരു അപ്രതീക്ഷിത പിശകുണ്ടായി. പിന്നീട് "
-"വീണ്ടും ശ്രമിക്കുക."
+"ക്ഷമിക്കണം! ഈ ടെക്‌സ്റ്റ് വിവർത്തനം ചെയ്യുന്ന സമയത്ത് ഒരു അപ്രതീക്ഷിത "
+"പിശകുണ്ടായി. പിന്നീട് വീണ്ടും ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Title shown in a fatal error modal when Duck.ai fails to load.
@@ -13386,8 +13532,8 @@ msgstr "%1$s വെബ്‌സൈറ്റ് തുറക്കുക"
 msgctxt "precise_user_location"
 msgid "Open %sLocation%s, and ensure location is %senabled%s"
 msgstr ""
-"%1$s'ലൊക്കേഷൻ'%2$s തുറക്കുക, തുടര്‍ന്ന് ലൊക്കേഷൻ %3$sപ്രവർത്തനക്ഷമമാക്കിയിട്ടുണ്ടെന്ന്%4$s "
-"ഉറപ്പാക്കുക"
+"%1$s'ലൊക്കേഷൻ'%2$s തുറക്കുക, തുടര്‍ന്ന് ലൊക്കേഷൻ "
+"%3$sപ്രവർത്തനക്ഷമമാക്കിയിട്ടുണ്ടെന്ന്%4$s ഉറപ്പാക്കുക"
 
 #  Chrome/Firefox on Android/iOS
 # smartling.placeholder_format=C
@@ -13408,7 +13554,8 @@ msgstr "%1$sക്രമീകരണം%2$s തുറക്കുക"
 msgctxt "precise_user_location"
 msgid "Open 'Location', and ensure location is %senabled%s."
 msgstr ""
-"'ലൊക്കേഷൻ' തുറക്കുക, തുടര്‍ന്ന് ലൊക്കേഷൻ %1$sപ്രവർത്തനക്ഷമമാക്കിയിട്ടുണ്ടെന്ന്%2$s ഉറപ്പാക്കുക."
+"'ലൊക്കേഷൻ' തുറക്കുക, തുടര്‍ന്ന് ലൊക്കേഷൻ "
+"%1$sപ്രവർത്തനക്ഷമമാക്കിയിട്ടുണ്ടെന്ന്%2$s ഉറപ്പാക്കുക."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -13551,7 +13698,9 @@ msgstr "How Duck.ai വർക്ക്സ് പാനൽ തുറക്കു�
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open the Safari menu and select %sSettings for DuckDuckGo...%s"
-msgstr "Safari മെനു തുറന്ന് %1$sDuckDuckGo എന്നതിനായുള്ള ക്രമീകരണങ്ങൾ%2$s തിരഞ്ഞെടുക്കുക..."
+msgstr ""
+"Safari മെനു തുറന്ന് %1$sDuckDuckGo എന്നതിനായുള്ള ക്രമീകരണങ്ങൾ%2$s "
+"തിരഞ്ഞെടുക്കുക..."
 
 # smartling.placeholder_format=C
 #. Label for the time a business opens. For example: 'Opens at 10am'
@@ -13652,8 +13801,9 @@ msgid ""
 "Other search engines track your searches even when you’re in private "
 "browsing mode. We don’t track you &mdash; period."
 msgstr ""
-"നിങ്ങൾ സ്വകാര്യ ബ്രൗസിംഗ് മോഡിൽ ആയിരിക്കുമ്പോൾ പോലും മറ്റ് തിരയൽ എഞ്ചിനുകൾ നിങ്ങളുടെ "
-"തിരയലുകളെ ട്രാക്ക് ചെയ്യുന്നു. ഞങ്ങൾ നിങ്ങളെ ട്രാക്ക് ചെയ്യുന്നില്ല — കാലഘട്ടം"
+"നിങ്ങൾ സ്വകാര്യ ബ്രൗസിംഗ് മോഡിൽ ആയിരിക്കുമ്പോൾ പോലും മറ്റ് തിരയൽ എഞ്ചിനുകൾ "
+"നിങ്ങളുടെ തിരയലുകളെ ട്രാക്ക് ചെയ്യുന്നു. ഞങ്ങൾ നിങ്ങളെ ട്രാക്ക് "
+"ചെയ്യുന്നില്ല — കാലഘട്ടം"
 
 # smartling.placeholder_format=C
 msgctxt "SERP footer content"
@@ -13666,8 +13816,8 @@ msgid ""
 "Our privacy policy is simple: we don’t collect or share any of your personal "
 "information."
 msgstr ""
-"ഞങ്ങളുടെ സ്വകാര്യത നയം ലളിതമാണ്: ഞങ്ങൾ നിങ്ങളുടെ വ്യക്തിഗത വിവരങ്ങളിൽ ഒന്നും ശേഖരിക്കുകയോ "
-"പങ്കുവയ്ക്കുകയോ ചെയ്യില്ല."
+"ഞങ്ങളുടെ സ്വകാര്യത നയം ലളിതമാണ്: ഞങ്ങൾ നിങ്ങളുടെ വ്യക്തിഗത വിവരങ്ങളിൽ ഒന്നും "
+"ശേഖരിക്കുകയോ പങ്കുവയ്ക്കുകയോ ചെയ്യില്ല."
 
 # smartling.placeholder_format=C
 msgid ""
@@ -13675,9 +13825,9 @@ msgid ""
 "tracker blocker, encryption enforcer, and more. Available on %siOS & "
 "Android%s."
 msgstr ""
-"ഞങ്ങളുടെ തിരയൽ എഞ്ചിൻ, ട്രാക്കർ ബ്ലോക്കർ, എൻക്രിപ്ഷൻ എൻഫോഴ്സർ തുടങ്ങിയവ ഉൾപ്പെടുത്തി "
-"മൊബൈലിനായുള്ള ഞങ്ങളുടെ സ്വകാര്യ ബ്രൗസർ ലഭിക്കുന്നു. %1$siOS, Android%2$s എന്നിവയിൽ "
-"ലഭ്യമാണ്."
+"ഞങ്ങളുടെ തിരയൽ എഞ്ചിൻ, ട്രാക്കർ ബ്ലോക്കർ, എൻക്രിപ്ഷൻ എൻഫോഴ്സർ തുടങ്ങിയവ "
+"ഉൾപ്പെടുത്തി മൊബൈലിനായുള്ള ഞങ്ങളുടെ സ്വകാര്യ ബ്രൗസർ ലഭിക്കുന്നു. %1$siOS, "
+"Android%2$s എന്നിവയിൽ ലഭ്യമാണ്."
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the information was out of date.
@@ -13930,8 +14080,9 @@ msgid ""
 "Passphrases cannot be recovered as we don't associate your IP address, "
 "browser fingerprint, or any other information with the file."
 msgstr ""
-"നിങ്ങളുടെ ഐപി വിലാസം, ബ്രൗസർ ഫിംഗർപ്രിന്റ് അല്ലെങ്കിൽ മറ്റേതെങ്കിലും വിവരങ്ങൾ ഞങ്ങൾ "
-"ഫയലുമായി ബന്ധപ്പെടുത്താത്തതിനാൽ പാസ്‌ഫ്രെയ്സുകൾ വീണ്ടെടുക്കാൻ കഴിയില്ല."
+"നിങ്ങളുടെ ഐപി വിലാസം, ബ്രൗസർ ഫിംഗർപ്രിന്റ് അല്ലെങ്കിൽ മറ്റേതെങ്കിലും "
+"വിവരങ്ങൾ ഞങ്ങൾ ഫയലുമായി ബന്ധപ്പെടുത്താത്തതിനാൽ പാസ്‌ഫ്രെയ്സുകൾ വീണ്ടെടുക്കാൻ "
+"കഴിയില്ല."
 
 # smartling.placeholder_format=C
 #. Label for the section of recent chats that were edited in the past 7 days.
@@ -14125,9 +14276,10 @@ msgid ""
 "answers. To turn them off and hide the Assist button visit %sSearch "
 "Settings%s."
 msgstr ""
-"നിങ്ങളുടെ തിരയൽ ഒരു ചോദ്യമായും സമ്പൂർണ്ണ വാക്യമായും ആവിഷ്കരിക്കുന്നത് AI സഹായമുള്ള ഉത്തരങ്ങൾ "
-"സ്വയമേവ പ്രത്യക്ഷപ്പെടാൻ കൂടുതൽ സാധ്യതയുണ്ടാക്കുകയും പലപ്പോഴും മികച്ച ഉത്തരങ്ങൾ നൽകുകയും ചെയ്യുന്നു. "
-"അവ ഓഫാക്കാനും Assist ബട്ടൺ മറയ്ക്കാനും %1$sതിരയൽ ക്രമീകരണങ്ങൾ%2$s സന്ദർശിക്കുക."
+"നിങ്ങളുടെ തിരയൽ ഒരു ചോദ്യമായും സമ്പൂർണ്ണ വാക്യമായും ആവിഷ്കരിക്കുന്നത് AI "
+"സഹായമുള്ള ഉത്തരങ്ങൾ സ്വയമേവ പ്രത്യക്ഷപ്പെടാൻ കൂടുതൽ സാധ്യതയുണ്ടാക്കുകയും "
+"പലപ്പോഴും മികച്ച ഉത്തരങ്ങൾ നൽകുകയും ചെയ്യുന്നു. അവ ഓഫാക്കാനും Assist ബട്ടൺ "
+"മറയ്ക്കാനും %1$sതിരയൽ ക്രമീകരണങ്ങൾ%2$s സന്ദർശിക്കുക."
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -14136,10 +14288,10 @@ msgid ""
 "DuckAssist more likely to appear and often yields better answers. To adjust "
 "how this feature works, or to turn it off, visit %sDuckAssist Settings%s."
 msgstr ""
-"നിങ്ങളുടെ തിരയൽ ഒരു ചോദ്യമായും സമ്പൂർണ്ണ വാക്യമായും ആവിഷ്കരിക്കുന്നത് DuckAssist "
-"പ്രത്യക്ഷപ്പെടാൻ കൂടുതൽ സാധ്യതയുണ്ടാക്കുകയും പലപ്പോഴും മികച്ച ഉത്തരങ്ങൾ നൽകുകയും ചെയ്യുന്നു. ഈ "
-"സവിശേഷത എങ്ങനെ പ്രവർത്തിക്കുന്നുവെന്ന് ക്രമീകരിക്കാനോ ഓഫ് ചെയ്യാനോ, %1$sDuckAssist "
-"ക്രമീകരണങ്ങൾ%2$sസന്ദർശിക്കുക."
+"നിങ്ങളുടെ തിരയൽ ഒരു ചോദ്യമായും സമ്പൂർണ്ണ വാക്യമായും ആവിഷ്കരിക്കുന്നത് "
+"DuckAssist പ്രത്യക്ഷപ്പെടാൻ കൂടുതൽ സാധ്യതയുണ്ടാക്കുകയും പലപ്പോഴും മികച്ച "
+"ഉത്തരങ്ങൾ നൽകുകയും ചെയ്യുന്നു. ഈ സവിശേഷത എങ്ങനെ പ്രവർത്തിക്കുന്നുവെന്ന് "
+"ക്രമീകരിക്കാനോ ഓഫ് ചെയ്യാനോ, %1$sDuckAssist ക്രമീകരണങ്ങൾ%2$sസന്ദർശിക്കുക."
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -14149,9 +14301,10 @@ msgid ""
 "answers. To turn it off and hide the Assist button visit %sDuckAssist "
 "Settings%s."
 msgstr ""
-"നിങ്ങളുടെ തിരയൽ ഒരു ചോദ്യമായും സമ്പൂർണ്ണ വാക്യമായും ആവിഷ്കരിക്കുന്നത് DuckAssist സ്വയമേവ "
-"പ്രത്യക്ഷപ്പെടാൻ കൂടുതൽ സാധ്യതയുണ്ടാക്കുകയും പലപ്പോഴും മികച്ച ഉത്തരങ്ങൾ നൽകുകയും ചെയ്യുന്നു. ഇത് "
-"ഓഫാക്കാനും അസിസ്റ്റ് ബട്ടൺ മറയ്ക്കാനും %1$sDuckAssist ക്രമീകരണം%2$s സന്ദർശിക്കുക."
+"നിങ്ങളുടെ തിരയൽ ഒരു ചോദ്യമായും സമ്പൂർണ്ണ വാക്യമായും ആവിഷ്കരിക്കുന്നത് "
+"DuckAssist സ്വയമേവ പ്രത്യക്ഷപ്പെടാൻ കൂടുതൽ സാധ്യതയുണ്ടാക്കുകയും പലപ്പോഴും "
+"മികച്ച ഉത്തരങ്ങൾ നൽകുകയും ചെയ്യുന്നു. ഇത് ഓഫാക്കാനും അസിസ്റ്റ് ബട്ടൺ "
+"മറയ്ക്കാനും %1$sDuckAssist ക്രമീകരണം%2$s സന്ദർശിക്കുക."
 
 # smartling.placeholder_format=C
 #. Button that allows users to manually select a location on a map.
@@ -14184,8 +14337,8 @@ msgid ""
 "Pick a popular AI to chat with, like GPT-5 mini, Claude Haiku 4.5, Mistral, "
 "etc."
 msgstr ""
-"GPT-5 mini, Claude Haiku 4.5, Mistra തുടങ്ങിയ ജനപ്രിയ AI-കളുമായി ചാറ്റ് ചെയ്യാൻ "
-"തിരഞ്ഞെടുക്കുക."
+"GPT-5 mini, Claude Haiku 4.5, Mistra തുടങ്ങിയ ജനപ്രിയ AI-കളുമായി ചാറ്റ് "
+"ചെയ്യാൻ തിരഞ്ഞെടുക്കുക."
 
 # smartling.placeholder_format=C
 #. Describes the ability to choose from popular AI models. Pairs with a chat-bubble pictogram.
@@ -14194,8 +14347,8 @@ msgid ""
 "Pick a popular AI to chat with, like GPT-5 mini, Claude Haiku 4.5, "
 "Mistral, etc."
 msgstr ""
-"GPT-5 mini, Claude Haiku 4.5, Mistral,   തുടങ്ങിയ ജനപ്രിയ AI-കളുമായി ചാറ്റ് ചെയ്യാൻ "
-"തിരഞ്ഞെടുക്കുക."
+"GPT-5 mini, Claude Haiku 4.5, Mistral,   തുടങ്ങിയ ജനപ്രിയ AI-കളുമായി ചാറ്റ് "
+"ചെയ്യാൻ തിരഞ്ഞെടുക്കുക."
 
 # smartling.placeholder_format=C
 #. The description of the third party map app picker, shown on iOS when a user is given an option of which app to navigate to a destination with
@@ -14204,8 +14357,8 @@ msgid ""
 "Pick a service to navigate to your destination. External apps won’t come "
 "with DuckDuckGo protections."
 msgstr ""
-"നിന്റെ ലക്ഷ്യസ്ഥാനത്തേക്ക് നാവിഗേറ്റ് ചെയ്യാൻ ഒരു സേവനം തിരഞ്ഞെടുക്കൂ. ബാഹ്യ ആപ്പുകൾക്ക് "
-"DuckDuckGo സംരക്ഷണങ്ങൾ ലഭ്യമല്ല."
+"നിന്റെ ലക്ഷ്യസ്ഥാനത്തേക്ക് നാവിഗേറ്റ് ചെയ്യാൻ ഒരു സേവനം തിരഞ്ഞെടുക്കൂ. ബാഹ്യ "
+"ആപ്പുകൾക്ക് DuckDuckGo സംരക്ഷണങ്ങൾ ലഭ്യമല്ല."
 
 # smartling.placeholder_format=C
 #. Label for a list of problems on a feedback form.
@@ -14218,8 +14371,8 @@ msgstr "ഒരു നിർദിഷ്ട പ്രശ്നം തിരഞ്
 msgid ""
 "Pick your ad blocker and follow the instructions to allow ads on DuckDuckGo."
 msgstr ""
-"നിങ്ങളുടെ പരസ്യ ബ്ലോക്കർ തിരഞ്ഞെടുക്കുക, DuckDuckGo-ൽ പരസ്യങ്ങൾ അനുവദിക്കാൻ നിർദ്ദേശങ്ങൾ "
-"പാലിക്കുക."
+"നിങ്ങളുടെ പരസ്യ ബ്ലോക്കർ തിരഞ്ഞെടുക്കുക, DuckDuckGo-ൽ പരസ്യങ്ങൾ അനുവദിക്കാൻ "
+"നിർദ്ദേശങ്ങൾ പാലിക്കുക."
 
 # smartling.placeholder_format=C
 #. Text for a button that pins a chat, as in it will it will add the chat to the pinned chats list.
@@ -14290,7 +14443,8 @@ msgid ""
 "Please complete the following challenge to confirm this prompt was made by a "
 "human."
 msgstr ""
-"ഈ പ്രോംപ്റ്റ് നടത്തിയത് ഒരു മനുഷ്യനാണെന്ന് സ്ഥിരീകരിക്കാൻ ഇനിപ്പറയുന്ന ചലഞ്ച് പൂർത്തിയാക്കുക."
+"ഈ പ്രോംപ്റ്റ് നടത്തിയത് ഒരു മനുഷ്യനാണെന്ന് സ്ഥിരീകരിക്കാൻ ഇനിപ്പറയുന്ന "
+"ചലഞ്ച് പൂർത്തിയാക്കുക."
 
 # smartling.placeholder_format=C
 #. Bot challenge explanation
@@ -14299,21 +14453,24 @@ msgid ""
 "Please complete the following challenge to confirm this search was made by a "
 "human."
 msgstr ""
-"ഈ തിരയൽ നടത്തിയത് ഒരു മനുഷ്യനാണെന്ന് സ്ഥിരീകരിക്കാൻ ഇനിപ്പറയുന്ന വെല്ലുവിളി പൂർത്തിയാക്കുക."
+"ഈ തിരയൽ നടത്തിയത് ഒരു മനുഷ്യനാണെന്ന് സ്ഥിരീകരിക്കാൻ ഇനിപ്പറയുന്ന വെല്ലുവിളി "
+"പൂർത്തിയാക്കുക."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is harmful or illegal. (optional)"
 msgstr ""
+"ചാറ്റ് പ്രതികരണം ദോഷകരമോ നിയമവിരുദ്ധമോ ആകുന്നത് എന്തുകൊണ്ടെന്ന് ദയവായി "
+"വിശദീകരിക്കുക. (ഓപ്ഷണൽ)"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
 msgstr ""
-"ചാറ്റ് പ്രതികരണം നിയമവിരുദ്ധമോ ദോഷകരമോ ആകുന്നത് എന്തുകൊണ്ടെന്ന് ദയവായി വിശദീകരിക്കുക. "
-"(ഓപ്ഷണൽ)"
+"ചാറ്റ് പ്രതികരണം നിയമവിരുദ്ധമോ ദോഷകരമോ ആകുന്നത് എന്തുകൊണ്ടെന്ന് ദയവായി "
+"വിശദീകരിക്കുക. (ഓപ്ഷണൽ)"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to enter their passphrase.
@@ -14334,8 +14491,8 @@ msgid ""
 "Please note: starting a new chat with any model will delete your current "
 "chat session."
 msgstr ""
-"ദയവായി ശ്രദ്ധിക്കുക: ഏതെങ്കിലും മോഡലുമായി ഒരു പുതിയ ചാറ്റ് ആരംഭിക്കുന്നത് നിങ്ങളുടെ നിലവിലെ "
-"ചാറ്റ് സെഷൻ ഇല്ലാതാക്കും."
+"ദയവായി ശ്രദ്ധിക്കുക: ഏതെങ്കിലും മോഡലുമായി ഒരു പുതിയ ചാറ്റ് ആരംഭിക്കുന്നത് "
+"നിങ്ങളുടെ നിലവിലെ ചാറ്റ് സെഷൻ ഇല്ലാതാക്കും."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -14344,6 +14501,9 @@ msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is harmful or illegal."
 msgstr ""
+"നിങ്ങളുടെ പ്രോംപ്റ്റും പ്രശ്നമുള്ള ഔട്ട്പുട്ടും (ഏതെങ്കിലും വ്യക്തിഗത "
+"വിവരങ്ങൾ നീക്കം ചെയ്തത്) ഒട്ടിക്കുക, കൂടാതെ ഉള്ളടക്കം ദോഷകരമോ നിയമവിരുദ്ധമോ "
+"ആകുന്നത് എന്തുകൊണ്ടെന്ന് വിവരിക്കുക."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -14352,8 +14512,9 @@ msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is illegal or harmful."
 msgstr ""
-"നിങ്ങളുടെ പ്രോംപ്റ്റും പ്രശ്നമുള്ള ഔട്ട്പുട്ടും (ഏതെങ്കിലും വ്യക്തിഗത വിവരങ്ങൾ നീക്കം ചെയ്തത്) "
-"ഒട്ടിക്കുക, കൂടാതെ ഉള്ളടക്കം നിയമവിരുദ്ധമോ ദോഷകരമോ ആകുന്നത് എന്തുകൊണ്ടെന്ന് വിവരിക്കുക."
+"നിങ്ങളുടെ പ്രോംപ്റ്റും പ്രശ്നമുള്ള ഔട്ട്പുട്ടും (ഏതെങ്കിലും വ്യക്തിഗത "
+"വിവരങ്ങൾ നീക്കം ചെയ്തത്) ഒട്ടിക്കുക, കൂടാതെ ഉള്ളടക്കം നിയമവിരുദ്ധമോ ദോഷകരമോ "
+"ആകുന്നത് എന്തുകൊണ്ടെന്ന് വിവരിക്കുക."
 
 # smartling.placeholder_format=C
 #. Title on a feedback form.
@@ -14506,7 +14667,8 @@ msgid ""
 "Plus, what you watch in Duck Player won’t influence your recommendations on "
 "YouTube."
 msgstr ""
-"കൂടാതെ, Duck Player-ൽ നിങ്ങൾ കാണുന്നത് YouTube-ലെ നിങ്ങളുടെ ശുപാർശകളെ സ്വാധീനിക്കുകയില്ല."
+"കൂടാതെ, Duck Player-ൽ നിങ്ങൾ കാണുന്നത് YouTube-ലെ നിങ്ങളുടെ ശുപാർശകളെ "
+"സ്വാധീനിക്കുകയില്ല."
 
 # smartling.placeholder_format=C
 #. A link to the Substack page (https://insideduckduckgo.substack.com/?showWelcome=true)
@@ -14815,7 +14977,7 @@ msgstr "സ്വകാര്യത"
 #. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
 msgctxt "Section heading on the Duck.ai settings page"
 msgid "Privacy & Terms"
-msgstr ""
+msgstr "സ്വകാര്യതയും & നിബന്ധനകളും"
 
 # smartling.placeholder_format=C
 msgid "Privacy Blog"
@@ -14891,7 +15053,7 @@ msgstr "സ്വകാര്യതാ നയവും സേവന നിബന
 #. Text for a button that links to the terms of use and privacy policy page.
 msgctxt "Secondary button text in active privacy modal"
 msgid "Privacy Policy and Terms of Service"
-msgstr ""
+msgstr "സ്വകാര്യതാ നയവും സേവന നിബന്ധനകളും"
 
 # smartling.placeholder_format=C
 #. Title displayed on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
@@ -15065,7 +15227,9 @@ msgstr "എന്നെ പ്രോംപ്റ്റ് ചെയ്യു�
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Prompt me to use my approximate location to get nearby results."
-msgstr "സമീപത്തുള്ള ഫലങ്ങൾക്കായി എന്റെ ഏകദേശ ലൊക്കേഷൻ ഉപയോഗിക്കാൻ എന്നോട് നിർദേശിക്കുക."
+msgstr ""
+"സമീപത്തുള്ള ഫലങ്ങൾക്കായി എന്റെ ഏകദേശ ലൊക്കേഷൻ ഉപയോഗിക്കാൻ എന്നോട് "
+"നിർദേശിക്കുക."
 
 # smartling.placeholder_format=C
 #. DuckDuckGo Email Protection removes trackers from emails
@@ -15083,7 +15247,9 @@ msgstr "നിങ്ങൾ തിരയുകയും ബ്രൗസ് ചെ
 #. Shown on the Mac and Windows browser promo cards. DuckDuckGo's desktop browser protects your data across search, browsing, and AI chat.
 msgctxt "SERP footer content"
 msgid "Protect your data as you search, browse, and use AI."
-msgstr "തിരയുമ്പോഴും, ബ്രൗസ് ചെയ്യുമ്പോഴും, AI ഉപയോഗിക്കുമ്പോഴും നിങ്ങളുടെ ഡാറ്റ സംരക്ഷിക്കുക."
+msgstr ""
+"തിരയുമ്പോഴും, ബ്രൗസ് ചെയ്യുമ്പോഴും, AI ഉപയോഗിക്കുമ്പോഴും നിങ്ങളുടെ ഡാറ്റ "
+"സംരക്ഷിക്കുക."
 
 # smartling.placeholder_format=C
 #. A title above links to download the DuckDuckGo apps.
@@ -15108,8 +15274,8 @@ msgid ""
 "Provide a few suggestions to make the following text more concise. [Insert "
 "your own text here.]"
 msgstr ""
-"ഇനിപ്പറയുന്ന വാചകം കൂടുതൽ സംക്ഷിപ്തമാക്കാൻ കുറച്ച് നിർദ്ദേശങ്ങൾ നൽകുക. [നിങ്ങളുടെ സ്വന്തം "
-"വാചകം ഇവിടെ ചേർക്കുക.]"
+"ഇനിപ്പറയുന്ന വാചകം കൂടുതൽ സംക്ഷിപ്തമാക്കാൻ കുറച്ച് നിർദ്ദേശങ്ങൾ നൽകുക. "
+"[നിങ്ങളുടെ സ്വന്തം വാചകം ഇവിടെ ചേർക്കുക.]"
 
 # smartling.placeholder_format=C
 #. In the context of a standings table for NHL (hockey), column title that abbreviates 'Total Points' (the total points of this team)
@@ -15346,8 +15512,8 @@ msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
 msgstr ""
-"സമീപകാല ചാറ്റുകൾ DuckDuckGo സെർവറുകൾക്കോ മറ്റ് വിദൂര സെർവറുകൾക്കോ പകരം നിങ്ങളുടെ "
-"ഉപകരണത്തിൽ പ്രാദേശികമായി സംഭരിച്ചിരിക്കുന്നു."
+"സമീപകാല ചാറ്റുകൾ DuckDuckGo സെർവറുകൾക്കോ മറ്റ് വിദൂര സെർവറുകൾക്കോ പകരം "
+"നിങ്ങളുടെ ഉപകരണത്തിൽ പ്രാദേശികമായി സംഭരിച്ചിരിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Text explaining that recent chats are stored locally on the user's device.
@@ -15356,8 +15522,8 @@ msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
 msgstr ""
-"സമീപകാല ചാറ്റുകൾ DuckDuckGo സെർവറുൾക്കോ മറ്റ് വിദൂര സെർവറുകൾക്കോ പകരം നിങ്ങളുടെ "
-"ഉപകരണത്തിൽ പ്രാദേശികമായി സംഭരിച്ചിരിക്കുന്നു."
+"സമീപകാല ചാറ്റുകൾ DuckDuckGo സെർവറുൾക്കോ മറ്റ് വിദൂര സെർവറുകൾക്കോ പകരം "
+"നിങ്ങളുടെ ഉപകരണത്തിൽ പ്രാദേശികമായി സംഭരിച്ചിരിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Text explaining how recent chats are stored locally on the user's device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection.
@@ -15367,9 +15533,10 @@ msgid ""
 "are encrypted and temporarily stored on a DuckDuckGo server after being "
 "sent, to help recover a chat if you lose your internet connection."
 msgstr ""
-"സമീപകാല ചാറ്റുകൾ നിങ്ങളുടെ ഉപകരണത്തിൽ തന്നെ സംഭരിച്ചിരിക്കുന്നു. പുതിയ പ്രോംപ്റ്റുകളും "
-"പ്രതികരണങ്ങളും അയച്ചതിനുശേഷം എൻക്രിപ്റ്റ് ചെയ്ത് താൽക്കാലികമായി ഒരു DuckDuckGo സെർവറിൽ "
-"സംഭരിക്കും, ഇത് നിങ്ങളുടെ ഇന്റർനെറ്റ് കണക്ഷൻ നഷ്ടപ്പെട്ടാൽ ഒരു ചാറ്റ് വീണ്ടെടുക്കാൻ സഹായിക്കും."
+"സമീപകാല ചാറ്റുകൾ നിങ്ങളുടെ ഉപകരണത്തിൽ തന്നെ സംഭരിച്ചിരിക്കുന്നു. പുതിയ "
+"പ്രോംപ്റ്റുകളും പ്രതികരണങ്ങളും അയച്ചതിനുശേഷം എൻക്രിപ്റ്റ് ചെയ്ത് "
+"താൽക്കാലികമായി ഒരു DuckDuckGo സെർവറിൽ സംഭരിക്കും, ഇത് നിങ്ങളുടെ ഇന്റർനെറ്റ് "
+"കണക്ഷൻ നഷ്ടപ്പെട്ടാൽ ഒരു ചാറ്റ് വീണ്ടെടുക്കാൻ സഹായിക്കും."
 
 # smartling.placeholder_format=C
 msgctxt "region filter"
@@ -15396,25 +15563,25 @@ msgstr "ഒരു പുസ്തകം ശുപാർശ ചെയ്യുക
 #. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Recommend similar books"
-msgstr ""
+msgstr "സമാനമായ പുസ്തകങ്ങൾ ശുപാർശ ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Recommend similar books."
-msgstr ""
+msgstr "സമാനമായ പുസ്തകങ്ങൾ ശുപാർശ ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Recommend similar movies or shows."
-msgstr ""
+msgstr "സമാനമായ സിനിമകളോ ഷോകളോ നിർദ്ദേശിക്കുക."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Recommend similar titles"
-msgstr ""
+msgstr "സമാനമായ തലക്കെട്ടുകൾ ശുപാർശ ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
@@ -15487,8 +15654,8 @@ msgid ""
 "Reduces extra space in and around results and reduces size of result title "
 "text"
 msgstr ""
-"ഫലങ്ങളിലും ചുറ്റുമുള്ള അധിക ഇടം കുറയ്ക്കുകയും ഫലമായുള്ള ശീർഷക ടെക്സ്റ്റിന്റെ വലുപ്പം കുറയ്ക്കുകയും "
-"ചെയ്യുന്നു"
+"ഫലങ്ങളിലും ചുറ്റുമുള്ള അധിക ഇടം കുറയ്ക്കുകയും ഫലമായുള്ള ശീർഷക ടെക്സ്റ്റിന്റെ "
+"വലുപ്പം കുറയ്ക്കുകയും ചെയ്യുന്നു"
 
 # smartling.placeholder_format=C
 #. Label for the input field where users specify how they want to be referred to. Example: 'Refer to me as John'
@@ -15629,8 +15796,9 @@ msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
 msgstr ""
-"നിർദ്ദേശങ്ങൾ പാലിച്ച് DuckDuckGo വീണ്ടും ലോഡ് ചെയ്യുക, അല്ലെങ്കിൽ നിങ്ങളുടെ ബ്രൗസറിലെ "
-"&quot;റിഫ്രഷ്&quot; അല്ലെങ്കിൽ &quot;റീലോഡ്&quot; ബട്ടൺ ക്ലിക്ക് ചെയ്യുക."
+"നിർദ്ദേശങ്ങൾ പാലിച്ച് DuckDuckGo വീണ്ടും ലോഡ് ചെയ്യുക, അല്ലെങ്കിൽ നിങ്ങളുടെ "
+"ബ്രൗസറിലെ &quot;റിഫ്രഷ്&quot; അല്ലെങ്കിൽ &quot;റീലോഡ്&quot; ബട്ടൺ ക്ലിക്ക് "
+"ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. checkbox label that allows the user to save the setting
@@ -15720,8 +15888,9 @@ msgid ""
 "Removes the \"Ask\" button so answers appear automatically in response to "
 "relevant searches. Cached answers always display automatically."
 msgstr ""
-"\"ചോദിക്കുക\" ബട്ടൺ നീക്കം ചെയ്യുന്നതിനാൽ പ്രസക്തമായ തിരയലുകളുടെ പ്രതികരണമായി ഉത്തരങ്ങൾ "
-"സ്വയമേവ ദൃശ്യമാകും. കാഷെ ചെയ്‌ത ഉത്തരങ്ങൾ എപ്പോഴും സ്വയമേവ പ്രദർശിപ്പിക്കും."
+"\"ചോദിക്കുക\" ബട്ടൺ നീക്കം ചെയ്യുന്നതിനാൽ പ്രസക്തമായ തിരയലുകളുടെ "
+"പ്രതികരണമായി ഉത്തരങ്ങൾ സ്വയമേവ ദൃശ്യമാകും. കാഷെ ചെയ്‌ത ഉത്തരങ്ങൾ എപ്പോഴും "
+"സ്വയമേവ പ്രദർശിപ്പിക്കും."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -15729,8 +15898,9 @@ msgid ""
 "Removes the \"Generate\" button so answers appear automatically in response "
 "to relevant searches. Cached answers always display automatically."
 msgstr ""
-"\"ചോദിക്കുക\" ബട്ടൺ നീക്കം ചെയ്യുന്നതിനാൽ പ്രസക്തമായ തിരയലുകളുടെ പ്രതികരണമായി ഉത്തരങ്ങൾ "
-"സ്വയമേവ ദൃശ്യമാകും. കാഷെ ചെയ്ത ഉത്തരങ്ങൾ എപ്പോഴും സ്വയമേവ പ്രദർശിപ്പിക്കും."
+"\"ചോദിക്കുക\" ബട്ടൺ നീക്കം ചെയ്യുന്നതിനാൽ പ്രസക്തമായ തിരയലുകളുടെ "
+"പ്രതികരണമായി ഉത്തരങ്ങൾ സ്വയമേവ ദൃശ്യമാകും. കാഷെ ചെയ്ത ഉത്തരങ്ങൾ എപ്പോഴും "
+"സ്വയമേവ പ്രദർശിപ്പിക്കും."
 
 # smartling.placeholder_format=C
 #. Text for a button to rename a chat, as in it will allow the user to change the title of the chat.
@@ -15788,9 +15958,10 @@ msgid ""
 "service. Your anonymous feedback is also shared with %s to help improve "
 "their services."
 msgstr ""
-"റിപ്പോർട്ടുകൾ അജ്ഞാതമാണ്, ഞങ്ങളുടെ തിരയൽ സേവനം മെച്ചപ്പെടുത്താൻ സഹായിക്കുന്നതിന് അവ "
-"DuckDuckGo-ലേക്ക് അയയ്ക്കുന്നു. അവരുടെ സേവനങ്ങൾ മെച്ചപ്പെടുത്താൻ സഹായിക്കുന്നതിന് നിങ്ങളുടെ "
-"അജ്ഞാത ഫീഡ്ബാക്കും %1$s-ലേക്ക് അയയ്ക്കാറുണ്ട്."
+"റിപ്പോർട്ടുകൾ അജ്ഞാതമാണ്, ഞങ്ങളുടെ തിരയൽ സേവനം മെച്ചപ്പെടുത്താൻ "
+"സഹായിക്കുന്നതിന് അവ DuckDuckGo-ലേക്ക് അയയ്ക്കുന്നു. അവരുടെ സേവനങ്ങൾ "
+"മെച്ചപ്പെടുത്താൻ സഹായിക്കുന്നതിന് നിങ്ങളുടെ അജ്ഞാത ഫീഡ്ബാക്കും %1$s-ലേക്ക് "
+"അയയ്ക്കാറുണ്ട്."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -15798,8 +15969,8 @@ msgid ""
 "Reports sent to DuckDuckGo are anonymous. Please do not include any personal "
 "or identifying information in your feedback."
 msgstr ""
-"DuckDuckGo-ലേക്ക് അയയ്ക്കുന്ന റിപ്പോർട്ടുകൾ അജ്ഞാതമാണ്. നിങ്ങളുടെ ഫീഡ്ബാക്കിൽ വ്യക്തിപരമോ "
-"തിരിച്ചറിയുന്നതോ ആയ വിവരങ്ങളൊന്നും ഉൾപ്പെടുത്തരുത്."
+"DuckDuckGo-ലേക്ക് അയയ്ക്കുന്ന റിപ്പോർട്ടുകൾ അജ്ഞാതമാണ്. നിങ്ങളുടെ "
+"ഫീഡ്ബാക്കിൽ വ്യക്തിപരമോ തിരിച്ചറിയുന്നതോ ആയ വിവരങ്ങളൊന്നും ഉൾപ്പെടുത്തരുത്."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -15808,9 +15979,10 @@ msgid ""
 "translate during this page load, and are anonymous. Please do not include "
 "any personal or identifying information in your feedback."
 msgstr ""
-"DuckDuckGo-ലേക്ക് അയച്ച റിപ്പോർട്ടുകളിൽ ഈ പേജ് ലോഡിനിടെ നിങ്ങൾ ഞങ്ങളോട് വിവർത്തനം "
-"ചെയ്യാൻ ആവശ്യപ്പെട്ട എല്ലാ വാചകങ്ങളും ഉൾപ്പെടുന്നു, അവ അജ്ഞാതവുമാണ്. നിങ്ങളുടെ ഫീഡ്ബാക്കിൽ "
-"വ്യക്തിപരമോ തിരിച്ചറിയുന്നതോ ആയ വിവരങ്ങളൊന്നും ഉൾപ്പെടുത്തരുത്."
+"DuckDuckGo-ലേക്ക് അയച്ച റിപ്പോർട്ടുകളിൽ ഈ പേജ് ലോഡിനിടെ നിങ്ങൾ ഞങ്ങളോട് "
+"വിവർത്തനം ചെയ്യാൻ ആവശ്യപ്പെട്ട എല്ലാ വാചകങ്ങളും ഉൾപ്പെടുന്നു, അവ "
+"അജ്ഞാതവുമാണ്. നിങ്ങളുടെ ഫീഡ്ബാക്കിൽ വ്യക്തിപരമോ തിരിച്ചറിയുന്നതോ ആയ "
+"വിവരങ്ങളൊന്നും ഉൾപ്പെടുത്തരുത്."
 
 # smartling.placeholder_format=C
 msgid "Republic of Moldova"
@@ -15823,7 +15995,7 @@ msgctxt ""
 "feedback form when the user has selected Harmful or Illegal as the feedback "
 "reason"
 msgid "Required for harmful or illegal reports"
-msgstr ""
+msgstr "ദോഷകരമോ നിയമവിരുദ്ധമോ ആയ റിപ്പോർട്ടുകൾക്ക് ആവശ്യമാണ്"
 
 # smartling.placeholder_format=C
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
@@ -15890,9 +16062,10 @@ msgid ""
 "legal, financial, investment, or other professional advice. AI-assisted "
 "answers are subject to our %sTerms of Service%s."
 msgstr ""
-"പ്രതികരണങ്ങൾ വിദ്യാഭ്യാസ ആവശ്യങ്ങൾക്കായി മാത്രമാണ്, അവ മെഡിക്കൽ, നിയമ, സാമ്പത്തിക, "
-"നിക്ഷേപം അല്ലെങ്കിൽ മറ്റ് പ്രൊഫഷണൽ ഉപദേശങ്ങൾ എന്ന നിലയിൽ ഉദ്ദേശിച്ചിട്ടില്ല. AI- "
-"സഹായത്തോടെയുള്ള ഉത്തരങ്ങൾ ഞങ്ങളുടെ %1$sസേവന നിബന്ധനകൾക്ക്%2$s വിധേയമാണ്."
+"പ്രതികരണങ്ങൾ വിദ്യാഭ്യാസ ആവശ്യങ്ങൾക്കായി മാത്രമാണ്, അവ മെഡിക്കൽ, നിയമ, "
+"സാമ്പത്തിക, നിക്ഷേപം അല്ലെങ്കിൽ മറ്റ് പ്രൊഫഷണൽ ഉപദേശങ്ങൾ എന്ന നിലയിൽ "
+"ഉദ്ദേശിച്ചിട്ടില്ല. AI- സഹായത്തോടെയുള്ള ഉത്തരങ്ങൾ ഞങ്ങളുടെ %1$sസേവന "
+"നിബന്ധനകൾക്ക്%2$s വിധേയമാണ്."
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -15901,9 +16074,9 @@ msgid ""
 "legal, financial, investment, or other professional advice. DuckAssist is "
 "subject to our %sTerms of Service%s."
 msgstr ""
-"പ്രതികരണങ്ങൾ വിദ്യാഭ്യാസ ആവശ്യങ്ങൾക്കായി മാത്രമാണ്, അവ മെഡിക്കൽ, നിയമ, സാമ്പത്തിക, "
-"നിക്ഷേപം അല്ലെങ്കിൽ മറ്റ് പ്രൊഫഷണൽ ഉപദേശങ്ങൾ എന്ന നിലയിൽ ഉദ്ദേശിച്ചിട്ടില്ല. DuckAssist "
-"ഞങ്ങളുടെ %1$sസേവന നിബന്ധനകൾക്ക്%2$s വിധേയമാണ്."
+"പ്രതികരണങ്ങൾ വിദ്യാഭ്യാസ ആവശ്യങ്ങൾക്കായി മാത്രമാണ്, അവ മെഡിക്കൽ, നിയമ, "
+"സാമ്പത്തിക, നിക്ഷേപം അല്ലെങ്കിൽ മറ്റ് പ്രൊഫഷണൽ ഉപദേശങ്ങൾ എന്ന നിലയിൽ "
+"ഉദ്ദേശിച്ചിട്ടില്ല. DuckAssist ഞങ്ങളുടെ %1$sസേവന നിബന്ധനകൾക്ക്%2$s വിധേയമാണ്."
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -15913,10 +16086,11 @@ msgid ""
 "generated based on web content and may contain inaccuracies. Search Assist "
 "is subject to our %sTerms of Service%s."
 msgstr ""
-"പ്രതികരണങ്ങൾ വിദ്യാഭ്യാസ ആവശ്യങ്ങൾക്കായി മാത്രമാണ്, അവ മെഡിക്കൽ, നിയമ, സാമ്പത്തിക, "
-"നിക്ഷേപം അല്ലെങ്കിൽ മറ്റ് പ്രൊഫഷണൽ ഉപദേശങ്ങൾ എന്ന നിലയിൽ ഉദ്ദേശിച്ചിട്ടില്ല. അവ വെബ് "
-"ഉള്ളടക്കത്തെ അടിസ്ഥാനമാക്കി സൃഷ്ടിക്കപ്പെട്ടതാണ്, കൂടാതെ കൃത്യതയില്ലായ്മകൾ ഉണ്ടാകാം. Search "
-"Assist ഞങ്ങളുടെ %1$sസേവന നിബന്ധനകൾക്ക്%2$s വിധേയമാണ്."
+"പ്രതികരണങ്ങൾ വിദ്യാഭ്യാസ ആവശ്യങ്ങൾക്കായി മാത്രമാണ്, അവ മെഡിക്കൽ, നിയമ, "
+"സാമ്പത്തിക, നിക്ഷേപം അല്ലെങ്കിൽ മറ്റ് പ്രൊഫഷണൽ ഉപദേശങ്ങൾ എന്ന നിലയിൽ "
+"ഉദ്ദേശിച്ചിട്ടില്ല. അവ വെബ് ഉള്ളടക്കത്തെ അടിസ്ഥാനമാക്കി "
+"സൃഷ്ടിക്കപ്പെട്ടതാണ്, കൂടാതെ കൃത്യതയില്ലായ്മകൾ ഉണ്ടാകാം. Search Assist "
+"ഞങ്ങളുടെ %1$sസേവന നിബന്ധനകൾക്ക്%2$s വിധേയമാണ്."
 
 # smartling.placeholder_format=C
 #. Label on the button for restoring all previous website data.
@@ -15993,8 +16167,8 @@ msgstr "ബ്ലോക്ക് ചെയ്‌ത സൈറ്റുകളി�
 msgctxt "Blocked sites filter disclaimer"
 msgid "Results exclude your blocked sites, which you can manage in your %s."
 msgstr ""
-"ഫലങ്ങളിൽ നിങ്ങളുടെ തടഞ്ഞ സൈറ്റുകൾ ഉൾപ്പെടുന്നില്ല, അവ നിങ്ങളുടെ %1$s-ൽ കൈകാര്യം ചെയ്യാൻ "
-"കഴിയും."
+"ഫലങ്ങളിൽ നിങ്ങളുടെ തടഞ്ഞ സൈറ്റുകൾ ഉൾപ്പെടുന്നില്ല, അവ നിങ്ങളുടെ %1$s-ൽ "
+"കൈകാര്യം ചെയ്യാൻ കഴിയും."
 
 # smartling.placeholder_format=C
 #. A label showing the source of the results, e.g. "Results from Reddit"
@@ -16065,7 +16239,7 @@ msgstr "അവലോകനങ്ങൾ"
 #. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Rewrite this recipe scaled for a different number of servings."
-msgstr ""
+msgstr "വ്യത്യസ്ത എണ്ണം സെർവിംഗുകൾക്കായി ഈ പാചകക്കുറിപ്പ് തിരുത്തിയെഴുതുക."
 
 # smartling.placeholder_format=C
 msgid "Romania"
@@ -16337,16 +16511,17 @@ msgid ""
 "Save up to 30 of your most recent chats locally on your device, with the "
 "option for more with Encrypted Storage."
 msgstr ""
-"എൻക്രിപ്റ്റ് ചെയ്ത സ്റ്റോറേജ് ഉപയോഗിച്ച് കൂടുതൽ എന്ന ഓപ്ഷൻ ഉപയോഗിച്ച് നിങ്ങളുടെ ഏറ്റവും പുതിയ "
-"ചാറ്റുകളിൽ 30 എണ്ണം വരെ നിങ്ങളുടെ ഉപകരണത്തിൽ പ്രാദേശികമായി സംരക്ഷിക്കുക."
+"എൻക്രിപ്റ്റ് ചെയ്ത സ്റ്റോറേജ് ഉപയോഗിച്ച് കൂടുതൽ എന്ന ഓപ്ഷൻ ഉപയോഗിച്ച് "
+"നിങ്ങളുടെ ഏറ്റവും പുതിയ ചാറ്റുകളിൽ 30 എണ്ണം വരെ നിങ്ങളുടെ ഉപകരണത്തിൽ "
+"പ്രാദേശികമായി സംരക്ഷിക്കുക."
 
 # smartling.placeholder_format=C
 #. Short text for native DDG browser users explaining how Chat History stores up to 30 of their most recent chats locally on their device.
 msgctxt "Short description for Chat History feature on native DDG browsers"
 msgid "Save up to 30 of your most recent chats locally on your device."
 msgstr ""
-"നിങ്ങളുടെ ഉപകരണത്തിൽ നിങ്ങളുടെ ഏറ്റവും പുതിയ ചാറ്റുകളിൽ 30 എണ്ണം വരെ പ്രാദേശികമായി "
-"സംരക്ഷിക്കുക."
+"നിങ്ങളുടെ ഉപകരണത്തിൽ നിങ്ങളുടെ ഏറ്റവും പുതിയ ചാറ്റുകളിൽ 30 എണ്ണം വരെ "
+"പ്രാദേശികമായി സംരക്ഷിക്കുക."
 
 # smartling.placeholder_format=C
 #. Desktop/mobile intro modal body under the title per Sync Chats Figma (choose step).
@@ -16354,7 +16529,8 @@ msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
 msgstr ""
-"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷൻ ഉപയോഗിച്ച് നിങ്ങളുടെ ഉപകരണങ്ങൾക്കിടയിൽ Duck.ai ചാറ്റുകൾ സംരക്ഷിക്കുക."
+"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷൻ ഉപയോഗിച്ച് നിങ്ങളുടെ ഉപകരണങ്ങൾക്കിടയിൽ Duck.ai "
+"ചാറ്റുകൾ സംരക്ഷിക്കുക."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -16470,13 +16646,17 @@ msgstr "സ്കോട്ട്ലൻഡ്"
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Scroll down and click %sView advanced settings%s"
-msgstr "താഴോട്ട് സ്ക്രോൾ ചെയ്ത് %1$sവിപുലമായ ക്രമീകരണം കാണുക%2$s എന്നത് തിരഞ്ഞെടുക്കുക"
+msgstr ""
+"താഴോട്ട് സ്ക്രോൾ ചെയ്ത് %1$sവിപുലമായ ക്രമീകരണം കാണുക%2$s എന്നത് "
+"തിരഞ്ഞെടുക്കുക"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down and click %sView advanced settings%s."
-msgstr "താഴേക്ക് സ്ക്രോൾ ചെയ്ത് %1$sവിപുലമായ ക്രമീകരണം കാണുക%2$s എന്നത് ക്ലിക്ക് ചെയ്യുക."
+msgstr ""
+"താഴേക്ക് സ്ക്രോൾ ചെയ്ത് %1$sവിപുലമായ ക്രമീകരണം കാണുക%2$s എന്നത് ക്ലിക്ക് "
+"ചെയ്യുക."
 
 #  Edge Legacy default search engine instruction, obsolete?
 # smartling.placeholder_format=C
@@ -16484,8 +16664,8 @@ msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)"
 msgstr ""
-"താഴേക്ക് സ്ക്രോൾ ചെയ്ത് %1$sവിലാസ ബാറിൽ തിരയുക%2$s കണ്ടെത്തുക. %3$sമാറ്റുക%4$s (അല്ലെങ്കിൽ "
-"%5$sപുതിയത് ചേർക്കുക%6$s ക്ലിക്ക് ചെയ്യുക)"
+"താഴേക്ക് സ്ക്രോൾ ചെയ്ത് %1$sവിലാസ ബാറിൽ തിരയുക%2$s കണ്ടെത്തുക. "
+"%3$sമാറ്റുക%4$s (അല്ലെങ്കിൽ %5$sപുതിയത് ചേർക്കുക%6$s ക്ലിക്ക് ചെയ്യുക)"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
@@ -16494,8 +16674,8 @@ msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)."
 msgstr ""
-"താഴേക്ക് സ്ക്രോൾ ചെയ്ത് %1$sവിലാസ ബാറിൽ തിരയുക%2$s കണ്ടെത്തുക. %3$sമാറ്റുക%4$s (അല്ലെങ്കിൽ "
-"%5$sപുതിയത് ചേർക്കുക%6$s ക്ലിക്ക് ചെയ്യുക)."
+"താഴേക്ക് സ്ക്രോൾ ചെയ്ത് %1$sവിലാസ ബാറിൽ തിരയുക%2$s കണ്ടെത്തുക. "
+"%3$sമാറ്റുക%4$s (അല്ലെങ്കിൽ %5$sപുതിയത് ചേർക്കുക%6$s ക്ലിക്ക് ചെയ്യുക)."
 
 # smartling.placeholder_format=C
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -16514,15 +16694,16 @@ msgstr "താഴേക്ക് സ്ക്രോൾ ചെയ്ത്, �
 msgctxt "precise_user_location"
 msgid "Scroll down to %sDuckDuckGo%s and allow it to use your location."
 msgstr ""
-"%1$sDuckDuckGo%2$s എന്നതിലേക്ക് താഴേക്ക് സ്ക്രോൾ ചെയ്ത് നിങ്ങളുടെ ലൊക്കേഷൻ ഉപയോഗിക്കാൻ "
-"അതിനെ അനുവദിക്കുക."
+"%1$sDuckDuckGo%2$s എന്നതിലേക്ക് താഴേക്ക് സ്ക്രോൾ ചെയ്ത് നിങ്ങളുടെ ലൊക്കേഷൻ "
+"ഉപയോഗിക്കാൻ അതിനെ അനുവദിക്കുക."
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down to the %sServices%s section and click %sAddress bar%s."
 msgstr ""
-"താഴേക്ക് സ്ക്രോൾ ചെയ്ത് %1$sസേവനങ്ങൾ%2$s വിഭാഗം എടുത്ത്, %3$sവിലാസ ബാർ%4$s ക്ലിക്ക് ചെയ്യുക."
+"താഴേക്ക് സ്ക്രോൾ ചെയ്ത് %1$sസേവനങ്ങൾ%2$s വിഭാഗം എടുത്ത്, %3$sവിലാസ ബാർ%4$s "
+"ക്ലിക്ക് ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Rugby match stats
@@ -16570,12 +16751,14 @@ msgid ""
 "(on a wide range of searches). For now, Search Assist is only available in a "
 "subset of English speaking regions."
 msgstr ""
-"Search Assist തിരയൽ ചോദ്യങ്ങൾക്കുള്ള ഉത്തരങ്ങൾ അജ്ഞാതമായി സൃഷ്ടിക്കുന്നു. ഇത് ചെയ്യുന്നതിന്, "
-"പ്രസക്തമായ ഉള്ളടക്കത്തിനായി ഇത് വെബ് സ്കാൻ ചെയ്യുകയും തുടർന്ന് AI ഉപയോഗിച്ച് ഒരു ഹ്രസ്വ ഉത്തരം "
-"സൃഷ്ടിക്കുകയും ചെയ്യുന്നു. നിങ്ങൾക്ക് ഇത് എത്ര തവണ പ്രത്യക്ഷപ്പെടണമെന്ന് തിരഞ്ഞെടുക്കാം: ഒരിക്കലും, "
-"ഓൺ-ഡിമാൻഡ് (Assist ക്ലിക്ക് ചെയ്യുമ്പോൾ മാത്രം), ചിലപ്പോൾ (വളരെ പ്രസക്തമാകുമ്പോൾ), "
-"അല്ലെങ്കിൽ പലപ്പോഴും (വിശാലമായ തിരയലുകളിൽ). ഈ സമയത്ത്, ഇംഗ്ലീഷ് സംസാരിക്കുന്ന പ്രദേശങ്ങളുടെ "
-"ഒരു ഭാഗത്ത് മാത്രമേ Search Assist ലഭ്യമാകൂ."
+"Search Assist തിരയൽ ചോദ്യങ്ങൾക്കുള്ള ഉത്തരങ്ങൾ അജ്ഞാതമായി സൃഷ്ടിക്കുന്നു. "
+"ഇത് ചെയ്യുന്നതിന്, പ്രസക്തമായ ഉള്ളടക്കത്തിനായി ഇത് വെബ് സ്കാൻ ചെയ്യുകയും "
+"തുടർന്ന് AI ഉപയോഗിച്ച് ഒരു ഹ്രസ്വ ഉത്തരം സൃഷ്ടിക്കുകയും ചെയ്യുന്നു. "
+"നിങ്ങൾക്ക് ഇത് എത്ര തവണ പ്രത്യക്ഷപ്പെടണമെന്ന് തിരഞ്ഞെടുക്കാം: ഒരിക്കലും, "
+"ഓൺ-ഡിമാൻഡ് (Assist ക്ലിക്ക് ചെയ്യുമ്പോൾ മാത്രം), ചിലപ്പോൾ (വളരെ "
+"പ്രസക്തമാകുമ്പോൾ), അല്ലെങ്കിൽ പലപ്പോഴും (വിശാലമായ തിരയലുകളിൽ). ഈ സമയത്ത്, "
+"ഇംഗ്ലീഷ് സംസാരിക്കുന്ന പ്രദേശങ്ങളുടെ ഒരു ഭാഗത്ത് മാത്രമേ Search Assist "
+"ലഭ്യമാകൂ."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI) when the answer is not found and the answer is unsourced or with no sources
@@ -16583,8 +16766,8 @@ msgid ""
 "Search Assist couldn't find enough reliable information to generate an "
 "answer for this question. Try another search."
 msgstr ""
-"ഈ ചോദ്യത്തിന് ഉത്തരം സൃഷ്ടിക്കുന്നതിന് വേണ്ടത്ര വിശ്വസനീയമായ വിവരങ്ങൾ Search Assist-ന് "
-"കണ്ടെത്താൻ കഴിഞ്ഞില്ല. മറ്റൊരു തിരയൽ ശ്രമിക്കുക."
+"ഈ ചോദ്യത്തിന് ഉത്തരം സൃഷ്ടിക്കുന്നതിന് വേണ്ടത്ര വിശ്വസനീയമായ വിവരങ്ങൾ Search "
+"Assist-ന് കണ്ടെത്താൻ കഴിഞ്ഞില്ല. മറ്റൊരു തിരയൽ ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -16593,9 +16776,10 @@ msgid ""
 "search queries. To do this, it %sscans the web%s for relevant content and "
 "then uses AI to generate a brief answer based on information found."
 msgstr ""
-"Search Assist എന്നത് തിരയൽ അന്വേഷണങ്ങൾക്ക് അജ്ഞാതമായി ഉത്തരങ്ങൾ സൃഷ്ടിക്കുന്ന ഒരു ഓപ്ഷണൽ "
-"സവിശേഷതയാണ്. ഇത് ചെയ്യാൻ, പ്രസക്തമായ ഉള്ളടക്കത്തിനായി %1$sവെബ് സ്കാൻ%2$s ചെയ്യുകയും "
-"കണ്ടെത്തിയ വിവരങ്ങളെ അടിസ്ഥാനമാക്കി AI ഉപയോഗിച്ച് ഒരു ഹ്രസ്വമായ ഉത്തരം സൃഷ്ടിക്കുകയും ചെയ്യുന്നു."
+"Search Assist എന്നത് തിരയൽ അന്വേഷണങ്ങൾക്ക് അജ്ഞാതമായി ഉത്തരങ്ങൾ "
+"സൃഷ്ടിക്കുന്ന ഒരു ഓപ്ഷണൽ സവിശേഷതയാണ്. ഇത് ചെയ്യാൻ, പ്രസക്തമായ "
+"ഉള്ളടക്കത്തിനായി %1$sവെബ് സ്കാൻ%2$s ചെയ്യുകയും കണ്ടെത്തിയ വിവരങ്ങളെ "
+"അടിസ്ഥാനമാക്കി AI ഉപയോഗിച്ച് ഒരു ഹ്രസ്വമായ ഉത്തരം സൃഷ്ടിക്കുകയും ചെയ്യുന്നു."
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/search_box. top header
@@ -16716,8 +16900,8 @@ msgid ""
 "Search other sites with %s shortcuts: a search for ”!w ducks” will search "
 "for “ducks” directly on Wikipedia."
 msgstr ""
-"%1$s ഷോർട്ട്കട്ടുകൾ ഉപയോഗിച്ച് മറ്റ് സൈറ്റുകൾ തിരയുക: ”!w ducks” എന്നതിനുള്ള തിരയൽ "
-"വിക്കിപീഡിയയിൽ “ducks” എന്നതിനായി നേരിട്ട് തിരയുന്നതാണ്."
+"%1$s ഷോർട്ട്കട്ടുകൾ ഉപയോഗിച്ച് മറ്റ് സൈറ്റുകൾ തിരയുക: ”!w ducks” എന്നതിനുള്ള "
+"തിരയൽ വിക്കിപീഡിയയിൽ “ducks” എന്നതിനായി നേരിട്ട് തിരയുന്നതാണ്."
 
 # smartling.placeholder_format=C
 #. Placeholder text for the search form when no text has been entered
@@ -16736,9 +16920,9 @@ msgid ""
 "Search privately with our app or extension, add private web search to your "
 "favorite browser, or search directly at %sduckduckgo.com%s."
 msgstr ""
-"ഞങ്ങളുടെ ആപ്പ് അല്ലെങ്കിൽ എക്സ്റ്റന്‍ഷന്‍ ഉപയോഗിച്ച് സ്വകാര്യമായി തിരയുക, നിങ്ങളുടെ പ്രിയപ്പെട്ട "
-"ബ്രൗസറിലേക്ക് സ്വകാര്യ വെബ് തിരയൽ ചേർക്കുക, അല്ലെങ്കിൽ %1$sduckduckgo.com%2$s-ൽ നേരിട്ട് "
-"തിരയുക."
+"ഞങ്ങളുടെ ആപ്പ് അല്ലെങ്കിൽ എക്സ്റ്റന്‍ഷന്‍ ഉപയോഗിച്ച് സ്വകാര്യമായി തിരയുക, "
+"നിങ്ങളുടെ പ്രിയപ്പെട്ട ബ്രൗസറിലേക്ക് സ്വകാര്യ വെബ് തിരയൽ ചേർക്കുക, "
+"അല്ലെങ്കിൽ %1$sduckduckgo.com%2$s-ൽ നേരിട്ട് തിരയുക."
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/6LZAoqH.png
@@ -16746,8 +16930,8 @@ msgctxt "settings"
 msgid ""
 "Search queries are included in URL (if off, searches will use POST requests)"
 msgstr ""
-"തിരയൽ അന്വേഷണങ്ങൾ URL-ൽ ഉൾപ്പെടുത്തിയിട്ടുണ്ട് (ഓഫാണെങ്കിൽ തിരയലുകൾ POST അഭ്യർത്ഥനകൾ "
-"ഉപയോഗിക്കും)"
+"തിരയൽ അന്വേഷണങ്ങൾ URL-ൽ ഉൾപ്പെടുത്തിയിട്ടുണ്ട് (ഓഫാണെങ്കിൽ തിരയലുകൾ POST "
+"അഭ്യർത്ഥനകൾ ഉപയോഗിക്കും)"
 
 # smartling.placeholder_format=C
 #. Describes how cookies are used to store user settings privately and securely.
@@ -16759,10 +16943,11 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"തിരയൽ ക്രമീകരണങ്ങൾ വ്യക്തിഗതമല്ലാത്ത ബ്രൗസർ കുക്കികളിലും പ്രാദേശിക സംഭരണത്തിലും നിങ്ങളുടെ "
-"ബ്രൗസറിലും സൂക്ഷിച്ചിരിക്കുന്നു, എന്നാൽ ക്ലൗഡിലെ ഒരു വിദൂര സെർവറിൽ നിങ്ങളുടെ ക്രമീകരണങ്ങൾ "
-"അജ്ഞാതമായി സൂക്ഷിക്കാൻ Cloud Save ഉപയോഗിക്കാം. വ്യക്തിപരമായി തിരിച്ചറിയാൻ കഴിയുന്ന "
-"വിവരങ്ങളൊന്നും ക്ലൗഡിൽ സംഭരിക്കപ്പെടില്ല, നിങ്ങളുടെ പാസ്‌ഫ്രെയ്സ് ഒരിക്കലും നിങ്ങളുടെ ബ്രൗസർ "
+"തിരയൽ ക്രമീകരണങ്ങൾ വ്യക്തിഗതമല്ലാത്ത ബ്രൗസർ കുക്കികളിലും പ്രാദേശിക "
+"സംഭരണത്തിലും നിങ്ങളുടെ ബ്രൗസറിലും സൂക്ഷിച്ചിരിക്കുന്നു, എന്നാൽ ക്ലൗഡിലെ ഒരു "
+"വിദൂര സെർവറിൽ നിങ്ങളുടെ ക്രമീകരണങ്ങൾ അജ്ഞാതമായി സൂക്ഷിക്കാൻ Cloud Save "
+"ഉപയോഗിക്കാം. വ്യക്തിപരമായി തിരിച്ചറിയാൻ കഴിയുന്ന വിവരങ്ങളൊന്നും ക്ലൗഡിൽ "
+"സംഭരിക്കപ്പെടില്ല, നിങ്ങളുടെ പാസ്‌ഫ്രെയ്സ് ഒരിക്കലും നിങ്ങളുടെ ബ്രൗസർ "
 "വിട്ടുപോകില്ല."
 
 # smartling.placeholder_format=C
@@ -16852,7 +17037,8 @@ msgstr "സീസൺ ആഴ്ചകൾ"
 msgctxt "Description for sync and backup feature"
 msgid "Securely save and sync your chats across all your devices."
 msgstr ""
-"നിങ്ങളുടെ എല്ലാ ഉപകരണങ്ങളിലും ചാറ്റുകൾ സുരക്ഷിതമായി സംരക്ഷിക്കുകയും സമന്വയിപ്പിക്കുകയും ചെയ്യുക."
+"നിങ്ങളുടെ എല്ലാ ഉപകരണങ്ങളിലും ചാറ്റുകൾ സുരക്ഷിതമായി സംരക്ഷിക്കുകയും "
+"സമന്വയിപ്പിക്കുകയും ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -16861,8 +17047,9 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
 msgstr ""
-"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷൻ ഉപയോഗിച്ച് ഞങ്ങളുടെ സെർവറിൽ പരിധിയില്ലാതെ ചാറ്റുകൾ സുരക്ഷിതമായി "
-"സംഭരിച്ച്, അവ നിങ്ങളുടെ എല്ലാ ഉപകരണങ്ങളിൽ നിന്നും ആക്സസ് ചെയ്യുക."
+"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷൻ ഉപയോഗിച്ച് ഞങ്ങളുടെ സെർവറിൽ പരിധിയില്ലാതെ ചാറ്റുകൾ "
+"സുരക്ഷിതമായി സംഭരിച്ച്, അവ നിങ്ങളുടെ എല്ലാ ഉപകരണങ്ങളിൽ നിന്നും ആക്സസ് "
+"ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Text explaining that the Encrypted Storage feature stores the user's chats encrypted on their device.
@@ -16871,8 +17058,9 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
 msgstr ""
-"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷൻ ഉപയോഗിച്ച് ഞങ്ങളുടെ സെർവറിൽ പരിധിയില്ലാതെ ചാറ്റുകൾ സുരക്ഷിതമായി "
-"സംഭരിച്ച്, അവ നിങ്ങളുടെ എല്ലാ ഉപകരണങ്ങളിൽ നിന്നും ആക്സസ് ചെയ്യുക."
+"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷൻ ഉപയോഗിച്ച് ഞങ്ങളുടെ സെർവറിൽ പരിധിയില്ലാതെ ചാറ്റുകൾ "
+"സുരക്ഷിതമായി സംഭരിച്ച്, അവ നിങ്ങളുടെ എല്ലാ ഉപകരണങ്ങളിൽ നിന്നും ആക്സസ് "
+"ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -16881,8 +17069,9 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your synced devices."
 msgstr ""
-"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷൻ ഉപയോഗിച്ച് ഞങ്ങളുടെ സെർവറിൽ പരിധിയില്ലാതെ ചാറ്റുകൾ സുരക്ഷിതമായി "
-"സംഭരിച്ച്, സിങ്ക് ചെയ്ത എല്ലാ ഉപകരണങ്ങളിൽ നിന്നും അവ ആക്സസ് ചെയ്യുക."
+"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷൻ ഉപയോഗിച്ച് ഞങ്ങളുടെ സെർവറിൽ പരിധിയില്ലാതെ ചാറ്റുകൾ "
+"സുരക്ഷിതമായി സംഭരിച്ച്, സിങ്ക് ചെയ്ത എല്ലാ ഉപകരണങ്ങളിൽ നിന്നും അവ ആക്സസ് "
+"ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -16891,15 +17080,17 @@ msgid ""
 "Securely store your chats on our server using end-to-end encryption, and "
 "access them from all your devices."
 msgstr ""
-"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷൻ ഉപയോഗിച്ച് നിങ്ങളുടെ ചാറ്റുകൾ ഞങ്ങളുടെ സെർവറിൽ സുരക്ഷിതമായി "
-"സംഭരിക്കുക, നിങ്ങളുടെ എല്ലാ ഉപകരണങ്ങളിൽ നിന്നും അവ ആക്സസ് ചെയ്യുക."
+"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷൻ ഉപയോഗിച്ച് നിങ്ങളുടെ ചാറ്റുകൾ ഞങ്ങളുടെ സെർവറിൽ "
+"സുരക്ഷിതമായി സംഭരിക്കുക, നിങ്ങളുടെ എല്ലാ ഉപകരണങ്ങളിൽ നിന്നും അവ ആക്സസ് "
+"ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
 msgctxt "Sync feature benefit description"
 msgid "Securely stored on DuckDuckGo's server with end-to-end encryption."
 msgstr ""
-"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷനോടെ DuckDuckGo-യുടെ സെർവറിൽ സുരക്ഷിതമായി സംഭരിച്ചിരിക്കുന്നു."
+"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷനോടെ DuckDuckGo-യുടെ സെർവറിൽ സുരക്ഷിതമായി "
+"സംഭരിച്ചിരിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. List item explaining that synced chats are stored with end-to-end encryption on DuckDuckGo's server and only the user can access them.
@@ -16908,8 +17099,9 @@ msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
 msgstr ""
-"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷനോടെ DuckDuckGo-യുടെ സെർവറിൽ സുരക്ഷിതമായി സംഭരിച്ചിരിക്കുന്നു. "
-"നിനക്കല്ലാതെ മറ്റാർക്കും നിന്റെ ഡാറ്റ കാണാൻ കഴിയില്ല, ഞങ്ങൾക്ക് പോലും."
+"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷനോടെ DuckDuckGo-യുടെ സെർവറിൽ സുരക്ഷിതമായി "
+"സംഭരിച്ചിരിക്കുന്നു. നിനക്കല്ലാതെ മറ്റാർക്കും നിന്റെ ഡാറ്റ കാണാൻ കഴിയില്ല, "
+"ഞങ്ങൾക്ക് പോലും."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -17048,34 +17240,38 @@ msgstr "%1$s%2$s%3$s തിരഞ്ഞെടുക്കുക, തുടർന
 msgctxt "precise_user_location"
 msgid "Select %s'Setting for this Website...'%s from the Safari menu."
 msgstr ""
-"Safari മെനുവിൽ നിന്ന് %1$s'ഈ വെബ്‌സൈറ്റിനായുള്ള ക്രമീകരണം...'%2$s എന്നത് തിരഞ്ഞെടുക്കുക."
+"Safari മെനുവിൽ നിന്ന് %1$s'ഈ വെബ്‌സൈറ്റിനായുള്ള ക്രമീകരണം...'%2$s എന്നത് "
+"തിരഞ്ഞെടുക്കുക."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
 msgstr ""
-"%1$sഇഷ്ടാനുസൃതമാക്കുക%2$s ഓപ്ഷൻ തിരഞ്ഞെടുത്ത ശേഷം %3$shttps://duckduckgo.com%4$s എന്ന് "
-"ഇൻപുട്ട് ഫീൽഡിൽ എന്റർ ചെയ്യുക"
+"%1$sഇഷ്ടാനുസൃതമാക്കുക%2$s ഓപ്ഷൻ തിരഞ്ഞെടുത്ത ശേഷം "
+"%3$shttps://duckduckgo.com%4$s എന്ന് ഇൻപുട്ട് ഫീൽഡിൽ എന്റർ ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
 msgstr ""
-"%1$sDuckDuckGo%2$s തിരഞ്ഞെടുത്ത ശേഷം %3$sഡിഫോൾട്ടായി ചേർക്കുക%4$s എന്നതിൽ ക്ലിക്ക് "
-"ചെയ്യുക!"
+"%1$sDuckDuckGo%2$s തിരഞ്ഞെടുത്ത ശേഷം %3$sഡിഫോൾട്ടായി ചേർക്കുക%4$s എന്നതിൽ "
+"ക്ലിക്ക് ചെയ്യുക!"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s"
-msgstr "%1$sDuckDuckGo%2$s തിരഞ്ഞെടുത്ത് %3$sഡിഫോൾട്ടായി സജ്ജീകരിക്കുക%4$s ക്ലിക്ക് ചെയ്യുക"
+msgstr ""
+"%1$sDuckDuckGo%2$s തിരഞ്ഞെടുത്ത് %3$sഡിഫോൾട്ടായി സജ്ജീകരിക്കുക%4$s ക്ലിക്ക് "
+"ചെയ്യുക"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s."
 msgstr ""
-"%1$sDuckDuckGo%2$s തിരഞ്ഞെടുത്ത് %3$sഡിഫോൾട്ടായി സജ്ജീകരിക്കുക%4$s ക്ലിക്ക് ചെയ്യുക."
+"%1$sDuckDuckGo%2$s തിരഞ്ഞെടുത്ത് %3$sഡിഫോൾട്ടായി സജ്ജീകരിക്കുക%4$s ക്ലിക്ക് "
+"ചെയ്യുക."
 
 #  Firefox 33
 # smartling.placeholder_format=C
@@ -17087,7 +17283,9 @@ msgstr "ഡിഫോൾട്ട് തിരയൽ എഞ്ചിൻ ഡ്ര
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %sDuckDuckGo%s in the list and %sallow%s location access"
-msgstr "ലിസ്റ്റിൽ %1$sDuckDuckGo%2$s തിരഞ്ഞെടുത്ത് ലൊക്കേഷൻ ആക്സസ് %4$sഅനുവദിക്കുക%3$s"
+msgstr ""
+"ലിസ്റ്റിൽ %1$sDuckDuckGo%2$s തിരഞ്ഞെടുത്ത് ലൊക്കേഷൻ ആക്സസ് "
+"%4$sഅനുവദിക്കുക%3$s"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -17100,7 +17298,8 @@ msgstr "തിരയൽ ദാതാക്കളുടെ പട്ടികയ�
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s under the%sDefault Search Engine%s section"
 msgstr ""
-"%3$sഡിഫോൾട്ട് തിരയൽ എഞ്ചിൻ%4$s വിഭാഗത്തിന് കീഴിൽ %1$sDuckDuckGo%2$s തിരഞ്ഞെടുക്കുക"
+"%3$sഡിഫോൾട്ട് തിരയൽ എഞ്ചിൻ%4$s വിഭാഗത്തിന് കീഴിൽ %1$sDuckDuckGo%2$s "
+"തിരഞ്ഞെടുക്കുക"
 
 # smartling.placeholder_format=C
 #. Tells the user were in the settings menu they can change their default search engine.
@@ -17111,13 +17310,17 @@ msgstr "%1$sDuckDuckGo%2$s തിരഞ്ഞെടുക്കുക!"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Select %sEdit Search Engines...%sin the dropdown"
-msgstr "ഡ്രോപ്പ്ഡൗണിൽ %1$sതിരയൽ എഞ്ചിനുകൾ എഡിറ്റ് ചെയ്യുക...%2$s എന്നത് തിരഞ്ഞെടുക്കുക"
+msgstr ""
+"ഡ്രോപ്പ്ഡൗണിൽ %1$sതിരയൽ എഞ്ചിനുകൾ എഡിറ്റ് ചെയ്യുക...%2$s എന്നത് "
+"തിരഞ്ഞെടുക്കുക"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sManage add-ons%s from the dropdown menu"
-msgstr "ഡ്രോപ്പ്ഡൗൺ മെനുവിൽ നിന്ന് %1$sആഡ്-ഓണുകൾ മാനേജ് ചെയ്യുക%2$s എന്നത് തിരഞ്ഞെടുക്കുക"
+msgstr ""
+"ഡ്രോപ്പ്ഡൗൺ മെനുവിൽ നിന്ന് %1$sആഡ്-ഓണുകൾ മാനേജ് ചെയ്യുക%2$s എന്നത് "
+"തിരഞ്ഞെടുക്കുക"
 
 #  Opera default search engine instruction
 # smartling.placeholder_format=C
@@ -17125,8 +17328,8 @@ msgstr "ഡ്രോപ്പ്ഡൗൺ മെനുവിൽ നിന്ന�
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sMenu > Settings%s (on Windows)"
 msgstr ""
-"(Mac-ൽ) %1$sOpera > മുൻഗണനകൾ%2$s എന്നും (Windows-ൽ) %3$sമെനു > ക്രമീകരണം%4$s എന്നും "
-"തിരഞ്ഞെടുക്കുക"
+"(Mac-ൽ) %1$sOpera > മുൻഗണനകൾ%2$s എന്നും (Windows-ൽ) %3$sമെനു > ക്രമീകരണം%4$s "
+"എന്നും തിരഞ്ഞെടുക്കുക"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -17134,8 +17337,8 @@ msgstr ""
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sOpera > Options%s (on Windows)"
 msgstr ""
-"(Mac-ൽ) %1$sOpera > മുൻഗണനകൾ%2$s എന്നും (Windows-ൽ) %3$sOpera > ഓപ്ഷനുകൾ%4$s എന്നും "
-"തിരഞ്ഞെടുക്കുക"
+"(Mac-ൽ) %1$sOpera > മുൻഗണനകൾ%2$s എന്നും (Windows-ൽ) %3$sOpera > ഓപ്ഷനുകൾ%4$s "
+"എന്നും തിരഞ്ഞെടുക്കുക"
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -17200,14 +17403,16 @@ msgid ""
 "Select %sUse this webpage as your only home page%s (or one of the other "
 "options if you prefer)"
 msgstr ""
-"%1$sഈ വെബ് പേജ് നിങ്ങളുടെ ഏക ഹോം പേജായി ഉപയോഗിക്കുക%2$s എന്നത് തിരഞ്ഞെടുക്കുക (അല്ലെങ്കിൽ "
-"നിങ്ങൾ ഇഷ്ടപ്പെടുന്നെങ്കിൽ മറ്റ് ഓപ്ഷനുകളിൽ ഒന്ന്)"
+"%1$sഈ വെബ് പേജ് നിങ്ങളുടെ ഏക ഹോം പേജായി ഉപയോഗിക്കുക%2$s എന്നത് "
+"തിരഞ്ഞെടുക്കുക (അല്ലെങ്കിൽ നിങ്ങൾ ഇഷ്ടപ്പെടുന്നെങ്കിൽ മറ്റ് ഓപ്ഷനുകളിൽ ഒന്ന്)"
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %syour browser%s in the list and %sallow%s location access"
-msgstr "ലിസ്റ്റിൽ %1$sനിങ്ങളുടെ ബ്രൗസർ%2$s തിരഞ്ഞെടുത്ത് ലൊക്കേഷൻ ആക്സസ് %3$sഅനുവദിക്കുക%4$s"
+msgstr ""
+"ലിസ്റ്റിൽ %1$sനിങ്ങളുടെ ബ്രൗസർ%2$s തിരഞ്ഞെടുത്ത് ലൊക്കേഷൻ ആക്സസ് "
+"%3$sഅനുവദിക്കുക%4$s"
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the modal for deleting all recent chats, that allows the user to select the chats to delete.
@@ -17280,7 +17485,8 @@ msgstr "%1$s-ൽ നിന്ന് തിരഞ്ഞെടുത്ത ടെ�
 msgctxt "Error message for selection input limit"
 msgid "Selected text is too long. Try again with a shorter selection."
 msgstr ""
-"തിരഞ്ഞെടുത്ത വാചകം വളരെ ദൈർഘ്യമേറിയതാണ്. ദൈർഘ്യം കുറഞ്ഞത് തിരഞ്ഞെടുത്ത് വീണ്ടും ശ്രമിക്കൂ."
+"തിരഞ്ഞെടുത്ത വാചകം വളരെ ദൈർഘ്യമേറിയതാണ്. ദൈർഘ്യം കുറഞ്ഞത് തിരഞ്ഞെടുത്ത് "
+"വീണ്ടും ശ്രമിക്കൂ."
 
 # smartling.placeholder_format=C
 #. Label for the semi-finals knockout stage in e.g. the soccer World Cup
@@ -17324,9 +17530,9 @@ msgid ""
 "respond. These instructions will apply to all of your conversations going "
 "forward."
 msgstr ""
-"എങ്ങനെ പ്രതികരിക്കണമെന്നതിനെക്കുറിച്ചുള്ള നിർദ്ദേശങ്ങളുള്ള നിങ്ങളുടെ സന്ദേശങ്ങളുമായി AI "
-"മോഡലുകളിലേക്ക് ഒരു പ്രോംപ്റ്റ് അയയ്ക്കുന്നു. ഈ നിർദ്ദേശങ്ങൾ ഇനി മുതൽ എല്ലാ സംഭാഷണങ്ങൾക്കും "
-"ബാധകമാകും."
+"എങ്ങനെ പ്രതികരിക്കണമെന്നതിനെക്കുറിച്ചുള്ള നിർദ്ദേശങ്ങളുള്ള നിങ്ങളുടെ "
+"സന്ദേശങ്ങളുമായി AI മോഡലുകളിലേക്ക് ഒരു പ്രോംപ്റ്റ് അയയ്ക്കുന്നു. ഈ "
+"നിർദ്ദേശങ്ങൾ ഇനി മുതൽ എല്ലാ സംഭാഷണങ്ങൾക്കും ബാധകമാകും."
 
 # smartling.placeholder_format=C
 msgid "Senegal"
@@ -17405,7 +17611,7 @@ msgstr "ഇപ്പോൾ സജ്ജീകരിക്കുക"
 #. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
 msgctxt "Encrypted storage setup button shown in native browsers"
 msgid "Set Up Sync & Backup"
-msgstr ""
+msgstr "Sync & Backup സജ്ജീകരിക്കുക"
 
 # smartling.placeholder_format=C
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
@@ -17436,8 +17642,8 @@ msgid ""
 "Set up Sync & Backup after turning on Chat History to keep your chats synced "
 "across devices."
 msgstr ""
-"നിങ്ങളുടെ ചാറ്റുകൾ ഉപകരണങ്ങളിലുടനീളം സമന്വയിപ്പിച്ച് നിലനിർത്താൻ, ചാറ്റ് ചരിത്രം ഓണാക്കിയ "
-"ശേഷം Sync & Backup സജ്ജമാക്കുക."
+"നിങ്ങളുടെ ചാറ്റുകൾ ഉപകരണങ്ങളിലുടനീളം സമന്വയിപ്പിച്ച് നിലനിർത്താൻ, ചാറ്റ് "
+"ചരിത്രം ഓണാക്കിയ ശേഷം Sync & Backup സജ്ജമാക്കുക."
 
 # smartling.placeholder_format=C
 #. Prompt for the user to indicate their location on a map, to enable more relevant search results.
@@ -17499,7 +17705,9 @@ msgstr "പങ്കിടുക"
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "Share DuckDuckGo and help friends take their privacy back!"
-msgstr "DuckDuckGo പങ്കിടുക, സുഹൃത്തുക്കളെ അവരുടെ സ്വകാര്യത തിരികെ കൊണ്ടുവരാൻ സഹായിക്കുക!"
+msgstr ""
+"DuckDuckGo പങ്കിടുക, സുഹൃത്തുക്കളെ അവരുടെ സ്വകാര്യത തിരികെ കൊണ്ടുവരാൻ "
+"സഹായിക്കുക!"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button that opens a feedback modal when clicked.
@@ -17526,8 +17734,9 @@ msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
 msgstr ""
-"പ്രസക്തി മെച്ചപ്പെടുത്തുന്നതിന് AI മോഡലുകളുമായി ഒരു നഗരതല ലൊക്കേഷൻ പങ്കിടുക. Duck.ai "
-"ഒരിക്കലും നിങ്ങളുടെ കൃത്യമായ ലൊക്കേഷൻ ഞങ്ങൾക്കോ AI മോഡലുകൾക്കോ വെളിപ്പെടുത്തുകയില്ല."
+"പ്രസക്തി മെച്ചപ്പെടുത്തുന്നതിന് AI മോഡലുകളുമായി ഒരു നഗരതല ലൊക്കേഷൻ പങ്കിടുക. "
+"Duck.ai ഒരിക്കലും നിങ്ങളുടെ കൃത്യമായ ലൊക്കേഷൻ ഞങ്ങൾക്കോ AI മോഡലുകൾക്കോ "
+"വെളിപ്പെടുത്തുകയില്ല."
 
 # smartling.placeholder_format=C
 #. Menu option to share feedback about a result
@@ -17592,7 +17801,7 @@ msgstr "പോസിറ്റീവ് ഫീഡ്ബാക്ക് പങ്�
 msgctxt ""
 "Label beside the share-content switch on the Duck.ai response feedback form"
 msgid "Share this conversation with DuckDuckGo"
-msgstr ""
+msgstr "ഈ സംഭാഷണം DuckDuckGo-യുമായി പങ്കിടുക"
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -17610,8 +17819,8 @@ msgid ""
 "Share your prompt and chat response with DuckDuckGo (required for illegal "
 "and harmful report)"
 msgstr ""
-"നിങ്ങളുടെ പ്രോംപ്റ്റും ചാറ്റ് പ്രതികരണവും DuckDuckGo-യുമായി പങ്കിടുക (നിയമവിരുദ്ധവും "
-"ദോഷകരവുമായ റിപ്പോർട്ടിന് ആവശ്യമാണ്)"
+"നിങ്ങളുടെ പ്രോംപ്റ്റും ചാറ്റ് പ്രതികരണവും DuckDuckGo-യുമായി പങ്കിടുക "
+"(നിയമവിരുദ്ധവും ദോഷകരവുമായ റിപ്പോർട്ടിന് ആവശ്യമാണ്)"
 
 # smartling.placeholder_format=C
 #. An invitation for users to leave feedback
@@ -17731,7 +17940,9 @@ msgstr "DuckAssist <sup>BETA</sup> കാണിക്കുക"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show DuckAssist more often. (You can also completely %sturn it off%s.)"
-msgstr "DuckAssist കൂടുതൽ തവണ കാണിക്കുക. (നിങ്ങൾക്ക് ഇത് പൂർണ്ണമായും %1$sഓഫാക്കാം%2$s.)"
+msgstr ""
+"DuckAssist കൂടുതൽ തവണ കാണിക്കുക. (നിങ്ങൾക്ക് ഇത് പൂർണ്ണമായും "
+"%1$sഓഫാക്കാം%2$s.)"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
@@ -17957,8 +18168,9 @@ msgid ""
 "Shows a reminder that searches on DuckDuckGo are always private. Turning "
 "this off hides the reminder and never affects search privacy."
 msgstr ""
-"DuckDuckGo-യിലെ തിരയലുകൾ എല്ലായ്പ്പോഴും സ്വകാര്യമാണെന്നുള്ള ഒരു ഓർമ്മപ്പെടുത്തൽ കാണിക്കുന്നു. "
-"ഇത് ഓഫാക്കുന്നത് ഓർമ്മപ്പെടുത്തൽ മറയ്ക്കുന്നു, കൂടാതെ തിരയലിന്റെ സ്വകാര്യതയെ ഒരിക്കലും ബാധിക്കില്ല."
+"DuckDuckGo-യിലെ തിരയലുകൾ എല്ലായ്പ്പോഴും സ്വകാര്യമാണെന്നുള്ള ഒരു "
+"ഓർമ്മപ്പെടുത്തൽ കാണിക്കുന്നു. ഇത് ഓഫാക്കുന്നത് ഓർമ്മപ്പെടുത്തൽ മറയ്ക്കുന്നു, "
+"കൂടാതെ തിരയലിന്റെ സ്വകാര്യതയെ ഒരിക്കലും ബാധിക്കില്ല."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -17966,9 +18178,9 @@ msgid ""
 "Shows a reminder that searches on DuckDuckGo are always protected. Turning "
 "this off hides the reminder and never affects search protection."
 msgstr ""
-"DuckDuckGo-യിലെ തിരയലുകൾ എല്ലായ്പ്പോഴും പരിരക്ഷിക്കപ്പെടുന്നു എന്നുള്ള ഒരു ഓർമ്മപ്പെടുത്തൽ "
-"കാണിക്കുന്നു. ഇത് ഓഫാക്കുന്നത് ഓർമ്മപ്പെടുത്തൽ മറയ്ക്കുന്നു, കൂടാതെ തിരയൽ പരിരക്ഷയെ ഒരിക്കലും "
-"ബാധിക്കുന്നില്ല."
+"DuckDuckGo-യിലെ തിരയലുകൾ എല്ലായ്പ്പോഴും പരിരക്ഷിക്കപ്പെടുന്നു എന്നുള്ള ഒരു "
+"ഓർമ്മപ്പെടുത്തൽ കാണിക്കുന്നു. ഇത് ഓഫാക്കുന്നത് ഓർമ്മപ്പെടുത്തൽ മറയ്ക്കുന്നു, "
+"കൂടാതെ തിരയൽ പരിരക്ഷയെ ഒരിക്കലും ബാധിക്കുന്നില്ല."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -17979,7 +18191,8 @@ msgstr "ഫല പേജ് ഇടവേളകളിൽ തിരശ്ചീന
 msgctxt "settings"
 msgid "Shows links to instructions for how to add DuckDuckGo to your browser"
 msgstr ""
-"DuckDuckGo നിങ്ങളുടെ ബ്രൗസറിലേക്ക് കൂട്ടിച്ചേർക്കാനുള്ള നിർദേശങ്ങളിലേക്കുള്ള ലിങ്കുകൾ കാണിക്കുന്നു"
+"DuckDuckGo നിങ്ങളുടെ ബ്രൗസറിലേക്ക് കൂട്ടിച്ചേർക്കാനുള്ള നിർദേശങ്ങളിലേക്കുള്ള "
+"ലിങ്കുകൾ കാണിക്കുന്നു"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers more frequently.
@@ -17996,21 +18209,23 @@ msgstr "പുതിയ ടാബ് പേജിൽ ഏറ്റവും ക�
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your browser"
 msgstr ""
-"നിങ്ങളുടെ ബ്രൗസറിലേക്ക് DuckDuckGo ചേർക്കാനുള്ള ഇടയ്ക്കിടെയുള്ള ഓർമപ്പെടുത്തലുകൾ കാണിക്കുന്നു"
+"നിങ്ങളുടെ ബ്രൗസറിലേക്ക് DuckDuckGo ചേർക്കാനുള്ള ഇടയ്ക്കിടെയുള്ള "
+"ഓർമപ്പെടുത്തലുകൾ കാണിക്കുന്നു"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
 msgstr ""
-"നിങ്ങളുടെ ഉപകരണങ്ങളിലേക്ക് DuckDuckGo ചേർക്കാനുള്ള ഇടയ്ക്കിടെയുള്ള ഓർമപ്പെടുത്തലുകൾ കാണിക്കുന്നു"
+"നിങ്ങളുടെ ഉപകരണങ്ങളിലേക്ക് DuckDuckGo ചേർക്കാനുള്ള ഇടയ്ക്കിടെയുള്ള "
+"ഓർമപ്പെടുത്തലുകൾ കാണിക്കുന്നു"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Shows occasional reminders to sign up for the DuckDuckGo privacy newsletters"
 msgstr ""
-"DuckDuckGo സ്വകാര്യതാ വാർത്താക്കുറിപ്പുകൾക്കായി സൈൻ അപ്പ് ചെയ്യുന്നതിന് ഇടയ്ക്കിടെയുള്ള "
-"ഓർമപ്പെടുത്തലുകൾ കാണിക്കുന്നു"
+"DuckDuckGo സ്വകാര്യതാ വാർത്താക്കുറിപ്പുകൾക്കായി സൈൻ അപ്പ് ചെയ്യുന്നതിന് "
+"ഇടയ്ക്കിടെയുള്ള ഓർമപ്പെടുത്തലുകൾ കാണിക്കുന്നു"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18118,12 +18333,16 @@ msgstr "സൈറ്റുകളുടെ പേരുകൾ"
 #. A message saying that site filters are not currently working
 msgctxt "Site filter message"
 msgid "Site search is temporarily unavailable. We are working on a fix."
-msgstr "സൈറ്റ് തിരയൽ താൽക്കാലികമായി ലഭ്യമല്ല. ഞങ്ങൾ ഒരു പരിഹാരം കണ്ടെത്താൻ പ്രവർത്തിക്കുന്നു."
+msgstr ""
+"സൈറ്റ് തിരയൽ താൽക്കാലികമായി ലഭ്യമല്ല. ഞങ്ങൾ ഒരു പരിഹാരം കണ്ടെത്താൻ "
+"പ്രവർത്തിക്കുന്നു."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Sites you block will be hidden from all your search results"
-msgstr "നിങ്ങൾ ബ്ലോക്ക് ചെയ്യുന്ന സൈറ്റുകൾ നിങ്ങളുടെ എല്ലാ തിരയൽ ഫലങ്ങളിൽ നിന്നും മറയ്ക്കും"
+msgstr ""
+"നിങ്ങൾ ബ്ലോക്ക് ചെയ്യുന്ന സൈറ്റുകൾ നിങ്ങളുടെ എല്ലാ തിരയൽ ഫലങ്ങളിൽ നിന്നും "
+"മറയ്ക്കും"
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes full name (tooltip)
@@ -18269,7 +18488,8 @@ msgstr "സെർവറിലേക്ക് സംരക്ഷിക്കു�
 msgctxt "Generic error shown when sync setup fails"
 msgid "Something went wrong while enabling Sync & Backup. Please try again."
 msgstr ""
-"Sync & Backup പ്രവർത്തനക്ഷമമാക്കുമ്പോൾ എന്തോ കുഴപ്പം സംഭവിച്ചു. ദയവായി വീണ്ടും ശ്രമിക്കുക."
+"Sync & Backup പ്രവർത്തനക്ഷമമാക്കുമ്പോൾ എന്തോ കുഴപ്പം സംഭവിച്ചു. ദയവായി "
+"വീണ്ടും ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Displayed when the voice chat session ends with an unknown error.
@@ -18294,8 +18514,8 @@ msgstr "ചിലപ്പോൾ"
 msgctxt "Error message from the image generation model"
 msgid "Sorry I can't help, please describe your image in a different way."
 msgstr ""
-"ക്ഷമിക്കണം, എനിക്ക് സഹായിക്കാനാകില്ല, ദയവായി നിങ്ങളുടെ ചിത്രത്തെ മറ്റൊരു രീതിയിൽ "
-"വിവരിക്കുക."
+"ക്ഷമിക്കണം, എനിക്ക് സഹായിക്കാനാകില്ല, ദയവായി നിങ്ങളുടെ ചിത്രത്തെ മറ്റൊരു "
+"രീതിയിൽ വിവരിക്കുക."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -18334,8 +18554,8 @@ msgid ""
 "Sorry, the uploaded image couldn't be processed. Please try a different "
 "image or format."
 msgstr ""
-"ക്ഷമിക്കണം, അപ്‌ലോഡ് ചെയ്ത ചിത്രം പ്രോസസ്സ് ചെയ്യാൻ കഴിഞ്ഞില്ല. ദയവായി മറ്റൊരു ചിത്രമോ "
-"ഫോർമാറ്റോ പരീക്ഷിച്ചുനോക്കൂ."
+"ക്ഷമിക്കണം, അപ്‌ലോഡ് ചെയ്ത ചിത്രം പ്രോസസ്സ് ചെയ്യാൻ കഴിഞ്ഞില്ല. ദയവായി "
+"മറ്റൊരു ചിത്രമോ ഫോർമാറ്റോ പരീക്ഷിച്ചുനോക്കൂ."
 
 # smartling.placeholder_format=C
 #. Body copy shown when a scanned or pasted pairing payload fails schema validation.
@@ -18344,16 +18564,16 @@ msgid ""
 "Sorry, this code is invalid. Please make sure the correct code was entered "
 "or scanned."
 msgstr ""
-"ക്ഷമിക്കണം, ഈ കോഡ് അസാധുവാണ്. ശരിയായ കോഡ് ആണ് നൽകിയത് അല്ലെങ്കിൽ സ്കാൻ ചെയ്തതെന്ന് "
-"ഉറപ്പാക്കുക."
+"ക്ഷമിക്കണം, ഈ കോഡ് അസാധുവാണ്. ശരിയായ കോഡ് ആണ് നൽകിയത് അല്ലെങ്കിൽ സ്കാൻ "
+"ചെയ്തതെന്ന് ഉറപ്പാക്കുക."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
 msgid ""
 "Sorry, we couldn't generate a richer answer. You can try asking Duck.ai."
 msgstr ""
-"ക്ഷമിക്കണം, ഞങ്ങൾക്ക് കൂടുതൽ മികച്ച ഒരു ഉത്തരം സൃഷ്ടിക്കാൻ കഴിഞ്ഞില്ല. നിങ്ങൾക്ക് Duck.ai-യോട് "
-"ചോദിക്കാൻ ശ്രമിക്കാം."
+"ക്ഷമിക്കണം, ഞങ്ങൾക്ക് കൂടുതൽ മികച്ച ഒരു ഉത്തരം സൃഷ്ടിക്കാൻ കഴിഞ്ഞില്ല. "
+"നിങ്ങൾക്ക് Duck.ai-യോട് ചോദിക്കാൻ ശ്രമിക്കാം."
 
 # smartling.placeholder_format=C
 #. Inform the users that "something" went wrong and that they could try to refresh the page to resolve the error. Placeholders are for markup, please ignore.
@@ -18362,15 +18582,16 @@ msgid ""
 "Sorry, we ran into an error displaying these results. %sClick here%s to try "
 "again."
 msgstr ""
-"ക്ഷമിക്കണം, ഈ ഫലങ്ങൾ പ്രദർശിപ്പിക്കുന്നതിൽ ഞങ്ങൾക്ക് ഒരു പിശക് നേരിട്ടു. വീണ്ടും ശ്രമിക്കാൻ "
-"%1$sഇവിടെ ക്ലിക്ക് ചെയ്യുക%2$s ."
+"ക്ഷമിക്കണം, ഈ ഫലങ്ങൾ പ്രദർശിപ്പിക്കുന്നതിൽ ഞങ്ങൾക്ക് ഒരു പിശക് നേരിട്ടു. "
+"വീണ്ടും ശ്രമിക്കാൻ %1$sഇവിടെ ക്ലിക്ക് ചെയ്യുക%2$s ."
 
 # smartling.placeholder_format=C
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
 msgstr ""
-"ക്ഷമിക്കണം, നിങ്ങളുടെ ഫീഡ്ബാക്ക് സമർപ്പിക്കാൻ ഞങ്ങൾക്ക് കഴിഞ്ഞില്ല. പിന്നീട് വീണ്ടും ശ്രമിക്കുക."
+"ക്ഷമിക്കണം, നിങ്ങളുടെ ഫീഡ്ബാക്ക് സമർപ്പിക്കാൻ ഞങ്ങൾക്ക് കഴിഞ്ഞില്ല. പിന്നീട് "
+"വീണ്ടും ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -18425,8 +18646,8 @@ msgctxt "Error message for summary selection input limit"
 msgid ""
 "Source text is too long to summarize. Try again with a shorter selection."
 msgstr ""
-"സംഗ്രഹിക്കാൻ കഴിയാത്തത്ര ദൈർഘ്യമുള്ളതാണ് ഉറവിട ടെക്‌സ്റ്റ്. ദൈർഘ്യം കുറഞ്ഞത് തിരഞ്ഞെടുത്ത് വീണ്ടും "
-"ശ്രമിക്കൂ."
+"സംഗ്രഹിക്കാൻ കഴിയാത്തത്ര ദൈർഘ്യമുള്ളതാണ് ഉറവിട ടെക്‌സ്റ്റ്. ദൈർഘ്യം കുറഞ്ഞത് "
+"തിരഞ്ഞെടുത്ത് വീണ്ടും ശ്രമിക്കൂ."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under Interface Settings.in the end. It is a header
@@ -18625,7 +18846,9 @@ msgstr "DuckDuckGo-യിൽ തുടരുക"
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletter."
-msgstr "ഞങ്ങളുടെ സ്വകാര്യതാ വാർത്താക്കുറിപ്പുകൾ ഉപയോഗിച്ച് പരിരക്ഷയോടെയും അറിവുള്ളവരായും തുടരുക."
+msgstr ""
+"ഞങ്ങളുടെ സ്വകാര്യതാ വാർത്താക്കുറിപ്പുകൾ ഉപയോഗിച്ച് പരിരക്ഷയോടെയും "
+"അറിവുള്ളവരായും തുടരുക."
 
 # smartling.placeholder_format=C
 #. Prompt to subscribe to a newsletter.
@@ -18675,7 +18898,9 @@ msgstr "സൃഷ്ടിക്കൽ നിർത്തുക"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop hidden trackers lurking on other websites."
-msgstr "മറ്റ് വെബ്‌സൈറ്റുകളിൽ പതിയിരിക്കുന്ന മറയ്ക്കപ്പെട്ട ട്രാക്കറുകൾ പ്രതിരോധിക്കുക."
+msgstr ""
+"മറ്റ് വെബ്‌സൈറ്റുകളിൽ പതിയിരിക്കുന്ന മറയ്ക്കപ്പെട്ട ട്രാക്കറുകൾ "
+"പ്രതിരോധിക്കുക."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -18770,8 +18995,8 @@ msgid ""
 "Subscribe to DuckDuckGo to unlock higher limits in Duck.ai, or come back "
 "later to create more images."
 msgstr ""
-"Duck.ai-ൽ ഉയർന്ന പരിധികൾ അൺലോക്ക് ചെയ്യാൻ DuckDuckGo സബ്‌സ്‌ക്രൈബ് ചെയ്യുക, അല്ലെങ്കിൽ "
-"കൂടുതൽ ഇമേജുകൾ സൃഷ്ടിക്കാൻ പിന്നീട് തിരികെ വരിക."
+"Duck.ai-ൽ ഉയർന്ന പരിധികൾ അൺലോക്ക് ചെയ്യാൻ DuckDuckGo സബ്‌സ്‌ക്രൈബ് ചെയ്യുക, "
+"അല്ലെങ്കിൽ കൂടുതൽ ഇമേജുകൾ സൃഷ്ടിക്കാൻ പിന്നീട് തിരികെ വരിക."
 
 # smartling.placeholder_format=C
 #. Description shown to free users who have reached their image generation limit, encouraging them to subscribe.
@@ -18840,8 +19065,8 @@ msgid ""
 "Suggest a phrase to write on a get-well card for someone recovering from a "
 "surgery?"
 msgstr ""
-"ഒരു ശസ്ത്രക്രിയയിൽ നിന്ന് സുഖം പ്രാപിക്കുന്ന ഒരാൾക്ക് ഒരു ഗെറ്റ്-വെൽ കാർഡിൽ എഴുതാൻ ഒരു വാക്യം "
-"നിർദ്ദേശിക്കാമോ?"
+"ഒരു ശസ്ത്രക്രിയയിൽ നിന്ന് സുഖം പ്രാപിക്കുന്ന ഒരാൾക്ക് ഒരു ഗെറ്റ്-വെൽ കാർഡിൽ "
+"എഴുതാൻ ഒരു വാക്യം നിർദ്ദേശിക്കാമോ?"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for asking for a suggestion of a blog post title.
@@ -18853,19 +19078,19 @@ msgstr "ഒരു ബ്ലോഗ് പോസ്റ്റിന് ഒരു �
 #. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Suggest related articles or topics worth exploring next."
-msgstr ""
+msgstr "തുടർന്ന് പരിശോധിക്കാൻ യോഗ്യമായ അനുബന്ധ ലേഖനങ്ങളോ വിഷയങ്ങളോ നിർദ്ദേശിക്കുക."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Suggest related articles to explore"
-msgstr ""
+msgstr "പര്യവേക്ഷണം ചെയ്യാൻ അനുബന്ധ ലേഖനങ്ങൾ നിർദ്ദേശിക്കുക"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Suggest some alternatives to this product."
-msgstr ""
+msgstr "ഈ ഉൽപ്പന്നത്തിന് പകരമുള്ള ചില മറ്റുവഴികൾ നിർദ്ദേശിക്കുക."
 
 # smartling.placeholder_format=C
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
@@ -18882,7 +19107,7 @@ msgstr "നിർദേശങ്ങൾ:"
 #. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Sum up the reviews"
-msgstr ""
+msgstr "അവലോകനങ്ങൾ സംഗ്രഹിക്കുക"
 
 # smartling.placeholder_format=C
 #. A short title for the a message asking the AI to summarize a text.
@@ -18894,85 +19119,85 @@ msgstr "സംഗ്രഹിക്കുക"
 #. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize the Q&As"
-msgstr ""
+msgstr "Q&A-കൾ സംഗ്രഹിക്കുക"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the background and notable work of this person."
-msgstr ""
+msgstr "ഈ വ്യക്തിയുടെ പശ്ചാത്തലവും ശ്രദ്ധേയമായ പ്രവർത്തനങ്ങളും സംഗ്രഹിക്കുക."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the key details of this event."
-msgstr ""
+msgstr "ഈ ഇവന്റിന്റെ പ്രധാന വിവരങ്ങൾ സംഗ്രഹിക്കുക."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the questions and answers on this page."
-msgstr ""
+msgstr "ഈ പേജിലെ ചോദ്യങ്ങളും ഉത്തരങ്ങളും സംഗ്രഹിക്കുക."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize their background"
-msgstr ""
+msgstr "അവയുടെ പശ്ചാത്തലം സംഗ്രഹിക്കുക"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this book"
-msgstr ""
+msgstr "ഈ പുസ്തകം സംഗ്രഹിക്കുക"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this book."
-msgstr ""
+msgstr "ഈ പുസ്തകം സംഗ്രഹിക്കുക."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this discussion"
-msgstr ""
+msgstr "ഈ ചര്‍ച്ച സംഗ്രഹിക്കുക"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this discussion thread."
-msgstr ""
+msgstr "ഈ ചർച്ചാ ത്രെഡ് സംഗ്രഹിക്കുക."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this page"
-msgstr ""
+msgstr "ഈ പേജ് സംഗ്രഹിക്കുക"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this page."
-msgstr ""
+msgstr "ഈ പേജ് സംഗ്രഹിക്കുക."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this video"
-msgstr ""
+msgstr "ഈ വീഡിയോ സംഗ്രഹിക്കുക"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this video."
-msgstr ""
+msgstr "ഈ വീഡിയോ സംഗ്രഹിക്കുക."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize what the reviews say."
-msgstr ""
+msgstr "റിവ്യൂകൾ എന്താണ് പറയുന്നതെന്ന് സംഗ്രഹിക്കുക."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -19133,7 +19358,9 @@ msgstr "നിങ്ങളെ ട്രാക്ക് ചെയ്യാത്�
 msgctxt "AI Chat warning when switching from an encrypted model"
 msgid ""
 "Switching will send your chat to a model without zero provider visibility"
-msgstr "മാറുന്നത് നിങ്ങളുടെ ചാറ്റിനെ ദാതാവിന്റെ ദൃശ്യപരതയില്ലാത്ത ഒരു മോഡലിലേക്ക് അയയ്ക്കും"
+msgstr ""
+"മാറുന്നത് നിങ്ങളുടെ ചാറ്റിനെ ദാതാവിന്റെ ദൃശ്യപരതയില്ലാത്ത ഒരു മോഡലിലേക്ക് "
+"അയയ്ക്കും"
 
 # smartling.placeholder_format=C
 msgid "Switzerland"
@@ -19187,7 +19414,9 @@ msgstr "Sync & Backup പ്രവർത്തനക്ഷമമാക്കി!
 #. Notice shown under the recovery code explaining that backup data has an inactivity expiration.
 msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
-msgstr "Sync & Backup ഡാറ്റ 18 മാസത്തെ നിഷ്‌ക്രിയത്വത്തിന് ശേഷം വീണ്ടെടുക്കാൻ കഴിയില്ല."
+msgstr ""
+"Sync & Backup ഡാറ്റ 18 മാസത്തെ നിഷ്‌ക്രിയത്വത്തിന് ശേഷം വീണ്ടെടുക്കാൻ "
+"കഴിയില്ല."
 
 # smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
@@ -19236,25 +19465,27 @@ msgid ""
 msgstr ""
 "വീണ്ടെടുക്കൽ കോഡ് സമന്വയിപ്പിക്കുക\n"
 "\n"
-" ഒന്നിലധികം ഉപകരണങ്ങളിലുടനീളം നിങ്ങളുടെ പാസ്‌വേഡുകൾ സമന്വയിപ്പിക്കാനും, ഡാറ്റ ഓട്ടോഫിൽ "
-"ചെയ്യാനും, Duck.ai ചാറ്റുകൾ ഉപയോഗിക്കാനും, ഒരു ഉപകരണത്തിലേക്കുള്ള ആക്‌സസ് നഷ്‌ടപ്പെടുകയാണെങ്കിൽ "
-"നിങ്ങളുടെ സമന്വയിപ്പിച്ച ഡാറ്റ വീണ്ടെടുക്കാനും വീണ്ടെടുക്കൽ കോഡ് നിങ്ങളെ അനുവദിക്കുന്നു.\n"
+" ഒന്നിലധികം ഉപകരണങ്ങളിലുടനീളം നിങ്ങളുടെ പാസ്‌വേഡുകൾ സമന്വയിപ്പിക്കാനും, "
+"ഡാറ്റ ഓട്ടോഫിൽ ചെയ്യാനും, Duck.ai ചാറ്റുകൾ ഉപയോഗിക്കാനും, ഒരു "
+"ഉപകരണത്തിലേക്കുള്ള ആക്‌സസ് നഷ്‌ടപ്പെടുകയാണെങ്കിൽ നിങ്ങളുടെ സമന്വയിപ്പിച്ച "
+"ഡാറ്റ വീണ്ടെടുക്കാനും വീണ്ടെടുക്കൽ കോഡ് നിങ്ങളെ അനുവദിക്കുന്നു.\n"
 "\n"
 "ഈ വിവരങ്ങൾ സുരക്ഷിതമായി സൂക്ഷിക്കുക.\n"
-"ഈ കോഡിന് പ്രവേശനം ഉള്ള ആരും നിങ്ങളുടെ സമന്വയിപ്പിച്ച ഡാറ്റ ആക്‌സസ് ചെയ്യാൻ കഴിയും.\n"
+"ഈ കോഡിന് പ്രവേശനം ഉള്ള ആരും നിങ്ങളുടെ സമന്വയിപ്പിച്ച ഡാറ്റ ആക്‌സസ് ചെയ്യാൻ "
+"കഴിയും.\n"
 "\n"
 "%1$s\n"
 "\n"
 "ഈ കോഡ് എങ്ങനെയാണ് പ്രവർത്തിക്കുന്നത്?\n"
 "1. നിങ്ങളുടെ ബ്രൗസറിൽ Duck.ai-ലേക്ക് പോയി Duck.ai സെറ്റിംഗ്സ് തുറക്കുക.\n"
-"2. \"Sync & Backup\" തിരഞ്ഞെടുക്കുക, തുടർന്ന് \"സമന്വയിപ്പിച്ച ഡാറ്റ വീണ്ടെടുക്കുക\" "
-"തിരഞ്ഞെടുക്കുക.\n"
-"3. മുകളിലുള്ള വീണ്ടെടുക്കൽ കോഡ് പകർത്തി \"നിങ്ങളുടെ കോഡ് ഇവിടെ ഒട്ടിക്കുക\" എന്ന് പറയുന്നിടത്ത് "
-"ഒട്ടിക്കുക.\n"
+"2. \"Sync & Backup\" തിരഞ്ഞെടുക്കുക, തുടർന്ന് \"സമന്വയിപ്പിച്ച ഡാറ്റ "
+"വീണ്ടെടുക്കുക\" തിരഞ്ഞെടുക്കുക.\n"
+"3. മുകളിലുള്ള വീണ്ടെടുക്കൽ കോഡ് പകർത്തി \"നിങ്ങളുടെ കോഡ് ഇവിടെ ഒട്ടിക്കുക\" "
+"എന്ന് പറയുന്നിടത്ത് ഒട്ടിക്കുക.\n"
 "\n"
-"Sync & Backup പ്രവർത്തനക്ഷമമാക്കിയ ഒരു DuckDuckGo ബ്രൗസർ ഉപയോഗിക്കാതെ നിങ്ങൾ 18 "
-"മാസത്തിൽ കൂടുതൽ ചെലവഴിച്ചാൽ, നിങ്ങളുടെ ഡാറ്റ സെർവറിൽ നിന്ന് ഇല്ലാതാക്കപ്പെടും, അത് "
-"പുനഃസ്ഥാപിക്കാൻ കഴിയില്ല."
+"Sync & Backup പ്രവർത്തനക്ഷമമാക്കിയ ഒരു DuckDuckGo ബ്രൗസർ ഉപയോഗിക്കാതെ നിങ്ങൾ "
+"18 മാസത്തിൽ കൂടുതൽ ചെലവഴിച്ചാൽ, നിങ്ങളുടെ ഡാറ്റ സെർവറിൽ നിന്ന് "
+"ഇല്ലാതാക്കപ്പെടും, അത് പുനഃസ്ഥാപിക്കാൻ കഴിയില്ല."
 
 # smartling.placeholder_format=C
 #. Secondary button label on the Sync & Backup intro screen that takes the user to the camera scan screen to pair with another device.
@@ -19300,7 +19531,7 @@ msgstr "സിറിയ"
 #. Text for a button that enables the theme to follow the operating system's color scheme preference.
 msgctxt "System theme button for theme selector"
 msgid "System"
-msgstr ""
+msgstr "സിസ്റ്റം"
 
 # smartling.placeholder_format=C
 #. Abbreviation indicating this is the total score for a game
@@ -19334,7 +19565,7 @@ msgstr "തഹിതിയൻ"
 #. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Tailor my resume"
-msgstr ""
+msgstr "എന്റെ റെസ്യൂമെ ഇഷ്ടാനുസൃതമാക്കുക"
 
 # smartling.placeholder_format=C
 msgid "Taiwan"
@@ -19371,6 +19602,8 @@ msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
+"Duck.ai എങ്ങനെ മെച്ചപ്പെടുത്താമെന്ന് ഞങ്ങളെ അറിയിക്കാൻ ഈ അജ്ഞാത സർവേയിൽ "
+"പങ്കെടുക്കൂ."
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -19585,9 +19818,10 @@ msgid ""
 "link is at increased risk of being intercepted by a third party. In rare "
 "cases this includes passwords, or payment details."
 msgstr ""
-"നിങ്ങളുടെ ഉപകരണത്തിനും ഈ ലിങ്കിന് പിന്നിലെ വെബ്‌പോജിനുമിടയിൽ അയച്ച വിവരങ്ങൾ ഒരു മൂന്നാം "
-"കക്ഷി തടസ്സപ്പെടുത്താനുള്ള സാധ്യത കൂടുതലാണ് എന്നാണ് ഇതിനർഥം. അപൂർവ സന്ദർഭങ്ങളിൽ ഇതിൽ "
-"പാസ്‍വേഡുകൾ അല്ലെങ്കിൽ പേയ്മെന്റ് വിശദാംശങ്ങൾ ഉൾപ്പെടുന്നു."
+"നിങ്ങളുടെ ഉപകരണത്തിനും ഈ ലിങ്കിന് പിന്നിലെ വെബ്‌പോജിനുമിടയിൽ അയച്ച വിവരങ്ങൾ "
+"ഒരു മൂന്നാം കക്ഷി തടസ്സപ്പെടുത്താനുള്ള സാധ്യത കൂടുതലാണ് എന്നാണ് ഇതിനർഥം. "
+"അപൂർവ സന്ദർഭങ്ങളിൽ ഇതിൽ പാസ്‍വേഡുകൾ അല്ലെങ്കിൽ പേയ്മെന്റ് വിശദാംശങ്ങൾ "
+"ഉൾപ്പെടുന്നു."
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -19596,8 +19830,8 @@ msgid ""
 "The Cloud Save bookmarklet allows any changes you make to your settings to "
 "automatically save in the cloud."
 msgstr ""
-"നിങ്ങളുടെ ക്രമീകരണത്തിൽ വരുത്തുന്ന ഏത് മാറ്റങ്ങളും ക്ലൗഡിൽ സ്വയമേവ സംരക്ഷിക്കാൻ Cloud Save "
-"ബുക്ക്‌മാർക്ക്‌ലെറ്റ് അനുവദിക്കുന്നു."
+"നിങ്ങളുടെ ക്രമീകരണത്തിൽ വരുത്തുന്ന ഏത് മാറ്റങ്ങളും ക്ലൗഡിൽ സ്വയമേവ "
+"സംരക്ഷിക്കാൻ Cloud Save ബുക്ക്‌മാർക്ക്‌ലെറ്റ് അനുവദിക്കുന്നു."
 
 # smartling.placeholder_format=C
 msgid "The Gambia"
@@ -19627,15 +19861,17 @@ msgid ""
 "The encryption key is only saved in your browser's local storage, and only "
 "you can access it."
 msgstr ""
-"എൻക്രിപ്ഷൻ കീ നിങ്ങളുടെ ബ്രൗസറിന്റെ ലോക്കൽ സ്റ്റോറേജിൽ മാത്രമേ സംരക്ഷിക്കപ്പെടുകയുള്ളൂ, കൂടാതെ "
-"നിങ്ങൾക്ക് മാത്രമേ അത് ആക്‌സസ് ചെയ്യാൻ കഴിയൂ."
+"എൻക്രിപ്ഷൻ കീ നിങ്ങളുടെ ബ്രൗസറിന്റെ ലോക്കൽ സ്റ്റോറേജിൽ മാത്രമേ "
+"സംരക്ഷിക്കപ്പെടുകയുള്ളൂ, കൂടാതെ നിങ്ങൾക്ക് മാത്രമേ അത് ആക്‌സസ് ചെയ്യാൻ കഴിയൂ."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider deletes all chat data within 30 days.
 msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider deletes any data associated with this chat within 30 days."
-msgstr "ഈ ചാറ്റുമായി ബന്ധപ്പെട്ട ഏതൊരു ഡാറ്റയും 30 ദിവസത്തിനുള്ളിൽ മോഡൽ ദാതാവ് ഇല്ലാതാക്കും."
+msgstr ""
+"ഈ ചാറ്റുമായി ബന്ധപ്പെട്ട ഏതൊരു ഡാറ്റയും 30 ദിവസത്തിനുള്ളിൽ മോഡൽ ദാതാവ് "
+"ഇല്ലാതാക്കും."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers.
@@ -19677,7 +19913,7 @@ msgstr "തീം"
 #. Text for the theme selector label that allows users to switch between Light and dark theme.
 msgctxt "Label for the theme selector feature"
 msgid "Theme"
-msgstr ""
+msgstr "തീം"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/LpFhb1e.png
@@ -19708,9 +19944,9 @@ msgid ""
 "There was an error saving this chat locally. Please check your browser "
 "settings to make sure local data storage is enabled."
 msgstr ""
-"ഈ ചാറ്റ് പ്രാദേശികമായി സേവ് ചെയ്യുന്നതിൽ ഒരു പിശക് സംഭവിച്ചു. പ്രാദേശിക ഡാറ്റ സംഭരണം "
-"പ്രവർത്തനക്ഷമമാക്കിയിട്ടുണ്ടെന്ന് ഉറപ്പുവരുത്താൻ ദയവായി നിങ്ങളുടെ ബ്രൗസർ ക്രമീകരണങ്ങൾ "
-"പരിശോധിക്കുക."
+"ഈ ചാറ്റ് പ്രാദേശികമായി സേവ് ചെയ്യുന്നതിൽ ഒരു പിശക് സംഭവിച്ചു. പ്രാദേശിക "
+"ഡാറ്റ സംഭരണം പ്രവർത്തനക്ഷമമാക്കിയിട്ടുണ്ടെന്ന് ഉറപ്പുവരുത്താൻ ദയവായി "
+"നിങ്ങളുടെ ബ്രൗസർ ക്രമീകരണങ്ങൾ പരിശോധിക്കുക."
 
 # smartling.placeholder_format=C
 #. Error modal body line 1.
@@ -19725,8 +19961,8 @@ msgid ""
 "There was still an error displaying the search results. Please wait a few "
 "minutes before you try again."
 msgstr ""
-"തിരയൽ ഫലങ്ങൾ പ്രദർശിപ്പിക്കുന്നതിൽ ഇപ്പോഴും ഒരു പിശകുണ്ടായിരുന്നു. നിങ്ങൾ വീണ്ടും ശ്രമിക്കുന്നതിന് "
-"മുമ്പ് ഏതാനും മിനിറ്റ് കാത്തിരിക്കൂ."
+"തിരയൽ ഫലങ്ങൾ പ്രദർശിപ്പിക്കുന്നതിൽ ഇപ്പോഴും ഒരു പിശകുണ്ടായിരുന്നു. നിങ്ങൾ "
+"വീണ്ടും ശ്രമിക്കുന്നതിന് മുമ്പ് ഏതാനും മിനിറ്റ് കാത്തിരിക്കൂ."
 
 # smartling.placeholder_format=C
 #. Error message for explore more questions when a retryable error occurs (timeout, network)
@@ -19745,10 +19981,10 @@ msgid ""
 "visit by blocking hidden trackers, encrypting connections where possible, "
 "and by making DuckDuckGo your default search engine."
 msgstr ""
-"മറഞ്ഞിരിക്കുന്ന ട്രാക്കറുകൾ തടയുന്നതിലൂടെയും സാധ്യമാകുന്നിടത്ത് കണക്ഷനുകൾ എൻക്രിപ്റ്റ് "
-"ചെയ്യുന്നതിലൂടെയും DuckDuckGo-യെ നിങ്ങളുടെ ഡിഫോൾട്ട് തിരയൽ എഞ്ചിനാക്കി മാറ്റുന്നതിലൂടെയും "
-"നിങ്ങൾ സന്ദർശിക്കുന്ന വെബ്‌സൈറ്റുകളിൽ സ്വകാര്യതാ പരിരക്ഷണം ചേർക്കാൻ ഈ ബ്രൗസർ അനുമതികൾ "
-"ഉപയോഗിക്കുന്നു."
+"മറഞ്ഞിരിക്കുന്ന ട്രാക്കറുകൾ തടയുന്നതിലൂടെയും സാധ്യമാകുന്നിടത്ത് കണക്ഷനുകൾ "
+"എൻക്രിപ്റ്റ് ചെയ്യുന്നതിലൂടെയും DuckDuckGo-യെ നിങ്ങളുടെ ഡിഫോൾട്ട് തിരയൽ "
+"എഞ്ചിനാക്കി മാറ്റുന്നതിലൂടെയും നിങ്ങൾ സന്ദർശിക്കുന്ന വെബ്‌സൈറ്റുകളിൽ "
+"സ്വകാര്യതാ പരിരക്ഷണം ചേർക്കാൻ ഈ ബ്രൗസർ അനുമതികൾ ഉപയോഗിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Secondary line under DUCKCHAT_SYNC_PAIRING_ALREADY_SYNCED_TITLE.
@@ -19794,8 +20030,8 @@ msgid ""
 "This AI model version is no longer supported. Try starting a new chat with "
 "the latest version of this model."
 msgstr ""
-"ഈ AI മോഡൽ പതിപ്പിനെ ഇനി പിന്തുണയ്ക്കുന്നില്ല. ഈ മോഡലിന്റെ ഏറ്റവും പുതിയ പതിപ്പിൽ ഒരു പുതിയ "
-"ചാറ്റ് ആരംഭിക്കാൻ ശ്രമിക്കൂ."
+"ഈ AI മോഡൽ പതിപ്പിനെ ഇനി പിന്തുണയ്ക്കുന്നില്ല. ഈ മോഡലിന്റെ ഏറ്റവും പുതിയ "
+"പതിപ്പിൽ ഒരു പുതിയ ചാറ്റ് ആരംഭിക്കാൻ ശ്രമിക്കൂ."
 
 # smartling.placeholder_format=C
 #. Appears below a type of search results called 'Instant Answers'
@@ -19822,9 +20058,9 @@ msgid ""
 "This conversation was generated with Duck.ai (%s) using %s's %s Model. AI "
 "chats may display inaccurate or offensive information (see %s for more info)."
 msgstr ""
-"%2$s-ന്റെ %3$s മോഡൽ ഉപയോഗിച്ച് Duck.ai (%1$s) വഴിയാണ് ഈ സംഭാഷണം സൃഷ്ടിച്ചത്. AI "
-"ചാറ്റുകൾ കൃത്യമല്ലാത്തതോ കുറ്റകരമായതോ ആയ വിവരങ്ങൾ പ്രദർശിപ്പിച്ചേക്കാം (കൂടുതൽ വിവരങ്ങൾക്ക് "
-"%4$s കാണുക)."
+"%2$s-ന്റെ %3$s മോഡൽ ഉപയോഗിച്ച് Duck.ai (%1$s) വഴിയാണ് ഈ സംഭാഷണം സൃഷ്ടിച്ചത്. "
+"AI ചാറ്റുകൾ കൃത്യമല്ലാത്തതോ കുറ്റകരമായതോ ആയ വിവരങ്ങൾ പ്രദർശിപ്പിച്ചേക്കാം "
+"(കൂടുതൽ വിവരങ്ങൾക്ക് %4$s കാണുക)."
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with multiple AI models in the same chat, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using multiple chat models. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -19834,9 +20070,9 @@ msgid ""
 "models. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
 msgstr ""
-"ഒന്നിലധികം ചാറ്റ് മോഡലുകൾ ഉപയോഗിച്ച് Duck.ai (%1$s) ഉപയോഗിച്ചാണ് ഈ സംഭാഷണം സൃഷ്ടിച്ചത്. "
-"AI ചാറ്റുകൾ കൃത്യമല്ലാത്തതോ കുറ്റകരമായതോ ആയ വിവരങ്ങൾ പ്രദർശിപ്പിച്ചേക്കാം (കൂടുതൽ വിവരങ്ങൾക്ക് "
-"%2$s കാണുക)."
+"ഒന്നിലധികം ചാറ്റ് മോഡലുകൾ ഉപയോഗിച്ച് Duck.ai (%1$s) ഉപയോഗിച്ചാണ് ഈ സംഭാഷണം "
+"സൃഷ്ടിച്ചത്. AI ചാറ്റുകൾ കൃത്യമല്ലാത്തതോ കുറ്റകരമായതോ ആയ വിവരങ്ങൾ "
+"പ്രദർശിപ്പിച്ചേക്കാം (കൂടുതൽ വിവരങ്ങൾക്ക് %2$s കാണുക)."
 
 # smartling.placeholder_format=C
 #. When a user exports a transcript of a voice chat they had with the AI. This text goes at the very top of the downloaded file as a header. Placeholders are for links. Example: 'This conversation was generated with Duck.ai voice chat (https://duck.ai). AI may provide inaccurate or offensive information. (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -19845,8 +20081,9 @@ msgid ""
 "This conversation was generated with Duck.ai voice chat (%s). AI may provide "
 "inaccurate or offensive information. (see %s for more info)."
 msgstr ""
-"Duck.ai വോയ്സ് ചാറ്റ് (%1$s) ഉപയോഗിച്ചാണ് ഈ സംഭാഷണം സൃഷ്ടിച്ചത്. AI കൃത്യതയില്ലാത്തതോ "
-"കുറ്റകരമോ ആയ വിവരങ്ങൾ നൽകിയേക്കാം. (കൂടുതൽ വിവരങ്ങൾക്ക് %2$s കാണുക)."
+"Duck.ai വോയ്സ് ചാറ്റ് (%1$s) ഉപയോഗിച്ചാണ് ഈ സംഭാഷണം സൃഷ്ടിച്ചത്. AI "
+"കൃത്യതയില്ലാത്തതോ കുറ്റകരമോ ആയ വിവരങ്ങൾ നൽകിയേക്കാം. (കൂടുതൽ വിവരങ്ങൾക്ക് "
+"%2$s കാണുക)."
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with DuckDuckGo AI Chat (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/aichat/privacy-terms for more info).'
@@ -19856,9 +20093,9 @@ msgid ""
 "Model. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
 msgstr ""
-"%2$s-ന്റെ %3$s മോഡൽ ഉപയോഗിച്ച് DuckDuckGo AI Chat (%1$s) ഉപയോഗിച്ചാണ് ഈ സംഭാഷണം "
-"സൃഷ്ടിച്ചത്. AI ചാറ്റുകൾ കൃത്യമല്ലാത്തതോ കുറ്റകരമായതോ ആയ വിവരങ്ങൾ പ്രദർശിപ്പിച്ചേക്കാം (കൂടുതൽ "
-"വിവരങ്ങൾക്ക് %4$s കാണുക)."
+"%2$s-ന്റെ %3$s മോഡൽ ഉപയോഗിച്ച് DuckDuckGo AI Chat (%1$s) ഉപയോഗിച്ചാണ് ഈ "
+"സംഭാഷണം സൃഷ്ടിച്ചത്. AI ചാറ്റുകൾ കൃത്യമല്ലാത്തതോ കുറ്റകരമായതോ ആയ വിവരങ്ങൾ "
+"പ്രദർശിപ്പിച്ചേക്കാം (കൂടുതൽ വിവരങ്ങൾക്ക് %4$s കാണുക)."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
@@ -19890,7 +20127,9 @@ msgctxt ""
 "Error message when an uploaded file type is not supported, with list ending "
 "in or"
 msgid "This file type is not supported, please attach a %s or %s"
-msgstr "ഈ ഫയൽ തരത്തെ പിന്തുണയ്ക്കുന്നില്ല, ദയവായി ഒരു %1$s അല്ലെങ്കിൽ %2$s അറ്റാച്ചുചെയ്യുക"
+msgstr ""
+"ഈ ഫയൽ തരത്തെ പിന്തുണയ്ക്കുന്നില്ല, ദയവായി ഒരു %1$s അല്ലെങ്കിൽ %2$s "
+"അറ്റാച്ചുചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. Error message for unsupported file type when multiple types are accepted. First placeholder is a comma-separated list of all accepted types except the last (e.g. PNG, JPG, WebP, GIF). Second placeholder is the last accepted type (e.g. PDF). Full example: This file type is not supported, please attach a PNG, JPG, WebP, GIF or PDF
@@ -19898,7 +20137,9 @@ msgctxt ""
 "Error message when an uploaded file type is not supported, with list ending "
 "in or"
 msgid "This file type is not supported, please attach a %s or %s."
-msgstr "ഈ ഫയൽ തരത്തെ പിന്തുണയ്ക്കുന്നില്ല, ദയവായി ഒരു %1$s അല്ലെങ്കിൽ %2$s അറ്റാച്ച് ചെയ്യുക."
+msgstr ""
+"ഈ ഫയൽ തരത്തെ പിന്തുണയ്ക്കുന്നില്ല, ദയവായി ഒരു %1$s അല്ലെങ്കിൽ %2$s അറ്റാച്ച് "
+"ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to upload an unsupported file type and we know which types are accepted. Placeholder is a single accepted type. E.g. This file type is not supported, please attach a PDF
@@ -19930,7 +20171,8 @@ msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF"
 msgstr ""
-"ഈ ഇമേജ് തരം പിന്തുണയ്ക്കുന്നില്ല, ദയവായി ഒരു JPG, PNG, WebP, അല്ലെങ്കിൽ GIF ചേർക്കുക"
+"ഈ ഇമേജ് തരം പിന്തുണയ്ക്കുന്നില്ല, ദയവായി ഒരു JPG, PNG, WebP, അല്ലെങ്കിൽ GIF "
+"ചേർക്കുക"
 
 # smartling.placeholder_format=C
 #. Error message displayed when a file that the user tried to upload is not of a supported format
@@ -19938,7 +20180,8 @@ msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF."
 msgstr ""
-"ഈ ഇമേജ് തരത്തെ പിന്തുണയ്ക്കുന്നില്ല, ദയവായി JPG, PNG, WebP, അല്ലെങ്കിൽ GIF ചേർക്കുക."
+"ഈ ഇമേജ് തരത്തെ പിന്തുണയ്ക്കുന്നില്ല, ദയവായി JPG, PNG, WebP, അല്ലെങ്കിൽ GIF "
+"ചേർക്കുക."
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
@@ -19964,8 +20207,8 @@ msgid ""
 "This model provider deletes data associated with this chat within 30 days. "
 "Other model providers follow a zero data retention model."
 msgstr ""
-"ഈ മോഡൽ ദാതാവ് ഈ ചാറ്റുമായി ബന്ധപ്പെട്ട ഡാറ്റ 30 ദിവസത്തിനുള്ളിൽ ഇല്ലാതാക്കും. മറ്റ് മോഡൽ "
-"ദാതാക്കൾ പൂജ്യം ഡാറ്റ നിലനിർത്തൽ മോഡൽ പിന്തുടരുന്നു."
+"ഈ മോഡൽ ദാതാവ് ഈ ചാറ്റുമായി ബന്ധപ്പെട്ട ഡാറ്റ 30 ദിവസത്തിനുള്ളിൽ "
+"ഇല്ലാതാക്കും. മറ്റ് മോഡൽ ദാതാക്കൾ പൂജ്യം ഡാറ്റ നിലനിർത്തൽ മോഡൽ പിന്തുടരുന്നു."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers, and that other providers may retain chat data for a limited time instead.
@@ -19974,8 +20217,8 @@ msgid ""
 "This model provider does not store any data associated with this chat. Other "
 "model providers follow a limited data retention model."
 msgstr ""
-"ഈ മോഡൽ ദാതാവ് ഈ ചാറ്റുമായി ബന്ധപ്പെട്ട ഒരു ഡാറ്റയും സംഭരിക്കുന്നില്ല. മറ്റ് മോഡൽ ദാതാക്കൾ ഒരു "
-"പരിമിത ഡാറ്റ നിലനിർത്തൽ മാതൃക പിന്തുടരുന്നു."
+"ഈ മോഡൽ ദാതാവ് ഈ ചാറ്റുമായി ബന്ധപ്പെട്ട ഒരു ഡാറ്റയും സംഭരിക്കുന്നില്ല. മറ്റ് "
+"മോഡൽ ദാതാക്കൾ ഒരു പരിമിത ഡാറ്റ നിലനിർത്തൽ മാതൃക പിന്തുടരുന്നു."
 
 # smartling.placeholder_format=C
 #. Info that page may refresh during update.
@@ -20012,8 +20255,9 @@ msgid ""
 "This saves your chats with end-to-end encryption on DuckDuckGo's secure "
 "server, which later can be accessed from any browser."
 msgstr ""
-"ഇത് നിങ്ങളുടെ ചാറ്റുകൾ DuckDuckGo-യുടെ സുരക്ഷിത സെർവറിൽ എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷൻ ഉപയോഗിച്ച് "
-"സംരക്ഷിക്കുന്നു, പിന്നീട് ഏത് ബ്രൗസറിൽ നിന്നും ഇത് ആക്‌സസ് ചെയ്യാൻ കഴിയും."
+"ഇത് നിങ്ങളുടെ ചാറ്റുകൾ DuckDuckGo-യുടെ സുരക്ഷിത സെർവറിൽ എൻഡ്-ടു-എൻഡ് "
+"എൻക്രിപ്ഷൻ ഉപയോഗിച്ച് സംരക്ഷിക്കുന്നു, പിന്നീട് ഏത് ബ്രൗസറിൽ നിന്നും ഇത് "
+"ആക്‌സസ് ചെയ്യാൻ കഴിയും."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -20022,8 +20266,9 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again."
 msgstr ""
-"ഈ ക്രമീകരണം നിങ്ങളുടെ ബ്രൗസറിൽ സൂക്ഷിച്ചിരിക്കുന്നു, അതായത് നിങ്ങൾ duckduckgo.com ബ്രൗസർ "
-"ഡാറ്റ മായ്ക്കുകയാണെങ്കിൽ, നിങ്ങൾക്ക് AI സഹായമുള്ള ഉത്തരങ്ങൾ വീണ്ടും കാണാൻ കഴിയുമെന്നർത്ഥം."
+"ഈ ക്രമീകരണം നിങ്ങളുടെ ബ്രൗസറിൽ സൂക്ഷിച്ചിരിക്കുന്നു, അതായത് നിങ്ങൾ "
+"duckduckgo.com ബ്രൗസർ ഡാറ്റ മായ്ക്കുകയാണെങ്കിൽ, നിങ്ങൾക്ക് AI സഹായമുള്ള "
+"ഉത്തരങ്ങൾ വീണ്ടും കാണാൻ കഴിയുമെന്നർത്ഥം."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -20033,10 +20278,10 @@ msgid ""
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
 msgstr ""
-"ഈ ക്രമീകരണം നിങ്ങളുടെ ബ്രൗസറിൽ സൂക്ഷിച്ചിരിക്കുന്നു, അതായത് നിങ്ങൾ duckduckgo.com ബ്രൗസർ "
-"ഡാറ്റ മായ്ക്കുകയാണെങ്കിൽ, നിങ്ങൾക്ക് AI സഹായമുള്ള ഉത്തരങ്ങൾ വീണ്ടും കാണാൻ കഴിയുമെന്നർത്ഥം. "
-"എന്നിരുന്നാലും, %1$s-ൽ AI സഹായത്തോടെ ഉത്തരങ്ങൾ ഒരിക്കലും കാണിക്കാത്ത ഒരു ആരംഭ പേജും "
-"ഞങ്ങൾക്ക് ഉണ്ട്."
+"ഈ ക്രമീകരണം നിങ്ങളുടെ ബ്രൗസറിൽ സൂക്ഷിച്ചിരിക്കുന്നു, അതായത് നിങ്ങൾ "
+"duckduckgo.com ബ്രൗസർ ഡാറ്റ മായ്ക്കുകയാണെങ്കിൽ, നിങ്ങൾക്ക് AI സഹായമുള്ള "
+"ഉത്തരങ്ങൾ വീണ്ടും കാണാൻ കഴിയുമെന്നർത്ഥം. എന്നിരുന്നാലും, %1$s-ൽ AI "
+"സഹായത്തോടെ ഉത്തരങ്ങൾ ഒരിക്കലും കാണിക്കാത്ത ഒരു ആരംഭ പേജും ഞങ്ങൾക്ക് ഉണ്ട്."
 
 # smartling.placeholder_format=C
 #. User feedback indicating that a translation is helpful
@@ -20065,7 +20310,9 @@ msgstr "ഈ വീഡിയോ ഇതുവരെ ഇവിടെ കാണാ�
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr "ഈ വെബ്‌പേജ് സുരക്ഷിതവും എൻക്രിപ്റ്റ് ചെയ്തതുമായ കണക്ഷൻ (HTTPS) ഉപയോഗിക്കുന്നില്ല."
+msgstr ""
+"ഈ വെബ്‌പേജ് സുരക്ഷിതവും എൻക്രിപ്റ്റ് ചെയ്തതുമായ കണക്ഷൻ (HTTPS) "
+"ഉപയോഗിക്കുന്നില്ല."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -20075,9 +20322,10 @@ msgid ""
 "Sync & Backup. You'll still be able to access your chats in other browsers "
 "connected to Sync & Backup."
 msgstr ""
-"ഇത് ഈ ബ്രൗസറിൽ നിന്ന് നിങ്ങളുടെ എല്ലാ Duck.ai ചാറ്റുകളും ഇല്ലാതാക്കുകയും Sync & Backup "
-"വിച്ഛേദിക്കുകയും ചെയ്യും. Sync & Backup-ലേക്ക് കണക്റ്റ് ചെയ്തിരിക്കുന്ന മറ്റ് ബ്രൗസറുകളിൽ "
-"നിങ്ങൾക്ക് തുടർന്നും ചാറ്റുകൾ ആക്സസ് ചെയ്യാൻ കഴിയും."
+"ഇത് ഈ ബ്രൗസറിൽ നിന്ന് നിങ്ങളുടെ എല്ലാ Duck.ai ചാറ്റുകളും ഇല്ലാതാക്കുകയും "
+"Sync & Backup വിച്ഛേദിക്കുകയും ചെയ്യും. Sync & Backup-ലേക്ക് കണക്റ്റ് "
+"ചെയ്തിരിക്കുന്ന മറ്റ് ബ്രൗസറുകളിൽ നിങ്ങൾക്ക് തുടർന്നും ചാറ്റുകൾ ആക്സസ് "
+"ചെയ്യാൻ കഴിയും."
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to clear all recentchats, with a warning that this action cannot be undone.
@@ -20086,8 +20334,8 @@ msgid ""
 "This will delete all your recent chats, unless they're pinned. This cannot "
 "be undone."
 msgstr ""
-"നിങ്ങളുടെ സമീപകാല ചാറ്റുകളെല്ലാം പിൻ ചെയ്തിട്ടില്ലെങ്കിൽ ഇത് ഇല്ലാതാക്കും. ഇത് "
-"പഴയപടിയാക്കാനാവില്ല."
+"നിങ്ങളുടെ സമീപകാല ചാറ്റുകളെല്ലാം പിൻ ചെയ്തിട്ടില്ലെങ്കിൽ ഇത് ഇല്ലാതാക്കും. "
+"ഇത് പഴയപടിയാക്കാനാവില്ല."
 
 # smartling.placeholder_format=C
 #. Message explaining what will happen when the user deletes an image.
@@ -20106,7 +20354,8 @@ msgstr "ഇത് എല്ലാ ക്രമീകരണവും മായ്
 msgctxt "settings"
 msgid "This will reset your saved settings to default values. Continue?"
 msgstr ""
-"ഇത് നിങ്ങളുടെ സംരക്ഷിച്ച ക്രമീകരണം ഡിഫോൾട്ട് മൂല്യങ്ങളിലേക്ക് പുനഃക്രമീകരിക്കും. തുടരണോ?"
+"ഇത് നിങ്ങളുടെ സംരക്ഷിച്ച ക്രമീകരണം ഡിഫോൾട്ട് മൂല്യങ്ങളിലേക്ക് "
+"പുനഃക്രമീകരിക്കും. തുടരണോ?"
 
 # smartling.placeholder_format=C
 #. Golf leaderboard column: holes completed in current round
@@ -20203,7 +20452,9 @@ msgstr "ശീർഷക അടിവര"
 # smartling.placeholder_format=C
 #. Informative header on a list of steps for the user to take to disable their adblocker
 msgid "To allowlist DuckDuckGo in other ad blocker extensions:"
-msgstr "മറ്റ് പരസ്യ ബ്ലോക്കർ എക്സ്റ്ൻഷനുകളിൽ DuckDuckGo-യെ അനുവദിക്കുന്ന ലിസ്റ്ൽ ചേർക്കാൻ:"
+msgstr ""
+"മറ്റ് പരസ്യ ബ്ലോക്കർ എക്സ്റ്ൻഷനുകളിൽ DuckDuckGo-യെ അനുവദിക്കുന്ന ലിസ്റ്ൽ "
+"ചേർക്കാൻ:"
 
 # smartling.placeholder_format=C
 #. Text stating agreement to Duck.ai Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'To continue, you must agree to Duck.ai’s Privacy Policy and Terms of Service'
@@ -20226,8 +20477,8 @@ msgid ""
 "To print directions:%sGo back to the map.%sSelect the route you want to "
 "print.%sClick the print icon.%s"
 msgstr ""
-"ദിശകൾ പ്രിന്റ് ചെയ്യാൻ:%1$sമാപ്പിലേക്ക് മടങ്ങുക.%2$sനിങ്ങൾക്ക് പ്രിന്റ് ചെയ്യേണ്ട റൂട്ട് "
-"തിരഞ്ഞെടുക്കുക.%3$sപ്രിന്റ് ഐക്കണിൽ ക്ലിക്ക് ചെയ്യുക.%4$s"
+"ദിശകൾ പ്രിന്റ് ചെയ്യാൻ:%1$sമാപ്പിലേക്ക് മടങ്ങുക.%2$sനിങ്ങൾക്ക് പ്രിന്റ് "
+"ചെയ്യേണ്ട റൂട്ട് തിരഞ്ഞെടുക്കുക.%3$sപ്രിന്റ് ഐക്കണിൽ ക്ലിക്ക് ചെയ്യുക.%4$s"
 
 # smartling.placeholder_format=C
 #. Explains where the user can find their recovery code. Figma frame 3703-44420.
@@ -20237,9 +20488,10 @@ msgid ""
 "you first set up Sync. This code may have been saved as a PDF on the device "
 "you originally used to set up Sync."
 msgstr ""
-"നിങ്ങളുടെ സമന്വയിപ്പിച്ച ഡാറ്റ പുനഃസ്ഥാപിക്കാൻ, നിങ്ങൾ ആദ്യമായി സമന്വയം സജ്ജമാക്കുമ്പോൾ "
-"സംരക്ഷിച്ച വീണ്ടെടുക്കൽ കോഡ് ആവശ്യമാണ്. നിങ്ങൾ സമന്വയം സജ്ജമാക്കാൻ ആദ്യം ഉപയോഗിച്ച "
-"ഉപകരണത്തിൽ ഈ കോഡ് ഒരു PDF ആയി സേവ് ചെയ്‌തിരിക്കാം."
+"നിങ്ങളുടെ സമന്വയിപ്പിച്ച ഡാറ്റ പുനഃസ്ഥാപിക്കാൻ, നിങ്ങൾ ആദ്യമായി സമന്വയം "
+"സജ്ജമാക്കുമ്പോൾ സംരക്ഷിച്ച വീണ്ടെടുക്കൽ കോഡ് ആവശ്യമാണ്. നിങ്ങൾ സമന്വയം "
+"സജ്ജമാക്കാൻ ആദ്യം ഉപയോഗിച്ച ഉപകരണത്തിൽ ഈ കോഡ് ഒരു PDF ആയി സേവ് "
+"ചെയ്‌തിരിക്കാം."
 
 # smartling.placeholder_format=C
 #. Body text explaining that the user needs to update their DDG browser before migration can proceed.
@@ -20248,8 +20500,8 @@ msgid ""
 "To transfer your chat history to Duck.ai, please update your DuckDuckGo "
 "browser to the latest version and try again."
 msgstr ""
-"നിങ്ങളുടെ ചാറ്റ് ചരിത്രം Duck.ai-ലേക്ക് മാറ്റാൻ, DuckDuckGo ബ്രൗസർ ഏറ്റവും പുതിയ "
-"പതിപ്പിലേക്ക് അപ്ഡേറ്റ് ചെയ്ത് വീണ്ടും ശ്രമിക്കുക."
+"നിങ്ങളുടെ ചാറ്റ് ചരിത്രം Duck.ai-ലേക്ക് മാറ്റാൻ, DuckDuckGo ബ്രൗസർ ഏറ്റവും "
+"പുതിയ പതിപ്പിലേക്ക് അപ്ഡേറ്റ് ചെയ്ത് വീണ്ടും ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
@@ -20257,8 +20509,8 @@ msgid ""
 "To use dictation, allow your browser to access the microphone in your system "
 "settings."
 msgstr ""
-"ഡിക്ടേഷൻ ഉപയോഗിക്കാൻ, നിങ്ങളുടെ ബ്രൗസറിനെ സിസ്റ്റം ക്രമീകരണത്തിൽ മൈക്രോഫോൺ ആക്‌സസ് ചെയ്യാൻ "
-"അനുവദിക്കുക."
+"ഡിക്ടേഷൻ ഉപയോഗിക്കാൻ, നിങ്ങളുടെ ബ്രൗസറിനെ സിസ്റ്റം ക്രമീകരണത്തിൽ മൈക്രോഫോൺ "
+"ആക്‌സസ് ചെയ്യാൻ അനുവദിക്കുക."
 
 # smartling.placeholder_format=C
 msgid "Today"
@@ -20448,8 +20700,8 @@ msgid ""
 "Tracking attempts blocked by DuckDuckGo appear here. Keep browsing to see "
 "how many we block."
 msgstr ""
-"DuckDuckGo തടഞ്ഞ ട്രാക്കിംഗ് ശ്രമങ്ങൾ ഇവിടെ ദൃശ്യമാകും. ഞങ്ങൾ എത്രയെണ്ണം ബ്ലോക്ക് ചെയ്യുന്നു "
-"എന്നറിയാൻ ബ്രൗസ് ചെയ്യുന്നത് തുടരുക."
+"DuckDuckGo തടഞ്ഞ ട്രാക്കിംഗ് ശ്രമങ്ങൾ ഇവിടെ ദൃശ്യമാകും. ഞങ്ങൾ എത്രയെണ്ണം "
+"ബ്ലോക്ക് ചെയ്യുന്നു എന്നറിയാൻ ബ്രൗസ് ചെയ്യുന്നത് തുടരുക."
 
 # smartling.placeholder_format=C
 #. Placeholder for when we cannot report any blocked trackers yet
@@ -20497,8 +20749,8 @@ msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
 msgstr ""
-"ഈ വാചകം ഫ്രഞ്ചിലേക്ക് വിവർത്തനം ചെയ്യുക: “അടുത്തുള്ള സിനിമാ തിയേറ്ററിലേക്ക് ഞാൻ എങ്ങനെ "
-"എത്തും?”"
+"ഈ വാചകം ഫ്രഞ്ചിലേക്ക് വിവർത്തനം ചെയ്യുക: “അടുത്തുള്ള സിനിമാ തിയേറ്ററിലേക്ക് "
+"ഞാൻ എങ്ങനെ എത്തും?”"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for translating a sentence into another language. Translate the whole sentence and please use target language instead of 'English' and modify the sentence to translate into 'English' instead of 'French'. Example: 'Translate this {target language} sentence into English: “How do I get to the nearest movie theatre?”'
@@ -20507,20 +20759,20 @@ msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
 msgstr ""
-"ഈ വാചകം ഫ്രഞ്ചിലേക്ക് വിവർത്തനം ചെയ്യുക: “അടുത്തുള്ള സിനിമാ തിയേറ്ററിലേക്ക് ഞാൻ എങ്ങനെ "
-"എത്തും?”"
+"ഈ വാചകം ഫ്രഞ്ചിലേക്ക് വിവർത്തനം ചെയ്യുക: “അടുത്തുള്ള സിനിമാ തിയേറ്ററിലേക്ക് "
+"ഞാൻ എങ്ങനെ എത്തും?”"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Translate this page"
-msgstr ""
+msgstr "ഈ പേജ് പരിഭാഷപ്പെടുത്തുക"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
 msgctxt "Page suggestion prompt"
 msgid "Translate this page into %s."
-msgstr ""
+msgstr "ഈ പേജ് %1$s-ലേക്ക് പരിഭാഷപ്പെടുത്തുക."
 
 # smartling.placeholder_format=C
 #. Placeholder text for a region that will display translated text.
@@ -20667,7 +20919,7 @@ msgstr "സൗജന്യമായി പരീക്ഷിക്കൂ"
 #. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
 msgctxt "settings"
 msgid "Try It Now"
-msgstr ""
+msgstr "ഇപ്പോൾ പരീക്ഷിക്കൂ"
 
 # smartling.placeholder_format=C
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -20726,8 +20978,8 @@ msgstr "വ്യത്യസ്ത കീവേഡുകൾ പരീക്ഷ�
 #. Prompt encouraging the user to turn off their ad blocker to see more results for their query.
 msgid "Try disabling your ad blocker on DuckDuckGo to see more results."
 msgstr ""
-"കൂടുതൽ ഫലങ്ങൾ കാണാൻ DuckDuckGo-യിൽ നിന്നുള്ള നിങ്ങളുടെ പരസ്യ ബ്ലോക്കർ പ്രവർത്തനരഹിതമാക്കാൻ "
-"ശ്രമിക്കുക."
+"കൂടുതൽ ഫലങ്ങൾ കാണാൻ DuckDuckGo-യിൽ നിന്നുള്ള നിങ്ങളുടെ പരസ്യ ബ്ലോക്കർ "
+"പ്രവർത്തനരഹിതമാക്കാൻ ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
@@ -20768,7 +21020,9 @@ msgstr "സൗജന്യമായി പരീക്ഷിക്കൂ"
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
-msgstr "സൗജന്യമായി പരീക്ഷിക്കൂ! സുരക്ഷിതമായ VPN, വിപുലവും സ്വകാര്യവുമായ AI, അങ്ങനെ പലതും."
+msgstr ""
+"സൗജന്യമായി പരീക്ഷിക്കൂ! സുരക്ഷിതമായ VPN, വിപുലവും സ്വകാര്യവുമായ AI, അങ്ങനെ "
+"പലതും."
 
 # smartling.placeholder_format=C
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -20877,7 +21131,8 @@ msgstr "അടുത്തിടെ ചേർത്തിട്ടുള്ള o
 msgctxt "Prompt suggestion message"
 msgid "Try these prompts to get started or enter your own prompt below"
 msgstr ""
-"ആരംഭിക്കുന്നതിന് ഈ പ്രോംപ്റ്റുകൾ പരീക്ഷിക്കുക, അല്ലെങ്കിൽ ചുവടെ നിങ്ങളുടെ സ്വന്തം പ്രോംപ്റ്റ് നൽകുക"
+"ആരംഭിക്കുന്നതിന് ഈ പ്രോംപ്റ്റുകൾ പരീക്ഷിക്കുക, അല്ലെങ്കിൽ ചുവടെ നിങ്ങളുടെ "
+"സ്വന്തം പ്രോംപ്റ്റ് നൽകുക"
 
 # smartling.placeholder_format=C
 #. Description for the empty state displayed when searching recent chats in Duck.ai returns no results, suggesting the user rephrase their search query.
@@ -20911,6 +21166,9 @@ msgid ""
 "Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
+"AI ഫീച്ചറുകൾ പ്രവർത്തനരഹിതമാക്കാൻ ശ്രമിക്കുകയാണോ? നിങ്ങളുടെ ക്രമീകരണങ്ങൾ "
+"ഓർമ്മിക്കാൻ %1$sDuckDuckGo No AI%2$s സെർച്ച് എക്സ്റ്റൻഷൻ ഇൻസ്റ്റാൾ ചെയ്യുക. "
+"%3$sകൂടുതലറിയുക%4$s"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -20919,6 +21177,9 @@ msgid ""
 "Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
+"AI ഫീച്ചറുകൾ പ്രവർത്തനരഹിതമാക്കാൻ ശ്രമിക്കുകയാണോ? നിങ്ങളുടെ ക്രമീകരണങ്ങൾ "
+"ഓർമ്മിക്കാൻ %1$sDuckDuckGo No AI%2$s സെർച്ച് എക്സ്റ്റൻഷനിലേക്ക് മാറുക. "
+"%3$sകൂടുതലറിയുക%4$s"
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -21089,8 +21350,9 @@ msgid ""
 "Types out DuckAssist answers as they're generated. Turning this off may "
 "result in a short delay between a search and the answer being displayed."
 msgstr ""
-"DuckAssist ഉത്തരങ്ങൾ സൃഷ്ടിക്കുമ്പോൾ ടൈപ്പ് ചെയ്യുന്നു. ഇത് ഓഫാക്കുന്നത് തിരയലിനും ഉത്തരം "
-"കാണിക്കുന്നതിനും ഇടയിൽ ഒരു ചെറിയ കാലതാമസത്തിന് കാരണമായേക്കാം."
+"DuckAssist ഉത്തരങ്ങൾ സൃഷ്ടിക്കുമ്പോൾ ടൈപ്പ് ചെയ്യുന്നു. ഇത് ഓഫാക്കുന്നത് "
+"തിരയലിനും ഉത്തരം കാണിക്കുന്നതിനും ഇടയിൽ ഒരു ചെറിയ കാലതാമസത്തിന് "
+"കാരണമായേക്കാം."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -21188,13 +21450,17 @@ msgstr "ഫീഡ് ബാക്ക് അയയ്ക്കുവാൻ സാ
 #. Message shown to the user when the voice chat failed to establish a connection, and they should try again later.
 msgctxt "voice chat"
 msgid "Unable to connect to voice chat, please try again later."
-msgstr "വോയ്സ് ചാറ്റിലേക്ക് കണക്റ്റ് ചെയ്യാൻ കഴിയുന്നില്ല, ദയവായി പിന്നീട് വീണ്ടും ശ്രമിക്കുക."
+msgstr ""
+"വോയ്സ് ചാറ്റിലേക്ക് കണക്റ്റ് ചെയ്യാൻ കഴിയുന്നില്ല, ദയവായി പിന്നീട് വീണ്ടും "
+"ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Message shown to the user when there was an issue connecting to their microphone.
 msgctxt "voice chat"
 msgid "Unable to connect to your mic. Please try again."
-msgstr "നിങ്ങളുടെ മൈക്കിലേക്ക് കണക്റ്റ് ചെയ്യാൻ കഴിഞ്ഞില്ല. ദയവായി വീണ്ടും ശ്രമിക്കുക."
+msgstr ""
+"നിങ്ങളുടെ മൈക്കിലേക്ക് കണക്റ്റ് ചെയ്യാൻ കഴിഞ്ഞില്ല. ദയവായി വീണ്ടും "
+"ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Error message for explore more questions when answer fails to load
@@ -21220,8 +21486,8 @@ msgid ""
 "Under %sOn startup%s, click %sOpen a specific page%s then click %sSet "
 "Pages%s."
 msgstr ""
-"%1$sആരംഭത്തിൽ%2$s എന്നതിന് കീഴിൽ, %3$sഒരു നിർദിഷ്ട പേജ് തുറക്കുക %4$s എന്നത് ക്ലിക്ക് "
-"ചെയ്യുക, തുടർന്ന് %5$sപേജുകൾ സജ്ജമാക്കുക%6$s ക്ലിക്ക് ചെയ്യുക."
+"%1$sആരംഭത്തിൽ%2$s എന്നതിന് കീഴിൽ, %3$sഒരു നിർദിഷ്ട പേജ് തുറക്കുക %4$s എന്നത് "
+"ക്ലിക്ക് ചെയ്യുക, തുടർന്ന് %5$sപേജുകൾ സജ്ജമാക്കുക%6$s ക്ലിക്ക് ചെയ്യുക."
 
 #  Maxthon homepage instruction
 # smartling.placeholder_format=C
@@ -21229,21 +21495,22 @@ msgstr ""
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
 msgstr ""
-"%1$sആരംഭത്തിൽ%2$s എന്നതിന് കീഴിൽ, %3$sഹോംപേജ്%4$s തിരഞ്ഞെടുത്ത് ഇത് എന്റർ ചെയ്യുക: "
-"https://duckduckgo.com"
+"%1$sആരംഭത്തിൽ%2$s എന്നതിന് കീഴിൽ, %3$sഹോംപേജ്%4$s തിരഞ്ഞെടുത്ത് ഇത് എന്റർ "
+"ചെയ്യുക: https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sOpen with%s select %sA specific page or pages%s"
 msgstr ""
-"%1$sഇതിൽ തുറക്കുക%2$s എന്നതിന് കീഴിൽ, %3$sഒരു പ്രത്യേക പേജ് അല്ലെങ്കിൽ പേജുകൾ%4$s "
-"തിരഞ്ഞെടുക്കുക"
+"%1$sഇതിൽ തുറക്കുക%2$s എന്നതിന് കീഴിൽ, %3$sഒരു പ്രത്യേക പേജ് അല്ലെങ്കിൽ "
+"പേജുകൾ%4$s തിരഞ്ഞെടുക്കുക"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
 msgstr ""
-"%1$sആരംഭം > ഹോംപേജ് %2$s എന്നതിന് കീഴിൽ ഇത് എന്റർ ചെയ്യുക: https://duckduckgo.com"
+"%1$sആരംഭം > ഹോംപേജ് %2$s എന്നതിന് കീഴിൽ ഇത് എന്റർ ചെയ്യുക: "
+"https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -21254,30 +21521,32 @@ msgstr "%1$sതിരയൽ ക്രമീകരണം%2$s എന്നതി�
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch in the address bar with%s select %sAdd New%s"
 msgstr ""
-"%1$sഇത് സഹിതം വിലാസ ബാറിൽ തിരയുക%2$s എന്നതിന് കീഴിൽ %3$sപുതിയത് ചേർക്കുക%4$s എന്നത് "
-"തിരഞ്ഞെടുക്കുക"
+"%1$sഇത് സഹിതം വിലാസ ബാറിൽ തിരയുക%2$s എന്നതിന് കീഴിൽ %3$sപുതിയത് ചേർക്കുക%4$s "
+"എന്നത് തിരഞ്ഞെടുക്കുക"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
 msgstr ""
-"%1$sതിരയുക%2$s വിഭാഗത്തിന് കീഴിൽ, %3$sതിരയൽ എഞ്ചിനുകൾ മാനേജ് ചെയ്യുക...%4$s ക്ലിക്ക് "
-"ചെയ്യുക"
+"%1$sതിരയുക%2$s വിഭാഗത്തിന് കീഴിൽ, %3$sതിരയൽ എഞ്ചിനുകൾ മാനേജ് ചെയ്യുക...%4$s "
+"ക്ലിക്ക് ചെയ്യുക"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under On startup select %sOpen a specific page or set of pages%s"
 msgstr ""
-"ആരംഭത്തിൽ എന്നതിന് കീഴിൽ %1$sഒരു നിർദിഷ്ട പേജ് അല്ലെങ്കിൽ ഒരു കൂട്ടം പേജുകൾ തുറക്കുക%2$s "
-"എന്നത് തിരഞ്ഞെടുക്കുക"
+"ആരംഭത്തിൽ എന്നതിന് കീഴിൽ %1$sഒരു നിർദിഷ്ട പേജ് അല്ലെങ്കിൽ ഒരു കൂട്ടം പേജുകൾ "
+"തുറക്കുക%2$s എന്നത് തിരഞ്ഞെടുക്കുക"
 
 #  Opera default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine
 msgid "Under Search click the drop down and select %sDuckDuckGo%s"
-msgstr "തിരയൽ എന്നതിന് കീഴിൽ ഡ്രോപ്പ്ഡൗൺ ക്ലിക്ക് ചെയ്ത് %1$sDuckDuckGo%2$s തിരഞ്ഞെടുക്കുക"
+msgstr ""
+"തിരയൽ എന്നതിന് കീഴിൽ ഡ്രോപ്പ്ഡൗൺ ക്ലിക്ക് ചെയ്ത് %1$sDuckDuckGo%2$s "
+"തിരഞ്ഞെടുക്കുക"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings" header
@@ -21355,8 +21624,8 @@ msgid ""
 "Unlock %s, higher AI reasoning, and 2x higher usage limits than the Plus "
 "plan by upgrading to Pro."
 msgstr ""
-"Pro-യിലേക്ക് അപ്‌ഗ്രേഡ് ചെയ്യുന്നതിലൂടെ %1$s, ഉയർന്ന AI റീസണിംഗ്, പ്ലസ് പ്ലാനിനേക്കാൾ 2 മടങ്ങ് "
-"ഉയർന്ന ഉപയോഗ പരിധി എന്നിവ അൺലോക്ക് ചെയ്യുക."
+"Pro-യിലേക്ക് അപ്‌ഗ്രേഡ് ചെയ്യുന്നതിലൂടെ %1$s, ഉയർന്ന AI റീസണിംഗ്, പ്ലസ് "
+"പ്ലാനിനേക്കാൾ 2 മടങ്ങ് ഉയർന്ന ഉപയോഗ പരിധി എന്നിവ അൺലോക്ക് ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Title for the subscription promo shown in the SERP sidemenu.
@@ -21378,7 +21647,8 @@ msgctxt "voice chat limit modal"
 msgid ""
 "Unlock advanced AI models and higher limits with a DuckDuckGo Subscription"
 msgstr ""
-"DuckDuckGo സബ്സ്ക്രിപ്ഷൻ ഉപയോഗിച്ച് നൂതന AI മോഡലുകളും ഉയർന്ന പരിധികളും അൺലോക്ക് ചെയ്യുക"
+"DuckDuckGo സബ്സ്ക്രിപ്ഷൻ ഉപയോഗിച്ച് നൂതന AI മോഡലുകളും ഉയർന്ന പരിധികളും "
+"അൺലോക്ക് ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. Text informing the user that advanced AI models can be unlocked with a subscription. The variable is used to insert a link that opens the subscription modal. Example: Unlock advanced AI models with a DuckDuckGo subscription.
@@ -21403,7 +21673,9 @@ msgstr "നിങ്ങളുടെ സബ്‌സ്‌ക്രിപ്‌�
 #. Upsell message shown in the voice chat duration limit modal for free users.
 msgctxt "voice chat duration limit modal"
 msgid "Unlock longer voice chats with a DuckDuckGo Subscription"
-msgstr "DuckDuckGo സബ്‌സ്‌ക്രിപ്‌ഷൻ ഉപയോഗിച്ച് ദൈർഘ്യമേറിയ വോയ്സ് ചാറ്റുകൾ അൺലോക്ക് ചെയ്യുക"
+msgstr ""
+"DuckDuckGo സബ്‌സ്‌ക്രിപ്‌ഷൻ ഉപയോഗിച്ച് ദൈർഘ്യമേറിയ വോയ്സ് ചാറ്റുകൾ അൺലോക്ക് "
+"ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. Text informing the user that more capable AI models can be unlocked with a subscription, with a trailing call-to-action link. %s is replaced with either the 'Try for free' link (for unauthenticated users) or the 'Learn more' link (for authenticated users). The link opens the subscription modal. Example: Unlock more capable AI models with a DuckDuckGo subscription. Try for free
@@ -21411,7 +21683,9 @@ msgctxt ""
 "Text shown in the subscription promo card, with a trailing call-to-action "
 "link."
 msgid "Unlock more capable AI models with a DuckDuckGo subscription. %s"
-msgstr "DuckDuckGo സബ്സ്ക്രിപ്ഷൻ ഉപയോഗിച്ച് കൂടുതൽ കഴിവുള്ള AI മോഡലുകൾ അൺലോക്ക് ചെയ്യുക. %1$s"
+msgstr ""
+"DuckDuckGo സബ്സ്ക്രിപ്ഷൻ ഉപയോഗിച്ച് കൂടുതൽ കഴിവുള്ള AI മോഡലുകൾ അൺലോക്ക് "
+"ചെയ്യുക. %1$s"
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to unmute the microphone.
@@ -21491,8 +21765,8 @@ msgid ""
 "Update the DuckDuckGo browser to activate your subscription in Duck.ai and "
 "access advanced models"
 msgstr ""
-"Duck.ai-ൽ നിങ്ങളുടെ സബ്സ്ക്രിപ്ഷൻ സജീവമാക്കാനും നൂതന മോഡലുകൾ ആക്സസ് ചെയ്യാനും DuckDuckGo "
-"ബ്രൗസർ അപ്‌ഡേറ്റ് ചെയ്യുക"
+"Duck.ai-ൽ നിങ്ങളുടെ സബ്സ്ക്രിപ്ഷൻ സജീവമാക്കാനും നൂതന മോഡലുകൾ ആക്സസ് "
+"ചെയ്യാനും DuckDuckGo ബ്രൗസർ അപ്‌ഡേറ്റ് ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. The placeholder indicates a formatted date (e.g., 'Updated 2 days ago')
@@ -21617,15 +21891,16 @@ msgid ""
 "Upgrade to Pro to unlock 2x higher limits than Plus, or come back later to "
 "create more images."
 msgstr ""
-"Plus-നേക്കാൾ 2 മടങ്ങ് ഉയർന്ന പരിധി അൺലോക്ക് ചെയ്യാൻ Pro-യിലേക്ക് അപ്ഗ്രേഡ് ചെയ്യുക, "
-"അല്ലെങ്കിൽ കൂടുതൽ ചിത്രങ്ങൾ സൃഷ്ടിക്കാനായി പിന്നീട് മടങ്ങി വരിക."
+"Plus-നേക്കാൾ 2 മടങ്ങ് ഉയർന്ന പരിധി അൺലോക്ക് ചെയ്യാൻ Pro-യിലേക്ക് അപ്ഗ്രേഡ് "
+"ചെയ്യുക, അല്ലെങ്കിൽ കൂടുതൽ ചിത്രങ്ങൾ സൃഷ്ടിക്കാനായി പിന്നീട് മടങ്ങി വരിക."
 
 # smartling.placeholder_format=C
 #. Upsell message shown in the voice chat limit and duration limit modals for Plus subscribers, encouraging them to upgrade to Pro.
 msgctxt "voice chat limit modal"
 msgid "Upgrade to Pro to unlock 2x higher usage limits than Plus"
 msgstr ""
-"Plus-നേക്കാൾ 2x ഉയർന്ന ഉപയോഗ പരിധികൾ അൺലോക്ക് ചെയ്യാൻ Pro-യിലേക്ക് അപ്ഗ്രേഡ് ചെയ്യുക"
+"Plus-നേക്കാൾ 2x ഉയർന്ന ഉപയോഗ പരിധികൾ അൺലോക്ക് ചെയ്യാൻ Pro-യിലേക്ക് അപ്ഗ്രേഡ് "
+"ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. Heading in a promotion for a desktop web browser
@@ -21677,7 +21952,7 @@ msgstr "ഉറുഗ്വേ"
 #. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
 msgctxt "Navigation label on the Duck.ai settings page"
 msgid "Usage"
-msgstr ""
+msgstr "ഉപയോഗം"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -21721,9 +21996,9 @@ msgid ""
 "Use ChatGPT, Claude, and other AIs, privately. Protect chats from hackers, "
 "scammers, and companies. Keep info confidential. Free. No account required."
 msgstr ""
-"ChatGPT, Claude, മറ്റ് AI-കൾ സ്വകാര്യമായി ഉപയോഗിക്കൂ. ഹാക്കർമാരിൽ നിന്നും, സ്കാമർമാരിൽ "
-"നിന്നും, കമ്പനികളിൽ നിന്നും നിന്റെ ചാറ്റുകൾ സംരക്ഷിക്കുക. വിവരങ്ങൾ രഹസ്യമായി സൂക്ഷിക്കൂ. "
-"സൗജന്യം. അക്കൗണ്ട് ആവശ്യമില്ല."
+"ChatGPT, Claude, മറ്റ് AI-കൾ സ്വകാര്യമായി ഉപയോഗിക്കൂ. ഹാക്കർമാരിൽ നിന്നും, "
+"സ്കാമർമാരിൽ നിന്നും, കമ്പനികളിൽ നിന്നും നിന്റെ ചാറ്റുകൾ സംരക്ഷിക്കുക. "
+"വിവരങ്ങൾ രഹസ്യമായി സൂക്ഷിക്കൂ. സൗജന്യം. അക്കൗണ്ട് ആവശ്യമില്ല."
 
 # smartling.placeholder_format=C
 #. Header above instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -21736,8 +22011,8 @@ msgstr "DuckDuckGo Private Search ഉപയോഗിക്കുക"
 msgctxt "mobile promotion on desktop"
 msgid "Use DuckDuckGo private search on your iPad, iPhone, or Android!"
 msgstr ""
-"നിങ്ങളുടെ iPad, iPhone അല്ലെങ്കിൽ Android എന്നിവയിൽ DuckDuckGo private search "
-"ഉപയോഗിക്കുക!"
+"നിങ്ങളുടെ iPad, iPhone അല്ലെങ്കിൽ Android എന്നിവയിൽ DuckDuckGo private "
+"search ഉപയോഗിക്കുക!"
 
 # smartling.placeholder_format=C
 #. User clicks this button to share their device's location
@@ -21767,8 +22042,8 @@ msgctxt "Description for the recovery section inside Manage"
 msgid ""
 "Use this code to restore your saved chats if you lose access to your devices."
 msgstr ""
-"നിങ്ങളുടെ ഉപകരണങ്ങളിലേക്കുള്ള ആക്സസ് നഷ്ടപ്പെട്ടാൽ, സംരക്ഷിച്ച ചാറ്റുകൾ വീണ്ടെടുക്കാൻ ഈ കോഡ് "
-"ഉപയോഗിക്കുക."
+"നിങ്ങളുടെ ഉപകരണങ്ങളിലേക്കുള്ള ആക്സസ് നഷ്ടപ്പെട്ടാൽ, സംരക്ഷിച്ച ചാറ്റുകൾ "
+"വീണ്ടെടുക്കാൻ ഈ കോഡ് ഉപയോഗിക്കുക."
 
 # smartling.placeholder_format=C
 #. Prompt to ask the user if they want to use their approximate location for more accurate results
@@ -21918,8 +22193,8 @@ msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Microsoft's ad network"
 msgstr ""
-"പരസ്യങ്ങൾ കാണുന്നത് DuckDuckGo സ്വകാര്യതാ പരിരക്ഷ ചെയ്തിരിക്കുന്നു. പരസ്യ ക്ലിക്കുകൾ "
-"നിയന്ത്രിക്കുന്നത് Microsoft-ന്റെ പരസ്യ നെറ്റ്‌വർക്കാണ്"
+"പരസ്യങ്ങൾ കാണുന്നത് DuckDuckGo സ്വകാര്യതാ പരിരക്ഷ ചെയ്തിരിക്കുന്നു. പരസ്യ "
+"ക്ലിക്കുകൾ നിയന്ത്രിക്കുന്നത് Microsoft-ന്റെ പരസ്യ നെറ്റ്‌വർക്കാണ്"
 
 # smartling.placeholder_format=C
 #. Information about TripAdvisor ads for DuckDuckGo's users. This appears in a tooltip.
@@ -21928,8 +22203,8 @@ msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "TripAdvisor's ad network."
 msgstr ""
-"പരസ്യങ്ങൾ കാണുന്നത് DuckDuckGo സംരക്ഷിച്ചിരിക്കുന്ന സ്വകാര്യതയാണ്. പരസ്യ ക്ലിക്കുകൾ "
-"നിയന്ത്രിക്കുന്നത് TripAdvisor ന്റെ പരസ്യ ശൃംഖലയാണ്."
+"പരസ്യങ്ങൾ കാണുന്നത് DuckDuckGo സംരക്ഷിച്ചിരിക്കുന്ന സ്വകാര്യതയാണ്. പരസ്യ "
+"ക്ലിക്കുകൾ നിയന്ത്രിക്കുന്നത് TripAdvisor ന്റെ പരസ്യ ശൃംഖലയാണ്."
 
 # smartling.placeholder_format=C
 msgid "Virgin Islands"
@@ -21941,8 +22216,8 @@ msgctxt "duckassist"
 msgid ""
 "Visit %sAssist Settings%s to adjust how this feature works or turn it off."
 msgstr ""
-"ഈ ഫീച്ചർ എങ്ങനെ പ്രവർത്തിക്കണമെന്ന് ക്രമീകരിക്കാനോ അത് ഓഫ് ചെയ്യാനോ %1$sAssist "
-"ക്രമീകരണം%2$s സന്ദർശിക്കുക."
+"ഈ ഫീച്ചർ എങ്ങനെ പ്രവർത്തിക്കണമെന്ന് ക്രമീകരിക്കാനോ അത് ഓഫ് ചെയ്യാനോ "
+"%1$sAssist ക്രമീകരണം%2$s സന്ദർശിക്കുക."
 
 # smartling.placeholder_format=C
 #. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
@@ -21951,8 +22226,8 @@ msgid ""
 "Visit %sDuckAssist Settings%s to adjust how this feature works or turn it "
 "off."
 msgstr ""
-"ഈ ഫീച്ചർ എങ്ങനെ പ്രവർത്തിക്കണമെന്ന് ക്രമീകരിക്കാനോ അത് ഓഫ് ചെയ്യാനോ %1$sDuckAssist "
-"ക്രമീകരണം%2$s സന്ദർശിക്കുക."
+"ഈ ഫീച്ചർ എങ്ങനെ പ്രവർത്തിക്കണമെന്ന് ക്രമീകരിക്കാനോ അത് ഓഫ് ചെയ്യാനോ "
+"%1$sDuckAssist ക്രമീകരണം%2$s സന്ദർശിക്കുക."
 
 # smartling.placeholder_format=C
 #. Prompt to visit DuckDuckGo on another device.
@@ -21961,8 +22236,8 @@ msgid ""
 "Visit %sDuckDuckGo.com%s on your tablet or phone and follow the provided "
 "instructions."
 msgstr ""
-"നിങ്ങളുടെ ടാബ്‍ലെറ്റിലോ ഫോണിലോ %1$sDuckDuckGo.com%2$s സന്ദർശിച്ച് നൽകിയ നിർദേശങ്ങൾ "
-"പാലിക്കുക."
+"നിങ്ങളുടെ ടാബ്‍ലെറ്റിലോ ഫോണിലോ %1$sDuckDuckGo.com%2$s സന്ദർശിച്ച് നൽകിയ "
+"നിർദേശങ്ങൾ പാലിക്കുക."
 
 # smartling.placeholder_format=C
 #. Primary button to visit Duck.ai.
@@ -21977,9 +22252,9 @@ msgid ""
 "Visit Duck.ai in your other browser and go to %sDuck.ai Settings%s > %sSync "
 "& Backup%s > %sManage%s then select %sSync With Another Device%s."
 msgstr ""
-"നിങ്ങളുടെ മറ്റ് ബ്രൗസറിൽ Duck.ai സന്ദർശിച്ച് %1$sDuck.ai ക്രമീകരണങ്ങൾ%2$s > %3$sSync & "
-"Backup%4$s > %5$sമാനേജ് ചെയ്യുക%6$s എന്നതിലേക്ക് പോയി %7$sമറ്റൊരു ഉപകരണവുമായി "
-"സമന്വയിപ്പിക്കുക%8$s തിരഞ്ഞെടുക്കുക."
+"നിങ്ങളുടെ മറ്റ് ബ്രൗസറിൽ Duck.ai സന്ദർശിച്ച് %1$sDuck.ai ക്രമീകരണങ്ങൾ%2$s > "
+"%3$sSync & Backup%4$s > %5$sമാനേജ് ചെയ്യുക%6$s എന്നതിലേക്ക് പോയി %7$sമറ്റൊരു "
+"ഉപകരണവുമായി സമന്വയിപ്പിക്കുക%8$s തിരഞ്ഞെടുക്കുക."
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -21989,9 +22264,10 @@ msgid ""
 "On” under Sync & Backup and select “Sync With Another Device”. Or scan the "
 "QR on your Recovery PDF."
 msgstr ""
-"നിങ്ങളുടെ മറ്റൊരു ബ്രൗസറിൽ Duck.ai സന്ദർശിച്ച് Duck.ai ക്രമീകരണങ്ങൾ തുറക്കുക. Sync & "
-"Backup എന്നതിന് കീഴിൽ \"ഓണാക്കുക\" തിരഞ്ഞെടുത്ത് \"മറ്റൊരു ഉപകരണവുമായി സമന്വയിപ്പിക്കുക\" "
-"തിരഞ്ഞെടുക്കുക. അല്ലെങ്കിൽ നിങ്ങളുടെ റിക്കവറി PDF-ലെ QR സ്കാൻ ചെയ്യുക."
+"നിങ്ങളുടെ മറ്റൊരു ബ്രൗസറിൽ Duck.ai സന്ദർശിച്ച് Duck.ai ക്രമീകരണങ്ങൾ "
+"തുറക്കുക. Sync & Backup എന്നതിന് കീഴിൽ \"ഓണാക്കുക\" തിരഞ്ഞെടുത്ത് \"മറ്റൊരു "
+"ഉപകരണവുമായി സമന്വയിപ്പിക്കുക\" തിരഞ്ഞെടുക്കുക. അല്ലെങ്കിൽ നിങ്ങളുടെ റിക്കവറി "
+"PDF-ലെ QR സ്കാൻ ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Shared body copy for every screen in the Sync Another Device flow (QR display, camera scan, camera-unavailable fallback, manual entry). Bold tags wrap navigation breadcrumbs. Render with <Translate /> so the HTML is interpreted; plain `translate()` will trip the html-string warning.
@@ -22001,9 +22277,10 @@ msgid ""
 "ai Settings%s > %sSync & Backup%s > %sManage%s then select %sSync With "
 "Another Device%s."
 msgstr ""
-"നിങ്ങളുടെ മറ്റൊരു ബ്രൗസറിലോ DuckDuckGo ആപ്പിലോ Duck.ai സന്ദർശിച്ച്, %1$sDuck.ai "
-"ക്രമീകരണങ്ങൾ%2$s > %3$sSync & Backup%4$s > %5$sമാനേജ് ചെയ്യുക%6$s എന്നിടത്ത് "
-"%7$sമറ്റൊരു ഉപകരണവുമായി സമന്വയിപ്പിക്കുക%8$s തിരഞ്ഞെടുക്കുക."
+"നിങ്ങളുടെ മറ്റൊരു ബ്രൗസറിലോ DuckDuckGo ആപ്പിലോ Duck.ai സന്ദർശിച്ച്, "
+"%1$sDuck.ai ക്രമീകരണങ്ങൾ%2$s > %3$sSync & Backup%4$s > %5$sമാനേജ് "
+"ചെയ്യുക%6$s എന്നിടത്ത് %7$sമറ്റൊരു ഉപകരണവുമായി സമന്വയിപ്പിക്കുക%8$s "
+"തിരഞ്ഞെടുക്കുക."
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -22013,9 +22290,10 @@ msgid ""
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
 msgstr ""
-"നിങ്ങളുടെ മറ്റ് ബ്രൗസറിലോ DuckDuckGo ആപ്പിലോ Duck.ai സന്ദർശിച്ച് Duck.ai ക്രമീകരണങ്ങൾ "
-"തുറക്കുക. Sync & Backup എന്നതിന് കീഴിൽ \"ഓണാക്കുക\" തിരഞ്ഞെടുത്ത് \"മറ്റൊരു ഉപകരണവുമായി "
-"സമന്വയിപ്പിക്കുക\" തിരഞ്ഞെടുക്കുക. അല്ലെങ്കിൽ നിങ്ങളുടെ റിക്കവറി PDF-ലെ QR സ്കാൻ ചെയ്യുക."
+"നിങ്ങളുടെ മറ്റ് ബ്രൗസറിലോ DuckDuckGo ആപ്പിലോ Duck.ai സന്ദർശിച്ച് Duck.ai "
+"ക്രമീകരണങ്ങൾ തുറക്കുക. Sync & Backup എന്നതിന് കീഴിൽ \"ഓണാക്കുക\" "
+"തിരഞ്ഞെടുത്ത് \"മറ്റൊരു ഉപകരണവുമായി സമന്വയിപ്പിക്കുക\" തിരഞ്ഞെടുക്കുക. "
+"അല്ലെങ്കിൽ നിങ്ങളുടെ റിക്കവറി PDF-ലെ QR സ്കാൻ ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -22068,8 +22346,8 @@ msgstr "വോയ്സ് ചാറ്റ് അവസാനിച്ചു"
 msgctxt "voice chat"
 msgid "Voice chat is anonymized by us, and never used to train AI models."
 msgstr ""
-"വോയ്സ് ചാറ്റ് ഞങ്ങൾ അജ്ഞാതമാക്കിയിരിക്കുന്നു, കൂടാതെ AI മോഡലുകളെ പരിശീലിപ്പിക്കാൻ ഒരിക്കലും "
-"ഉപയോഗിച്ചിട്ടില്ല."
+"വോയ്സ് ചാറ്റ് ഞങ്ങൾ അജ്ഞാതമാക്കിയിരിക്കുന്നു, കൂടാതെ AI മോഡലുകളെ "
+"പരിശീലിപ്പിക്കാൻ ഒരിക്കലും ഉപയോഗിച്ചിട്ടില്ല."
 
 # smartling.placeholder_format=C
 #. Title of the modal shown when the user has reached their daily voice chat limit.
@@ -22133,7 +22411,7 @@ msgstr "വെയിൽസ്"
 #. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Walk me through the steps"
-msgstr ""
+msgstr "ഘട്ടങ്ങളിലൂടെ എന്നെ നയിക്കുക"
 
 # smartling.placeholder_format=C
 #. Label for walking directions on a map.
@@ -22213,8 +22491,9 @@ msgid ""
 "Watch in Duck Player to block personalized ads on YouTube and prevent your "
 "viewing activity from influencing YouTube recommendations."
 msgstr ""
-"YouTube-ൽ വ്യക്തിഗതമാക്കിയ പരസ്യങ്ങൾ തടയുന്നതിനും നിങ്ങളുടെ കാഴ്ച പ്രവർത്തനത്തെ YouTube "
-"ശുപാർശകൾ സ്വാധീനിക്കുന്നതിൽ നിന്ന് തടയുന്നതിനും Duck Player-ൽ കാണുക."
+"YouTube-ൽ വ്യക്തിഗതമാക്കിയ പരസ്യങ്ങൾ തടയുന്നതിനും നിങ്ങളുടെ കാഴ്ച "
+"പ്രവർത്തനത്തെ YouTube ശുപാർശകൾ സ്വാധീനിക്കുന്നതിൽ നിന്ന് തടയുന്നതിനും Duck "
+"Player-ൽ കാണുക."
 
 # smartling.placeholder_format=C
 #. A button that takes a user to another site in order to watch a video. The placeholder is the name of the video site. For example: 'Watch on Vimeo'
@@ -22234,10 +22513,11 @@ msgid ""
 "independent company and has no relationship with YouTube, where most videos "
 "are hosted."
 msgstr ""
-"ഇവിടെ ഒരു വീഡിയോ കാണുക എന്നതിനർത്ഥം അത് ഹോസ്റ്റ് ചെയ്തിരിക്കുന്ന വെബ്‌സൈറ്റിന് നിങ്ങളെ ട്രാക്ക് "
-"ചെയ്യാൻ കഴിയും എന്നാണ്, കാരണം ഞങ്ങൾ അവിടെ നിന്ന് ഉള്ളടക്കം സ്ട്രീം ചെയ്യേണ്ടതുണ്ട്. "
-"DuckDuckGo ഒരു സ്വതന്ത്ര കമ്പനിയാണ് കൂടാതെ മിക്ക വീഡിയോകളും ഹോസ്റ്റ് ചെയ്യുന്ന YouTube-മായി "
-"യാതൊരു ബന്ധവുമില്ല."
+"ഇവിടെ ഒരു വീഡിയോ കാണുക എന്നതിനർത്ഥം അത് ഹോസ്റ്റ് ചെയ്തിരിക്കുന്ന "
+"വെബ്‌സൈറ്റിന് നിങ്ങളെ ട്രാക്ക് ചെയ്യാൻ കഴിയും എന്നാണ്, കാരണം ഞങ്ങൾ അവിടെ "
+"നിന്ന് ഉള്ളടക്കം സ്ട്രീം ചെയ്യേണ്ടതുണ്ട്. DuckDuckGo ഒരു സ്വതന്ത്ര "
+"കമ്പനിയാണ് കൂടാതെ മിക്ക വീഡിയോകളും ഹോസ്റ്റ് ചെയ്യുന്ന YouTube-മായി യാതൊരു "
+"ബന്ധവുമില്ല."
 
 # smartling.placeholder_format=C
 #. Heading for the highlight card explaining anonymized prompt delivery.
@@ -22250,8 +22530,8 @@ msgstr "ഞങ്ങൾ അജ്ഞാതമാക്കുന്നു"
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
 msgstr ""
-"നിങ്ങൾക്ക് കൂടുതൽ കൃത്യമായ ഫലങ്ങൾ കാണിക്കുന്നതിന് ഞങ്ങൾക്ക്%1$s നിങ്ങളുടെ ലൊക്കേഷൻ%2$s "
-"അജ്ഞാതമാക്കാൻ കഴിയും."
+"നിങ്ങൾക്ക് കൂടുതൽ കൃത്യമായ ഫലങ്ങൾ കാണിക്കുന്നതിന് ഞങ്ങൾക്ക്%1$s നിങ്ങളുടെ "
+"ലൊക്കേഷൻ%2$s അജ്ഞാതമാക്കാൻ കഴിയും."
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
@@ -22263,6 +22543,10 @@ msgid ""
 "please share this conversation with DuckDuckGo so we can investigate and "
 "address the issue."
 msgstr ""
+"കാണാൻ കഴിയുന്നത് മാത്രമേ ഞങ്ങൾക്ക് പരിഹരിക്കാൻ കഴിയൂ. ദോഷകരമോ നിയമവിരുദ്ധമോ "
+"ആയ ഒരു പ്രതികരണം റിപ്പോർട്ട് ചെയ്യാൻ, ദയവായി ഈ സംഭാഷണം DuckDuckGo-യുമായി "
+"പങ്കിടുക, അതുവഴി ഞങ്ങൾക്ക് പ്രശ്നത്തെക്കുറിച്ച് അന്വേഷിച്ച് പരിഹരിക്കാൻ "
+"കഴിയും."
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -22274,17 +22558,18 @@ msgid ""
 "please share your prompt and response so we can investigate and address the "
 "issue."
 msgstr ""
-"കാണാൻ കഴിയുന്നത് മാത്രമേ ഞങ്ങൾക്ക് ശരിയാക്കാൻ കഴിയൂ. ദോഷകരമോ നിയമവിരുദ്ധമോ ആയ ഒരു "
-"പ്രതികരണം റിപ്പോർട്ട് ചെയ്യാൻ, ദയവായി നിങ്ങളുടെ പ്രോംപ്റ്റും പ്രതികരണവും പങ്കിടുക, അതുവഴി "
-"ഞങ്ങൾക്ക് പ്രശ്നം അന്വേഷിച്ച് പരിഹരിക്കാൻ കഴിയും."
+"കാണാൻ കഴിയുന്നത് മാത്രമേ ഞങ്ങൾക്ക് ശരിയാക്കാൻ കഴിയൂ. ദോഷകരമോ നിയമവിരുദ്ധമോ "
+"ആയ ഒരു പ്രതികരണം റിപ്പോർട്ട് ചെയ്യാൻ, ദയവായി നിങ്ങളുടെ പ്രോംപ്റ്റും "
+"പ്രതികരണവും പങ്കിടുക, അതുവഴി ഞങ്ങൾക്ക് പ്രശ്നം അന്വേഷിച്ച് പരിഹരിക്കാൻ "
+"കഴിയും."
 
 # smartling.placeholder_format=C
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can use your anonymous%s location%s to show you nearby results."
 msgstr ""
-"സമീപത്തുള്ള ഫലങ്ങൾ കാണിക്കുന്നതിന് ഞങ്ങൾക്ക് നിങ്ങളുടെ അജ്ഞാത%1$s ലൊക്കേഷൻ%2$s "
-"ഉപയോഗിക്കാനാകും."
+"സമീപത്തുള്ള ഫലങ്ങൾ കാണിക്കുന്നതിന് ഞങ്ങൾക്ക് നിങ്ങളുടെ അജ്ഞാത%1$s "
+"ലൊക്കേഷൻ%2$s ഉപയോഗിക്കാനാകും."
 
 # smartling.placeholder_format=C
 #. Error message displayed when one or more attached files are encrypted and cannot be read.
@@ -22292,8 +22577,8 @@ msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
 msgstr ""
-"അറ്റാച്ച് ചെയ്ത ഫയലുകളിൽ ഒരെണ്ണമെങ്കിലും എൻക്രിപ്റ്റ് ചെയ്തിരിക്കുന്നതിനാൽ ഞങ്ങൾക്ക് അവ "
-"വായിക്കാൻ കഴിയില്ല."
+"അറ്റാച്ച് ചെയ്ത ഫയലുകളിൽ ഒരെണ്ണമെങ്കിലും എൻക്രിപ്റ്റ് ചെയ്തിരിക്കുന്നതിനാൽ "
+"ഞങ്ങൾക്ക് അവ വായിക്കാൻ കഴിയില്ല."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -22304,13 +22589,16 @@ msgstr "പരസ്യങ്ങളുമായി ഞങ്ങൾ നിങ്�
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
 msgid "We don't store usernames or any personally identifiable information."
-msgstr "ഞങ്ങൾ ഉപയോക്തൃനാമങ്ങളോ വ്യക്തിപരമായി തിരിച്ചറിയിക്കുന്ന വിവരങ്ങളോ സംഭരിക്കുന്നില്ല."
+msgstr ""
+"ഞങ്ങൾ ഉപയോക്തൃനാമങ്ങളോ വ്യക്തിപരമായി തിരിച്ചറിയിക്കുന്ന വിവരങ്ങളോ "
+"സംഭരിക്കുന്നില്ല."
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don't store your personal info or track you. Ever."
 msgstr ""
-"ഞങ്ങൾ നിങ്ങളുടെ സ്വകാര്യ വിവരങ്ങൾ സംഭരിക്കുകയോ നിങ്ങളെ ട്രാക്ക് ചെയ്യുകയോ ഇല്ല. എപ്പോഴും."
+"ഞങ്ങൾ നിങ്ങളുടെ സ്വകാര്യ വിവരങ്ങൾ സംഭരിക്കുകയോ നിങ്ങളെ ട്രാക്ക് ചെയ്യുകയോ "
+"ഇല്ല. എപ്പോഴും."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -22322,8 +22610,8 @@ msgid ""
 "We don't store your personal info. We don't follow you around with ads. We "
 "don't track you. Ever."
 msgstr ""
-"നിങ്ങളുടെ വ്യക്തിഗത വിവരങ്ങൾ ഞങ്ങൾ സംഭരിക്കാറില്ല. പരസ്യങ്ങളുമായി ഞങ്ങൾ നിങ്ങളെ "
-"പിന്തുടരില്ല. ഞങ്ങൾ നിങ്ങളെ ട്രാക്ക് ചെയ്യില്ല. എപ്പോഴും."
+"നിങ്ങളുടെ വ്യക്തിഗത വിവരങ്ങൾ ഞങ്ങൾ സംഭരിക്കാറില്ല. പരസ്യങ്ങളുമായി ഞങ്ങൾ "
+"നിങ്ങളെ പിന്തുടരില്ല. ഞങ്ങൾ നിങ്ങളെ ട്രാക്ക് ചെയ്യില്ല. എപ്പോഴും."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -22337,8 +22625,9 @@ msgid ""
 "We don't track you, so we could use your help telling us what brought you "
 "back today:"
 msgstr ""
-"ഞങ്ങൾ നിങ്ങളെ ട്രാക്ക് ചെയ്യുന്നില്ല, അതിനാൽ ഇന്ന് നിങ്ങളെ തിരികെ കൊണ്ടുവന്നത് എന്താണെന്ന് "
-"ഞങ്ങളോട് പറയാൻ നിങ്ങളുടെ സഹായം ഞങ്ങൾക്ക് ഉപയോഗിക്കാം:"
+"ഞങ്ങൾ നിങ്ങളെ ട്രാക്ക് ചെയ്യുന്നില്ല, അതിനാൽ ഇന്ന് നിങ്ങളെ തിരികെ "
+"കൊണ്ടുവന്നത് എന്താണെന്ന് ഞങ്ങളോട് പറയാൻ നിങ്ങളുടെ സഹായം ഞങ്ങൾക്ക് "
+"ഉപയോഗിക്കാം:"
 
 # smartling.placeholder_format=C
 #. Message prompting users to fill out a feedback form.
@@ -22347,8 +22636,9 @@ msgid ""
 "We don't track you, so we could use your help telling us what convinced you "
 "to try us out today:"
 msgstr ""
-"ഞങ്ങൾ നിങ്ങളെ ട്രാക്ക് ചെയ്യുന്നില്ല, അതിനാൽ ഇന്ന് ഞങ്ങളെ പരീക്ഷിച്ചുനോക്കാൻ നിങ്ങൾക്ക് "
-"ബോധ്യംപകർന്നത് എന്താണെന്ന് ഞങ്ങളോട് പറയാൻ നിങ്ങളുടെ സഹായം ഞങ്ങൾക്ക് ഉപയോഗിക്കാം:"
+"ഞങ്ങൾ നിങ്ങളെ ട്രാക്ക് ചെയ്യുന്നില്ല, അതിനാൽ ഇന്ന് ഞങ്ങളെ പരീക്ഷിച്ചുനോക്കാൻ "
+"നിങ്ങൾക്ക് ബോധ്യംപകർന്നത് എന്താണെന്ന് ഞങ്ങളോട് പറയാൻ നിങ്ങളുടെ സഹായം "
+"ഞങ്ങൾക്ക് ഉപയോഗിക്കാം:"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -22359,7 +22649,9 @@ msgstr "ഞങ്ങൾ നിങ്ങളെ ട്രാക്ക് ചെയ
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with a Continue button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don't track you. That's our Privacy Policy in a nutshell."
-msgstr "ഞങ്ങൾ നിങ്ങളെ ട്രാക്ക് ചെയ്യുന്നില്ല. ചുരുക്കത്തിൽ അതാണ് ഞങ്ങളുടെ സ്വകാര്യതാ നയം."
+msgstr ""
+"ഞങ്ങൾ നിങ്ങളെ ട്രാക്ക് ചെയ്യുന്നില്ല. ചുരുക്കത്തിൽ അതാണ് ഞങ്ങളുടെ സ്വകാര്യതാ "
+"നയം."
 
 # smartling.placeholder_format=C
 #. Description for the audio identification highlight in the dictation consent modal.
@@ -22388,8 +22680,8 @@ msgid ""
 "We don’t store your search history. We therefore have nothing to sell to "
 "advertisers that track you across the Internet."
 msgstr ""
-"ഞങ്ങൾ നിങ്ങളുടെ തിരയൽ ചരിത്രം സൂക്ഷിക്കില്ല. അതുകൊണ്ട് നിങ്ങളെ ഇന്റർനെറ്റിൽ ഉടനീളം "
-"പിന്തുടരുന്ന പരസ്യദാതാക്കൾക്ക് വിൽക്കാൻ ഞങ്ങൾക്ക് ഒന്നുമില്ല"
+"ഞങ്ങൾ നിങ്ങളുടെ തിരയൽ ചരിത്രം സൂക്ഷിക്കില്ല. അതുകൊണ്ട് നിങ്ങളെ ഇന്റർനെറ്റിൽ "
+"ഉടനീളം പിന്തുടരുന്ന പരസ്യദാതാക്കൾക്ക് വിൽക്കാൻ ഞങ്ങൾക്ക് ഒന്നുമില്ല"
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -22415,8 +22707,8 @@ msgid ""
 "We have agreements with all AI providers to ensure your chats aren't used to "
 "train AIs."
 msgstr ""
-"നിങ്ങളുടെ ചാറ്റുകൾ AI-കളെ പരിശീലിപ്പിക്കാൻ ഉപയോഗിക്കപ്പെടുകയില്ലെന്ന് ഉറപ്പാക്കാൻ എല്ലാ AI "
-"ദാതാക്കളുമായും ഞങ്ങൾക്ക് കരാറുകളുണ്ട്."
+"നിങ്ങളുടെ ചാറ്റുകൾ AI-കളെ പരിശീലിപ്പിക്കാൻ ഉപയോഗിക്കപ്പെടുകയില്ലെന്ന് "
+"ഉറപ്പാക്കാൻ എല്ലാ AI ദാതാക്കളുമായും ഞങ്ങൾക്ക് കരാറുകളുണ്ട്."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -22433,7 +22725,9 @@ msgstr "ഞങ്ങൾക്ക് കണക്ഷൻ നഷ്ടപ്പെ�
 #. We store chats for 15 minutes in the BE. If the user tries to fetch it after the 15 minutes elapsed or if we had an issue saving it we show them this error message so they can re-submit their prompt.
 msgctxt "AI Chat: Error message for unsaved or expired chats saved in sync"
 msgid "We lost the connection. Please try sending your message again."
-msgstr "ഞങ്ങൾക്ക് കണക്ഷൻ നഷ്ടപ്പെട്ടു. ദയവായി നിങ്ങളുടെ സന്ദേശം വീണ്ടും അയയ്ക്കാൻ ശ്രമിക്കൂ."
+msgstr ""
+"ഞങ്ങൾക്ക് കണക്ഷൻ നഷ്ടപ്പെട്ടു. ദയവായി നിങ്ങളുടെ സന്ദേശം വീണ്ടും അയയ്ക്കാൻ "
+"ശ്രമിക്കൂ."
 
 # smartling.placeholder_format=C
 #. Message asking the user to disable their ad blocker, with a link to how our ads don't track you. The placeholders are for the start and end tags of that link (e.g. <a href="%">, </a>)
@@ -22441,8 +22735,8 @@ msgid ""
 "We make money from %sprivacy-respecting search ads%s, not by exploiting your "
 "data."
 msgstr ""
-"ഞങ്ങൾ നിങ്ങളുടെ ഡാറ്റ ചൂഷണം ചെയ്യുന്നതിലൂടെയല്ല, %1$sസ്വകാര്യത മാനിക്കുന്ന തിരയൽ "
-"പരസ്യങ്ങളിൽ%2$s നിന്നാണ് പണം സമ്പാദിക്കുന്നത്."
+"ഞങ്ങൾ നിങ്ങളുടെ ഡാറ്റ ചൂഷണം ചെയ്യുന്നതിലൂടെയല്ല, %1$sസ്വകാര്യത മാനിക്കുന്ന "
+"തിരയൽ പരസ്യങ്ങളിൽ%2$s നിന്നാണ് പണം സമ്പാദിക്കുന്നത്."
 
 # smartling.placeholder_format=C
 #. Message describing how DuckDuckGo users location access anonymously to provide better search results.
@@ -22451,20 +22745,24 @@ msgid ""
 "We only use your anonymous location to deliver better results, closer to "
 "you. You can always change your mind later."
 msgstr ""
-"നിങ്ങളുടെ സമീപത്തുള്ള മികച്ച ഫലങ്ങൾ നൽകാൻ മാത്രമേ ഞങ്ങൾ നിങ്ങളുടെ അജ്ഞാത ലൊക്കേഷൻ "
-"ഉപയോഗിക്കുകയുള്ളൂ. പിന്നീട് എപ്പോൾ വേണമെങ്കിലും നിങ്ങളുടെ മനസ്സ് മാറ്റാൻ കഴിയും."
+"നിങ്ങളുടെ സമീപത്തുള്ള മികച്ച ഫലങ്ങൾ നൽകാൻ മാത്രമേ ഞങ്ങൾ നിങ്ങളുടെ അജ്ഞാത "
+"ലൊക്കേഷൻ ഉപയോഗിക്കുകയുള്ളൂ. പിന്നീട് എപ്പോൾ വേണമെങ്കിലും നിങ്ങളുടെ മനസ്സ് "
+"മാറ്റാൻ കഴിയും."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
 msgstr ""
-"എല്ലാവർക്കും DuckDuckGo മികച്ചതാക്കാൻ ഞങ്ങൾ നിങ്ങളുടെ അജ്ഞാത ഫീഡ്ബാക്കിനെ ആശ്രയിക്കുന്നു."
+"എല്ലാവർക്കും DuckDuckGo മികച്ചതാക്കാൻ ഞങ്ങൾ നിങ്ങളുടെ അജ്ഞാത ഫീഡ്ബാക്കിനെ "
+"ആശ്രയിക്കുന്നു."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We stop anyone from getting your search history, including us."
-msgstr "ഞങ്ങൾ ഉൾപ്പെടെ, നിങ്ങളുടെ തിരയൽ ചരിത്രം ആർക്കും ലഭിക്കുന്നതിൽ നിന്ന് ഞങ്ങൾ തടയുന്നു."
+msgstr ""
+"ഞങ്ങൾ ഉൾപ്പെടെ, നിങ്ങളുടെ തിരയൽ ചരിത്രം ആർക്കും ലഭിക്കുന്നതിൽ നിന്ന് ഞങ്ങൾ "
+"തടയുന്നു."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -22480,15 +22778,16 @@ msgid ""
 "incorporated at the discretion of %s. Corrections may not show up in results "
 "right away."
 msgstr ""
-"DuckDuckGo മെച്ചപ്പെടുത്തുന്നതിന് ഞങ്ങൾ ഇതുപോലുള്ള ഫീഡ്ബാക്ക് ഉപയോഗിക്കാറുണ്ട്. %1$s-ന്റെ "
-"വിവേചനാധികാര പ്രകാരം നിർദേശങ്ങൾ സംയോജിപ്പിക്കുന്നതാണ്. തിരുത്തലുകൾ ഫലങ്ങളിൽ സത്വരം "
-"ദൃശ്യമാകണമെന്നില്ല."
+"DuckDuckGo മെച്ചപ്പെടുത്തുന്നതിന് ഞങ്ങൾ ഇതുപോലുള്ള ഫീഡ്ബാക്ക് "
+"ഉപയോഗിക്കാറുണ്ട്. %1$s-ന്റെ വിവേചനാധികാര പ്രകാരം നിർദേശങ്ങൾ "
+"സംയോജിപ്പിക്കുന്നതാണ്. തിരുത്തലുകൾ ഫലങ്ങളിൽ സത്വരം ദൃശ്യമാകണമെന്നില്ല."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
 msgstr ""
-"നിങ്ങൾ ബ്രൗസ് ചെയ്യുമ്പോൾ നിങ്ങളുടെ ഡാറ്റ ശേഖരിക്കാൻ ശ്രമിക്കുന്ന ട്രാക്കർമാരെ ഞങ്ങൾ തടയും."
+"നിങ്ങൾ ബ്രൗസ് ചെയ്യുമ്പോൾ നിങ്ങളുടെ ഡാറ്റ ശേഖരിക്കാൻ ശ്രമിക്കുന്ന "
+"ട്രാക്കർമാരെ ഞങ്ങൾ തടയും."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -22498,8 +22797,8 @@ msgid ""
 "continue to see this error, please reach out to %s."
 msgstr ""
 "ഈ പ്രശ്നത്തെക്കുറിച്ച് ഞങ്ങൾക്കറിയാം, അത് പരിഹരിക്കാൻ ഞങ്ങൾ ഇപ്പോൾ "
-"പ്രവർത്തിച്ചുകൊണ്ടിരിക്കുകയാണ്. നിങ്ങൾക്ക് ഈ പിശക് തുടർന്നും കാണുകയാണെങ്കിൽ, ദയവായി %1$s-നെ "
-"സമീപിക്കുക."
+"പ്രവർത്തിച്ചുകൊണ്ടിരിക്കുകയാണ്. നിങ്ങൾക്ക് ഈ പിശക് തുടർന്നും കാണുകയാണെങ്കിൽ, "
+"ദയവായി %1$s-നെ സമീപിക്കുക."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -22509,7 +22808,8 @@ msgid ""
 "clearing your browser's cache can help."
 msgstr ""
 "ഈ പ്രശ്നത്തെക്കുറിച്ച് ഞങ്ങൾക്കറിയാം, അത് പരിഹരിക്കാൻ ഞങ്ങൾ ഇപ്പോൾ "
-"പ്രവർത്തിച്ചുകൊണ്ടിരിക്കുകയാണ്. ചിലപ്പോൾ നിങ്ങളുടെ ബ്രൗസറിന്റെ കാഷെ മായ്ക്കുന്നത് സഹായിക്കാം."
+"പ്രവർത്തിച്ചുകൊണ്ടിരിക്കുകയാണ്. ചിലപ്പോൾ നിങ്ങളുടെ ബ്രൗസറിന്റെ കാഷെ "
+"മായ്ക്കുന്നത് സഹായിക്കാം."
 
 # smartling.placeholder_format=C
 #. Header for a feedback form for new users.
@@ -22524,8 +22824,8 @@ msgid ""
 "We're sorry for this inconvenience. We’re working hard to make your "
 "experience better."
 msgstr ""
-"ഈ അസൗകര്യത്തിന് ഞങ്ങൾ ക്ഷമ ചോദിക്കുന്നു. നിങ്ങളുടെ അനുഭവം മികച്ചതാക്കാൻ ഞങ്ങൾ കഠിനമായി "
-"പരിശ്രമിക്കുന്നു."
+"ഈ അസൗകര്യത്തിന് ഞങ്ങൾ ക്ഷമ ചോദിക്കുന്നു. നിങ്ങളുടെ അനുഭവം മികച്ചതാക്കാൻ "
+"ഞങ്ങൾ കഠിനമായി പരിശ്രമിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Body text explaining the service update requires a page reload.
@@ -22534,8 +22834,8 @@ msgid ""
 "We've updated the Duck.ai service. For the change to take effect, we need to "
 "reload the page."
 msgstr ""
-"ഞങ്ങൾ Duck.ai സേവനം അപ്ഡേറ്റ് ചെയ്തു. മാറ്റം പ്രാബല്യത്തിൽ വരാൻ, നമ്മൾ പേജ് വീണ്ടും ലോഡ് "
-"ചെയ്യേണ്ടതുണ്ട്."
+"ഞങ്ങൾ Duck.ai സേവനം അപ്ഡേറ്റ് ചെയ്തു. മാറ്റം പ്രാബല്യത്തിൽ വരാൻ, നമ്മൾ പേജ് "
+"വീണ്ടും ലോഡ് ചെയ്യേണ്ടതുണ്ട്."
 
 # smartling.placeholder_format=C
 #. Instant Answer Tab Name
@@ -22637,7 +22937,9 @@ msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "Weekly usage limit reached. You can keep chatting by using your monthly "
 "limit."
-msgstr "പ്രതിവാര ഉപയോഗ പരിധി എത്തി. നിങ്ങളുടെ പ്രതിമാസ പരിധി ഉപയോഗിച്ച് ചാറ്റ് തുടരാം."
+msgstr ""
+"പ്രതിവാര ഉപയോഗ പരിധി എത്തി. നിങ്ങളുടെ പ്രതിമാസ പരിധി ഉപയോഗിച്ച് ചാറ്റ് "
+"തുടരാം."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -22651,8 +22953,9 @@ msgid ""
 "Welcome to Duck.ai! All of your chats here are private, anonymized by us and "
 "not used to train AI models."
 msgstr ""
-"Duck.ai-യിലേക്ക് സ്വാഗതം! ഇവിടെയുള്ള നിങ്ങളുടെ എല്ലാ ചാറ്റുകളും സ്വകാര്യമാണ്, അവ ഞങ്ങൾ "
-"അജ്ഞാതമാക്കും, കൂടാതെ AI മോഡലുകളെ പരിശീലിപ്പിക്കാൻ ഉപയോഗിക്കുന്നില്ല."
+"Duck.ai-യിലേക്ക് സ്വാഗതം! ഇവിടെയുള്ള നിങ്ങളുടെ എല്ലാ ചാറ്റുകളും "
+"സ്വകാര്യമാണ്, അവ ഞങ്ങൾ അജ്ഞാതമാക്കും, കൂടാതെ AI മോഡലുകളെ പരിശീലിപ്പിക്കാൻ "
+"ഉപയോഗിക്കുന്നില്ല."
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened.
@@ -22661,9 +22964,9 @@ msgid ""
 "Welcome to DuckDuckGo AI Chat! All of your chats here are private, "
 "anonymized by us and not used to train AI models."
 msgstr ""
-"DuckDuckGo AI Chat-ലേക്ക് സ്വാഗതം! ഇവിടെയുള്ള നിങ്ങളുടെ എല്ലാ ചാറ്റുകളും സ്വകാര്യമാണ്, അവ "
-"ഒരിക്കലും DuckDuckGo സംഭരിക്കുകയോ AI മോഡലുകളെ പരിശീലിപ്പിക്കാൻ ഉപയോഗിക്കുകയോ "
-"ചെയ്യുന്നില്ല."
+"DuckDuckGo AI Chat-ലേക്ക് സ്വാഗതം! ഇവിടെയുള്ള നിങ്ങളുടെ എല്ലാ ചാറ്റുകളും "
+"സ്വകാര്യമാണ്, അവ ഒരിക്കലും DuckDuckGo സംഭരിക്കുകയോ AI മോഡലുകളെ "
+"പരിശീലിപ്പിക്കാൻ ഉപയോഗിക്കുകയോ ചെയ്യുന്നില്ല."
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened. Example: 'Welcome to DuckDuckGo AI Chat! This chat session is powered by OpenAI’s GPT-3. All of your chats here are private, and are never stored by DuckDuckGo or used to train AI models.'
@@ -22673,16 +22976,17 @@ msgid ""
 "of your chats here are private, and are never stored by DuckDuckGo or used "
 "to train AI models."
 msgstr ""
-"DuckDuckGo AI Chat-ലേക്ക് സ്വാഗതം! ഈ ചാറ്റ് സെഷൻ നൽകുന്നത് %1$s-ൻ്റെ %2$s ആണ്. "
-"ഇവിടെയുള്ള നിങ്ങളുടെ എല്ലാ ചാറ്റുകളും സ്വകാര്യമാണ്, അവ ഒരിക്കലും DuckDuckGo സംഭരിക്കുകയോ AI "
-"മോഡലുകളെ പരിശീലിപ്പിക്കുകയോ ചെയ്യുന്നില്ല."
+"DuckDuckGo AI Chat-ലേക്ക് സ്വാഗതം! ഈ ചാറ്റ് സെഷൻ നൽകുന്നത് %1$s-ൻ്റെ %2$s "
+"ആണ്. ഇവിടെയുള്ള നിങ്ങളുടെ എല്ലാ ചാറ്റുകളും സ്വകാര്യമാണ്, അവ ഒരിക്കലും "
+"DuckDuckGo സംഭരിക്കുകയോ AI മോഡലുകളെ പരിശീലിപ്പിക്കുകയോ ചെയ്യുന്നില്ല."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai! You can now import your downloaded chats."
 msgstr ""
-"പുതിയ Duck.ai-യിലേക്ക് സ്വാഗതം! ഇപ്പോൾ നിങ്ങൾ ഡൗൺലോഡ് ചെയ്ത ചാറ്റുകൾ ഇംപോർട്ട് ചെയ്യാം."
+"പുതിയ Duck.ai-യിലേക്ക് സ്വാഗതം! ഇപ്പോൾ നിങ്ങൾ ഡൗൺലോഡ് ചെയ്ത ചാറ്റുകൾ "
+"ഇംപോർട്ട് ചെയ്യാം."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -22750,8 +23054,8 @@ msgid ""
 "We’re really sorry, but it seems there was a problem loading Duck.ai. Try "
 "reloading the page."
 msgstr ""
-"ഞങ്ങൾക്കു വളരെ ക്ഷമിക്കണം, പക്ഷേ Duck.ai ലോഡ് ചെയ്യുന്നതിൽ ഒരു പ്രശ്നമുണ്ടായതായി തോന്നുന്നു. "
-"പേജ് വീണ്ടും ലോഡ് ചെയ്യാൻ ശ്രമിക്കൂ."
+"ഞങ്ങൾക്കു വളരെ ക്ഷമിക്കണം, പക്ഷേ Duck.ai ലോഡ് ചെയ്യുന്നതിൽ ഒരു "
+"പ്രശ്നമുണ്ടായതായി തോന്നുന്നു. പേജ് വീണ്ടും ലോഡ് ചെയ്യാൻ ശ്രമിക്കൂ."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to suggest an AI (Artificial Intelligence) model to be added to the product, and this field is optional.
@@ -22766,8 +23070,8 @@ msgid ""
 "What are some arguments, counter-arguments, and rebuttals to the concept of "
 "a plant-based diet?"
 msgstr ""
-"ഒരു സസ്യാധിഷ്ഠിത ഭക്ഷണക്രമ ആശയത്തിനുള്ള ചില വാദങ്ങളും എതിർവാദങ്ങളും പ്രതിവാദങ്ങളും "
-"എന്തൊക്കെയാണ്?"
+"ഒരു സസ്യാധിഷ്ഠിത ഭക്ഷണക്രമ ആശയത്തിനുള്ള ചില വാദങ്ങളും എതിർവാദങ്ങളും "
+"പ്രതിവാദങ്ങളും എന്തൊക്കെയാണ്?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for considering factors when purchasing a computer monitor.
@@ -22788,8 +23092,8 @@ msgid ""
 "What are some options for the word ‘better’ in the context of “We really "
 "need to do better.”"
 msgstr ""
-"“ഞങ്ങൾ ശരിക്കും മികച്ചത് ചെയ്യേണ്ടതുണ്ട്” എന്ന പശ്ചാത്തലത്തിൽ 'മികച്ചത്' എന്ന വാക്കിനുള്ള ചില "
-"ഓപ്ഷനുകൾ എന്തൊക്കെയാണ്."
+"“ഞങ്ങൾ ശരിക്കും മികച്ചത് ചെയ്യേണ്ടതുണ്ട്” എന്ന പശ്ചാത്തലത്തിൽ 'മികച്ചത്' "
+"എന്ന വാക്കിനുള്ള ചില ഓപ്ഷനുകൾ എന്തൊക്കെയാണ്."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
@@ -22808,89 +23112,90 @@ msgid ""
 "easy to understand for people with or without much AI, or technical, "
 "experience."
 msgstr ""
-"Duck.ai ഉപയോഗിക്കാൻ താൽപ്പര്യമുള്ള ഒരാൾക്ക് DuckDuckGo ബ്രൗസർ ഡൗൺലോഡ് ചെയ്യുന്നതിന്റെ "
-"പ്രയോജനങ്ങൾ എന്തൊക്കെയാണ്? ഔദ്യോഗിക DuckDuckGo സ്രോതസ്സുകൾ മാത്രം അവലംബിക്കുന്നു. Duck.ai "
-"സംയോജനങ്ങളിലും സ്വകാര്യതാ സംരക്ഷണങ്ങളിലും ശ്രദ്ധ കേന്ദ്രീകരിച്ച്, തലക്കെട്ടുകൾ ഉപയോഗിച്ച് "
-"പ്രതികരണത്തെ വ്യക്തമായ വിഭാഗങ്ങളായി വിഭജിക്കുന്നു. AI അല്ലെങ്കിൽ സാങ്കേതിക പരിചയം "
-"കൂടുതലുള്ളവർക്കും ഇല്ലാത്തവർക്കും ഇത് വളരെ ചെറുതും ലളിതവും മനസ്സിലാക്കാൻ എളുപ്പവുമാക്കുന്നു."
+"Duck.ai ഉപയോഗിക്കാൻ താൽപ്പര്യമുള്ള ഒരാൾക്ക് DuckDuckGo ബ്രൗസർ ഡൗൺലോഡ് "
+"ചെയ്യുന്നതിന്റെ പ്രയോജനങ്ങൾ എന്തൊക്കെയാണ്? ഔദ്യോഗിക DuckDuckGo സ്രോതസ്സുകൾ "
+"മാത്രം അവലംബിക്കുന്നു. Duck.ai സംയോജനങ്ങളിലും സ്വകാര്യതാ സംരക്ഷണങ്ങളിലും "
+"ശ്രദ്ധ കേന്ദ്രീകരിച്ച്, തലക്കെട്ടുകൾ ഉപയോഗിച്ച് പ്രതികരണത്തെ വ്യക്തമായ "
+"വിഭാഗങ്ങളായി വിഭജിക്കുന്നു. AI അല്ലെങ്കിൽ സാങ്കേതിക പരിചയം കൂടുതലുള്ളവർക്കും "
+"ഇല്ലാത്തവർക്കും ഇത് വളരെ ചെറുതും ലളിതവും മനസ്സിലാക്കാൻ എളുപ്പവുമാക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the counterarguments?"
-msgstr ""
+msgstr "എന്തൊക്കെയാണ് എതിർവാദങ്ങൾ?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the hours & location?"
-msgstr ""
+msgstr "പ്രവർത്തന സമയവും ലൊക്കേഷനും എന്തൊക്കെയാണ്?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key contributions of this paper?"
-msgstr ""
+msgstr "ഈ പ്രബന്ധത്തിന്റെ പ്രധാന സംഭാവനകൾ എന്തൊക്കെയാണ്?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key contributions?"
-msgstr ""
+msgstr "എന്തൊക്കെയാണ് പ്രധാന സംഭാവനകൾ?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key details?"
-msgstr ""
+msgstr "പ്രധാന വിശദാംശങ്ങൾ എന്തൊക്കെയാണ്?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key points covered in this video?"
-msgstr ""
+msgstr "ഈ വീഡിയോയിൽ ഉൾപ്പെടുത്തിയിരിക്കുന്ന പ്രധാന കാര്യങ്ങൾ എന്തൊക്കെയാണ്?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key points?"
-msgstr ""
+msgstr "പ്രധാന കാര്യങ്ങൾ എന്തൊക്കെയാണ്?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key takeaways from this article?"
-msgstr ""
+msgstr "ഈ ലേഖനത്തിലെ പ്രധാന ആശയങ്ങൾ എന്തൊക്കെയാണ്?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key takeaways?"
-msgstr ""
+msgstr "പ്രധാന ആശയങ്ങൾ എന്തൊക്കെയാണ്?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key things I will learn from this course?"
-msgstr ""
+msgstr "ഈ കോഴ്സിൽ നിന്ന് ഞാൻ പഠിക്കാൻ പോകുന്ന പ്രധാന കാര്യങ്ങൾ എന്തൊക്കെയാണ്?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the main counterarguments or criticisms of this?"
-msgstr ""
+msgstr "ഇതിനെതിരെയുള്ള പ്രധാന വാദങ്ങൾ അല്ലെങ്കിൽ വിമർശനങ്ങൾ എന്തൊക്കെയാണ്?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the main questions this page answers?"
-msgstr ""
+msgstr "ഈ പേജ് ഉത്തരം നൽകുന്ന പ്രധാന ചോദ്യങ്ങൾ എന്തൊക്കെയാണ്?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the must-try dishes here?"
-msgstr ""
+msgstr "ഇവിടെ പരീക്ഷിക്കേണ്ട പ്രധാന വിഭവങ്ങൾ എന്തൊക്കെയാണ്?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
@@ -22898,18 +23203,20 @@ msgctxt "Page suggestion prompt"
 msgid ""
 "What are the opening hours, location, and contact details for this place?"
 msgstr ""
+"ഈ സ്ഥലത്തിന്റെ പ്രവർത്തന സമയം, ലൊക്കേഷൻ, ബന്ധപ്പെടാനുള്ള വിവരങ്ങൾ എന്നിവ "
+"എന്തൊക്കെയാണ്?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the pros and cons of this product?"
-msgstr ""
+msgstr "ഈ ഉൽപ്പന്നത്തിന്റെ ഗുണങ്ങളും ദോഷങ്ങളും എന്തൊക്കെയാണ്?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the pros and cons?"
-msgstr ""
+msgstr "ഗുണങ്ങളും ദോഷങ്ങളും എന്തൊക്കെയാണ്?"
 
 # smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
@@ -23015,7 +23322,7 @@ msgstr "ഒരു മെഡിക്കൽ ലേഖനത്തിന്റെ 
 #. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What does this answer?"
-msgstr ""
+msgstr "ഇത് എന്തിനുള്ള ഉത്തരമാണ്?"
 
 # smartling.placeholder_format=C
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
@@ -23033,7 +23340,7 @@ msgstr "ഏതെല്ലാം വിവരങ്ങളാണ് സംരക�
 #. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What interview questions might come up for this role?"
-msgstr ""
+msgstr "ഈ റോളിനായി എന്ത് ഇന്റർവ്യൂ ചോദ്യങ്ങളാണ് വരാൻ സാധ്യതയുള്ളത്?"
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -23042,8 +23349,8 @@ msgid ""
 "What is the Cloud Save bookmarklet and how does it differ from the URL "
 "parameter bookmarklet?"
 msgstr ""
-"Cloud Save ബുക്ക്മാര്‍ക്കലെറ്റ് എന്നാല്‍ എന്ത്? URL പാരാമീറ്റർ ബുക്ക്മാർക്ലറ്റിൽ നിന്ന് ഇത് എങ്ങനെ "
-"വ്യത്യാസപ്പെട്ടിരിക്കുന്നു?"
+"Cloud Save ബുക്ക്മാര്‍ക്കലെറ്റ് എന്നാല്‍ എന്ത്? URL പാരാമീറ്റർ "
+"ബുക്ക്മാർക്ലറ്റിൽ നിന്ന് ഇത് എങ്ങനെ വ്യത്യാസപ്പെട്ടിരിക്കുന്നു?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for looking up the capital city of Albania.
@@ -23055,7 +23362,7 @@ msgstr "അൽബേനിയയുടെ തലസ്ഥാന നഗരം ഏ
 #. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What is the overall verdict and rating for this?"
-msgstr ""
+msgstr "ഇതിനെക്കുറിച്ചുള്ള മൊത്തത്തിലുള്ള തീർപ്പും റേറ്റിംഗും എന്താണ്?"
 
 # smartling.placeholder_format=C
 #. Link to a page with additional information.
@@ -23083,7 +23390,7 @@ msgstr "ആളുകൾ പറയുന്നത്:"
 #. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What should I order?"
-msgstr ""
+msgstr "ഞാൻ എന്താണ് ഓർഡർ ചെയ്യേണ്ടത്?"
 
 # smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
@@ -23101,13 +23408,13 @@ msgstr "പ്രതികരണത്തിൽ എന്തായിരുന�
 #. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What will I learn?"
-msgstr ""
+msgstr "ഞാൻ എന്ത് പഠിക്കും?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What will I need?"
-msgstr ""
+msgstr "എനിക്ക് എന്തൊക്കെ ആവശ്യമാണ്?"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -23119,7 +23426,8 @@ msgstr "നിങ്ങൾ എന്തിനെക്കുറിച്ചാ�
 msgid ""
 "What you watch in DuckDuckGo won't influence your recommendations on YouTube."
 msgstr ""
-"DuckDuckGo-യിൽ നിങ്ങൾ എന്ത് കാണുന്നുവെന്നത് YouTube-ലെ നിങ്ങളുടെ ശുപാർശകളെ സ്വാധീനിക്കില്ല."
+"DuckDuckGo-യിൽ നിങ്ങൾ എന്ത് കാണുന്നുവെന്നത് YouTube-ലെ നിങ്ങളുടെ ശുപാർശകളെ "
+"സ്വാധീനിക്കില്ല."
 
 # smartling.placeholder_format=C
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
@@ -23131,7 +23439,7 @@ msgstr "പുതിയതായി എന്തുണ്ട്"
 #. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What's the verdict?"
-msgstr ""
+msgstr "എന്താണ് തീർപ്പ്?"
 
 # smartling.placeholder_format=C
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -23145,8 +23453,8 @@ msgid ""
 "When buying an electric guitar for a beginner, what are the top product "
 "brands I should consider?"
 msgstr ""
-"ഒരു തുടക്കക്കാരന് വേണ്ടി ഒരു ഇലക്ട്രിക് ഗിറ്റാർ വാങ്ങുമ്പോൾ, ഞാൻ പരിഗണിക്കേണ്ട മുൻനിര ഉൽപ്പന്ന "
-"ബ്രാൻഡുകൾ എന്തൊക്കെയാണ്?"
+"ഒരു തുടക്കക്കാരന് വേണ്ടി ഒരു ഇലക്ട്രിക് ഗിറ്റാർ വാങ്ങുമ്പോൾ, ഞാൻ "
+"പരിഗണിക്കേണ്ട മുൻനിര ഉൽപ്പന്ന ബ്രാൻഡുകൾ എന്തൊക്കെയാണ്?"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -23170,7 +23478,8 @@ msgstr "<strong>%1$s</strong> എവിടെ കാണാം"
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Where it says Homepage click %sSet to Current Page%s."
 msgstr ""
-"അത് ഹോംപേജ് എന്ന് പറയുന്നിടത്ത്, %1$sനിലവിലെ പേജിലേക്ക് സജ്ജമാക്കുക%2$s എന്നത് ക്ലിക്ക് ചെയ്യുക."
+"അത് ഹോംപേജ് എന്ന് പറയുന്നിടത്ത്, %1$sനിലവിലെ പേജിലേക്ക് സജ്ജമാക്കുക%2$s "
+"എന്നത് ക്ലിക്ക് ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Heading of a module showing what streaming services are showing a movie or series, e.g. Where to Watch The Matrix
@@ -23188,7 +23497,7 @@ msgstr "ഏത് സവിശേഷതകളാണ് നഷ്ടമായത�
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Which features are missing? (optional)"
-msgstr ""
+msgstr "ഏത് സവിശേഷതകളാണ് നഷ്ടമായത്? (ഓപ്ഷണൽ)"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
@@ -23211,12 +23520,14 @@ msgstr "ആരാണ് ഞങ്ങൾ"
 msgctxt "Page suggestion prompt"
 msgid "Who are the main cast and crew, and what else are they known for?"
 msgstr ""
+"പ്രധാന അഭിനേതാക്കളും അണിയറപ്രവർത്തകരും ആരൊക്കെയാണ്, അവർ മറ്റെന്തിനൊക്കെയാണ് "
+"അറിയപ്പെടുന്നത്?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Who is this person?"
-msgstr ""
+msgstr "ആരാണ് ഈ വ്യക്തി?"
 
 # smartling.placeholder_format=C
 #. Header above a collection of privacy-related links.
@@ -23588,7 +23899,8 @@ msgctxt "cloudsave"
 msgid ""
 "Yes, we throw away data when you’re done with it, and it cannot be recovered."
 msgstr ""
-"അതെ, നിങ്ങൾ ഡാറ്റ പൂർത്തിയാക്കുമ്പോൾ ഞങ്ങൾ അത് വലിച്ചെറിയുന്നു, അത് വീണ്ടെടുക്കാൻ കഴിയില്ല."
+"അതെ, നിങ്ങൾ ഡാറ്റ പൂർത്തിയാക്കുമ്പോൾ ഞങ്ങൾ അത് വലിച്ചെറിയുന്നു, അത് "
+"വീണ്ടെടുക്കാൻ കഴിയില്ല."
 
 # smartling.placeholder_format=C
 #. Option for the filter-by-date search.
@@ -23608,8 +23920,8 @@ msgid ""
 "You are chatting with %s. AI chats may display inaccurate or offensive "
 "information."
 msgstr ""
-"നിങ്ങൾ %1$s എന്നയാളുമായി ചാറ്റ് ചെയ്യുന്നു. AI ചാറ്റുകൾ കൃത്യമല്ലാത്തതോ കുറ്റകരമായതോ ആയ "
-"വിവരങ്ങൾ പ്രദർശിപ്പിച്ചേക്കാം."
+"നിങ്ങൾ %1$s എന്നയാളുമായി ചാറ്റ് ചെയ്യുന്നു. AI ചാറ്റുകൾ കൃത്യമല്ലാത്തതോ "
+"കുറ്റകരമായതോ ആയ വിവരങ്ങൾ പ്രദർശിപ്പിച്ചേക്കാം."
 
 # smartling.placeholder_format=C
 #. Provide users with the ability to retry their search on a different search engine. First placeholder will be a link with the text "try your search again" OR "try your search later". Second is a URL to the !bangs page: https://duckduckgo.com/bangs.
@@ -23618,8 +23930,8 @@ msgid ""
 "You can %s or search directly on other search engines from DuckDuckGo using "
 "%s search shortcuts."
 msgstr ""
-"%2$s തിരയൽ കുറുക്കുവഴികൾ ഉപയോഗിച്ച് നിങ്ങൾക്ക് %1$s അല്ലെങ്കിൽ DuckDuckGo-യിൽ നിന്ന് മറ്റ് "
-"തിരയൽ എഞ്ചിനുകളിൽ നേരിട്ട് തിരയാൻ കഴിയും."
+"%2$s തിരയൽ കുറുക്കുവഴികൾ ഉപയോഗിച്ച് നിങ്ങൾക്ക് %1$s അല്ലെങ്കിൽ "
+"DuckDuckGo-യിൽ നിന്ന് മറ്റ് തിരയൽ എഞ്ചിനുകളിൽ നേരിട്ട് തിരയാൻ കഴിയും."
 
 # smartling.placeholder_format=C
 #. Text informing the user that they can access DuckDuckGo AI Chat directly at a specific URL. The placeholder %s will be replaced with the link. Example: 'You can access DuckDuckGo AI Chat directly at duck.ai.'
@@ -23633,8 +23945,8 @@ msgctxt "duckassist"
 msgid ""
 "You can adjust how %s works or turn it off anytime in %sSearch Settings%s."
 msgstr ""
-"നിങ്ങൾക്ക് %1$s എങ്ങനെ പ്രവർത്തിക്കുന്നുവെന്നത് ക്രമീകരിക്കാനോ %2$sതിരയൽ ക്രമീകരണങ്ങൾ%3$s-ൽ "
-"എപ്പോൾ വേണമെങ്കിലും അത് ഓഫാക്കാനോ കഴിയും."
+"നിങ്ങൾക്ക് %1$s എങ്ങനെ പ്രവർത്തിക്കുന്നുവെന്നത് ക്രമീകരിക്കാനോ %2$sതിരയൽ "
+"ക്രമീകരണങ്ങൾ%3$s-ൽ എപ്പോൾ വേണമെങ്കിലും അത് ഓഫാക്കാനോ കഴിയും."
 
 # smartling.placeholder_format=C
 #. Assist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate Assist.
@@ -23643,21 +23955,22 @@ msgid ""
 "You can adjust how Assist works or turn it off anytime in %sSearch "
 "Settings%s."
 msgstr ""
-"Assist എങ്ങനെ പ്രവർത്തിക്കുന്നുവെന്നത് ക്രമീകരിക്കാനോ %1$sതിരയൽ ക്രമീകരണങ്ങൾ%2$s-ൽ അത് "
-"എപ്പോൾ വേണമെങ്കിലും ഓഫാക്കാനോ നിങ്ങൾക്ക് കഴിയും."
+"Assist എങ്ങനെ പ്രവർത്തിക്കുന്നുവെന്നത് ക്രമീകരിക്കാനോ %1$sതിരയൽ "
+"ക്രമീകരണങ്ങൾ%2$s-ൽ അത് എപ്പോൾ വേണമെങ്കിലും ഓഫാക്കാനോ നിങ്ങൾക്ക് കഴിയും."
 
 # smartling.placeholder_format=C
 msgid "You can also use %sDuck.ai%s to answer questions or summarize text."
 msgstr ""
-"ചോദ്യങ്ങൾക്ക് ഉത്തരം നൽകാനും വാചകം സംഗ്രഹിക്കാനും നിങ്ങൾക്ക് %1$sDuck.ai%2$s ഉപയോഗിക്കാം."
+"ചോദ്യങ്ങൾക്ക് ഉത്തരം നൽകാനും വാചകം സംഗ്രഹിക്കാനും നിങ്ങൾക്ക് %1$sDuck.ai%2$s "
+"ഉപയോഗിക്കാം."
 
 # smartling.placeholder_format=C
 msgid ""
 "You can also use %sDuckDuckGo AI Chat%s to answer questions or summarize "
 "text."
 msgstr ""
-"ചോദ്യങ്ങൾക്ക് ഉത്തരം നൽകാനോ വാചകം സംഗ്രഹിക്കാനോ നിങ്ങൾക്ക് %1$sDuckDuckGo AI Chat%2$s "
-"ഉപയോഗിക്കാനും കഴിയും."
+"ചോദ്യങ്ങൾക്ക് ഉത്തരം നൽകാനോ വാചകം സംഗ്രഹിക്കാനോ നിങ്ങൾക്ക് %1$sDuckDuckGo AI "
+"Chat%2$s ഉപയോഗിക്കാനും കഴിയും."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach more text selections than are allowed. Placeholder is the maximum number of text selections. E.g. You can attach up to 5 text selections.
@@ -23671,8 +23984,8 @@ msgid ""
 "You can change how frequently you see Search Assist, or turn it off "
 "entirely, in %sSearch Settings%s."
 msgstr ""
-"%1$sതിരയൽ ക്രമീകരണങ്ങൾ%2$s എന്നതിൽ നിങ്ങൾക്ക് എത്ര തവണ Search Assist കാണണമെന്നത് "
-"മാറ്റാനോ, പൂർണ്ണമായും ഓഫാക്കാനോ കഴിയും."
+"%1$sതിരയൽ ക്രമീകരണങ്ങൾ%2$s എന്നതിൽ നിങ്ങൾക്ക് എത്ര തവണ Search Assist "
+"കാണണമെന്നത് മാറ്റാനോ, പൂർണ്ണമായും ഓഫാക്കാനോ കഴിയും."
 
 # smartling.placeholder_format=C
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
@@ -23687,8 +24000,8 @@ msgid ""
 "You can do this by saving your settings under a different passphrase, "
 "optionally deleting the first set."
 msgstr ""
-"ആദ്യ സെറ്റ് ഓപ്ഷണലായി ഇല്ലാതാക്കിക്കൊണ്ട്, നിങ്ങളുടെ ക്രമീകരണം മറ്റൊരു പാസ്‌ഫ്രെയ്സിന് കീഴിൽ "
-"സംരക്ഷിച്ചുകൊണ്ട് നിങ്ങൾക്ക് ഇത് ചെയ്യാൻ കഴിയും."
+"ആദ്യ സെറ്റ് ഓപ്ഷണലായി ഇല്ലാതാക്കിക്കൊണ്ട്, നിങ്ങളുടെ ക്രമീകരണം മറ്റൊരു "
+"പാസ്‌ഫ്രെയ്സിന് കീഴിൽ സംരക്ഷിച്ചുകൊണ്ട് നിങ്ങൾക്ക് ഇത് ചെയ്യാൻ കഴിയും."
 
 # smartling.placeholder_format=C
 #. Prefix for filename location sentence.
@@ -23712,7 +24025,8 @@ msgstr "%1$sതിരയൽ ക്രമീകരണത്തിൽ%2$s നി�
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
 msgstr ""
-"നിങ്ങൾക്ക് ഇപ്പോൾ ഈ ഉപകരണത്തിൽ 100 ചാറ്റുകൾ വരെ സംരക്ഷിക്കാൻ കഴിയും. ചാറ്റ് തുടർന്നോളൂ!"
+"നിങ്ങൾക്ക് ഇപ്പോൾ ഈ ഉപകരണത്തിൽ 100 ചാറ്റുകൾ വരെ സംരക്ഷിക്കാൻ കഴിയും. ചാറ്റ് "
+"തുടർന്നോളൂ!"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -23769,8 +24083,8 @@ msgid ""
 "You can only block up to %s sites. To block %s, you'll need to unblock "
 "another site first."
 msgstr ""
-"നിങ്ങൾക്ക് %1$s സൈറ്റുകൾ വരെ മാത്രമേ ബ്ലോക്ക് ചെയ്യാനാകൂ. %2$s തടയാൻ, ആദ്യം മറ്റൊരു സൈറ്റ് "
-"അൺബ്ലോക്ക് ചെയ്യണം."
+"നിങ്ങൾക്ക് %1$s സൈറ്റുകൾ വരെ മാത്രമേ ബ്ലോക്ക് ചെയ്യാനാകൂ. %2$s തടയാൻ, ആദ്യം "
+"മറ്റൊരു സൈറ്റ് അൺബ്ലോക്ക് ചെയ്യണം."
 
 # smartling.placeholder_format=C
 #. Text explaining the benefits of the cloud save feature.
@@ -23806,7 +24120,9 @@ msgstr "നിങ്ങൾക്ക് ഈ പുതിയ ഡൊമെയ്ന
 #. Text explaining the benefits of the cloud save feature.
 msgctxt "cloudsave"
 msgid "You can store several sets of settings for different purposes."
-msgstr "പലതരം ആവശ്യങ്ങൾക്കായി ക്രമീകരണത്തിന്റെ വിവിധ സെറ്റുകൾ നിങ്ങൾക്ക് ഇവിടെ സൂക്ഷിക്കാം."
+msgstr ""
+"പലതരം ആവശ്യങ്ങൾക്കായി ക്രമീകരണത്തിന്റെ വിവിധ സെറ്റുകൾ നിങ്ങൾക്ക് ഇവിടെ "
+"സൂക്ഷിക്കാം."
 
 # smartling.placeholder_format=C
 #. Instructions for user once they've failed the bot challenge
@@ -23827,8 +24143,8 @@ msgid ""
 "You now have access to %s, higher AI reasoning, and 2x higher usage limits "
 "than Plus."
 msgstr ""
-"നിങ്ങൾക്ക് ഇപ്പോൾ %1$s എന്നതിലേക്ക് ആക്സസ് ഉണ്ട്, ഉയർന്ന AI റീസണിംഗ്, Plus-നേക്കാൾ 2 മടങ്ങ് "
-"ഉയർന്ന ഉപയോഗ പരിധി എന്നിവയുണ്ട്."
+"നിങ്ങൾക്ക് ഇപ്പോൾ %1$s എന്നതിലേക്ക് ആക്സസ് ഉണ്ട്, ഉയർന്ന AI റീസണിംഗ്, "
+"Plus-നേക്കാൾ 2 മടങ്ങ് ഉയർന്ന ഉപയോഗ പരിധി എന്നിവയുണ്ട്."
 
 # smartling.placeholder_format=C
 #. Description text for the welcome modal displayed after the user subscribes to DuckDuckGo.
@@ -23837,8 +24153,9 @@ msgid ""
 "You now have access to advanced AI models. You can access the VPN and other "
 "DuckDuckGo subscription protections in the DuckDuckGo browser."
 msgstr ""
-"നിങ്ങൾക്ക് ഇപ്പോൾ നൂതന AI മോഡലുകളിലേക്ക് ആക്‌സസ് ഉണ്ട്. നിങ്ങൾക്ക് DuckDuckGo ബ്രൗസറിൽ VPN, "
-"മറ്റ് DuckDuckGo സബ്സ്ക്രിപ്ഷൻ പരിരക്ഷകൾ ആക്സസ് ചെയ്യാം."
+"നിങ്ങൾക്ക് ഇപ്പോൾ നൂതന AI മോഡലുകളിലേക്ക് ആക്‌സസ് ഉണ്ട്. നിങ്ങൾക്ക് "
+"DuckDuckGo ബ്രൗസറിൽ VPN, മറ്റ് DuckDuckGo സബ്സ്ക്രിപ്ഷൻ പരിരക്ഷകൾ ആക്സസ് "
+"ചെയ്യാം."
 
 # smartling.placeholder_format=C
 #. Welcome message that appears after the DuckDuckGo extension is installed.
@@ -23860,9 +24177,9 @@ msgid ""
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
 msgstr ""
-"ഈ ബ്രൗസറിൽ നിന്ന് നിങ്ങളുടെസംരക്ഷിച്ച ചാറ്റുകൾ ഇനി നിങ്ങൾക്ക് ആക്‌സസ് ചെയ്യാൻ കഴിയില്ല. അവസാന "
-"30 ചാറ്റുകൾ ഇപ്പോഴും ലോക്കൽ സ്റ്റോറേജിൽ ലഭ്യമാകും. ഇത് എൻക്രിപ്റ്റ് ചെയ്ത സെർവറിൽ നിന്ന് "
-"നിങ്ങളുടെ ചാറ്റുകൾ ഇല്ലാതാക്കില്ല."
+"ഈ ബ്രൗസറിൽ നിന്ന് നിങ്ങളുടെസംരക്ഷിച്ച ചാറ്റുകൾ ഇനി നിങ്ങൾക്ക് ആക്‌സസ് "
+"ചെയ്യാൻ കഴിയില്ല. അവസാന 30 ചാറ്റുകൾ ഇപ്പോഴും ലോക്കൽ സ്റ്റോറേജിൽ ലഭ്യമാകും. "
+"ഇത് എൻക്രിപ്റ്റ് ചെയ്ത സെർവറിൽ നിന്ന് നിങ്ങളുടെ ചാറ്റുകൾ ഇല്ലാതാക്കില്ല."
 
 # smartling.placeholder_format=C
 #. Explains that turning off disconnects this browser only; the last 30 chats stay in local storage and the encrypted server backup is not deleted.
@@ -23872,9 +24189,9 @@ msgid ""
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
 msgstr ""
-"ഈ ബ്രൗസറിൽ നിന്ന് നിങ്ങളുടെ സംരക്ഷിച്ച ചാറ്റുകൾ ഇനി ആക്‌സസ് ചെയ്യാൻ കഴിയില്ല. അവസാന 30 "
-"ചാറ്റുകൾ ഇപ്പോഴും ലോക്കൽ സ്റ്റോറേജിൽ ലഭ്യമാകും. ഇത് എൻക്രിപ്റ്റ് ചെയ്ത സെർവറിൽ നിന്ന് നിങ്ങളുടെ "
-"ചാറ്റുകൾ ഇല്ലാതാക്കില്ല."
+"ഈ ബ്രൗസറിൽ നിന്ന് നിങ്ങളുടെ സംരക്ഷിച്ച ചാറ്റുകൾ ഇനി ആക്‌സസ് ചെയ്യാൻ "
+"കഴിയില്ല. അവസാന 30 ചാറ്റുകൾ ഇപ്പോഴും ലോക്കൽ സ്റ്റോറേജിൽ ലഭ്യമാകും. ഇത് "
+"എൻക്രിപ്റ്റ് ചെയ്ത സെർവറിൽ നിന്ന് നിങ്ങളുടെ ചാറ്റുകൾ ഇല്ലാതാക്കില്ല."
 
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
@@ -23888,8 +24205,8 @@ msgid ""
 "You'll receive automatic DuckDuckGo app updates once you have the latest "
 "version."
 msgstr ""
-"ഏറ്റവും പുതിയ പതിപ്പ് ലഭിച്ചുകഴിഞ്ഞാൽ നിങ്ങൾക്ക് സ്വയമേവയുള്ള DuckDuckGo ആപ്പ് അപ്ഡേറ്റുകൾ "
-"ലഭിക്കും."
+"ഏറ്റവും പുതിയ പതിപ്പ് ലഭിച്ചുകഴിഞ്ഞാൽ നിങ്ങൾക്ക് സ്വയമേവയുള്ള DuckDuckGo "
+"ആപ്പ് അപ്ഡേറ്റുകൾ ലഭിക്കും."
 
 # smartling.placeholder_format=C
 #. shown when DDG is selected after eu preference menu on android
@@ -23898,8 +24215,9 @@ msgid ""
 "You're now searching privately in Chrome. Use our app instead of Chrome to "
 "browse privately too. It’s already installed and can:"
 msgstr ""
-"നിങ്ങൾ ഇപ്പോൾ Chrome-ൽ സ്വകാര്യമായി തിരയുന്നു. സ്വകാര്യമായി ബ്രൗസ് ചെയ്യുന്നതിന് Chrome-ന് "
-"പകരം ഞങ്ങളുടെ ആപ്പും ഉപയോഗിക്കുക. ഇത് ഇതിനകം ഇൻസ്റ്റാൾ ചെയ്തിട്ടുണ്ട്, ഇതിന് ഇവ ചെയ്യാനാകും:"
+"നിങ്ങൾ ഇപ്പോൾ Chrome-ൽ സ്വകാര്യമായി തിരയുന്നു. സ്വകാര്യമായി ബ്രൗസ് "
+"ചെയ്യുന്നതിന് Chrome-ന് പകരം ഞങ്ങളുടെ ആപ്പും ഉപയോഗിക്കുക. ഇത് ഇതിനകം "
+"ഇൻസ്റ്റാൾ ചെയ്തിട്ടുണ്ട്, ഇതിന് ഇവ ചെയ്യാനാകും:"
 
 # smartling.placeholder_format=C
 #. Confirmation message that appears after the DuckDuckGo browser extension is installed.
@@ -23912,8 +24230,8 @@ msgid ""
 "You're now searching with privacy. %sGet tips to reduce your footprint even "
 "more."
 msgstr ""
-"നിങ്ങൾ ഇപ്പോൾ സ്വകാര്യത ഉപയോഗിച്ച് തിരയുന്നു. %1$sനിങ്ങളുടെ പാദമുദ്ര ഇനിയും കുറയ്ക്കുന്നതിന് "
-"നുറുങ്ങുകൾ നേടുക."
+"നിങ്ങൾ ഇപ്പോൾ സ്വകാര്യത ഉപയോഗിച്ച് തിരയുന്നു. %1$sനിങ്ങളുടെ പാദമുദ്ര ഇനിയും "
+"കുറയ്ക്കുന്നതിന് നുറുങ്ങുകൾ നേടുക."
 
 # smartling.placeholder_format=C
 #. Title of a notice thanking the user for turning off their adblocker
@@ -23957,8 +24275,8 @@ msgid ""
 "You've reached the maximum number of messages for the moment. Please try "
 "again later."
 msgstr ""
-"നിങ്ങൾ തൽക്കാലത്തേക്ക് സന്ദേശങ്ങളുടെ പരമാവധി എണ്ണത്തിൽ എത്തിയിരിക്കുന്നു. ദയവായി വീണ്ടും "
-"ശ്രമിക്കുക."
+"നിങ്ങൾ തൽക്കാലത്തേക്ക് സന്ദേശങ്ങളുടെ പരമാവധി എണ്ണത്തിൽ എത്തിയിരിക്കുന്നു. "
+"ദയവായി വീണ്ടും ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -23985,8 +24303,9 @@ msgid ""
 "You've run out of Sync & Backup storage for Duck.ai chats with attachments. "
 "Delete the %s oldest chats to resume Sync. Pinned chats will not be deleted."
 msgstr ""
-"അറ്റാച്ചുമെന്റുകളുള്ള Duck.ai ചാറ്റുകൾക്കുള്ള നിങ്ങളുടെ Sync & Backup സംഭരണം തീർന്നു. സമന്വയം "
-"പുനരാരംഭിക്കാൻ ഏറ്റവും പഴയ %1$s ചാറ്റുകൾ ഇല്ലാതാക്കുക. പിൻ ചെയ്ത ചാറ്റുകൾ ഇല്ലാതാക്കില്ല."
+"അറ്റാച്ചുമെന്റുകളുള്ള Duck.ai ചാറ്റുകൾക്കുള്ള നിങ്ങളുടെ Sync & Backup സംഭരണം "
+"തീർന്നു. സമന്വയം പുനരാരംഭിക്കാൻ ഏറ്റവും പഴയ %1$s ചാറ്റുകൾ ഇല്ലാതാക്കുക. പിൻ "
+"ചെയ്ത ചാറ്റുകൾ ഇല്ലാതാക്കില്ല."
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -23997,8 +24316,8 @@ msgid ""
 "deleted."
 msgstr ""
 "Duck.ai ചാറ്റുകൾക്കുള്ള Sync & Backup സ്റ്റോറേജ് തീർന്നിരിക്കുന്നു. സമന്വയം "
-"പുനരാരംഭിക്കുന്നതിന് അറ്റാച്ചുമെന്റുകളുള്ള %1$s ഏറ്റവും പഴയ ചാറ്റുകൾ ഇല്ലാതാക്കുക. പിൻ ചെയ്ത "
-"ചാറ്റുകൾ ഇല്ലാതാക്കില്ല."
+"പുനരാരംഭിക്കുന്നതിന് അറ്റാച്ചുമെന്റുകളുള്ള %1$s ഏറ്റവും പഴയ ചാറ്റുകൾ "
+"ഇല്ലാതാക്കുക. പിൻ ചെയ്ത ചാറ്റുകൾ ഇല്ലാതാക്കില്ല."
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the sync storage limit.
@@ -24012,8 +24331,9 @@ msgid ""
 "YouTube (owned by Google) does not let you watch videos anonymously. As "
 "such, watching YouTube videos here will be tracked by YouTube/Google."
 msgstr ""
-"(Google ഉടമസ്ഥതയിലുള്ള) YouTube അജ്ഞാതനായി വീഡിയോകൾ കാണാൻ നിങ്ങളെ അനുവദിക്കുന്നില്ല. "
-"അതുപോലെ, ഇവിടെ YouTube വീഡിയോകൾ കാണുന്നത് YouTube/Google ട്രാക്ക് ചെയ്യും."
+"(Google ഉടമസ്ഥതയിലുള്ള) YouTube അജ്ഞാതനായി വീഡിയോകൾ കാണാൻ നിങ്ങളെ "
+"അനുവദിക്കുന്നില്ല. അതുപോലെ, ഇവിടെ YouTube വീഡിയോകൾ കാണുന്നത് "
+"YouTube/Google ട്രാക്ക് ചെയ്യും."
 
 # smartling.placeholder_format=C
 #. Label for a privacy disclaimer related to YouTube videos
@@ -24057,9 +24377,9 @@ msgid ""
 "disconnected from sync. Your %s most recent chats will be available in local "
 "storage on these browsers:"
 msgstr ""
-"DuckDuckGo-യുടെ സെർവറിൽ നിന്ന് നിങ്ങളുടെ ബാക്കപ്പ് ഇല്ലാതാക്കപ്പെടും. എല്ലാ ഉപകരണങ്ങളും "
-"സമന്വയത്തിൽ നിന്ന് വിച്ഛേദിക്കപ്പെടും. നിങ്ങളുടെ ഏറ്റവും പുതിയ %1$s ചാറ്റുകൾ ഈ ബ്രൗസറുകളിലെ "
-"ലോക്കൽ സ്റ്റോറേജിൽ ലഭ്യമാകും:"
+"DuckDuckGo-യുടെ സെർവറിൽ നിന്ന് നിങ്ങളുടെ ബാക്കപ്പ് ഇല്ലാതാക്കപ്പെടും. എല്ലാ "
+"ഉപകരണങ്ങളും സമന്വയത്തിൽ നിന്ന് വിച്ഛേദിക്കപ്പെടും. നിങ്ങളുടെ ഏറ്റവും പുതിയ "
+"%1$s ചാറ്റുകൾ ഈ ബ്രൗസറുകളിലെ ലോക്കൽ സ്റ്റോറേജിൽ ലഭ്യമാകും:"
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list.
@@ -24069,9 +24389,9 @@ msgid ""
 "disconnected from sync. Your 100 most recent chats will be available in "
 "local storage on these browsers:"
 msgstr ""
-"DuckDuckGo-യുടെ സെർവറിൽ നിന്ന് നിങ്ങളുടെ ബാക്കപ്പ് ഇല്ലാതാക്കപ്പെടും. എല്ലാ ഉപകരണങ്ങളും "
-"സമന്വയത്തിൽ നിന്ന് വിച്ഛേദിക്കപ്പെടും. നിങ്ങളുടെ ഏറ്റവും പുതിയ 100 ചാറ്റുകൾ ഈ ബ്രൗസറുകളിലെ "
-"ലോക്കൽ സ്റ്റോറേജിൽ ലഭ്യമാകും:"
+"DuckDuckGo-യുടെ സെർവറിൽ നിന്ന് നിങ്ങളുടെ ബാക്കപ്പ് ഇല്ലാതാക്കപ്പെടും. എല്ലാ "
+"ഉപകരണങ്ങളും സമന്വയത്തിൽ നിന്ന് വിച്ഛേദിക്കപ്പെടും. നിങ്ങളുടെ ഏറ്റവും പുതിയ "
+"100 ചാറ്റുകൾ ഈ ബ്രൗസറുകളിലെ ലോക്കൽ സ്റ്റോറേജിൽ ലഭ്യമാകും:"
 
 # smartling.placeholder_format=C
 #. List item indicating that a site exclusion filter is currently active for the search
@@ -24087,7 +24407,9 @@ msgstr "നിങ്ങൾ ഈ ലിങ്ക് സന്ദർശിച്ച
 # smartling.placeholder_format=C
 msgctxt "new tab page"
 msgid "Your browser provides a list of your most-visited sites."
-msgstr "നിങ്ങൾ ഏറ്റവും കൂടുതൽ സന്ദർശിച്ച സൈറ്റുകളുടെ ഒരു ലിസ്റ്റ് നിങ്ങളുടെ ബ്രൗസർ നൽകുന്നു."
+msgstr ""
+"നിങ്ങൾ ഏറ്റവും കൂടുതൽ സന്ദർശിച്ച സൈറ്റുകളുടെ ഒരു ലിസ്റ്റ് നിങ്ങളുടെ ബ്രൗസർ "
+"നൽകുന്നു."
 
 # smartling.placeholder_format=C
 #. Used as a description in a menu
@@ -24096,8 +24418,8 @@ msgid ""
 "Your browser provides a list of your most-visited sites. DuckDuckGo never "
 "has access to this data."
 msgstr ""
-"നിങ്ങൾ ഏറ്റവും കൂടുതൽ സന്ദർശിച്ച സൈറ്റുകളുടെ ഒരു ലിസ്റ്റ് നിങ്ങളുടെ ബ്രൗസർ നൽകുന്നു. DuckDuckGo-"
-"യ്ക്ക് ഒരിക്കലും ഈ ഡാറ്റയിലേക്ക് ആക്സസ് ഇല്ല."
+"നിങ്ങൾ ഏറ്റവും കൂടുതൽ സന്ദർശിച്ച സൈറ്റുകളുടെ ഒരു ലിസ്റ്റ് നിങ്ങളുടെ ബ്രൗസർ "
+"നൽകുന്നു. DuckDuckGo-യ്ക്ക് ഒരിക്കലും ഈ ഡാറ്റയിലേക്ക് ആക്സസ് ഇല്ല."
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
@@ -24105,8 +24427,8 @@ msgid ""
 "Your browser provides the list of most-visited sites. DuckDuckGo never has "
 "access to this data."
 msgstr ""
-"നിങ്ങളുടെ ബ്രൗസർ ഏറ്റവും കൂടുതൽ സന്ദർശിച്ച സൈറ്റുകളുടെ പട്ടിക നൽകുന്നു. DuckDuckGo-യ്ക്ക് "
-"ഒരിക്കലും ഈ ഡാറ്റയിലേക്ക് ആക്സസ് ഇല്ല."
+"നിങ്ങളുടെ ബ്രൗസർ ഏറ്റവും കൂടുതൽ സന്ദർശിച്ച സൈറ്റുകളുടെ പട്ടിക നൽകുന്നു. "
+"DuckDuckGo-യ്ക്ക് ഒരിക്കലും ഈ ഡാറ്റയിലേക്ക് ആക്സസ് ഇല്ല."
 
 # smartling.placeholder_format=C
 #. Disclaimer text shown bellow chat input. Example: 'You are chatting with GPT-3. AI chats may display inaccurate or offensive information.'
@@ -24115,8 +24437,8 @@ msgid ""
 "Your chat with %s is private. AI chats may display inaccurate or offensive "
 "information."
 msgstr ""
-"%1$s -നോടുള്ള നിങ്ങളുടെ ചാറ്റ് സ്വകാര്യമാണ്. AI ചാറ്റുകൾ കൃത്യമല്ലാത്തതോ കുറ്റകരമായതോ ആയ "
-"വിവരങ്ങൾ പ്രദർശിപ്പിച്ചേക്കാം."
+"%1$s -നോടുള്ള നിങ്ങളുടെ ചാറ്റ് സ്വകാര്യമാണ്. AI ചാറ്റുകൾ കൃത്യമല്ലാത്തതോ "
+"കുറ്റകരമായതോ ആയ വിവരങ്ങൾ പ്രദർശിപ്പിച്ചേക്കാം."
 
 # smartling.placeholder_format=C
 #. Body copy shown after Sync & Backup is enabled, confirming chats are now syncing.
@@ -24129,15 +24451,16 @@ msgstr "നിങ്ങളുടെ ചാറ്റുകൾ ഇപ്പോൾ 
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never saved or used to train AI models"
 msgstr ""
-"നിങ്ങളുടെ ചാറ്റുകൾ സ്വകാര്യമാണ്, മാത്രമല്ല AI മോഡലുകളെ പരിശീലിപ്പിക്കാൻ ഒരിക്കലും "
-"സംരക്ഷിക്കുകയോ ഉപയോഗിക്കുകയോ ചെയ്യുന്നില്ല"
+"നിങ്ങളുടെ ചാറ്റുകൾ സ്വകാര്യമാണ്, മാത്രമല്ല AI മോഡലുകളെ പരിശീലിപ്പിക്കാൻ "
+"ഒരിക്കലും സംരക്ഷിക്കുകയോ ഉപയോഗിക്കുകയോ ചെയ്യുന്നില്ല"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never used to train AI models"
 msgstr ""
-"നിങ്ങളുടെ ചാറ്റുകൾ സ്വകാര്യമാണ്, അവ AI മോഡലുകളെ പരിശീലിപ്പിക്കാൻ ഒരിക്കലും ഉപയോഗിക്കില്ല"
+"നിങ്ങളുടെ ചാറ്റുകൾ സ്വകാര്യമാണ്, അവ AI മോഡലുകളെ പരിശീലിപ്പിക്കാൻ ഒരിക്കലും "
+"ഉപയോഗിക്കില്ല"
 
 # smartling.placeholder_format=C
 #. Text for a description of the active privacy protection for DuckDuckGo's AI Chat feature.
@@ -24163,8 +24486,8 @@ msgctxt "Menu item description"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
 msgstr ""
-"നിങ്ങളുടെ ചാറ്റുകൾ സ്വകാര്യമാണ്, ഞങ്ങൾ ഒരിക്കലും സംരക്ഷിച്ചിട്ടില്ല, AI മോഡലുകളെ "
-"പരിശീലിപ്പിക്കാൻ ഉപയോഗിക്കുന്നില്ല."
+"നിങ്ങളുടെ ചാറ്റുകൾ സ്വകാര്യമാണ്, ഞങ്ങൾ ഒരിക്കലും സംരക്ഷിച്ചിട്ടില്ല, AI "
+"മോഡലുകളെ പരിശീലിപ്പിക്കാൻ ഉപയോഗിക്കുന്നില്ല."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the active privacy protection.
@@ -24172,8 +24495,8 @@ msgctxt "Modal body for privacy"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
 msgstr ""
-"നിങ്ങളുടെ ചാറ്റുകൾ സ്വകാര്യമാണ്, ഞങ്ങൾ ഒരിക്കലും സംരക്ഷിച്ചിട്ടില്ല, AI മോഡലുകളെ "
-"പരിശീലിപ്പിക്കാൻ ഉപയോഗിക്കുന്നില്ല."
+"നിങ്ങളുടെ ചാറ്റുകൾ സ്വകാര്യമാണ്, ഞങ്ങൾ ഒരിക്കലും സംരക്ഷിച്ചിട്ടില്ല, AI "
+"മോഡലുകളെ പരിശീലിപ്പിക്കാൻ ഉപയോഗിക്കുന്നില്ല."
 
 # smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that chats are stored locally on the user's device.
@@ -24188,9 +24511,9 @@ msgid ""
 "Your chats are still private, anonymized by us, and not used to train AI "
 "models. Follow these steps to keep your chat history."
 msgstr ""
-"നിങ്ങളുടെ ചാറ്റുകൾ ഇപ്പോഴും സ്വകാര്യമാണ്, ഞങ്ങൾ അത് അജ്ഞാതമാക്കിയിരിക്കുന്നു, കൂടാതെ അവയെ AI "
-"മോഡലുകളെ പരിശീലിപ്പിക്കാൻ ഉപയോഗിക്കാറില്ല. നിങ്ങളുടെ ചാറ്റ് ചരിത്രം സൂക്ഷിക്കാൻ ഈ ഘട്ടങ്ങൾ "
-"പാലിക്കൂ."
+"നിങ്ങളുടെ ചാറ്റുകൾ ഇപ്പോഴും സ്വകാര്യമാണ്, ഞങ്ങൾ അത് "
+"അജ്ഞാതമാക്കിയിരിക്കുന്നു, കൂടാതെ അവയെ AI മോഡലുകളെ പരിശീലിപ്പിക്കാൻ "
+"ഉപയോഗിക്കാറില്ല. നിങ്ങളുടെ ചാറ്റ് ചരിത്രം സൂക്ഷിക്കാൻ ഈ ഘട്ടങ്ങൾ പാലിക്കൂ."
 
 # smartling.placeholder_format=C
 #. Body shown after import completes.
@@ -24199,8 +24522,8 @@ msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
 msgstr ""
-"നിങ്ങളുടെ ചാറ്റുകൾ ഇംപോർട്ട് ചെയ്തിരിക്കുന്നു. നിങ്ങൾ മുന്നോട്ട് പോയി Duck.ai-ൽ നിർത്തിയിടത്ത് "
-"നിന്ന് തുടരൂ."
+"നിങ്ങളുടെ ചാറ്റുകൾ ഇംപോർട്ട് ചെയ്തിരിക്കുന്നു. നിങ്ങൾ മുന്നോട്ട് പോയി "
+"Duck.ai-ൽ നിർത്തിയിടത്ത് നിന്ന് തുടരൂ."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.
@@ -24248,8 +24571,8 @@ msgctxt ""
 "an AI response"
 msgid "Your feedback is anonymized and not used to train AI."
 msgstr ""
-"നിങ്ങളുടെ ഫീഡ്‌ബാക്ക് അജ്ഞാതമാക്കിയിരിക്കുന്നു, കൂടാതെ AI മോഡലുകളെ പരിശീലിപ്പിക്കാൻ "
-"ഉപയോഗിക്കാറില്ല."
+"നിങ്ങളുടെ ഫീഡ്‌ബാക്ക് അജ്ഞാതമാക്കിയിരിക്കുന്നു, കൂടാതെ AI മോഡലുകളെ "
+"പരിശീലിപ്പിക്കാൻ ഉപയോഗിക്കാറില്ല."
 
 # smartling.placeholder_format=C
 #. Explains that the User's Location is always private to DuckDuckGo.
@@ -24278,10 +24601,11 @@ msgid ""
 "browser. We save the settings file using the key as the name. DuckDuckGo "
 "never knows your passphrase."
 msgstr ""
-"%1$sSHA-2%2$s എന്നറിയപ്പെടുന്ന ഒരു സുരക്ഷിത ഹാഷ് അൽഗോരിതം ഉപയോഗിച്ച് നിങ്ങളുടെ പാസ്‌ഫ്രെയ്സ് "
-"ഒരു 512-ബിറ്റ് കീ സൃഷ്ടിക്കുന്നു. കീയും അനുബന്ധ ക്രമീകരണ ഫയലും മാത്രമേ നിങ്ങളുടെ ബ്രൗസർ "
-"ഉപേക്ഷിക്കുകയുള്ളൂ. പേരായി കീ ഉപയോഗിച്ചുകൊണ്ട് ക്രമീകരണ ഫയൽ ഞങ്ങൾ സംരക്ഷിക്കുന്നു. DuckDuckGo-"
-"യ്ക്ക് നിങ്ങളുടെ പാസ്‌ഫ്രെയ്സ് ഒരിക്കലും അറിയില്ല."
+"%1$sSHA-2%2$s എന്നറിയപ്പെടുന്ന ഒരു സുരക്ഷിത ഹാഷ് അൽഗോരിതം ഉപയോഗിച്ച് "
+"നിങ്ങളുടെ പാസ്‌ഫ്രെയ്സ് ഒരു 512-ബിറ്റ് കീ സൃഷ്ടിക്കുന്നു. കീയും അനുബന്ധ "
+"ക്രമീകരണ ഫയലും മാത്രമേ നിങ്ങളുടെ ബ്രൗസർ ഉപേക്ഷിക്കുകയുള്ളൂ. പേരായി കീ "
+"ഉപയോഗിച്ചുകൊണ്ട് ക്രമീകരണ ഫയൽ ഞങ്ങൾ സംരക്ഷിക്കുന്നു. DuckDuckGo-യ്ക്ക് "
+"നിങ്ങളുടെ പാസ്‌ഫ്രെയ്സ് ഒരിക്കലും അറിയില്ല."
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -24296,9 +24620,10 @@ msgid ""
 "personally identifiable metadata, so model providers can't tie your "
 "conversations back to you."
 msgstr ""
-"നിങ്ങളുടെ നിർദ്ദേശങ്ങൾ DuckDuckGo സെർവറുകളിലൂടെ കൈമാറുകയും വ്യക്തിപരമായി തിരിച്ചറിയാൻ "
-"കഴിയുന്ന മെറ്റാഡാറ്റ നീക്കം ചെയ്യുകയും ചെയ്യുന്നു, അതിനാൽ മോഡൽ ദാതാക്കൾക്ക് നിങ്ങളുടെ "
-"സംഭാഷണങ്ങൾ നിങ്ങളിലേക്ക് തിരികെ ബന്ധിപ്പിക്കാൻ കഴിയില്ല."
+"നിങ്ങളുടെ നിർദ്ദേശങ്ങൾ DuckDuckGo സെർവറുകളിലൂടെ കൈമാറുകയും വ്യക്തിപരമായി "
+"തിരിച്ചറിയാൻ കഴിയുന്ന മെറ്റാഡാറ്റ നീക്കം ചെയ്യുകയും ചെയ്യുന്നു, അതിനാൽ മോഡൽ "
+"ദാതാക്കൾക്ക് നിങ്ങളുടെ സംഭാഷണങ്ങൾ നിങ്ങളിലേക്ക് തിരികെ ബന്ധിപ്പിക്കാൻ "
+"കഴിയില്ല."
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -24312,8 +24637,8 @@ msgid ""
 "Your recent chats live here! You can refer to your chats or clear them "
 "anytime."
 msgstr ""
-"നിങ്ങളുടെ സമീപകാല ചാറ്റുകൾ ഇവിടെ കാണാം! നിങ്ങൾക്ക് നിങ്ങളുടെ ചാറ്റുകൾ പരിശോധിക്കാനോ "
-"എപ്പോൾ വേണമെങ്കിലും അവ മായ്ച്ചുകളയാനോ കഴിയും."
+"നിങ്ങളുടെ സമീപകാല ചാറ്റുകൾ ഇവിടെ കാണാം! നിങ്ങൾക്ക് നിങ്ങളുടെ ചാറ്റുകൾ "
+"പരിശോധിക്കാനോ എപ്പോൾ വേണമെങ്കിലും അവ മായ്ച്ചുകളയാനോ കഴിയും."
 
 # smartling.placeholder_format=C
 #. Message on a feedback form.
@@ -24356,8 +24681,9 @@ msgid ""
 "You’re now searching privately in Chrome. Use our browser instead of Chrome "
 "for more protection. It’s already installed and can:"
 msgstr ""
-"നിങ്ങൾ ഇപ്പോൾ Chrome-ൽ സ്വകാര്യമായി തിരയുന്നു. കൂടുതൽ സുരക്ഷയ്ക്കായി Chrome-ന് പകരം ഞങ്ങളുടെ "
-"ബ്രൗസർ ഉപയോഗിക്കുക. ഇത് ഇതിനകം ഇൻസ്റ്റാൾ ചെയ്തിട്ടുണ്ട്, ഇതിന് ഇവ ചെയ്യാനാകും:"
+"നിങ്ങൾ ഇപ്പോൾ Chrome-ൽ സ്വകാര്യമായി തിരയുന്നു. കൂടുതൽ സുരക്ഷയ്ക്കായി "
+"Chrome-ന് പകരം ഞങ്ങളുടെ ബ്രൗസർ ഉപയോഗിക്കുക. ഇത് ഇതിനകം ഇൻസ്റ്റാൾ "
+"ചെയ്തിട്ടുണ്ട്, ഇതിന് ഇവ ചെയ്യാനാകും:"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has exceeded the maximum message size.
@@ -24366,8 +24692,8 @@ msgid ""
 "You’ve exceeded the maximum message size. Please shorten your message and "
 "try again."
 msgstr ""
-"നിങ്ങൾ സന്ദേശത്തിൻ്റെ പരമാവധി വലുപ്പം കവിഞ്ഞു. ദയവായി നിങ്ങളുടെ സന്ദേശം ചുരുക്കി വീണ്ടും "
-"ശ്രമിക്കുക."
+"നിങ്ങൾ സന്ദേശത്തിൻ്റെ പരമാവധി വലുപ്പം കവിഞ്ഞു. ദയവായി നിങ്ങളുടെ സന്ദേശം "
+"ചുരുക്കി വീണ്ടും ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -24376,8 +24702,8 @@ msgid ""
 "You’ve reached the maximum chat length in this conversation. Clear this "
 "conversation with the Fire Button to continue."
 msgstr ""
-"ഈ സംഭാഷണത്തിൽ നിങ്ങൾ പരമാവധി ചാറ്റ് ദൈർഘ്യത്തിൽ എത്തി. തുടരാൻ Fire Button ഉപയോഗിച്ച് ഈ "
-"സംഭാഷണം മായ്ക്കുക."
+"ഈ സംഭാഷണത്തിൽ നിങ്ങൾ പരമാവധി ചാറ്റ് ദൈർഘ്യത്തിൽ എത്തി. തുടരാൻ Fire Button "
+"ഉപയോഗിച്ച് ഈ സംഭാഷണം മായ്ക്കുക."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -24386,7 +24712,8 @@ msgid ""
 "You’ve reached the maximum chat length in this conversation. Start a new "
 "chat to continue."
 msgstr ""
-"ഈ സംഭാഷണത്തിൽ നിങ്ങൾ പരമാവധി ചാറ്റ് ദൈർഘ്യത്തിൽ എത്തി. തുടരാൻ ഒരു പുതിയ ചാറ്റ് ആരംഭിക്കുക."
+"ഈ സംഭാഷണത്തിൽ നിങ്ങൾ പരമാവധി ചാറ്റ് ദൈർഘ്യത്തിൽ എത്തി. തുടരാൻ ഒരു പുതിയ "
+"ചാറ്റ് ആരംഭിക്കുക."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -24401,8 +24728,8 @@ msgid ""
 "You’ve reached the maximum number of messages for one day. Please continue "
 "this chat tomorrow."
 msgstr ""
-"ഒരു ദിവസത്തേക്കുള്ള പരമാവധി സന്ദേശങ്ങളുടെ എണ്ണത്തിൽ നിങ്ങൾ എത്തി. ദയവായി നാളെ ഈ ചാറ്റ് "
-"തുടരുക."
+"ഒരു ദിവസത്തേക്കുള്ള പരമാവധി സന്ദേശങ്ങളുടെ എണ്ണത്തിൽ നിങ്ങൾ എത്തി. ദയവായി "
+"നാളെ ഈ ചാറ്റ് തുടരുക."
 
 # smartling.placeholder_format=C
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
@@ -24705,8 +25032,8 @@ msgstr "ഔദ്യോഗിക വെബ്സൈറ്റ്"
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
 msgstr ""
-"അല്ലെങ്കിൽ നിങ്ങൾക്ക് വേണ്ട നിറത്തിനുള്ള കോഡ് എഴുതുക, ഉദാ. %1$s (%2$s ഒരു എന്‍കോഡ് ചെയ്ത %3$s "
-"പ്രതീകം ആണ്)."
+"അല്ലെങ്കിൽ നിങ്ങൾക്ക് വേണ്ട നിറത്തിനുള്ള കോഡ് എഴുതുക, ഉദാ. %1$s (%2$s ഒരു "
+"എന്‍കോഡ് ചെയ്ത %3$s പ്രതീകം ആണ്)."
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "

--- a/locales/ml_IN/LC_MESSAGES/duckduckgo.po
+++ b/locales/ml_IN/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: ml_IN\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -176,9 +176,8 @@ msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
 msgstr ""
-"Pro-യുടെ ഒപ്പം മാത്രമേ %1$s ലഭ്യമാകൂ. ചാറ്റ് തുടരാൻ ഈ ബ്രൗസറിൽ നിങ്ങളുടെ "
-"DuckDuckGo സബ്‌സ്‌ക്രിപ്‌ഷൻ വീണ്ടും അപ്‌ഗ്രേഡ് ചെയ്യുക, അല്ലെങ്കിൽ Plus "
-"അല്ലെങ്കിൽ സൗജന്യ മോഡലിലേക്ക് മാറുക."
+"Pro-യുടെ ഒപ്പം മാത്രമേ %1$s ലഭ്യമാകൂ. ചാറ്റ് തുടരാൻ ഈ ബ്രൗസറിൽ നിങ്ങളുടെ DuckDuckGo "
+"സബ്‌സ്‌ക്രിപ്‌ഷൻ വീണ്ടും അപ്‌ഗ്രേഡ് ചെയ്യുക, അല്ലെങ്കിൽ Plus അല്ലെങ്കിൽ സൗജന്യ മോഡലിലേക്ക് മാറുക."
 
 # smartling.placeholder_format=C
 #. Text for the disclaimer message that appears when a Plus subscriber tries to use a Pro-only model. %s is replaced with the model name. Example: Claude Opus 4.6 is only available with Pro. Upgrade your DuckDuckGo subscription in this browser again to continue the chat, or switch to a Plus or free model.
@@ -188,9 +187,8 @@ msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
 msgstr ""
-"Pro-യുടെ ഒപ്പം മാത്രമേ %1$s ലഭ്യമാകൂ. ചാറ്റ് തുടരാൻ ഈ ബ്രൗസറിൽ നിങ്ങളുടെ "
-"DuckDuckGo സബ്‌സ്‌ക്രിപ്‌ഷൻ വീണ്ടും അപ്‌ഗ്രേഡ് ചെയ്യുക, അല്ലെങ്കിൽ Plus "
-"അല്ലെങ്കിൽ സൗജന്യ മോഡലിലേക്ക് മാറുക."
+"Pro-യുടെ ഒപ്പം മാത്രമേ %1$s ലഭ്യമാകൂ. ചാറ്റ് തുടരാൻ ഈ ബ്രൗസറിൽ നിങ്ങളുടെ DuckDuckGo "
+"സബ്‌സ്‌ക്രിപ്‌ഷൻ വീണ്ടും അപ്‌ഗ്രേഡ് ചെയ്യുക, അല്ലെങ്കിൽ Plus അല്ലെങ്കിൽ സൗജന്യ മോഡലിലേക്ക് മാറുക."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI (Artificial Intelligence) chat model is temporarily unavailable. Example: 'GPT 4o is only available with a DuckDuckGo subscription.'
@@ -206,9 +204,8 @@ msgid ""
 "subscription in this browser again to continue the chat, or switch to a free "
 "model."
 msgstr ""
-"%1$s DuckDuckGo സബ്‌സ്‌ക്രിപ്‌ഷനോടൊപ്പം മാത്രമേ ലഭ്യമാകൂ. ഈ ബ്രൗസറിൽ ചാറ്റ് "
-"തുടരാൻ, നിങ്ങളുടെ സബ്സ്ക്രിപ്ഷൻ വീണ്ടും സജീവമാക്കുക, അല്ലെങ്കിൽ ഒരു സൗജന്യ "
-"മോഡലിലേക്ക് മാറുക."
+"%1$s DuckDuckGo സബ്‌സ്‌ക്രിപ്‌ഷനോടൊപ്പം മാത്രമേ ലഭ്യമാകൂ. ഈ ബ്രൗസറിൽ ചാറ്റ് തുടരാൻ, നിങ്ങളുടെ "
+"സബ്സ്ക്രിപ്ഷൻ വീണ്ടും സജീവമാക്കുക, അല്ലെങ്കിൽ ഒരു സൗജന്യ മോഡലിലേക്ക് മാറുക."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is temporarily unavailable. Example: 'GPT 3.5 Turbo is temporarily unavailable. Please switch to a different model or try again later.'
@@ -217,8 +214,8 @@ msgid ""
 "%s is temporarily unavailable. Please switch to a different model or try "
 "again later."
 msgstr ""
-"%1$s താൽക്കാലികമായി ലഭ്യമല്ല. ദയവായി മറ്റൊരു മോഡലിലേക്ക് മാറുക അല്ലെങ്കിൽ "
-"പിന്നീട് വീണ്ടും ശ്രമിക്കുക."
+"%1$s താൽക്കാലികമായി ലഭ്യമല്ല. ദയവായി മറ്റൊരു മോഡലിലേക്ക് മാറുക അല്ലെങ്കിൽ പിന്നീട് വീണ്ടും "
+"ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Reddit's "fake internet points". https://support.reddithelp.com/hc/en-us/articles/204511829-What-is-karma
@@ -309,9 +306,9 @@ msgid ""
 "provider can see your prompts or the model’s responses, or save this chat on "
 "their servers."
 msgstr ""
-"%1$s ഒരു വിശ്വസനീയമായ നിർവഹണ അന്തരീക്ഷത്തിൽ പ്രവർത്തിക്കുന്നു. മോഡൽ ദാതാവിന് "
-"പോലും നിങ്ങളുടെ പ്രോംപ്റ്റുകളോ മോഡലിന്റെ പ്രതികരണങ്ങളോ കാണാനോ ഈ ചാറ്റ് "
-"അവരുടെ സെർവറുകളിൽ സംരക്ഷിക്കാനോ കഴിയില്ല എന്നാണ്."
+"%1$s ഒരു വിശ്വസനീയമായ നിർവഹണ അന്തരീക്ഷത്തിൽ പ്രവർത്തിക്കുന്നു. മോഡൽ ദാതാവിന് പോലും "
+"നിങ്ങളുടെ പ്രോംപ്റ്റുകളോ മോഡലിന്റെ പ്രതികരണങ്ങളോ കാണാനോ ഈ ചാറ്റ് അവരുടെ സെർവറുകളിൽ "
+"സംരക്ഷിക്കാനോ കഴിയില്ല എന്നാണ്."
 
 # smartling.placeholder_format=C
 #. Label shown in the batch selection toolbar when exactly one chat is selected. %s is replaced with 1. Use singular agreement where the language requires it.
@@ -391,8 +388,8 @@ msgid ""
 "%s will be leaving Duck.ai in %s days (%s). After that, you can switch "
 "models to continue this chat."
 msgstr ""
-"%1$s %2$s ദിവസങ്ങൾക്കുള്ളിൽ (%3$s) Duck.ai ഉപേക്ഷിച്ച് പോകും. അതിനുശേഷം, ഈ "
-"ചാറ്റ് തുടരുന്നതിന് നിങ്ങൾക്ക് മോഡലുകൾ മാറ്റാം."
+"%1$s %2$s ദിവസങ്ങൾക്കുള്ളിൽ (%3$s) Duck.ai ഉപേക്ഷിച്ച് പോകും. അതിനുശേഷം, ഈ ചാറ്റ് "
+"തുടരുന്നതിന് നിങ്ങൾക്ക് മോഡലുകൾ മാറ്റാം."
 
 # smartling.placeholder_format=C
 #. Displayed in a saved chat when its AI model is about to be retired tomorrow. First placeholder is the friendly model name, second placeholder is the removal date formatted in the user's browser locale (e.g., 'June 15, 2026' in en-US). Singular-day form.
@@ -403,8 +400,8 @@ msgid ""
 "%s will be leaving Duck.ai in 1 day (%s). After that, you can switch models "
 "to continue this chat."
 msgstr ""
-"%1$s 1 ദിവസം കൊണ്ട് Duck.ai വിടുന്നതായിരിക്കും (%2$s). അതിനുശേഷം, ഈ ചാറ്റ് "
-"തുടരുന്നതിന് നിങ്ങൾക്ക് മോഡലുകൾ മാറ്റാം."
+"%1$s 1 ദിവസം കൊണ്ട് Duck.ai വിടുന്നതായിരിക്കും (%2$s). അതിനുശേഷം, ഈ ചാറ്റ് തുടരുന്നതിന് "
+"നിങ്ങൾക്ക് മോഡലുകൾ മാറ്റാം."
 
 # smartling.placeholder_format=C
 #. Shown in a text selection chip when the selection contains multiple words. %s is replaced with the number of words, e.g. '142 words'.
@@ -417,8 +414,8 @@ msgstr "%1$s വാക്കുകൾ"
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
 msgstr ""
-"%1$s%2$sചേർക്കുക%3$s ക്ലിക്ക് ചെയ്യുക %4$sഅനുവദിക്കുക%5$s ചെക്ക് ചെയ്യുക, "
-"തുടർന്ന് %6$sശരി%7$s ക്ലിക്ക് ചെയ്യുക"
+"%1$s%2$sചേർക്കുക%3$s ക്ലിക്ക് ചെയ്യുക %4$sഅനുവദിക്കുക%5$s ചെക്ക് ചെയ്യുക, തുടർന്ന് "
+"%6$sശരി%7$s ക്ലിക്ക് ചെയ്യുക"
 
 # Firefox, obsolete
 # smartling.placeholder_format=C
@@ -426,8 +423,8 @@ msgstr ""
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAllow%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
 msgstr ""
-"%1$s%2$sഅനുവദിക്കുക%3$s ക്ലിക്ക് ചെയ്യുക%4$sചേർക്കുക%5$s ക്ലിക്ക് "
-"ചെയ്യുക%6$sഅനുവദിക്കുക%7$s ശരിയിടുക, തുടർന്ന് %8$sശരി%9$s ക്ലിക്ക് ചെയ്യുക"
+"%1$s%2$sഅനുവദിക്കുക%3$s ക്ലിക്ക് ചെയ്യുക%4$sചേർക്കുക%5$s ക്ലിക്ക് ചെയ്യുക%6$sഅനുവദിക്കുക%7$s "
+"ശരിയിടുക, തുടർന്ന് %8$sശരി%9$s ക്ലിക്ക് ചെയ്യുക"
 
 # Firefox
 # smartling.placeholder_format=C
@@ -437,9 +434,8 @@ msgid ""
 "%sClick %sContinue To Installation%sClick %sAdd%sCheck %sAllow%s, then click "
 "%sOkay%s"
 msgstr ""
-"%1$s%2$sഇൻസ്റ്റാളേഷനിലേക്ക് തുടരുക%3$s ക്ലിക്ക് ചെയ്യുക %4$sചേർക്കുക%5$s "
-"ക്ലിക്ക് ചെയ്യുക%6$sഅനുവദിക്കുക%7$s അടയാളപ്പെടുത്തുക, തുടർന്ന് %8$sശരി%9$s "
-"ക്ലിക്ക് ചെയ്യുക"
+"%1$s%2$sഇൻസ്റ്റാളേഷനിലേക്ക് തുടരുക%3$s ക്ലിക്ക് ചെയ്യുക %4$sചേർക്കുക%5$s ക്ലിക്ക് "
+"ചെയ്യുക%6$sഅനുവദിക്കുക%7$s അടയാളപ്പെടുത്തുക, തുടർന്ന് %8$sശരി%9$s ക്ലിക്ക് ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. A button that reloads search results when an error occurs.
@@ -448,8 +444,8 @@ msgid ""
 "%sClick here%s to try again, if you think there should be results for this "
 "search."
 msgstr ""
-"വീണ്ടും ശ്രമിക്കാൻ %1$sഇവിടെ അമർത്തുക%2$s, ഈ തിരയലിന് ഫലങ്ങൾ "
-"ഉണ്ടായിരിക്കണമെന്ന് നിങ്ങൾ കരുതുന്നുണ്ടെങ്കിൽ."
+"വീണ്ടും ശ്രമിക്കാൻ %1$sഇവിടെ അമർത്തുക%2$s, ഈ തിരയലിന് ഫലങ്ങൾ ഉണ്ടായിരിക്കണമെന്ന് നിങ്ങൾ "
+"കരുതുന്നുണ്ടെങ്കിൽ."
 
 # smartling.placeholder_format=C
 #. Header for a page with information about sharing DuckDuckGo.
@@ -468,8 +464,7 @@ msgstr "%1$sകൂടുതലറിയുക%2$s ."
 msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
 msgstr ""
-"%1$sനിങ്ങളുടെ ലൊക്കേഷൻ ഞങ്ങൾ സ്വകാര്യമായി സൂക്ഷിക്കുന്നത് എങ്ങനെയെന്ന് "
-"മനസ്സിലാക്കുക%2$s."
+"%1$sനിങ്ങളുടെ ലൊക്കേഷൻ ഞങ്ങൾ സ്വകാര്യമായി സൂക്ഷിക്കുന്നത് എങ്ങനെയെന്ന് മനസ്സിലാക്കുക%2$s."
 
 # smartling.placeholder_format=C
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
@@ -477,16 +472,16 @@ msgctxt "Footer text for About Sync modal"
 msgid ""
 "%sLearn more%s about how chats are stored privately on DuckDuckGo's server."
 msgstr ""
-"DuckDuckGo-യുടെ സെർവറിൽ ചാറ്റുകൾ എങ്ങനെ സ്വകാര്യമായി സൂക്ഷിക്കപ്പെടുന്നു "
-"എന്നതിനെക്കുറിച്ച് %1$sകൂടുതൽ അറിയുക%2$s."
+"DuckDuckGo-യുടെ സെർവറിൽ ചാറ്റുകൾ എങ്ങനെ സ്വകാര്യമായി സൂക്ഷിക്കപ്പെടുന്നു എന്നതിനെക്കുറിച്ച് "
+"%1$sകൂടുതൽ അറിയുക%2$s."
 
 # smartling.placeholder_format=C
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "%sLearn more%s about how chats are stored privately on your device."
 msgstr ""
-"ചാറ്റുകൾ നിങ്ങളുടെ ഉപകരണത്തിൽ എങ്ങനെ സ്വകാര്യമായി സൂക്ഷിക്കപ്പെടുന്നു "
-"എന്നതിനെക്കുറിച്ച് %1$sകൂടുതൽ അറിയുക%2$s."
+"ചാറ്റുകൾ നിങ്ങളുടെ ഉപകരണത്തിൽ എങ്ങനെ സ്വകാര്യമായി സൂക്ഷിക്കപ്പെടുന്നു എന്നതിനെക്കുറിച്ച് "
+"%1$sകൂടുതൽ അറിയുക%2$s."
 
 # smartling.placeholder_format=C
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
@@ -499,8 +494,7 @@ msgstr "ഹോം സ്ക്രീനിൽ DuckDuckGo ആപ്പ് ഐക�
 msgctxt "Error or no results message"
 msgid "%sOops!%s%sSomething went wrong. Please %srefresh%s and try again."
 msgstr ""
-"%1$sക്ഷമിക്കണം!%2$s%3$sഎന്തോ കുഴപ്പം സംഭവിച്ചു. ദയവായി %4$sപുതുക്കി%5$s "
-"വീണ്ടും ശ്രമിക്കുക."
+"%1$sക്ഷമിക്കണം!%2$s%3$sഎന്തോ കുഴപ്പം സംഭവിച്ചു. ദയവായി %4$sപുതുക്കി%5$s വീണ്ടും ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Tagline in a popover encouraging the user to download the DuckDuckGo browser
@@ -824,9 +818,7 @@ msgstr "6 മണിക്കൂർ ഉപയോഗ പരിധി കഴിഞ�
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "6-hour usage limit reached. You can keep chatting by using your daily limit."
-msgstr ""
-"6 മണിക്കൂർ ഉപയോഗ പരിധി കഴിഞ്ഞു. നിങ്ങളുടെ ദൈനംദിന പരിധി ഉപയോഗിച്ച് ചാറ്റ് "
-"തുടരാം."
+msgstr "6 മണിക്കൂർ ഉപയോഗ പരിധി കഴിഞ്ഞു. നിങ്ങളുടെ ദൈനംദിന പരിധി ഉപയോഗിച്ച് ചാറ്റ് തുടരാം."
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes abbreviation
@@ -880,8 +872,8 @@ msgid ""
 "A network issue is preventing Search Assist from generating an answer. "
 "Please check your connection and try again."
 msgstr ""
-"ഒരു നെറ്റ്‌വർക്ക് പ്രശ്‌നം Search Assist ഉത്തരം സൃഷ്ടിക്കുന്നതിനെ തടയുന്നു. "
-"നിങ്ങളുടെ കണക്ഷൻ പരിശോധിച്ച് വീണ്ടും ശ്രമിക്കുക."
+"ഒരു നെറ്റ്‌വർക്ക് പ്രശ്‌നം Search Assist ഉത്തരം സൃഷ്ടിക്കുന്നതിനെ തടയുന്നു. നിങ്ങളുടെ കണക്ഷൻ "
+"പരിശോധിച്ച് വീണ്ടും ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of AI Chat is available and they need to refresh the page.
@@ -933,10 +925,10 @@ msgid ""
 "still access AI Chat when this setting is off by visiting %sduckduckgo.com/"
 "aichat%s."
 msgstr ""
-"3കക്ഷി AI Chat മോഡലുകളുമായി അജ്ഞാത സംഭാഷണങ്ങൾ നടത്താൻ AI Chat നിങ്ങളെ "
-"അനുവദിക്കുന്നു. ഇത് ഓഫാക്കുന്നത് DuckDuckGo Search-ലെ AI Chat സവിശേഷത "
-"മറയ്ക്കും. %1$sduckduckgo.com/aichat%2$s സന്ദർശിച്ച് ഈ ക്രമീകരണം ഓഫ് "
-"ചെയ്യുമ്പോഴും നിങ്ങൾക്ക് AI Chat ആക്സസ് ചെയ്യാൻ കഴിയും."
+"3കക്ഷി AI Chat മോഡലുകളുമായി അജ്ഞാത സംഭാഷണങ്ങൾ നടത്താൻ AI Chat നിങ്ങളെ അനുവദിക്കുന്നു. ഇത് "
+"ഓഫാക്കുന്നത് DuckDuckGo Search-ലെ AI Chat സവിശേഷത മറയ്ക്കും. %1$sduckduckgo.com/"
+"aichat%2$s സന്ദർശിച്ച് ഈ ക്രമീകരണം ഓഫ് ചെയ്യുമ്പോഴും നിങ്ങൾക്ക് AI Chat ആക്സസ് ചെയ്യാൻ "
+"കഴിയും."
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -997,11 +989,10 @@ msgid ""
 "questions, which is our private AI-powered chat service that supports chat "
 "models from OpenAI, and Anthropic, and more."
 msgstr ""
-"AI- സഹായത്തോടെയുള്ള ഉത്തരങ്ങൾ നിലവിൽ ഫോളോ-അപ്പ് ചോദ്യങ്ങളെ നേരിട്ട് "
-"പിന്തുണയ്ക്കുന്നില്ല. എന്നിരുന്നാലും, ഞങ്ങൾ ഫോളോ-അപ്പ് ചോദ്യങ്ങൾക്കായി "
-"%1$sDuck.ai%2$s വാഗ്ദാനം ചെയ്യുകയും പലപ്പോഴും ലിങ്ക് ചെയ്യുകയും ചെയ്യുന്നു, "
-"ഇത് OpenAI, Anthropic തുടങ്ങിയവയിൽ നിന്നുള്ള ചാറ്റ് മോഡലുകളെ "
-"പിന്തുണയ്ക്കുന്ന ഞങ്ങളുടെ സ്വകാര്യ AI-പിന്തുണയുള്ള ചാറ്റ് സേവനമാണ്."
+"AI- സഹായത്തോടെയുള്ള ഉത്തരങ്ങൾ നിലവിൽ ഫോളോ-അപ്പ് ചോദ്യങ്ങളെ നേരിട്ട് പിന്തുണയ്ക്കുന്നില്ല. "
+"എന്നിരുന്നാലും, ഞങ്ങൾ ഫോളോ-അപ്പ് ചോദ്യങ്ങൾക്കായി %1$sDuck.ai%2$s വാഗ്ദാനം ചെയ്യുകയും "
+"പലപ്പോഴും ലിങ്ക് ചെയ്യുകയും ചെയ്യുന്നു, ഇത് OpenAI, Anthropic തുടങ്ങിയവയിൽ നിന്നുള്ള ചാറ്റ് "
+"മോഡലുകളെ പിന്തുണയ്ക്കുന്ന ഞങ്ങളുടെ സ്വകാര്യ AI-പിന്തുണയുള്ള ചാറ്റ് സേവനമാണ്."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has turned off AI features and will no longer see AI-assisted answers.
@@ -1186,8 +1177,8 @@ msgid ""
 "Activate your %s in this browser again to continue the chat, or switch to a "
 "free model."
 msgstr ""
-"ചാറ്റ് തുടരാൻ നിങ്ങളുടെ %1$s ഈ ബ്രൗസറിൽ വീണ്ടും സജീവമാക്കുക, അല്ലെങ്കിൽ ഒരു "
-"സൗജന്യ മോഡലിലേക്ക് മാറുക."
+"ചാറ്റ് തുടരാൻ നിങ്ങളുടെ %1$s ഈ ബ്രൗസറിൽ വീണ്ടും സജീവമാക്കുക, അല്ലെങ്കിൽ ഒരു സൗജന്യ "
+"മോഡലിലേക്ക് മാറുക."
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an active DuckDuckGo subscription.
@@ -1223,8 +1214,8 @@ msgstr "പരസ്യം"
 msgid ""
 "Ad clicks are managed by %s’s ad network and are not used to profile you."
 msgstr ""
-"%1$s-ൻ്റെ പരസ്യ നെറ്റ്വർക്കുകൾ ആണ് പരസ്യ ക്ലിക്കുകൾ കൈകാര്യം ചെയ്യുന്നത്, അവ "
-"നിങ്ങളെ തിരിച്ചറിയാൻ ഉപയോഗിക്കപ്പെടാറില്ല."
+"%1$s-ൻ്റെ പരസ്യ നെറ്റ്വർക്കുകൾ ആണ് പരസ്യ ക്ലിക്കുകൾ കൈകാര്യം ചെയ്യുന്നത്, അവ നിങ്ങളെ "
+"തിരിച്ചറിയാൻ ഉപയോഗിക്കപ്പെടാറില്ല."
 
 # smartling.placeholder_format=C
 #. Information that ad clicks are managed by Microsoft.
@@ -1232,8 +1223,8 @@ msgid ""
 "Ad clicks are managed by Microsoft’s ad network and are not used to profile "
 "you."
 msgstr ""
-"പരസ്യ ക്ലിക്കുകൾ നിയന്ത്രിക്കുന്നത് Microsoft-ന്റെ പരസ്യ ശൃംഖലയാണ്, നിങ്ങളെ "
-"പ്രൊഫൈൽ ചെയ്യുന്നതിനായി അവ ഉപയോഗിക്കപ്പെടുന്നില്ല."
+"പരസ്യ ക്ലിക്കുകൾ നിയന്ത്രിക്കുന്നത് Microsoft-ന്റെ പരസ്യ ശൃംഖലയാണ്, നിങ്ങളെ പ്രൊഫൈൽ "
+"ചെയ്യുന്നതിനായി അവ ഉപയോഗിക്കപ്പെടുന്നില്ല."
 
 # smartling.placeholder_format=C
 #. An item in the ads tooltip that explains that ad clicks aren’t used to profile you.
@@ -1284,8 +1275,8 @@ msgstr "DuckDuckGo എക്സ്റ്റൻഷൻ ചേർക്കുക"
 msgid ""
 "Add DuckDuckGo Privacy Essentials to your browser for free with one download:"
 msgstr ""
-"ഒരു ഡൗൺ ലോഡിനൊപ്പം സൗജന്യമായി നിങ്ങളുടെ ബ്രൗസറിലേക്ക് DuckDuckGo Privacy "
-"Essentials ചേർക്കുക:"
+"ഒരു ഡൗൺ ലോഡിനൊപ്പം സൗജന്യമായി നിങ്ങളുടെ ബ്രൗസറിലേക്ക് DuckDuckGo Privacy Essentials "
+"ചേർക്കുക:"
 
 #  IE default search engine instruction
 # smartling.placeholder_format=C
@@ -1440,6 +1431,12 @@ msgid "Address is incorrect"
 msgstr "വിലാസം തെറ്റാണ്"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Adjust the servings"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. as in multiple advertisements
 msgid "Ads"
 msgstr "പരസ്യങ്ങൾ"
@@ -1515,17 +1512,15 @@ msgstr "ആഫ്രികാൻസ്"
 # smartling.placeholder_format=C
 #. Instructions on how to install the DuckDuckGo browser extension after it downloads.
 msgid "After it downloads and opens, click %sInstall%s"
-msgstr ""
-"ഇത് ഡൗൺലോഡ് ചെയ്ത് തുറന്ന ശേഷം %1$sഇൻസ്റ്റാൾ ചെയ്യുക%2$s എന്നതിൽ ക്ലിക്ക് "
-"ചെയ്യുക"
+msgstr "ഇത് ഡൗൺലോഡ് ചെയ്ത് തുറന്ന ശേഷം %1$sഇൻസ്റ്റാൾ ചെയ്യുക%2$s എന്നതിൽ ക്ലിക്ക് ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. Instructions on how to install the DuckDuckGo browser extension after it downloads.
 msgid ""
 "After it downloads, locate the extension file and double-click it to install"
 msgstr ""
-"അത് ഡൗൺലോഡ് ചെയ്ത ശേഷം, എക്സ്റ്റൻഷൻ ഫയൽ കണ്ടെത്തി, ഇൻസ്റ്റാൾ ചെയ്യാൻ അത് "
-"ഡബിൾ ക്ലിക്ക് ചെയ്യുക"
+"അത് ഡൗൺലോഡ് ചെയ്ത ശേഷം, എക്സ്റ്റൻഷൻ ഫയൽ കണ്ടെത്തി, ഇൻസ്റ്റാൾ ചെയ്യാൻ അത് ഡബിൾ ക്ലിക്ക് "
+"ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an age below a web search result.
@@ -1655,6 +1650,14 @@ msgid "All chats are %sprivate%s"
 msgstr "എല്ലാ ചാറ്റുകളും %1$sസ്വകാര്യമാണ്%2$s"
 
 # smartling.placeholder_format=C
+#. Paragraph in the Privacy & Terms section of the About & Legal page in Duck.ai settings, summarizing how chats are anonymized and are not stored or used to train chat models.
+msgctxt "Privacy & Terms section description on the Duck.ai settings page"
+msgid ""
+"All chats are anonymized by DuckDuckGo, and your conversations are not used "
+"to train chat models by DuckDuckGo or the model providers"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
 msgctxt "Privacy modal header in Duck.ai chat"
 msgid "All chats are private"
@@ -1685,8 +1688,8 @@ msgid ""
 "All model providers are prevented from training their AI on your "
 "conversations."
 msgstr ""
-"നിങ്ങളുടെ സംഭാഷണങ്ങൾ ഉപയോഗിച്ച് അവരുടെ AI പരിശീലിപ്പിക്കാൻ എല്ലാ മോഡൽ "
-"ദാതാക്കളെയും അനുവദിക്കില്ല."
+"നിങ്ങളുടെ സംഭാഷണങ്ങൾ ഉപയോഗിച്ച് അവരുടെ AI പരിശീലിപ്പിക്കാൻ എല്ലാ മോഡൽ ദാതാക്കളെയും "
+"അനുവദിക്കില്ല."
 
 # smartling.placeholder_format=C
 #. Text displayed in the subheader of the modal that allows the user to pick an AI chat model.
@@ -1701,8 +1704,8 @@ msgid ""
 "All personal metadata (for example, your IP address) is removed before "
 "sending a chat to the AI provider."
 msgstr ""
-"AI ദാതാവിന് ഒരു ചാറ്റ് അയയ്ക്കുന്നതിന് മുമ്പ് എല്ലാ വ്യക്തിഗത മെറ്റാഡാറ്റയും "
-"(ഉദാഹരണത്തിന്, നിങ്ങളുടെ IP വിലാസം) നീക്കംചെയ്യപ്പെടുന്നു."
+"AI ദാതാവിന് ഒരു ചാറ്റ് അയയ്ക്കുന്നതിന് മുമ്പ് എല്ലാ വ്യക്തിഗത മെറ്റാഡാറ്റയും (ഉദാഹരണത്തിന്, "
+"നിങ്ങളുടെ IP വിലാസം) നീക്കംചെയ്യപ്പെടുന്നു."
 
 # smartling.placeholder_format=C
 #. A filter that shows search results from all countries.
@@ -1728,8 +1731,7 @@ msgctxt "voice chat"
 msgid ""
 "Allow DuckDuckGo microphone access in System Settings to use voice chat."
 msgstr ""
-"വോയ്സ് ചാറ്റ് ഉപയോഗിക്കാൻ സിസ്റ്റം ക്രമീകരണങ്ങളിൽ DuckDuckGo മൈക്രോഫോൺ "
-"ആക്സസ് അനുവദിക്കുക."
+"വോയ്സ് ചാറ്റ് ഉപയോഗിക്കാൻ സിസ്റ്റം ക്രമീകരണങ്ങളിൽ DuckDuckGo മൈക്രോഫോൺ ആക്സസ് അനുവദിക്കുക."
 
 # smartling.placeholder_format=C
 #. Tells users which icon to press in their browser. Part of a list of instructions on how to enable location service.
@@ -1755,11 +1757,10 @@ msgid ""
 "sends AI-generated queries to a search engine with limited data retention. "
 "Prompts and responses with %s still have %szero provider visibility%s."
 msgstr ""
-"പ്രസക്തമായ പ്രോംപ്റ്റുകൾക്കുള്ള പ്രതികരണങ്ങൾ മെച്ചപ്പെടുത്താൻ വെബിൽ തിരയാൻ "
-"%1$s-നെ അനുവദിക്കുന്നു. പരിമിതമായ ഡാറ്റ നിലനിർത്തൽ ഉള്ള ഒരു സെർച്ച് "
-"എഞ്ചിനിലേക്ക് മാത്രമേ AI സൃഷ്ടിച്ച ചോദ്യങ്ങൾ അയയ്ക്കൂ. %2$s ഉള്ള "
-"പ്രോംപ്റ്റുകൾക്കും പ്രതികരണങ്ങൾക്കും ഇപ്പോഴും %3$sദാതാവിന്റെ ദൃശ്യപരത പൂജ്യം "
-"ആണ്%4$s."
+"പ്രസക്തമായ പ്രോംപ്റ്റുകൾക്കുള്ള പ്രതികരണങ്ങൾ മെച്ചപ്പെടുത്താൻ വെബിൽ തിരയാൻ %1$s-നെ "
+"അനുവദിക്കുന്നു. പരിമിതമായ ഡാറ്റ നിലനിർത്തൽ ഉള്ള ഒരു സെർച്ച് എഞ്ചിനിലേക്ക് മാത്രമേ AI സൃഷ്ടിച്ച "
+"ചോദ്യങ്ങൾ അയയ്ക്കൂ. %2$s ഉള്ള പ്രോംപ്റ്റുകൾക്കും പ്രതികരണങ്ങൾക്കും ഇപ്പോഴും %3$sദാതാവിന്റെ "
+"ദൃശ്യപരത പൂജ്യം ആണ്%4$s."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -1906,8 +1907,8 @@ msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
 msgstr ""
-"%1$s, %2$s, കൂടാതെ ഓപ്പൺ സോഴ്സ് %3$s, %4$s ഉൾപ്പെടെയുള്ള ജനപ്രിയ AI "
-"മോഡലുകളിലേക്കുള്ള അജ്ഞാത ആക്സസ്."
+"%1$s, %2$s, കൂടാതെ ഓപ്പൺ സോഴ്സ് %3$s, %4$s ഉൾപ്പെടെയുള്ള ജനപ്രിയ AI മോഡലുകളിലേക്കുള്ള "
+"അജ്ഞാത ആക്സസ്."
 
 # smartling.placeholder_format=C
 #. Text with information about Duck.ai and supported AI models, the placeholders list AI models. Example: 'Anonymous access to popular AI models, including GPT, Claude, and open-source Llama and Mistral.'
@@ -1916,14 +1917,21 @@ msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
 msgstr ""
-"%1$s, %2$s, കൂടാതെ ഓപ്പൺ സോഴ്സ് %3$s, %4$s ഉൾപ്പെടെയുള്ള ജനപ്രിയ AI "
-"മോഡലുകളിലേക്കുള്ള അജ്ഞാത ആക്സസ്."
+"%1$s, %2$s, കൂടാതെ ഓപ്പൺ സോഴ്സ് %3$s, %4$s ഉൾപ്പെടെയുള്ള ജനപ്രിയ AI മോഡലുകളിലേക്കുള്ള "
+"അജ്ഞാത ആക്സസ്."
 
 # smartling.placeholder_format=C
 #. Confirmation message after location service is enabled.
 msgctxt "precise_user_location"
 msgid "Anonymous location enabled"
 msgstr "അജ്ഞാത സ്ഥാനം പ്രവർത്തനക്ഷമമാക്കി"
+
+# smartling.placeholder_format=C
+msgctxt "settings"
+msgid ""
+"Anonymously generates answers for search queries based on web content. "
+"Choose how often you want it to appear, or disable it completely."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -2091,8 +2099,8 @@ msgid ""
 "Are you sure you want to disable history? This will delete all chats, "
 "including pinned chats."
 msgstr ""
-"ചരിത്രം പ്രവർത്തനരഹിതമാക്കണമെന്ന് നിങ്ങൾക്ക് ഉറപ്പാണോ? ഇത് പിൻ ചെയ്ത "
-"ചാറ്റുകൾ ഉൾപ്പെടെ എല്ലാ ചാറ്റുകളും ഇല്ലാതാക്കും."
+"ചരിത്രം പ്രവർത്തനരഹിതമാക്കണമെന്ന് നിങ്ങൾക്ക് ഉറപ്പാണോ? ഇത് പിൻ ചെയ്ത ചാറ്റുകൾ ഉൾപ്പെടെ എല്ലാ "
+"ചാറ്റുകളും ഇല്ലാതാക്കും."
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to disable recent chats, with a warning that it will also delete currently saved chats.
@@ -2101,8 +2109,8 @@ msgid ""
 "Are you sure you want to disable recent chats? This will also delete any "
 "recent chats that are currently saved."
 msgstr ""
-"സമീപകാല ചാറ്റുകൾ പ്രവർത്തനരഹിതമാക്കണമെന്ന് നിങ്ങൾക്ക് ഉറപ്പാണോ? നിലവിൽ സേവ് "
-"ചെയ്ത സമീപകാല ചാറ്റുകളും ഇത് ഇല്ലാതാക്കും."
+"സമീപകാല ചാറ്റുകൾ പ്രവർത്തനരഹിതമാക്കണമെന്ന് നിങ്ങൾക്ക് ഉറപ്പാണോ? നിലവിൽ സേവ് ചെയ്ത സമീപകാല "
+"ചാറ്റുകളും ഇത് ഇല്ലാതാക്കും."
 
 # smartling.placeholder_format=C
 #. Question asking user if they want to share the URL of the page they were on when giving feedback
@@ -2140,9 +2148,8 @@ msgid ""
 "As per our privacy policy, we do not collect or share any personal "
 "information ourselves. All of this privacy protection happens on your device."
 msgstr ""
-"ഞങ്ങളുടെ സ്വകാര്യത നയം അനുസരിച്ച്, ഞങ്ങൾ നിങ്ങളുടെ വ്യക്തിഗത വിവരങ്ങൾ ഒന്നും "
-"ശേഖരിക്കുകയോ പങ്കുവയ്ക്കുകയോ ചെയ്യില്ല. ഈ സ്വകാര്യതാ പരിരക്ഷ എല്ലാം "
-"നിങ്ങളുടെ ഉപകരണത്തിൽ സംഭവിക്കുന്നു."
+"ഞങ്ങളുടെ സ്വകാര്യത നയം അനുസരിച്ച്, ഞങ്ങൾ നിങ്ങളുടെ വ്യക്തിഗത വിവരങ്ങൾ ഒന്നും ശേഖരിക്കുകയോ "
+"പങ്കുവയ്ക്കുകയോ ചെയ്യില്ല. ഈ സ്വകാര്യതാ പരിരക്ഷ എല്ലാം നിങ്ങളുടെ ഉപകരണത്തിൽ സംഭവിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. A button to ask Duck.ai a question
@@ -2203,6 +2210,12 @@ msgstr "ഒരു ഫോളോ-അപ്പ് ചോദ്യം ചോദി�
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse
 msgid "Ask a follow-up with Duck.ai"
 msgstr "Duck.ai-യിൽ ഒരു ഫോളോ-അപ്പ് ചോദിക്കൂ"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
+msgctxt "Page suggestion chip label"
+msgid "Ask about this page"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2266,15 +2279,13 @@ msgid ""
 "(shows more frequently on a wider range of searches). For now, AI-assisted "
 "answers are only available in the U.S. (English) region."
 msgstr ""
-"പ്രസക്തമായ വെബ് ഉള്ളടക്കം സംഗ്രഹിച്ച് ചില തിരയലുകൾക്ക് AI സഹായത്തോടെ "
-"ഉത്തരങ്ങൾ അജ്ഞാതമായി സൃഷ്ടിക്കാൻ Assist-ന് കഴിയും. Assist എത്ര തവണ "
-"പ്രത്യക്ഷപ്പെടണമെന്ന് നിങ്ങൾക്ക് തിരഞ്ഞെടുക്കാം: ഒരിക്കലും ഇല്ല (തിരയൽ "
-"ഫലങ്ങളിൽ നിന്ന് Assist UI പൂർണ്ണമായും നീക്കം ചെയ്യുന്നു), ആവശ്യാനുസരണം "
-"(നിങ്ങൾ Assist ബട്ടൺ ക്ലിക്ക് ചെയ്താൽ മാത്രമേ AI സഹായിക്കുന്ന ഉത്തരങ്ങൾ "
-"കാണിക്കൂ), ചിലപ്പോൾ (വളരെ പ്രസക്തമാകുമ്പോൾ മാത്രമേ AI സഹായിക്കുന്ന ഉത്തരങ്ങൾ "
-"കാണിക്കൂ), ഇടയ്ക്കിടെ (വിശാലമായ തിരയൽ ശ്രേണികളിൽ കൂടുതൽ പതിവായി "
-"കാണിക്കുന്നു). ഇപ്പോൾ, AI സഹായിക്കുന്ന ഉത്തരങ്ങൾ യു.എസ്. (ഇംഗ്ലീഷ്) മേഖലയിൽ "
-"മാത്രമേ ലഭ്യമാകൂ."
+"പ്രസക്തമായ വെബ് ഉള്ളടക്കം സംഗ്രഹിച്ച് ചില തിരയലുകൾക്ക് AI സഹായത്തോടെ ഉത്തരങ്ങൾ അജ്ഞാതമായി "
+"സൃഷ്ടിക്കാൻ Assist-ന് കഴിയും. Assist എത്ര തവണ പ്രത്യക്ഷപ്പെടണമെന്ന് നിങ്ങൾക്ക് തിരഞ്ഞെടുക്കാം: "
+"ഒരിക്കലും ഇല്ല (തിരയൽ ഫലങ്ങളിൽ നിന്ന് Assist UI പൂർണ്ണമായും നീക്കം ചെയ്യുന്നു), ആവശ്യാനുസരണം "
+"(നിങ്ങൾ Assist ബട്ടൺ ക്ലിക്ക് ചെയ്താൽ മാത്രമേ AI സഹായിക്കുന്ന ഉത്തരങ്ങൾ കാണിക്കൂ), ചിലപ്പോൾ "
+"(വളരെ പ്രസക്തമാകുമ്പോൾ മാത്രമേ AI സഹായിക്കുന്ന ഉത്തരങ്ങൾ കാണിക്കൂ), ഇടയ്ക്കിടെ (വിശാലമായ "
+"തിരയൽ ശ്രേണികളിൽ കൂടുതൽ പതിവായി കാണിക്കുന്നു). ഇപ്പോൾ, AI സഹായിക്കുന്ന ഉത്തരങ്ങൾ യു.എസ്. "
+"(ഇംഗ്ലീഷ്) മേഖലയിൽ മാത്രമേ ലഭ്യമാകൂ."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2286,14 +2297,13 @@ msgid ""
 "to remember that responses are auto-generated from cited sources and based "
 "on %scrawling the web%s."
 msgstr ""
-"ഞങ്ങളുടെ തിരയൽ ഫലങ്ങളിലെ ഒരു ഓപ്ഷണൽ സവിശേഷതയാണ് Assist, അതിന് തിരയൽ "
-"അന്വേഷണങ്ങൾക്ക് അജ്ഞാതമായി AI സഹായത്തോടെയുള്ള ഉത്തരങ്ങൾ സൃഷ്ടിക്കാൻ കഴിയും. "
-"ഇത് ചെയ്യുന്നതിന്, പ്രസക്തമായ ഉള്ളടക്കത്തിനായി ഇത് വെബ് സ്കാൻ ചെയ്യുകയും "
-"തുടർന്ന് കണ്ടെത്തിയ പ്രസക്തമായ വിവരങ്ങളെ അടിസ്ഥാനമാക്കി ഒരു ഹ്രസ്വമായ ഉത്തരം "
-"സൃഷ്ടിക്കുന്നതിന് AI- പിന്തുണയ്ക്കുന്ന സ്വഭാവിക ഭാഷ സാങ്കേതികവിദ്യ "
-"ഉപയോഗിക്കുകയും ചെയ്യുന്നു. ഉദ്ധരിച്ച ഉറവിടങ്ങളിൽ നിന്ന് പ്രതികരണങ്ങൾ സ്വയം "
-"സൃഷ്ടിക്കപ്പെട്ടതാണെന്നും%2$s വെബ് ക്രൗളിങ്ങിനെ "
-"%1$sഅടിസ്ഥാനമാക്കിയുള്ളതാണെന്നും ഓർമ്മിക്കേണ്ടത് പ്രധാനമാണ്."
+"ഞങ്ങളുടെ തിരയൽ ഫലങ്ങളിലെ ഒരു ഓപ്ഷണൽ സവിശേഷതയാണ് Assist, അതിന് തിരയൽ അന്വേഷണങ്ങൾക്ക് "
+"അജ്ഞാതമായി AI സഹായത്തോടെയുള്ള ഉത്തരങ്ങൾ സൃഷ്ടിക്കാൻ കഴിയും. ഇത് ചെയ്യുന്നതിന്, പ്രസക്തമായ "
+"ഉള്ളടക്കത്തിനായി ഇത് വെബ് സ്കാൻ ചെയ്യുകയും തുടർന്ന് കണ്ടെത്തിയ പ്രസക്തമായ വിവരങ്ങളെ "
+"അടിസ്ഥാനമാക്കി ഒരു ഹ്രസ്വമായ ഉത്തരം സൃഷ്ടിക്കുന്നതിന് AI- പിന്തുണയ്ക്കുന്ന സ്വഭാവിക ഭാഷ "
+"സാങ്കേതികവിദ്യ ഉപയോഗിക്കുകയും ചെയ്യുന്നു. ഉദ്ധരിച്ച ഉറവിടങ്ങളിൽ നിന്ന് പ്രതികരണങ്ങൾ സ്വയം "
+"സൃഷ്ടിക്കപ്പെട്ടതാണെന്നും%2$s വെബ് ക്രൗളിങ്ങിനെ %1$sഅടിസ്ഥാനമാക്കിയുള്ളതാണെന്നും ഓർമ്മിക്കേണ്ടത് "
+"പ്രധാനമാണ്."
 
 # smartling.placeholder_format=C
 #. Title for the dropdown menu where users select the assistant's role. Example: 'Assistant role: Travel guide'
@@ -2426,16 +2436,15 @@ msgstr "സ്വയമേവയുള്ള-ഉത്തരം"
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid "Auto-generated based on listed sources. May contain inaccuracies."
 msgstr ""
-"ലിസ്റ്റ് ചെയ്ത ഉറവിടങ്ങളെ അടിസ്ഥാനമാക്കി യാന്ത്രികമായി സൃഷ്ടിച്ചത്. അപാകതകൾ "
-"അടങ്ങിയിരിക്കാം."
+"ലിസ്റ്റ് ചെയ്ത ഉറവിടങ്ങളെ അടിസ്ഥാനമാക്കി യാന്ത്രികമായി സൃഷ്ടിച്ചത്. അപാകതകൾ അടങ്ങിയിരിക്കാം."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid ""
 "Auto-generated based on listed sources. Responses may contain inaccuracies."
 msgstr ""
-"ലിസ്റ്റ് ചെയ്ത ഉറവിടങ്ങളെ അടിസ്ഥാനമാക്കി യാന്ത്രികമായി സൃഷ്ടിച്ചത്. "
-"പ്രതികരണങ്ങളിൽ അപാകതകൾ അടങ്ങിയിരിക്കാം."
+"ലിസ്റ്റ് ചെയ്ത ഉറവിടങ്ങളെ അടിസ്ഥാനമാക്കി യാന്ത്രികമായി സൃഷ്ടിച്ചത്. പ്രതികരണങ്ങളിൽ അപാകതകൾ "
+"അടങ്ങിയിരിക്കാം."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI) on mobile
@@ -2460,9 +2469,9 @@ msgid ""
 "look up and summarize information in response to some searches. For now, "
 "Assist is only available in English regions."
 msgstr ""
-"പ്രസക്തമായ തിരയലുകൾക്കായി സ്വയമേവ Assist കാണിക്കുന്നു. Assist-ന് അജ്ഞാതമായി "
-"തിരയാനും ചില സെർച്ചുകൾക്ക് മറുപടിയായി വിവരങ്ങൾ സംഗ്രഹിക്കാനും കഴിയും. "
-"ഇപ്പോൾ, ഇംഗ്ലീഷ് പ്രദേശങ്ങളിൽ മാത്രമേ Assist ലഭ്യമാകൂ."
+"പ്രസക്തമായ തിരയലുകൾക്കായി സ്വയമേവ Assist കാണിക്കുന്നു. Assist-ന് അജ്ഞാതമായി തിരയാനും ചില "
+"സെർച്ചുകൾക്ക് മറുപടിയായി വിവരങ്ങൾ സംഗ്രഹിക്കാനും കഴിയും. ഇപ്പോൾ, ഇംഗ്ലീഷ് പ്രദേശങ്ങളിൽ "
+"മാത്രമേ Assist ലഭ്യമാകൂ."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2471,17 +2480,16 @@ msgid ""
 "anonymously look up and summarize information in response to some searches. "
 "For now, DuckAssist is only available in English regions."
 msgstr ""
-"പ്രസക്തമായ തിരയലുകൾക്കായി സ്വയമേവ DuckAssist കാണിക്കുന്നു. DuckAssist-ന് "
-"അജ്ഞാതമായി തിരയാനും ചില തിരയലുകൾക്ക് മറുപടിയായി വിവരങ്ങൾ സംഗ്രഹിക്കാനും "
-"കഴിയും. ഇപ്പോൾ, ഇംഗ്ലീഷ് പ്രദേശങ്ങളിൽ മാത്രമേ DuckAssist ലഭ്യമാകൂ."
+"പ്രസക്തമായ തിരയലുകൾക്കായി സ്വയമേവ DuckAssist കാണിക്കുന്നു. DuckAssist-ന് അജ്ഞാതമായി "
+"തിരയാനും ചില തിരയലുകൾക്ക് മറുപടിയായി വിവരങ്ങൾ സംഗ്രഹിക്കാനും കഴിയും. ഇപ്പോൾ, ഇംഗ്ലീഷ് "
+"പ്രദേശങ്ങളിൽ മാത്രമേ DuckAssist ലഭ്യമാകൂ."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Autoplay short, silent video previews when you hover over video results."
 msgstr ""
-"വീഡിയോ ഫലങ്ങളിൽ ഹോവർ ചെയ്യുമ്പോൾ ചെറുതും നിശബ്‌ദവുമായ വീഡിയോ പ്രിവ്യൂകൾ "
-"സ്വയമേവ പ്ലേ ചെയ്യുക."
+"വീഡിയോ ഫലങ്ങളിൽ ഹോവർ ചെയ്യുമ്പോൾ ചെറുതും നിശബ്‌ദവുമായ വീഡിയോ പ്രിവ്യൂകൾ സ്വയമേവ പ്ലേ ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Screen-reader label for the radiogroup of tool options inside the Tools dropdown. Announced when assistive technology enters the group of menuitemradio items.
@@ -2507,9 +2515,7 @@ msgstr "ശരാശരി വോളിയം"
 #. Warning text shown below the chat input when the user has attached files, advising them not to upload files from untrusted sources.
 msgctxt "Disclaimer below chat input in Duck.ai when files are attached"
 msgid "Avoid uploading files from sources you don't trust."
-msgstr ""
-"നിങ്ങൾ വിശ്വസിക്കാത്ത ഉറവിടങ്ങളിൽ നിന്ന് ഫയലുകൾ അപ്‌ലോഡ് ചെയ്യുന്നത് "
-"ഒഴിവാക്കുക."
+msgstr "നിങ്ങൾ വിശ്വസിക്കാത്ത ഉറവിടങ്ങളിൽ നിന്ന് ഫയലുകൾ അപ്‌ലോഡ് ചെയ്യുന്നത് ഒഴിവാക്കുക."
 
 # smartling.placeholder_format=C
 #. Indicates the Win-Loss record of a team when playing away
@@ -2625,6 +2631,12 @@ msgid "Barcode"
 msgstr "ബാർകോഡ്"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Based on this page, is this course worth taking?"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Basic"
 msgstr "അടിസ്ഥാനം"
@@ -2663,6 +2675,14 @@ msgstr "ബാറ്റർ"
 msgctxt "Assistant response placeholder"
 msgid "Before continuing..."
 msgstr "തുടരുന്നതിന് മുൻപ്..."
+
+# smartling.placeholder_format=C
+#. Explains that before storing the report, DuckDuckGo will anonymize the conversation by removing PII like names, email addresses, and identifying metadata.
+msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
+msgid ""
+"Before storing this report, DuckDuckGo will anonymize your conversation by "
+"removing PII like names, email addresses, and identifying metadata."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -2981,6 +3001,12 @@ msgid "Break Points Won"
 msgstr "നേടിയ ബ്രേക്ക് പോയിന്റുകൾ"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Break this down into clear, numbered steps."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
 msgctxt "Weather IA"
 msgid "Breezy"
@@ -3037,18 +3063,18 @@ msgid ""
 "Browse as usual while we add privacy protection. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
 msgstr ""
-"ഞങ്ങൾ സ്വകാര്യത പരിരക്ഷണം ചേർക്കുമ്പോൾ പതിവുപോലെ ബ്രൗസ് ചെയ്യുക. ഞങ്ങളുടെ "
-"തിരയൽ എഞ്ചിൻ, ട്രാക്കർ ബ്ലോക്കർ, എൻക്രിപ്ഷൻ എൻഫോഴ്സർ എന്നിവ ഒറ്റ %1$s%2$s "
-"വിപുലീകരണത്തിലേക്ക്%3$s ഞങ്ങൾ ഒരുമിച്ചുചേർത്തു."
+"ഞങ്ങൾ സ്വകാര്യത പരിരക്ഷണം ചേർക്കുമ്പോൾ പതിവുപോലെ ബ്രൗസ് ചെയ്യുക. ഞങ്ങളുടെ തിരയൽ എഞ്ചിൻ, "
+"ട്രാക്കർ ബ്ലോക്കർ, എൻക്രിപ്ഷൻ എൻഫോഴ്സർ എന്നിവ ഒറ്റ %1$s%2$s വിപുലീകരണത്തിലേക്ക്%3$s ഞങ്ങൾ "
+"ഒരുമിച്ചുചേർത്തു."
 
 # smartling.placeholder_format=C
 msgid ""
 "Browse as usual, and we'll take care of the rest. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
 msgstr ""
-"സാധാരണപോലെ ബ്രൗസ് ചെയ്യുക, ബാക്കി കാര്യങ്ങൾ ഞങ്ങൾ നോക്കിക്കൊള്ളാം. ഞങ്ങളുടെ "
-"തിരയൽ എഞ്ചിൻ, ട്രാക്കർ ബ്ലോക്കർ, എൻക്രിപ്ഷൻ എൻഫോഴ്സർ എന്നിവ ഒറ്റ %1$s%2$s "
-"വിപുലീകരണത്തിലേക്ക്%3$s ഞങ്ങൾ ഒരുമിച്ചുചേർത്തു."
+"സാധാരണപോലെ ബ്രൗസ് ചെയ്യുക, ബാക്കി കാര്യങ്ങൾ ഞങ്ങൾ നോക്കിക്കൊള്ളാം. ഞങ്ങളുടെ തിരയൽ എഞ്ചിൻ, "
+"ട്രാക്കർ ബ്ലോക്കർ, എൻക്രിപ്ഷൻ എൻഫോഴ്സർ എന്നിവ ഒറ്റ %1$s%2$s വിപുലീകരണത്തിലേക്ക്%3$s ഞങ്ങൾ "
+"ഒരുമിച്ചുചേർത്തു."
 
 # smartling.placeholder_format=C
 msgid ""
@@ -3056,9 +3082,9 @@ msgid ""
 "search, tracker blocking, and site encryption, all in one download, for "
 "%smajor browsers%s."
 msgstr ""
-"സാധാരണപോലെ ബ്രൗസ് ചെയ്യുക, ബാക്കി കാര്യങ്ങൾ ഞങ്ങൾ നോക്കിക്കൊള്ളാം. "
-"%1$sപ്രധാന ബ്രൗസറുകൾക്കായുള്ള%2$s private search, ട്രാക്കർ ബ്ലോക്കിംഗ്, "
-"സൈറ്റ് എൻക്രിപ്ഷൻ എന്നിവ മൊത്തത്തിൽ ഒറ്റ ഡൗൺലോഡിൽ നേടുക."
+"സാധാരണപോലെ ബ്രൗസ് ചെയ്യുക, ബാക്കി കാര്യങ്ങൾ ഞങ്ങൾ നോക്കിക്കൊള്ളാം. %1$sപ്രധാന "
+"ബ്രൗസറുകൾക്കായുള്ള%2$s private search, ട്രാക്കർ ബ്ലോക്കിംഗ്, സൈറ്റ് എൻക്രിപ്ഷൻ എന്നിവ "
+"മൊത്തത്തിൽ ഒറ്റ ഡൗൺലോഡിൽ നേടുക."
 
 # smartling.placeholder_format=C
 #. Header for a call to action to browse with the DuckDuckGo browser
@@ -3144,9 +3170,7 @@ msgstr "'%1$s' ക്ലിക്ക് ചെയ്യുക വഴി, നി�
 msgctxt ""
 "Copy stating agreement to Duck.ai Privacy Policy and Terms of Service."
 msgid "By clicking “%s,” you accept Duck.ai’s %s and %s."
-msgstr ""
-"“%1$s” ക്ലിക്ക് ചെയ്യുന്നതിലൂടെ നീ Duck.ai-യുടെ %2$s ഉം %3$s ഉം "
-"അംഗീകരിക്കുന്നു."
+msgstr "“%1$s” ക്ലിക്ക് ചെയ്യുന്നതിലൂടെ നീ Duck.ai-യുടെ %2$s ഉം %3$s ഉം അംഗീകരിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Text stating agreement to Duck.ai Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'By clicking “Agree and Continue,” you accept Duck.ai’s Privacy Policy and Terms of Service.'
@@ -3167,11 +3191,10 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"സ്വതവേ, വ്യക്തിഗതമല്ലാത്ത ബ്രൗസർ കുക്കികളിലാണ് (നിങ്ങളുടെ ബ്രൗസറിൽ), "
-"ക്രമീകരണം സൂക്ഷിച്ചിരിക്കുന്നത്. നിങ്ങളുടെ ക്രമീകരണം കൂടുതൽ സ്ഥിരമായ ഒരു "
-"വിധത്തിൽ സംഭരിക്കാൻ (ക്ലൗഡിലെ ഒരു റിമോട്ട് സെർവറിൽ), നിങ്ങൾക്ക് അജ്ഞാത "
-"Cloud Save ഉപയോഗിക്കാൻ കഴിയും. വ്യക്തിപരമായി തിരിച്ചറിയാൻ കഴിയുന്ന "
-"വിവരങ്ങളൊന്നും ക്ലൗഡിൽ സംഭരിക്കില്ല, നിങ്ങളുടെ പാസ്‌ഫ്രെയ്സ് ഒരിക്കലും "
+"സ്വതവേ, വ്യക്തിഗതമല്ലാത്ത ബ്രൗസർ കുക്കികളിലാണ് (നിങ്ങളുടെ ബ്രൗസറിൽ), ക്രമീകരണം "
+"സൂക്ഷിച്ചിരിക്കുന്നത്. നിങ്ങളുടെ ക്രമീകരണം കൂടുതൽ സ്ഥിരമായ ഒരു വിധത്തിൽ സംഭരിക്കാൻ (ക്ലൗഡിലെ "
+"ഒരു റിമോട്ട് സെർവറിൽ), നിങ്ങൾക്ക് അജ്ഞാത Cloud Save ഉപയോഗിക്കാൻ കഴിയും. വ്യക്തിപരമായി "
+"തിരിച്ചറിയാൻ കഴിയുന്ന വിവരങ്ങളൊന്നും ക്ലൗഡിൽ സംഭരിക്കില്ല, നിങ്ങളുടെ പാസ്‌ഫ്രെയ്സ് ഒരിക്കലും "
 "നിങ്ങളുടെ ബ്രൗസറിൽ നിന്ന് പുറത്തുപോകില്ല."
 
 # smartling.placeholder_format=C
@@ -3180,9 +3203,8 @@ msgid ""
 "By enabling dictation, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
 msgstr ""
-"ഡിക്ടേഷന്‍ പ്രവര്‍ത്തനക്ഷമമാക്കുന്നതിലൂടെ, ഈ സവിശേഷത ഉപയോഗിക്കുന്നതിനായി "
-"നിങ്ങളുടെ ശബ്ദ ഡാറ്റ OpenAI-ലേക്ക് അയയ്ക്കുന്നതിന് നിങ്ങൾ സമ്മതം നൽകുന്നു. "
-"ആരംഭിക്കുന്നതിന് മുമ്പ് ഞങ്ങളുടെ %1$s കാണൂ."
+"ഡിക്ടേഷന്‍ പ്രവര്‍ത്തനക്ഷമമാക്കുന്നതിലൂടെ, ഈ സവിശേഷത ഉപയോഗിക്കുന്നതിനായി നിങ്ങളുടെ ശബ്ദ ഡാറ്റ "
+"OpenAI-ലേക്ക് അയയ്ക്കുന്നതിന് നിങ്ങൾ സമ്മതം നൽകുന്നു. ആരംഭിക്കുന്നതിന് മുമ്പ് ഞങ്ങളുടെ %1$s കാണൂ."
 
 # smartling.placeholder_format=C
 #. Description for the 'enable voice chat' section of the voice chat consent modal. Placeholder for the voice chat help page link and text. Example: 'By enabling voice chat, you consent to your voice data being sent to OpenAI for the use of this feature. See our voice chat help page before getting started.'
@@ -3191,9 +3213,9 @@ msgid ""
 "By enabling voice chat, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
 msgstr ""
-"വോയ്സ് ചാറ്റ് പ്രവർത്തനക്ഷമമാക്കുന്നതിലൂടെ, ഈ സവിശേഷത ഉപയോഗിക്കുന്നതിനായി "
-"നിങ്ങളുടെ വോയ്സ് ഡാറ്റ OpenAI-ലേക്ക് അയയ്ക്കുന്നതിന് നിങ്ങൾ സമ്മതം നൽകുന്നു. "
-"ആരംഭിക്കുന്നതിന് മുമ്പ് ഞങ്ങളുടെ %1$s കാണൂ."
+"വോയ്സ് ചാറ്റ് പ്രവർത്തനക്ഷമമാക്കുന്നതിലൂടെ, ഈ സവിശേഷത ഉപയോഗിക്കുന്നതിനായി നിങ്ങളുടെ വോയ്സ് "
+"ഡാറ്റ OpenAI-ലേക്ക് അയയ്ക്കുന്നതിന് നിങ്ങൾ സമ്മതം നൽകുന്നു. ആരംഭിക്കുന്നതിന് മുമ്പ് ഞങ്ങളുടെ %1$s "
+"കാണൂ."
 
 # smartling.placeholder_format=C
 #. Golf leaderboard: player missed the cut
@@ -3229,8 +3251,8 @@ msgstr "കാമറൂൺ"
 msgctxt "Full sentence for crafting a recipe"
 msgid "Can you create a few simple recipes using chicken, broccoli, and rice?"
 msgstr ""
-"കോഴിയിറച്ചി, ബ്രോക്കോളി, അരി എന്നിവ ഉപയോഗിച്ച് നിങ്ങൾക്ക് ഏതാനും ലളിതമായ "
-"പാചകക്കുറിപ്പുകൾ സൃഷ്ടിക്കാൻ കഴിയുമോ?"
+"കോഴിയിറച്ചി, ബ്രോക്കോളി, അരി എന്നിവ ഉപയോഗിച്ച് നിങ്ങൾക്ക് ഏതാനും ലളിതമായ പാചകക്കുറിപ്പുകൾ "
+"സൃഷ്ടിക്കാൻ കഴിയുമോ?"
 
 # smartling.placeholder_format=C
 msgid "Canada"
@@ -3441,6 +3463,12 @@ msgid "Cast"
 msgstr "കാസ്റ്റ്"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Cast & Crew"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
 msgctxt "Tone option label for Casual"
 msgid "Casual"
@@ -3526,8 +3554,7 @@ msgstr "ഫലങ്ങളുടെ URL-കൾ എങ്ങനെ പ്രദ�
 msgctxt "settings"
 msgid "Changes how the header is displayed and its behavior as you scroll"
 msgstr ""
-"നിങ്ങൾ സ്ക്രോൾ ചെയ്യുമ്പോൾ ശീർഷകം എങ്ങനെ പ്രദർശിപ്പിക്കുന്നു എന്നതും അതിന്റെ "
-"പെരുമാറ്റവും മാറുന്നു"
+"നിങ്ങൾ സ്ക്രോൾ ചെയ്യുമ്പോൾ ശീർഷകം എങ്ങനെ പ്രദർശിപ്പിക്കുന്നു എന്നതും അതിന്റെ പെരുമാറ്റവും മാറുന്നു"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/mcZdcaF.png
@@ -3546,17 +3573,13 @@ msgstr "മുഴുവൻ സൈറ്റിലും പശ്ചാത്ത�
 msgctxt "settings"
 msgid ""
 "Changes the background color of results on hover, modules, and dropdown menus"
-msgstr ""
-"ഹോവർ, മൊഡ്യൂളുകൾ, ഡ്രോപ്പ്ഡൗൺ മെനുകൾ എന്നിവയിലെ ഫലങ്ങളുടെ പശ്ചാത്തല നിറം "
-"മാറ്റുന്നു"
+msgstr "ഹോവർ, മൊഡ്യൂളുകൾ, ഡ്രോപ്പ്ഡൗൺ മെനുകൾ എന്നിവയിലെ ഫലങ്ങളുടെ പശ്ചാത്തല നിറം മാറ്റുന്നു"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/NdpkbY0.png
 msgctxt "settings"
 msgid "Changes the background color when hovering over a result"
-msgstr ""
-"ഫലങ്ങളുടെ മുകളില്‍ കൂടി മൗസ് ചലിപ്പിക്കുമ്പോള്‍ പശ്ചാത്തലത്തിന്റെ നിറം "
-"മാറ്റുന്നു"
+msgstr "ഫലങ്ങളുടെ മുകളില്‍ കൂടി മൗസ് ചലിപ്പിക്കുമ്പോള്‍ പശ്ചാത്തലത്തിന്റെ നിറം മാറ്റുന്നു"
 
 # smartling.placeholder_format=C
 #. Description of a setting managing the color of search result snippet text.
@@ -3679,11 +3702,10 @@ msgid ""
 "DuckDuckGo Search. However, you can still access Chat when this setting is "
 "off by visiting %shttps://duck.ai%s directly."
 msgstr ""
-"നിങ്ങൾക്ക് മൂന്നാം കക്ഷി AI ചാറ്റ് മോഡലുകളുമായി അജ്ഞാത സംഭാഷണങ്ങൾ നടത്താൻ "
-"ചാറ്റ് (Duck.ai സേവനം വഴി) നിങ്ങളെ അനുവദിക്കുന്നു, ഇത് OpenAI, Anthropic "
-"തുടങ്ങിയ മോഡലുകളെ പിന്തുണയ്ക്കുന്നു. ഈ ക്രമീകരണം ഓഫാക്കുന്നത് DuckDuckGo "
-"Search-ൽ ചാറ്റ് ബട്ടണുകളും ലിങ്കുകളും മറയ്ക്കും. എന്നിരുന്നാലും, "
-"%1$shttps://duck.ai%2$s സന്ദർശിച്ച് ഈ ക്രമീകരണം ഓഫ് ആയിരിക്കുമ്പോഴും "
+"നിങ്ങൾക്ക് മൂന്നാം കക്ഷി AI ചാറ്റ് മോഡലുകളുമായി അജ്ഞാത സംഭാഷണങ്ങൾ നടത്താൻ ചാറ്റ് (Duck.ai "
+"സേവനം വഴി) നിങ്ങളെ അനുവദിക്കുന്നു, ഇത് OpenAI, Anthropic തുടങ്ങിയ മോഡലുകളെ പിന്തുണയ്ക്കുന്നു. "
+"ഈ ക്രമീകരണം ഓഫാക്കുന്നത് DuckDuckGo Search-ൽ ചാറ്റ് ബട്ടണുകളും ലിങ്കുകളും മറയ്ക്കും. "
+"എന്നിരുന്നാലും, %1$shttps://duck.ai%2$s സന്ദർശിച്ച് ഈ ക്രമീകരണം ഓഫ് ആയിരിക്കുമ്പോഴും "
 "നിങ്ങൾക്ക് ചാറ്റ് ആക്സസ് ചെയ്യാൻ കഴിയും. നേരിട്ട്."
 
 # smartling.placeholder_format=C
@@ -3740,8 +3762,8 @@ msgstr "സ്വകാര്യമായി ചാറ്റ് ചെയ്യ�
 msgctxt "Promotional text (mobile)"
 msgid "Chat privately on any website with Duck.ai built into our free browser."
 msgstr ""
-"ഞങ്ങളുടെ സൗജന്യ ബ്രൗസറിൽ തന്നെയുള്ള Duck.ai ഉപയോഗിച്ച് ഏത് വെബ്‌സൈറ്റിലും "
-"സ്വകാര്യമായി ചാറ്റ് ചെയ്യുക."
+"ഞങ്ങളുടെ സൗജന്യ ബ്രൗസറിൽ തന്നെയുള്ള Duck.ai ഉപയോഗിച്ച് ഏത് വെബ്‌സൈറ്റിലും സ്വകാര്യമായി ചാറ്റ് "
+"ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card encouraging third-party browser users to download the DuckDuckGo browser. Not shown in the DuckDuckGo browser or on Linux.
@@ -3749,8 +3771,8 @@ msgctxt "Promotional text"
 msgid ""
 "Chat privately on any website with the Duck.ai sidebar in our free browser."
 msgstr ""
-"ഞങ്ങളുടെ സൗജന്യ ബ്രൗസറിലെ Duck.ai സൈഡ്‌ബാർ ഉപയോഗിച്ച് ഏത് വെബ്‌സൈറ്റിലും "
-"സ്വകാര്യമായി ചാറ്റ് ചെയ്യുക."
+"ഞങ്ങളുടെ സൗജന്യ ബ്രൗസറിലെ Duck.ai സൈഡ്‌ബാർ ഉപയോഗിച്ച് ഏത് വെബ്‌സൈറ്റിലും സ്വകാര്യമായി ചാറ്റ് "
+"ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
@@ -3813,9 +3835,9 @@ msgid ""
 "Chats are stored locally on your device instead of on DuckDuckGo servers or "
 "remote servers. Disabling chat history will delete pinned chats."
 msgstr ""
-"ചാറ്റുകൾ DuckDuckGo സെർവറുകളിലോ വിദൂര സെർവറുകളിലോ സംഭരിക്കുന്നതിന് പകരം "
-"നിങ്ങളുടെ ഉപകരണത്തിൽ പ്രാദേശികമായി സംഭരിക്കുന്നു. ചാറ്റ് ചരിത്രം "
-"പ്രവർത്തനരഹിതമാക്കുന്നത് പിൻ ചെയ്ത ചാറ്റുകൾ നീക്കം ചെയ്യും."
+"ചാറ്റുകൾ DuckDuckGo സെർവറുകളിലോ വിദൂര സെർവറുകളിലോ സംഭരിക്കുന്നതിന് പകരം നിങ്ങളുടെ "
+"ഉപകരണത്തിൽ പ്രാദേശികമായി സംഭരിക്കുന്നു. ചാറ്റ് ചരിത്രം പ്രവർത്തനരഹിതമാക്കുന്നത് പിൻ ചെയ്ത "
+"ചാറ്റുകൾ നീക്കം ചെയ്യും."
 
 # smartling.placeholder_format=C
 #. Text explaining how the Chat History feature stores the user's chats locally to their device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection. Also explains that disabling chat history will delete pinned chats.
@@ -3827,13 +3849,11 @@ msgid ""
 "history will delete pinned chats, and disable the temporary storage of new "
 "prompts and responses."
 msgstr ""
-"ചാറ്റുകൾ നിങ്ങളുടെ ഉപകരണത്തിൽ തന്നെ സംഭരിക്കപ്പെടുന്നു. പുതിയ "
-"പ്രോംപ്റ്റുകളും പ്രതികരണങ്ങളും അയച്ചതിനുശേഷം എൻക്രിപ്റ്റ് ചെയ്ത് "
-"താൽക്കാലികമായി ഒരു DuckDuckGo സെർവറിൽ സംഭരിക്കും, ഇത് നിങ്ങളുടെ ഇന്റർനെറ്റ് "
-"കണക്ഷൻ നഷ്ടപ്പെട്ടാൽ ഒരു ചാറ്റ് വീണ്ടെടുക്കാൻ സഹായിക്കും. ചാറ്റ് ചരിത്രം "
-"പ്രവർത്തനരഹിതമാക്കുന്നത് പിൻ ചെയ്‌ത ചാറ്റുകൾ ഇല്ലാതാക്കുകയും പുതിയ "
-"പ്രോംപ്റ്റുകളുടെയും പ്രതികരണങ്ങളുടെയും താൽക്കാലിക സ്റ്റോറേജ് "
-"പ്രവർത്തനരഹിതമാക്കുകയും ചെയ്യും."
+"ചാറ്റുകൾ നിങ്ങളുടെ ഉപകരണത്തിൽ തന്നെ സംഭരിക്കപ്പെടുന്നു. പുതിയ പ്രോംപ്റ്റുകളും പ്രതികരണങ്ങളും "
+"അയച്ചതിനുശേഷം എൻക്രിപ്റ്റ് ചെയ്ത് താൽക്കാലികമായി ഒരു DuckDuckGo സെർവറിൽ സംഭരിക്കും, ഇത് "
+"നിങ്ങളുടെ ഇന്റർനെറ്റ് കണക്ഷൻ നഷ്ടപ്പെട്ടാൽ ഒരു ചാറ്റ് വീണ്ടെടുക്കാൻ സഹായിക്കും. ചാറ്റ് ചരിത്രം "
+"പ്രവർത്തനരഹിതമാക്കുന്നത് പിൻ ചെയ്‌ത ചാറ്റുകൾ ഇല്ലാതാക്കുകയും പുതിയ പ്രോംപ്റ്റുകളുടെയും "
+"പ്രതികരണങ്ങളുടെയും താൽക്കാലിക സ്റ്റോറേജ് പ്രവർത്തനരഹിതമാക്കുകയും ചെയ്യും."
 
 # smartling.placeholder_format=C
 #. Title shown above the body copy in the Duck.ai recent chats IndexedDB unavailable notice.
@@ -3855,8 +3875,8 @@ msgctxt "Sync file storage inline disclaimer body"
 msgid ""
 "Chats with attachments have stopped syncing. Free up storage to resume Sync."
 msgstr ""
-"അറ്റാച്ചുമെന്റുകളുള്ള ചാറ്റുകൾ സമന്വയിപ്പിക്കുന്നത് നിർത്തിയിരിക്കുന്നു. "
-"സമന്വയം പുനരാരംഭിക്കാൻ സംഭരണ സ്ഥലം ശൂന്യമാക്കുക."
+"അറ്റാച്ചുമെന്റുകളുള്ള ചാറ്റുകൾ സമന്വയിപ്പിക്കുന്നത് നിർത്തിയിരിക്കുന്നു. സമന്വയം പുനരാരംഭിക്കാൻ "
+"സംഭരണ സ്ഥലം ശൂന്യമാക്കുക."
 
 # smartling.placeholder_format=C
 #. Message shown when we have no data from upstream to display
@@ -3909,9 +3929,7 @@ msgstr "സ്പെല്ലിംഗ് പരിശോധിക്കുക"
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
 msgctxt "noresults"
 msgid "Check the DuckDuckGo subreddit for updates on this outage."
-msgstr ""
-"ഈ തടസ്സത്തിനെക്കുറിച്ചുള്ള അപ്ഡേറ്റുകൾക്കായി DuckDuckGo സബ് റെഡ്ഡിറ്റ് "
-"പരിശോധിക്കുക."
+msgstr "ഈ തടസ്സത്തിനെക്കുറിച്ചുള്ള അപ്ഡേറ്റുകൾക്കായി DuckDuckGo സബ് റെഡ്ഡിറ്റ് പരിശോധിക്കുക."
 
 # smartling.placeholder_format=C
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
@@ -3976,9 +3994,7 @@ msgstr "%1$s , %2$s എന്നിവ ഉൾപ്പെടെ AI മോഡല�
 # smartling.placeholder_format=C
 #. As in 'Choose to keep DuckDuckGo as your default search engine'. Placeholders are for markup, you can ignore them.
 msgid "Choose %skeep it%s to continue protecting your privacy."
-msgstr ""
-"നിങ്ങളുടെ സ്വകാര്യത പരിരക്ഷിക്കുന്നത് തുടരാൻ %1$sനിലനിർത്തുക%2$s "
-"തിരഞ്ഞെടുക്കുക."
+msgstr "നിങ്ങളുടെ സ്വകാര്യത പരിരക്ഷിക്കുന്നത് തുടരാൻ %1$sനിലനിർത്തുക%2$s തിരഞ്ഞെടുക്കുക."
 
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
@@ -4013,8 +4029,8 @@ msgctxt "settings"
 msgid ""
 "Choose which app to use when you need directions for a location search result"
 msgstr ""
-"നിങ്ങൾക്ക് ഒരു ലൊക്കേഷൻ തിരയൽ ഫലത്തിനായി നിർദ്ദേശങ്ങൾ ആവശ്യമുള്ളപ്പോൾ ഏത് "
-"ആപ്പ് ഉപയോഗിക്കണമെന്ന് തിരഞ്ഞെടുക്കുക"
+"നിങ്ങൾക്ക് ഒരു ലൊക്കേഷൻ തിരയൽ ഫലത്തിനായി നിർദ്ദേശങ്ങൾ ആവശ്യമുള്ളപ്പോൾ ഏത് ആപ്പ് "
+"ഉപയോഗിക്കണമെന്ന് തിരഞ്ഞെടുക്കുക"
 
 # smartling.placeholder_format=C
 #. Accessible label for the citations popover dialog in Duck.ai chat responses.
@@ -4195,9 +4211,9 @@ msgid ""
 "Clearing browser data deletes chats. Some browsers may keep recent chats "
 "indefinitely or auto-delete them after 7+ days of no AI Chat use."
 msgstr ""
-"ബ്രൗസർ ഡാറ്റ മായ്ക്കുന്നത് ചാറ്റുകൾ ഇല്ലാതാക്കും. ചില ബ്രൗസറുകൾ അടുത്തിടെ "
-"നടന്ന ചാറ്റുകൾ അനിശ്ചിതകാലം സൂക്ഷിക്കുകയോ AI Chat ഉപയോഗം ഇല്ലാത്ത 7 "
-"ദിവസങ്ങൾക്ക് ശേഷം യാന്ത്രികമായി ഇല്ലാതാക്കുകയോ ചെയ്തേക്കാം."
+"ബ്രൗസർ ഡാറ്റ മായ്ക്കുന്നത് ചാറ്റുകൾ ഇല്ലാതാക്കും. ചില ബ്രൗസറുകൾ അടുത്തിടെ നടന്ന ചാറ്റുകൾ "
+"അനിശ്ചിതകാലം സൂക്ഷിക്കുകയോ AI Chat ഉപയോഗം ഇല്ലാത്ത 7 ദിവസങ്ങൾക്ക് ശേഷം യാന്ത്രികമായി "
+"ഇല്ലാതാക്കുകയോ ചെയ്തേക്കാം."
 
 # smartling.placeholder_format=C
 #. Text explaining what happens to recent chats when browser data is cleared.
@@ -4207,10 +4223,9 @@ msgid ""
 "indefinitely or auto-deleted after 7 days without using Duck.ai, depending "
 "on your browser."
 msgstr ""
-"ബ്രൗസർ ഡാറ്റ മായ്ക്കുന്നത് സമീപകാല ചാറ്റുകൾ ഇല്ലാതാക്കും. സമീപകാല ചാറ്റുകൾ "
-"Duck.ai ഉപയോഗിക്കാതെ 7 ദിവസത്തിനുശേഷം അനിശ്ചിതകാലം സൂക്ഷിക്കപ്പെടുകയോ "
-"യാന്ത്രികമായി ഇല്ലാതാക്കുകയോ ചെയ്യാം. നിങ്ങളുടെ ബ്രൗസറിനെ "
-"ആശ്രയിച്ചിരിക്കുന്നു."
+"ബ്രൗസർ ഡാറ്റ മായ്ക്കുന്നത് സമീപകാല ചാറ്റുകൾ ഇല്ലാതാക്കും. സമീപകാല ചാറ്റുകൾ Duck.ai "
+"ഉപയോഗിക്കാതെ 7 ദിവസത്തിനുശേഷം അനിശ്ചിതകാലം സൂക്ഷിക്കപ്പെടുകയോ യാന്ത്രികമായി ഇല്ലാതാക്കുകയോ "
+"ചെയ്യാം. നിങ്ങളുടെ ബ്രൗസറിനെ ആശ്രയിച്ചിരിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Warning message shown on the Block domain success modal. Blocked sites are stored in localStorage which is cleared alongside cookies when users clear browser data. Followed by a linked 'our free browser' text.
@@ -4219,8 +4234,8 @@ msgid ""
 "Clearing browser data will reset your blocked sites. Save your block list "
 "permanently in"
 msgstr ""
-"ബ്രൗസർ ഡാറ്റ മായ്ക്കുന്നത് നിങ്ങൾ തടഞ്ഞ സൈറ്റുകളെ റീസെറ്റ് ചെയ്യും. "
-"നിങ്ങളുടെ ബ്ലോക്ക് ലിസ്റ്റ് ശാശ്വതമായി ഞങ്ങളുടെ സൗജന്യ"
+"ബ്രൗസർ ഡാറ്റ മായ്ക്കുന്നത് നിങ്ങൾ തടഞ്ഞ സൈറ്റുകളെ റീസെറ്റ് ചെയ്യും. നിങ്ങളുടെ ബ്ലോക്ക് ലിസ്റ്റ് "
+"ശാശ്വതമായി ഞങ്ങളുടെ സൗജന്യ"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -4229,10 +4244,9 @@ msgid ""
 "%sDuck.ai%s, our private AI chat service that supports chat models from "
 "OpenAI, Anthropic, and more."
 msgstr ""
-"ഒരു വിഷയത്തിൽ കൂടുതൽ ആഴത്തിൽ പോകാൻ \"കൂടുതൽ\" ക്ലിക്ക് ചെയ്യുക, കൂടാതെ "
-"%1$sDuck.ai%2$s വഴി ഫോളോ-അപ്പ് ചോദ്യങ്ങൾ ചോദിക്കൂ OpenAI, Anthropic "
-"എന്നിവയിൽ നിന്നുള്ള ചാറ്റ് മോഡലുകളെ പിന്തുണയ്ക്കുന്ന ഞങ്ങളുടെ സ്വകാര്യ AI "
-"ചാറ്റ് സേവനം."
+"ഒരു വിഷയത്തിൽ കൂടുതൽ ആഴത്തിൽ പോകാൻ \"കൂടുതൽ\" ക്ലിക്ക് ചെയ്യുക, കൂടാതെ %1$sDuck.ai%2$s "
+"വഴി ഫോളോ-അപ്പ് ചോദ്യങ്ങൾ ചോദിക്കൂ OpenAI, Anthropic എന്നിവയിൽ നിന്നുള്ള ചാറ്റ് മോഡലുകളെ "
+"പിന്തുണയ്ക്കുന്ന ഞങ്ങളുടെ സ്വകാര്യ AI ചാറ്റ് സേവനം."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4291,9 +4305,7 @@ msgstr "DuckDuckGo എക്സ്റ്റൻഷൻ ഡൗൺലോഡ് ച�
 # smartling.placeholder_format=C
 #. Link to download the DuckDuckGo browser extension.
 msgid "Click %sOpen%s to download and open the DuckDuckGo Safari extension"
-msgstr ""
-"DuckDuckGo Safari എക്സ്റ്റൻഷൻ ഡൗൺലോഡ് ചെയ്യാൻ %1$sതുറക്കുക%2$s ക്ലിക്ക് "
-"ചെയ്യുക"
+msgstr "DuckDuckGo Safari എക്സ്റ്റൻഷൻ ഡൗൺലോഡ് ചെയ്യാൻ %1$sതുറക്കുക%2$s ക്ലിക്ക് ചെയ്യുക"
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -4310,8 +4322,8 @@ msgid ""
 "Click %sSafari%s in the top menu (On Windows, click the %sgears icon%s in "
 "the top right)"
 msgstr ""
-"മുകളിലെ മെനുവിലെ %1$sSafari%2$s ക്ലിക്ക് ചെയ്യുക (Windows-ൽ, മുകളിൽ "
-"വലതുവശത്തുള്ള %3$sഗിയേഴ്സ് ഐക്കൺ%4$s ക്ലിക്ക് ചെയ്യുക)"
+"മുകളിലെ മെനുവിലെ %1$sSafari%2$s ക്ലിക്ക് ചെയ്യുക (Windows-ൽ, മുകളിൽ വലതുവശത്തുള്ള "
+"%3$sഗിയേഴ്സ് ഐക്കൺ%4$s ക്ലിക്ക് ചെയ്യുക)"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4329,8 +4341,7 @@ msgstr "ഡ്രോപ്പ്ഡൗണിൽ %1$sക്രമീകരണം%
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
 msgstr ""
-"%1$sനിലവിലുള്ള പേജുകൾ ഉപയോഗിക്കുക%2$s ക്ലിക്ക് ചെയ്യുക, തുടർന്ന് %3$sശരി "
-"ക്ലിക്ക് ചെയ്യുക%4$s."
+"%1$sനിലവിലുള്ള പേജുകൾ ഉപയോഗിക്കുക%2$s ക്ലിക്ക് ചെയ്യുക, തുടർന്ന് %3$sശരി ക്ലിക്ക് ചെയ്യുക%4$s."
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -4343,8 +4354,7 @@ msgstr "%1$sഉവ്വ്%2$s ക്ലിക്ക് ചെയ്യുക"
 #. Tells the user where to click to open their browser's settings menu.
 msgid "Click %ssettings/hamburger icon %s on the Chrome toolbar (top right)."
 msgstr ""
-"(മുകളിൽ വലത്), Chrome ടൂൾബാറിലെ %1$sക്രമീകരണം/ഹാംബർഗർ ഐക്കൺ %2$s ക്ലിക്ക് "
-"ചെയ്യുക."
+"(മുകളിൽ വലത്), Chrome ടൂൾബാറിലെ %1$sക്രമീകരണം/ഹാംബർഗർ ഐക്കൺ %2$s ക്ലിക്ക് ചെയ്യുക."
 
 #  Maxthon default search engine instruction
 # smartling.placeholder_format=C
@@ -4406,10 +4416,9 @@ msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Search Settings%s."
 msgstr ""
-"%1$sഎൻ്റെ ഡാറ്റ ഇല്ലാതാക്കുക%2$s ക്ലിക്ക് ചെയ്യുക അല്ലെങ്കിൽ ടാപ്പ് ചെയ്യുക. "
-"ഇത് ക്ലൗഡിൽ നിന്ന് ഡാറ്റ നീക്കംചെയ്യുന്നു, എന്നാൽ നിങ്ങൾ %3$sഎല്ലാ തിരയൽ "
-"ക്രമീകരണവും പുനഃക്രമീകരിക്കുക%4$s ക്ലിക്ക്/ടാപ്പ് ചെയ്യുന്നതുവരെ ഇത് "
-"നിങ്ങളുടെ ബ്രൗസറിൽ തുടരും."
+"%1$sഎൻ്റെ ഡാറ്റ ഇല്ലാതാക്കുക%2$s ക്ലിക്ക് ചെയ്യുക അല്ലെങ്കിൽ ടാപ്പ് ചെയ്യുക. ഇത് ക്ലൗഡിൽ നിന്ന് "
+"ഡാറ്റ നീക്കംചെയ്യുന്നു, എന്നാൽ നിങ്ങൾ %3$sഎല്ലാ തിരയൽ ക്രമീകരണവും പുനഃക്രമീകരിക്കുക%4$s "
+"ക്ലിക്ക്/ടാപ്പ് ചെയ്യുന്നതുവരെ ഇത് നിങ്ങളുടെ ബ്രൗസറിൽ തുടരും."
 
 # smartling.placeholder_format=C
 #. Tells users where to click in order to disable the cloud save feature and delete any data backed-up to the cloud.
@@ -4420,10 +4429,9 @@ msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Settings%s."
 msgstr ""
-"%1$sഎന്റെ ഡാറ്റ ഇല്ലാതാക്കുക%2$s ക്ലിക്ക് ചെയ്യുക അല്ലെങ്കിൽ ടാപ്പ് ചെയ്യുക. "
-"ഇത് ക്ലൗഡിൽ നിന്ന് ഡാറ്റ നീക്കംചെയ്യുന്നു, എന്നാൽ നിങ്ങൾ %3$sഎല്ലാ "
-"ക്രമീകരണവും പുനഃക്രമീകരിക്കുക%4$s ക്ലിക്ക്/ടാപ്പ് ചെയ്യുന്നതുവരെ ഇത് "
-"നിങ്ങളുടെ ബ്രൗസറിൽ തുടരും."
+"%1$sഎന്റെ ഡാറ്റ ഇല്ലാതാക്കുക%2$s ക്ലിക്ക് ചെയ്യുക അല്ലെങ്കിൽ ടാപ്പ് ചെയ്യുക. ഇത് ക്ലൗഡിൽ നിന്ന് "
+"ഡാറ്റ നീക്കംചെയ്യുന്നു, എന്നാൽ നിങ്ങൾ %3$sഎല്ലാ ക്രമീകരണവും പുനഃക്രമീകരിക്കുക%4$s ക്ലിക്ക്/"
+"ടാപ്പ് ചെയ്യുന്നതുവരെ ഇത് നിങ്ങളുടെ ബ്രൗസറിൽ തുടരും."
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -4492,8 +4500,8 @@ msgid ""
 "Click the dropdown menu beside %sSearch engine used in the address bar%s and "
 "select %sDuckDuckGo%s."
 msgstr ""
-"%1$sവിലാസ ബാറിൽ ഉപയോഗിച്ചിരിക്കുന്ന തിരയൽ എഞ്ചിന്%2$s സമീപമുള്ള ഡ്രോപ്പ്ഡൗൺ "
-"മെനുവിൽ ക്ലിക്ക് ചെയ്ത്, %3$sDuckDuckGo%4$s തിരഞ്ഞെടുക്കുക."
+"%1$sവിലാസ ബാറിൽ ഉപയോഗിച്ചിരിക്കുന്ന തിരയൽ എഞ്ചിന്%2$s സമീപമുള്ള ഡ്രോപ്പ്ഡൗൺ മെനുവിൽ "
+"ക്ലിക്ക് ചെയ്ത്, %3$sDuckDuckGo%4$s തിരഞ്ഞെടുക്കുക."
 
 # smartling.placeholder_format=C
 #. First step in a list of steps to take to disable the user's ad blocker
@@ -4501,8 +4509,8 @@ msgid ""
 "Click the icon of the ad blocker extension. It's usually in the upper right "
 "hand corner of your browser."
 msgstr ""
-"Ad blocker എക്സ്റ്റൻഷന്റെ ഐക്കണിൽ ക്ലിക്ക് ചെയ്യുക. ഇത് സാധാരണയായി നിങ്ങളുടെ "
-"ബ്രൗസറിന്റെ മുകളിൽ വലത് കോണിലായിരിക്കും."
+"Ad blocker എക്സ്റ്റൻഷന്റെ ഐക്കണിൽ ക്ലിക്ക് ചെയ്യുക. ഇത് സാധാരണയായി നിങ്ങളുടെ ബ്രൗസറിന്റെ "
+"മുകളിൽ വലത് കോണിലായിരിക്കും."
 
 #  Safari default search engine instruction
 # smartling.placeholder_format=C
@@ -4691,8 +4699,8 @@ msgid ""
 "Cloud Save lets you save your settings more permanently by entering a "
 "passphrase. It is entirely optional."
 msgstr ""
-"Cloud Save പാസ്‌ഫ്രെയ്സ് നൽകുക വഴി നിങ്ങളുടെ ക്രമീകരണം സ്ഥിരമായി "
-"സംരക്ഷിക്കാൻ അനുവദിക്കും. ഇത് തീർത്തും ഓപ്ഷണല്‍ ആണ്."
+"Cloud Save പാസ്‌ഫ്രെയ്സ് നൽകുക വഴി നിങ്ങളുടെ ക്രമീകരണം സ്ഥിരമായി സംരക്ഷിക്കാൻ അനുവദിക്കും. "
+"ഇത് തീർത്തും ഓപ്ഷണല്‍ ആണ്."
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -5121,9 +5129,7 @@ msgstr "കോസ്റ്റാ റിക്ക"
 #. Inline error shown on the recovery code screen when exportSyncSettings rejects.
 msgctxt "Error message when the recovery code fails to generate"
 msgid "Couldn't load your recovery code. Please close this and try again."
-msgstr ""
-"നിങ്ങളുടെ റിക്കവറി കോഡ് ലോഡ് ചെയ്യാൻ കഴിഞ്ഞില്ല. ദയവായി ഇത് അടച്ച് വീണ്ടും "
-"ശ്രമിക്കു."
+msgstr "നിങ്ങളുടെ റിക്കവറി കോഡ് ലോഡ് ചെയ്യാൻ കഴിഞ്ഞില്ല. ദയവായി ഇത് അടച്ച് വീണ്ടും ശ്രമിക്കു."
 
 # smartling.placeholder_format=C
 #. Pairs with a Retry button. Shown after two consecutive failed attempts to load the device list.
@@ -5167,6 +5173,12 @@ msgstr "ചിത്രം സൃഷ്ടിക്കുക"
 msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr "ചിത്രം സൃഷ്ടിക്കുക"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Create a shopping list with quantities from this recipe."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed in the input field when starting a new image generation session.
@@ -5430,9 +5442,7 @@ msgstr "ദൈനംദിന ഉപയോഗ പരിധി കവിഞ്ഞ
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "Daily usage limit reached. You can keep chatting by using your weekly limit."
-msgstr ""
-"ദൈനംദിന ഉപയോഗ പരിധി കവിഞ്ഞു. നിങ്ങൾക്ക് പ്രതിവാര പരിധി ഉപയോഗിച്ച് ചാറ്റ് "
-"തുടരാം."
+msgstr "ദൈനംദിന ഉപയോഗ പരിധി കവിഞ്ഞു. നിങ്ങൾക്ക് പ്രതിവാര പരിധി ഉപയോഗിച്ച് ചാറ്റ് തുടരാം."
 
 # smartling.placeholder_format=C
 #. The name of the Danish language
@@ -5690,9 +5700,7 @@ msgstr "സംഭരണ സ്ഥലം ശൂന്യമാക്കാൻ ഏ
 #. Title shown when user has reached the file storage sync quota (5GB).
 msgctxt "Sync file storage limit modal title"
 msgid "Delete oldest chats with attachments to free up storage?"
-msgstr ""
-"സ്റ്റോറേജ് ഒഴിവാക്കാൻ അറ്റാച്ച്മെന്റുകളുള്ള ഏറ്റവും പഴയ ചാറ്റുകൾ "
-"ഇല്ലാതാക്കണോ?"
+msgstr "സ്റ്റോറേജ് ഒഴിവാക്കാൻ അറ്റാച്ച്മെന്റുകളുള്ള ഏറ്റവും പഴയ ചാറ്റുകൾ ഇല്ലാതാക്കണോ?"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to delete all recent chats.
@@ -5802,8 +5810,8 @@ msgstr "Duck.ai-യിലെ ഡിക്റ്റേഷൻ"
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
 msgstr ""
-"ഡിക്റ്റേഷൻ നമ്മൾ അജ്ഞാതമാക്കിയിരിക്കുന്നു, മാത്രമല്ല AI മോഡലുകളെ "
-"പരിശീലിപ്പിക്കാൻ ഒരിക്കലും ഉപയോഗിക്കാറില്ല."
+"ഡിക്റ്റേഷൻ നമ്മൾ അജ്ഞാതമാക്കിയിരിക്കുന്നു, മാത്രമല്ല AI മോഡലുകളെ പരിശീലിപ്പിക്കാൻ ഒരിക്കലും "
+"ഉപയോഗിക്കാറില്ല."
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
@@ -5811,14 +5819,18 @@ msgid "Dictation limit reached"
 msgstr "ഡിക്റ്റേഷൻ പരിധിയിൽ എത്തി"
 
 # smartling.placeholder_format=C
+#. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
+msgid "Dictation temporarily unavailable"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
 "chat in Duck.ai without having to type."
 msgstr ""
-"നിങ്ങളുടെ സംസാരം ടെക്സ്റ്റാക്കി മാറ്റുന്നതിനായി ഡിക്റ്റേഷൻ ഒരു OpenAI മോഡൽ "
-"ഉപയോഗിക്കുന്നു, അതിനാൽ നിങ്ങൾക്ക് ടൈപ്പ് ചെയ്യാതെ തന്നെ Duck.ai-യിൽ ചാറ്റ് "
-"ചെയ്യാൻ സാധിക്കും."
+"നിങ്ങളുടെ സംസാരം ടെക്സ്റ്റാക്കി മാറ്റുന്നതിനായി ഡിക്റ്റേഷൻ ഒരു OpenAI മോഡൽ ഉപയോഗിക്കുന്നു, "
+"അതിനാൽ നിങ്ങൾക്ക് ടൈപ്പ് ചെയ്യാതെ തന്നെ Duck.ai-യിൽ ചാറ്റ് ചെയ്യാൻ സാധിക്കും."
 
 # smartling.placeholder_format=C
 #. In 0-click box -- link to definition.
@@ -6086,9 +6098,7 @@ msgstr "പട്ടികയിൽ DuckDuckGo കാണുന്നില്ല
 #. Link to download a file again if the user can't find it on their computer.
 msgctxt "install-extension"
 msgid "Don't see it? %s%s%sClick here to re-download%s"
-msgstr ""
-"അത് കാണുന്നില്ലേ? %1$s%2$s%3$sവീണ്ടും ഡൗൺലോഡ് ചെയ്യാൻ ഇവിടെ ക്ലിക്ക് "
-"ചെയ്യുക%4$s"
+msgstr "അത് കാണുന്നില്ലേ? %1$s%2$s%3$sവീണ്ടും ഡൗൺലോഡ് ചെയ്യാൻ ഇവിടെ ക്ലിക്ക് ചെയ്യുക%4$s"
 
 #  IE < 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -6112,6 +6122,22 @@ msgstr "പൂർത്തിയായി"
 msgctxt "precise_user_location"
 msgid "Done"
 msgstr "പൂർത്തിയായി"
+
+# smartling.placeholder_format=C
+#. Message shown in a modal after DuckDuckGo browser users disable AI features in Settings. The first two placeholders bold noai.duckduckgo.com. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
+"filtered out. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
+"and AI images filtered out. %sLearn more%s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6214,8 +6240,8 @@ msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for "
 "ceiling fan repair services."
 msgstr ""
-"സീലിംഗ് ഫാൻ അറ്റകുറ്റപ്പണി സേവനങ്ങൾക്കായി ഒരു ക്വൊട്ടേഷൻ അഭ്യർത്ഥിച്ച് ഒരു "
-"വെണ്ടറിന് സംക്ഷിപ്തവും വിശദവുമായ ഒരു ഇമെയിൽ തയ്യാറാക്കുക."
+"സീലിംഗ് ഫാൻ അറ്റകുറ്റപ്പണി സേവനങ്ങൾക്കായി ഒരു ക്വൊട്ടേഷൻ അഭ്യർത്ഥിച്ച് ഒരു വെണ്ടറിന് "
+"സംക്ഷിപ്തവും വിശദവുമായ ഒരു ഇമെയിൽ തയ്യാറാക്കുക."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion asking for an email draft to a vendor requesting a quote for home refrigerator repair services.
@@ -6224,8 +6250,20 @@ msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
 msgstr ""
-"വീട്ടിലെ റഫ്രിജറേറ്റർ അറ്റകുറ്റപ്പണി സേവനങ്ങൾക്കായി ഒരു ക്വൊട്ടേഷൻ "
-"അഭ്യർത്ഥിച്ച് ഒരു വെണ്ടർക്ക് സംക്ഷിപ്തവും വിശദവുമായ ഒരു ഇമെയിൽ തയ്യാറാക്കുക."
+"വീട്ടിലെ റഫ്രിജറേറ്റർ അറ്റകുറ്റപ്പണി സേവനങ്ങൾക്കായി ഒരു ക്വൊട്ടേഷൻ അഭ്യർത്ഥിച്ച് ഒരു വെണ്ടർക്ക് "
+"സംക്ഷിപ്തവും വിശദവുമായ ഒരു ഇമെയിൽ തയ്യാറാക്കുക."
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Draft a cover letter"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Draft a cover letter for this job."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -6234,8 +6272,8 @@ msgid ""
 "Draft a few options for a social media post inviting people to my upcoming "
 "party."
 msgstr ""
-"എന്റെ വരാനിരിക്കുന്ന പാർട്ടിയിലേക്ക് ആളുകളെ ക്ഷണിക്കുന്ന ഒരു സോഷ്യൽ മീഡിയ "
-"പോസ്റ്റിന് കുറച്ച് ഓപ്ഷനുകൾ ഡ്രാഫ്റ്റ് ചെയ്യുക."
+"എന്റെ വരാനിരിക്കുന്ന പാർട്ടിയിലേക്ക് ആളുകളെ ക്ഷണിക്കുന്ന ഒരു സോഷ്യൽ മീഡിയ പോസ്റ്റിന് കുറച്ച് "
+"ഓപ്ഷനുകൾ ഡ്രാഫ്റ്റ് ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a few options for a blog post title about strategies to increase team collaboration.
@@ -6244,8 +6282,8 @@ msgid ""
 "Draft a few options for a title of a post I’m writing about strategies to "
 "increase team collaboration."
 msgstr ""
-"ടീം സഹകരണം വർദ്ധിപ്പിക്കുന്നതിനുള്ള തന്ത്രങ്ങളെക്കുറിച്ച് ഞാൻ എഴുതുന്ന ഒരു "
-"പോസ്റ്റിന്റെ തലക്കെട്ടിനായി കുറച്ച് ഓപ്ഷനുകൾ തയ്യാറാക്കുക."
+"ടീം സഹകരണം വർദ്ധിപ്പിക്കുന്നതിനുള്ള തന്ത്രങ്ങളെക്കുറിച്ച് ഞാൻ എഴുതുന്ന ഒരു പോസ്റ്റിന്റെ "
+"തലക്കെട്ടിനായി കുറച്ച് ഓപ്ഷനുകൾ തയ്യാറാക്കുക."
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for drafting a social media post.
@@ -6315,9 +6353,7 @@ msgstr "നിങ്ങളുടെ ഫോട്ടോകളോ PDF ഫയലു
 # smartling.placeholder_format=C
 #. A title explaining what Duck Player (DDG's feature to watch youtube videos more privately) does
 msgid "Duck Player lets you watch YouTube without targeted ads"
-msgstr ""
-"ലക്ഷ്യമിട്ടുള്ള പരസ്യങ്ങളില്ലാതെ YouTube കാണാൻ Duck Player നിങ്ങളെ "
-"അനുവദിക്കുന്നു"
+msgstr "ലക്ഷ്യമിട്ടുള്ള പരസ്യങ്ങളില്ലാതെ YouTube കാണാൻ Duck Player നിങ്ങളെ അനുവദിക്കുന്നു"
 
 # smartling.placeholder_format=C
 #. This is the DDG version of "Google it", meaning "search it".
@@ -6373,10 +6409,9 @@ msgid ""
 "content is only included when you attach it, unless you choose to attach "
 "pages automatically in Settings."
 msgstr ""
-"നിങ്ങൾ കാണുന്ന പേജിനെക്കുറിച്ചുള്ള ചോദ്യങ്ങൾക്ക് ഇപ്പോൾ Duck.ai-യ്ക്ക് "
-"ഉത്തരം നൽകാൻ സഹായിക്കാനാവും. ക്രമീകരണങ്ങളിൽ പേജുകൾ സ്വയമേവ അറ്റാച്ച് ചെയ്യാൻ "
-"നിങ്ങൾ തിരഞ്ഞെടുക്കുന്നില്ലെങ്കിൽ മാത്രമേ അത് അറ്റാച്ചുചെയ്യുമ്പോൾ പേജ് "
-"ഉള്ളടക്കം ഉൾപ്പെടുത്തൂ."
+"നിങ്ങൾ കാണുന്ന പേജിനെക്കുറിച്ചുള്ള ചോദ്യങ്ങൾക്ക് ഇപ്പോൾ Duck.ai-യ്ക്ക് ഉത്തരം നൽകാൻ "
+"സഹായിക്കാനാവും. ക്രമീകരണങ്ങളിൽ പേജുകൾ സ്വയമേവ അറ്റാച്ച് ചെയ്യാൻ നിങ്ങൾ "
+"തിരഞ്ഞെടുക്കുന്നില്ലെങ്കിൽ മാത്രമേ അത് അറ്റാച്ചുചെയ്യുമ്പോൾ പേജ് ഉള്ളടക്കം ഉൾപ്പെടുത്തൂ."
 
 # smartling.placeholder_format=C
 #. Shown in the Duck.ai recent chats list on standalone when the browser API needed to store chats locally is missing or unavailable.
@@ -6386,9 +6421,9 @@ msgid ""
 "Duck.ai can’t access local storage to save your chats. Please check your "
 "browser settings or disable any extensions and try again."
 msgstr ""
-"നിങ്ങളുടെ ചാറ്റുകൾ സംരക്ഷിക്കാനായി Duck.ai-ക്ക് ലോക്കൽ സ്റ്റോറേജ് ആക്‌സസ് "
-"ചെയ്യാൻ കഴിയില്ല. നിങ്ങളുടെ ബ്രൗസർ ക്രമീകരണങ്ങൾ പരിശോധിക്കുകയോ ഏതെങ്കിലും "
-"എക്സ്റ്റൻഷനുകൾ പ്രവർത്തനരഹിതമാക്കുകയോ ചെയ്ത് വീണ്ടും ശ്രമിക്കുക."
+"നിങ്ങളുടെ ചാറ്റുകൾ സംരക്ഷിക്കാനായി Duck.ai-ക്ക് ലോക്കൽ സ്റ്റോറേജ് ആക്‌സസ് ചെയ്യാൻ കഴിയില്ല. "
+"നിങ്ങളുടെ ബ്രൗസർ ക്രമീകരണങ്ങൾ പരിശോധിക്കുകയോ ഏതെങ്കിലും എക്സ്റ്റൻഷനുകൾ പ്രവർത്തനരഹിതമാക്കുകയോ "
+"ചെയ്ത് വീണ്ടും ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Displayed when the chat service has reached the maximum number of messages for one day.
@@ -6397,16 +6432,23 @@ msgid ""
 "Duck.ai has reached the maximum number of messages for one day. Please "
 "continue this chat tomorrow."
 msgstr ""
-"ഒരു ദിവസത്തേക്കുള്ള പരമാവധി സന്ദേശങ്ങളുടെ എണ്ണത്തിൽ Duck.ai എത്തിച്ചേർന്നു. "
-"ദയവായി നാളെ ഈ ചാറ്റ് തുടരുക."
+"ഒരു ദിവസത്തേക്കുള്ള പരമാവധി സന്ദേശങ്ങളുടെ എണ്ണത്തിൽ Duck.ai എത്തിച്ചേർന്നു. ദയവായി നാളെ ഈ "
+"ചാറ്റ് തുടരുക."
 
 # smartling.placeholder_format=C
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
+msgstr "ഞങ്ങളുടെ സ്വകാര്യവും സൗജന്യവുമായ DuckDuckGo ബ്രൗസറിൽ Duck.ai ആണ് ഏറ്റവും മികച്ചത്!"
+
+# smartling.placeholder_format=C
+#. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
+msgctxt "About section description on the Duck.ai settings page"
+msgid ""
+"Duck.ai is created by DuckDuckGo. We're an independent online protection "
+"company for anyone who wants to take back control of their personal "
+"information."
 msgstr ""
-"ഞങ്ങളുടെ സ്വകാര്യവും സൗജന്യവുമായ DuckDuckGo ബ്രൗസറിൽ Duck.ai ആണ് ഏറ്റവും "
-"മികച്ചത്!"
 
 # smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
@@ -6421,8 +6463,8 @@ msgid ""
 "Duck.ai is still a DuckDuckGo product, but will now have an easier to "
 "remember home on the web: https://duck.ai"
 msgstr ""
-"Duck.ai ഇപ്പോഴും ഒരു DuckDuckGo ഉൽപ്പന്നമാണ്, പക്ഷേ ഇനി വെബിൽ ഓർമ്മിക്കാൻ "
-"എളുപ്പമുള്ള ഒരു വിലാസം ലഭിക്കും: https://duck.ai"
+"Duck.ai ഇപ്പോഴും ഒരു DuckDuckGo ഉൽപ്പന്നമാണ്, പക്ഷേ ഇനി വെബിൽ ഓർമ്മിക്കാൻ എളുപ്പമുള്ള ഒരു "
+"വിലാസം ലഭിക്കും: https://duck.ai"
 
 # smartling.placeholder_format=C
 #. Headline for domain change notice.
@@ -6437,8 +6479,8 @@ msgid ""
 "Duck.ai is temporarily unavailable. If this persists, please email this "
 "anonymous code %s to %s"
 msgstr ""
-"Duck.ai താൽക്കാലികമായി ലഭ്യമല്ല. ഇത് നിലനിൽക്കുകയാണെങ്കിൽ, ദയവായി ഈ %1$s "
-"അജ്ഞാത കോഡ് %2$s എന്നതിലേക്ക് ഇമെയിൽ ചെയ്യുക"
+"Duck.ai താൽക്കാലികമായി ലഭ്യമല്ല. ഇത് നിലനിൽക്കുകയാണെങ്കിൽ, ദയവായി ഈ %1$s അജ്ഞാത കോഡ് "
+"%2$s എന്നതിലേക്ക് ഇമെയിൽ ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -6456,18 +6498,24 @@ msgstr "Duck.ai താൽക്കാലികമായി ലഭ്യമല്
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
+"Duck.ai lets you chat privately with popular AI models. Disabling it hides "
+"Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
+msgstr ""
+
+# smartling.placeholder_format=C
+msgctxt "settings"
+msgid ""
 "Duck.ai lets you have anonymous conversations with 3rd-party AI chat models, "
 "including models from OpenAI, Anthropic, and others. Turning this setting "
 "off will hide Duck.ai buttons and links on DuckDuckGo Search. However, you "
 "can still access Duck.ai when this setting is off by visiting %shttps://duck."
 "ai%s directly."
 msgstr ""
-"OpenAI, Anthropic, കൂടാതെ മറ്റുള്ളവയിൽ നിന്നുമുള്ള മോഡലുകൾ ഉൾപ്പെടെ മൂന്നാം "
-"കക്ഷി AI ചാറ്റ് മോഡലുകളുമായി അജ്ഞാത സംഭാഷണങ്ങൾ നടത്താൻ Duck.ai നിങ്ങളെ "
-"അനുവദിക്കുന്നു. ഈ ക്രമീകരണം ഓഫാക്കുന്നത് DuckDuckGo Search-ലെ Duck.ai "
-"ബട്ടണുകളും ലിങ്കുകളും മറയ്ക്കും. എന്നിരുന്നാലും, ഈ ക്രമീകരണം ഓഫ് "
-"ആയിരിക്കുമ്പോൾ %1$shttps://duck.ai%2$s സന്ദർശിച്ച് നിങ്ങൾക്ക് Duck.ai ആക്സസ് "
-"ചെയ്യാൻ കഴിയും. നേരിട്ട്."
+"OpenAI, Anthropic, കൂടാതെ മറ്റുള്ളവയിൽ നിന്നുമുള്ള മോഡലുകൾ ഉൾപ്പെടെ മൂന്നാം കക്ഷി AI ചാറ്റ് "
+"മോഡലുകളുമായി അജ്ഞാത സംഭാഷണങ്ങൾ നടത്താൻ Duck.ai നിങ്ങളെ അനുവദിക്കുന്നു. ഈ ക്രമീകരണം "
+"ഓഫാക്കുന്നത് DuckDuckGo Search-ലെ Duck.ai ബട്ടണുകളും ലിങ്കുകളും മറയ്ക്കും. എന്നിരുന്നാലും, ഈ "
+"ക്രമീകരണം ഓഫ് ആയിരിക്കുമ്പോൾ %1$shttps://duck.ai%2$s സന്ദർശിച്ച് നിങ്ങൾക്ക് Duck.ai "
+"ആക്സസ് ചെയ്യാൻ കഴിയും. നേരിട്ട്."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
@@ -6482,16 +6530,15 @@ msgid ""
 "Duck.ai might have lost your recent chats. You can still use Duck.ai as "
 "usual."
 msgstr ""
-"Duck.ai-ക്ക് നിങ്ങളുടെ അടുത്തിടെ നടന്ന ചാറ്റുകൾ നഷ്ടപ്പെട്ടിരിക്കാം. "
-"നിങ്ങൾക്ക് ഇപ്പോഴും പതിവുപോലെ Duck.ai ഉപയോഗിക്കാം."
+"Duck.ai-ക്ക് നിങ്ങളുടെ അടുത്തിടെ നടന്ന ചാറ്റുകൾ നഷ്ടപ്പെട്ടിരിക്കാം. നിങ്ങൾക്ക് ഇപ്പോഴും "
+"പതിവുപോലെ Duck.ai ഉപയോഗിക്കാം."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
 msgctxt "Promotional text for PDF upload feature"
 msgid "Duck.ai now can read and analyze PDFs. Give it a try!"
 msgstr ""
-"Duck.ai-ക്ക് ഇപ്പോൾ PDF-കൾ വായിക്കാനും വിശകലനം ചെയ്യാനും കഴിയും. ഒന്ന് "
-"പരീക്ഷിച്ചു നോക്കൂ!"
+"Duck.ai-ക്ക് ഇപ്പോൾ PDF-കൾ വായിക്കാനും വിശകലനം ചെയ്യാനും കഴിയും. ഒന്ന് പരീക്ഷിച്ചു നോക്കൂ!"
 
 # smartling.placeholder_format=C
 #. Disclaimer text shown above the chat input only when coming from a DuckAssist grounded response into ungrounded models.
@@ -6499,8 +6546,8 @@ msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
 msgstr ""
-"Duck.ai പ്രതികരണങ്ങൾ പ്രത്യേക ഉറവിടങ്ങളെ അടിസ്ഥാനമാക്കിയുള്ളതല്ല, അല്ലെങ്കിൽ "
-"കൃത്യതയ്ക്കായി പരിശോധിച്ചിട്ടുമില്ല."
+"Duck.ai പ്രതികരണങ്ങൾ പ്രത്യേക ഉറവിടങ്ങളെ അടിസ്ഥാനമാക്കിയുള്ളതല്ല, അല്ലെങ്കിൽ കൃത്യതയ്ക്കായി "
+"പരിശോധിച്ചിട്ടുമില്ല."
 
 # smartling.placeholder_format=C
 #. Title shown when native app needs to reload for service update.
@@ -6519,8 +6566,8 @@ msgstr "Duck.ai അപ്ഗ്രേഡ് ചെയ്തു!"
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
 msgstr ""
-"Duck.ai ഏറ്റവും മികച്ച രീതിയിൽ പ്രവർത്തിക്കുന്നത് ഞങ്ങളുടെ സ്വകാര്യവും "
-"സൗജന്യവുമായ DuckDuckGo ആപ്പിലാണ്!"
+"Duck.ai ഏറ്റവും മികച്ച രീതിയിൽ പ്രവർത്തിക്കുന്നത് ഞങ്ങളുടെ സ്വകാര്യവും സൗജന്യവുമായ "
+"DuckDuckGo ആപ്പിലാണ്!"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -6530,10 +6577,9 @@ msgid ""
 "AI chat no sign up, OpenAI, Anthropic, Llama, Mistral, open source AI "
 "models, privacy focused AI, no account AI chat"
 msgstr ""
-"Duck.ai, DuckDuckGo AI, സ്വകാര്യ AI ചാറ്റ്ബോട്ട്, സൗജന്യ AI ചാറ്റ്, അജ്ഞാത "
-"AI ചാറ്റ്, സൈൻ അപ്പ് ആവശ്യമില്ലാത്ത AI ചാറ്റ്, OpenAI, ആന്ത്രോപിക്, ലാമ, "
-"മിസ്ട്രൽ, ഓപ്പൺ സോഴ്‌സ് AI മോഡലുകൾ, സ്വകാര്യത കേന്ദ്രീകരിച്ചുള്ള AI, "
-"അക്കൗണ്ടില്ലാത്ത AI ചാറ്റ്"
+"Duck.ai, DuckDuckGo AI, സ്വകാര്യ AI ചാറ്റ്ബോട്ട്, സൗജന്യ AI ചാറ്റ്, അജ്ഞാത AI ചാറ്റ്, "
+"സൈൻ അപ്പ് ആവശ്യമില്ലാത്ത AI ചാറ്റ്, OpenAI, ആന്ത്രോപിക്, ലാമ, മിസ്ട്രൽ, ഓപ്പൺ സോഴ്‌സ് AI "
+"മോഡലുകൾ, സ്വകാര്യത കേന്ദ്രീകരിച്ചുള്ള AI, അക്കൗണ്ടില്ലാത്ത AI ചാറ്റ്"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -6561,12 +6607,11 @@ msgid ""
 "relevant), or Often (shows more frequently on a wider range of searches). "
 "For now, DuckAssist is only available in the U.S. (English) region."
 msgstr ""
-"DuckAssist-ന് അജ്ഞാതമായി തിരയാനും ചില search-കൾക്ക് മറുപടിയായി വിവരങ്ങൾ "
-"സംഗ്രഹിക്കാനും കഴിയും. DuckAssist എത്ര തവണ ദൃശ്യമാകാൻ ആഗ്രഹിക്കുന്നുവെന്ന് "
-"നിങ്ങൾക്ക് തിരഞ്ഞെടുക്കാം: ഒരിക്കലുമില്ല (Search ഫലങ്ങളിൽ നിന്ന് DuckAssist "
-"UI പൂർണ്ണമായും നീക്കംചെയ്യുന്നു), ഓൺ-ഡിമാൻഡ് (നിങ്ങൾ അസിസ്റ്റ് ബട്ടൺ "
-"ക്ലിക്ക് ചെയ്താൽ മാത്രം കാണിക്കുന്നു), ചിലപ്പോൾ (വളരെ പ്രസക്തമാകുമ്പോൾ "
-"മാത്രം കാണിക്കുക), ഇടയ്ക്കിടെ (വിശാലമായ Search-കളിൽ കൂടുതൽ പതിവായി "
+"DuckAssist-ന് അജ്ഞാതമായി തിരയാനും ചില search-കൾക്ക് മറുപടിയായി വിവരങ്ങൾ സംഗ്രഹിക്കാനും "
+"കഴിയും. DuckAssist എത്ര തവണ ദൃശ്യമാകാൻ ആഗ്രഹിക്കുന്നുവെന്ന് നിങ്ങൾക്ക് തിരഞ്ഞെടുക്കാം: "
+"ഒരിക്കലുമില്ല (Search ഫലങ്ങളിൽ നിന്ന് DuckAssist UI പൂർണ്ണമായും നീക്കംചെയ്യുന്നു), ഓൺ-"
+"ഡിമാൻഡ് (നിങ്ങൾ അസിസ്റ്റ് ബട്ടൺ ക്ലിക്ക് ചെയ്താൽ മാത്രം കാണിക്കുന്നു), ചിലപ്പോൾ (വളരെ "
+"പ്രസക്തമാകുമ്പോൾ മാത്രം കാണിക്കുക), ഇടയ്ക്കിടെ (വിശാലമായ Search-കളിൽ കൂടുതൽ പതിവായി "
 "കാണിക്കുന്നു). ഇപ്പോൾ, DuckAssist യുഎസ് (ഇംഗ്ലീഷ്) മേഖലയിൽ മാത്രമേ ലഭ്യമാകൂ."
 
 # smartling.placeholder_format=C
@@ -6576,10 +6621,9 @@ msgid ""
 "%sDuckDuckGo AI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI, and Anthropic, and more."
 msgstr ""
-"DuckAssist-ന് ഫോളോ-അപ്പ് ചോദ്യങ്ങൾക്ക് ഉത്തരം നൽകാൻ കഴിയില്ല, "
-"എന്നിരുന്നാലും, ഞങ്ങൾ %1$sDuckDuckGo AI Chat%2$s വാഗ്ദാനം ചെയ്യുന്നു, ഇത് "
-"OpenAI, Anthropic തുടങ്ങിയവയിൽ നിന്നുള്ള ചാറ്റ് മോഡലുകളെ പിന്തുണയ്ക്കുന്ന "
-"ഒരു സ്വകാര്യ AI-പിന്തുണയുള്ള ചാറ്റ് സേവനമാണ്."
+"DuckAssist-ന് ഫോളോ-അപ്പ് ചോദ്യങ്ങൾക്ക് ഉത്തരം നൽകാൻ കഴിയില്ല, എന്നിരുന്നാലും, ഞങ്ങൾ "
+"%1$sDuckDuckGo AI Chat%2$s വാഗ്ദാനം ചെയ്യുന്നു, ഇത് OpenAI, Anthropic തുടങ്ങിയവയിൽ "
+"നിന്നുള്ള ചാറ്റ് മോഡലുകളെ പിന്തുണയ്ക്കുന്ന ഒരു സ്വകാര്യ AI-പിന്തുണയുള്ള ചാറ്റ് സേവനമാണ്."
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6588,10 +6632,9 @@ msgid ""
 "DuckDuckGo %sAI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI and Anthropic."
 msgstr ""
-"DuckAssist-ന് ഫോളോ-അപ്പ് ചോദ്യങ്ങൾക്ക് ഉത്തരം നൽകാൻ കഴിയില്ല, "
-"എന്നിരുന്നാലും, ഞങ്ങൾ DuckDuckGo %1$sAI Chat%2$s എന്നിവയും വാഗ്ദാനം "
-"ചെയ്യുന്നു, ഇത് OpenAI, Anthropic എന്നിവയിൽ നിന്നുള്ള ചാറ്റ് മോഡലുകളെ "
-"പിന്തുണയ്ക്കുന്ന ഒരു സ്വകാര്യ AI-പിന്തുണയുള്ള ചാറ്റ് സേവനമാണ്."
+"DuckAssist-ന് ഫോളോ-അപ്പ് ചോദ്യങ്ങൾക്ക് ഉത്തരം നൽകാൻ കഴിയില്ല, എന്നിരുന്നാലും, ഞങ്ങൾ "
+"DuckDuckGo %1$sAI Chat%2$s എന്നിവയും വാഗ്ദാനം ചെയ്യുന്നു, ഇത് OpenAI, Anthropic "
+"എന്നിവയിൽ നിന്നുള്ള ചാറ്റ് മോഡലുകളെ പിന്തുണയ്ക്കുന്ന ഒരു സ്വകാര്യ AI-പിന്തുണയുള്ള ചാറ്റ് സേവനമാണ്."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6603,13 +6646,12 @@ msgid ""
 "responses are currently based on Wikipedia and related content and are not "
 "checked for accuracy."
 msgstr ""
-"ഞങ്ങളുടെ തിരയൽ ഫലങ്ങളിലെ ഒരു പുതിയ സവിശേഷതയാണ് DuckAssist, അതിന് തിരയൽ "
-"അന്വേഷണങ്ങൾക്ക് അജ്ഞാതമായി ഉത്തരങ്ങൾ സൃഷ്ടിക്കാൻ കഴിയും. ഇതിനായി, പ്രസക്തമായ "
-"ഉള്ളടക്കത്തിനായി വിക്കിപീഡിയയെയും അനുബന്ധ സൈറ്റുകളെയും സ്കാൻ ചെയ്യുകയും "
-"തുടർന്ന് ആ വിവരങ്ങളുടെ സംഗ്രഹം സൃഷ്ടിക്കാൻ AI-പിന്തുണയുള്ള സ്വാഭാവിക ഭാഷാ "
-"സാങ്കേതികവിദ്യ ഉപയോഗിക്കുകയും ചെയ്യുന്നു. അതിന്റെ പ്രതികരണങ്ങൾ നിലവിൽ "
-"വിക്കിപീഡിയയെയും അനുബന്ധ ഉള്ളടക്കത്തെയും അടിസ്ഥാനമാക്കിയുള്ളതാണെന്നും കൃത്യത "
-"പരിശോധിച്ചിട്ടില്ലെന്നതും ശ്രദ്ധിക്കുക."
+"ഞങ്ങളുടെ തിരയൽ ഫലങ്ങളിലെ ഒരു പുതിയ സവിശേഷതയാണ് DuckAssist, അതിന് തിരയൽ അന്വേഷണങ്ങൾക്ക് "
+"അജ്ഞാതമായി ഉത്തരങ്ങൾ സൃഷ്ടിക്കാൻ കഴിയും. ഇതിനായി, പ്രസക്തമായ ഉള്ളടക്കത്തിനായി "
+"വിക്കിപീഡിയയെയും അനുബന്ധ സൈറ്റുകളെയും സ്കാൻ ചെയ്യുകയും തുടർന്ന് ആ വിവരങ്ങളുടെ സംഗ്രഹം "
+"സൃഷ്ടിക്കാൻ AI-പിന്തുണയുള്ള സ്വാഭാവിക ഭാഷാ സാങ്കേതികവിദ്യ ഉപയോഗിക്കുകയും ചെയ്യുന്നു. അതിന്റെ "
+"പ്രതികരണങ്ങൾ നിലവിൽ വിക്കിപീഡിയയെയും അനുബന്ധ ഉള്ളടക്കത്തെയും അടിസ്ഥാനമാക്കിയുള്ളതാണെന്നും "
+"കൃത്യത പരിശോധിച്ചിട്ടില്ലെന്നതും ശ്രദ്ധിക്കുക."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6623,16 +6665,14 @@ msgid ""
 "It’s important to remember that responses are auto-generated from cited "
 "sources and based on %scrawling the web%s."
 msgstr ""
-"ഞങ്ങളുടെ തിരയൽ ഫലങ്ങളിലെ ഒരു പുതിയ ഓപ്ഷണൽ സവിശേഷതയാണ് DuckAssist, അതിന് "
-"തിരയൽ അന്വേഷണങ്ങൾക്ക് അജ്ഞാതമായി ഉത്തരങ്ങൾ സൃഷ്ടിക്കാൻ കഴിയും. ഇത് "
-"ചെയ്യുന്നതിന്, പ്രസക്തമായ ഉള്ളടക്കത്തിനായി ഇത് വെബ് സ്കാൻ ചെയ്യുകയും "
-"തുടർന്ന് കണ്ടെത്തിയ പ്രസക്തമായ വിവരങ്ങളെ അടിസ്ഥാനമാക്കി ഒരു ഹ്രസ്വമായ ഉത്തരം "
-"സൃഷ്ടിക്കുന്നതിന് AI- പിന്തുണയ്ക്കുന്ന സ്വഭാവിക ഭാഷ സാങ്കേതികവിദ്യ "
-"ഉപയോഗിക്കുകയും ചെയ്യുന്നു. DuckAssist പ്രതികരണങ്ങൾ എല്ലായ്പ്പോഴും ഒന്നോ "
-"രണ്ടോ ഉറവിടങ്ങളിലേക്ക് നേരിട്ട് ലിങ്ക് ചെയ്യുന്നു, ഉത്തരം എവിടെ നിന്ന് "
-"വന്നുവെന്ന് ഉദ്ധരിക്കുന്നു, അതിനാൽ നിങ്ങൾക്ക് എളുപ്പത്തിൽ കൂടുതൽ വിശദമായ "
-"വിവരങ്ങൾ നേടാനാവും. ഉദ്ധരിച്ച ഉറവിടങ്ങളിൽ നിന്ന് പ്രതികരണങ്ങൾ സ്വയം "
-"സൃഷ്ടിക്കപ്പെട്ടതാണെന്നും%2$s വെബ് ക്രൗളിങ്ങിനെ "
+"ഞങ്ങളുടെ തിരയൽ ഫലങ്ങളിലെ ഒരു പുതിയ ഓപ്ഷണൽ സവിശേഷതയാണ് DuckAssist, അതിന് തിരയൽ "
+"അന്വേഷണങ്ങൾക്ക് അജ്ഞാതമായി ഉത്തരങ്ങൾ സൃഷ്ടിക്കാൻ കഴിയും. ഇത് ചെയ്യുന്നതിന്, പ്രസക്തമായ "
+"ഉള്ളടക്കത്തിനായി ഇത് വെബ് സ്കാൻ ചെയ്യുകയും തുടർന്ന് കണ്ടെത്തിയ പ്രസക്തമായ വിവരങ്ങളെ "
+"അടിസ്ഥാനമാക്കി ഒരു ഹ്രസ്വമായ ഉത്തരം സൃഷ്ടിക്കുന്നതിന് AI- പിന്തുണയ്ക്കുന്ന സ്വഭാവിക ഭാഷ "
+"സാങ്കേതികവിദ്യ ഉപയോഗിക്കുകയും ചെയ്യുന്നു. DuckAssist പ്രതികരണങ്ങൾ എല്ലായ്പ്പോഴും ഒന്നോ രണ്ടോ "
+"ഉറവിടങ്ങളിലേക്ക് നേരിട്ട് ലിങ്ക് ചെയ്യുന്നു, ഉത്തരം എവിടെ നിന്ന് വന്നുവെന്ന് ഉദ്ധരിക്കുന്നു, അതിനാൽ "
+"നിങ്ങൾക്ക് എളുപ്പത്തിൽ കൂടുതൽ വിശദമായ വിവരങ്ങൾ നേടാനാവും. ഉദ്ധരിച്ച ഉറവിടങ്ങളിൽ നിന്ന് "
+"പ്രതികരണങ്ങൾ സ്വയം സൃഷ്ടിക്കപ്പെട്ടതാണെന്നും%2$s വെബ് ക്രൗളിങ്ങിനെ "
 "%1$sഅടിസ്ഥാനമാക്കിയുള്ളതാണെന്നും ഓർമ്മിക്കേണ്ടത് പ്രധാനമാണ്."
 
 # smartling.placeholder_format=C
@@ -6651,8 +6691,8 @@ msgid ""
 "DuckDuckGo AI Chat has reached the maximum number of messages for one day. "
 "Please continue this chat tomorrow."
 msgstr ""
-"DuckDuckGo AI Chat ഒരു ദിവസത്തേക്ക് പരമാവധി മെസേജുകള് എത്തിയിട്ടുണ്ട്. "
-"ദയവായി നാളെ ഈ ചാറ്റ് തുടരുക."
+"DuckDuckGo AI Chat ഒരു ദിവസത്തേക്ക് പരമാവധി മെസേജുകള് എത്തിയിട്ടുണ്ട്. ദയവായി നാളെ ഈ "
+"ചാറ്റ് തുടരുക."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the AI chat service and supported AI models. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -6661,8 +6701,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"നിലവിൽ %1$sന്റെ %2$s, %3$sന്റെ %4$s ചാറ്റ് മോഡലുകളെ പിന്തുണയ്ക്കുന്ന ഒരു "
-"സ്വകാര്യ AI പ്രവർത്തിപ്പിക്കുന്ന ചാറ്റ് സേവനമാണ് DuckDuckGo AI Chat."
+"നിലവിൽ %1$sന്റെ %2$s, %3$sന്റെ %4$s ചാറ്റ് മോഡലുകളെ പിന്തുണയ്ക്കുന്ന ഒരു സ്വകാര്യ AI "
+"പ്രവർത്തിപ്പിക്കുന്ന ചാറ്റ് സേവനമാണ് DuckDuckGo AI Chat."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the welcome screen of the onboarding. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -6671,8 +6711,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"നിലവിൽ %1$sന്റെ %2$s, %3$sന്റെ %4$s ചാറ്റ് മോഡലുകളെ പിന്തുണയ്ക്കുന്ന ഒരു "
-"സ്വകാര്യ AI പ്രവർത്തിപ്പിക്കുന്ന ചാറ്റ് സേവനമാണ് DuckDuckGo AI Chat."
+"നിലവിൽ %1$sന്റെ %2$s, %3$sന്റെ %4$s ചാറ്റ് മോഡലുകളെ പിന്തുണയ്ക്കുന്ന ഒരു സ്വകാര്യ AI "
+"പ്രവർത്തിപ്പിക്കുന്ന ചാറ്റ് സേവനമാണ് DuckDuckGo AI Chat."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding DuckDuckGo AI Chat.
@@ -6681,8 +6721,8 @@ msgid ""
 "DuckDuckGo AI Chat is in Beta, it may display inaccurate or offensive "
 "information."
 msgstr ""
-"DuckDuckGo AI Chat ബീറ്റയിലാണുള്ളത്, ഇത് കൃത്യമല്ലാത്തതോ കുറ്റകരമായതോ ആയ "
-"വിവരങ്ങൾ പ്രദർശിപ്പിച്ചേക്കാം."
+"DuckDuckGo AI Chat ബീറ്റയിലാണുള്ളത്, ഇത് കൃത്യമല്ലാത്തതോ കുറ്റകരമായതോ ആയ വിവരങ്ങൾ "
+"പ്രദർശിപ്പിച്ചേക്കാം."
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat making it unavailable, and asking the user to send an email with a specific code if the error persists. E.g. 'DuckDuckGo AI Chat is temporarily unavailable. If this persists, please email this anonymous code abcdefg12345 to aichat-error@duckduckgo.com'
@@ -6691,8 +6731,8 @@ msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. If this persists, please "
 "email this anonymous code %s to %s"
 msgstr ""
-"DuckDuckGo AI Chat താൽക്കാലികമായി ലഭ്യമല്ല. ഇത് നിലനിൽക്കുകയാണെങ്കിൽ, ദയവായി "
-"ഈ അജ്ഞാത കോഡ് %1$s %2$s എന്നതിലേക്ക് ഇമെയിൽ ചെയ്യുക"
+"DuckDuckGo AI Chat താൽക്കാലികമായി ലഭ്യമല്ല. ഇത് നിലനിൽക്കുകയാണെങ്കിൽ, ദയവായി ഈ "
+"അജ്ഞാത കോഡ് %1$s %2$s എന്നതിലേക്ക് ഇമെയിൽ ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -6825,9 +6865,8 @@ msgid ""
 "DuckDuckGo anonymizes these reports by automatically removing PII like "
 "names, email addresses, phone numbers, and identifying metadata."
 msgstr ""
-"പേരുകൾ, ഇമെയിൽ വിലാസങ്ങൾ, ഫോൺ നമ്പറുകൾ, തിരിച്ചറിയൽ മെറ്റാഡാറ്റ എന്നിവ "
-"പോലുള്ള PII സ്വയമേവ നീക്കം ചെയ്തുകൊണ്ട് DuckDuckGo ഈ റിപ്പോർട്ടുകൾ "
-"അജ്ഞാതമാക്കുന്നു."
+"പേരുകൾ, ഇമെയിൽ വിലാസങ്ങൾ, ഫോൺ നമ്പറുകൾ, തിരിച്ചറിയൽ മെറ്റാഡാറ്റ എന്നിവ പോലുള്ള PII "
+"സ്വയമേവ നീക്കം ചെയ്തുകൊണ്ട് DuckDuckGo ഈ റിപ്പോർട്ടുകൾ അജ്ഞാതമാക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. The first %s is the agree button label ('Agree'). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. The leading sentence mirrors the drawer-style inline disclaimer (DUCKCHAT_TOS_INLINE_DISCLAIMER).
@@ -6835,8 +6874,8 @@ msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid ""
 "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to Duck.ai's %s."
 msgstr ""
-"DuckDuckGo നിങ്ങളുടെ ചാറ്റുകൾ അജ്ഞാതമാക്കുന്നു. '%1$s' ക്ലിക്ക് ചെയ്യുക വഴി, "
-"നിങ്ങൾ Duck.ai-യുടെ %2$s സമ്മതിക്കുന്നു."
+"DuckDuckGo നിങ്ങളുടെ ചാറ്റുകൾ അജ്ഞാതമാക്കുന്നു. '%1$s' ക്ലിക്ക് ചെയ്യുക വഴി, നിങ്ങൾ Duck.ai-"
+"യുടെ %2$s സമ്മതിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Shown below the input on the empty state when the user has not yet accepted the terms of service. The first %s is the action button label ('Ask' for chat, 'Create' for image generation). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. Clicking the action button both accepts the terms and submits the prompt.
@@ -6845,8 +6884,8 @@ msgctxt ""
 "users"
 msgid "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to our %s."
 msgstr ""
-"DuckDuckGo നിങ്ങളുടെ ചാറ്റുകൾ അജ്ഞാതമാക്കുന്നു. '%1$s' ക്ലിക്ക് ചെയ്യുക വഴി, "
-"നിങ്ങൾ ഞങ്ങളുടെ %2$s-നെ അംഗീകരിക്കുന്നു."
+"DuckDuckGo നിങ്ങളുടെ ചാറ്റുകൾ അജ്ഞാതമാക്കുന്നു. '%1$s' ക്ലിക്ക് ചെയ്യുക വഴി, നിങ്ങൾ ഞങ്ങളുടെ "
+"%2$s-നെ അംഗീകരിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. An information popup explaining that we block trackers
@@ -6855,9 +6894,9 @@ msgid ""
 "companies like Google and Facebook, who often try to track you on other "
 "websites."
 msgstr ""
-"മറ്റ് വെബ്‌സൈറ്റുകളിൽ ഇടയ്ക്കിടെ നിങ്ങളെ ട്രാക്ക് ചെയ്യാൻ ശ്രമിക്കുന്ന "
-"Google, Facebook പോലുള്ള കമ്പനികളിൽ നിന്നുള്ള ട്രാക്കറുകൾ ഉൾപ്പെടെ, നിങ്ങൾ "
-"സന്ദർശിക്കുന്ന വെബ്‌സൈറ്റുകളിലെ ട്രാക്കറുകളെ DuckDuckGo തടയുന്നു."
+"മറ്റ് വെബ്‌സൈറ്റുകളിൽ ഇടയ്ക്കിടെ നിങ്ങളെ ട്രാക്ക് ചെയ്യാൻ ശ്രമിക്കുന്ന Google, Facebook പോലുള്ള "
+"കമ്പനികളിൽ നിന്നുള്ള ട്രാക്കറുകൾ ഉൾപ്പെടെ, നിങ്ങൾ സന്ദർശിക്കുന്ന വെബ്‌സൈറ്റുകളിലെ ട്രാക്കറുകളെ "
+"DuckDuckGo തടയുന്നു."
 
 # smartling.placeholder_format=C
 #. Description of how DuckDuckGo keeps a user's location anonymous while the user searches on a map of their area.
@@ -6869,13 +6908,12 @@ msgid ""
 "away, such that you remain anonymous. %sLearn more about how we designed "
 "this technology to protect your privacy%s."
 msgstr ""
-"ഡിസൈൻ പ്രകാരം DuckDuckGo സ്വകാര്യമാണ്. നിങ്ങൾ ലൊക്കേഷൻ "
-"പ്രവർത്തനക്ഷമമാക്കുമ്പോൾ, നിങ്ങളുടെ ലോക്കൽ ഉപകരണത്തിൽ മാത്രം അത് "
-"സംഭരിക്കപ്പെടുന്നു. നിങ്ങൾ തിരയുമ്പോൾ, നിങ്ങളുടെ ഉപകരണം അത് ഞങ്ങൾക്ക് "
-"അയയ്ക്കുന്നു, ആ തിരയലിനായുള്ള ഫലങ്ങൾ മെച്ചപ്പെടുത്തുന്നതിന് ഞങ്ങൾ അത് "
-"ഉപയോഗിക്കുന്നു, തുടർന്ന് നിങ്ങൾ അജ്ഞാതമായി തുടരുന്ന തരത്തിൽ ഞങ്ങൾ അത് ഉടനടി "
-"ഉപേക്ഷിച്ചുകളയുന്നു. %1$sനിങ്ങളുടെ സ്വകാര്യത പരിരക്ഷിക്കുന്നതിന് ഞങ്ങൾ ഈ "
-"സാങ്കേതികവിദ്യ രൂപകൽപ്പന ചെയ്തത് എങ്ങനെയെന്ന് കൂടുതൽ അറിയുക%2$s."
+"ഡിസൈൻ പ്രകാരം DuckDuckGo സ്വകാര്യമാണ്. നിങ്ങൾ ലൊക്കേഷൻ പ്രവർത്തനക്ഷമമാക്കുമ്പോൾ, നിങ്ങളുടെ "
+"ലോക്കൽ ഉപകരണത്തിൽ മാത്രം അത് സംഭരിക്കപ്പെടുന്നു. നിങ്ങൾ തിരയുമ്പോൾ, നിങ്ങളുടെ ഉപകരണം അത് "
+"ഞങ്ങൾക്ക് അയയ്ക്കുന്നു, ആ തിരയലിനായുള്ള ഫലങ്ങൾ മെച്ചപ്പെടുത്തുന്നതിന് ഞങ്ങൾ അത് ഉപയോഗിക്കുന്നു, "
+"തുടർന്ന് നിങ്ങൾ അജ്ഞാതമായി തുടരുന്ന തരത്തിൽ ഞങ്ങൾ അത് ഉടനടി ഉപേക്ഷിച്ചുകളയുന്നു. %1$sനിങ്ങളുടെ "
+"സ്വകാര്യത പരിരക്ഷിക്കുന്നതിന് ഞങ്ങൾ ഈ സാങ്കേതികവിദ്യ രൂപകൽപ്പന ചെയ്തത് എങ്ങനെയെന്ന് കൂടുതൽ "
+"അറിയുക%2$s."
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
@@ -6895,9 +6933,8 @@ msgid ""
 "DuckDuckGo only uses your approximate location. That's all we need to "
 "deliver better results, closer to you. %sLearn more%s."
 msgstr ""
-"നിങ്ങളുടെ ഏകദേശ ലൊക്കേഷൻ മാത്രമേ DuckDuckGo ഉപയോഗിക്കുകയുള്ളൂ. നിങ്ങൾക്ക് "
-"കൂടുതൽ ബന്ധമുള്ള, മികച്ച ഫലങ്ങൾ നൽകാൻ ഞങ്ങൾ ചെയ്യേണ്ടത് അതുമാത്രമാണ്. "
-"%1$sകൂടുതൽ അറിയുക%2$s."
+"നിങ്ങളുടെ ഏകദേശ ലൊക്കേഷൻ മാത്രമേ DuckDuckGo ഉപയോഗിക്കുകയുള്ളൂ. നിങ്ങൾക്ക് കൂടുതൽ ബന്ധമുള്ള, "
+"മികച്ച ഫലങ്ങൾ നൽകാൻ ഞങ്ങൾ ചെയ്യേണ്ടത് അതുമാത്രമാണ്. %1$sകൂടുതൽ അറിയുക%2$s."
 
 # smartling.placeholder_format=C
 msgid "DuckDuckGo search"
@@ -6983,11 +7020,10 @@ msgid ""
 "random words from that list, ensuring that the passphrase is at least 18-20 "
 "characters long."
 msgstr ""
-"ഓരോ തവണയും നിങ്ങൾ ഒരു പാസ്‌ഫ്രെയ്സ് നിർദേശം ആവശ്യപ്പെടുമ്പോൾ, DuckDuckGo "
-"സെർവറുകളിൽ നിന്ന് ക്രമരഹിതമായ പദങ്ങളുടെ ഒരു നീണ്ട പട്ടിക ഞങ്ങൾക്ക് ലഭിക്കും. "
-"പിന്നീട്, ബ്രൗസറിൽ, ആ പട്ടികയിൽ നിന്നും ഞങ്ങൾ 4-5 ക്രമരഹിതമായ പദങ്ങൾ "
-"തിരഞ്ഞെടുത്തുകൊണ്ട്, പാസ്‌ഫ്രെയ്സിന് കുറഞ്ഞത് 18-20 അക്ഷരങ്ങളെങ്കിലും "
-"ദൈർഘ്യമുണ്ടെന്ന് ഉറപ്പാക്കുന്നു."
+"ഓരോ തവണയും നിങ്ങൾ ഒരു പാസ്‌ഫ്രെയ്സ് നിർദേശം ആവശ്യപ്പെടുമ്പോൾ, DuckDuckGo സെർവറുകളിൽ നിന്ന് "
+"ക്രമരഹിതമായ പദങ്ങളുടെ ഒരു നീണ്ട പട്ടിക ഞങ്ങൾക്ക് ലഭിക്കും. പിന്നീട്, ബ്രൗസറിൽ, ആ പട്ടികയിൽ "
+"നിന്നും ഞങ്ങൾ 4-5 ക്രമരഹിതമായ പദങ്ങൾ തിരഞ്ഞെടുത്തുകൊണ്ട്, പാസ്‌ഫ്രെയ്സിന് കുറഞ്ഞത് 18-20 "
+"അക്ഷരങ്ങളെങ്കിലും ദൈർഘ്യമുണ്ടെന്ന് ഉറപ്പാക്കുന്നു."
 
 # smartling.placeholder_format=C
 msgctxt "Sports module"
@@ -7052,8 +7088,8 @@ msgctxt "Info text for the editing message feature"
 msgid ""
 "Editing your message will remove the response below and generate a new one."
 msgstr ""
-"നിങ്ങളുടെ സന്ദേശം എഡിറ്റ് ചെയ്യുന്നത് ചുവടെയുള്ള പ്രതികരണം നീക്കംചെയ്യുകയും "
-"പുതിയത് സൃഷ്ടിക്കുകയും ചെയ്യും."
+"നിങ്ങളുടെ സന്ദേശം എഡിറ്റ് ചെയ്യുന്നത് ചുവടെയുള്ള പ്രതികരണം നീക്കംചെയ്യുകയും പുതിയത് സൃഷ്ടിക്കുകയും "
+"ചെയ്യും."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of an editor in its responses.
@@ -7114,9 +7150,7 @@ msgstr "AI സവിശേഷതകൾ പ്രവർത്തനക്ഷമ�
 #. Text explaining how to enable the cloud save feature.
 msgctxt "cloudsave"
 msgid "Enable Cloud Save by entering your existing passphrase."
-msgstr ""
-"നിങ്ങളുടെ നിലവിലുള്ള പാസ്‌ഫ്രെയ്സ് ഉപയോഗിച്ച് Cloud Save "
-"പ്രവർത്തനക്ഷമമാക്കുക."
+msgstr "നിങ്ങളുടെ നിലവിലുള്ള പാസ്‌ഫ്രെയ്സ് ഉപയോഗിച്ച് Cloud Save പ്രവർത്തനക്ഷമമാക്കുക."
 
 # smartling.placeholder_format=C
 #. Primary button text in the dictation privacy consent modal to enable dictation.
@@ -7187,8 +7221,8 @@ msgid ""
 "Enable anonymous location for more accurate results. You can always change "
 "your mind later."
 msgstr ""
-"കൂടുതൽ കൃത്യമായ ഫലങ്ങൾക്കായി അജ്ഞാത ലൊക്കേഷൻ പ്രവർത്തനക്ഷമമാക്കുക. പിന്നീട് "
-"എപ്പോൾ വേണമെങ്കിലും നിങ്ങളുടെ മനസ്സ് മാറ്റാൻ കഴിയും."
+"കൂടുതൽ കൃത്യമായ ഫലങ്ങൾക്കായി അജ്ഞാത ലൊക്കേഷൻ പ്രവർത്തനക്ഷമമാക്കുക. പിന്നീട് എപ്പോൾ "
+"വേണമെങ്കിലും നിങ്ങളുടെ മനസ്സ് മാറ്റാൻ കഴിയും."
 
 # smartling.placeholder_format=C
 #. Title of the dictation privacy consent modal shown on first use.
@@ -7233,9 +7267,8 @@ msgid ""
 "Enabling anonymous location gives more accurate results but still keeps your "
 "searches and exact location private to DuckDuckGo."
 msgstr ""
-"അജ്ഞാത ലൊക്കേഷൻ പ്രവർത്തനക്ഷമമാക്കുന്നത് കൂടുതൽ കൃത്യമായ ഫലങ്ങൾ നൽകുന്നു, "
-"പക്ഷേ അപ്പോഴും നിങ്ങളുടെ തിരയലുകളും കൃത്യമായ ലൊക്കേഷനും DuckDuckGo-യിലേക്ക് "
-"സ്വകാര്യമായി സൂക്ഷിക്കുന്നു."
+"അജ്ഞാത ലൊക്കേഷൻ പ്രവർത്തനക്ഷമമാക്കുന്നത് കൂടുതൽ കൃത്യമായ ഫലങ്ങൾ നൽകുന്നു, പക്ഷേ അപ്പോഴും നിങ്ങളുടെ "
+"തിരയലുകളും കൃത്യമായ ലൊക്കേഷനും DuckDuckGo-യിലേക്ക് സ്വകാര്യമായി സൂക്ഷിക്കുന്നു."
 
 # smartling.placeholder_format=C
 msgid "Encrypt Connections"
@@ -7312,8 +7345,7 @@ msgstr "Duck.ai ആസ്വദിക്കുകയാണോ?"
 msgctxt "precise_user_location"
 msgid "Ensure %s'Allow'%s is selected for the 'Location' setting."
 msgstr ""
-"'ലൊക്കേഷൻ' ക്രമീകരണത്തിനായി %1$s'അനുവദിക്കുക'%2$s തിരഞ്ഞെടുത്തിട്ടുണ്ടെന്ന് "
-"ഉറപ്പാക്കുക."
+"'ലൊക്കേഷൻ' ക്രമീകരണത്തിനായി %1$s'അനുവദിക്കുക'%2$s തിരഞ്ഞെടുത്തിട്ടുണ്ടെന്ന് ഉറപ്പാക്കുക."
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
@@ -7399,8 +7431,8 @@ msgid ""
 "Enter a new passphrase and click/tap %sSave Settings%s. This will save your "
 "data under your new passphrase."
 msgstr ""
-"ഒരു പുതിയ പാസ്‌ഫ്രെയ്സ് നൽകിയിട്ട്, %1$sക്രമീകരണം സംരക്ഷിക്കുക%2$s ക്ലിക്ക് "
-"ചെയ്യുക. ഇത് നിങ്ങളുടെ പുതിയ പാസ്‌ഫ്രെയ്സിന് കീഴിൽ ഡാറ്റ രക്ഷിക്കും."
+"ഒരു പുതിയ പാസ്‌ഫ്രെയ്സ് നൽകിയിട്ട്, %1$sക്രമീകരണം സംരക്ഷിക്കുക%2$s ക്ലിക്ക് ചെയ്യുക. ഇത് "
+"നിങ്ങളുടെ പുതിയ പാസ്‌ഫ്രെയ്സിന് കീഴിൽ ഡാറ്റ രക്ഷിക്കും."
 
 # smartling.placeholder_format=C
 #. Label for the field where a user enters their passphrase.
@@ -7426,8 +7458,8 @@ msgstr "ടെക്‌സ്റ്റ് നൽകുക"
 msgid ""
 "Enter the following details: %sName%s: DuckDuckGo%s URL%s: %s Alias%s: d%s"
 msgstr ""
-"ഇനിപ്പറയുന്ന വിശദാംശങ്ങൾ നൽകുക: %1$s പേര് %2$s: DuckDuckGo%3$sURL%4$s: "
-"%5$sഅപരനാമം %6$s: ഡി%7$s"
+"ഇനിപ്പറയുന്ന വിശദാംശങ്ങൾ നൽകുക: %1$s പേര് %2$s: DuckDuckGo%3$sURL%4$s: %5$sഅപരനാമം "
+"%6$s: ഡി%7$s"
 
 # smartling.placeholder_format=C
 #. Prompt to enter a destination for driving directions.
@@ -7462,12 +7494,23 @@ msgstr "ഇക്വറ്റോറിയൽ ഗിനിയ"
 msgctxt "Browser Promo Popover"
 msgid "Erase your browsing data in a flash with our %sFire Button%s"
 msgstr ""
-"ഞങ്ങളുടെ Fire Button ഉപയോഗിച്ച് ഒറ്റ ഫ്ലാഷിൽ നിങ്ങളുടെ ബ്രൗസിംഗ് ഡാറ്റ "
-"മായ്ക്കുക %1$s%2$s"
+"ഞങ്ങളുടെ Fire Button ഉപയോഗിച്ച് ഒറ്റ ഫ്ലാഷിൽ നിങ്ങളുടെ ബ്രൗസിംഗ് ഡാറ്റ മായ്ക്കുക %1$s%2$s"
 
 # smartling.placeholder_format=C
 msgid "Eritrea"
 msgstr "എറിത്രിയ"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Estimate the nutrition"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Estimate the nutritional information for this recipe."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Estonia"
@@ -7503,9 +7546,7 @@ msgstr "മാപ്പ് വികസിപ്പിക്കുക"
 #. Subtitle for the Collaborations promotional card at the bottom of search results. Describes the branded merchandise line. 'Give a duck' is a wordplay on the DuckDuckGo brand name.
 msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
-msgstr ""
-"സ്വകാര്യതയെ ശരിക്കും ശ്രദ്ധിക്കുന്നവർക്കായി വിദഗ്ദ്ധമായി രൂപകൽപ്പന ചെയ്ത "
-"ഉൽപ്പന്നങ്ങൾ."
+msgstr "സ്വകാര്യതയെ ശരിക്കും ശ്രദ്ധിക്കുന്നവർക്കായി വിദഗ്ദ്ധമായി രൂപകൽപ്പന ചെയ്ത ഉൽപ്പന്നങ്ങൾ."
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
@@ -7526,11 +7567,59 @@ msgid "Expires in 1 day"
 msgstr "1 ദിവസത്തിനുള്ളിൽ കാലഹരണപ്പെടുന്നു"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain the accepted answer in simple terms."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
 msgstr "ഹൈസ്കൂൾ തലത്തിൽ തമോദ്വാരങ്ങളുടെ അടിസ്ഥാന ആശയങ്ങൾ എനിക്ക് വിശദീകരിക്കുക."
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain the top answer"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this in simple, plain language."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this paper"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this repo"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this research paper in plain language."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this simply"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain what this repository does and how to use it."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label to show if song lyrics contain explicit content
@@ -7708,8 +7797,8 @@ msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and improvements."
 msgstr ""
-"നിങ്ങളുടെ ഫീഡ്ബാക്ക് ഞങ്ങളുടെ ഉൽപ്പന്ന അപ്ഡേറ്റുകളെയും "
-"മെച്ചപ്പെടുത്തലുകളെയും നേരിട്ട് സ്വാധീനിക്കുന്നു."
+"നിങ്ങളുടെ ഫീഡ്ബാക്ക് ഞങ്ങളുടെ ഉൽപ്പന്ന അപ്ഡേറ്റുകളെയും മെച്ചപ്പെടുത്തലുകളെയും നേരിട്ട് "
+"സ്വാധീനിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -7718,9 +7807,8 @@ msgid ""
 "Feedback like yours directly influences our product updates and "
 "improvements. Hopefully we can address the issue you shared too."
 msgstr ""
-"നിങ്ങളുടേത് പോലുള്ള ഫീഡ്ബാക്ക് ഞങ്ങളുടെ ഉൽപ്പന്ന അപ്ഡേറ്റുകളെയും "
-"മെച്ചപ്പെടുത്തലുകളെയും നേരിട്ട് സ്വാധീനിക്കുന്നു. നിങ്ങൾ പങ്കിട്ട പ്രശ്നവും "
-"പരിഹരിക്കാൻ ഞങ്ങൾക്ക് കഴിയുമെന്ന് പ്രതീക്ഷിക്കുന്നു."
+"നിങ്ങളുടേത് പോലുള്ള ഫീഡ്ബാക്ക് ഞങ്ങളുടെ ഉൽപ്പന്ന അപ്ഡേറ്റുകളെയും മെച്ചപ്പെടുത്തലുകളെയും നേരിട്ട് "
+"സ്വാധീനിക്കുന്നു. നിങ്ങൾ പങ്കിട്ട പ്രശ്നവും പരിഹരിക്കാൻ ഞങ്ങൾക്ക് കഴിയുമെന്ന് പ്രതീക്ഷിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box
@@ -7728,8 +7816,8 @@ msgid ""
 "Feel free to adjust the settings below. Then, just copy and paste the code "
 "into your website."
 msgstr ""
-"ഇഷ്ട പ്രകാരം താഴെയുള്ള ക്രമീകരണം ക്രമപ്പെടുത്തുക. തുടർന്ന് കോഡ് താങ്കളുടെ "
-"സൈറ്റിലേക്കു പകർത്തി ഒട്ടിക്കുക"
+"ഇഷ്ട പ്രകാരം താഴെയുള്ള ക്രമീകരണം ക്രമപ്പെടുത്തുക. തുടർന്ന് കോഡ് താങ്കളുടെ സൈറ്റിലേക്കു പകർത്തി "
+"ഒട്ടിക്കുക"
 
 # smartling.placeholder_format=C
 msgid "Fiji"
@@ -7813,8 +7901,14 @@ msgctxt "settings"
 msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
 msgstr ""
-"AI ഉപയോഗിച്ച് നിർമ്മിച്ച ചിത്രങ്ങൾ, ചിത്രങ്ങൾ തിരയുന്നതിൻ്റെ ഫലത്തിൽ നിന്ന് "
-"ഫിൽട്ടർ ചെയ്ത് ഒഴിവാക്കുന്നു. %1$sകൂടുതലറിയുക%2$s"
+"AI ഉപയോഗിച്ച് നിർമ്മിച്ച ചിത്രങ്ങൾ, ചിത്രങ്ങൾ തിരയുന്നതിൻ്റെ ഫലത്തിൽ നിന്ന് ഫിൽട്ടർ ചെയ്ത് "
+"ഒഴിവാക്കുന്നു. %1$sകൂടുതലറിയുക%2$s"
+
+# smartling.placeholder_format=C
+msgctxt "settings"
+msgid ""
+"Filters out known AI spam sites from image search results. %sLearn More%s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the final score of a sporting event.
@@ -7856,8 +7950,7 @@ msgstr "<b>%1$s</b> നിങ്ങളുടെ ഡൗൺലോഡുകൾ ഫ�
 #. Tells users how to change their default search engine to DuckDuckGo.
 msgid "Find DuckDuckGo in the displayed list and click %sMake Default%s"
 msgstr ""
-"പ്രദർശിപ്പിച്ച പട്ടികയിൽ DuckDuckGo കണ്ടെത്തി %1$sഡിഫോൾട്ട് ആക്കുക%2$s "
-"എന്നത് ക്ലിക്ക് ചെയ്യുക"
+"പ്രദർശിപ്പിച്ച പട്ടികയിൽ DuckDuckGo കണ്ടെത്തി %1$sഡിഫോൾട്ട് ആക്കുക%2$s എന്നത് ക്ലിക്ക് ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for finding a better word.
@@ -7870,6 +7963,12 @@ msgstr "ഇതിലും നല്ലൊരു വാക്ക് കണ്ട
 msgctxt "Subtitle for the Web Search tool entry in the Tools dropdown menu"
 msgid "Find current information"
 msgstr "നിലവിലെ വിവരങ്ങൾ കണ്ടെത്തുക"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Find me alternatives"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button that searches for results closer to the user's current location.
@@ -7889,8 +7988,8 @@ msgctxt "Precise user location overlay"
 msgid ""
 "Find results near you. %sYour location stays private, secure, and anonymous."
 msgstr ""
-"നിങ്ങളോട് അടുത്തുള്ള ഫലങ്ങൾ കണ്ടെത്തുക. %1$sനിങ്ങളുടെ ലൊക്കേഷൻ സ്വകാര്യവും "
-"സുരക്ഷിതവും അജ്ഞാതവുമാണ്."
+"നിങ്ങളോട് അടുത്തുള്ള ഫലങ്ങൾ കണ്ടെത്തുക. %1$sനിങ്ങളുടെ ലൊക്കേഷൻ സ്വകാര്യവും സുരക്ഷിതവും "
+"അജ്ഞാതവുമാണ്."
 
 # smartling.placeholder_format=C
 #. Loading message shown while generating explore more follow-up questions
@@ -7954,9 +8053,8 @@ msgid ""
 "Follow the instructions for turning off the ad blocker for DuckDuckGo. You "
 "may have to select a menu option or click a button."
 msgstr ""
-"DuckDuckGo-യ്ക്കായി Ad blocker ഓഫാക്കാൻ നിർദ്ദേശങ്ങൾ പിന്തുടരുക. നിങ്ങൾ ഒരു "
-"മെനു ഓപ്ഷൻ തിരഞ്ഞെടുക്കുകയോ ഒരു ബട്ടൺ ക്ലിക്ക് ചെയ്യുകയോ ചെയ്യേണ്ടി "
-"വന്നേക്കാം."
+"DuckDuckGo-യ്ക്കായി Ad blocker ഓഫാക്കാൻ നിർദ്ദേശങ്ങൾ പിന്തുടരുക. നിങ്ങൾ ഒരു മെനു ഓപ്ഷൻ "
+"തിരഞ്ഞെടുക്കുകയോ ഒരു ബട്ടൺ ക്ലിക്ക് ചെയ്യുകയോ ചെയ്യേണ്ടി വന്നേക്കാം."
 
 # smartling.placeholder_format=C
 #. Privacy reassurance and instructions intro.
@@ -8067,9 +8165,7 @@ msgstr "സൗജന്യവും സ്വകാര്യവുമായ ച�
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr ""
-"സൗജന്യവും സ്വകാര്യവുമായ ചാറ്റുകൾ, ഞങ്ങൾ അജ്ഞാതമാക്കിയിരിക്കുന്നു. അക്കൗണ്ട് "
-"ആവശ്യമില്ല."
+msgstr "സൗജന്യവും സ്വകാര്യവുമായ ചാറ്റുകൾ, ഞങ്ങൾ അജ്ഞാതമാക്കിയിരിക്കുന്നു. അക്കൗണ്ട് ആവശ്യമില്ല."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -8099,9 +8195,7 @@ msgstr "പങ്കിടലും വാണിജ്യപരമായി ഉ�
 #. Description text explaining how to free up sync storage. Pinned chats are chats the user has explicitly marked to keep.
 msgctxt "Sync limit modal description"
 msgid "Free up space by deleting your chats. Pinned chats will not be deleted."
-msgstr ""
-"നിങ്ങളുടെ ചാറ്റുകൾ ഇല്ലാതാക്കി സ്ഥലം ശൂന്യമാക്കുക. പിൻ ചെയ്ത ചാറ്റുകൾ "
-"ഇല്ലാതാക്കില്ല."
+msgstr "നിങ്ങളുടെ ചാറ്റുകൾ ഇല്ലാതാക്കി സ്ഥലം ശൂന്യമാക്കുക. പിൻ ചെയ്ത ചാറ്റുകൾ ഇല്ലാതാക്കില്ല."
 
 # smartling.placeholder_format=C
 #. Indicates that this streaming service is free to watch but shows ads
@@ -8182,9 +8276,9 @@ msgid ""
 "<strong>Check for Updates...</strong>, then select <strong>Install Update</"
 "strong>."
 msgstr ""
-"Mac-ലെ ആപ്പ് മെനു ബാറിൽ നിന്ന്, <strong>DuckDuckGo</strong> &gt; "
-"<strong>അപ്ഡേറ്റുകൾ പരിശോധിക്കുക...</strong>, തുടർന്ന് <strong>അപ്ഡേറ്റ് "
-"ഇൻസ്റ്റാൾ ചെയ്യുക</strong> തിരഞ്ഞെടുക്കുക."
+"Mac-ലെ ആപ്പ് മെനു ബാറിൽ നിന്ന്, <strong>DuckDuckGo</strong> &gt; <strong>അപ്ഡേറ്റുകൾ "
+"പരിശോധിക്കുക...</strong>, തുടർന്ന് <strong>അപ്ഡേറ്റ് ഇൻസ്റ്റാൾ ചെയ്യുക</strong> "
+"തിരഞ്ഞെടുക്കുക."
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -8350,6 +8444,12 @@ msgstr "ഇമേജ് സൃഷ്ടിക്കുക"
 #. Text for the button that generates more of an answer from duckassist when the answer has come from a collapsed state
 msgid "Generate More"
 msgstr "കൂടുതൽ സൃഷ്ടിക്കുക"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Generate a shopping list"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
@@ -8529,9 +8629,8 @@ msgid ""
 "Get access to advanced AI models in Duck.ai by subscribing to DuckDuckGo, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"ഞങ്ങളുടെ VPN-ഉം മറ്റ് പ്രീമിയം സ്വകാര്യതാ പരിരക്ഷകളും ഉൾപ്പെടുന്ന "
-"DuckDuckGo-യിലേക്ക് സബ്സ്ക്രൈബ് ചെയ്തുകൊണ്ട് Duck.ai-ലെ നൂതന AI "
-"മോഡലുകളിലേക്ക് ആക്സസ് നേടുക."
+"ഞങ്ങളുടെ VPN-ഉം മറ്റ് പ്രീമിയം സ്വകാര്യതാ പരിരക്ഷകളും ഉൾപ്പെടുന്ന DuckDuckGo-യിലേക്ക് "
+"സബ്സ്ക്രൈബ് ചെയ്തുകൊണ്ട് Duck.ai-ലെ നൂതന AI മോഡലുകളിലേക്ക് ആക്സസ് നേടുക."
 
 # smartling.placeholder_format=C
 #. Description for the subscription setting where users can subscribe to DuckDuckGo.
@@ -8542,8 +8641,8 @@ msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"ഞങ്ങളുടെ VPN-ഉം മറ്റ് പ്രീമിയം സ്വകാര്യതാ പരിരക്ഷകളും ഉൾപ്പെടുന്ന DuckDuckGo "
-"സബ്സ്ക്രിപ്ഷൻ ഉപയോഗിച്ച് Duck.ai-ലെ നൂതന AI മോഡലുകളിലേക്ക് ആക്സസ് നേടുക."
+"ഞങ്ങളുടെ VPN-ഉം മറ്റ് പ്രീമിയം സ്വകാര്യതാ പരിരക്ഷകളും ഉൾപ്പെടുന്ന DuckDuckGo സബ്സ്ക്രിപ്ഷൻ "
+"ഉപയോഗിച്ച് Duck.ai-ലെ നൂതന AI മോഡലുകളിലേക്ക് ആക്സസ് നേടുക."
 
 # smartling.placeholder_format=C
 #. A button for users to generate an AI generated answer from their query on the duckassist module
@@ -8578,8 +8677,7 @@ msgstr "നിങ്ങളുടെ ക്രമീകരണങ്ങൾ ഒര�
 msgid ""
 "Get seamless privacy protection on your browser for free with one download:"
 msgstr ""
-"ഒറ്റ ഡൗൺലോഡിൽ നിങ്ങളുടെ ബ്രൗസറിൽ തടസ്സമില്ലാത്ത സ്വകാര്യതാ പരിരക്ഷ "
-"സൗജന്യമായി നേടുക:"
+"ഒറ്റ ഡൗൺലോഡിൽ നിങ്ങളുടെ ബ്രൗസറിൽ തടസ്സമില്ലാത്ത സ്വകാര്യതാ പരിരക്ഷ സൗജന്യമായി നേടുക:"
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo app when clicked
@@ -8644,6 +8742,12 @@ msgid "Give it a Try"
 msgstr "ഒന്ന് പരീക്ഷിച്ചു നോക്കൂ"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Give me a quick background on this person."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
@@ -8656,8 +8760,8 @@ msgid ""
 "Go to %sSettings > Privacy & Security > Location Services%s, and make sure "
 "“Location Services” is turned on."
 msgstr ""
-"%1$sക്രമീകരണം > സ്വകാര്യതയും സുരക്ഷയും > ലൊക്കേഷൻ സേവനങ്ങൾ%2$sഎന്നതിലേക്ക് "
-"പോയി \"ലൊക്കേഷൻ സേവനങ്ങൾ\" ഓണാക്കിയിട്ടുണ്ടെന്ന് ഉറപ്പാക്കുക."
+"%1$sക്രമീകരണം > സ്വകാര്യതയും സുരക്ഷയും > ലൊക്കേഷൻ സേവനങ്ങൾ%2$sഎന്നതിലേക്ക് പോയി "
+"\"ലൊക്കേഷൻ സേവനങ്ങൾ\" ഓണാക്കിയിട്ടുണ്ടെന്ന് ഉറപ്പാക്കുക."
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -8911,9 +9015,7 @@ msgstr "ഗ്വാട്ടിമാല"
 #. Text for a prompt suggestion for guiding through the basic steps of replacing a window wiper.
 msgctxt "Full sentence for learning a new skill"
 msgid "Guide me through the basic steps of replacing a window wiper."
-msgstr ""
-"ഒരു വിൻഡോ വൈപ്പർ മാറ്റിസ്ഥാപിക്കുന്നതിനുള്ള അടിസ്ഥാന ഘട്ടങ്ങളിലൂടെ എന്നെ "
-"നയിക്കുക."
+msgstr "ഒരു വിൻഡോ വൈപ്പർ മാറ്റിസ്ഥാപിക്കുന്നതിനുള്ള അടിസ്ഥാന ഘട്ടങ്ങളിലൂടെ എന്നെ നയിക്കുക."
 
 # smartling.placeholder_format=C
 msgid "Guinea"
@@ -9092,6 +9194,18 @@ msgid "Help Spread Privacy"
 msgstr "സ്വകാര്യത വ്യാപിപ്പിക്കാൻ സഹായിക്കുക"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Help me prep for the interview"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Help me tailor my resume for this job."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title of a SERP popup that invites users to take a survey (desktop only)
 msgctxt "User survey popup"
 msgid "Help us improve DuckDuckGo"
@@ -9101,9 +9215,7 @@ msgstr "DuckDuckGo മെച്ചപ്പെടുത്താൻ ഞങ്ങ
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Help us improve DuckDuckGo searches with your feedback"
-msgstr ""
-"നിങ്ങളുടെ ഫീഡ്ബാക്ക് ഉപയോഗിച്ച് DuckDuckGo തിരയലുകൾ മെച്ചപ്പെടുത്താൻ ഞങ്ങളെ "
-"സഹായിക്കൂ"
+msgstr "നിങ്ങളുടെ ഫീഡ്ബാക്ക് ഉപയോഗിച്ച് DuckDuckGo തിരയലുകൾ മെച്ചപ്പെടുത്താൻ ഞങ്ങളെ സഹായിക്കൂ"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -9161,9 +9273,7 @@ msgstr "Duck ഭാഗത്ത് ചേരാൻ നിങ്ങളുടെ �
 #. Text description for the Spread card in the SERP footer
 msgctxt "footer_card"
 msgid "Help your friends and family take back their privacy!"
-msgstr ""
-"നിങ്ങളുടെ സുഹൃത്തുക്കളെയും കുടുംബാംഗങ്ങളെയും അവരുടെ സ്വകാര്യത വീണ്ടെടുക്കാൻ "
-"സഹായിക്കൂ!"
+msgstr "നിങ്ങളുടെ സുഹൃത്തുക്കളെയും കുടുംബാംഗങ്ങളെയും അവരുടെ സ്വകാര്യത വീണ്ടെടുക്കാൻ സഹായിക്കൂ!"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -9332,8 +9442,8 @@ msgid ""
 "Highlights key facts in Search Assist answers to help you find important "
 "information faster."
 msgstr ""
-"പ്രധാനപ്പെട്ട വിവരങ്ങൾ വേഗത്തിൽ കണ്ടെത്താൻ നിങ്ങളെ സഹായിക്കുന്നതിന് Search "
-"Assist ഉത്തരങ്ങളിൽ പ്രധാന വസ്തുതകൾ എടുത്തുകാണിക്കുന്നു."
+"പ്രധാനപ്പെട്ട വിവരങ്ങൾ വേഗത്തിൽ കണ്ടെത്താൻ നിങ്ങളെ സഹായിക്കുന്നതിന് Search Assist "
+"ഉത്തരങ്ങളിൽ പ്രധാന വസ്തുതകൾ എടുത്തുകാണിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. The name of the Hindi language
@@ -9360,9 +9470,8 @@ msgid ""
 "Hit %sReturn%s on your keyboard to %ssave DuckDuckGo to the list. %sThen "
 "click %sMake Default%s"
 msgstr ""
-"DuckDuckGo പട്ടികയിലേക്ക് %3$sസംരക്ഷിക്കാൻ നിങ്ങളുടെ കീബോർഡിൽ "
-"%1$sമടങ്ങുക%2$s അമർത്തുക. %4$sതുടർന്ന് %5$sഡിഫോൾട്ട് ആക്കുക%6$s എന്നത് "
-"ക്ലിക്ക് ചെയ്യുക"
+"DuckDuckGo പട്ടികയിലേക്ക് %3$sസംരക്ഷിക്കാൻ നിങ്ങളുടെ കീബോർഡിൽ %1$sമടങ്ങുക%2$s "
+"അമർത്തുക. %4$sതുടർന്ന് %5$sഡിഫോൾട്ട് ആക്കുക%6$s എന്നത് ക്ലിക്ക് ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. The name of the Hmong Daw language
@@ -9376,8 +9485,8 @@ msgid ""
 "Hold on! Changing it back will disable the DuckDuckGo extension and you'll "
 "lose our privacy protection."
 msgstr ""
-"ഹോൾഡ് ഓൺ! ഇത് തിരികെ മാറ്റുന്നത് DuckDuckGo വിപുലീകരണം പ്രവർത്തനരഹിതമാക്കും, "
-"നിങ്ങൾക്ക് ഞങ്ങളുടെ സ്വകാര്യതാ പരിരക്ഷണം നഷ്‌ടമാകും."
+"ഹോൾഡ് ഓൺ! ഇത് തിരികെ മാറ്റുന്നത് DuckDuckGo വിപുലീകരണം പ്രവർത്തനരഹിതമാക്കും, നിങ്ങൾക്ക് "
+"ഞങ്ങളുടെ സ്വകാര്യതാ പരിരക്ഷണം നഷ്‌ടമാകും."
 
 # smartling.placeholder_format=C
 #. Heading shown above warning messages in the AI chat, for non-critical issues like unsupported file formats or file size limits. Analogous to 'Oops...' for error messages.
@@ -9427,8 +9536,8 @@ msgid ""
 "Hotel ad clicks are managed by Tripadvisor’s ad network and are not used to "
 "profile you."
 msgstr ""
-"ഹോട്ടൽ പരസ്യ ക്ലിക്കുകൾ കൈകാര്യം ചെയ്യുന്നത് ട്രിപ്പ് അഡ്വൈസറിന്റെ പരസ്യ "
-"ശൃംഖലയാണ്, നിങ്ങളെ പ്രൊഫൈൽ ചെയ്യുന്നതിനായി അവ ഉപയോഗിക്കപ്പെടുന്നില്ല."
+"ഹോട്ടൽ പരസ്യ ക്ലിക്കുകൾ കൈകാര്യം ചെയ്യുന്നത് ട്രിപ്പ് അഡ്വൈസറിന്റെ പരസ്യ ശൃംഖലയാണ്, നിങ്ങളെ "
+"പ്രൊഫൈൽ ചെയ്യുന്നതിനായി അവ ഉപയോഗിക്കപ്പെടുന്നില്ല."
 
 # smartling.placeholder_format=C
 #. Refers to hours of operation for a business.
@@ -9537,9 +9646,7 @@ msgstr "ഇത് എങ്ങനെ പ്രവർത്തിക്കുന�
 #. Header for the assist settings modal where the user can choose how often they want AI-assisted answers to appear.
 msgctxt "duckassist"
 msgid "How much do you want AI-assisted answers to appear?"
-msgstr ""
-"നിങ്ങൾ എത്രത്തോളം AI- സഹായത്തോടെയുള്ള ഉത്തരങ്ങൾ ദൃശ്യമാകണമെന്നാണ് "
-"ആഗ്രഹിക്കുന്നത്?"
+msgstr "നിങ്ങൾ എത്രത്തോളം AI- സഹായത്തോടെയുള്ള ഉത്തരങ്ങൾ ദൃശ്യമാകണമെന്നാണ് ആഗ്രഹിക്കുന്നത്?"
 
 # smartling.placeholder_format=C
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
@@ -9572,8 +9679,8 @@ msgid ""
 "How should I tactfully approach a colleague about their constant pencil "
 "tapping and what should I say?"
 msgstr ""
-"അവരുടെ നിരന്തരമായ പെൻസിൽ ടാപ്പിംഗിനെക്കുറിച്ച് ഒരു സഹപ്രവർത്തകനെ എങ്ങനെ "
-"തന്ത്രപൂർവ്വം സമീപിക്കണം, ഞാൻ എന്താണ് പറയേണ്ടത്?"
+"അവരുടെ നിരന്തരമായ പെൻസിൽ ടാപ്പിംഗിനെക്കുറിച്ച് ഒരു സഹപ്രവർത്തകനെ എങ്ങനെ തന്ത്രപൂർവ്വം "
+"സമീപിക്കണം, ഞാൻ എന്താണ് പറയേണ്ടത്?"
 
 # smartling.placeholder_format=C
 #. The title for a feedback prompt that includes thumbs up and thumbs down buttons
@@ -9612,6 +9719,14 @@ msgstr "ചുഴലിക്കാറ്റ്"
 msgctxt "Onboarding terms screen button text"
 msgid "I Agree"
 msgstr "ഞാൻ യോജിക്കുന്നു"
+
+# smartling.placeholder_format=C
+#. Text for the button that takes the user to the external DuckDuckGo login subscription page.
+msgctxt ""
+"Text for the I already have a subscription button in the Duck.ai settings "
+"page"
+msgid "I Already Have a Subscription"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the button that takes the user to the login subscription page.
@@ -9672,9 +9787,7 @@ msgstr "കൂടുതൽ വിൽപ്പനക്കാരിൽ നിന�
 #. Header above text explaining that passwords can't be recovered.
 msgctxt "cloudsave"
 msgid "I forgot my passphrase. Can you recover it?"
-msgstr ""
-"എന്റെ പാസ്‌ഫ്രെയ്സ് മറന്നു പോയി, നിങ്ങള്‍ക്ക് അത് വീണ്ടെടുക്കുവാന്‍ "
-"സാധിക്കുമോ?"
+msgstr "എന്റെ പാസ്‌ഫ്രെയ്സ് മറന്നു പോയി, നിങ്ങള്‍ക്ക് അത് വീണ്ടെടുക്കുവാന്‍ സാധിക്കുമോ?"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the user hits a chat limit.
@@ -9689,16 +9802,14 @@ msgid ""
 "I like the book Name of the Wind. What are some other good books/series most "
 "like it and why?"
 msgstr ""
-"കാറ്റിൻ്റെ പേര് എന്ന പുസ്തകം എനിക്കിഷ്ടമാണ്. മറ്റു ചില നല്ല "
-"പുസ്തകങ്ങൾ/പരമ്പരകൾ ഏതൊക്കെയാണ് ഏറ്റവും ഇഷ്ടപ്പെടുന്നത്, എന്തുകൊണ്ട്?"
+"കാറ്റിൻ്റെ പേര് എന്ന പുസ്തകം എനിക്കിഷ്ടമാണ്. മറ്റു ചില നല്ല പുസ്തകങ്ങൾ/പരമ്പരകൾ ഏതൊക്കെയാണ് "
+"ഏറ്റവും ഇഷ്ടപ്പെടുന്നത്, എന്തുകൊണ്ട്?"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the user needs more help or information on how to use the chat.
 msgctxt "Feedback option for difficulty in using chat"
 msgid "I need more help/info on how to use Chat"
-msgstr ""
-"ചാറ്റ് എങ്ങനെ ഉപയോഗിക്കാം എന്നതിനെക്കുറിച്ചുള്ള കൂടുതൽ സഹായം/വിവരങ്ങൾ "
-"എനിക്ക് ആവശ്യമാണ്"
+msgstr "ചാറ്റ് എങ്ങനെ ഉപയോഗിക്കാം എന്നതിനെക്കുറിച്ചുള്ള കൂടുതൽ സഹായം/വിവരങ്ങൾ എനിക്ക് ആവശ്യമാണ്"
 
 # smartling.placeholder_format=C
 msgid "IR Iran"
@@ -9727,9 +9838,8 @@ msgid ""
 "If the browser location remains unavailable, then go to %sSettings > General "
 "> Reset > 'Reset Location & Privacy'%s."
 msgstr ""
-"ബ്രൗസർ ലൊക്കേഷൻ തുടർന്നും ലഭ്യമല്ലെങ്കിൽ, %1$sക്രമീകരണം > പൊതുവായത് > "
-"പുനഃക്രമീകരിക്കുക > 'ലൊക്കേഷനും സ്വകാര്യതയും പുനഃക്രമീകരിക്കുക'%2$s "
-"എന്നതിലേക്ക് പോകുക."
+"ബ്രൗസർ ലൊക്കേഷൻ തുടർന്നും ലഭ്യമല്ലെങ്കിൽ, %1$sക്രമീകരണം > പൊതുവായത് > പുനഃക്രമീകരിക്കുക > "
+"'ലൊക്കേഷനും സ്വകാര്യതയും പുനഃക്രമീകരിക്കുക'%2$s എന്നതിലേക്ക് പോകുക."
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -9739,9 +9849,9 @@ msgid ""
 "> Menu > Settings > Site settings > Location%s, and ensure DuckDuckGo is "
 "allowed location access."
 msgstr ""
-"ബ്രൗസർ ലൊക്കേഷൻ തുടർന്നും ലഭ്യമല്ലെങ്കിൽ, നിങ്ങളുടെ ബ്രൗസറിൽ ഇതിലേക്ക് പോകുക "
-"%1$s⋮ > മെനു > ക്രമീകരണം > സൈറ്റ് ക്രമീകരണം > ലൊക്കേഷൻ%2$s, തുടർന്ന് "
-"DuckDuckGo-യ്ക്ക് ലൊക്കേഷൻ ആക്സസ് അനുവദനീയമാണെന്ന് ഉറപ്പാക്കുക."
+"ബ്രൗസർ ലൊക്കേഷൻ തുടർന്നും ലഭ്യമല്ലെങ്കിൽ, നിങ്ങളുടെ ബ്രൗസറിൽ ഇതിലേക്ക് പോകുക %1$s⋮ > മെനു > "
+"ക്രമീകരണം > സൈറ്റ് ക്രമീകരണം > ലൊക്കേഷൻ%2$s, തുടർന്ന് DuckDuckGo-യ്ക്ക് ലൊക്കേഷൻ ആക്സസ് "
+"അനുവദനീയമാണെന്ന് ഉറപ്പാക്കുക."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -9756,8 +9866,8 @@ msgid ""
 "If you don't see %sDuckDuckGo,%s you will need to add it to the list of "
 "%sOther Search Engines%s"
 msgstr ""
-"നിങ്ങൾ %1$sDuckDuckGo%2$s കാണുന്നില്ലെങ്കിൽ നിങ്ങൾ അത് %3$sമറ്റ് തിരയൽ "
-"എഞ്ചിനുകളുടെ%4$s പട്ടികയിലേക്ക് ചേർക്കേണ്ടതുണ്ട്"
+"നിങ്ങൾ %1$sDuckDuckGo%2$s കാണുന്നില്ലെങ്കിൽ നിങ്ങൾ അത് %3$sമറ്റ് തിരയൽ എഞ്ചിനുകളുടെ%4$s "
+"പട്ടികയിലേക്ക് ചേർക്കേണ്ടതുണ്ട്"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding the AI model providers and links to their support pages. Example: 'If you have concerns about our chat providers or any particular chat response, you can also reach out directly to OpenAI and Anthropic support pages.'
@@ -9766,9 +9876,8 @@ msgid ""
 "If you have concerns about our chat providers or any particular chat "
 "response, you can also reach out directly to %s and %s support pages."
 msgstr ""
-"ഞങ്ങളുടെ ചാറ്റ് ദാതാക്കളെക്കുറിച്ചോ ഏതെങ്കിലും പ്രത്യേക ചാറ്റ് "
-"പ്രതികരണത്തെക്കുറിച്ചോ നിങ്ങൾക്ക് ആശങ്കയുണ്ടെങ്കിൽ, നിങ്ങൾക്ക് നേരിട്ട് "
-"%1$s, %2$s പിന്തുണാ പേജുകളിലേക്കും ബന്ധപ്പെടാം."
+"ഞങ്ങളുടെ ചാറ്റ് ദാതാക്കളെക്കുറിച്ചോ ഏതെങ്കിലും പ്രത്യേക ചാറ്റ് പ്രതികരണത്തെക്കുറിച്ചോ നിങ്ങൾക്ക് "
+"ആശങ്കയുണ്ടെങ്കിൽ, നിങ്ങൾക്ക് നേരിട്ട് %1$s, %2$s പിന്തുണാ പേജുകളിലേക്കും ബന്ധപ്പെടാം."
 
 # smartling.placeholder_format=C
 #. Body copy explaining what the recovery code is for and how it can be saved.
@@ -9777,17 +9886,16 @@ msgid ""
 "If you lose access to your devices, you will need this code to recover your "
 "saved chats. You can save this code to your device as a text file."
 msgstr ""
-"നിങ്ങളുടെ ഉപകരണങ്ങളിലേക്കുള്ള ആക്‌സസ് നഷ്‌ടപ്പെട്ടാൽ, നിങ്ങളുടെ സംരക്ഷിച്ച "
-"ചാറ്റുകൾ വീണ്ടെടുക്കാൻ ഈ കോഡ് ആവശ്യമായി വരും. ഈ കോഡ് നിങ്ങളുടെ ഉപകരണത്തിൽ "
-"ഒരു ടെക്സ്റ്റ് ഫയലായി സംരക്ഷിക്കാം."
+"നിങ്ങളുടെ ഉപകരണങ്ങളിലേക്കുള്ള ആക്‌സസ് നഷ്‌ടപ്പെട്ടാൽ, നിങ്ങളുടെ സംരക്ഷിച്ച ചാറ്റുകൾ വീണ്ടെടുക്കാൻ "
+"ഈ കോഡ് ആവശ്യമായി വരും. ഈ കോഡ് നിങ്ങളുടെ ഉപകരണത്തിൽ ഒരു ടെക്സ്റ്റ് ഫയലായി സംരക്ഷിക്കാം."
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
 msgstr ""
-"നിങ്ങൾ ഇപ്പോഴും ഞങ്ങളെ പിന്തുണയ്ക്കാൻ ആഗ്രഹിക്കുന്നുണ്ടെങ്കിൽ, "
-"%1$sDuckDuckGo പ്രചരിപ്പിക്കുന്നതിനായി സഹായിക്കുക%2$s"
+"നിങ്ങൾ ഇപ്പോഴും ഞങ്ങളെ പിന്തുണയ്ക്കാൻ ആഗ്രഹിക്കുന്നുണ്ടെങ്കിൽ, %1$sDuckDuckGo "
+"പ്രചരിപ്പിക്കുന്നതിനായി സഹായിക്കുക%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -9797,8 +9905,8 @@ msgid ""
 "If you want to use DuckDuckGo without JavaScript, please use our %s or %s "
 "versions."
 msgstr ""
-"JavaScript ഇല്ലാതെ DuckDuckGo ഉപയോഗിക്കാൻ താൽപ്പര്യപ്പെടുന്നെങ്കിൽ, ഞങ്ങളുടെ "
-"%1$s അല്ലെങ്കിൽ %2$s പതിപ്പുകൾ ഉപയോഗിക്കുക."
+"JavaScript ഇല്ലാതെ DuckDuckGo ഉപയോഗിക്കാൻ താൽപ്പര്യപ്പെടുന്നെങ്കിൽ, ഞങ്ങളുടെ %1$s "
+"അല്ലെങ്കിൽ %2$s പതിപ്പുകൾ ഉപയോഗിക്കുക."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -9806,8 +9914,8 @@ msgstr ""
 msgid ""
 "If you want, select Home Page next to New windows and New tabs (open with)."
 msgstr ""
-"നിങ്ങൾ ആഗ്രഹിക്കുന്നെങ്കിൽ, അടുത്ത പുതിയ ജാലകങ്ങൾക്കും പുതിയ ടാബുകൾക്കും "
-"അടുത്തുള്ള ഹോം പേജ് തിരഞ്ഞെടുക്കുക (ഇതിൽ തുറക്കുക)."
+"നിങ്ങൾ ആഗ്രഹിക്കുന്നെങ്കിൽ, അടുത്ത പുതിയ ജാലകങ്ങൾക്കും പുതിയ ടാബുകൾക്കും അടുത്തുള്ള ഹോം പേജ് "
+"തിരഞ്ഞെടുക്കുക (ഇതിൽ തുറക്കുക)."
 
 # smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that adds an image to the AI chat message being composed.
@@ -9936,8 +10044,8 @@ msgctxt "settings"
 msgid ""
 "Improves result legibility with updated URL format, placement, and color"
 msgstr ""
-"അപ്‌ഡേറ്റ് ചെയ്‌ത URL ഫോർമാറ്റ്, പ്ലേസ്‌മെന്റ്, നിറം എന്നിവ ഉപയോഗിച്ച് "
-"ഫലത്തിന്റെ വ്യക്തത മെച്ചപ്പെടുത്തുന്നു"
+"അപ്‌ഡേറ്റ് ചെയ്‌ത URL ഫോർമാറ്റ്, പ്ലേസ്‌മെന്റ്, നിറം എന്നിവ ഉപയോഗിച്ച് ഫലത്തിന്റെ വ്യക്തത "
+"മെച്ചപ്പെടുത്തുന്നു"
 
 # smartling.placeholder_format=C
 #. A label that appears in front of the name of a company that DuckDuckGo has partnered with. For example, 'In partnership with Wikipedia'
@@ -9950,8 +10058,8 @@ msgid ""
 "In some older browsers, it's necessary to redirect your clicks through our "
 "server to prevent search leakage. %sLearn more%s."
 msgstr ""
-"ചില പഴയ ബ്രൗസറുകളിൽ തിരയൽ ചോർച്ച തടയുന്നതിന് ഞങ്ങളുടെ സെർവറിലൂടെ നിങ്ങളുടെ "
-"ക്ലിക്കുകൾ റീഡയറക്റ്റ് ചെയ്യേണ്ടത് ആവശ്യമാണ്. %1$sകൂടുതൽ അറിയുക%2$s."
+"ചില പഴയ ബ്രൗസറുകളിൽ തിരയൽ ചോർച്ച തടയുന്നതിന് ഞങ്ങളുടെ സെർവറിലൂടെ നിങ്ങളുടെ ക്ലിക്കുകൾ "
+"റീഡയറക്റ്റ് ചെയ്യേണ്ടത് ആവശ്യമാണ്. %1$sകൂടുതൽ അറിയുക%2$s."
 
 # smartling.placeholder_format=C
 #. Instructions accompanying DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE; tells the user where to use the code on a DuckDuckGo browser.
@@ -9962,8 +10070,8 @@ msgid ""
 "In the DuckDuckGo browser, go to Settings › Sync & Backup, and then “Sync "
 "with another device”."
 msgstr ""
-"DuckDuckGo ബ്രൗസറിൽ, ക്രമീകരണങ്ങൾ › Sync & Backup എന്നതിലേക്ക് പോയി, "
-"തുടർന്ന് \"മറ്റൊരു ഉപകരണവുമായി സമന്വയിപ്പിക്കുക\" തിരഞ്ഞെടുക്കുക."
+"DuckDuckGo ബ്രൗസറിൽ, ക്രമീകരണങ്ങൾ › Sync & Backup എന്നതിലേക്ക് പോയി, തുടർന്ന് \"മറ്റൊരു "
+"ഉപകരണവുമായി സമന്വയിപ്പിക്കുക\" തിരഞ്ഞെടുക്കുക."
 
 #  SeaMonkey default search engine instruction
 # smartling.placeholder_format=C
@@ -9978,9 +10086,8 @@ msgid ""
 "In the interest of transparency, this data is not encrypted: You can see "
 "exactly what information we store."
 msgstr ""
-"സുതാര്യതയ്ക്കു വേണ്ടി ഈ ഡാറ്റകള്‍ എൻക്രിപ്റ്റ് ചെയ്തിട്ടില്ല: ഏതു തരം "
-"വിവരങ്ങളാണ് ഞങ്ങള്‍ ശേഖരിക്കുക എന്നത് നിങ്ങൾക്ക് വ്യക്തമായി "
-"പരിശോധിക്കാവുന്നതാണ്."
+"സുതാര്യതയ്ക്കു വേണ്ടി ഈ ഡാറ്റകള്‍ എൻക്രിപ്റ്റ് ചെയ്തിട്ടില്ല: ഏതു തരം വിവരങ്ങളാണ് ഞങ്ങള്‍ ശേഖരിക്കുക "
+"എന്നത് നിങ്ങൾക്ക് വ്യക്തമായി പരിശോധിക്കാവുന്നതാണ്."
 
 # smartling.placeholder_format=C
 msgid "In the menu at the top select %sTools%s > %sSettings%s"
@@ -10196,6 +10303,12 @@ msgid "Install Mac Browser"
 msgstr "Mac ബ്രൗസർ ഇൻസ്റ്റാൾ ചെയ്യുക"
 
 # smartling.placeholder_format=C
+#. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
+msgctxt "settings"
+msgid "Install Now"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of a button to install the DuckDuckGo app
 msgctxt "Serp footer content"
 msgid "Install Our App"
@@ -10293,10 +10406,42 @@ msgid "Is deleted data really deleted?"
 msgstr "ഇല്ലാതാക്കിയ വിവരങ്ങൾ ശരിക്കും ഇല്ലാതാകുന്നുണ്ടോ?"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is it worth taking?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this place any good?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"Is this place any good? Summarize its reputation based on reviews and "
+"ratings."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "Is this video helpful?"
 msgstr "ഈ വീഡിയോ സഹായകമാണോ?"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this worth watching?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Is this worth watching? Give me a spoiler-free take."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -10322,17 +10467,15 @@ msgstr "ഇതിന് ഏതാനും നിമിഷങ്ങൾ എടു
 #. Body text of a card that promotes installing the DuckDuckGo desktop browser.
 msgctxt "new tab page"
 msgid "It's fast, free, and gives you even more online protection."
-msgstr ""
-"ഇത് വേഗതയേറിയതും സൗജന്യവുമാണ്, കൂടാതെ നിങ്ങൾക്ക് കൂടുതൽ ഓൺലൈൻ സുരക്ഷയും "
-"നൽകുന്നു."
+msgstr "ഇത് വേഗതയേറിയതും സൗജന്യവുമാണ്, കൂടാതെ നിങ്ങൾക്ക് കൂടുതൽ ഓൺലൈൻ സുരക്ഷയും നൽകുന്നു."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "It's okay to (very infrequently) ask me about my experience using DuckDuckGo"
 msgstr ""
-"DuckDuckGo ഉപയോഗിച്ച എന്റെ അനുഭവത്തെക്കുറിച്ച് എന്നോട് (വളരെ അപൂർവമായി) "
-"ചോദിക്കുന്നതിൽ കുഴപ്പമില്ല"
+"DuckDuckGo ഉപയോഗിച്ച എന്റെ അനുഭവത്തെക്കുറിച്ച് എന്നോട് (വളരെ അപൂർവമായി) ചോദിക്കുന്നതിൽ "
+"കുഴപ്പമില്ല"
 
 # smartling.placeholder_format=C
 #. The name of the Italian language
@@ -10351,10 +10494,10 @@ msgid ""
 "through Microsoft's Ad Network. Clicks lead directly to merchant landing "
 "pages and unlike ads, DuckDuckGo is not compensated for these results."
 msgstr ""
-"ഇനങ്ങൾ നിങ്ങളുടെ തിരയൽ പദങ്ങളുടെ പ്രസക്തിയെ അടിസ്ഥാനമാക്കി റാങ്ക് ചെയ്ത്, "
-"Microsoft-ന്റെ പരസ്യ നെറ്റ്‌വർക്ക് വഴി ഡെലിവറി ചെയ്യുന്നു. ക്ലിക്കുകൾ "
-"നേരിട്ട് മർച്ചന്റ് ലാൻഡിംഗ് പേജുകളിലേക്ക് നയിക്കുന്നു, പരസ്യങ്ങളിൽ നിന്ന് "
-"വ്യത്യസ്തമായി ഈ ഫലങ്ങൾക്കായി DuckDuckGo-യ്ക്ക് പ്രതിഫലം ലഭിക്കുന്നില്ല."
+"ഇനങ്ങൾ നിങ്ങളുടെ തിരയൽ പദങ്ങളുടെ പ്രസക്തിയെ അടിസ്ഥാനമാക്കി റാങ്ക് ചെയ്ത്, Microsoft-ന്റെ "
+"പരസ്യ നെറ്റ്‌വർക്ക് വഴി ഡെലിവറി ചെയ്യുന്നു. ക്ലിക്കുകൾ നേരിട്ട് മർച്ചന്റ് ലാൻഡിംഗ് പേജുകളിലേക്ക് "
+"നയിക്കുന്നു, പരസ്യങ്ങളിൽ നിന്ന് വ്യത്യസ്തമായി ഈ ഫലങ്ങൾക്കായി DuckDuckGo-യ്ക്ക് പ്രതിഫലം "
+"ലഭിക്കുന്നില്ല."
 
 # smartling.placeholder_format=C
 #. Text explaining why passphrases use a series of words instead of random numbers and letters.
@@ -10363,8 +10506,8 @@ msgid ""
 "It’s easier to remember 4-5 words than 10 random letters and numbers, and "
 "far more secure."
 msgstr ""
-"10 ക്രമരഹിത പദങ്ങളും സംഖ്യകളും ഓര്‍മിക്കുന്നതിനെക്കാൾ എളുപ്പമാണ് 4-5 "
-"വാക്കുകൾ ഓർമിക്കുവാൻ, വളരെ അധികം സുരക്ഷിതവും."
+"10 ക്രമരഹിത പദങ്ങളും സംഖ്യകളും ഓര്‍മിക്കുന്നതിനെക്കാൾ എളുപ്പമാണ് 4-5 വാക്കുകൾ ഓർമിക്കുവാൻ, "
+"വളരെ അധികം സുരക്ഷിതവും."
 
 # smartling.placeholder_format=C
 msgid "Ivory Coast"
@@ -10731,9 +10874,7 @@ msgstr "DuckDuckGo ക്രമീകരണങ്ങൾ എങ്ങനെ ക�
 #. Description of a page with more information about how anonymous location works.
 msgctxt "precise_user_location"
 msgid "Learn how we keep your location private"
-msgstr ""
-"നിങ്ങളുടെ ലൊക്കേഷൻ ഞങ്ങൾ സ്വകാര്യമായി സൂക്ഷിക്കുന്നത് എങ്ങനെയെന്ന് "
-"മനസ്സിലാക്കുക"
+msgstr "നിങ്ങളുടെ ലൊക്കേഷൻ ഞങ്ങൾ സ്വകാര്യമായി സൂക്ഷിക്കുന്നത് എങ്ങനെയെന്ന് മനസ്സിലാക്കുക"
 
 # smartling.placeholder_format=C
 #. Link text in the Usage section of Duck.ai settings that opens a help page explaining Duck.ai usage limits.
@@ -10775,9 +10916,7 @@ msgstr "ഇത് എങ്ങനെ പ്രവർത്തിക്കുന�
 # smartling.placeholder_format=C
 msgctxt "SERP footer content"
 msgid "Learn why reducing online tracking is important."
-msgstr ""
-"ഓൺലൈൻ ട്രാക്കിംഗ് കുറയ്ക്കുന്നത് പ്രധാനമായിരിക്കുന്നത് എന്തുകൊണ്ടാണെന്ന് "
-"അറിയുക."
+msgstr "ഓൺലൈൻ ട്രാക്കിംഗ് കുറയ്ക്കുന്നത് പ്രധാനമായിരിക്കുന്നത് എന്തുകൊണ്ടാണെന്ന് അറിയുക."
 
 # smartling.placeholder_format=C
 #. A link that takes users to a page where they can learn more about the dangers of online tracking.
@@ -10890,9 +11029,7 @@ msgstr "ഈ ചാറ്റിനായി പരിമിതമായ ഡാറ
 #. Description of a setting managing the length of search result snippet text.
 msgctxt "settings"
 msgid "Limits the amount of descriptive content shown for results"
-msgstr ""
-"ഫലങ്ങൾക്കായി കാണിക്കുന്ന വിവരണാത്മക ഉള്ളടക്കത്തിന്റെ അളവ് "
-"പരിമിതപ്പെടുത്തുന്നു"
+msgstr "ഫലങ്ങൾക്കായി കാണിക്കുന്ന വിവരണാത്മക ഉള്ളടക്കത്തിന്റെ അളവ് പരിമിതപ്പെടുത്തുന്നു"
 
 # smartling.placeholder_format=C
 #. i.e. a type of image comprised of lines without gradiations in shade or hue
@@ -10915,6 +11052,12 @@ msgstr "ലിങ്ക് ഫോണ്ട്:"
 #. https://duckduckgo.com/params under "Color Settings"
 msgid "Links:"
 msgstr "ലിങ്കുകൾ:"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "List the tools, materials, or prerequisites I need for this."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -11026,8 +11169,7 @@ msgstr "സ്ക്രോൾ ചെയ്യുമ്പോൾ കൂടുത�
 msgctxt "settings"
 msgid "Loads more results in Images, Videos, and Shopping when scrolling"
 msgstr ""
-"സ്ക്രോൾ ചെയ്യുമ്പോൾ ഇമേജുകൾ, വീഡിയോകൾ, ഷോപ്പിംഗ് എന്നിവയിൽ കൂടുതൽ ഫലങ്ങൾ "
-"ലോഡ് ചെയ്യുന്നു"
+"സ്ക്രോൾ ചെയ്യുമ്പോൾ ഇമേജുകൾ, വീഡിയോകൾ, ഷോപ്പിംഗ് എന്നിവയിൽ കൂടുതൽ ഫലങ്ങൾ ലോഡ് ചെയ്യുന്നു"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/WTkvs9I.png
@@ -11208,8 +11350,7 @@ msgstr "എല്ലാ വാക്കുകളും അക്ഷരത്ത�
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Make sure to check %s\"Make this my default search provider\"%s"
 msgstr ""
-"%1$s\"ഇതിനെ എന്റെ ഡിഫോൾട്ട് തിരയല്‍ ദാതാവാക്കുക\"%2$s എന്നത് "
-"തിരഞ്ഞെടുത്തുവെന്ന് ഉറപ്പാക്കുക"
+"%1$s\"ഇതിനെ എന്റെ ഡിഫോൾട്ട് തിരയല്‍ ദാതാവാക്കുക\"%2$s എന്നത് തിരഞ്ഞെടുത്തുവെന്ന് ഉറപ്പാക്കുക"
 
 # smartling.placeholder_format=C
 #. Message prompting users to check the spelling of their search term.
@@ -11325,6 +11466,12 @@ msgstr "നിങ്ങളുടെ സബ്സ്ക്രിപ്ഷൻ മ�
 msgctxt "Exclusion message manage sites button"
 msgid "Manage blocked sites"
 msgstr "ബ്ലോക്ക് ചെയ്ത സൈറ്റുകൾ കൈകാര്യം ചെയ്യുക"
+
+# smartling.placeholder_format=C
+#. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
+msgctxt "setting"
+msgid "Manage in Browser Settings"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to the site exclusion settings page
@@ -11549,9 +11696,7 @@ msgstr "മൈക്രോനേഷ്യ"
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
 msgid ""
 "Microphone access was denied. Please allow microphone access and try again."
-msgstr ""
-"മൈക്രോഫോൺ പ്രവേശനം നിഷേധിച്ചു. മൈക്രോഫോൺ ആക്‌സസ് അനുവദിച്ച് വീണ്ടും "
-"ശ്രമിക്കുക."
+msgstr "മൈക്രോഫോൺ പ്രവേശനം നിഷേധിച്ചു. മൈക്രോഫോൺ ആക്‌സസ് അനുവദിച്ച് വീണ്ടും ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. The Microsoft brand name.
@@ -12299,11 +12444,10 @@ msgid ""
 "internet connection. Disabling chat history will delete pinned chats, and "
 "disable the temporary storage of new prompts and responses."
 msgstr ""
-"പുതിയ പ്രോംപ്റ്റുകളും പ്രതികരണങ്ങളും അയച്ചതിനുശേഷം എൻക്രിപ്റ്റ് ചെയ്ത് "
-"താൽക്കാലികമായി ഒരു DuckDuckGo സെർവറിൽ സംഭരിക്കും, ഇത് നിങ്ങളുടെ ഇന്റർനെറ്റ് "
-"കണക്ഷൻ നഷ്ടപ്പെട്ടാൽ ഒരു ചാറ്റ് വീണ്ടെടുക്കാൻ സഹായിക്കും. ചാറ്റ് ചരിത്രം "
-"പ്രവർത്തനരഹിതമാക്കുന്നത് പിൻ ചെയ്‌ത ചാറ്റുകൾ ഇല്ലാതാക്കുകയും പുതിയ "
-"പ്രോംപ്റ്റുകളുടെയും പ്രതികരണങ്ങളുടെയും താൽക്കാലിക സ്റ്റോറേജ് "
+"പുതിയ പ്രോംപ്റ്റുകളും പ്രതികരണങ്ങളും അയച്ചതിനുശേഷം എൻക്രിപ്റ്റ് ചെയ്ത് താൽക്കാലികമായി ഒരു "
+"DuckDuckGo സെർവറിൽ സംഭരിക്കും, ഇത് നിങ്ങളുടെ ഇന്റർനെറ്റ് കണക്ഷൻ നഷ്ടപ്പെട്ടാൽ ഒരു ചാറ്റ് "
+"വീണ്ടെടുക്കാൻ സഹായിക്കും. ചാറ്റ് ചരിത്രം പ്രവർത്തനരഹിതമാക്കുന്നത് പിൻ ചെയ്‌ത ചാറ്റുകൾ "
+"ഇല്ലാതാക്കുകയും പുതിയ പ്രോംപ്റ്റുകളുടെയും പ്രതികരണങ്ങളുടെയും താൽക്കാലിക സ്റ്റോറേജ് "
 "പ്രവർത്തനരഹിതമാക്കുകയും ചെയ്യും."
 
 # smartling.placeholder_format=C
@@ -13143,9 +13287,8 @@ msgid ""
 "One of the files attached has more pages than we support. Please upload "
 "files with %s pages or fewer."
 msgstr ""
-"അറ്റാച്ച് ചെയ്തിരിക്കുന്ന ഫയലുകളിൽ ഒന്നിൽ ഞങ്ങൾ പിന്തുണയ്ക്കുന്നതിനേക്കാൾ "
-"കൂടുതൽ പേജുകളുണ്ട്. %1$s അല്ലെങ്കിൽ അതിൽ കുറവ് പേജുകളുള്ള ഫയലുകൾ അപ്‌ലോഡ് "
-"ചെയ്യുക."
+"അറ്റാച്ച് ചെയ്തിരിക്കുന്ന ഫയലുകളിൽ ഒന്നിൽ ഞങ്ങൾ പിന്തുണയ്ക്കുന്നതിനേക്കാൾ കൂടുതൽ പേജുകളുണ്ട്. %1$s "
+"അല്ലെങ്കിൽ അതിൽ കുറവ് പേജുകളുള്ള ഫയലുകൾ അപ്‌ലോഡ് ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Response a user can select in a feedback form, indicating that they heard about DuckDuckGo in an online article.
@@ -13188,8 +13331,8 @@ msgid ""
 "Oops! An unexpected error occurred while translating this text. Please try "
 "again later."
 msgstr ""
-"ക്ഷമിക്കണം! ഈ ടെക്‌സ്റ്റ് വിവർത്തനം ചെയ്യുന്ന സമയത്ത് ഒരു അപ്രതീക്ഷിത "
-"പിശകുണ്ടായി. പിന്നീട് വീണ്ടും ശ്രമിക്കുക."
+"ക്ഷമിക്കണം! ഈ ടെക്‌സ്റ്റ് വിവർത്തനം ചെയ്യുന്ന സമയത്ത് ഒരു അപ്രതീക്ഷിത പിശകുണ്ടായി. പിന്നീട് "
+"വീണ്ടും ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Title shown in a fatal error modal when Duck.ai fails to load.
@@ -13243,8 +13386,8 @@ msgstr "%1$s വെബ്‌സൈറ്റ് തുറക്കുക"
 msgctxt "precise_user_location"
 msgid "Open %sLocation%s, and ensure location is %senabled%s"
 msgstr ""
-"%1$s'ലൊക്കേഷൻ'%2$s തുറക്കുക, തുടര്‍ന്ന് ലൊക്കേഷൻ "
-"%3$sപ്രവർത്തനക്ഷമമാക്കിയിട്ടുണ്ടെന്ന്%4$s ഉറപ്പാക്കുക"
+"%1$s'ലൊക്കേഷൻ'%2$s തുറക്കുക, തുടര്‍ന്ന് ലൊക്കേഷൻ %3$sപ്രവർത്തനക്ഷമമാക്കിയിട്ടുണ്ടെന്ന്%4$s "
+"ഉറപ്പാക്കുക"
 
 #  Chrome/Firefox on Android/iOS
 # smartling.placeholder_format=C
@@ -13265,8 +13408,7 @@ msgstr "%1$sക്രമീകരണം%2$s തുറക്കുക"
 msgctxt "precise_user_location"
 msgid "Open 'Location', and ensure location is %senabled%s."
 msgstr ""
-"'ലൊക്കേഷൻ' തുറക്കുക, തുടര്‍ന്ന് ലൊക്കേഷൻ "
-"%1$sപ്രവർത്തനക്ഷമമാക്കിയിട്ടുണ്ടെന്ന്%2$s ഉറപ്പാക്കുക."
+"'ലൊക്കേഷൻ' തുറക്കുക, തുടര്‍ന്ന് ലൊക്കേഷൻ %1$sപ്രവർത്തനക്ഷമമാക്കിയിട്ടുണ്ടെന്ന്%2$s ഉറപ്പാക്കുക."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -13409,9 +13551,7 @@ msgstr "How Duck.ai വർക്ക്സ് പാനൽ തുറക്കു�
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open the Safari menu and select %sSettings for DuckDuckGo...%s"
-msgstr ""
-"Safari മെനു തുറന്ന് %1$sDuckDuckGo എന്നതിനായുള്ള ക്രമീകരണങ്ങൾ%2$s "
-"തിരഞ്ഞെടുക്കുക..."
+msgstr "Safari മെനു തുറന്ന് %1$sDuckDuckGo എന്നതിനായുള്ള ക്രമീകരണങ്ങൾ%2$s തിരഞ്ഞെടുക്കുക..."
 
 # smartling.placeholder_format=C
 #. Label for the time a business opens. For example: 'Opens at 10am'
@@ -13512,9 +13652,8 @@ msgid ""
 "Other search engines track your searches even when you’re in private "
 "browsing mode. We don’t track you &mdash; period."
 msgstr ""
-"നിങ്ങൾ സ്വകാര്യ ബ്രൗസിംഗ് മോഡിൽ ആയിരിക്കുമ്പോൾ പോലും മറ്റ് തിരയൽ എഞ്ചിനുകൾ "
-"നിങ്ങളുടെ തിരയലുകളെ ട്രാക്ക് ചെയ്യുന്നു. ഞങ്ങൾ നിങ്ങളെ ട്രാക്ക് "
-"ചെയ്യുന്നില്ല — കാലഘട്ടം"
+"നിങ്ങൾ സ്വകാര്യ ബ്രൗസിംഗ് മോഡിൽ ആയിരിക്കുമ്പോൾ പോലും മറ്റ് തിരയൽ എഞ്ചിനുകൾ നിങ്ങളുടെ "
+"തിരയലുകളെ ട്രാക്ക് ചെയ്യുന്നു. ഞങ്ങൾ നിങ്ങളെ ട്രാക്ക് ചെയ്യുന്നില്ല — കാലഘട്ടം"
 
 # smartling.placeholder_format=C
 msgctxt "SERP footer content"
@@ -13527,8 +13666,8 @@ msgid ""
 "Our privacy policy is simple: we don’t collect or share any of your personal "
 "information."
 msgstr ""
-"ഞങ്ങളുടെ സ്വകാര്യത നയം ലളിതമാണ്: ഞങ്ങൾ നിങ്ങളുടെ വ്യക്തിഗത വിവരങ്ങളിൽ ഒന്നും "
-"ശേഖരിക്കുകയോ പങ്കുവയ്ക്കുകയോ ചെയ്യില്ല."
+"ഞങ്ങളുടെ സ്വകാര്യത നയം ലളിതമാണ്: ഞങ്ങൾ നിങ്ങളുടെ വ്യക്തിഗത വിവരങ്ങളിൽ ഒന്നും ശേഖരിക്കുകയോ "
+"പങ്കുവയ്ക്കുകയോ ചെയ്യില്ല."
 
 # smartling.placeholder_format=C
 msgid ""
@@ -13536,9 +13675,9 @@ msgid ""
 "tracker blocker, encryption enforcer, and more. Available on %siOS & "
 "Android%s."
 msgstr ""
-"ഞങ്ങളുടെ തിരയൽ എഞ്ചിൻ, ട്രാക്കർ ബ്ലോക്കർ, എൻക്രിപ്ഷൻ എൻഫോഴ്സർ തുടങ്ങിയവ "
-"ഉൾപ്പെടുത്തി മൊബൈലിനായുള്ള ഞങ്ങളുടെ സ്വകാര്യ ബ്രൗസർ ലഭിക്കുന്നു. %1$siOS, "
-"Android%2$s എന്നിവയിൽ ലഭ്യമാണ്."
+"ഞങ്ങളുടെ തിരയൽ എഞ്ചിൻ, ട്രാക്കർ ബ്ലോക്കർ, എൻക്രിപ്ഷൻ എൻഫോഴ്സർ തുടങ്ങിയവ ഉൾപ്പെടുത്തി "
+"മൊബൈലിനായുള്ള ഞങ്ങളുടെ സ്വകാര്യ ബ്രൗസർ ലഭിക്കുന്നു. %1$siOS, Android%2$s എന്നിവയിൽ "
+"ലഭ്യമാണ്."
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the information was out of date.
@@ -13791,9 +13930,8 @@ msgid ""
 "Passphrases cannot be recovered as we don't associate your IP address, "
 "browser fingerprint, or any other information with the file."
 msgstr ""
-"നിങ്ങളുടെ ഐപി വിലാസം, ബ്രൗസർ ഫിംഗർപ്രിന്റ് അല്ലെങ്കിൽ മറ്റേതെങ്കിലും "
-"വിവരങ്ങൾ ഞങ്ങൾ ഫയലുമായി ബന്ധപ്പെടുത്താത്തതിനാൽ പാസ്‌ഫ്രെയ്സുകൾ വീണ്ടെടുക്കാൻ "
-"കഴിയില്ല."
+"നിങ്ങളുടെ ഐപി വിലാസം, ബ്രൗസർ ഫിംഗർപ്രിന്റ് അല്ലെങ്കിൽ മറ്റേതെങ്കിലും വിവരങ്ങൾ ഞങ്ങൾ "
+"ഫയലുമായി ബന്ധപ്പെടുത്താത്തതിനാൽ പാസ്‌ഫ്രെയ്സുകൾ വീണ്ടെടുക്കാൻ കഴിയില്ല."
 
 # smartling.placeholder_format=C
 #. Label for the section of recent chats that were edited in the past 7 days.
@@ -13987,10 +14125,9 @@ msgid ""
 "answers. To turn them off and hide the Assist button visit %sSearch "
 "Settings%s."
 msgstr ""
-"നിങ്ങളുടെ തിരയൽ ഒരു ചോദ്യമായും സമ്പൂർണ്ണ വാക്യമായും ആവിഷ്കരിക്കുന്നത് AI "
-"സഹായമുള്ള ഉത്തരങ്ങൾ സ്വയമേവ പ്രത്യക്ഷപ്പെടാൻ കൂടുതൽ സാധ്യതയുണ്ടാക്കുകയും "
-"പലപ്പോഴും മികച്ച ഉത്തരങ്ങൾ നൽകുകയും ചെയ്യുന്നു. അവ ഓഫാക്കാനും Assist ബട്ടൺ "
-"മറയ്ക്കാനും %1$sതിരയൽ ക്രമീകരണങ്ങൾ%2$s സന്ദർശിക്കുക."
+"നിങ്ങളുടെ തിരയൽ ഒരു ചോദ്യമായും സമ്പൂർണ്ണ വാക്യമായും ആവിഷ്കരിക്കുന്നത് AI സഹായമുള്ള ഉത്തരങ്ങൾ "
+"സ്വയമേവ പ്രത്യക്ഷപ്പെടാൻ കൂടുതൽ സാധ്യതയുണ്ടാക്കുകയും പലപ്പോഴും മികച്ച ഉത്തരങ്ങൾ നൽകുകയും ചെയ്യുന്നു. "
+"അവ ഓഫാക്കാനും Assist ബട്ടൺ മറയ്ക്കാനും %1$sതിരയൽ ക്രമീകരണങ്ങൾ%2$s സന്ദർശിക്കുക."
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -13999,10 +14136,10 @@ msgid ""
 "DuckAssist more likely to appear and often yields better answers. To adjust "
 "how this feature works, or to turn it off, visit %sDuckAssist Settings%s."
 msgstr ""
-"നിങ്ങളുടെ തിരയൽ ഒരു ചോദ്യമായും സമ്പൂർണ്ണ വാക്യമായും ആവിഷ്കരിക്കുന്നത് "
-"DuckAssist പ്രത്യക്ഷപ്പെടാൻ കൂടുതൽ സാധ്യതയുണ്ടാക്കുകയും പലപ്പോഴും മികച്ച "
-"ഉത്തരങ്ങൾ നൽകുകയും ചെയ്യുന്നു. ഈ സവിശേഷത എങ്ങനെ പ്രവർത്തിക്കുന്നുവെന്ന് "
-"ക്രമീകരിക്കാനോ ഓഫ് ചെയ്യാനോ, %1$sDuckAssist ക്രമീകരണങ്ങൾ%2$sസന്ദർശിക്കുക."
+"നിങ്ങളുടെ തിരയൽ ഒരു ചോദ്യമായും സമ്പൂർണ്ണ വാക്യമായും ആവിഷ്കരിക്കുന്നത് DuckAssist "
+"പ്രത്യക്ഷപ്പെടാൻ കൂടുതൽ സാധ്യതയുണ്ടാക്കുകയും പലപ്പോഴും മികച്ച ഉത്തരങ്ങൾ നൽകുകയും ചെയ്യുന്നു. ഈ "
+"സവിശേഷത എങ്ങനെ പ്രവർത്തിക്കുന്നുവെന്ന് ക്രമീകരിക്കാനോ ഓഫ് ചെയ്യാനോ, %1$sDuckAssist "
+"ക്രമീകരണങ്ങൾ%2$sസന്ദർശിക്കുക."
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -14012,10 +14149,9 @@ msgid ""
 "answers. To turn it off and hide the Assist button visit %sDuckAssist "
 "Settings%s."
 msgstr ""
-"നിങ്ങളുടെ തിരയൽ ഒരു ചോദ്യമായും സമ്പൂർണ്ണ വാക്യമായും ആവിഷ്കരിക്കുന്നത് "
-"DuckAssist സ്വയമേവ പ്രത്യക്ഷപ്പെടാൻ കൂടുതൽ സാധ്യതയുണ്ടാക്കുകയും പലപ്പോഴും "
-"മികച്ച ഉത്തരങ്ങൾ നൽകുകയും ചെയ്യുന്നു. ഇത് ഓഫാക്കാനും അസിസ്റ്റ് ബട്ടൺ "
-"മറയ്ക്കാനും %1$sDuckAssist ക്രമീകരണം%2$s സന്ദർശിക്കുക."
+"നിങ്ങളുടെ തിരയൽ ഒരു ചോദ്യമായും സമ്പൂർണ്ണ വാക്യമായും ആവിഷ്കരിക്കുന്നത് DuckAssist സ്വയമേവ "
+"പ്രത്യക്ഷപ്പെടാൻ കൂടുതൽ സാധ്യതയുണ്ടാക്കുകയും പലപ്പോഴും മികച്ച ഉത്തരങ്ങൾ നൽകുകയും ചെയ്യുന്നു. ഇത് "
+"ഓഫാക്കാനും അസിസ്റ്റ് ബട്ടൺ മറയ്ക്കാനും %1$sDuckAssist ക്രമീകരണം%2$s സന്ദർശിക്കുക."
 
 # smartling.placeholder_format=C
 #. Button that allows users to manually select a location on a map.
@@ -14048,8 +14184,8 @@ msgid ""
 "Pick a popular AI to chat with, like GPT-5 mini, Claude Haiku 4.5, Mistral, "
 "etc."
 msgstr ""
-"GPT-5 mini, Claude Haiku 4.5, Mistra തുടങ്ങിയ ജനപ്രിയ AI-കളുമായി ചാറ്റ് "
-"ചെയ്യാൻ തിരഞ്ഞെടുക്കുക."
+"GPT-5 mini, Claude Haiku 4.5, Mistra തുടങ്ങിയ ജനപ്രിയ AI-കളുമായി ചാറ്റ് ചെയ്യാൻ "
+"തിരഞ്ഞെടുക്കുക."
 
 # smartling.placeholder_format=C
 #. Describes the ability to choose from popular AI models. Pairs with a chat-bubble pictogram.
@@ -14058,8 +14194,8 @@ msgid ""
 "Pick a popular AI to chat with, like GPT-5 mini, Claude Haiku 4.5, "
 "Mistral, etc."
 msgstr ""
-"GPT-5 mini, Claude Haiku 4.5, Mistral,   തുടങ്ങിയ ജനപ്രിയ AI-കളുമായി ചാറ്റ് "
-"ചെയ്യാൻ തിരഞ്ഞെടുക്കുക."
+"GPT-5 mini, Claude Haiku 4.5, Mistral,   തുടങ്ങിയ ജനപ്രിയ AI-കളുമായി ചാറ്റ് ചെയ്യാൻ "
+"തിരഞ്ഞെടുക്കുക."
 
 # smartling.placeholder_format=C
 #. The description of the third party map app picker, shown on iOS when a user is given an option of which app to navigate to a destination with
@@ -14068,8 +14204,8 @@ msgid ""
 "Pick a service to navigate to your destination. External apps won’t come "
 "with DuckDuckGo protections."
 msgstr ""
-"നിന്റെ ലക്ഷ്യസ്ഥാനത്തേക്ക് നാവിഗേറ്റ് ചെയ്യാൻ ഒരു സേവനം തിരഞ്ഞെടുക്കൂ. ബാഹ്യ "
-"ആപ്പുകൾക്ക് DuckDuckGo സംരക്ഷണങ്ങൾ ലഭ്യമല്ല."
+"നിന്റെ ലക്ഷ്യസ്ഥാനത്തേക്ക് നാവിഗേറ്റ് ചെയ്യാൻ ഒരു സേവനം തിരഞ്ഞെടുക്കൂ. ബാഹ്യ ആപ്പുകൾക്ക് "
+"DuckDuckGo സംരക്ഷണങ്ങൾ ലഭ്യമല്ല."
 
 # smartling.placeholder_format=C
 #. Label for a list of problems on a feedback form.
@@ -14082,8 +14218,8 @@ msgstr "ഒരു നിർദിഷ്ട പ്രശ്നം തിരഞ്
 msgid ""
 "Pick your ad blocker and follow the instructions to allow ads on DuckDuckGo."
 msgstr ""
-"നിങ്ങളുടെ പരസ്യ ബ്ലോക്കർ തിരഞ്ഞെടുക്കുക, DuckDuckGo-ൽ പരസ്യങ്ങൾ അനുവദിക്കാൻ "
-"നിർദ്ദേശങ്ങൾ പാലിക്കുക."
+"നിങ്ങളുടെ പരസ്യ ബ്ലോക്കർ തിരഞ്ഞെടുക്കുക, DuckDuckGo-ൽ പരസ്യങ്ങൾ അനുവദിക്കാൻ നിർദ്ദേശങ്ങൾ "
+"പാലിക്കുക."
 
 # smartling.placeholder_format=C
 #. Text for a button that pins a chat, as in it will it will add the chat to the pinned chats list.
@@ -14154,8 +14290,7 @@ msgid ""
 "Please complete the following challenge to confirm this prompt was made by a "
 "human."
 msgstr ""
-"ഈ പ്രോംപ്റ്റ് നടത്തിയത് ഒരു മനുഷ്യനാണെന്ന് സ്ഥിരീകരിക്കാൻ ഇനിപ്പറയുന്ന "
-"ചലഞ്ച് പൂർത്തിയാക്കുക."
+"ഈ പ്രോംപ്റ്റ് നടത്തിയത് ഒരു മനുഷ്യനാണെന്ന് സ്ഥിരീകരിക്കാൻ ഇനിപ്പറയുന്ന ചലഞ്ച് പൂർത്തിയാക്കുക."
 
 # smartling.placeholder_format=C
 #. Bot challenge explanation
@@ -14164,16 +14299,21 @@ msgid ""
 "Please complete the following challenge to confirm this search was made by a "
 "human."
 msgstr ""
-"ഈ തിരയൽ നടത്തിയത് ഒരു മനുഷ്യനാണെന്ന് സ്ഥിരീകരിക്കാൻ ഇനിപ്പറയുന്ന വെല്ലുവിളി "
-"പൂർത്തിയാക്കുക."
+"ഈ തിരയൽ നടത്തിയത് ഒരു മനുഷ്യനാണെന്ന് സ്ഥിരീകരിക്കാൻ ഇനിപ്പറയുന്ന വെല്ലുവിളി പൂർത്തിയാക്കുക."
+
+# smartling.placeholder_format=C
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
+msgctxt "Feedback prompt"
+msgid "Please describe why the chat response is harmful or illegal. (optional)"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
 msgstr ""
-"ചാറ്റ് പ്രതികരണം നിയമവിരുദ്ധമോ ദോഷകരമോ ആകുന്നത് എന്തുകൊണ്ടെന്ന് ദയവായി "
-"വിശദീകരിക്കുക. (ഓപ്ഷണൽ)"
+"ചാറ്റ് പ്രതികരണം നിയമവിരുദ്ധമോ ദോഷകരമോ ആകുന്നത് എന്തുകൊണ്ടെന്ന് ദയവായി വിശദീകരിക്കുക. "
+"(ഓപ്ഷണൽ)"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to enter their passphrase.
@@ -14194,8 +14334,16 @@ msgid ""
 "Please note: starting a new chat with any model will delete your current "
 "chat session."
 msgstr ""
-"ദയവായി ശ്രദ്ധിക്കുക: ഏതെങ്കിലും മോഡലുമായി ഒരു പുതിയ ചാറ്റ് ആരംഭിക്കുന്നത് "
-"നിങ്ങളുടെ നിലവിലെ ചാറ്റ് സെഷൻ ഇല്ലാതാക്കും."
+"ദയവായി ശ്രദ്ധിക്കുക: ഏതെങ്കിലും മോഡലുമായി ഒരു പുതിയ ചാറ്റ് ആരംഭിക്കുന്നത് നിങ്ങളുടെ നിലവിലെ "
+"ചാറ്റ് സെഷൻ ഇല്ലാതാക്കും."
+
+# smartling.placeholder_format=C
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
+msgctxt "Feedback prompt"
+msgid ""
+"Please paste your prompt and the problematic output (with any personal "
+"information removed) and describe why the content is harmful or illegal."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -14204,9 +14352,8 @@ msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is illegal or harmful."
 msgstr ""
-"നിങ്ങളുടെ പ്രോംപ്റ്റും പ്രശ്നമുള്ള ഔട്ട്പുട്ടും (ഏതെങ്കിലും വ്യക്തിഗത "
-"വിവരങ്ങൾ നീക്കം ചെയ്തത്) ഒട്ടിക്കുക, കൂടാതെ ഉള്ളടക്കം നിയമവിരുദ്ധമോ ദോഷകരമോ "
-"ആകുന്നത് എന്തുകൊണ്ടെന്ന് വിവരിക്കുക."
+"നിങ്ങളുടെ പ്രോംപ്റ്റും പ്രശ്നമുള്ള ഔട്ട്പുട്ടും (ഏതെങ്കിലും വ്യക്തിഗത വിവരങ്ങൾ നീക്കം ചെയ്തത്) "
+"ഒട്ടിക്കുക, കൂടാതെ ഉള്ളടക്കം നിയമവിരുദ്ധമോ ദോഷകരമോ ആകുന്നത് എന്തുകൊണ്ടെന്ന് വിവരിക്കുക."
 
 # smartling.placeholder_format=C
 #. Title on a feedback form.
@@ -14359,8 +14506,7 @@ msgid ""
 "Plus, what you watch in Duck Player won’t influence your recommendations on "
 "YouTube."
 msgstr ""
-"കൂടാതെ, Duck Player-ൽ നിങ്ങൾ കാണുന്നത് YouTube-ലെ നിങ്ങളുടെ ശുപാർശകളെ "
-"സ്വാധീനിക്കുകയില്ല."
+"കൂടാതെ, Duck Player-ൽ നിങ്ങൾ കാണുന്നത് YouTube-ലെ നിങ്ങളുടെ ശുപാർശകളെ സ്വാധീനിക്കുകയില്ല."
 
 # smartling.placeholder_format=C
 #. A link to the Substack page (https://insideduckduckgo.substack.com/?showWelcome=true)
@@ -14666,6 +14812,12 @@ msgid "Privacy"
 msgstr "സ്വകാര്യത"
 
 # smartling.placeholder_format=C
+#. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
+msgctxt "Section heading on the Duck.ai settings page"
+msgid "Privacy & Terms"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Privacy Blog"
 msgstr "സ്വകാര്യതാ ബ്ലോഗ്"
 
@@ -14734,6 +14886,12 @@ msgstr "സ്വകാര്യതാ നയവും ഉപയോഗ നിബ
 msgctxt "Copy used to compose link in sentences"
 msgid "Privacy Policy and Terms of Service"
 msgstr "സ്വകാര്യതാ നയവും സേവന നിബന്ധനകളും"
+
+# smartling.placeholder_format=C
+#. Text for a button that links to the terms of use and privacy policy page.
+msgctxt "Secondary button text in active privacy modal"
+msgid "Privacy Policy and Terms of Service"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title displayed on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
@@ -14907,9 +15065,7 @@ msgstr "എന്നെ പ്രോംപ്റ്റ് ചെയ്യു�
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Prompt me to use my approximate location to get nearby results."
-msgstr ""
-"സമീപത്തുള്ള ഫലങ്ങൾക്കായി എന്റെ ഏകദേശ ലൊക്കേഷൻ ഉപയോഗിക്കാൻ എന്നോട് "
-"നിർദേശിക്കുക."
+msgstr "സമീപത്തുള്ള ഫലങ്ങൾക്കായി എന്റെ ഏകദേശ ലൊക്കേഷൻ ഉപയോഗിക്കാൻ എന്നോട് നിർദേശിക്കുക."
 
 # smartling.placeholder_format=C
 #. DuckDuckGo Email Protection removes trackers from emails
@@ -14927,9 +15083,7 @@ msgstr "നിങ്ങൾ തിരയുകയും ബ്രൗസ് ചെ
 #. Shown on the Mac and Windows browser promo cards. DuckDuckGo's desktop browser protects your data across search, browsing, and AI chat.
 msgctxt "SERP footer content"
 msgid "Protect your data as you search, browse, and use AI."
-msgstr ""
-"തിരയുമ്പോഴും, ബ്രൗസ് ചെയ്യുമ്പോഴും, AI ഉപയോഗിക്കുമ്പോഴും നിങ്ങളുടെ ഡാറ്റ "
-"സംരക്ഷിക്കുക."
+msgstr "തിരയുമ്പോഴും, ബ്രൗസ് ചെയ്യുമ്പോഴും, AI ഉപയോഗിക്കുമ്പോഴും നിങ്ങളുടെ ഡാറ്റ സംരക്ഷിക്കുക."
 
 # smartling.placeholder_format=C
 #. A title above links to download the DuckDuckGo apps.
@@ -14954,8 +15108,8 @@ msgid ""
 "Provide a few suggestions to make the following text more concise. [Insert "
 "your own text here.]"
 msgstr ""
-"ഇനിപ്പറയുന്ന വാചകം കൂടുതൽ സംക്ഷിപ്തമാക്കാൻ കുറച്ച് നിർദ്ദേശങ്ങൾ നൽകുക. "
-"[നിങ്ങളുടെ സ്വന്തം വാചകം ഇവിടെ ചേർക്കുക.]"
+"ഇനിപ്പറയുന്ന വാചകം കൂടുതൽ സംക്ഷിപ്തമാക്കാൻ കുറച്ച് നിർദ്ദേശങ്ങൾ നൽകുക. [നിങ്ങളുടെ സ്വന്തം "
+"വാചകം ഇവിടെ ചേർക്കുക.]"
 
 # smartling.placeholder_format=C
 #. In the context of a standings table for NHL (hockey), column title that abbreviates 'Total Points' (the total points of this team)
@@ -15192,8 +15346,8 @@ msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
 msgstr ""
-"സമീപകാല ചാറ്റുകൾ DuckDuckGo സെർവറുകൾക്കോ മറ്റ് വിദൂര സെർവറുകൾക്കോ പകരം "
-"നിങ്ങളുടെ ഉപകരണത്തിൽ പ്രാദേശികമായി സംഭരിച്ചിരിക്കുന്നു."
+"സമീപകാല ചാറ്റുകൾ DuckDuckGo സെർവറുകൾക്കോ മറ്റ് വിദൂര സെർവറുകൾക്കോ പകരം നിങ്ങളുടെ "
+"ഉപകരണത്തിൽ പ്രാദേശികമായി സംഭരിച്ചിരിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Text explaining that recent chats are stored locally on the user's device.
@@ -15202,8 +15356,8 @@ msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
 msgstr ""
-"സമീപകാല ചാറ്റുകൾ DuckDuckGo സെർവറുൾക്കോ മറ്റ് വിദൂര സെർവറുകൾക്കോ പകരം "
-"നിങ്ങളുടെ ഉപകരണത്തിൽ പ്രാദേശികമായി സംഭരിച്ചിരിക്കുന്നു."
+"സമീപകാല ചാറ്റുകൾ DuckDuckGo സെർവറുൾക്കോ മറ്റ് വിദൂര സെർവറുകൾക്കോ പകരം നിങ്ങളുടെ "
+"ഉപകരണത്തിൽ പ്രാദേശികമായി സംഭരിച്ചിരിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Text explaining how recent chats are stored locally on the user's device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection.
@@ -15213,10 +15367,9 @@ msgid ""
 "are encrypted and temporarily stored on a DuckDuckGo server after being "
 "sent, to help recover a chat if you lose your internet connection."
 msgstr ""
-"സമീപകാല ചാറ്റുകൾ നിങ്ങളുടെ ഉപകരണത്തിൽ തന്നെ സംഭരിച്ചിരിക്കുന്നു. പുതിയ "
-"പ്രോംപ്റ്റുകളും പ്രതികരണങ്ങളും അയച്ചതിനുശേഷം എൻക്രിപ്റ്റ് ചെയ്ത് "
-"താൽക്കാലികമായി ഒരു DuckDuckGo സെർവറിൽ സംഭരിക്കും, ഇത് നിങ്ങളുടെ ഇന്റർനെറ്റ് "
-"കണക്ഷൻ നഷ്ടപ്പെട്ടാൽ ഒരു ചാറ്റ് വീണ്ടെടുക്കാൻ സഹായിക്കും."
+"സമീപകാല ചാറ്റുകൾ നിങ്ങളുടെ ഉപകരണത്തിൽ തന്നെ സംഭരിച്ചിരിക്കുന്നു. പുതിയ പ്രോംപ്റ്റുകളും "
+"പ്രതികരണങ്ങളും അയച്ചതിനുശേഷം എൻക്രിപ്റ്റ് ചെയ്ത് താൽക്കാലികമായി ഒരു DuckDuckGo സെർവറിൽ "
+"സംഭരിക്കും, ഇത് നിങ്ങളുടെ ഇന്റർനെറ്റ് കണക്ഷൻ നഷ്ടപ്പെട്ടാൽ ഒരു ചാറ്റ് വീണ്ടെടുക്കാൻ സഹായിക്കും."
 
 # smartling.placeholder_format=C
 msgctxt "region filter"
@@ -15238,6 +15391,30 @@ msgstr "%1$s%2$s%3$s എന്നതിനായുള്ള പാചകക്�
 msgctxt "Brief for recommending a book"
 msgid "Recommend a book"
 msgstr "ഒരു പുസ്തകം ശുപാർശ ചെയ്യുക"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar books"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar books."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar movies or shows."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar titles"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
@@ -15310,8 +15487,8 @@ msgid ""
 "Reduces extra space in and around results and reduces size of result title "
 "text"
 msgstr ""
-"ഫലങ്ങളിലും ചുറ്റുമുള്ള അധിക ഇടം കുറയ്ക്കുകയും ഫലമായുള്ള ശീർഷക ടെക്സ്റ്റിന്റെ "
-"വലുപ്പം കുറയ്ക്കുകയും ചെയ്യുന്നു"
+"ഫലങ്ങളിലും ചുറ്റുമുള്ള അധിക ഇടം കുറയ്ക്കുകയും ഫലമായുള്ള ശീർഷക ടെക്സ്റ്റിന്റെ വലുപ്പം കുറയ്ക്കുകയും "
+"ചെയ്യുന്നു"
 
 # smartling.placeholder_format=C
 #. Label for the input field where users specify how they want to be referred to. Example: 'Refer to me as John'
@@ -15452,9 +15629,8 @@ msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
 msgstr ""
-"നിർദ്ദേശങ്ങൾ പാലിച്ച് DuckDuckGo വീണ്ടും ലോഡ് ചെയ്യുക, അല്ലെങ്കിൽ നിങ്ങളുടെ "
-"ബ്രൗസറിലെ &quot;റിഫ്രഷ്&quot; അല്ലെങ്കിൽ &quot;റീലോഡ്&quot; ബട്ടൺ ക്ലിക്ക് "
-"ചെയ്യുക."
+"നിർദ്ദേശങ്ങൾ പാലിച്ച് DuckDuckGo വീണ്ടും ലോഡ് ചെയ്യുക, അല്ലെങ്കിൽ നിങ്ങളുടെ ബ്രൗസറിലെ "
+"&quot;റിഫ്രഷ്&quot; അല്ലെങ്കിൽ &quot;റീലോഡ്&quot; ബട്ടൺ ക്ലിക്ക് ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. checkbox label that allows the user to save the setting
@@ -15544,9 +15720,8 @@ msgid ""
 "Removes the \"Ask\" button so answers appear automatically in response to "
 "relevant searches. Cached answers always display automatically."
 msgstr ""
-"\"ചോദിക്കുക\" ബട്ടൺ നീക്കം ചെയ്യുന്നതിനാൽ പ്രസക്തമായ തിരയലുകളുടെ "
-"പ്രതികരണമായി ഉത്തരങ്ങൾ സ്വയമേവ ദൃശ്യമാകും. കാഷെ ചെയ്‌ത ഉത്തരങ്ങൾ എപ്പോഴും "
-"സ്വയമേവ പ്രദർശിപ്പിക്കും."
+"\"ചോദിക്കുക\" ബട്ടൺ നീക്കം ചെയ്യുന്നതിനാൽ പ്രസക്തമായ തിരയലുകളുടെ പ്രതികരണമായി ഉത്തരങ്ങൾ "
+"സ്വയമേവ ദൃശ്യമാകും. കാഷെ ചെയ്‌ത ഉത്തരങ്ങൾ എപ്പോഴും സ്വയമേവ പ്രദർശിപ്പിക്കും."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -15554,9 +15729,8 @@ msgid ""
 "Removes the \"Generate\" button so answers appear automatically in response "
 "to relevant searches. Cached answers always display automatically."
 msgstr ""
-"\"ചോദിക്കുക\" ബട്ടൺ നീക്കം ചെയ്യുന്നതിനാൽ പ്രസക്തമായ തിരയലുകളുടെ "
-"പ്രതികരണമായി ഉത്തരങ്ങൾ സ്വയമേവ ദൃശ്യമാകും. കാഷെ ചെയ്ത ഉത്തരങ്ങൾ എപ്പോഴും "
-"സ്വയമേവ പ്രദർശിപ്പിക്കും."
+"\"ചോദിക്കുക\" ബട്ടൺ നീക്കം ചെയ്യുന്നതിനാൽ പ്രസക്തമായ തിരയലുകളുടെ പ്രതികരണമായി ഉത്തരങ്ങൾ "
+"സ്വയമേവ ദൃശ്യമാകും. കാഷെ ചെയ്ത ഉത്തരങ്ങൾ എപ്പോഴും സ്വയമേവ പ്രദർശിപ്പിക്കും."
 
 # smartling.placeholder_format=C
 #. Text for a button to rename a chat, as in it will allow the user to change the title of the chat.
@@ -15614,10 +15788,9 @@ msgid ""
 "service. Your anonymous feedback is also shared with %s to help improve "
 "their services."
 msgstr ""
-"റിപ്പോർട്ടുകൾ അജ്ഞാതമാണ്, ഞങ്ങളുടെ തിരയൽ സേവനം മെച്ചപ്പെടുത്താൻ "
-"സഹായിക്കുന്നതിന് അവ DuckDuckGo-ലേക്ക് അയയ്ക്കുന്നു. അവരുടെ സേവനങ്ങൾ "
-"മെച്ചപ്പെടുത്താൻ സഹായിക്കുന്നതിന് നിങ്ങളുടെ അജ്ഞാത ഫീഡ്ബാക്കും %1$s-ലേക്ക് "
-"അയയ്ക്കാറുണ്ട്."
+"റിപ്പോർട്ടുകൾ അജ്ഞാതമാണ്, ഞങ്ങളുടെ തിരയൽ സേവനം മെച്ചപ്പെടുത്താൻ സഹായിക്കുന്നതിന് അവ "
+"DuckDuckGo-ലേക്ക് അയയ്ക്കുന്നു. അവരുടെ സേവനങ്ങൾ മെച്ചപ്പെടുത്താൻ സഹായിക്കുന്നതിന് നിങ്ങളുടെ "
+"അജ്ഞാത ഫീഡ്ബാക്കും %1$s-ലേക്ക് അയയ്ക്കാറുണ്ട്."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -15625,8 +15798,8 @@ msgid ""
 "Reports sent to DuckDuckGo are anonymous. Please do not include any personal "
 "or identifying information in your feedback."
 msgstr ""
-"DuckDuckGo-ലേക്ക് അയയ്ക്കുന്ന റിപ്പോർട്ടുകൾ അജ്ഞാതമാണ്. നിങ്ങളുടെ "
-"ഫീഡ്ബാക്കിൽ വ്യക്തിപരമോ തിരിച്ചറിയുന്നതോ ആയ വിവരങ്ങളൊന്നും ഉൾപ്പെടുത്തരുത്."
+"DuckDuckGo-ലേക്ക് അയയ്ക്കുന്ന റിപ്പോർട്ടുകൾ അജ്ഞാതമാണ്. നിങ്ങളുടെ ഫീഡ്ബാക്കിൽ വ്യക്തിപരമോ "
+"തിരിച്ചറിയുന്നതോ ആയ വിവരങ്ങളൊന്നും ഉൾപ്പെടുത്തരുത്."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -15635,14 +15808,22 @@ msgid ""
 "translate during this page load, and are anonymous. Please do not include "
 "any personal or identifying information in your feedback."
 msgstr ""
-"DuckDuckGo-ലേക്ക് അയച്ച റിപ്പോർട്ടുകളിൽ ഈ പേജ് ലോഡിനിടെ നിങ്ങൾ ഞങ്ങളോട് "
-"വിവർത്തനം ചെയ്യാൻ ആവശ്യപ്പെട്ട എല്ലാ വാചകങ്ങളും ഉൾപ്പെടുന്നു, അവ "
-"അജ്ഞാതവുമാണ്. നിങ്ങളുടെ ഫീഡ്ബാക്കിൽ വ്യക്തിപരമോ തിരിച്ചറിയുന്നതോ ആയ "
-"വിവരങ്ങളൊന്നും ഉൾപ്പെടുത്തരുത്."
+"DuckDuckGo-ലേക്ക് അയച്ച റിപ്പോർട്ടുകളിൽ ഈ പേജ് ലോഡിനിടെ നിങ്ങൾ ഞങ്ങളോട് വിവർത്തനം "
+"ചെയ്യാൻ ആവശ്യപ്പെട്ട എല്ലാ വാചകങ്ങളും ഉൾപ്പെടുന്നു, അവ അജ്ഞാതവുമാണ്. നിങ്ങളുടെ ഫീഡ്ബാക്കിൽ "
+"വ്യക്തിപരമോ തിരിച്ചറിയുന്നതോ ആയ വിവരങ്ങളൊന്നും ഉൾപ്പെടുത്തരുത്."
 
 # smartling.placeholder_format=C
 msgid "Republic of Moldova"
 msgstr "റിപ്പബ്ലിക് ഓഫ് മോൾഡോവ"
+
+# smartling.placeholder_format=C
+#. Note indicating that sharing the conversation is mandatory when reporting harmful or illegal content. Rendered alongside the standard share label (DUCKCHAT_RESPONSE_FEEDBACK_SHARE_PROMPT_RESPONSE_LABEL), not replacing it.
+msgctxt ""
+"Note shown under the share-content switch label on the Duck.ai response "
+"feedback form when the user has selected Harmful or Illegal as the feedback "
+"reason"
+msgid "Required for harmful or illegal reports"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
@@ -15709,10 +15890,9 @@ msgid ""
 "legal, financial, investment, or other professional advice. AI-assisted "
 "answers are subject to our %sTerms of Service%s."
 msgstr ""
-"പ്രതികരണങ്ങൾ വിദ്യാഭ്യാസ ആവശ്യങ്ങൾക്കായി മാത്രമാണ്, അവ മെഡിക്കൽ, നിയമ, "
-"സാമ്പത്തിക, നിക്ഷേപം അല്ലെങ്കിൽ മറ്റ് പ്രൊഫഷണൽ ഉപദേശങ്ങൾ എന്ന നിലയിൽ "
-"ഉദ്ദേശിച്ചിട്ടില്ല. AI- സഹായത്തോടെയുള്ള ഉത്തരങ്ങൾ ഞങ്ങളുടെ %1$sസേവന "
-"നിബന്ധനകൾക്ക്%2$s വിധേയമാണ്."
+"പ്രതികരണങ്ങൾ വിദ്യാഭ്യാസ ആവശ്യങ്ങൾക്കായി മാത്രമാണ്, അവ മെഡിക്കൽ, നിയമ, സാമ്പത്തിക, "
+"നിക്ഷേപം അല്ലെങ്കിൽ മറ്റ് പ്രൊഫഷണൽ ഉപദേശങ്ങൾ എന്ന നിലയിൽ ഉദ്ദേശിച്ചിട്ടില്ല. AI- "
+"സഹായത്തോടെയുള്ള ഉത്തരങ്ങൾ ഞങ്ങളുടെ %1$sസേവന നിബന്ധനകൾക്ക്%2$s വിധേയമാണ്."
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -15721,9 +15901,9 @@ msgid ""
 "legal, financial, investment, or other professional advice. DuckAssist is "
 "subject to our %sTerms of Service%s."
 msgstr ""
-"പ്രതികരണങ്ങൾ വിദ്യാഭ്യാസ ആവശ്യങ്ങൾക്കായി മാത്രമാണ്, അവ മെഡിക്കൽ, നിയമ, "
-"സാമ്പത്തിക, നിക്ഷേപം അല്ലെങ്കിൽ മറ്റ് പ്രൊഫഷണൽ ഉപദേശങ്ങൾ എന്ന നിലയിൽ "
-"ഉദ്ദേശിച്ചിട്ടില്ല. DuckAssist ഞങ്ങളുടെ %1$sസേവന നിബന്ധനകൾക്ക്%2$s വിധേയമാണ്."
+"പ്രതികരണങ്ങൾ വിദ്യാഭ്യാസ ആവശ്യങ്ങൾക്കായി മാത്രമാണ്, അവ മെഡിക്കൽ, നിയമ, സാമ്പത്തിക, "
+"നിക്ഷേപം അല്ലെങ്കിൽ മറ്റ് പ്രൊഫഷണൽ ഉപദേശങ്ങൾ എന്ന നിലയിൽ ഉദ്ദേശിച്ചിട്ടില്ല. DuckAssist "
+"ഞങ്ങളുടെ %1$sസേവന നിബന്ധനകൾക്ക്%2$s വിധേയമാണ്."
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -15733,11 +15913,10 @@ msgid ""
 "generated based on web content and may contain inaccuracies. Search Assist "
 "is subject to our %sTerms of Service%s."
 msgstr ""
-"പ്രതികരണങ്ങൾ വിദ്യാഭ്യാസ ആവശ്യങ്ങൾക്കായി മാത്രമാണ്, അവ മെഡിക്കൽ, നിയമ, "
-"സാമ്പത്തിക, നിക്ഷേപം അല്ലെങ്കിൽ മറ്റ് പ്രൊഫഷണൽ ഉപദേശങ്ങൾ എന്ന നിലയിൽ "
-"ഉദ്ദേശിച്ചിട്ടില്ല. അവ വെബ് ഉള്ളടക്കത്തെ അടിസ്ഥാനമാക്കി "
-"സൃഷ്ടിക്കപ്പെട്ടതാണ്, കൂടാതെ കൃത്യതയില്ലായ്മകൾ ഉണ്ടാകാം. Search Assist "
-"ഞങ്ങളുടെ %1$sസേവന നിബന്ധനകൾക്ക്%2$s വിധേയമാണ്."
+"പ്രതികരണങ്ങൾ വിദ്യാഭ്യാസ ആവശ്യങ്ങൾക്കായി മാത്രമാണ്, അവ മെഡിക്കൽ, നിയമ, സാമ്പത്തിക, "
+"നിക്ഷേപം അല്ലെങ്കിൽ മറ്റ് പ്രൊഫഷണൽ ഉപദേശങ്ങൾ എന്ന നിലയിൽ ഉദ്ദേശിച്ചിട്ടില്ല. അവ വെബ് "
+"ഉള്ളടക്കത്തെ അടിസ്ഥാനമാക്കി സൃഷ്ടിക്കപ്പെട്ടതാണ്, കൂടാതെ കൃത്യതയില്ലായ്മകൾ ഉണ്ടാകാം. Search "
+"Assist ഞങ്ങളുടെ %1$sസേവന നിബന്ധനകൾക്ക്%2$s വിധേയമാണ്."
 
 # smartling.placeholder_format=C
 #. Label on the button for restoring all previous website data.
@@ -15814,8 +15993,8 @@ msgstr "ബ്ലോക്ക് ചെയ്‌ത സൈറ്റുകളി�
 msgctxt "Blocked sites filter disclaimer"
 msgid "Results exclude your blocked sites, which you can manage in your %s."
 msgstr ""
-"ഫലങ്ങളിൽ നിങ്ങളുടെ തടഞ്ഞ സൈറ്റുകൾ ഉൾപ്പെടുന്നില്ല, അവ നിങ്ങളുടെ %1$s-ൽ "
-"കൈകാര്യം ചെയ്യാൻ കഴിയും."
+"ഫലങ്ങളിൽ നിങ്ങളുടെ തടഞ്ഞ സൈറ്റുകൾ ഉൾപ്പെടുന്നില്ല, അവ നിങ്ങളുടെ %1$s-ൽ കൈകാര്യം ചെയ്യാൻ "
+"കഴിയും."
 
 # smartling.placeholder_format=C
 #. A label showing the source of the results, e.g. "Results from Reddit"
@@ -15881,6 +16060,12 @@ msgstr "അവലോകനങ്ങൾ"
 msgctxt "maps_places"
 msgid "Reviews"
 msgstr "അവലോകനങ്ങൾ"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Rewrite this recipe scaled for a different number of servings."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Romania"
@@ -16152,17 +16337,16 @@ msgid ""
 "Save up to 30 of your most recent chats locally on your device, with the "
 "option for more with Encrypted Storage."
 msgstr ""
-"എൻക്രിപ്റ്റ് ചെയ്ത സ്റ്റോറേജ് ഉപയോഗിച്ച് കൂടുതൽ എന്ന ഓപ്ഷൻ ഉപയോഗിച്ച് "
-"നിങ്ങളുടെ ഏറ്റവും പുതിയ ചാറ്റുകളിൽ 30 എണ്ണം വരെ നിങ്ങളുടെ ഉപകരണത്തിൽ "
-"പ്രാദേശികമായി സംരക്ഷിക്കുക."
+"എൻക്രിപ്റ്റ് ചെയ്ത സ്റ്റോറേജ് ഉപയോഗിച്ച് കൂടുതൽ എന്ന ഓപ്ഷൻ ഉപയോഗിച്ച് നിങ്ങളുടെ ഏറ്റവും പുതിയ "
+"ചാറ്റുകളിൽ 30 എണ്ണം വരെ നിങ്ങളുടെ ഉപകരണത്തിൽ പ്രാദേശികമായി സംരക്ഷിക്കുക."
 
 # smartling.placeholder_format=C
 #. Short text for native DDG browser users explaining how Chat History stores up to 30 of their most recent chats locally on their device.
 msgctxt "Short description for Chat History feature on native DDG browsers"
 msgid "Save up to 30 of your most recent chats locally on your device."
 msgstr ""
-"നിങ്ങളുടെ ഉപകരണത്തിൽ നിങ്ങളുടെ ഏറ്റവും പുതിയ ചാറ്റുകളിൽ 30 എണ്ണം വരെ "
-"പ്രാദേശികമായി സംരക്ഷിക്കുക."
+"നിങ്ങളുടെ ഉപകരണത്തിൽ നിങ്ങളുടെ ഏറ്റവും പുതിയ ചാറ്റുകളിൽ 30 എണ്ണം വരെ പ്രാദേശികമായി "
+"സംരക്ഷിക്കുക."
 
 # smartling.placeholder_format=C
 #. Desktop/mobile intro modal body under the title per Sync Chats Figma (choose step).
@@ -16170,8 +16354,7 @@ msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
 msgstr ""
-"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷൻ ഉപയോഗിച്ച് നിങ്ങളുടെ ഉപകരണങ്ങൾക്കിടയിൽ Duck.ai "
-"ചാറ്റുകൾ സംരക്ഷിക്കുക."
+"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷൻ ഉപയോഗിച്ച് നിങ്ങളുടെ ഉപകരണങ്ങൾക്കിടയിൽ Duck.ai ചാറ്റുകൾ സംരക്ഷിക്കുക."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -16287,17 +16470,13 @@ msgstr "സ്കോട്ട്ലൻഡ്"
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Scroll down and click %sView advanced settings%s"
-msgstr ""
-"താഴോട്ട് സ്ക്രോൾ ചെയ്ത് %1$sവിപുലമായ ക്രമീകരണം കാണുക%2$s എന്നത് "
-"തിരഞ്ഞെടുക്കുക"
+msgstr "താഴോട്ട് സ്ക്രോൾ ചെയ്ത് %1$sവിപുലമായ ക്രമീകരണം കാണുക%2$s എന്നത് തിരഞ്ഞെടുക്കുക"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down and click %sView advanced settings%s."
-msgstr ""
-"താഴേക്ക് സ്ക്രോൾ ചെയ്ത് %1$sവിപുലമായ ക്രമീകരണം കാണുക%2$s എന്നത് ക്ലിക്ക് "
-"ചെയ്യുക."
+msgstr "താഴേക്ക് സ്ക്രോൾ ചെയ്ത് %1$sവിപുലമായ ക്രമീകരണം കാണുക%2$s എന്നത് ക്ലിക്ക് ചെയ്യുക."
 
 #  Edge Legacy default search engine instruction, obsolete?
 # smartling.placeholder_format=C
@@ -16305,8 +16484,8 @@ msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)"
 msgstr ""
-"താഴേക്ക് സ്ക്രോൾ ചെയ്ത് %1$sവിലാസ ബാറിൽ തിരയുക%2$s കണ്ടെത്തുക. "
-"%3$sമാറ്റുക%4$s (അല്ലെങ്കിൽ %5$sപുതിയത് ചേർക്കുക%6$s ക്ലിക്ക് ചെയ്യുക)"
+"താഴേക്ക് സ്ക്രോൾ ചെയ്ത് %1$sവിലാസ ബാറിൽ തിരയുക%2$s കണ്ടെത്തുക. %3$sമാറ്റുക%4$s (അല്ലെങ്കിൽ "
+"%5$sപുതിയത് ചേർക്കുക%6$s ക്ലിക്ക് ചെയ്യുക)"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
@@ -16315,8 +16494,8 @@ msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)."
 msgstr ""
-"താഴേക്ക് സ്ക്രോൾ ചെയ്ത് %1$sവിലാസ ബാറിൽ തിരയുക%2$s കണ്ടെത്തുക. "
-"%3$sമാറ്റുക%4$s (അല്ലെങ്കിൽ %5$sപുതിയത് ചേർക്കുക%6$s ക്ലിക്ക് ചെയ്യുക)."
+"താഴേക്ക് സ്ക്രോൾ ചെയ്ത് %1$sവിലാസ ബാറിൽ തിരയുക%2$s കണ്ടെത്തുക. %3$sമാറ്റുക%4$s (അല്ലെങ്കിൽ "
+"%5$sപുതിയത് ചേർക്കുക%6$s ക്ലിക്ക് ചെയ്യുക)."
 
 # smartling.placeholder_format=C
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -16335,16 +16514,15 @@ msgstr "താഴേക്ക് സ്ക്രോൾ ചെയ്ത്, �
 msgctxt "precise_user_location"
 msgid "Scroll down to %sDuckDuckGo%s and allow it to use your location."
 msgstr ""
-"%1$sDuckDuckGo%2$s എന്നതിലേക്ക് താഴേക്ക് സ്ക്രോൾ ചെയ്ത് നിങ്ങളുടെ ലൊക്കേഷൻ "
-"ഉപയോഗിക്കാൻ അതിനെ അനുവദിക്കുക."
+"%1$sDuckDuckGo%2$s എന്നതിലേക്ക് താഴേക്ക് സ്ക്രോൾ ചെയ്ത് നിങ്ങളുടെ ലൊക്കേഷൻ ഉപയോഗിക്കാൻ "
+"അതിനെ അനുവദിക്കുക."
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down to the %sServices%s section and click %sAddress bar%s."
 msgstr ""
-"താഴേക്ക് സ്ക്രോൾ ചെയ്ത് %1$sസേവനങ്ങൾ%2$s വിഭാഗം എടുത്ത്, %3$sവിലാസ ബാർ%4$s "
-"ക്ലിക്ക് ചെയ്യുക."
+"താഴേക്ക് സ്ക്രോൾ ചെയ്ത് %1$sസേവനങ്ങൾ%2$s വിഭാഗം എടുത്ത്, %3$sവിലാസ ബാർ%4$s ക്ലിക്ക് ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Rugby match stats
@@ -16392,14 +16570,12 @@ msgid ""
 "(on a wide range of searches). For now, Search Assist is only available in a "
 "subset of English speaking regions."
 msgstr ""
-"Search Assist തിരയൽ ചോദ്യങ്ങൾക്കുള്ള ഉത്തരങ്ങൾ അജ്ഞാതമായി സൃഷ്ടിക്കുന്നു. "
-"ഇത് ചെയ്യുന്നതിന്, പ്രസക്തമായ ഉള്ളടക്കത്തിനായി ഇത് വെബ് സ്കാൻ ചെയ്യുകയും "
-"തുടർന്ന് AI ഉപയോഗിച്ച് ഒരു ഹ്രസ്വ ഉത്തരം സൃഷ്ടിക്കുകയും ചെയ്യുന്നു. "
-"നിങ്ങൾക്ക് ഇത് എത്ര തവണ പ്രത്യക്ഷപ്പെടണമെന്ന് തിരഞ്ഞെടുക്കാം: ഒരിക്കലും, "
-"ഓൺ-ഡിമാൻഡ് (Assist ക്ലിക്ക് ചെയ്യുമ്പോൾ മാത്രം), ചിലപ്പോൾ (വളരെ "
-"പ്രസക്തമാകുമ്പോൾ), അല്ലെങ്കിൽ പലപ്പോഴും (വിശാലമായ തിരയലുകളിൽ). ഈ സമയത്ത്, "
-"ഇംഗ്ലീഷ് സംസാരിക്കുന്ന പ്രദേശങ്ങളുടെ ഒരു ഭാഗത്ത് മാത്രമേ Search Assist "
-"ലഭ്യമാകൂ."
+"Search Assist തിരയൽ ചോദ്യങ്ങൾക്കുള്ള ഉത്തരങ്ങൾ അജ്ഞാതമായി സൃഷ്ടിക്കുന്നു. ഇത് ചെയ്യുന്നതിന്, "
+"പ്രസക്തമായ ഉള്ളടക്കത്തിനായി ഇത് വെബ് സ്കാൻ ചെയ്യുകയും തുടർന്ന് AI ഉപയോഗിച്ച് ഒരു ഹ്രസ്വ ഉത്തരം "
+"സൃഷ്ടിക്കുകയും ചെയ്യുന്നു. നിങ്ങൾക്ക് ഇത് എത്ര തവണ പ്രത്യക്ഷപ്പെടണമെന്ന് തിരഞ്ഞെടുക്കാം: ഒരിക്കലും, "
+"ഓൺ-ഡിമാൻഡ് (Assist ക്ലിക്ക് ചെയ്യുമ്പോൾ മാത്രം), ചിലപ്പോൾ (വളരെ പ്രസക്തമാകുമ്പോൾ), "
+"അല്ലെങ്കിൽ പലപ്പോഴും (വിശാലമായ തിരയലുകളിൽ). ഈ സമയത്ത്, ഇംഗ്ലീഷ് സംസാരിക്കുന്ന പ്രദേശങ്ങളുടെ "
+"ഒരു ഭാഗത്ത് മാത്രമേ Search Assist ലഭ്യമാകൂ."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI) when the answer is not found and the answer is unsourced or with no sources
@@ -16407,8 +16583,8 @@ msgid ""
 "Search Assist couldn't find enough reliable information to generate an "
 "answer for this question. Try another search."
 msgstr ""
-"ഈ ചോദ്യത്തിന് ഉത്തരം സൃഷ്ടിക്കുന്നതിന് വേണ്ടത്ര വിശ്വസനീയമായ വിവരങ്ങൾ Search "
-"Assist-ന് കണ്ടെത്താൻ കഴിഞ്ഞില്ല. മറ്റൊരു തിരയൽ ശ്രമിക്കുക."
+"ഈ ചോദ്യത്തിന് ഉത്തരം സൃഷ്ടിക്കുന്നതിന് വേണ്ടത്ര വിശ്വസനീയമായ വിവരങ്ങൾ Search Assist-ന് "
+"കണ്ടെത്താൻ കഴിഞ്ഞില്ല. മറ്റൊരു തിരയൽ ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -16417,10 +16593,9 @@ msgid ""
 "search queries. To do this, it %sscans the web%s for relevant content and "
 "then uses AI to generate a brief answer based on information found."
 msgstr ""
-"Search Assist എന്നത് തിരയൽ അന്വേഷണങ്ങൾക്ക് അജ്ഞാതമായി ഉത്തരങ്ങൾ "
-"സൃഷ്ടിക്കുന്ന ഒരു ഓപ്ഷണൽ സവിശേഷതയാണ്. ഇത് ചെയ്യാൻ, പ്രസക്തമായ "
-"ഉള്ളടക്കത്തിനായി %1$sവെബ് സ്കാൻ%2$s ചെയ്യുകയും കണ്ടെത്തിയ വിവരങ്ങളെ "
-"അടിസ്ഥാനമാക്കി AI ഉപയോഗിച്ച് ഒരു ഹ്രസ്വമായ ഉത്തരം സൃഷ്ടിക്കുകയും ചെയ്യുന്നു."
+"Search Assist എന്നത് തിരയൽ അന്വേഷണങ്ങൾക്ക് അജ്ഞാതമായി ഉത്തരങ്ങൾ സൃഷ്ടിക്കുന്ന ഒരു ഓപ്ഷണൽ "
+"സവിശേഷതയാണ്. ഇത് ചെയ്യാൻ, പ്രസക്തമായ ഉള്ളടക്കത്തിനായി %1$sവെബ് സ്കാൻ%2$s ചെയ്യുകയും "
+"കണ്ടെത്തിയ വിവരങ്ങളെ അടിസ്ഥാനമാക്കി AI ഉപയോഗിച്ച് ഒരു ഹ്രസ്വമായ ഉത്തരം സൃഷ്ടിക്കുകയും ചെയ്യുന്നു."
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/search_box. top header
@@ -16541,8 +16716,8 @@ msgid ""
 "Search other sites with %s shortcuts: a search for ”!w ducks” will search "
 "for “ducks” directly on Wikipedia."
 msgstr ""
-"%1$s ഷോർട്ട്കട്ടുകൾ ഉപയോഗിച്ച് മറ്റ് സൈറ്റുകൾ തിരയുക: ”!w ducks” എന്നതിനുള്ള "
-"തിരയൽ വിക്കിപീഡിയയിൽ “ducks” എന്നതിനായി നേരിട്ട് തിരയുന്നതാണ്."
+"%1$s ഷോർട്ട്കട്ടുകൾ ഉപയോഗിച്ച് മറ്റ് സൈറ്റുകൾ തിരയുക: ”!w ducks” എന്നതിനുള്ള തിരയൽ "
+"വിക്കിപീഡിയയിൽ “ducks” എന്നതിനായി നേരിട്ട് തിരയുന്നതാണ്."
 
 # smartling.placeholder_format=C
 #. Placeholder text for the search form when no text has been entered
@@ -16561,9 +16736,9 @@ msgid ""
 "Search privately with our app or extension, add private web search to your "
 "favorite browser, or search directly at %sduckduckgo.com%s."
 msgstr ""
-"ഞങ്ങളുടെ ആപ്പ് അല്ലെങ്കിൽ എക്സ്റ്റന്‍ഷന്‍ ഉപയോഗിച്ച് സ്വകാര്യമായി തിരയുക, "
-"നിങ്ങളുടെ പ്രിയപ്പെട്ട ബ്രൗസറിലേക്ക് സ്വകാര്യ വെബ് തിരയൽ ചേർക്കുക, "
-"അല്ലെങ്കിൽ %1$sduckduckgo.com%2$s-ൽ നേരിട്ട് തിരയുക."
+"ഞങ്ങളുടെ ആപ്പ് അല്ലെങ്കിൽ എക്സ്റ്റന്‍ഷന്‍ ഉപയോഗിച്ച് സ്വകാര്യമായി തിരയുക, നിങ്ങളുടെ പ്രിയപ്പെട്ട "
+"ബ്രൗസറിലേക്ക് സ്വകാര്യ വെബ് തിരയൽ ചേർക്കുക, അല്ലെങ്കിൽ %1$sduckduckgo.com%2$s-ൽ നേരിട്ട് "
+"തിരയുക."
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/6LZAoqH.png
@@ -16571,8 +16746,8 @@ msgctxt "settings"
 msgid ""
 "Search queries are included in URL (if off, searches will use POST requests)"
 msgstr ""
-"തിരയൽ അന്വേഷണങ്ങൾ URL-ൽ ഉൾപ്പെടുത്തിയിട്ടുണ്ട് (ഓഫാണെങ്കിൽ തിരയലുകൾ POST "
-"അഭ്യർത്ഥനകൾ ഉപയോഗിക്കും)"
+"തിരയൽ അന്വേഷണങ്ങൾ URL-ൽ ഉൾപ്പെടുത്തിയിട്ടുണ്ട് (ഓഫാണെങ്കിൽ തിരയലുകൾ POST അഭ്യർത്ഥനകൾ "
+"ഉപയോഗിക്കും)"
 
 # smartling.placeholder_format=C
 #. Describes how cookies are used to store user settings privately and securely.
@@ -16584,11 +16759,10 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"തിരയൽ ക്രമീകരണങ്ങൾ വ്യക്തിഗതമല്ലാത്ത ബ്രൗസർ കുക്കികളിലും പ്രാദേശിക "
-"സംഭരണത്തിലും നിങ്ങളുടെ ബ്രൗസറിലും സൂക്ഷിച്ചിരിക്കുന്നു, എന്നാൽ ക്ലൗഡിലെ ഒരു "
-"വിദൂര സെർവറിൽ നിങ്ങളുടെ ക്രമീകരണങ്ങൾ അജ്ഞാതമായി സൂക്ഷിക്കാൻ Cloud Save "
-"ഉപയോഗിക്കാം. വ്യക്തിപരമായി തിരിച്ചറിയാൻ കഴിയുന്ന വിവരങ്ങളൊന്നും ക്ലൗഡിൽ "
-"സംഭരിക്കപ്പെടില്ല, നിങ്ങളുടെ പാസ്‌ഫ്രെയ്സ് ഒരിക്കലും നിങ്ങളുടെ ബ്രൗസർ "
+"തിരയൽ ക്രമീകരണങ്ങൾ വ്യക്തിഗതമല്ലാത്ത ബ്രൗസർ കുക്കികളിലും പ്രാദേശിക സംഭരണത്തിലും നിങ്ങളുടെ "
+"ബ്രൗസറിലും സൂക്ഷിച്ചിരിക്കുന്നു, എന്നാൽ ക്ലൗഡിലെ ഒരു വിദൂര സെർവറിൽ നിങ്ങളുടെ ക്രമീകരണങ്ങൾ "
+"അജ്ഞാതമായി സൂക്ഷിക്കാൻ Cloud Save ഉപയോഗിക്കാം. വ്യക്തിപരമായി തിരിച്ചറിയാൻ കഴിയുന്ന "
+"വിവരങ്ങളൊന്നും ക്ലൗഡിൽ സംഭരിക്കപ്പെടില്ല, നിങ്ങളുടെ പാസ്‌ഫ്രെയ്സ് ഒരിക്കലും നിങ്ങളുടെ ബ്രൗസർ "
 "വിട്ടുപോകില്ല."
 
 # smartling.placeholder_format=C
@@ -16678,8 +16852,7 @@ msgstr "സീസൺ ആഴ്ചകൾ"
 msgctxt "Description for sync and backup feature"
 msgid "Securely save and sync your chats across all your devices."
 msgstr ""
-"നിങ്ങളുടെ എല്ലാ ഉപകരണങ്ങളിലും ചാറ്റുകൾ സുരക്ഷിതമായി സംരക്ഷിക്കുകയും "
-"സമന്വയിപ്പിക്കുകയും ചെയ്യുക."
+"നിങ്ങളുടെ എല്ലാ ഉപകരണങ്ങളിലും ചാറ്റുകൾ സുരക്ഷിതമായി സംരക്ഷിക്കുകയും സമന്വയിപ്പിക്കുകയും ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -16688,9 +16861,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
 msgstr ""
-"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷൻ ഉപയോഗിച്ച് ഞങ്ങളുടെ സെർവറിൽ പരിധിയില്ലാതെ ചാറ്റുകൾ "
-"സുരക്ഷിതമായി സംഭരിച്ച്, അവ നിങ്ങളുടെ എല്ലാ ഉപകരണങ്ങളിൽ നിന്നും ആക്സസ് "
-"ചെയ്യുക."
+"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷൻ ഉപയോഗിച്ച് ഞങ്ങളുടെ സെർവറിൽ പരിധിയില്ലാതെ ചാറ്റുകൾ സുരക്ഷിതമായി "
+"സംഭരിച്ച്, അവ നിങ്ങളുടെ എല്ലാ ഉപകരണങ്ങളിൽ നിന്നും ആക്സസ് ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Text explaining that the Encrypted Storage feature stores the user's chats encrypted on their device.
@@ -16699,9 +16871,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
 msgstr ""
-"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷൻ ഉപയോഗിച്ച് ഞങ്ങളുടെ സെർവറിൽ പരിധിയില്ലാതെ ചാറ്റുകൾ "
-"സുരക്ഷിതമായി സംഭരിച്ച്, അവ നിങ്ങളുടെ എല്ലാ ഉപകരണങ്ങളിൽ നിന്നും ആക്സസ് "
-"ചെയ്യുക."
+"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷൻ ഉപയോഗിച്ച് ഞങ്ങളുടെ സെർവറിൽ പരിധിയില്ലാതെ ചാറ്റുകൾ സുരക്ഷിതമായി "
+"സംഭരിച്ച്, അവ നിങ്ങളുടെ എല്ലാ ഉപകരണങ്ങളിൽ നിന്നും ആക്സസ് ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -16710,9 +16881,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your synced devices."
 msgstr ""
-"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷൻ ഉപയോഗിച്ച് ഞങ്ങളുടെ സെർവറിൽ പരിധിയില്ലാതെ ചാറ്റുകൾ "
-"സുരക്ഷിതമായി സംഭരിച്ച്, സിങ്ക് ചെയ്ത എല്ലാ ഉപകരണങ്ങളിൽ നിന്നും അവ ആക്സസ് "
-"ചെയ്യുക."
+"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷൻ ഉപയോഗിച്ച് ഞങ്ങളുടെ സെർവറിൽ പരിധിയില്ലാതെ ചാറ്റുകൾ സുരക്ഷിതമായി "
+"സംഭരിച്ച്, സിങ്ക് ചെയ്ത എല്ലാ ഉപകരണങ്ങളിൽ നിന്നും അവ ആക്സസ് ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -16721,17 +16891,15 @@ msgid ""
 "Securely store your chats on our server using end-to-end encryption, and "
 "access them from all your devices."
 msgstr ""
-"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷൻ ഉപയോഗിച്ച് നിങ്ങളുടെ ചാറ്റുകൾ ഞങ്ങളുടെ സെർവറിൽ "
-"സുരക്ഷിതമായി സംഭരിക്കുക, നിങ്ങളുടെ എല്ലാ ഉപകരണങ്ങളിൽ നിന്നും അവ ആക്സസ് "
-"ചെയ്യുക."
+"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷൻ ഉപയോഗിച്ച് നിങ്ങളുടെ ചാറ്റുകൾ ഞങ്ങളുടെ സെർവറിൽ സുരക്ഷിതമായി "
+"സംഭരിക്കുക, നിങ്ങളുടെ എല്ലാ ഉപകരണങ്ങളിൽ നിന്നും അവ ആക്സസ് ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
 msgctxt "Sync feature benefit description"
 msgid "Securely stored on DuckDuckGo's server with end-to-end encryption."
 msgstr ""
-"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷനോടെ DuckDuckGo-യുടെ സെർവറിൽ സുരക്ഷിതമായി "
-"സംഭരിച്ചിരിക്കുന്നു."
+"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷനോടെ DuckDuckGo-യുടെ സെർവറിൽ സുരക്ഷിതമായി സംഭരിച്ചിരിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. List item explaining that synced chats are stored with end-to-end encryption on DuckDuckGo's server and only the user can access them.
@@ -16740,9 +16908,8 @@ msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
 msgstr ""
-"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷനോടെ DuckDuckGo-യുടെ സെർവറിൽ സുരക്ഷിതമായി "
-"സംഭരിച്ചിരിക്കുന്നു. നിനക്കല്ലാതെ മറ്റാർക്കും നിന്റെ ഡാറ്റ കാണാൻ കഴിയില്ല, "
-"ഞങ്ങൾക്ക് പോലും."
+"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷനോടെ DuckDuckGo-യുടെ സെർവറിൽ സുരക്ഷിതമായി സംഭരിച്ചിരിക്കുന്നു. "
+"നിനക്കല്ലാതെ മറ്റാർക്കും നിന്റെ ഡാറ്റ കാണാൻ കഴിയില്ല, ഞങ്ങൾക്ക് പോലും."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -16881,38 +17048,34 @@ msgstr "%1$s%2$s%3$s തിരഞ്ഞെടുക്കുക, തുടർന
 msgctxt "precise_user_location"
 msgid "Select %s'Setting for this Website...'%s from the Safari menu."
 msgstr ""
-"Safari മെനുവിൽ നിന്ന് %1$s'ഈ വെബ്‌സൈറ്റിനായുള്ള ക്രമീകരണം...'%2$s എന്നത് "
-"തിരഞ്ഞെടുക്കുക."
+"Safari മെനുവിൽ നിന്ന് %1$s'ഈ വെബ്‌സൈറ്റിനായുള്ള ക്രമീകരണം...'%2$s എന്നത് തിരഞ്ഞെടുക്കുക."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
 msgstr ""
-"%1$sഇഷ്ടാനുസൃതമാക്കുക%2$s ഓപ്ഷൻ തിരഞ്ഞെടുത്ത ശേഷം "
-"%3$shttps://duckduckgo.com%4$s എന്ന് ഇൻപുട്ട് ഫീൽഡിൽ എന്റർ ചെയ്യുക"
+"%1$sഇഷ്ടാനുസൃതമാക്കുക%2$s ഓപ്ഷൻ തിരഞ്ഞെടുത്ത ശേഷം %3$shttps://duckduckgo.com%4$s എന്ന് "
+"ഇൻപുട്ട് ഫീൽഡിൽ എന്റർ ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
 msgstr ""
-"%1$sDuckDuckGo%2$s തിരഞ്ഞെടുത്ത ശേഷം %3$sഡിഫോൾട്ടായി ചേർക്കുക%4$s എന്നതിൽ "
-"ക്ലിക്ക് ചെയ്യുക!"
+"%1$sDuckDuckGo%2$s തിരഞ്ഞെടുത്ത ശേഷം %3$sഡിഫോൾട്ടായി ചേർക്കുക%4$s എന്നതിൽ ക്ലിക്ക് "
+"ചെയ്യുക!"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s"
-msgstr ""
-"%1$sDuckDuckGo%2$s തിരഞ്ഞെടുത്ത് %3$sഡിഫോൾട്ടായി സജ്ജീകരിക്കുക%4$s ക്ലിക്ക് "
-"ചെയ്യുക"
+msgstr "%1$sDuckDuckGo%2$s തിരഞ്ഞെടുത്ത് %3$sഡിഫോൾട്ടായി സജ്ജീകരിക്കുക%4$s ക്ലിക്ക് ചെയ്യുക"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s."
 msgstr ""
-"%1$sDuckDuckGo%2$s തിരഞ്ഞെടുത്ത് %3$sഡിഫോൾട്ടായി സജ്ജീകരിക്കുക%4$s ക്ലിക്ക് "
-"ചെയ്യുക."
+"%1$sDuckDuckGo%2$s തിരഞ്ഞെടുത്ത് %3$sഡിഫോൾട്ടായി സജ്ജീകരിക്കുക%4$s ക്ലിക്ക് ചെയ്യുക."
 
 #  Firefox 33
 # smartling.placeholder_format=C
@@ -16924,9 +17087,7 @@ msgstr "ഡിഫോൾട്ട് തിരയൽ എഞ്ചിൻ ഡ്ര
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %sDuckDuckGo%s in the list and %sallow%s location access"
-msgstr ""
-"ലിസ്റ്റിൽ %1$sDuckDuckGo%2$s തിരഞ്ഞെടുത്ത് ലൊക്കേഷൻ ആക്സസ് "
-"%4$sഅനുവദിക്കുക%3$s"
+msgstr "ലിസ്റ്റിൽ %1$sDuckDuckGo%2$s തിരഞ്ഞെടുത്ത് ലൊക്കേഷൻ ആക്സസ് %4$sഅനുവദിക്കുക%3$s"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -16939,8 +17100,7 @@ msgstr "തിരയൽ ദാതാക്കളുടെ പട്ടികയ�
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s under the%sDefault Search Engine%s section"
 msgstr ""
-"%3$sഡിഫോൾട്ട് തിരയൽ എഞ്ചിൻ%4$s വിഭാഗത്തിന് കീഴിൽ %1$sDuckDuckGo%2$s "
-"തിരഞ്ഞെടുക്കുക"
+"%3$sഡിഫോൾട്ട് തിരയൽ എഞ്ചിൻ%4$s വിഭാഗത്തിന് കീഴിൽ %1$sDuckDuckGo%2$s തിരഞ്ഞെടുക്കുക"
 
 # smartling.placeholder_format=C
 #. Tells the user were in the settings menu they can change their default search engine.
@@ -16951,17 +17111,13 @@ msgstr "%1$sDuckDuckGo%2$s തിരഞ്ഞെടുക്കുക!"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Select %sEdit Search Engines...%sin the dropdown"
-msgstr ""
-"ഡ്രോപ്പ്ഡൗണിൽ %1$sതിരയൽ എഞ്ചിനുകൾ എഡിറ്റ് ചെയ്യുക...%2$s എന്നത് "
-"തിരഞ്ഞെടുക്കുക"
+msgstr "ഡ്രോപ്പ്ഡൗണിൽ %1$sതിരയൽ എഞ്ചിനുകൾ എഡിറ്റ് ചെയ്യുക...%2$s എന്നത് തിരഞ്ഞെടുക്കുക"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sManage add-ons%s from the dropdown menu"
-msgstr ""
-"ഡ്രോപ്പ്ഡൗൺ മെനുവിൽ നിന്ന് %1$sആഡ്-ഓണുകൾ മാനേജ് ചെയ്യുക%2$s എന്നത് "
-"തിരഞ്ഞെടുക്കുക"
+msgstr "ഡ്രോപ്പ്ഡൗൺ മെനുവിൽ നിന്ന് %1$sആഡ്-ഓണുകൾ മാനേജ് ചെയ്യുക%2$s എന്നത് തിരഞ്ഞെടുക്കുക"
 
 #  Opera default search engine instruction
 # smartling.placeholder_format=C
@@ -16969,8 +17125,8 @@ msgstr ""
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sMenu > Settings%s (on Windows)"
 msgstr ""
-"(Mac-ൽ) %1$sOpera > മുൻഗണനകൾ%2$s എന്നും (Windows-ൽ) %3$sമെനു > ക്രമീകരണം%4$s "
-"എന്നും തിരഞ്ഞെടുക്കുക"
+"(Mac-ൽ) %1$sOpera > മുൻഗണനകൾ%2$s എന്നും (Windows-ൽ) %3$sമെനു > ക്രമീകരണം%4$s എന്നും "
+"തിരഞ്ഞെടുക്കുക"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -16978,8 +17134,8 @@ msgstr ""
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sOpera > Options%s (on Windows)"
 msgstr ""
-"(Mac-ൽ) %1$sOpera > മുൻഗണനകൾ%2$s എന്നും (Windows-ൽ) %3$sOpera > ഓപ്ഷനുകൾ%4$s "
-"എന്നും തിരഞ്ഞെടുക്കുക"
+"(Mac-ൽ) %1$sOpera > മുൻഗണനകൾ%2$s എന്നും (Windows-ൽ) %3$sOpera > ഓപ്ഷനുകൾ%4$s എന്നും "
+"തിരഞ്ഞെടുക്കുക"
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -17044,16 +17200,14 @@ msgid ""
 "Select %sUse this webpage as your only home page%s (or one of the other "
 "options if you prefer)"
 msgstr ""
-"%1$sഈ വെബ് പേജ് നിങ്ങളുടെ ഏക ഹോം പേജായി ഉപയോഗിക്കുക%2$s എന്നത് "
-"തിരഞ്ഞെടുക്കുക (അല്ലെങ്കിൽ നിങ്ങൾ ഇഷ്ടപ്പെടുന്നെങ്കിൽ മറ്റ് ഓപ്ഷനുകളിൽ ഒന്ന്)"
+"%1$sഈ വെബ് പേജ് നിങ്ങളുടെ ഏക ഹോം പേജായി ഉപയോഗിക്കുക%2$s എന്നത് തിരഞ്ഞെടുക്കുക (അല്ലെങ്കിൽ "
+"നിങ്ങൾ ഇഷ്ടപ്പെടുന്നെങ്കിൽ മറ്റ് ഓപ്ഷനുകളിൽ ഒന്ന്)"
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %syour browser%s in the list and %sallow%s location access"
-msgstr ""
-"ലിസ്റ്റിൽ %1$sനിങ്ങളുടെ ബ്രൗസർ%2$s തിരഞ്ഞെടുത്ത് ലൊക്കേഷൻ ആക്സസ് "
-"%3$sഅനുവദിക്കുക%4$s"
+msgstr "ലിസ്റ്റിൽ %1$sനിങ്ങളുടെ ബ്രൗസർ%2$s തിരഞ്ഞെടുത്ത് ലൊക്കേഷൻ ആക്സസ് %3$sഅനുവദിക്കുക%4$s"
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the modal for deleting all recent chats, that allows the user to select the chats to delete.
@@ -17126,8 +17280,7 @@ msgstr "%1$s-ൽ നിന്ന് തിരഞ്ഞെടുത്ത ടെ�
 msgctxt "Error message for selection input limit"
 msgid "Selected text is too long. Try again with a shorter selection."
 msgstr ""
-"തിരഞ്ഞെടുത്ത വാചകം വളരെ ദൈർഘ്യമേറിയതാണ്. ദൈർഘ്യം കുറഞ്ഞത് തിരഞ്ഞെടുത്ത് "
-"വീണ്ടും ശ്രമിക്കൂ."
+"തിരഞ്ഞെടുത്ത വാചകം വളരെ ദൈർഘ്യമേറിയതാണ്. ദൈർഘ്യം കുറഞ്ഞത് തിരഞ്ഞെടുത്ത് വീണ്ടും ശ്രമിക്കൂ."
 
 # smartling.placeholder_format=C
 #. Label for the semi-finals knockout stage in e.g. the soccer World Cup
@@ -17171,9 +17324,9 @@ msgid ""
 "respond. These instructions will apply to all of your conversations going "
 "forward."
 msgstr ""
-"എങ്ങനെ പ്രതികരിക്കണമെന്നതിനെക്കുറിച്ചുള്ള നിർദ്ദേശങ്ങളുള്ള നിങ്ങളുടെ "
-"സന്ദേശങ്ങളുമായി AI മോഡലുകളിലേക്ക് ഒരു പ്രോംപ്റ്റ് അയയ്ക്കുന്നു. ഈ "
-"നിർദ്ദേശങ്ങൾ ഇനി മുതൽ എല്ലാ സംഭാഷണങ്ങൾക്കും ബാധകമാകും."
+"എങ്ങനെ പ്രതികരിക്കണമെന്നതിനെക്കുറിച്ചുള്ള നിർദ്ദേശങ്ങളുള്ള നിങ്ങളുടെ സന്ദേശങ്ങളുമായി AI "
+"മോഡലുകളിലേക്ക് ഒരു പ്രോംപ്റ്റ് അയയ്ക്കുന്നു. ഈ നിർദ്ദേശങ്ങൾ ഇനി മുതൽ എല്ലാ സംഭാഷണങ്ങൾക്കും "
+"ബാധകമാകും."
 
 # smartling.placeholder_format=C
 msgid "Senegal"
@@ -17249,6 +17402,12 @@ msgid "Set Up Now"
 msgstr "ഇപ്പോൾ സജ്ജീകരിക്കുക"
 
 # smartling.placeholder_format=C
+#. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
+msgctxt "Encrypted storage setup button shown in native browsers"
+msgid "Set Up Sync & Backup"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
 msgctxt "Title for the Sync & Backup intro screen"
 msgid "Set Up Sync & Backup"
@@ -17277,8 +17436,8 @@ msgid ""
 "Set up Sync & Backup after turning on Chat History to keep your chats synced "
 "across devices."
 msgstr ""
-"നിങ്ങളുടെ ചാറ്റുകൾ ഉപകരണങ്ങളിലുടനീളം സമന്വയിപ്പിച്ച് നിലനിർത്താൻ, ചാറ്റ് "
-"ചരിത്രം ഓണാക്കിയ ശേഷം Sync & Backup സജ്ജമാക്കുക."
+"നിങ്ങളുടെ ചാറ്റുകൾ ഉപകരണങ്ങളിലുടനീളം സമന്വയിപ്പിച്ച് നിലനിർത്താൻ, ചാറ്റ് ചരിത്രം ഓണാക്കിയ "
+"ശേഷം Sync & Backup സജ്ജമാക്കുക."
 
 # smartling.placeholder_format=C
 #. Prompt for the user to indicate their location on a map, to enable more relevant search results.
@@ -17340,9 +17499,7 @@ msgstr "പങ്കിടുക"
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "Share DuckDuckGo and help friends take their privacy back!"
-msgstr ""
-"DuckDuckGo പങ്കിടുക, സുഹൃത്തുക്കളെ അവരുടെ സ്വകാര്യത തിരികെ കൊണ്ടുവരാൻ "
-"സഹായിക്കുക!"
+msgstr "DuckDuckGo പങ്കിടുക, സുഹൃത്തുക്കളെ അവരുടെ സ്വകാര്യത തിരികെ കൊണ്ടുവരാൻ സഹായിക്കുക!"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button that opens a feedback modal when clicked.
@@ -17369,9 +17526,8 @@ msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
 msgstr ""
-"പ്രസക്തി മെച്ചപ്പെടുത്തുന്നതിന് AI മോഡലുകളുമായി ഒരു നഗരതല ലൊക്കേഷൻ പങ്കിടുക. "
-"Duck.ai ഒരിക്കലും നിങ്ങളുടെ കൃത്യമായ ലൊക്കേഷൻ ഞങ്ങൾക്കോ AI മോഡലുകൾക്കോ "
-"വെളിപ്പെടുത്തുകയില്ല."
+"പ്രസക്തി മെച്ചപ്പെടുത്തുന്നതിന് AI മോഡലുകളുമായി ഒരു നഗരതല ലൊക്കേഷൻ പങ്കിടുക. Duck.ai "
+"ഒരിക്കലും നിങ്ങളുടെ കൃത്യമായ ലൊക്കേഷൻ ഞങ്ങൾക്കോ AI മോഡലുകൾക്കോ വെളിപ്പെടുത്തുകയില്ല."
 
 # smartling.placeholder_format=C
 #. Menu option to share feedback about a result
@@ -17432,6 +17588,13 @@ msgid "Share positive feedback"
 msgstr "പോസിറ്റീവ് ഫീഡ്ബാക്ക് പങ്കിടുക"
 
 # smartling.placeholder_format=C
+#. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
+msgctxt ""
+"Label beside the share-content switch on the Duck.ai response feedback form"
+msgid "Share this conversation with DuckDuckGo"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
 msgctxt ""
 "Label beside the share-content switch on the Duck.ai response feedback form"
@@ -17447,8 +17610,8 @@ msgid ""
 "Share your prompt and chat response with DuckDuckGo (required for illegal "
 "and harmful report)"
 msgstr ""
-"നിങ്ങളുടെ പ്രോംപ്റ്റും ചാറ്റ് പ്രതികരണവും DuckDuckGo-യുമായി പങ്കിടുക "
-"(നിയമവിരുദ്ധവും ദോഷകരവുമായ റിപ്പോർട്ടിന് ആവശ്യമാണ്)"
+"നിങ്ങളുടെ പ്രോംപ്റ്റും ചാറ്റ് പ്രതികരണവും DuckDuckGo-യുമായി പങ്കിടുക (നിയമവിരുദ്ധവും "
+"ദോഷകരവുമായ റിപ്പോർട്ടിന് ആവശ്യമാണ്)"
 
 # smartling.placeholder_format=C
 #. An invitation for users to leave feedback
@@ -17568,9 +17731,7 @@ msgstr "DuckAssist <sup>BETA</sup> കാണിക്കുക"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show DuckAssist more often. (You can also completely %sturn it off%s.)"
-msgstr ""
-"DuckAssist കൂടുതൽ തവണ കാണിക്കുക. (നിങ്ങൾക്ക് ഇത് പൂർണ്ണമായും "
-"%1$sഓഫാക്കാം%2$s.)"
+msgstr "DuckAssist കൂടുതൽ തവണ കാണിക്കുക. (നിങ്ങൾക്ക് ഇത് പൂർണ്ണമായും %1$sഓഫാക്കാം%2$s.)"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
@@ -17796,9 +17957,8 @@ msgid ""
 "Shows a reminder that searches on DuckDuckGo are always private. Turning "
 "this off hides the reminder and never affects search privacy."
 msgstr ""
-"DuckDuckGo-യിലെ തിരയലുകൾ എല്ലായ്പ്പോഴും സ്വകാര്യമാണെന്നുള്ള ഒരു "
-"ഓർമ്മപ്പെടുത്തൽ കാണിക്കുന്നു. ഇത് ഓഫാക്കുന്നത് ഓർമ്മപ്പെടുത്തൽ മറയ്ക്കുന്നു, "
-"കൂടാതെ തിരയലിന്റെ സ്വകാര്യതയെ ഒരിക്കലും ബാധിക്കില്ല."
+"DuckDuckGo-യിലെ തിരയലുകൾ എല്ലായ്പ്പോഴും സ്വകാര്യമാണെന്നുള്ള ഒരു ഓർമ്മപ്പെടുത്തൽ കാണിക്കുന്നു. "
+"ഇത് ഓഫാക്കുന്നത് ഓർമ്മപ്പെടുത്തൽ മറയ്ക്കുന്നു, കൂടാതെ തിരയലിന്റെ സ്വകാര്യതയെ ഒരിക്കലും ബാധിക്കില്ല."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -17806,9 +17966,9 @@ msgid ""
 "Shows a reminder that searches on DuckDuckGo are always protected. Turning "
 "this off hides the reminder and never affects search protection."
 msgstr ""
-"DuckDuckGo-യിലെ തിരയലുകൾ എല്ലായ്പ്പോഴും പരിരക്ഷിക്കപ്പെടുന്നു എന്നുള്ള ഒരു "
-"ഓർമ്മപ്പെടുത്തൽ കാണിക്കുന്നു. ഇത് ഓഫാക്കുന്നത് ഓർമ്മപ്പെടുത്തൽ മറയ്ക്കുന്നു, "
-"കൂടാതെ തിരയൽ പരിരക്ഷയെ ഒരിക്കലും ബാധിക്കുന്നില്ല."
+"DuckDuckGo-യിലെ തിരയലുകൾ എല്ലായ്പ്പോഴും പരിരക്ഷിക്കപ്പെടുന്നു എന്നുള്ള ഒരു ഓർമ്മപ്പെടുത്തൽ "
+"കാണിക്കുന്നു. ഇത് ഓഫാക്കുന്നത് ഓർമ്മപ്പെടുത്തൽ മറയ്ക്കുന്നു, കൂടാതെ തിരയൽ പരിരക്ഷയെ ഒരിക്കലും "
+"ബാധിക്കുന്നില്ല."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -17819,8 +17979,7 @@ msgstr "ഫല പേജ് ഇടവേളകളിൽ തിരശ്ചീന
 msgctxt "settings"
 msgid "Shows links to instructions for how to add DuckDuckGo to your browser"
 msgstr ""
-"DuckDuckGo നിങ്ങളുടെ ബ്രൗസറിലേക്ക് കൂട്ടിച്ചേർക്കാനുള്ള നിർദേശങ്ങളിലേക്കുള്ള "
-"ലിങ്കുകൾ കാണിക്കുന്നു"
+"DuckDuckGo നിങ്ങളുടെ ബ്രൗസറിലേക്ക് കൂട്ടിച്ചേർക്കാനുള്ള നിർദേശങ്ങളിലേക്കുള്ള ലിങ്കുകൾ കാണിക്കുന്നു"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers more frequently.
@@ -17837,23 +17996,21 @@ msgstr "പുതിയ ടാബ് പേജിൽ ഏറ്റവും ക�
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your browser"
 msgstr ""
-"നിങ്ങളുടെ ബ്രൗസറിലേക്ക് DuckDuckGo ചേർക്കാനുള്ള ഇടയ്ക്കിടെയുള്ള "
-"ഓർമപ്പെടുത്തലുകൾ കാണിക്കുന്നു"
+"നിങ്ങളുടെ ബ്രൗസറിലേക്ക് DuckDuckGo ചേർക്കാനുള്ള ഇടയ്ക്കിടെയുള്ള ഓർമപ്പെടുത്തലുകൾ കാണിക്കുന്നു"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
 msgstr ""
-"നിങ്ങളുടെ ഉപകരണങ്ങളിലേക്ക് DuckDuckGo ചേർക്കാനുള്ള ഇടയ്ക്കിടെയുള്ള "
-"ഓർമപ്പെടുത്തലുകൾ കാണിക്കുന്നു"
+"നിങ്ങളുടെ ഉപകരണങ്ങളിലേക്ക് DuckDuckGo ചേർക്കാനുള്ള ഇടയ്ക്കിടെയുള്ള ഓർമപ്പെടുത്തലുകൾ കാണിക്കുന്നു"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Shows occasional reminders to sign up for the DuckDuckGo privacy newsletters"
 msgstr ""
-"DuckDuckGo സ്വകാര്യതാ വാർത്താക്കുറിപ്പുകൾക്കായി സൈൻ അപ്പ് ചെയ്യുന്നതിന് "
-"ഇടയ്ക്കിടെയുള്ള ഓർമപ്പെടുത്തലുകൾ കാണിക്കുന്നു"
+"DuckDuckGo സ്വകാര്യതാ വാർത്താക്കുറിപ്പുകൾക്കായി സൈൻ അപ്പ് ചെയ്യുന്നതിന് ഇടയ്ക്കിടെയുള്ള "
+"ഓർമപ്പെടുത്തലുകൾ കാണിക്കുന്നു"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -17961,16 +18118,12 @@ msgstr "സൈറ്റുകളുടെ പേരുകൾ"
 #. A message saying that site filters are not currently working
 msgctxt "Site filter message"
 msgid "Site search is temporarily unavailable. We are working on a fix."
-msgstr ""
-"സൈറ്റ് തിരയൽ താൽക്കാലികമായി ലഭ്യമല്ല. ഞങ്ങൾ ഒരു പരിഹാരം കണ്ടെത്താൻ "
-"പ്രവർത്തിക്കുന്നു."
+msgstr "സൈറ്റ് തിരയൽ താൽക്കാലികമായി ലഭ്യമല്ല. ഞങ്ങൾ ഒരു പരിഹാരം കണ്ടെത്താൻ പ്രവർത്തിക്കുന്നു."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Sites you block will be hidden from all your search results"
-msgstr ""
-"നിങ്ങൾ ബ്ലോക്ക് ചെയ്യുന്ന സൈറ്റുകൾ നിങ്ങളുടെ എല്ലാ തിരയൽ ഫലങ്ങളിൽ നിന്നും "
-"മറയ്ക്കും"
+msgstr "നിങ്ങൾ ബ്ലോക്ക് ചെയ്യുന്ന സൈറ്റുകൾ നിങ്ങളുടെ എല്ലാ തിരയൽ ഫലങ്ങളിൽ നിന്നും മറയ്ക്കും"
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes full name (tooltip)
@@ -18116,8 +18269,7 @@ msgstr "സെർവറിലേക്ക് സംരക്ഷിക്കു�
 msgctxt "Generic error shown when sync setup fails"
 msgid "Something went wrong while enabling Sync & Backup. Please try again."
 msgstr ""
-"Sync & Backup പ്രവർത്തനക്ഷമമാക്കുമ്പോൾ എന്തോ കുഴപ്പം സംഭവിച്ചു. ദയവായി "
-"വീണ്ടും ശ്രമിക്കുക."
+"Sync & Backup പ്രവർത്തനക്ഷമമാക്കുമ്പോൾ എന്തോ കുഴപ്പം സംഭവിച്ചു. ദയവായി വീണ്ടും ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Displayed when the voice chat session ends with an unknown error.
@@ -18142,8 +18294,8 @@ msgstr "ചിലപ്പോൾ"
 msgctxt "Error message from the image generation model"
 msgid "Sorry I can't help, please describe your image in a different way."
 msgstr ""
-"ക്ഷമിക്കണം, എനിക്ക് സഹായിക്കാനാകില്ല, ദയവായി നിങ്ങളുടെ ചിത്രത്തെ മറ്റൊരു "
-"രീതിയിൽ വിവരിക്കുക."
+"ക്ഷമിക്കണം, എനിക്ക് സഹായിക്കാനാകില്ല, ദയവായി നിങ്ങളുടെ ചിത്രത്തെ മറ്റൊരു രീതിയിൽ "
+"വിവരിക്കുക."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -18182,8 +18334,8 @@ msgid ""
 "Sorry, the uploaded image couldn't be processed. Please try a different "
 "image or format."
 msgstr ""
-"ക്ഷമിക്കണം, അപ്‌ലോഡ് ചെയ്ത ചിത്രം പ്രോസസ്സ് ചെയ്യാൻ കഴിഞ്ഞില്ല. ദയവായി "
-"മറ്റൊരു ചിത്രമോ ഫോർമാറ്റോ പരീക്ഷിച്ചുനോക്കൂ."
+"ക്ഷമിക്കണം, അപ്‌ലോഡ് ചെയ്ത ചിത്രം പ്രോസസ്സ് ചെയ്യാൻ കഴിഞ്ഞില്ല. ദയവായി മറ്റൊരു ചിത്രമോ "
+"ഫോർമാറ്റോ പരീക്ഷിച്ചുനോക്കൂ."
 
 # smartling.placeholder_format=C
 #. Body copy shown when a scanned or pasted pairing payload fails schema validation.
@@ -18192,16 +18344,16 @@ msgid ""
 "Sorry, this code is invalid. Please make sure the correct code was entered "
 "or scanned."
 msgstr ""
-"ക്ഷമിക്കണം, ഈ കോഡ് അസാധുവാണ്. ശരിയായ കോഡ് ആണ് നൽകിയത് അല്ലെങ്കിൽ സ്കാൻ "
-"ചെയ്തതെന്ന് ഉറപ്പാക്കുക."
+"ക്ഷമിക്കണം, ഈ കോഡ് അസാധുവാണ്. ശരിയായ കോഡ് ആണ് നൽകിയത് അല്ലെങ്കിൽ സ്കാൻ ചെയ്തതെന്ന് "
+"ഉറപ്പാക്കുക."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
 msgid ""
 "Sorry, we couldn't generate a richer answer. You can try asking Duck.ai."
 msgstr ""
-"ക്ഷമിക്കണം, ഞങ്ങൾക്ക് കൂടുതൽ മികച്ച ഒരു ഉത്തരം സൃഷ്ടിക്കാൻ കഴിഞ്ഞില്ല. "
-"നിങ്ങൾക്ക് Duck.ai-യോട് ചോദിക്കാൻ ശ്രമിക്കാം."
+"ക്ഷമിക്കണം, ഞങ്ങൾക്ക് കൂടുതൽ മികച്ച ഒരു ഉത്തരം സൃഷ്ടിക്കാൻ കഴിഞ്ഞില്ല. നിങ്ങൾക്ക് Duck.ai-യോട് "
+"ചോദിക്കാൻ ശ്രമിക്കാം."
 
 # smartling.placeholder_format=C
 #. Inform the users that "something" went wrong and that they could try to refresh the page to resolve the error. Placeholders are for markup, please ignore.
@@ -18210,16 +18362,15 @@ msgid ""
 "Sorry, we ran into an error displaying these results. %sClick here%s to try "
 "again."
 msgstr ""
-"ക്ഷമിക്കണം, ഈ ഫലങ്ങൾ പ്രദർശിപ്പിക്കുന്നതിൽ ഞങ്ങൾക്ക് ഒരു പിശക് നേരിട്ടു. "
-"വീണ്ടും ശ്രമിക്കാൻ %1$sഇവിടെ ക്ലിക്ക് ചെയ്യുക%2$s ."
+"ക്ഷമിക്കണം, ഈ ഫലങ്ങൾ പ്രദർശിപ്പിക്കുന്നതിൽ ഞങ്ങൾക്ക് ഒരു പിശക് നേരിട്ടു. വീണ്ടും ശ്രമിക്കാൻ "
+"%1$sഇവിടെ ക്ലിക്ക് ചെയ്യുക%2$s ."
 
 # smartling.placeholder_format=C
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
 msgstr ""
-"ക്ഷമിക്കണം, നിങ്ങളുടെ ഫീഡ്ബാക്ക് സമർപ്പിക്കാൻ ഞങ്ങൾക്ക് കഴിഞ്ഞില്ല. പിന്നീട് "
-"വീണ്ടും ശ്രമിക്കുക."
+"ക്ഷമിക്കണം, നിങ്ങളുടെ ഫീഡ്ബാക്ക് സമർപ്പിക്കാൻ ഞങ്ങൾക്ക് കഴിഞ്ഞില്ല. പിന്നീട് വീണ്ടും ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -18274,8 +18425,8 @@ msgctxt "Error message for summary selection input limit"
 msgid ""
 "Source text is too long to summarize. Try again with a shorter selection."
 msgstr ""
-"സംഗ്രഹിക്കാൻ കഴിയാത്തത്ര ദൈർഘ്യമുള്ളതാണ് ഉറവിട ടെക്‌സ്റ്റ്. ദൈർഘ്യം കുറഞ്ഞത് "
-"തിരഞ്ഞെടുത്ത് വീണ്ടും ശ്രമിക്കൂ."
+"സംഗ്രഹിക്കാൻ കഴിയാത്തത്ര ദൈർഘ്യമുള്ളതാണ് ഉറവിട ടെക്‌സ്റ്റ്. ദൈർഘ്യം കുറഞ്ഞത് തിരഞ്ഞെടുത്ത് വീണ്ടും "
+"ശ്രമിക്കൂ."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under Interface Settings.in the end. It is a header
@@ -18474,9 +18625,7 @@ msgstr "DuckDuckGo-യിൽ തുടരുക"
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletter."
-msgstr ""
-"ഞങ്ങളുടെ സ്വകാര്യതാ വാർത്താക്കുറിപ്പുകൾ ഉപയോഗിച്ച് പരിരക്ഷയോടെയും "
-"അറിവുള്ളവരായും തുടരുക."
+msgstr "ഞങ്ങളുടെ സ്വകാര്യതാ വാർത്താക്കുറിപ്പുകൾ ഉപയോഗിച്ച് പരിരക്ഷയോടെയും അറിവുള്ളവരായും തുടരുക."
 
 # smartling.placeholder_format=C
 #. Prompt to subscribe to a newsletter.
@@ -18526,9 +18675,7 @@ msgstr "സൃഷ്ടിക്കൽ നിർത്തുക"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop hidden trackers lurking on other websites."
-msgstr ""
-"മറ്റ് വെബ്‌സൈറ്റുകളിൽ പതിയിരിക്കുന്ന മറയ്ക്കപ്പെട്ട ട്രാക്കറുകൾ "
-"പ്രതിരോധിക്കുക."
+msgstr "മറ്റ് വെബ്‌സൈറ്റുകളിൽ പതിയിരിക്കുന്ന മറയ്ക്കപ്പെട്ട ട്രാക്കറുകൾ പ്രതിരോധിക്കുക."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -18623,8 +18770,8 @@ msgid ""
 "Subscribe to DuckDuckGo to unlock higher limits in Duck.ai, or come back "
 "later to create more images."
 msgstr ""
-"Duck.ai-ൽ ഉയർന്ന പരിധികൾ അൺലോക്ക് ചെയ്യാൻ DuckDuckGo സബ്‌സ്‌ക്രൈബ് ചെയ്യുക, "
-"അല്ലെങ്കിൽ കൂടുതൽ ഇമേജുകൾ സൃഷ്ടിക്കാൻ പിന്നീട് തിരികെ വരിക."
+"Duck.ai-ൽ ഉയർന്ന പരിധികൾ അൺലോക്ക് ചെയ്യാൻ DuckDuckGo സബ്‌സ്‌ക്രൈബ് ചെയ്യുക, അല്ലെങ്കിൽ "
+"കൂടുതൽ ഇമേജുകൾ സൃഷ്ടിക്കാൻ പിന്നീട് തിരികെ വരിക."
 
 # smartling.placeholder_format=C
 #. Description shown to free users who have reached their image generation limit, encouraging them to subscribe.
@@ -18693,14 +18840,32 @@ msgid ""
 "Suggest a phrase to write on a get-well card for someone recovering from a "
 "surgery?"
 msgstr ""
-"ഒരു ശസ്ത്രക്രിയയിൽ നിന്ന് സുഖം പ്രാപിക്കുന്ന ഒരാൾക്ക് ഒരു ഗെറ്റ്-വെൽ കാർഡിൽ "
-"എഴുതാൻ ഒരു വാക്യം നിർദ്ദേശിക്കാമോ?"
+"ഒരു ശസ്ത്രക്രിയയിൽ നിന്ന് സുഖം പ്രാപിക്കുന്ന ഒരാൾക്ക് ഒരു ഗെറ്റ്-വെൽ കാർഡിൽ എഴുതാൻ ഒരു വാക്യം "
+"നിർദ്ദേശിക്കാമോ?"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for asking for a suggestion of a blog post title.
 msgctxt "Brief for suggesting a blog post title"
 msgid "Suggest a title for a blog post"
 msgstr "ഒരു ബ്ലോഗ് പോസ്റ്റിന് ഒരു തലക്കെട്ട് നിർദ്ദേശിക്കുക"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest related articles or topics worth exploring next."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Suggest related articles to explore"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest some alternatives to this product."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
@@ -18714,10 +18879,100 @@ msgid "Suggestions:"
 msgstr "നിർദേശങ്ങൾ:"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Sum up the reviews"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A short title for the a message asking the AI to summarize a text.
 msgctxt "Title for the summarize message"
 msgid "Summarize"
 msgstr "സംഗ്രഹിക്കുക"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize the Q&As"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the background and notable work of this person."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the key details of this event."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the questions and answers on this page."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize their background"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this book"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this book."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this discussion"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this discussion thread."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this page"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this page."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this video"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this video."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize what the reviews say."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -18878,9 +19133,7 @@ msgstr "നിങ്ങളെ ട്രാക്ക് ചെയ്യാത്�
 msgctxt "AI Chat warning when switching from an encrypted model"
 msgid ""
 "Switching will send your chat to a model without zero provider visibility"
-msgstr ""
-"മാറുന്നത് നിങ്ങളുടെ ചാറ്റിനെ ദാതാവിന്റെ ദൃശ്യപരതയില്ലാത്ത ഒരു മോഡലിലേക്ക് "
-"അയയ്ക്കും"
+msgstr "മാറുന്നത് നിങ്ങളുടെ ചാറ്റിനെ ദാതാവിന്റെ ദൃശ്യപരതയില്ലാത്ത ഒരു മോഡലിലേക്ക് അയയ്ക്കും"
 
 # smartling.placeholder_format=C
 msgid "Switzerland"
@@ -18934,9 +19187,7 @@ msgstr "Sync & Backup പ്രവർത്തനക്ഷമമാക്കി!
 #. Notice shown under the recovery code explaining that backup data has an inactivity expiration.
 msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
-msgstr ""
-"Sync & Backup ഡാറ്റ 18 മാസത്തെ നിഷ്‌ക്രിയത്വത്തിന് ശേഷം വീണ്ടെടുക്കാൻ "
-"കഴിയില്ല."
+msgstr "Sync & Backup ഡാറ്റ 18 മാസത്തെ നിഷ്‌ക്രിയത്വത്തിന് ശേഷം വീണ്ടെടുക്കാൻ കഴിയില്ല."
 
 # smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
@@ -18985,27 +19236,25 @@ msgid ""
 msgstr ""
 "വീണ്ടെടുക്കൽ കോഡ് സമന്വയിപ്പിക്കുക\n"
 "\n"
-" ഒന്നിലധികം ഉപകരണങ്ങളിലുടനീളം നിങ്ങളുടെ പാസ്‌വേഡുകൾ സമന്വയിപ്പിക്കാനും, "
-"ഡാറ്റ ഓട്ടോഫിൽ ചെയ്യാനും, Duck.ai ചാറ്റുകൾ ഉപയോഗിക്കാനും, ഒരു "
-"ഉപകരണത്തിലേക്കുള്ള ആക്‌സസ് നഷ്‌ടപ്പെടുകയാണെങ്കിൽ നിങ്ങളുടെ സമന്വയിപ്പിച്ച "
-"ഡാറ്റ വീണ്ടെടുക്കാനും വീണ്ടെടുക്കൽ കോഡ് നിങ്ങളെ അനുവദിക്കുന്നു.\n"
+" ഒന്നിലധികം ഉപകരണങ്ങളിലുടനീളം നിങ്ങളുടെ പാസ്‌വേഡുകൾ സമന്വയിപ്പിക്കാനും, ഡാറ്റ ഓട്ടോഫിൽ "
+"ചെയ്യാനും, Duck.ai ചാറ്റുകൾ ഉപയോഗിക്കാനും, ഒരു ഉപകരണത്തിലേക്കുള്ള ആക്‌സസ് നഷ്‌ടപ്പെടുകയാണെങ്കിൽ "
+"നിങ്ങളുടെ സമന്വയിപ്പിച്ച ഡാറ്റ വീണ്ടെടുക്കാനും വീണ്ടെടുക്കൽ കോഡ് നിങ്ങളെ അനുവദിക്കുന്നു.\n"
 "\n"
 "ഈ വിവരങ്ങൾ സുരക്ഷിതമായി സൂക്ഷിക്കുക.\n"
-"ഈ കോഡിന് പ്രവേശനം ഉള്ള ആരും നിങ്ങളുടെ സമന്വയിപ്പിച്ച ഡാറ്റ ആക്‌സസ് ചെയ്യാൻ "
-"കഴിയും.\n"
+"ഈ കോഡിന് പ്രവേശനം ഉള്ള ആരും നിങ്ങളുടെ സമന്വയിപ്പിച്ച ഡാറ്റ ആക്‌സസ് ചെയ്യാൻ കഴിയും.\n"
 "\n"
 "%1$s\n"
 "\n"
 "ഈ കോഡ് എങ്ങനെയാണ് പ്രവർത്തിക്കുന്നത്?\n"
 "1. നിങ്ങളുടെ ബ്രൗസറിൽ Duck.ai-ലേക്ക് പോയി Duck.ai സെറ്റിംഗ്സ് തുറക്കുക.\n"
-"2. \"Sync & Backup\" തിരഞ്ഞെടുക്കുക, തുടർന്ന് \"സമന്വയിപ്പിച്ച ഡാറ്റ "
-"വീണ്ടെടുക്കുക\" തിരഞ്ഞെടുക്കുക.\n"
-"3. മുകളിലുള്ള വീണ്ടെടുക്കൽ കോഡ് പകർത്തി \"നിങ്ങളുടെ കോഡ് ഇവിടെ ഒട്ടിക്കുക\" "
-"എന്ന് പറയുന്നിടത്ത് ഒട്ടിക്കുക.\n"
+"2. \"Sync & Backup\" തിരഞ്ഞെടുക്കുക, തുടർന്ന് \"സമന്വയിപ്പിച്ച ഡാറ്റ വീണ്ടെടുക്കുക\" "
+"തിരഞ്ഞെടുക്കുക.\n"
+"3. മുകളിലുള്ള വീണ്ടെടുക്കൽ കോഡ് പകർത്തി \"നിങ്ങളുടെ കോഡ് ഇവിടെ ഒട്ടിക്കുക\" എന്ന് പറയുന്നിടത്ത് "
+"ഒട്ടിക്കുക.\n"
 "\n"
-"Sync & Backup പ്രവർത്തനക്ഷമമാക്കിയ ഒരു DuckDuckGo ബ്രൗസർ ഉപയോഗിക്കാതെ നിങ്ങൾ "
-"18 മാസത്തിൽ കൂടുതൽ ചെലവഴിച്ചാൽ, നിങ്ങളുടെ ഡാറ്റ സെർവറിൽ നിന്ന് "
-"ഇല്ലാതാക്കപ്പെടും, അത് പുനഃസ്ഥാപിക്കാൻ കഴിയില്ല."
+"Sync & Backup പ്രവർത്തനക്ഷമമാക്കിയ ഒരു DuckDuckGo ബ്രൗസർ ഉപയോഗിക്കാതെ നിങ്ങൾ 18 "
+"മാസത്തിൽ കൂടുതൽ ചെലവഴിച്ചാൽ, നിങ്ങളുടെ ഡാറ്റ സെർവറിൽ നിന്ന് ഇല്ലാതാക്കപ്പെടും, അത് "
+"പുനഃസ്ഥാപിക്കാൻ കഴിയില്ല."
 
 # smartling.placeholder_format=C
 #. Secondary button label on the Sync & Backup intro screen that takes the user to the camera scan screen to pair with another device.
@@ -19048,6 +19297,12 @@ msgid "Syria"
 msgstr "സിറിയ"
 
 # smartling.placeholder_format=C
+#. Text for a button that enables the theme to follow the operating system's color scheme preference.
+msgctxt "System theme button for theme selector"
+msgid "System"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Abbreviation indicating this is the total score for a game
 msgctxt "Sports module"
 msgid "T"
@@ -19074,6 +19329,12 @@ msgstr "ടിവി"
 msgctxt "language_name"
 msgid "Tahitian"
 msgstr "തഹിതിയൻ"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Tailor my resume"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Taiwan"
@@ -19103,6 +19364,13 @@ msgstr "നിങ്ങളുടെ സ്വകാര്യ ഡാറ്റയ�
 msgctxt "homepage ATB modal"
 msgid "Take control of your personal data!"
 msgstr "നിങ്ങളുടെ സ്വകാര്യ ഡാറ്റയുടെ നിയന്ത്രണം ഏറ്റെടുക്കുക!"
+
+# smartling.placeholder_format=C
+#. Description for the Feedback section of the Duck.ai settings page, asking the user to take an anonymous survey to let us know how we can make Duck.ai better.
+msgctxt "Feedback section description on the Duck.ai settings page"
+msgid ""
+"Take this anonymous survey to let us know how we can make Duck.ai better."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -19317,10 +19585,9 @@ msgid ""
 "link is at increased risk of being intercepted by a third party. In rare "
 "cases this includes passwords, or payment details."
 msgstr ""
-"നിങ്ങളുടെ ഉപകരണത്തിനും ഈ ലിങ്കിന് പിന്നിലെ വെബ്‌പോജിനുമിടയിൽ അയച്ച വിവരങ്ങൾ "
-"ഒരു മൂന്നാം കക്ഷി തടസ്സപ്പെടുത്താനുള്ള സാധ്യത കൂടുതലാണ് എന്നാണ് ഇതിനർഥം. "
-"അപൂർവ സന്ദർഭങ്ങളിൽ ഇതിൽ പാസ്‍വേഡുകൾ അല്ലെങ്കിൽ പേയ്മെന്റ് വിശദാംശങ്ങൾ "
-"ഉൾപ്പെടുന്നു."
+"നിങ്ങളുടെ ഉപകരണത്തിനും ഈ ലിങ്കിന് പിന്നിലെ വെബ്‌പോജിനുമിടയിൽ അയച്ച വിവരങ്ങൾ ഒരു മൂന്നാം "
+"കക്ഷി തടസ്സപ്പെടുത്താനുള്ള സാധ്യത കൂടുതലാണ് എന്നാണ് ഇതിനർഥം. അപൂർവ സന്ദർഭങ്ങളിൽ ഇതിൽ "
+"പാസ്‍വേഡുകൾ അല്ലെങ്കിൽ പേയ്മെന്റ് വിശദാംശങ്ങൾ ഉൾപ്പെടുന്നു."
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -19329,8 +19596,8 @@ msgid ""
 "The Cloud Save bookmarklet allows any changes you make to your settings to "
 "automatically save in the cloud."
 msgstr ""
-"നിങ്ങളുടെ ക്രമീകരണത്തിൽ വരുത്തുന്ന ഏത് മാറ്റങ്ങളും ക്ലൗഡിൽ സ്വയമേവ "
-"സംരക്ഷിക്കാൻ Cloud Save ബുക്ക്‌മാർക്ക്‌ലെറ്റ് അനുവദിക്കുന്നു."
+"നിങ്ങളുടെ ക്രമീകരണത്തിൽ വരുത്തുന്ന ഏത് മാറ്റങ്ങളും ക്ലൗഡിൽ സ്വയമേവ സംരക്ഷിക്കാൻ Cloud Save "
+"ബുക്ക്‌മാർക്ക്‌ലെറ്റ് അനുവദിക്കുന്നു."
 
 # smartling.placeholder_format=C
 msgid "The Gambia"
@@ -19360,17 +19627,15 @@ msgid ""
 "The encryption key is only saved in your browser's local storage, and only "
 "you can access it."
 msgstr ""
-"എൻക്രിപ്ഷൻ കീ നിങ്ങളുടെ ബ്രൗസറിന്റെ ലോക്കൽ സ്റ്റോറേജിൽ മാത്രമേ "
-"സംരക്ഷിക്കപ്പെടുകയുള്ളൂ, കൂടാതെ നിങ്ങൾക്ക് മാത്രമേ അത് ആക്‌സസ് ചെയ്യാൻ കഴിയൂ."
+"എൻക്രിപ്ഷൻ കീ നിങ്ങളുടെ ബ്രൗസറിന്റെ ലോക്കൽ സ്റ്റോറേജിൽ മാത്രമേ സംരക്ഷിക്കപ്പെടുകയുള്ളൂ, കൂടാതെ "
+"നിങ്ങൾക്ക് മാത്രമേ അത് ആക്‌സസ് ചെയ്യാൻ കഴിയൂ."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider deletes all chat data within 30 days.
 msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider deletes any data associated with this chat within 30 days."
-msgstr ""
-"ഈ ചാറ്റുമായി ബന്ധപ്പെട്ട ഏതൊരു ഡാറ്റയും 30 ദിവസത്തിനുള്ളിൽ മോഡൽ ദാതാവ് "
-"ഇല്ലാതാക്കും."
+msgstr "ഈ ചാറ്റുമായി ബന്ധപ്പെട്ട ഏതൊരു ഡാറ്റയും 30 ദിവസത്തിനുള്ളിൽ മോഡൽ ദാതാവ് ഇല്ലാതാക്കും."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers.
@@ -19409,6 +19674,12 @@ msgid "Theme"
 msgstr "തീം"
 
 # smartling.placeholder_format=C
+#. Text for the theme selector label that allows users to switch between Light and dark theme.
+msgctxt "Label for the theme selector feature"
+msgid "Theme"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. http://i.imgur.com/LpFhb1e.png
 msgctxt "settings"
 msgid "Theme"
@@ -19437,9 +19708,9 @@ msgid ""
 "There was an error saving this chat locally. Please check your browser "
 "settings to make sure local data storage is enabled."
 msgstr ""
-"ഈ ചാറ്റ് പ്രാദേശികമായി സേവ് ചെയ്യുന്നതിൽ ഒരു പിശക് സംഭവിച്ചു. പ്രാദേശിക "
-"ഡാറ്റ സംഭരണം പ്രവർത്തനക്ഷമമാക്കിയിട്ടുണ്ടെന്ന് ഉറപ്പുവരുത്താൻ ദയവായി "
-"നിങ്ങളുടെ ബ്രൗസർ ക്രമീകരണങ്ങൾ പരിശോധിക്കുക."
+"ഈ ചാറ്റ് പ്രാദേശികമായി സേവ് ചെയ്യുന്നതിൽ ഒരു പിശക് സംഭവിച്ചു. പ്രാദേശിക ഡാറ്റ സംഭരണം "
+"പ്രവർത്തനക്ഷമമാക്കിയിട്ടുണ്ടെന്ന് ഉറപ്പുവരുത്താൻ ദയവായി നിങ്ങളുടെ ബ്രൗസർ ക്രമീകരണങ്ങൾ "
+"പരിശോധിക്കുക."
 
 # smartling.placeholder_format=C
 #. Error modal body line 1.
@@ -19454,8 +19725,8 @@ msgid ""
 "There was still an error displaying the search results. Please wait a few "
 "minutes before you try again."
 msgstr ""
-"തിരയൽ ഫലങ്ങൾ പ്രദർശിപ്പിക്കുന്നതിൽ ഇപ്പോഴും ഒരു പിശകുണ്ടായിരുന്നു. നിങ്ങൾ "
-"വീണ്ടും ശ്രമിക്കുന്നതിന് മുമ്പ് ഏതാനും മിനിറ്റ് കാത്തിരിക്കൂ."
+"തിരയൽ ഫലങ്ങൾ പ്രദർശിപ്പിക്കുന്നതിൽ ഇപ്പോഴും ഒരു പിശകുണ്ടായിരുന്നു. നിങ്ങൾ വീണ്ടും ശ്രമിക്കുന്നതിന് "
+"മുമ്പ് ഏതാനും മിനിറ്റ് കാത്തിരിക്കൂ."
 
 # smartling.placeholder_format=C
 #. Error message for explore more questions when a retryable error occurs (timeout, network)
@@ -19474,10 +19745,10 @@ msgid ""
 "visit by blocking hidden trackers, encrypting connections where possible, "
 "and by making DuckDuckGo your default search engine."
 msgstr ""
-"മറഞ്ഞിരിക്കുന്ന ട്രാക്കറുകൾ തടയുന്നതിലൂടെയും സാധ്യമാകുന്നിടത്ത് കണക്ഷനുകൾ "
-"എൻക്രിപ്റ്റ് ചെയ്യുന്നതിലൂടെയും DuckDuckGo-യെ നിങ്ങളുടെ ഡിഫോൾട്ട് തിരയൽ "
-"എഞ്ചിനാക്കി മാറ്റുന്നതിലൂടെയും നിങ്ങൾ സന്ദർശിക്കുന്ന വെബ്‌സൈറ്റുകളിൽ "
-"സ്വകാര്യതാ പരിരക്ഷണം ചേർക്കാൻ ഈ ബ്രൗസർ അനുമതികൾ ഉപയോഗിക്കുന്നു."
+"മറഞ്ഞിരിക്കുന്ന ട്രാക്കറുകൾ തടയുന്നതിലൂടെയും സാധ്യമാകുന്നിടത്ത് കണക്ഷനുകൾ എൻക്രിപ്റ്റ് "
+"ചെയ്യുന്നതിലൂടെയും DuckDuckGo-യെ നിങ്ങളുടെ ഡിഫോൾട്ട് തിരയൽ എഞ്ചിനാക്കി മാറ്റുന്നതിലൂടെയും "
+"നിങ്ങൾ സന്ദർശിക്കുന്ന വെബ്‌സൈറ്റുകളിൽ സ്വകാര്യതാ പരിരക്ഷണം ചേർക്കാൻ ഈ ബ്രൗസർ അനുമതികൾ "
+"ഉപയോഗിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Secondary line under DUCKCHAT_SYNC_PAIRING_ALREADY_SYNCED_TITLE.
@@ -19523,8 +19794,8 @@ msgid ""
 "This AI model version is no longer supported. Try starting a new chat with "
 "the latest version of this model."
 msgstr ""
-"ഈ AI മോഡൽ പതിപ്പിനെ ഇനി പിന്തുണയ്ക്കുന്നില്ല. ഈ മോഡലിന്റെ ഏറ്റവും പുതിയ "
-"പതിപ്പിൽ ഒരു പുതിയ ചാറ്റ് ആരംഭിക്കാൻ ശ്രമിക്കൂ."
+"ഈ AI മോഡൽ പതിപ്പിനെ ഇനി പിന്തുണയ്ക്കുന്നില്ല. ഈ മോഡലിന്റെ ഏറ്റവും പുതിയ പതിപ്പിൽ ഒരു പുതിയ "
+"ചാറ്റ് ആരംഭിക്കാൻ ശ്രമിക്കൂ."
 
 # smartling.placeholder_format=C
 #. Appears below a type of search results called 'Instant Answers'
@@ -19551,9 +19822,9 @@ msgid ""
 "This conversation was generated with Duck.ai (%s) using %s's %s Model. AI "
 "chats may display inaccurate or offensive information (see %s for more info)."
 msgstr ""
-"%2$s-ന്റെ %3$s മോഡൽ ഉപയോഗിച്ച് Duck.ai (%1$s) വഴിയാണ് ഈ സംഭാഷണം സൃഷ്ടിച്ചത്. "
-"AI ചാറ്റുകൾ കൃത്യമല്ലാത്തതോ കുറ്റകരമായതോ ആയ വിവരങ്ങൾ പ്രദർശിപ്പിച്ചേക്കാം "
-"(കൂടുതൽ വിവരങ്ങൾക്ക് %4$s കാണുക)."
+"%2$s-ന്റെ %3$s മോഡൽ ഉപയോഗിച്ച് Duck.ai (%1$s) വഴിയാണ് ഈ സംഭാഷണം സൃഷ്ടിച്ചത്. AI "
+"ചാറ്റുകൾ കൃത്യമല്ലാത്തതോ കുറ്റകരമായതോ ആയ വിവരങ്ങൾ പ്രദർശിപ്പിച്ചേക്കാം (കൂടുതൽ വിവരങ്ങൾക്ക് "
+"%4$s കാണുക)."
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with multiple AI models in the same chat, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using multiple chat models. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -19563,9 +19834,9 @@ msgid ""
 "models. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
 msgstr ""
-"ഒന്നിലധികം ചാറ്റ് മോഡലുകൾ ഉപയോഗിച്ച് Duck.ai (%1$s) ഉപയോഗിച്ചാണ് ഈ സംഭാഷണം "
-"സൃഷ്ടിച്ചത്. AI ചാറ്റുകൾ കൃത്യമല്ലാത്തതോ കുറ്റകരമായതോ ആയ വിവരങ്ങൾ "
-"പ്രദർശിപ്പിച്ചേക്കാം (കൂടുതൽ വിവരങ്ങൾക്ക് %2$s കാണുക)."
+"ഒന്നിലധികം ചാറ്റ് മോഡലുകൾ ഉപയോഗിച്ച് Duck.ai (%1$s) ഉപയോഗിച്ചാണ് ഈ സംഭാഷണം സൃഷ്ടിച്ചത്. "
+"AI ചാറ്റുകൾ കൃത്യമല്ലാത്തതോ കുറ്റകരമായതോ ആയ വിവരങ്ങൾ പ്രദർശിപ്പിച്ചേക്കാം (കൂടുതൽ വിവരങ്ങൾക്ക് "
+"%2$s കാണുക)."
 
 # smartling.placeholder_format=C
 #. When a user exports a transcript of a voice chat they had with the AI. This text goes at the very top of the downloaded file as a header. Placeholders are for links. Example: 'This conversation was generated with Duck.ai voice chat (https://duck.ai). AI may provide inaccurate or offensive information. (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -19574,9 +19845,8 @@ msgid ""
 "This conversation was generated with Duck.ai voice chat (%s). AI may provide "
 "inaccurate or offensive information. (see %s for more info)."
 msgstr ""
-"Duck.ai വോയ്സ് ചാറ്റ് (%1$s) ഉപയോഗിച്ചാണ് ഈ സംഭാഷണം സൃഷ്ടിച്ചത്. AI "
-"കൃത്യതയില്ലാത്തതോ കുറ്റകരമോ ആയ വിവരങ്ങൾ നൽകിയേക്കാം. (കൂടുതൽ വിവരങ്ങൾക്ക് "
-"%2$s കാണുക)."
+"Duck.ai വോയ്സ് ചാറ്റ് (%1$s) ഉപയോഗിച്ചാണ് ഈ സംഭാഷണം സൃഷ്ടിച്ചത്. AI കൃത്യതയില്ലാത്തതോ "
+"കുറ്റകരമോ ആയ വിവരങ്ങൾ നൽകിയേക്കാം. (കൂടുതൽ വിവരങ്ങൾക്ക് %2$s കാണുക)."
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with DuckDuckGo AI Chat (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/aichat/privacy-terms for more info).'
@@ -19586,9 +19856,9 @@ msgid ""
 "Model. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
 msgstr ""
-"%2$s-ന്റെ %3$s മോഡൽ ഉപയോഗിച്ച് DuckDuckGo AI Chat (%1$s) ഉപയോഗിച്ചാണ് ഈ "
-"സംഭാഷണം സൃഷ്ടിച്ചത്. AI ചാറ്റുകൾ കൃത്യമല്ലാത്തതോ കുറ്റകരമായതോ ആയ വിവരങ്ങൾ "
-"പ്രദർശിപ്പിച്ചേക്കാം (കൂടുതൽ വിവരങ്ങൾക്ക് %4$s കാണുക)."
+"%2$s-ന്റെ %3$s മോഡൽ ഉപയോഗിച്ച് DuckDuckGo AI Chat (%1$s) ഉപയോഗിച്ചാണ് ഈ സംഭാഷണം "
+"സൃഷ്ടിച്ചത്. AI ചാറ്റുകൾ കൃത്യമല്ലാത്തതോ കുറ്റകരമായതോ ആയ വിവരങ്ങൾ പ്രദർശിപ്പിച്ചേക്കാം (കൂടുതൽ "
+"വിവരങ്ങൾക്ക് %4$s കാണുക)."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
@@ -19620,9 +19890,7 @@ msgctxt ""
 "Error message when an uploaded file type is not supported, with list ending "
 "in or"
 msgid "This file type is not supported, please attach a %s or %s"
-msgstr ""
-"ഈ ഫയൽ തരത്തെ പിന്തുണയ്ക്കുന്നില്ല, ദയവായി ഒരു %1$s അല്ലെങ്കിൽ %2$s "
-"അറ്റാച്ചുചെയ്യുക"
+msgstr "ഈ ഫയൽ തരത്തെ പിന്തുണയ്ക്കുന്നില്ല, ദയവായി ഒരു %1$s അല്ലെങ്കിൽ %2$s അറ്റാച്ചുചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. Error message for unsupported file type when multiple types are accepted. First placeholder is a comma-separated list of all accepted types except the last (e.g. PNG, JPG, WebP, GIF). Second placeholder is the last accepted type (e.g. PDF). Full example: This file type is not supported, please attach a PNG, JPG, WebP, GIF or PDF
@@ -19630,9 +19898,7 @@ msgctxt ""
 "Error message when an uploaded file type is not supported, with list ending "
 "in or"
 msgid "This file type is not supported, please attach a %s or %s."
-msgstr ""
-"ഈ ഫയൽ തരത്തെ പിന്തുണയ്ക്കുന്നില്ല, ദയവായി ഒരു %1$s അല്ലെങ്കിൽ %2$s അറ്റാച്ച് "
-"ചെയ്യുക."
+msgstr "ഈ ഫയൽ തരത്തെ പിന്തുണയ്ക്കുന്നില്ല, ദയവായി ഒരു %1$s അല്ലെങ്കിൽ %2$s അറ്റാച്ച് ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to upload an unsupported file type and we know which types are accepted. Placeholder is a single accepted type. E.g. This file type is not supported, please attach a PDF
@@ -19664,8 +19930,7 @@ msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF"
 msgstr ""
-"ഈ ഇമേജ് തരം പിന്തുണയ്ക്കുന്നില്ല, ദയവായി ഒരു JPG, PNG, WebP, അല്ലെങ്കിൽ GIF "
-"ചേർക്കുക"
+"ഈ ഇമേജ് തരം പിന്തുണയ്ക്കുന്നില്ല, ദയവായി ഒരു JPG, PNG, WebP, അല്ലെങ്കിൽ GIF ചേർക്കുക"
 
 # smartling.placeholder_format=C
 #. Error message displayed when a file that the user tried to upload is not of a supported format
@@ -19673,8 +19938,7 @@ msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF."
 msgstr ""
-"ഈ ഇമേജ് തരത്തെ പിന്തുണയ്ക്കുന്നില്ല, ദയവായി JPG, PNG, WebP, അല്ലെങ്കിൽ GIF "
-"ചേർക്കുക."
+"ഈ ഇമേജ് തരത്തെ പിന്തുണയ്ക്കുന്നില്ല, ദയവായി JPG, PNG, WebP, അല്ലെങ്കിൽ GIF ചേർക്കുക."
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
@@ -19700,8 +19964,8 @@ msgid ""
 "This model provider deletes data associated with this chat within 30 days. "
 "Other model providers follow a zero data retention model."
 msgstr ""
-"ഈ മോഡൽ ദാതാവ് ഈ ചാറ്റുമായി ബന്ധപ്പെട്ട ഡാറ്റ 30 ദിവസത്തിനുള്ളിൽ "
-"ഇല്ലാതാക്കും. മറ്റ് മോഡൽ ദാതാക്കൾ പൂജ്യം ഡാറ്റ നിലനിർത്തൽ മോഡൽ പിന്തുടരുന്നു."
+"ഈ മോഡൽ ദാതാവ് ഈ ചാറ്റുമായി ബന്ധപ്പെട്ട ഡാറ്റ 30 ദിവസത്തിനുള്ളിൽ ഇല്ലാതാക്കും. മറ്റ് മോഡൽ "
+"ദാതാക്കൾ പൂജ്യം ഡാറ്റ നിലനിർത്തൽ മോഡൽ പിന്തുടരുന്നു."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers, and that other providers may retain chat data for a limited time instead.
@@ -19710,8 +19974,8 @@ msgid ""
 "This model provider does not store any data associated with this chat. Other "
 "model providers follow a limited data retention model."
 msgstr ""
-"ഈ മോഡൽ ദാതാവ് ഈ ചാറ്റുമായി ബന്ധപ്പെട്ട ഒരു ഡാറ്റയും സംഭരിക്കുന്നില്ല. മറ്റ് "
-"മോഡൽ ദാതാക്കൾ ഒരു പരിമിത ഡാറ്റ നിലനിർത്തൽ മാതൃക പിന്തുടരുന്നു."
+"ഈ മോഡൽ ദാതാവ് ഈ ചാറ്റുമായി ബന്ധപ്പെട്ട ഒരു ഡാറ്റയും സംഭരിക്കുന്നില്ല. മറ്റ് മോഡൽ ദാതാക്കൾ ഒരു "
+"പരിമിത ഡാറ്റ നിലനിർത്തൽ മാതൃക പിന്തുടരുന്നു."
 
 # smartling.placeholder_format=C
 #. Info that page may refresh during update.
@@ -19748,9 +20012,8 @@ msgid ""
 "This saves your chats with end-to-end encryption on DuckDuckGo's secure "
 "server, which later can be accessed from any browser."
 msgstr ""
-"ഇത് നിങ്ങളുടെ ചാറ്റുകൾ DuckDuckGo-യുടെ സുരക്ഷിത സെർവറിൽ എൻഡ്-ടു-എൻഡ് "
-"എൻക്രിപ്ഷൻ ഉപയോഗിച്ച് സംരക്ഷിക്കുന്നു, പിന്നീട് ഏത് ബ്രൗസറിൽ നിന്നും ഇത് "
-"ആക്‌സസ് ചെയ്യാൻ കഴിയും."
+"ഇത് നിങ്ങളുടെ ചാറ്റുകൾ DuckDuckGo-യുടെ സുരക്ഷിത സെർവറിൽ എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷൻ ഉപയോഗിച്ച് "
+"സംരക്ഷിക്കുന്നു, പിന്നീട് ഏത് ബ്രൗസറിൽ നിന്നും ഇത് ആക്‌സസ് ചെയ്യാൻ കഴിയും."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -19759,9 +20022,8 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again."
 msgstr ""
-"ഈ ക്രമീകരണം നിങ്ങളുടെ ബ്രൗസറിൽ സൂക്ഷിച്ചിരിക്കുന്നു, അതായത് നിങ്ങൾ "
-"duckduckgo.com ബ്രൗസർ ഡാറ്റ മായ്ക്കുകയാണെങ്കിൽ, നിങ്ങൾക്ക് AI സഹായമുള്ള "
-"ഉത്തരങ്ങൾ വീണ്ടും കാണാൻ കഴിയുമെന്നർത്ഥം."
+"ഈ ക്രമീകരണം നിങ്ങളുടെ ബ്രൗസറിൽ സൂക്ഷിച്ചിരിക്കുന്നു, അതായത് നിങ്ങൾ duckduckgo.com ബ്രൗസർ "
+"ഡാറ്റ മായ്ക്കുകയാണെങ്കിൽ, നിങ്ങൾക്ക് AI സഹായമുള്ള ഉത്തരങ്ങൾ വീണ്ടും കാണാൻ കഴിയുമെന്നർത്ഥം."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -19771,10 +20033,10 @@ msgid ""
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
 msgstr ""
-"ഈ ക്രമീകരണം നിങ്ങളുടെ ബ്രൗസറിൽ സൂക്ഷിച്ചിരിക്കുന്നു, അതായത് നിങ്ങൾ "
-"duckduckgo.com ബ്രൗസർ ഡാറ്റ മായ്ക്കുകയാണെങ്കിൽ, നിങ്ങൾക്ക് AI സഹായമുള്ള "
-"ഉത്തരങ്ങൾ വീണ്ടും കാണാൻ കഴിയുമെന്നർത്ഥം. എന്നിരുന്നാലും, %1$s-ൽ AI "
-"സഹായത്തോടെ ഉത്തരങ്ങൾ ഒരിക്കലും കാണിക്കാത്ത ഒരു ആരംഭ പേജും ഞങ്ങൾക്ക് ഉണ്ട്."
+"ഈ ക്രമീകരണം നിങ്ങളുടെ ബ്രൗസറിൽ സൂക്ഷിച്ചിരിക്കുന്നു, അതായത് നിങ്ങൾ duckduckgo.com ബ്രൗസർ "
+"ഡാറ്റ മായ്ക്കുകയാണെങ്കിൽ, നിങ്ങൾക്ക് AI സഹായമുള്ള ഉത്തരങ്ങൾ വീണ്ടും കാണാൻ കഴിയുമെന്നർത്ഥം. "
+"എന്നിരുന്നാലും, %1$s-ൽ AI സഹായത്തോടെ ഉത്തരങ്ങൾ ഒരിക്കലും കാണിക്കാത്ത ഒരു ആരംഭ പേജും "
+"ഞങ്ങൾക്ക് ഉണ്ട്."
 
 # smartling.placeholder_format=C
 #. User feedback indicating that a translation is helpful
@@ -19803,9 +20065,7 @@ msgstr "ഈ വീഡിയോ ഇതുവരെ ഇവിടെ കാണാ�
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr ""
-"ഈ വെബ്‌പേജ് സുരക്ഷിതവും എൻക്രിപ്റ്റ് ചെയ്തതുമായ കണക്ഷൻ (HTTPS) "
-"ഉപയോഗിക്കുന്നില്ല."
+msgstr "ഈ വെബ്‌പേജ് സുരക്ഷിതവും എൻക്രിപ്റ്റ് ചെയ്തതുമായ കണക്ഷൻ (HTTPS) ഉപയോഗിക്കുന്നില്ല."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -19815,10 +20075,9 @@ msgid ""
 "Sync & Backup. You'll still be able to access your chats in other browsers "
 "connected to Sync & Backup."
 msgstr ""
-"ഇത് ഈ ബ്രൗസറിൽ നിന്ന് നിങ്ങളുടെ എല്ലാ Duck.ai ചാറ്റുകളും ഇല്ലാതാക്കുകയും "
-"Sync & Backup വിച്ഛേദിക്കുകയും ചെയ്യും. Sync & Backup-ലേക്ക് കണക്റ്റ് "
-"ചെയ്തിരിക്കുന്ന മറ്റ് ബ്രൗസറുകളിൽ നിങ്ങൾക്ക് തുടർന്നും ചാറ്റുകൾ ആക്സസ് "
-"ചെയ്യാൻ കഴിയും."
+"ഇത് ഈ ബ്രൗസറിൽ നിന്ന് നിങ്ങളുടെ എല്ലാ Duck.ai ചാറ്റുകളും ഇല്ലാതാക്കുകയും Sync & Backup "
+"വിച്ഛേദിക്കുകയും ചെയ്യും. Sync & Backup-ലേക്ക് കണക്റ്റ് ചെയ്തിരിക്കുന്ന മറ്റ് ബ്രൗസറുകളിൽ "
+"നിങ്ങൾക്ക് തുടർന്നും ചാറ്റുകൾ ആക്സസ് ചെയ്യാൻ കഴിയും."
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to clear all recentchats, with a warning that this action cannot be undone.
@@ -19827,8 +20086,8 @@ msgid ""
 "This will delete all your recent chats, unless they're pinned. This cannot "
 "be undone."
 msgstr ""
-"നിങ്ങളുടെ സമീപകാല ചാറ്റുകളെല്ലാം പിൻ ചെയ്തിട്ടില്ലെങ്കിൽ ഇത് ഇല്ലാതാക്കും. "
-"ഇത് പഴയപടിയാക്കാനാവില്ല."
+"നിങ്ങളുടെ സമീപകാല ചാറ്റുകളെല്ലാം പിൻ ചെയ്തിട്ടില്ലെങ്കിൽ ഇത് ഇല്ലാതാക്കും. ഇത് "
+"പഴയപടിയാക്കാനാവില്ല."
 
 # smartling.placeholder_format=C
 #. Message explaining what will happen when the user deletes an image.
@@ -19847,8 +20106,7 @@ msgstr "ഇത് എല്ലാ ക്രമീകരണവും മായ്
 msgctxt "settings"
 msgid "This will reset your saved settings to default values. Continue?"
 msgstr ""
-"ഇത് നിങ്ങളുടെ സംരക്ഷിച്ച ക്രമീകരണം ഡിഫോൾട്ട് മൂല്യങ്ങളിലേക്ക് "
-"പുനഃക്രമീകരിക്കും. തുടരണോ?"
+"ഇത് നിങ്ങളുടെ സംരക്ഷിച്ച ക്രമീകരണം ഡിഫോൾട്ട് മൂല്യങ്ങളിലേക്ക് പുനഃക്രമീകരിക്കും. തുടരണോ?"
 
 # smartling.placeholder_format=C
 #. Golf leaderboard column: holes completed in current round
@@ -19945,9 +20203,7 @@ msgstr "ശീർഷക അടിവര"
 # smartling.placeholder_format=C
 #. Informative header on a list of steps for the user to take to disable their adblocker
 msgid "To allowlist DuckDuckGo in other ad blocker extensions:"
-msgstr ""
-"മറ്റ് പരസ്യ ബ്ലോക്കർ എക്സ്റ്ൻഷനുകളിൽ DuckDuckGo-യെ അനുവദിക്കുന്ന ലിസ്റ്ൽ "
-"ചേർക്കാൻ:"
+msgstr "മറ്റ് പരസ്യ ബ്ലോക്കർ എക്സ്റ്ൻഷനുകളിൽ DuckDuckGo-യെ അനുവദിക്കുന്ന ലിസ്റ്ൽ ചേർക്കാൻ:"
 
 # smartling.placeholder_format=C
 #. Text stating agreement to Duck.ai Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'To continue, you must agree to Duck.ai’s Privacy Policy and Terms of Service'
@@ -19970,8 +20226,8 @@ msgid ""
 "To print directions:%sGo back to the map.%sSelect the route you want to "
 "print.%sClick the print icon.%s"
 msgstr ""
-"ദിശകൾ പ്രിന്റ് ചെയ്യാൻ:%1$sമാപ്പിലേക്ക് മടങ്ങുക.%2$sനിങ്ങൾക്ക് പ്രിന്റ് "
-"ചെയ്യേണ്ട റൂട്ട് തിരഞ്ഞെടുക്കുക.%3$sപ്രിന്റ് ഐക്കണിൽ ക്ലിക്ക് ചെയ്യുക.%4$s"
+"ദിശകൾ പ്രിന്റ് ചെയ്യാൻ:%1$sമാപ്പിലേക്ക് മടങ്ങുക.%2$sനിങ്ങൾക്ക് പ്രിന്റ് ചെയ്യേണ്ട റൂട്ട് "
+"തിരഞ്ഞെടുക്കുക.%3$sപ്രിന്റ് ഐക്കണിൽ ക്ലിക്ക് ചെയ്യുക.%4$s"
 
 # smartling.placeholder_format=C
 #. Explains where the user can find their recovery code. Figma frame 3703-44420.
@@ -19981,10 +20237,9 @@ msgid ""
 "you first set up Sync. This code may have been saved as a PDF on the device "
 "you originally used to set up Sync."
 msgstr ""
-"നിങ്ങളുടെ സമന്വയിപ്പിച്ച ഡാറ്റ പുനഃസ്ഥാപിക്കാൻ, നിങ്ങൾ ആദ്യമായി സമന്വയം "
-"സജ്ജമാക്കുമ്പോൾ സംരക്ഷിച്ച വീണ്ടെടുക്കൽ കോഡ് ആവശ്യമാണ്. നിങ്ങൾ സമന്വയം "
-"സജ്ജമാക്കാൻ ആദ്യം ഉപയോഗിച്ച ഉപകരണത്തിൽ ഈ കോഡ് ഒരു PDF ആയി സേവ് "
-"ചെയ്‌തിരിക്കാം."
+"നിങ്ങളുടെ സമന്വയിപ്പിച്ച ഡാറ്റ പുനഃസ്ഥാപിക്കാൻ, നിങ്ങൾ ആദ്യമായി സമന്വയം സജ്ജമാക്കുമ്പോൾ "
+"സംരക്ഷിച്ച വീണ്ടെടുക്കൽ കോഡ് ആവശ്യമാണ്. നിങ്ങൾ സമന്വയം സജ്ജമാക്കാൻ ആദ്യം ഉപയോഗിച്ച "
+"ഉപകരണത്തിൽ ഈ കോഡ് ഒരു PDF ആയി സേവ് ചെയ്‌തിരിക്കാം."
 
 # smartling.placeholder_format=C
 #. Body text explaining that the user needs to update their DDG browser before migration can proceed.
@@ -19993,8 +20248,8 @@ msgid ""
 "To transfer your chat history to Duck.ai, please update your DuckDuckGo "
 "browser to the latest version and try again."
 msgstr ""
-"നിങ്ങളുടെ ചാറ്റ് ചരിത്രം Duck.ai-ലേക്ക് മാറ്റാൻ, DuckDuckGo ബ്രൗസർ ഏറ്റവും "
-"പുതിയ പതിപ്പിലേക്ക് അപ്ഡേറ്റ് ചെയ്ത് വീണ്ടും ശ്രമിക്കുക."
+"നിങ്ങളുടെ ചാറ്റ് ചരിത്രം Duck.ai-ലേക്ക് മാറ്റാൻ, DuckDuckGo ബ്രൗസർ ഏറ്റവും പുതിയ "
+"പതിപ്പിലേക്ക് അപ്ഡേറ്റ് ചെയ്ത് വീണ്ടും ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
@@ -20002,8 +20257,8 @@ msgid ""
 "To use dictation, allow your browser to access the microphone in your system "
 "settings."
 msgstr ""
-"ഡിക്ടേഷൻ ഉപയോഗിക്കാൻ, നിങ്ങളുടെ ബ്രൗസറിനെ സിസ്റ്റം ക്രമീകരണത്തിൽ മൈക്രോഫോൺ "
-"ആക്‌സസ് ചെയ്യാൻ അനുവദിക്കുക."
+"ഡിക്ടേഷൻ ഉപയോഗിക്കാൻ, നിങ്ങളുടെ ബ്രൗസറിനെ സിസ്റ്റം ക്രമീകരണത്തിൽ മൈക്രോഫോൺ ആക്‌സസ് ചെയ്യാൻ "
+"അനുവദിക്കുക."
 
 # smartling.placeholder_format=C
 msgid "Today"
@@ -20193,8 +20448,8 @@ msgid ""
 "Tracking attempts blocked by DuckDuckGo appear here. Keep browsing to see "
 "how many we block."
 msgstr ""
-"DuckDuckGo തടഞ്ഞ ട്രാക്കിംഗ് ശ്രമങ്ങൾ ഇവിടെ ദൃശ്യമാകും. ഞങ്ങൾ എത്രയെണ്ണം "
-"ബ്ലോക്ക് ചെയ്യുന്നു എന്നറിയാൻ ബ്രൗസ് ചെയ്യുന്നത് തുടരുക."
+"DuckDuckGo തടഞ്ഞ ട്രാക്കിംഗ് ശ്രമങ്ങൾ ഇവിടെ ദൃശ്യമാകും. ഞങ്ങൾ എത്രയെണ്ണം ബ്ലോക്ക് ചെയ്യുന്നു "
+"എന്നറിയാൻ ബ്രൗസ് ചെയ്യുന്നത് തുടരുക."
 
 # smartling.placeholder_format=C
 #. Placeholder for when we cannot report any blocked trackers yet
@@ -20242,8 +20497,8 @@ msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
 msgstr ""
-"ഈ വാചകം ഫ്രഞ്ചിലേക്ക് വിവർത്തനം ചെയ്യുക: “അടുത്തുള്ള സിനിമാ തിയേറ്ററിലേക്ക് "
-"ഞാൻ എങ്ങനെ എത്തും?”"
+"ഈ വാചകം ഫ്രഞ്ചിലേക്ക് വിവർത്തനം ചെയ്യുക: “അടുത്തുള്ള സിനിമാ തിയേറ്ററിലേക്ക് ഞാൻ എങ്ങനെ "
+"എത്തും?”"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for translating a sentence into another language. Translate the whole sentence and please use target language instead of 'English' and modify the sentence to translate into 'English' instead of 'French'. Example: 'Translate this {target language} sentence into English: “How do I get to the nearest movie theatre?”'
@@ -20252,8 +20507,20 @@ msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
 msgstr ""
-"ഈ വാചകം ഫ്രഞ്ചിലേക്ക് വിവർത്തനം ചെയ്യുക: “അടുത്തുള്ള സിനിമാ തിയേറ്ററിലേക്ക് "
-"ഞാൻ എങ്ങനെ എത്തും?”"
+"ഈ വാചകം ഫ്രഞ്ചിലേക്ക് വിവർത്തനം ചെയ്യുക: “അടുത്തുള്ള സിനിമാ തിയേറ്ററിലേക്ക് ഞാൻ എങ്ങനെ "
+"എത്തും?”"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Translate this page"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
+msgctxt "Page suggestion prompt"
+msgid "Translate this page into %s."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder text for a region that will display translated text.
@@ -20397,6 +20664,12 @@ msgid "Try Free"
 msgstr "സൗജന്യമായി പരീക്ഷിക്കൂ"
 
 # smartling.placeholder_format=C
+#. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
+msgctxt "settings"
+msgid "Try It Now"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
 msgctxt "Promotional CTA for new AI models"
 msgid "Try Now"
@@ -20453,8 +20726,8 @@ msgstr "വ്യത്യസ്ത കീവേഡുകൾ പരീക്ഷ�
 #. Prompt encouraging the user to turn off their ad blocker to see more results for their query.
 msgid "Try disabling your ad blocker on DuckDuckGo to see more results."
 msgstr ""
-"കൂടുതൽ ഫലങ്ങൾ കാണാൻ DuckDuckGo-യിൽ നിന്നുള്ള നിങ്ങളുടെ പരസ്യ ബ്ലോക്കർ "
-"പ്രവർത്തനരഹിതമാക്കാൻ ശ്രമിക്കുക."
+"കൂടുതൽ ഫലങ്ങൾ കാണാൻ DuckDuckGo-യിൽ നിന്നുള്ള നിങ്ങളുടെ പരസ്യ ബ്ലോക്കർ പ്രവർത്തനരഹിതമാക്കാൻ "
+"ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
@@ -20495,9 +20768,7 @@ msgstr "സൗജന്യമായി പരീക്ഷിക്കൂ"
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
-msgstr ""
-"സൗജന്യമായി പരീക്ഷിക്കൂ! സുരക്ഷിതമായ VPN, വിപുലവും സ്വകാര്യവുമായ AI, അങ്ങനെ "
-"പലതും."
+msgstr "സൗജന്യമായി പരീക്ഷിക്കൂ! സുരക്ഷിതമായ VPN, വിപുലവും സ്വകാര്യവുമായ AI, അങ്ങനെ പലതും."
 
 # smartling.placeholder_format=C
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -20606,8 +20877,7 @@ msgstr "അടുത്തിടെ ചേർത്തിട്ടുള്ള o
 msgctxt "Prompt suggestion message"
 msgid "Try these prompts to get started or enter your own prompt below"
 msgstr ""
-"ആരംഭിക്കുന്നതിന് ഈ പ്രോംപ്റ്റുകൾ പരീക്ഷിക്കുക, അല്ലെങ്കിൽ ചുവടെ നിങ്ങളുടെ "
-"സ്വന്തം പ്രോംപ്റ്റ് നൽകുക"
+"ആരംഭിക്കുന്നതിന് ഈ പ്രോംപ്റ്റുകൾ പരീക്ഷിക്കുക, അല്ലെങ്കിൽ ചുവടെ നിങ്ങളുടെ സ്വന്തം പ്രോംപ്റ്റ് നൽകുക"
 
 # smartling.placeholder_format=C
 #. Description for the empty state displayed when searching recent chats in Duck.ai returns no results, suggesting the user rephrase their search query.
@@ -20633,6 +20903,22 @@ msgstr "ശ്രമിച്ച് നോക്കുക: %1$s"
 msgctxt "new user poll"
 msgid "Trying DuckDuckGo again"
 msgstr "DuckDuckGo വീണ്ടും ശ്രമിക്കുന്നു"
+
+# smartling.placeholder_format=C
+#. Message shown in a modal after supported third-party browser users disable AI features in Settings. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -20803,9 +21089,8 @@ msgid ""
 "Types out DuckAssist answers as they're generated. Turning this off may "
 "result in a short delay between a search and the answer being displayed."
 msgstr ""
-"DuckAssist ഉത്തരങ്ങൾ സൃഷ്ടിക്കുമ്പോൾ ടൈപ്പ് ചെയ്യുന്നു. ഇത് ഓഫാക്കുന്നത് "
-"തിരയലിനും ഉത്തരം കാണിക്കുന്നതിനും ഇടയിൽ ഒരു ചെറിയ കാലതാമസത്തിന് "
-"കാരണമായേക്കാം."
+"DuckAssist ഉത്തരങ്ങൾ സൃഷ്ടിക്കുമ്പോൾ ടൈപ്പ് ചെയ്യുന്നു. ഇത് ഓഫാക്കുന്നത് തിരയലിനും ഉത്തരം "
+"കാണിക്കുന്നതിനും ഇടയിൽ ഒരു ചെറിയ കാലതാമസത്തിന് കാരണമായേക്കാം."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -20903,17 +21188,13 @@ msgstr "ഫീഡ് ബാക്ക് അയയ്ക്കുവാൻ സാ
 #. Message shown to the user when the voice chat failed to establish a connection, and they should try again later.
 msgctxt "voice chat"
 msgid "Unable to connect to voice chat, please try again later."
-msgstr ""
-"വോയ്സ് ചാറ്റിലേക്ക് കണക്റ്റ് ചെയ്യാൻ കഴിയുന്നില്ല, ദയവായി പിന്നീട് വീണ്ടും "
-"ശ്രമിക്കുക."
+msgstr "വോയ്സ് ചാറ്റിലേക്ക് കണക്റ്റ് ചെയ്യാൻ കഴിയുന്നില്ല, ദയവായി പിന്നീട് വീണ്ടും ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Message shown to the user when there was an issue connecting to their microphone.
 msgctxt "voice chat"
 msgid "Unable to connect to your mic. Please try again."
-msgstr ""
-"നിങ്ങളുടെ മൈക്കിലേക്ക് കണക്റ്റ് ചെയ്യാൻ കഴിഞ്ഞില്ല. ദയവായി വീണ്ടും "
-"ശ്രമിക്കുക."
+msgstr "നിങ്ങളുടെ മൈക്കിലേക്ക് കണക്റ്റ് ചെയ്യാൻ കഴിഞ്ഞില്ല. ദയവായി വീണ്ടും ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Error message for explore more questions when answer fails to load
@@ -20939,8 +21220,8 @@ msgid ""
 "Under %sOn startup%s, click %sOpen a specific page%s then click %sSet "
 "Pages%s."
 msgstr ""
-"%1$sആരംഭത്തിൽ%2$s എന്നതിന് കീഴിൽ, %3$sഒരു നിർദിഷ്ട പേജ് തുറക്കുക %4$s എന്നത് "
-"ക്ലിക്ക് ചെയ്യുക, തുടർന്ന് %5$sപേജുകൾ സജ്ജമാക്കുക%6$s ക്ലിക്ക് ചെയ്യുക."
+"%1$sആരംഭത്തിൽ%2$s എന്നതിന് കീഴിൽ, %3$sഒരു നിർദിഷ്ട പേജ് തുറക്കുക %4$s എന്നത് ക്ലിക്ക് "
+"ചെയ്യുക, തുടർന്ന് %5$sപേജുകൾ സജ്ജമാക്കുക%6$s ക്ലിക്ക് ചെയ്യുക."
 
 #  Maxthon homepage instruction
 # smartling.placeholder_format=C
@@ -20948,22 +21229,21 @@ msgstr ""
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
 msgstr ""
-"%1$sആരംഭത്തിൽ%2$s എന്നതിന് കീഴിൽ, %3$sഹോംപേജ്%4$s തിരഞ്ഞെടുത്ത് ഇത് എന്റർ "
-"ചെയ്യുക: https://duckduckgo.com"
+"%1$sആരംഭത്തിൽ%2$s എന്നതിന് കീഴിൽ, %3$sഹോംപേജ്%4$s തിരഞ്ഞെടുത്ത് ഇത് എന്റർ ചെയ്യുക: "
+"https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sOpen with%s select %sA specific page or pages%s"
 msgstr ""
-"%1$sഇതിൽ തുറക്കുക%2$s എന്നതിന് കീഴിൽ, %3$sഒരു പ്രത്യേക പേജ് അല്ലെങ്കിൽ "
-"പേജുകൾ%4$s തിരഞ്ഞെടുക്കുക"
+"%1$sഇതിൽ തുറക്കുക%2$s എന്നതിന് കീഴിൽ, %3$sഒരു പ്രത്യേക പേജ് അല്ലെങ്കിൽ പേജുകൾ%4$s "
+"തിരഞ്ഞെടുക്കുക"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
 msgstr ""
-"%1$sആരംഭം > ഹോംപേജ് %2$s എന്നതിന് കീഴിൽ ഇത് എന്റർ ചെയ്യുക: "
-"https://duckduckgo.com"
+"%1$sആരംഭം > ഹോംപേജ് %2$s എന്നതിന് കീഴിൽ ഇത് എന്റർ ചെയ്യുക: https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -20974,32 +21254,30 @@ msgstr "%1$sതിരയൽ ക്രമീകരണം%2$s എന്നതി�
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch in the address bar with%s select %sAdd New%s"
 msgstr ""
-"%1$sഇത് സഹിതം വിലാസ ബാറിൽ തിരയുക%2$s എന്നതിന് കീഴിൽ %3$sപുതിയത് ചേർക്കുക%4$s "
-"എന്നത് തിരഞ്ഞെടുക്കുക"
+"%1$sഇത് സഹിതം വിലാസ ബാറിൽ തിരയുക%2$s എന്നതിന് കീഴിൽ %3$sപുതിയത് ചേർക്കുക%4$s എന്നത് "
+"തിരഞ്ഞെടുക്കുക"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
 msgstr ""
-"%1$sതിരയുക%2$s വിഭാഗത്തിന് കീഴിൽ, %3$sതിരയൽ എഞ്ചിനുകൾ മാനേജ് ചെയ്യുക...%4$s "
-"ക്ലിക്ക് ചെയ്യുക"
+"%1$sതിരയുക%2$s വിഭാഗത്തിന് കീഴിൽ, %3$sതിരയൽ എഞ്ചിനുകൾ മാനേജ് ചെയ്യുക...%4$s ക്ലിക്ക് "
+"ചെയ്യുക"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under On startup select %sOpen a specific page or set of pages%s"
 msgstr ""
-"ആരംഭത്തിൽ എന്നതിന് കീഴിൽ %1$sഒരു നിർദിഷ്ട പേജ് അല്ലെങ്കിൽ ഒരു കൂട്ടം പേജുകൾ "
-"തുറക്കുക%2$s എന്നത് തിരഞ്ഞെടുക്കുക"
+"ആരംഭത്തിൽ എന്നതിന് കീഴിൽ %1$sഒരു നിർദിഷ്ട പേജ് അല്ലെങ്കിൽ ഒരു കൂട്ടം പേജുകൾ തുറക്കുക%2$s "
+"എന്നത് തിരഞ്ഞെടുക്കുക"
 
 #  Opera default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine
 msgid "Under Search click the drop down and select %sDuckDuckGo%s"
-msgstr ""
-"തിരയൽ എന്നതിന് കീഴിൽ ഡ്രോപ്പ്ഡൗൺ ക്ലിക്ക് ചെയ്ത് %1$sDuckDuckGo%2$s "
-"തിരഞ്ഞെടുക്കുക"
+msgstr "തിരയൽ എന്നതിന് കീഴിൽ ഡ്രോപ്പ്ഡൗൺ ക്ലിക്ക് ചെയ്ത് %1$sDuckDuckGo%2$s തിരഞ്ഞെടുക്കുക"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings" header
@@ -21077,8 +21355,8 @@ msgid ""
 "Unlock %s, higher AI reasoning, and 2x higher usage limits than the Plus "
 "plan by upgrading to Pro."
 msgstr ""
-"Pro-യിലേക്ക് അപ്‌ഗ്രേഡ് ചെയ്യുന്നതിലൂടെ %1$s, ഉയർന്ന AI റീസണിംഗ്, പ്ലസ് "
-"പ്ലാനിനേക്കാൾ 2 മടങ്ങ് ഉയർന്ന ഉപയോഗ പരിധി എന്നിവ അൺലോക്ക് ചെയ്യുക."
+"Pro-യിലേക്ക് അപ്‌ഗ്രേഡ് ചെയ്യുന്നതിലൂടെ %1$s, ഉയർന്ന AI റീസണിംഗ്, പ്ലസ് പ്ലാനിനേക്കാൾ 2 മടങ്ങ് "
+"ഉയർന്ന ഉപയോഗ പരിധി എന്നിവ അൺലോക്ക് ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Title for the subscription promo shown in the SERP sidemenu.
@@ -21100,8 +21378,7 @@ msgctxt "voice chat limit modal"
 msgid ""
 "Unlock advanced AI models and higher limits with a DuckDuckGo Subscription"
 msgstr ""
-"DuckDuckGo സബ്സ്ക്രിപ്ഷൻ ഉപയോഗിച്ച് നൂതന AI മോഡലുകളും ഉയർന്ന പരിധികളും "
-"അൺലോക്ക് ചെയ്യുക"
+"DuckDuckGo സബ്സ്ക്രിപ്ഷൻ ഉപയോഗിച്ച് നൂതന AI മോഡലുകളും ഉയർന്ന പരിധികളും അൺലോക്ക് ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. Text informing the user that advanced AI models can be unlocked with a subscription. The variable is used to insert a link that opens the subscription modal. Example: Unlock advanced AI models with a DuckDuckGo subscription.
@@ -21126,9 +21403,7 @@ msgstr "നിങ്ങളുടെ സബ്‌സ്‌ക്രിപ്‌�
 #. Upsell message shown in the voice chat duration limit modal for free users.
 msgctxt "voice chat duration limit modal"
 msgid "Unlock longer voice chats with a DuckDuckGo Subscription"
-msgstr ""
-"DuckDuckGo സബ്‌സ്‌ക്രിപ്‌ഷൻ ഉപയോഗിച്ച് ദൈർഘ്യമേറിയ വോയ്സ് ചാറ്റുകൾ അൺലോക്ക് "
-"ചെയ്യുക"
+msgstr "DuckDuckGo സബ്‌സ്‌ക്രിപ്‌ഷൻ ഉപയോഗിച്ച് ദൈർഘ്യമേറിയ വോയ്സ് ചാറ്റുകൾ അൺലോക്ക് ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. Text informing the user that more capable AI models can be unlocked with a subscription, with a trailing call-to-action link. %s is replaced with either the 'Try for free' link (for unauthenticated users) or the 'Learn more' link (for authenticated users). The link opens the subscription modal. Example: Unlock more capable AI models with a DuckDuckGo subscription. Try for free
@@ -21136,9 +21411,7 @@ msgctxt ""
 "Text shown in the subscription promo card, with a trailing call-to-action "
 "link."
 msgid "Unlock more capable AI models with a DuckDuckGo subscription. %s"
-msgstr ""
-"DuckDuckGo സബ്സ്ക്രിപ്ഷൻ ഉപയോഗിച്ച് കൂടുതൽ കഴിവുള്ള AI മോഡലുകൾ അൺലോക്ക് "
-"ചെയ്യുക. %1$s"
+msgstr "DuckDuckGo സബ്സ്ക്രിപ്ഷൻ ഉപയോഗിച്ച് കൂടുതൽ കഴിവുള്ള AI മോഡലുകൾ അൺലോക്ക് ചെയ്യുക. %1$s"
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to unmute the microphone.
@@ -21218,8 +21491,8 @@ msgid ""
 "Update the DuckDuckGo browser to activate your subscription in Duck.ai and "
 "access advanced models"
 msgstr ""
-"Duck.ai-ൽ നിങ്ങളുടെ സബ്സ്ക്രിപ്ഷൻ സജീവമാക്കാനും നൂതന മോഡലുകൾ ആക്സസ് "
-"ചെയ്യാനും DuckDuckGo ബ്രൗസർ അപ്‌ഡേറ്റ് ചെയ്യുക"
+"Duck.ai-ൽ നിങ്ങളുടെ സബ്സ്ക്രിപ്ഷൻ സജീവമാക്കാനും നൂതന മോഡലുകൾ ആക്സസ് ചെയ്യാനും DuckDuckGo "
+"ബ്രൗസർ അപ്‌ഡേറ്റ് ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. The placeholder indicates a formatted date (e.g., 'Updated 2 days ago')
@@ -21344,16 +21617,15 @@ msgid ""
 "Upgrade to Pro to unlock 2x higher limits than Plus, or come back later to "
 "create more images."
 msgstr ""
-"Plus-നേക്കാൾ 2 മടങ്ങ് ഉയർന്ന പരിധി അൺലോക്ക് ചെയ്യാൻ Pro-യിലേക്ക് അപ്ഗ്രേഡ് "
-"ചെയ്യുക, അല്ലെങ്കിൽ കൂടുതൽ ചിത്രങ്ങൾ സൃഷ്ടിക്കാനായി പിന്നീട് മടങ്ങി വരിക."
+"Plus-നേക്കാൾ 2 മടങ്ങ് ഉയർന്ന പരിധി അൺലോക്ക് ചെയ്യാൻ Pro-യിലേക്ക് അപ്ഗ്രേഡ് ചെയ്യുക, "
+"അല്ലെങ്കിൽ കൂടുതൽ ചിത്രങ്ങൾ സൃഷ്ടിക്കാനായി പിന്നീട് മടങ്ങി വരിക."
 
 # smartling.placeholder_format=C
 #. Upsell message shown in the voice chat limit and duration limit modals for Plus subscribers, encouraging them to upgrade to Pro.
 msgctxt "voice chat limit modal"
 msgid "Upgrade to Pro to unlock 2x higher usage limits than Plus"
 msgstr ""
-"Plus-നേക്കാൾ 2x ഉയർന്ന ഉപയോഗ പരിധികൾ അൺലോക്ക് ചെയ്യാൻ Pro-യിലേക്ക് അപ്ഗ്രേഡ് "
-"ചെയ്യുക"
+"Plus-നേക്കാൾ 2x ഉയർന്ന ഉപയോഗ പരിധികൾ അൺലോക്ക് ചെയ്യാൻ Pro-യിലേക്ക് അപ്ഗ്രേഡ് ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. Heading in a promotion for a desktop web browser
@@ -21402,6 +21674,12 @@ msgid "Uruguay"
 msgstr "ഉറുഗ്വേ"
 
 # smartling.placeholder_format=C
+#. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
+msgctxt "Navigation label on the Duck.ai settings page"
+msgid "Usage"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A feedback suggestion
 msgctxt "Feedback prompt"
 msgid "Usage limit"
@@ -21443,9 +21721,9 @@ msgid ""
 "Use ChatGPT, Claude, and other AIs, privately. Protect chats from hackers, "
 "scammers, and companies. Keep info confidential. Free. No account required."
 msgstr ""
-"ChatGPT, Claude, മറ്റ് AI-കൾ സ്വകാര്യമായി ഉപയോഗിക്കൂ. ഹാക്കർമാരിൽ നിന്നും, "
-"സ്കാമർമാരിൽ നിന്നും, കമ്പനികളിൽ നിന്നും നിന്റെ ചാറ്റുകൾ സംരക്ഷിക്കുക. "
-"വിവരങ്ങൾ രഹസ്യമായി സൂക്ഷിക്കൂ. സൗജന്യം. അക്കൗണ്ട് ആവശ്യമില്ല."
+"ChatGPT, Claude, മറ്റ് AI-കൾ സ്വകാര്യമായി ഉപയോഗിക്കൂ. ഹാക്കർമാരിൽ നിന്നും, സ്കാമർമാരിൽ "
+"നിന്നും, കമ്പനികളിൽ നിന്നും നിന്റെ ചാറ്റുകൾ സംരക്ഷിക്കുക. വിവരങ്ങൾ രഹസ്യമായി സൂക്ഷിക്കൂ. "
+"സൗജന്യം. അക്കൗണ്ട് ആവശ്യമില്ല."
 
 # smartling.placeholder_format=C
 #. Header above instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -21458,8 +21736,8 @@ msgstr "DuckDuckGo Private Search ഉപയോഗിക്കുക"
 msgctxt "mobile promotion on desktop"
 msgid "Use DuckDuckGo private search on your iPad, iPhone, or Android!"
 msgstr ""
-"നിങ്ങളുടെ iPad, iPhone അല്ലെങ്കിൽ Android എന്നിവയിൽ DuckDuckGo private "
-"search ഉപയോഗിക്കുക!"
+"നിങ്ങളുടെ iPad, iPhone അല്ലെങ്കിൽ Android എന്നിവയിൽ DuckDuckGo private search "
+"ഉപയോഗിക്കുക!"
 
 # smartling.placeholder_format=C
 #. User clicks this button to share their device's location
@@ -21489,8 +21767,8 @@ msgctxt "Description for the recovery section inside Manage"
 msgid ""
 "Use this code to restore your saved chats if you lose access to your devices."
 msgstr ""
-"നിങ്ങളുടെ ഉപകരണങ്ങളിലേക്കുള്ള ആക്സസ് നഷ്ടപ്പെട്ടാൽ, സംരക്ഷിച്ച ചാറ്റുകൾ "
-"വീണ്ടെടുക്കാൻ ഈ കോഡ് ഉപയോഗിക്കുക."
+"നിങ്ങളുടെ ഉപകരണങ്ങളിലേക്കുള്ള ആക്സസ് നഷ്ടപ്പെട്ടാൽ, സംരക്ഷിച്ച ചാറ്റുകൾ വീണ്ടെടുക്കാൻ ഈ കോഡ് "
+"ഉപയോഗിക്കുക."
 
 # smartling.placeholder_format=C
 #. Prompt to ask the user if they want to use their approximate location for more accurate results
@@ -21640,8 +21918,8 @@ msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Microsoft's ad network"
 msgstr ""
-"പരസ്യങ്ങൾ കാണുന്നത് DuckDuckGo സ്വകാര്യതാ പരിരക്ഷ ചെയ്തിരിക്കുന്നു. പരസ്യ "
-"ക്ലിക്കുകൾ നിയന്ത്രിക്കുന്നത് Microsoft-ന്റെ പരസ്യ നെറ്റ്‌വർക്കാണ്"
+"പരസ്യങ്ങൾ കാണുന്നത് DuckDuckGo സ്വകാര്യതാ പരിരക്ഷ ചെയ്തിരിക്കുന്നു. പരസ്യ ക്ലിക്കുകൾ "
+"നിയന്ത്രിക്കുന്നത് Microsoft-ന്റെ പരസ്യ നെറ്റ്‌വർക്കാണ്"
 
 # smartling.placeholder_format=C
 #. Information about TripAdvisor ads for DuckDuckGo's users. This appears in a tooltip.
@@ -21650,8 +21928,8 @@ msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "TripAdvisor's ad network."
 msgstr ""
-"പരസ്യങ്ങൾ കാണുന്നത് DuckDuckGo സംരക്ഷിച്ചിരിക്കുന്ന സ്വകാര്യതയാണ്. പരസ്യ "
-"ക്ലിക്കുകൾ നിയന്ത്രിക്കുന്നത് TripAdvisor ന്റെ പരസ്യ ശൃംഖലയാണ്."
+"പരസ്യങ്ങൾ കാണുന്നത് DuckDuckGo സംരക്ഷിച്ചിരിക്കുന്ന സ്വകാര്യതയാണ്. പരസ്യ ക്ലിക്കുകൾ "
+"നിയന്ത്രിക്കുന്നത് TripAdvisor ന്റെ പരസ്യ ശൃംഖലയാണ്."
 
 # smartling.placeholder_format=C
 msgid "Virgin Islands"
@@ -21663,8 +21941,8 @@ msgctxt "duckassist"
 msgid ""
 "Visit %sAssist Settings%s to adjust how this feature works or turn it off."
 msgstr ""
-"ഈ ഫീച്ചർ എങ്ങനെ പ്രവർത്തിക്കണമെന്ന് ക്രമീകരിക്കാനോ അത് ഓഫ് ചെയ്യാനോ "
-"%1$sAssist ക്രമീകരണം%2$s സന്ദർശിക്കുക."
+"ഈ ഫീച്ചർ എങ്ങനെ പ്രവർത്തിക്കണമെന്ന് ക്രമീകരിക്കാനോ അത് ഓഫ് ചെയ്യാനോ %1$sAssist "
+"ക്രമീകരണം%2$s സന്ദർശിക്കുക."
 
 # smartling.placeholder_format=C
 #. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
@@ -21673,8 +21951,8 @@ msgid ""
 "Visit %sDuckAssist Settings%s to adjust how this feature works or turn it "
 "off."
 msgstr ""
-"ഈ ഫീച്ചർ എങ്ങനെ പ്രവർത്തിക്കണമെന്ന് ക്രമീകരിക്കാനോ അത് ഓഫ് ചെയ്യാനോ "
-"%1$sDuckAssist ക്രമീകരണം%2$s സന്ദർശിക്കുക."
+"ഈ ഫീച്ചർ എങ്ങനെ പ്രവർത്തിക്കണമെന്ന് ക്രമീകരിക്കാനോ അത് ഓഫ് ചെയ്യാനോ %1$sDuckAssist "
+"ക്രമീകരണം%2$s സന്ദർശിക്കുക."
 
 # smartling.placeholder_format=C
 #. Prompt to visit DuckDuckGo on another device.
@@ -21683,8 +21961,8 @@ msgid ""
 "Visit %sDuckDuckGo.com%s on your tablet or phone and follow the provided "
 "instructions."
 msgstr ""
-"നിങ്ങളുടെ ടാബ്‍ലെറ്റിലോ ഫോണിലോ %1$sDuckDuckGo.com%2$s സന്ദർശിച്ച് നൽകിയ "
-"നിർദേശങ്ങൾ പാലിക്കുക."
+"നിങ്ങളുടെ ടാബ്‍ലെറ്റിലോ ഫോണിലോ %1$sDuckDuckGo.com%2$s സന്ദർശിച്ച് നൽകിയ നിർദേശങ്ങൾ "
+"പാലിക്കുക."
 
 # smartling.placeholder_format=C
 #. Primary button to visit Duck.ai.
@@ -21699,9 +21977,9 @@ msgid ""
 "Visit Duck.ai in your other browser and go to %sDuck.ai Settings%s > %sSync "
 "& Backup%s > %sManage%s then select %sSync With Another Device%s."
 msgstr ""
-"നിങ്ങളുടെ മറ്റ് ബ്രൗസറിൽ Duck.ai സന്ദർശിച്ച് %1$sDuck.ai ക്രമീകരണങ്ങൾ%2$s > "
-"%3$sSync & Backup%4$s > %5$sമാനേജ് ചെയ്യുക%6$s എന്നതിലേക്ക് പോയി %7$sമറ്റൊരു "
-"ഉപകരണവുമായി സമന്വയിപ്പിക്കുക%8$s തിരഞ്ഞെടുക്കുക."
+"നിങ്ങളുടെ മറ്റ് ബ്രൗസറിൽ Duck.ai സന്ദർശിച്ച് %1$sDuck.ai ക്രമീകരണങ്ങൾ%2$s > %3$sSync & "
+"Backup%4$s > %5$sമാനേജ് ചെയ്യുക%6$s എന്നതിലേക്ക് പോയി %7$sമറ്റൊരു ഉപകരണവുമായി "
+"സമന്വയിപ്പിക്കുക%8$s തിരഞ്ഞെടുക്കുക."
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -21711,10 +21989,9 @@ msgid ""
 "On” under Sync & Backup and select “Sync With Another Device”. Or scan the "
 "QR on your Recovery PDF."
 msgstr ""
-"നിങ്ങളുടെ മറ്റൊരു ബ്രൗസറിൽ Duck.ai സന്ദർശിച്ച് Duck.ai ക്രമീകരണങ്ങൾ "
-"തുറക്കുക. Sync & Backup എന്നതിന് കീഴിൽ \"ഓണാക്കുക\" തിരഞ്ഞെടുത്ത് \"മറ്റൊരു "
-"ഉപകരണവുമായി സമന്വയിപ്പിക്കുക\" തിരഞ്ഞെടുക്കുക. അല്ലെങ്കിൽ നിങ്ങളുടെ റിക്കവറി "
-"PDF-ലെ QR സ്കാൻ ചെയ്യുക."
+"നിങ്ങളുടെ മറ്റൊരു ബ്രൗസറിൽ Duck.ai സന്ദർശിച്ച് Duck.ai ക്രമീകരണങ്ങൾ തുറക്കുക. Sync & "
+"Backup എന്നതിന് കീഴിൽ \"ഓണാക്കുക\" തിരഞ്ഞെടുത്ത് \"മറ്റൊരു ഉപകരണവുമായി സമന്വയിപ്പിക്കുക\" "
+"തിരഞ്ഞെടുക്കുക. അല്ലെങ്കിൽ നിങ്ങളുടെ റിക്കവറി PDF-ലെ QR സ്കാൻ ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Shared body copy for every screen in the Sync Another Device flow (QR display, camera scan, camera-unavailable fallback, manual entry). Bold tags wrap navigation breadcrumbs. Render with <Translate /> so the HTML is interpreted; plain `translate()` will trip the html-string warning.
@@ -21724,10 +22001,9 @@ msgid ""
 "ai Settings%s > %sSync & Backup%s > %sManage%s then select %sSync With "
 "Another Device%s."
 msgstr ""
-"നിങ്ങളുടെ മറ്റൊരു ബ്രൗസറിലോ DuckDuckGo ആപ്പിലോ Duck.ai സന്ദർശിച്ച്, "
-"%1$sDuck.ai ക്രമീകരണങ്ങൾ%2$s > %3$sSync & Backup%4$s > %5$sമാനേജ് "
-"ചെയ്യുക%6$s എന്നിടത്ത് %7$sമറ്റൊരു ഉപകരണവുമായി സമന്വയിപ്പിക്കുക%8$s "
-"തിരഞ്ഞെടുക്കുക."
+"നിങ്ങളുടെ മറ്റൊരു ബ്രൗസറിലോ DuckDuckGo ആപ്പിലോ Duck.ai സന്ദർശിച്ച്, %1$sDuck.ai "
+"ക്രമീകരണങ്ങൾ%2$s > %3$sSync & Backup%4$s > %5$sമാനേജ് ചെയ്യുക%6$s എന്നിടത്ത് "
+"%7$sമറ്റൊരു ഉപകരണവുമായി സമന്വയിപ്പിക്കുക%8$s തിരഞ്ഞെടുക്കുക."
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -21737,10 +22013,9 @@ msgid ""
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
 msgstr ""
-"നിങ്ങളുടെ മറ്റ് ബ്രൗസറിലോ DuckDuckGo ആപ്പിലോ Duck.ai സന്ദർശിച്ച് Duck.ai "
-"ക്രമീകരണങ്ങൾ തുറക്കുക. Sync & Backup എന്നതിന് കീഴിൽ \"ഓണാക്കുക\" "
-"തിരഞ്ഞെടുത്ത് \"മറ്റൊരു ഉപകരണവുമായി സമന്വയിപ്പിക്കുക\" തിരഞ്ഞെടുക്കുക. "
-"അല്ലെങ്കിൽ നിങ്ങളുടെ റിക്കവറി PDF-ലെ QR സ്കാൻ ചെയ്യുക."
+"നിങ്ങളുടെ മറ്റ് ബ്രൗസറിലോ DuckDuckGo ആപ്പിലോ Duck.ai സന്ദർശിച്ച് Duck.ai ക്രമീകരണങ്ങൾ "
+"തുറക്കുക. Sync & Backup എന്നതിന് കീഴിൽ \"ഓണാക്കുക\" തിരഞ്ഞെടുത്ത് \"മറ്റൊരു ഉപകരണവുമായി "
+"സമന്വയിപ്പിക്കുക\" തിരഞ്ഞെടുക്കുക. അല്ലെങ്കിൽ നിങ്ങളുടെ റിക്കവറി PDF-ലെ QR സ്കാൻ ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -21793,8 +22068,8 @@ msgstr "വോയ്സ് ചാറ്റ് അവസാനിച്ചു"
 msgctxt "voice chat"
 msgid "Voice chat is anonymized by us, and never used to train AI models."
 msgstr ""
-"വോയ്സ് ചാറ്റ് ഞങ്ങൾ അജ്ഞാതമാക്കിയിരിക്കുന്നു, കൂടാതെ AI മോഡലുകളെ "
-"പരിശീലിപ്പിക്കാൻ ഒരിക്കലും ഉപയോഗിച്ചിട്ടില്ല."
+"വോയ്സ് ചാറ്റ് ഞങ്ങൾ അജ്ഞാതമാക്കിയിരിക്കുന്നു, കൂടാതെ AI മോഡലുകളെ പരിശീലിപ്പിക്കാൻ ഒരിക്കലും "
+"ഉപയോഗിച്ചിട്ടില്ല."
 
 # smartling.placeholder_format=C
 #. Title of the modal shown when the user has reached their daily voice chat limit.
@@ -21853,6 +22128,12 @@ msgstr "ലൊക്കേഷനായി കാത്തിരിക്കു�
 # smartling.placeholder_format=C
 msgid "Wales"
 msgstr "വെയിൽസ്"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Walk me through the steps"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for walking directions on a map.
@@ -21932,9 +22213,8 @@ msgid ""
 "Watch in Duck Player to block personalized ads on YouTube and prevent your "
 "viewing activity from influencing YouTube recommendations."
 msgstr ""
-"YouTube-ൽ വ്യക്തിഗതമാക്കിയ പരസ്യങ്ങൾ തടയുന്നതിനും നിങ്ങളുടെ കാഴ്ച "
-"പ്രവർത്തനത്തെ YouTube ശുപാർശകൾ സ്വാധീനിക്കുന്നതിൽ നിന്ന് തടയുന്നതിനും Duck "
-"Player-ൽ കാണുക."
+"YouTube-ൽ വ്യക്തിഗതമാക്കിയ പരസ്യങ്ങൾ തടയുന്നതിനും നിങ്ങളുടെ കാഴ്ച പ്രവർത്തനത്തെ YouTube "
+"ശുപാർശകൾ സ്വാധീനിക്കുന്നതിൽ നിന്ന് തടയുന്നതിനും Duck Player-ൽ കാണുക."
 
 # smartling.placeholder_format=C
 #. A button that takes a user to another site in order to watch a video. The placeholder is the name of the video site. For example: 'Watch on Vimeo'
@@ -21954,11 +22234,10 @@ msgid ""
 "independent company and has no relationship with YouTube, where most videos "
 "are hosted."
 msgstr ""
-"ഇവിടെ ഒരു വീഡിയോ കാണുക എന്നതിനർത്ഥം അത് ഹോസ്റ്റ് ചെയ്തിരിക്കുന്ന "
-"വെബ്‌സൈറ്റിന് നിങ്ങളെ ട്രാക്ക് ചെയ്യാൻ കഴിയും എന്നാണ്, കാരണം ഞങ്ങൾ അവിടെ "
-"നിന്ന് ഉള്ളടക്കം സ്ട്രീം ചെയ്യേണ്ടതുണ്ട്. DuckDuckGo ഒരു സ്വതന്ത്ര "
-"കമ്പനിയാണ് കൂടാതെ മിക്ക വീഡിയോകളും ഹോസ്റ്റ് ചെയ്യുന്ന YouTube-മായി യാതൊരു "
-"ബന്ധവുമില്ല."
+"ഇവിടെ ഒരു വീഡിയോ കാണുക എന്നതിനർത്ഥം അത് ഹോസ്റ്റ് ചെയ്തിരിക്കുന്ന വെബ്‌സൈറ്റിന് നിങ്ങളെ ട്രാക്ക് "
+"ചെയ്യാൻ കഴിയും എന്നാണ്, കാരണം ഞങ്ങൾ അവിടെ നിന്ന് ഉള്ളടക്കം സ്ട്രീം ചെയ്യേണ്ടതുണ്ട്. "
+"DuckDuckGo ഒരു സ്വതന്ത്ര കമ്പനിയാണ് കൂടാതെ മിക്ക വീഡിയോകളും ഹോസ്റ്റ് ചെയ്യുന്ന YouTube-മായി "
+"യാതൊരു ബന്ധവുമില്ല."
 
 # smartling.placeholder_format=C
 #. Heading for the highlight card explaining anonymized prompt delivery.
@@ -21971,8 +22250,19 @@ msgstr "ഞങ്ങൾ അജ്ഞാതമാക്കുന്നു"
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
 msgstr ""
-"നിങ്ങൾക്ക് കൂടുതൽ കൃത്യമായ ഫലങ്ങൾ കാണിക്കുന്നതിന് ഞങ്ങൾക്ക്%1$s നിങ്ങളുടെ "
-"ലൊക്കേഷൻ%2$s അജ്ഞാതമാക്കാൻ കഴിയും."
+"നിങ്ങൾക്ക് കൂടുതൽ കൃത്യമായ ഫലങ്ങൾ കാണിക്കുന്നതിന് ഞങ്ങൾക്ക്%1$s നിങ്ങളുടെ ലൊക്കേഷൻ%2$s "
+"അജ്ഞാതമാക്കാൻ കഴിയും."
+
+# smartling.placeholder_format=C
+#. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
+msgctxt ""
+"Inline warning shown below the share-content toggle when the user selects "
+"Harmful or Illegal but has not enabled sharing"
+msgid ""
+"We can only fix what we can see. To report a harmful or illegal response, "
+"please share this conversation with DuckDuckGo so we can investigate and "
+"address the issue."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -21984,18 +22274,17 @@ msgid ""
 "please share your prompt and response so we can investigate and address the "
 "issue."
 msgstr ""
-"കാണാൻ കഴിയുന്നത് മാത്രമേ ഞങ്ങൾക്ക് ശരിയാക്കാൻ കഴിയൂ. ദോഷകരമോ നിയമവിരുദ്ധമോ "
-"ആയ ഒരു പ്രതികരണം റിപ്പോർട്ട് ചെയ്യാൻ, ദയവായി നിങ്ങളുടെ പ്രോംപ്റ്റും "
-"പ്രതികരണവും പങ്കിടുക, അതുവഴി ഞങ്ങൾക്ക് പ്രശ്നം അന്വേഷിച്ച് പരിഹരിക്കാൻ "
-"കഴിയും."
+"കാണാൻ കഴിയുന്നത് മാത്രമേ ഞങ്ങൾക്ക് ശരിയാക്കാൻ കഴിയൂ. ദോഷകരമോ നിയമവിരുദ്ധമോ ആയ ഒരു "
+"പ്രതികരണം റിപ്പോർട്ട് ചെയ്യാൻ, ദയവായി നിങ്ങളുടെ പ്രോംപ്റ്റും പ്രതികരണവും പങ്കിടുക, അതുവഴി "
+"ഞങ്ങൾക്ക് പ്രശ്നം അന്വേഷിച്ച് പരിഹരിക്കാൻ കഴിയും."
 
 # smartling.placeholder_format=C
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can use your anonymous%s location%s to show you nearby results."
 msgstr ""
-"സമീപത്തുള്ള ഫലങ്ങൾ കാണിക്കുന്നതിന് ഞങ്ങൾക്ക് നിങ്ങളുടെ അജ്ഞാത%1$s "
-"ലൊക്കേഷൻ%2$s ഉപയോഗിക്കാനാകും."
+"സമീപത്തുള്ള ഫലങ്ങൾ കാണിക്കുന്നതിന് ഞങ്ങൾക്ക് നിങ്ങളുടെ അജ്ഞാത%1$s ലൊക്കേഷൻ%2$s "
+"ഉപയോഗിക്കാനാകും."
 
 # smartling.placeholder_format=C
 #. Error message displayed when one or more attached files are encrypted and cannot be read.
@@ -22003,8 +22292,8 @@ msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
 msgstr ""
-"അറ്റാച്ച് ചെയ്ത ഫയലുകളിൽ ഒരെണ്ണമെങ്കിലും എൻക്രിപ്റ്റ് ചെയ്തിരിക്കുന്നതിനാൽ "
-"ഞങ്ങൾക്ക് അവ വായിക്കാൻ കഴിയില്ല."
+"അറ്റാച്ച് ചെയ്ത ഫയലുകളിൽ ഒരെണ്ണമെങ്കിലും എൻക്രിപ്റ്റ് ചെയ്തിരിക്കുന്നതിനാൽ ഞങ്ങൾക്ക് അവ "
+"വായിക്കാൻ കഴിയില്ല."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -22015,16 +22304,13 @@ msgstr "പരസ്യങ്ങളുമായി ഞങ്ങൾ നിങ്�
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
 msgid "We don't store usernames or any personally identifiable information."
-msgstr ""
-"ഞങ്ങൾ ഉപയോക്തൃനാമങ്ങളോ വ്യക്തിപരമായി തിരിച്ചറിയിക്കുന്ന വിവരങ്ങളോ "
-"സംഭരിക്കുന്നില്ല."
+msgstr "ഞങ്ങൾ ഉപയോക്തൃനാമങ്ങളോ വ്യക്തിപരമായി തിരിച്ചറിയിക്കുന്ന വിവരങ്ങളോ സംഭരിക്കുന്നില്ല."
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don't store your personal info or track you. Ever."
 msgstr ""
-"ഞങ്ങൾ നിങ്ങളുടെ സ്വകാര്യ വിവരങ്ങൾ സംഭരിക്കുകയോ നിങ്ങളെ ട്രാക്ക് ചെയ്യുകയോ "
-"ഇല്ല. എപ്പോഴും."
+"ഞങ്ങൾ നിങ്ങളുടെ സ്വകാര്യ വിവരങ്ങൾ സംഭരിക്കുകയോ നിങ്ങളെ ട്രാക്ക് ചെയ്യുകയോ ഇല്ല. എപ്പോഴും."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -22036,8 +22322,8 @@ msgid ""
 "We don't store your personal info. We don't follow you around with ads. We "
 "don't track you. Ever."
 msgstr ""
-"നിങ്ങളുടെ വ്യക്തിഗത വിവരങ്ങൾ ഞങ്ങൾ സംഭരിക്കാറില്ല. പരസ്യങ്ങളുമായി ഞങ്ങൾ "
-"നിങ്ങളെ പിന്തുടരില്ല. ഞങ്ങൾ നിങ്ങളെ ട്രാക്ക് ചെയ്യില്ല. എപ്പോഴും."
+"നിങ്ങളുടെ വ്യക്തിഗത വിവരങ്ങൾ ഞങ്ങൾ സംഭരിക്കാറില്ല. പരസ്യങ്ങളുമായി ഞങ്ങൾ നിങ്ങളെ "
+"പിന്തുടരില്ല. ഞങ്ങൾ നിങ്ങളെ ട്രാക്ക് ചെയ്യില്ല. എപ്പോഴും."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -22051,9 +22337,8 @@ msgid ""
 "We don't track you, so we could use your help telling us what brought you "
 "back today:"
 msgstr ""
-"ഞങ്ങൾ നിങ്ങളെ ട്രാക്ക് ചെയ്യുന്നില്ല, അതിനാൽ ഇന്ന് നിങ്ങളെ തിരികെ "
-"കൊണ്ടുവന്നത് എന്താണെന്ന് ഞങ്ങളോട് പറയാൻ നിങ്ങളുടെ സഹായം ഞങ്ങൾക്ക് "
-"ഉപയോഗിക്കാം:"
+"ഞങ്ങൾ നിങ്ങളെ ട്രാക്ക് ചെയ്യുന്നില്ല, അതിനാൽ ഇന്ന് നിങ്ങളെ തിരികെ കൊണ്ടുവന്നത് എന്താണെന്ന് "
+"ഞങ്ങളോട് പറയാൻ നിങ്ങളുടെ സഹായം ഞങ്ങൾക്ക് ഉപയോഗിക്കാം:"
 
 # smartling.placeholder_format=C
 #. Message prompting users to fill out a feedback form.
@@ -22062,9 +22347,8 @@ msgid ""
 "We don't track you, so we could use your help telling us what convinced you "
 "to try us out today:"
 msgstr ""
-"ഞങ്ങൾ നിങ്ങളെ ട്രാക്ക് ചെയ്യുന്നില്ല, അതിനാൽ ഇന്ന് ഞങ്ങളെ പരീക്ഷിച്ചുനോക്കാൻ "
-"നിങ്ങൾക്ക് ബോധ്യംപകർന്നത് എന്താണെന്ന് ഞങ്ങളോട് പറയാൻ നിങ്ങളുടെ സഹായം "
-"ഞങ്ങൾക്ക് ഉപയോഗിക്കാം:"
+"ഞങ്ങൾ നിങ്ങളെ ട്രാക്ക് ചെയ്യുന്നില്ല, അതിനാൽ ഇന്ന് ഞങ്ങളെ പരീക്ഷിച്ചുനോക്കാൻ നിങ്ങൾക്ക് "
+"ബോധ്യംപകർന്നത് എന്താണെന്ന് ഞങ്ങളോട് പറയാൻ നിങ്ങളുടെ സഹായം ഞങ്ങൾക്ക് ഉപയോഗിക്കാം:"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -22075,9 +22359,7 @@ msgstr "ഞങ്ങൾ നിങ്ങളെ ട്രാക്ക് ചെയ
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with a Continue button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don't track you. That's our Privacy Policy in a nutshell."
-msgstr ""
-"ഞങ്ങൾ നിങ്ങളെ ട്രാക്ക് ചെയ്യുന്നില്ല. ചുരുക്കത്തിൽ അതാണ് ഞങ്ങളുടെ സ്വകാര്യതാ "
-"നയം."
+msgstr "ഞങ്ങൾ നിങ്ങളെ ട്രാക്ക് ചെയ്യുന്നില്ല. ചുരുക്കത്തിൽ അതാണ് ഞങ്ങളുടെ സ്വകാര്യതാ നയം."
 
 # smartling.placeholder_format=C
 #. Description for the audio identification highlight in the dictation consent modal.
@@ -22106,8 +22388,8 @@ msgid ""
 "We don’t store your search history. We therefore have nothing to sell to "
 "advertisers that track you across the Internet."
 msgstr ""
-"ഞങ്ങൾ നിങ്ങളുടെ തിരയൽ ചരിത്രം സൂക്ഷിക്കില്ല. അതുകൊണ്ട് നിങ്ങളെ ഇന്റർനെറ്റിൽ "
-"ഉടനീളം പിന്തുടരുന്ന പരസ്യദാതാക്കൾക്ക് വിൽക്കാൻ ഞങ്ങൾക്ക് ഒന്നുമില്ല"
+"ഞങ്ങൾ നിങ്ങളുടെ തിരയൽ ചരിത്രം സൂക്ഷിക്കില്ല. അതുകൊണ്ട് നിങ്ങളെ ഇന്റർനെറ്റിൽ ഉടനീളം "
+"പിന്തുടരുന്ന പരസ്യദാതാക്കൾക്ക് വിൽക്കാൻ ഞങ്ങൾക്ക് ഒന്നുമില്ല"
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -22133,8 +22415,8 @@ msgid ""
 "We have agreements with all AI providers to ensure your chats aren't used to "
 "train AIs."
 msgstr ""
-"നിങ്ങളുടെ ചാറ്റുകൾ AI-കളെ പരിശീലിപ്പിക്കാൻ ഉപയോഗിക്കപ്പെടുകയില്ലെന്ന് "
-"ഉറപ്പാക്കാൻ എല്ലാ AI ദാതാക്കളുമായും ഞങ്ങൾക്ക് കരാറുകളുണ്ട്."
+"നിങ്ങളുടെ ചാറ്റുകൾ AI-കളെ പരിശീലിപ്പിക്കാൻ ഉപയോഗിക്കപ്പെടുകയില്ലെന്ന് ഉറപ്പാക്കാൻ എല്ലാ AI "
+"ദാതാക്കളുമായും ഞങ്ങൾക്ക് കരാറുകളുണ്ട്."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -22151,9 +22433,7 @@ msgstr "ഞങ്ങൾക്ക് കണക്ഷൻ നഷ്ടപ്പെ�
 #. We store chats for 15 minutes in the BE. If the user tries to fetch it after the 15 minutes elapsed or if we had an issue saving it we show them this error message so they can re-submit their prompt.
 msgctxt "AI Chat: Error message for unsaved or expired chats saved in sync"
 msgid "We lost the connection. Please try sending your message again."
-msgstr ""
-"ഞങ്ങൾക്ക് കണക്ഷൻ നഷ്ടപ്പെട്ടു. ദയവായി നിങ്ങളുടെ സന്ദേശം വീണ്ടും അയയ്ക്കാൻ "
-"ശ്രമിക്കൂ."
+msgstr "ഞങ്ങൾക്ക് കണക്ഷൻ നഷ്ടപ്പെട്ടു. ദയവായി നിങ്ങളുടെ സന്ദേശം വീണ്ടും അയയ്ക്കാൻ ശ്രമിക്കൂ."
 
 # smartling.placeholder_format=C
 #. Message asking the user to disable their ad blocker, with a link to how our ads don't track you. The placeholders are for the start and end tags of that link (e.g. <a href="%">, </a>)
@@ -22161,8 +22441,8 @@ msgid ""
 "We make money from %sprivacy-respecting search ads%s, not by exploiting your "
 "data."
 msgstr ""
-"ഞങ്ങൾ നിങ്ങളുടെ ഡാറ്റ ചൂഷണം ചെയ്യുന്നതിലൂടെയല്ല, %1$sസ്വകാര്യത മാനിക്കുന്ന "
-"തിരയൽ പരസ്യങ്ങളിൽ%2$s നിന്നാണ് പണം സമ്പാദിക്കുന്നത്."
+"ഞങ്ങൾ നിങ്ങളുടെ ഡാറ്റ ചൂഷണം ചെയ്യുന്നതിലൂടെയല്ല, %1$sസ്വകാര്യത മാനിക്കുന്ന തിരയൽ "
+"പരസ്യങ്ങളിൽ%2$s നിന്നാണ് പണം സമ്പാദിക്കുന്നത്."
 
 # smartling.placeholder_format=C
 #. Message describing how DuckDuckGo users location access anonymously to provide better search results.
@@ -22171,24 +22451,20 @@ msgid ""
 "We only use your anonymous location to deliver better results, closer to "
 "you. You can always change your mind later."
 msgstr ""
-"നിങ്ങളുടെ സമീപത്തുള്ള മികച്ച ഫലങ്ങൾ നൽകാൻ മാത്രമേ ഞങ്ങൾ നിങ്ങളുടെ അജ്ഞാത "
-"ലൊക്കേഷൻ ഉപയോഗിക്കുകയുള്ളൂ. പിന്നീട് എപ്പോൾ വേണമെങ്കിലും നിങ്ങളുടെ മനസ്സ് "
-"മാറ്റാൻ കഴിയും."
+"നിങ്ങളുടെ സമീപത്തുള്ള മികച്ച ഫലങ്ങൾ നൽകാൻ മാത്രമേ ഞങ്ങൾ നിങ്ങളുടെ അജ്ഞാത ലൊക്കേഷൻ "
+"ഉപയോഗിക്കുകയുള്ളൂ. പിന്നീട് എപ്പോൾ വേണമെങ്കിലും നിങ്ങളുടെ മനസ്സ് മാറ്റാൻ കഴിയും."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
 msgstr ""
-"എല്ലാവർക്കും DuckDuckGo മികച്ചതാക്കാൻ ഞങ്ങൾ നിങ്ങളുടെ അജ്ഞാത ഫീഡ്ബാക്കിനെ "
-"ആശ്രയിക്കുന്നു."
+"എല്ലാവർക്കും DuckDuckGo മികച്ചതാക്കാൻ ഞങ്ങൾ നിങ്ങളുടെ അജ്ഞാത ഫീഡ്ബാക്കിനെ ആശ്രയിക്കുന്നു."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We stop anyone from getting your search history, including us."
-msgstr ""
-"ഞങ്ങൾ ഉൾപ്പെടെ, നിങ്ങളുടെ തിരയൽ ചരിത്രം ആർക്കും ലഭിക്കുന്നതിൽ നിന്ന് ഞങ്ങൾ "
-"തടയുന്നു."
+msgstr "ഞങ്ങൾ ഉൾപ്പെടെ, നിങ്ങളുടെ തിരയൽ ചരിത്രം ആർക്കും ലഭിക്കുന്നതിൽ നിന്ന് ഞങ്ങൾ തടയുന്നു."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -22204,16 +22480,15 @@ msgid ""
 "incorporated at the discretion of %s. Corrections may not show up in results "
 "right away."
 msgstr ""
-"DuckDuckGo മെച്ചപ്പെടുത്തുന്നതിന് ഞങ്ങൾ ഇതുപോലുള്ള ഫീഡ്ബാക്ക് "
-"ഉപയോഗിക്കാറുണ്ട്. %1$s-ന്റെ വിവേചനാധികാര പ്രകാരം നിർദേശങ്ങൾ "
-"സംയോജിപ്പിക്കുന്നതാണ്. തിരുത്തലുകൾ ഫലങ്ങളിൽ സത്വരം ദൃശ്യമാകണമെന്നില്ല."
+"DuckDuckGo മെച്ചപ്പെടുത്തുന്നതിന് ഞങ്ങൾ ഇതുപോലുള്ള ഫീഡ്ബാക്ക് ഉപയോഗിക്കാറുണ്ട്. %1$s-ന്റെ "
+"വിവേചനാധികാര പ്രകാരം നിർദേശങ്ങൾ സംയോജിപ്പിക്കുന്നതാണ്. തിരുത്തലുകൾ ഫലങ്ങളിൽ സത്വരം "
+"ദൃശ്യമാകണമെന്നില്ല."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
 msgstr ""
-"നിങ്ങൾ ബ്രൗസ് ചെയ്യുമ്പോൾ നിങ്ങളുടെ ഡാറ്റ ശേഖരിക്കാൻ ശ്രമിക്കുന്ന "
-"ട്രാക്കർമാരെ ഞങ്ങൾ തടയും."
+"നിങ്ങൾ ബ്രൗസ് ചെയ്യുമ്പോൾ നിങ്ങളുടെ ഡാറ്റ ശേഖരിക്കാൻ ശ്രമിക്കുന്ന ട്രാക്കർമാരെ ഞങ്ങൾ തടയും."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -22223,8 +22498,8 @@ msgid ""
 "continue to see this error, please reach out to %s."
 msgstr ""
 "ഈ പ്രശ്നത്തെക്കുറിച്ച് ഞങ്ങൾക്കറിയാം, അത് പരിഹരിക്കാൻ ഞങ്ങൾ ഇപ്പോൾ "
-"പ്രവർത്തിച്ചുകൊണ്ടിരിക്കുകയാണ്. നിങ്ങൾക്ക് ഈ പിശക് തുടർന്നും കാണുകയാണെങ്കിൽ, "
-"ദയവായി %1$s-നെ സമീപിക്കുക."
+"പ്രവർത്തിച്ചുകൊണ്ടിരിക്കുകയാണ്. നിങ്ങൾക്ക് ഈ പിശക് തുടർന്നും കാണുകയാണെങ്കിൽ, ദയവായി %1$s-നെ "
+"സമീപിക്കുക."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -22234,8 +22509,7 @@ msgid ""
 "clearing your browser's cache can help."
 msgstr ""
 "ഈ പ്രശ്നത്തെക്കുറിച്ച് ഞങ്ങൾക്കറിയാം, അത് പരിഹരിക്കാൻ ഞങ്ങൾ ഇപ്പോൾ "
-"പ്രവർത്തിച്ചുകൊണ്ടിരിക്കുകയാണ്. ചിലപ്പോൾ നിങ്ങളുടെ ബ്രൗസറിന്റെ കാഷെ "
-"മായ്ക്കുന്നത് സഹായിക്കാം."
+"പ്രവർത്തിച്ചുകൊണ്ടിരിക്കുകയാണ്. ചിലപ്പോൾ നിങ്ങളുടെ ബ്രൗസറിന്റെ കാഷെ മായ്ക്കുന്നത് സഹായിക്കാം."
 
 # smartling.placeholder_format=C
 #. Header for a feedback form for new users.
@@ -22250,8 +22524,8 @@ msgid ""
 "We're sorry for this inconvenience. We’re working hard to make your "
 "experience better."
 msgstr ""
-"ഈ അസൗകര്യത്തിന് ഞങ്ങൾ ക്ഷമ ചോദിക്കുന്നു. നിങ്ങളുടെ അനുഭവം മികച്ചതാക്കാൻ "
-"ഞങ്ങൾ കഠിനമായി പരിശ്രമിക്കുന്നു."
+"ഈ അസൗകര്യത്തിന് ഞങ്ങൾ ക്ഷമ ചോദിക്കുന്നു. നിങ്ങളുടെ അനുഭവം മികച്ചതാക്കാൻ ഞങ്ങൾ കഠിനമായി "
+"പരിശ്രമിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Body text explaining the service update requires a page reload.
@@ -22260,8 +22534,8 @@ msgid ""
 "We've updated the Duck.ai service. For the change to take effect, we need to "
 "reload the page."
 msgstr ""
-"ഞങ്ങൾ Duck.ai സേവനം അപ്ഡേറ്റ് ചെയ്തു. മാറ്റം പ്രാബല്യത്തിൽ വരാൻ, നമ്മൾ പേജ് "
-"വീണ്ടും ലോഡ് ചെയ്യേണ്ടതുണ്ട്."
+"ഞങ്ങൾ Duck.ai സേവനം അപ്ഡേറ്റ് ചെയ്തു. മാറ്റം പ്രാബല്യത്തിൽ വരാൻ, നമ്മൾ പേജ് വീണ്ടും ലോഡ് "
+"ചെയ്യേണ്ടതുണ്ട്."
 
 # smartling.placeholder_format=C
 #. Instant Answer Tab Name
@@ -22363,9 +22637,7 @@ msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "Weekly usage limit reached. You can keep chatting by using your monthly "
 "limit."
-msgstr ""
-"പ്രതിവാര ഉപയോഗ പരിധി എത്തി. നിങ്ങളുടെ പ്രതിമാസ പരിധി ഉപയോഗിച്ച് ചാറ്റ് "
-"തുടരാം."
+msgstr "പ്രതിവാര ഉപയോഗ പരിധി എത്തി. നിങ്ങളുടെ പ്രതിമാസ പരിധി ഉപയോഗിച്ച് ചാറ്റ് തുടരാം."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -22379,9 +22651,8 @@ msgid ""
 "Welcome to Duck.ai! All of your chats here are private, anonymized by us and "
 "not used to train AI models."
 msgstr ""
-"Duck.ai-യിലേക്ക് സ്വാഗതം! ഇവിടെയുള്ള നിങ്ങളുടെ എല്ലാ ചാറ്റുകളും "
-"സ്വകാര്യമാണ്, അവ ഞങ്ങൾ അജ്ഞാതമാക്കും, കൂടാതെ AI മോഡലുകളെ പരിശീലിപ്പിക്കാൻ "
-"ഉപയോഗിക്കുന്നില്ല."
+"Duck.ai-യിലേക്ക് സ്വാഗതം! ഇവിടെയുള്ള നിങ്ങളുടെ എല്ലാ ചാറ്റുകളും സ്വകാര്യമാണ്, അവ ഞങ്ങൾ "
+"അജ്ഞാതമാക്കും, കൂടാതെ AI മോഡലുകളെ പരിശീലിപ്പിക്കാൻ ഉപയോഗിക്കുന്നില്ല."
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened.
@@ -22390,9 +22661,9 @@ msgid ""
 "Welcome to DuckDuckGo AI Chat! All of your chats here are private, "
 "anonymized by us and not used to train AI models."
 msgstr ""
-"DuckDuckGo AI Chat-ലേക്ക് സ്വാഗതം! ഇവിടെയുള്ള നിങ്ങളുടെ എല്ലാ ചാറ്റുകളും "
-"സ്വകാര്യമാണ്, അവ ഒരിക്കലും DuckDuckGo സംഭരിക്കുകയോ AI മോഡലുകളെ "
-"പരിശീലിപ്പിക്കാൻ ഉപയോഗിക്കുകയോ ചെയ്യുന്നില്ല."
+"DuckDuckGo AI Chat-ലേക്ക് സ്വാഗതം! ഇവിടെയുള്ള നിങ്ങളുടെ എല്ലാ ചാറ്റുകളും സ്വകാര്യമാണ്, അവ "
+"ഒരിക്കലും DuckDuckGo സംഭരിക്കുകയോ AI മോഡലുകളെ പരിശീലിപ്പിക്കാൻ ഉപയോഗിക്കുകയോ "
+"ചെയ്യുന്നില്ല."
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened. Example: 'Welcome to DuckDuckGo AI Chat! This chat session is powered by OpenAI’s GPT-3. All of your chats here are private, and are never stored by DuckDuckGo or used to train AI models.'
@@ -22402,17 +22673,16 @@ msgid ""
 "of your chats here are private, and are never stored by DuckDuckGo or used "
 "to train AI models."
 msgstr ""
-"DuckDuckGo AI Chat-ലേക്ക് സ്വാഗതം! ഈ ചാറ്റ് സെഷൻ നൽകുന്നത് %1$s-ൻ്റെ %2$s "
-"ആണ്. ഇവിടെയുള്ള നിങ്ങളുടെ എല്ലാ ചാറ്റുകളും സ്വകാര്യമാണ്, അവ ഒരിക്കലും "
-"DuckDuckGo സംഭരിക്കുകയോ AI മോഡലുകളെ പരിശീലിപ്പിക്കുകയോ ചെയ്യുന്നില്ല."
+"DuckDuckGo AI Chat-ലേക്ക് സ്വാഗതം! ഈ ചാറ്റ് സെഷൻ നൽകുന്നത് %1$s-ൻ്റെ %2$s ആണ്. "
+"ഇവിടെയുള്ള നിങ്ങളുടെ എല്ലാ ചാറ്റുകളും സ്വകാര്യമാണ്, അവ ഒരിക്കലും DuckDuckGo സംഭരിക്കുകയോ AI "
+"മോഡലുകളെ പരിശീലിപ്പിക്കുകയോ ചെയ്യുന്നില്ല."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai! You can now import your downloaded chats."
 msgstr ""
-"പുതിയ Duck.ai-യിലേക്ക് സ്വാഗതം! ഇപ്പോൾ നിങ്ങൾ ഡൗൺലോഡ് ചെയ്ത ചാറ്റുകൾ "
-"ഇംപോർട്ട് ചെയ്യാം."
+"പുതിയ Duck.ai-യിലേക്ക് സ്വാഗതം! ഇപ്പോൾ നിങ്ങൾ ഡൗൺലോഡ് ചെയ്ത ചാറ്റുകൾ ഇംപോർട്ട് ചെയ്യാം."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -22480,8 +22750,8 @@ msgid ""
 "We’re really sorry, but it seems there was a problem loading Duck.ai. Try "
 "reloading the page."
 msgstr ""
-"ഞങ്ങൾക്കു വളരെ ക്ഷമിക്കണം, പക്ഷേ Duck.ai ലോഡ് ചെയ്യുന്നതിൽ ഒരു "
-"പ്രശ്നമുണ്ടായതായി തോന്നുന്നു. പേജ് വീണ്ടും ലോഡ് ചെയ്യാൻ ശ്രമിക്കൂ."
+"ഞങ്ങൾക്കു വളരെ ക്ഷമിക്കണം, പക്ഷേ Duck.ai ലോഡ് ചെയ്യുന്നതിൽ ഒരു പ്രശ്നമുണ്ടായതായി തോന്നുന്നു. "
+"പേജ് വീണ്ടും ലോഡ് ചെയ്യാൻ ശ്രമിക്കൂ."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to suggest an AI (Artificial Intelligence) model to be added to the product, and this field is optional.
@@ -22496,8 +22766,8 @@ msgid ""
 "What are some arguments, counter-arguments, and rebuttals to the concept of "
 "a plant-based diet?"
 msgstr ""
-"ഒരു സസ്യാധിഷ്ഠിത ഭക്ഷണക്രമ ആശയത്തിനുള്ള ചില വാദങ്ങളും എതിർവാദങ്ങളും "
-"പ്രതിവാദങ്ങളും എന്തൊക്കെയാണ്?"
+"ഒരു സസ്യാധിഷ്ഠിത ഭക്ഷണക്രമ ആശയത്തിനുള്ള ചില വാദങ്ങളും എതിർവാദങ്ങളും പ്രതിവാദങ്ങളും "
+"എന്തൊക്കെയാണ്?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for considering factors when purchasing a computer monitor.
@@ -22518,8 +22788,8 @@ msgid ""
 "What are some options for the word ‘better’ in the context of “We really "
 "need to do better.”"
 msgstr ""
-"“ഞങ്ങൾ ശരിക്കും മികച്ചത് ചെയ്യേണ്ടതുണ്ട്” എന്ന പശ്ചാത്തലത്തിൽ 'മികച്ചത്' "
-"എന്ന വാക്കിനുള്ള ചില ഓപ്ഷനുകൾ എന്തൊക്കെയാണ്."
+"“ഞങ്ങൾ ശരിക്കും മികച്ചത് ചെയ്യേണ്ടതുണ്ട്” എന്ന പശ്ചാത്തലത്തിൽ 'മികച്ചത്' എന്ന വാക്കിനുള്ള ചില "
+"ഓപ്ഷനുകൾ എന്തൊക്കെയാണ്."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
@@ -22538,12 +22808,108 @@ msgid ""
 "easy to understand for people with or without much AI, or technical, "
 "experience."
 msgstr ""
-"Duck.ai ഉപയോഗിക്കാൻ താൽപ്പര്യമുള്ള ഒരാൾക്ക് DuckDuckGo ബ്രൗസർ ഡൗൺലോഡ് "
-"ചെയ്യുന്നതിന്റെ പ്രയോജനങ്ങൾ എന്തൊക്കെയാണ്? ഔദ്യോഗിക DuckDuckGo സ്രോതസ്സുകൾ "
-"മാത്രം അവലംബിക്കുന്നു. Duck.ai സംയോജനങ്ങളിലും സ്വകാര്യതാ സംരക്ഷണങ്ങളിലും "
-"ശ്രദ്ധ കേന്ദ്രീകരിച്ച്, തലക്കെട്ടുകൾ ഉപയോഗിച്ച് പ്രതികരണത്തെ വ്യക്തമായ "
-"വിഭാഗങ്ങളായി വിഭജിക്കുന്നു. AI അല്ലെങ്കിൽ സാങ്കേതിക പരിചയം കൂടുതലുള്ളവർക്കും "
-"ഇല്ലാത്തവർക്കും ഇത് വളരെ ചെറുതും ലളിതവും മനസ്സിലാക്കാൻ എളുപ്പവുമാക്കുന്നു."
+"Duck.ai ഉപയോഗിക്കാൻ താൽപ്പര്യമുള്ള ഒരാൾക്ക് DuckDuckGo ബ്രൗസർ ഡൗൺലോഡ് ചെയ്യുന്നതിന്റെ "
+"പ്രയോജനങ്ങൾ എന്തൊക്കെയാണ്? ഔദ്യോഗിക DuckDuckGo സ്രോതസ്സുകൾ മാത്രം അവലംബിക്കുന്നു. Duck.ai "
+"സംയോജനങ്ങളിലും സ്വകാര്യതാ സംരക്ഷണങ്ങളിലും ശ്രദ്ധ കേന്ദ്രീകരിച്ച്, തലക്കെട്ടുകൾ ഉപയോഗിച്ച് "
+"പ്രതികരണത്തെ വ്യക്തമായ വിഭാഗങ്ങളായി വിഭജിക്കുന്നു. AI അല്ലെങ്കിൽ സാങ്കേതിക പരിചയം "
+"കൂടുതലുള്ളവർക്കും ഇല്ലാത്തവർക്കും ഇത് വളരെ ചെറുതും ലളിതവും മനസ്സിലാക്കാൻ എളുപ്പവുമാക്കുന്നു."
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the counterarguments?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the hours & location?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key contributions of this paper?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key contributions?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key details?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key points covered in this video?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key points?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key takeaways from this article?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key takeaways?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key things I will learn from this course?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main counterarguments or criticisms of this?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main questions this page answers?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the must-try dishes here?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"What are the opening hours, location, and contact details for this place?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the pros and cons of this product?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the pros and cons?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
@@ -22646,6 +23012,12 @@ msgid "What does atria mean in the context of a medical article?"
 msgstr "ഒരു മെഡിക്കൽ ലേഖനത്തിന്റെ പശ്ചാത്തലത്തിൽ അട്രിയ എന്താണ് അർത്ഥമാക്കുന്നത്?"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What does this answer?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
@@ -22658,20 +23030,32 @@ msgid "What information gets saved?"
 msgstr "ഏതെല്ലാം വിവരങ്ങളാണ് സംരക്ഷിക്കപ്പെടുക?"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What interview questions might come up for this role?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
 msgid ""
 "What is the Cloud Save bookmarklet and how does it differ from the URL "
 "parameter bookmarklet?"
 msgstr ""
-"Cloud Save ബുക്ക്മാര്‍ക്കലെറ്റ് എന്നാല്‍ എന്ത്? URL പാരാമീറ്റർ "
-"ബുക്ക്മാർക്ലറ്റിൽ നിന്ന് ഇത് എങ്ങനെ വ്യത്യാസപ്പെട്ടിരിക്കുന്നു?"
+"Cloud Save ബുക്ക്മാര്‍ക്കലെറ്റ് എന്നാല്‍ എന്ത്? URL പാരാമീറ്റർ ബുക്ക്മാർക്ലറ്റിൽ നിന്ന് ഇത് എങ്ങനെ "
+"വ്യത്യാസപ്പെട്ടിരിക്കുന്നു?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for looking up the capital city of Albania.
 msgctxt "Full sentence for looking up basic facts"
 msgid "What is the capital city of Albania?"
 msgstr "അൽബേനിയയുടെ തലസ്ഥാന നഗരം ഏതാണ്?"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What is the overall verdict and rating for this?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to a page with additional information.
@@ -22696,6 +23080,12 @@ msgid "What people say:"
 msgstr "ആളുകൾ പറയുന്നത്:"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What should I order?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
 msgctxt "feedback form"
 msgid "What stood out?"
@@ -22708,6 +23098,18 @@ msgid "What was wrong with the response? (optional)"
 msgstr "പ്രതികരണത്തിൽ എന്തായിരുന്നു തെറ്റ്? (ഓപ്ഷണൽ)"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I learn?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I need?"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid "What would you like to provide feedback on?"
 msgstr "നിങ്ങൾ എന്തിനെക്കുറിച്ചാണ് ഫീഡ്ബാക്ക് നൽകാൻ ആഗ്രഹിക്കുന്നത്?"
@@ -22717,14 +23119,19 @@ msgstr "നിങ്ങൾ എന്തിനെക്കുറിച്ചാ�
 msgid ""
 "What you watch in DuckDuckGo won't influence your recommendations on YouTube."
 msgstr ""
-"DuckDuckGo-യിൽ നിങ്ങൾ എന്ത് കാണുന്നുവെന്നത് YouTube-ലെ നിങ്ങളുടെ ശുപാർശകളെ "
-"സ്വാധീനിക്കില്ല."
+"DuckDuckGo-യിൽ നിങ്ങൾ എന്ത് കാണുന്നുവെന്നത് YouTube-ലെ നിങ്ങളുടെ ശുപാർശകളെ സ്വാധീനിക്കില്ല."
 
 # smartling.placeholder_format=C
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
 msgctxt "SERP footer content"
 msgid "What's New"
 msgstr "പുതിയതായി എന്തുണ്ട്"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What's the verdict?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -22738,8 +23145,8 @@ msgid ""
 "When buying an electric guitar for a beginner, what are the top product "
 "brands I should consider?"
 msgstr ""
-"ഒരു തുടക്കക്കാരന് വേണ്ടി ഒരു ഇലക്ട്രിക് ഗിറ്റാർ വാങ്ങുമ്പോൾ, ഞാൻ "
-"പരിഗണിക്കേണ്ട മുൻനിര ഉൽപ്പന്ന ബ്രാൻഡുകൾ എന്തൊക്കെയാണ്?"
+"ഒരു തുടക്കക്കാരന് വേണ്ടി ഒരു ഇലക്ട്രിക് ഗിറ്റാർ വാങ്ങുമ്പോൾ, ഞാൻ പരിഗണിക്കേണ്ട മുൻനിര ഉൽപ്പന്ന "
+"ബ്രാൻഡുകൾ എന്തൊക്കെയാണ്?"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -22763,8 +23170,7 @@ msgstr "<strong>%1$s</strong> എവിടെ കാണാം"
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Where it says Homepage click %sSet to Current Page%s."
 msgstr ""
-"അത് ഹോംപേജ് എന്ന് പറയുന്നിടത്ത്, %1$sനിലവിലെ പേജിലേക്ക് സജ്ജമാക്കുക%2$s "
-"എന്നത് ക്ലിക്ക് ചെയ്യുക."
+"അത് ഹോംപേജ് എന്ന് പറയുന്നിടത്ത്, %1$sനിലവിലെ പേജിലേക്ക് സജ്ജമാക്കുക%2$s എന്നത് ക്ലിക്ക് ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Heading of a module showing what streaming services are showing a movie or series, e.g. Where to Watch The Matrix
@@ -22777,6 +23183,12 @@ msgstr "<strong>%1$s</strong> എവിടെ കാണാം"
 msgctxt "Feedback prompt"
 msgid "Which features are missing? (Optional)"
 msgstr "ഏത് സവിശേഷതകളാണ് നഷ്ടമായത്? (ഓപ്ഷണൽ)"
+
+# smartling.placeholder_format=C
+#. An invitation for users to leave feedback
+msgctxt "Feedback prompt"
+msgid "Which features are missing? (optional)"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
@@ -22793,6 +23205,18 @@ msgstr "വെളുപ്പ്"
 #. Link to an about us page.
 msgid "Who We Are"
 msgstr "ആരാണ് ഞങ്ങൾ"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Who are the main cast and crew, and what else are they known for?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Who is this person?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Header above a collection of privacy-related links.
@@ -23164,8 +23588,7 @@ msgctxt "cloudsave"
 msgid ""
 "Yes, we throw away data when you’re done with it, and it cannot be recovered."
 msgstr ""
-"അതെ, നിങ്ങൾ ഡാറ്റ പൂർത്തിയാക്കുമ്പോൾ ഞങ്ങൾ അത് വലിച്ചെറിയുന്നു, അത് "
-"വീണ്ടെടുക്കാൻ കഴിയില്ല."
+"അതെ, നിങ്ങൾ ഡാറ്റ പൂർത്തിയാക്കുമ്പോൾ ഞങ്ങൾ അത് വലിച്ചെറിയുന്നു, അത് വീണ്ടെടുക്കാൻ കഴിയില്ല."
 
 # smartling.placeholder_format=C
 #. Option for the filter-by-date search.
@@ -23185,8 +23608,8 @@ msgid ""
 "You are chatting with %s. AI chats may display inaccurate or offensive "
 "information."
 msgstr ""
-"നിങ്ങൾ %1$s എന്നയാളുമായി ചാറ്റ് ചെയ്യുന്നു. AI ചാറ്റുകൾ കൃത്യമല്ലാത്തതോ "
-"കുറ്റകരമായതോ ആയ വിവരങ്ങൾ പ്രദർശിപ്പിച്ചേക്കാം."
+"നിങ്ങൾ %1$s എന്നയാളുമായി ചാറ്റ് ചെയ്യുന്നു. AI ചാറ്റുകൾ കൃത്യമല്ലാത്തതോ കുറ്റകരമായതോ ആയ "
+"വിവരങ്ങൾ പ്രദർശിപ്പിച്ചേക്കാം."
 
 # smartling.placeholder_format=C
 #. Provide users with the ability to retry their search on a different search engine. First placeholder will be a link with the text "try your search again" OR "try your search later". Second is a URL to the !bangs page: https://duckduckgo.com/bangs.
@@ -23195,8 +23618,8 @@ msgid ""
 "You can %s or search directly on other search engines from DuckDuckGo using "
 "%s search shortcuts."
 msgstr ""
-"%2$s തിരയൽ കുറുക്കുവഴികൾ ഉപയോഗിച്ച് നിങ്ങൾക്ക് %1$s അല്ലെങ്കിൽ "
-"DuckDuckGo-യിൽ നിന്ന് മറ്റ് തിരയൽ എഞ്ചിനുകളിൽ നേരിട്ട് തിരയാൻ കഴിയും."
+"%2$s തിരയൽ കുറുക്കുവഴികൾ ഉപയോഗിച്ച് നിങ്ങൾക്ക് %1$s അല്ലെങ്കിൽ DuckDuckGo-യിൽ നിന്ന് മറ്റ് "
+"തിരയൽ എഞ്ചിനുകളിൽ നേരിട്ട് തിരയാൻ കഴിയും."
 
 # smartling.placeholder_format=C
 #. Text informing the user that they can access DuckDuckGo AI Chat directly at a specific URL. The placeholder %s will be replaced with the link. Example: 'You can access DuckDuckGo AI Chat directly at duck.ai.'
@@ -23210,8 +23633,8 @@ msgctxt "duckassist"
 msgid ""
 "You can adjust how %s works or turn it off anytime in %sSearch Settings%s."
 msgstr ""
-"നിങ്ങൾക്ക് %1$s എങ്ങനെ പ്രവർത്തിക്കുന്നുവെന്നത് ക്രമീകരിക്കാനോ %2$sതിരയൽ "
-"ക്രമീകരണങ്ങൾ%3$s-ൽ എപ്പോൾ വേണമെങ്കിലും അത് ഓഫാക്കാനോ കഴിയും."
+"നിങ്ങൾക്ക് %1$s എങ്ങനെ പ്രവർത്തിക്കുന്നുവെന്നത് ക്രമീകരിക്കാനോ %2$sതിരയൽ ക്രമീകരണങ്ങൾ%3$s-ൽ "
+"എപ്പോൾ വേണമെങ്കിലും അത് ഓഫാക്കാനോ കഴിയും."
 
 # smartling.placeholder_format=C
 #. Assist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate Assist.
@@ -23220,22 +23643,21 @@ msgid ""
 "You can adjust how Assist works or turn it off anytime in %sSearch "
 "Settings%s."
 msgstr ""
-"Assist എങ്ങനെ പ്രവർത്തിക്കുന്നുവെന്നത് ക്രമീകരിക്കാനോ %1$sതിരയൽ "
-"ക്രമീകരണങ്ങൾ%2$s-ൽ അത് എപ്പോൾ വേണമെങ്കിലും ഓഫാക്കാനോ നിങ്ങൾക്ക് കഴിയും."
+"Assist എങ്ങനെ പ്രവർത്തിക്കുന്നുവെന്നത് ക്രമീകരിക്കാനോ %1$sതിരയൽ ക്രമീകരണങ്ങൾ%2$s-ൽ അത് "
+"എപ്പോൾ വേണമെങ്കിലും ഓഫാക്കാനോ നിങ്ങൾക്ക് കഴിയും."
 
 # smartling.placeholder_format=C
 msgid "You can also use %sDuck.ai%s to answer questions or summarize text."
 msgstr ""
-"ചോദ്യങ്ങൾക്ക് ഉത്തരം നൽകാനും വാചകം സംഗ്രഹിക്കാനും നിങ്ങൾക്ക് %1$sDuck.ai%2$s "
-"ഉപയോഗിക്കാം."
+"ചോദ്യങ്ങൾക്ക് ഉത്തരം നൽകാനും വാചകം സംഗ്രഹിക്കാനും നിങ്ങൾക്ക് %1$sDuck.ai%2$s ഉപയോഗിക്കാം."
 
 # smartling.placeholder_format=C
 msgid ""
 "You can also use %sDuckDuckGo AI Chat%s to answer questions or summarize "
 "text."
 msgstr ""
-"ചോദ്യങ്ങൾക്ക് ഉത്തരം നൽകാനോ വാചകം സംഗ്രഹിക്കാനോ നിങ്ങൾക്ക് %1$sDuckDuckGo AI "
-"Chat%2$s ഉപയോഗിക്കാനും കഴിയും."
+"ചോദ്യങ്ങൾക്ക് ഉത്തരം നൽകാനോ വാചകം സംഗ്രഹിക്കാനോ നിങ്ങൾക്ക് %1$sDuckDuckGo AI Chat%2$s "
+"ഉപയോഗിക്കാനും കഴിയും."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach more text selections than are allowed. Placeholder is the maximum number of text selections. E.g. You can attach up to 5 text selections.
@@ -23249,8 +23671,8 @@ msgid ""
 "You can change how frequently you see Search Assist, or turn it off "
 "entirely, in %sSearch Settings%s."
 msgstr ""
-"%1$sതിരയൽ ക്രമീകരണങ്ങൾ%2$s എന്നതിൽ നിങ്ങൾക്ക് എത്ര തവണ Search Assist "
-"കാണണമെന്നത് മാറ്റാനോ, പൂർണ്ണമായും ഓഫാക്കാനോ കഴിയും."
+"%1$sതിരയൽ ക്രമീകരണങ്ങൾ%2$s എന്നതിൽ നിങ്ങൾക്ക് എത്ര തവണ Search Assist കാണണമെന്നത് "
+"മാറ്റാനോ, പൂർണ്ണമായും ഓഫാക്കാനോ കഴിയും."
 
 # smartling.placeholder_format=C
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
@@ -23265,8 +23687,8 @@ msgid ""
 "You can do this by saving your settings under a different passphrase, "
 "optionally deleting the first set."
 msgstr ""
-"ആദ്യ സെറ്റ് ഓപ്ഷണലായി ഇല്ലാതാക്കിക്കൊണ്ട്, നിങ്ങളുടെ ക്രമീകരണം മറ്റൊരു "
-"പാസ്‌ഫ്രെയ്സിന് കീഴിൽ സംരക്ഷിച്ചുകൊണ്ട് നിങ്ങൾക്ക് ഇത് ചെയ്യാൻ കഴിയും."
+"ആദ്യ സെറ്റ് ഓപ്ഷണലായി ഇല്ലാതാക്കിക്കൊണ്ട്, നിങ്ങളുടെ ക്രമീകരണം മറ്റൊരു പാസ്‌ഫ്രെയ്സിന് കീഴിൽ "
+"സംരക്ഷിച്ചുകൊണ്ട് നിങ്ങൾക്ക് ഇത് ചെയ്യാൻ കഴിയും."
 
 # smartling.placeholder_format=C
 #. Prefix for filename location sentence.
@@ -23290,8 +23712,7 @@ msgstr "%1$sതിരയൽ ക്രമീകരണത്തിൽ%2$s നി�
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
 msgstr ""
-"നിങ്ങൾക്ക് ഇപ്പോൾ ഈ ഉപകരണത്തിൽ 100 ചാറ്റുകൾ വരെ സംരക്ഷിക്കാൻ കഴിയും. ചാറ്റ് "
-"തുടർന്നോളൂ!"
+"നിങ്ങൾക്ക് ഇപ്പോൾ ഈ ഉപകരണത്തിൽ 100 ചാറ്റുകൾ വരെ സംരക്ഷിക്കാൻ കഴിയും. ചാറ്റ് തുടർന്നോളൂ!"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -23348,8 +23769,8 @@ msgid ""
 "You can only block up to %s sites. To block %s, you'll need to unblock "
 "another site first."
 msgstr ""
-"നിങ്ങൾക്ക് %1$s സൈറ്റുകൾ വരെ മാത്രമേ ബ്ലോക്ക് ചെയ്യാനാകൂ. %2$s തടയാൻ, ആദ്യം "
-"മറ്റൊരു സൈറ്റ് അൺബ്ലോക്ക് ചെയ്യണം."
+"നിങ്ങൾക്ക് %1$s സൈറ്റുകൾ വരെ മാത്രമേ ബ്ലോക്ക് ചെയ്യാനാകൂ. %2$s തടയാൻ, ആദ്യം മറ്റൊരു സൈറ്റ് "
+"അൺബ്ലോക്ക് ചെയ്യണം."
 
 # smartling.placeholder_format=C
 #. Text explaining the benefits of the cloud save feature.
@@ -23385,9 +23806,7 @@ msgstr "നിങ്ങൾക്ക് ഈ പുതിയ ഡൊമെയ്ന
 #. Text explaining the benefits of the cloud save feature.
 msgctxt "cloudsave"
 msgid "You can store several sets of settings for different purposes."
-msgstr ""
-"പലതരം ആവശ്യങ്ങൾക്കായി ക്രമീകരണത്തിന്റെ വിവിധ സെറ്റുകൾ നിങ്ങൾക്ക് ഇവിടെ "
-"സൂക്ഷിക്കാം."
+msgstr "പലതരം ആവശ്യങ്ങൾക്കായി ക്രമീകരണത്തിന്റെ വിവിധ സെറ്റുകൾ നിങ്ങൾക്ക് ഇവിടെ സൂക്ഷിക്കാം."
 
 # smartling.placeholder_format=C
 #. Instructions for user once they've failed the bot challenge
@@ -23408,8 +23827,8 @@ msgid ""
 "You now have access to %s, higher AI reasoning, and 2x higher usage limits "
 "than Plus."
 msgstr ""
-"നിങ്ങൾക്ക് ഇപ്പോൾ %1$s എന്നതിലേക്ക് ആക്സസ് ഉണ്ട്, ഉയർന്ന AI റീസണിംഗ്, "
-"Plus-നേക്കാൾ 2 മടങ്ങ് ഉയർന്ന ഉപയോഗ പരിധി എന്നിവയുണ്ട്."
+"നിങ്ങൾക്ക് ഇപ്പോൾ %1$s എന്നതിലേക്ക് ആക്സസ് ഉണ്ട്, ഉയർന്ന AI റീസണിംഗ്, Plus-നേക്കാൾ 2 മടങ്ങ് "
+"ഉയർന്ന ഉപയോഗ പരിധി എന്നിവയുണ്ട്."
 
 # smartling.placeholder_format=C
 #. Description text for the welcome modal displayed after the user subscribes to DuckDuckGo.
@@ -23418,9 +23837,8 @@ msgid ""
 "You now have access to advanced AI models. You can access the VPN and other "
 "DuckDuckGo subscription protections in the DuckDuckGo browser."
 msgstr ""
-"നിങ്ങൾക്ക് ഇപ്പോൾ നൂതന AI മോഡലുകളിലേക്ക് ആക്‌സസ് ഉണ്ട്. നിങ്ങൾക്ക് "
-"DuckDuckGo ബ്രൗസറിൽ VPN, മറ്റ് DuckDuckGo സബ്സ്ക്രിപ്ഷൻ പരിരക്ഷകൾ ആക്സസ് "
-"ചെയ്യാം."
+"നിങ്ങൾക്ക് ഇപ്പോൾ നൂതന AI മോഡലുകളിലേക്ക് ആക്‌സസ് ഉണ്ട്. നിങ്ങൾക്ക് DuckDuckGo ബ്രൗസറിൽ VPN, "
+"മറ്റ് DuckDuckGo സബ്സ്ക്രിപ്ഷൻ പരിരക്ഷകൾ ആക്സസ് ചെയ്യാം."
 
 # smartling.placeholder_format=C
 #. Welcome message that appears after the DuckDuckGo extension is installed.
@@ -23442,9 +23860,9 @@ msgid ""
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
 msgstr ""
-"ഈ ബ്രൗസറിൽ നിന്ന് നിങ്ങളുടെസംരക്ഷിച്ച ചാറ്റുകൾ ഇനി നിങ്ങൾക്ക് ആക്‌സസ് "
-"ചെയ്യാൻ കഴിയില്ല. അവസാന 30 ചാറ്റുകൾ ഇപ്പോഴും ലോക്കൽ സ്റ്റോറേജിൽ ലഭ്യമാകും. "
-"ഇത് എൻക്രിപ്റ്റ് ചെയ്ത സെർവറിൽ നിന്ന് നിങ്ങളുടെ ചാറ്റുകൾ ഇല്ലാതാക്കില്ല."
+"ഈ ബ്രൗസറിൽ നിന്ന് നിങ്ങളുടെസംരക്ഷിച്ച ചാറ്റുകൾ ഇനി നിങ്ങൾക്ക് ആക്‌സസ് ചെയ്യാൻ കഴിയില്ല. അവസാന "
+"30 ചാറ്റുകൾ ഇപ്പോഴും ലോക്കൽ സ്റ്റോറേജിൽ ലഭ്യമാകും. ഇത് എൻക്രിപ്റ്റ് ചെയ്ത സെർവറിൽ നിന്ന് "
+"നിങ്ങളുടെ ചാറ്റുകൾ ഇല്ലാതാക്കില്ല."
 
 # smartling.placeholder_format=C
 #. Explains that turning off disconnects this browser only; the last 30 chats stay in local storage and the encrypted server backup is not deleted.
@@ -23454,9 +23872,9 @@ msgid ""
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
 msgstr ""
-"ഈ ബ്രൗസറിൽ നിന്ന് നിങ്ങളുടെ സംരക്ഷിച്ച ചാറ്റുകൾ ഇനി ആക്‌സസ് ചെയ്യാൻ "
-"കഴിയില്ല. അവസാന 30 ചാറ്റുകൾ ഇപ്പോഴും ലോക്കൽ സ്റ്റോറേജിൽ ലഭ്യമാകും. ഇത് "
-"എൻക്രിപ്റ്റ് ചെയ്ത സെർവറിൽ നിന്ന് നിങ്ങളുടെ ചാറ്റുകൾ ഇല്ലാതാക്കില്ല."
+"ഈ ബ്രൗസറിൽ നിന്ന് നിങ്ങളുടെ സംരക്ഷിച്ച ചാറ്റുകൾ ഇനി ആക്‌സസ് ചെയ്യാൻ കഴിയില്ല. അവസാന 30 "
+"ചാറ്റുകൾ ഇപ്പോഴും ലോക്കൽ സ്റ്റോറേജിൽ ലഭ്യമാകും. ഇത് എൻക്രിപ്റ്റ് ചെയ്ത സെർവറിൽ നിന്ന് നിങ്ങളുടെ "
+"ചാറ്റുകൾ ഇല്ലാതാക്കില്ല."
 
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
@@ -23470,8 +23888,8 @@ msgid ""
 "You'll receive automatic DuckDuckGo app updates once you have the latest "
 "version."
 msgstr ""
-"ഏറ്റവും പുതിയ പതിപ്പ് ലഭിച്ചുകഴിഞ്ഞാൽ നിങ്ങൾക്ക് സ്വയമേവയുള്ള DuckDuckGo "
-"ആപ്പ് അപ്ഡേറ്റുകൾ ലഭിക്കും."
+"ഏറ്റവും പുതിയ പതിപ്പ് ലഭിച്ചുകഴിഞ്ഞാൽ നിങ്ങൾക്ക് സ്വയമേവയുള്ള DuckDuckGo ആപ്പ് അപ്ഡേറ്റുകൾ "
+"ലഭിക്കും."
 
 # smartling.placeholder_format=C
 #. shown when DDG is selected after eu preference menu on android
@@ -23480,9 +23898,8 @@ msgid ""
 "You're now searching privately in Chrome. Use our app instead of Chrome to "
 "browse privately too. It’s already installed and can:"
 msgstr ""
-"നിങ്ങൾ ഇപ്പോൾ Chrome-ൽ സ്വകാര്യമായി തിരയുന്നു. സ്വകാര്യമായി ബ്രൗസ് "
-"ചെയ്യുന്നതിന് Chrome-ന് പകരം ഞങ്ങളുടെ ആപ്പും ഉപയോഗിക്കുക. ഇത് ഇതിനകം "
-"ഇൻസ്റ്റാൾ ചെയ്തിട്ടുണ്ട്, ഇതിന് ഇവ ചെയ്യാനാകും:"
+"നിങ്ങൾ ഇപ്പോൾ Chrome-ൽ സ്വകാര്യമായി തിരയുന്നു. സ്വകാര്യമായി ബ്രൗസ് ചെയ്യുന്നതിന് Chrome-ന് "
+"പകരം ഞങ്ങളുടെ ആപ്പും ഉപയോഗിക്കുക. ഇത് ഇതിനകം ഇൻസ്റ്റാൾ ചെയ്തിട്ടുണ്ട്, ഇതിന് ഇവ ചെയ്യാനാകും:"
 
 # smartling.placeholder_format=C
 #. Confirmation message that appears after the DuckDuckGo browser extension is installed.
@@ -23495,8 +23912,8 @@ msgid ""
 "You're now searching with privacy. %sGet tips to reduce your footprint even "
 "more."
 msgstr ""
-"നിങ്ങൾ ഇപ്പോൾ സ്വകാര്യത ഉപയോഗിച്ച് തിരയുന്നു. %1$sനിങ്ങളുടെ പാദമുദ്ര ഇനിയും "
-"കുറയ്ക്കുന്നതിന് നുറുങ്ങുകൾ നേടുക."
+"നിങ്ങൾ ഇപ്പോൾ സ്വകാര്യത ഉപയോഗിച്ച് തിരയുന്നു. %1$sനിങ്ങളുടെ പാദമുദ്ര ഇനിയും കുറയ്ക്കുന്നതിന് "
+"നുറുങ്ങുകൾ നേടുക."
 
 # smartling.placeholder_format=C
 #. Title of a notice thanking the user for turning off their adblocker
@@ -23540,8 +23957,8 @@ msgid ""
 "You've reached the maximum number of messages for the moment. Please try "
 "again later."
 msgstr ""
-"നിങ്ങൾ തൽക്കാലത്തേക്ക് സന്ദേശങ്ങളുടെ പരമാവധി എണ്ണത്തിൽ എത്തിയിരിക്കുന്നു. "
-"ദയവായി വീണ്ടും ശ്രമിക്കുക."
+"നിങ്ങൾ തൽക്കാലത്തേക്ക് സന്ദേശങ്ങളുടെ പരമാവധി എണ്ണത്തിൽ എത്തിയിരിക്കുന്നു. ദയവായി വീണ്ടും "
+"ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -23568,9 +23985,8 @@ msgid ""
 "You've run out of Sync & Backup storage for Duck.ai chats with attachments. "
 "Delete the %s oldest chats to resume Sync. Pinned chats will not be deleted."
 msgstr ""
-"അറ്റാച്ചുമെന്റുകളുള്ള Duck.ai ചാറ്റുകൾക്കുള്ള നിങ്ങളുടെ Sync & Backup സംഭരണം "
-"തീർന്നു. സമന്വയം പുനരാരംഭിക്കാൻ ഏറ്റവും പഴയ %1$s ചാറ്റുകൾ ഇല്ലാതാക്കുക. പിൻ "
-"ചെയ്ത ചാറ്റുകൾ ഇല്ലാതാക്കില്ല."
+"അറ്റാച്ചുമെന്റുകളുള്ള Duck.ai ചാറ്റുകൾക്കുള്ള നിങ്ങളുടെ Sync & Backup സംഭരണം തീർന്നു. സമന്വയം "
+"പുനരാരംഭിക്കാൻ ഏറ്റവും പഴയ %1$s ചാറ്റുകൾ ഇല്ലാതാക്കുക. പിൻ ചെയ്ത ചാറ്റുകൾ ഇല്ലാതാക്കില്ല."
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -23581,8 +23997,8 @@ msgid ""
 "deleted."
 msgstr ""
 "Duck.ai ചാറ്റുകൾക്കുള്ള Sync & Backup സ്റ്റോറേജ് തീർന്നിരിക്കുന്നു. സമന്വയം "
-"പുനരാരംഭിക്കുന്നതിന് അറ്റാച്ചുമെന്റുകളുള്ള %1$s ഏറ്റവും പഴയ ചാറ്റുകൾ "
-"ഇല്ലാതാക്കുക. പിൻ ചെയ്ത ചാറ്റുകൾ ഇല്ലാതാക്കില്ല."
+"പുനരാരംഭിക്കുന്നതിന് അറ്റാച്ചുമെന്റുകളുള്ള %1$s ഏറ്റവും പഴയ ചാറ്റുകൾ ഇല്ലാതാക്കുക. പിൻ ചെയ്ത "
+"ചാറ്റുകൾ ഇല്ലാതാക്കില്ല."
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the sync storage limit.
@@ -23596,9 +24012,8 @@ msgid ""
 "YouTube (owned by Google) does not let you watch videos anonymously. As "
 "such, watching YouTube videos here will be tracked by YouTube/Google."
 msgstr ""
-"(Google ഉടമസ്ഥതയിലുള്ള) YouTube അജ്ഞാതനായി വീഡിയോകൾ കാണാൻ നിങ്ങളെ "
-"അനുവദിക്കുന്നില്ല. അതുപോലെ, ഇവിടെ YouTube വീഡിയോകൾ കാണുന്നത് "
-"YouTube/Google ട്രാക്ക് ചെയ്യും."
+"(Google ഉടമസ്ഥതയിലുള്ള) YouTube അജ്ഞാതനായി വീഡിയോകൾ കാണാൻ നിങ്ങളെ അനുവദിക്കുന്നില്ല. "
+"അതുപോലെ, ഇവിടെ YouTube വീഡിയോകൾ കാണുന്നത് YouTube/Google ട്രാക്ക് ചെയ്യും."
 
 # smartling.placeholder_format=C
 #. Label for a privacy disclaimer related to YouTube videos
@@ -23642,9 +24057,9 @@ msgid ""
 "disconnected from sync. Your %s most recent chats will be available in local "
 "storage on these browsers:"
 msgstr ""
-"DuckDuckGo-യുടെ സെർവറിൽ നിന്ന് നിങ്ങളുടെ ബാക്കപ്പ് ഇല്ലാതാക്കപ്പെടും. എല്ലാ "
-"ഉപകരണങ്ങളും സമന്വയത്തിൽ നിന്ന് വിച്ഛേദിക്കപ്പെടും. നിങ്ങളുടെ ഏറ്റവും പുതിയ "
-"%1$s ചാറ്റുകൾ ഈ ബ്രൗസറുകളിലെ ലോക്കൽ സ്റ്റോറേജിൽ ലഭ്യമാകും:"
+"DuckDuckGo-യുടെ സെർവറിൽ നിന്ന് നിങ്ങളുടെ ബാക്കപ്പ് ഇല്ലാതാക്കപ്പെടും. എല്ലാ ഉപകരണങ്ങളും "
+"സമന്വയത്തിൽ നിന്ന് വിച്ഛേദിക്കപ്പെടും. നിങ്ങളുടെ ഏറ്റവും പുതിയ %1$s ചാറ്റുകൾ ഈ ബ്രൗസറുകളിലെ "
+"ലോക്കൽ സ്റ്റോറേജിൽ ലഭ്യമാകും:"
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list.
@@ -23654,9 +24069,9 @@ msgid ""
 "disconnected from sync. Your 100 most recent chats will be available in "
 "local storage on these browsers:"
 msgstr ""
-"DuckDuckGo-യുടെ സെർവറിൽ നിന്ന് നിങ്ങളുടെ ബാക്കപ്പ് ഇല്ലാതാക്കപ്പെടും. എല്ലാ "
-"ഉപകരണങ്ങളും സമന്വയത്തിൽ നിന്ന് വിച്ഛേദിക്കപ്പെടും. നിങ്ങളുടെ ഏറ്റവും പുതിയ "
-"100 ചാറ്റുകൾ ഈ ബ്രൗസറുകളിലെ ലോക്കൽ സ്റ്റോറേജിൽ ലഭ്യമാകും:"
+"DuckDuckGo-യുടെ സെർവറിൽ നിന്ന് നിങ്ങളുടെ ബാക്കപ്പ് ഇല്ലാതാക്കപ്പെടും. എല്ലാ ഉപകരണങ്ങളും "
+"സമന്വയത്തിൽ നിന്ന് വിച്ഛേദിക്കപ്പെടും. നിങ്ങളുടെ ഏറ്റവും പുതിയ 100 ചാറ്റുകൾ ഈ ബ്രൗസറുകളിലെ "
+"ലോക്കൽ സ്റ്റോറേജിൽ ലഭ്യമാകും:"
 
 # smartling.placeholder_format=C
 #. List item indicating that a site exclusion filter is currently active for the search
@@ -23672,9 +24087,7 @@ msgstr "നിങ്ങൾ ഈ ലിങ്ക് സന്ദർശിച്ച
 # smartling.placeholder_format=C
 msgctxt "new tab page"
 msgid "Your browser provides a list of your most-visited sites."
-msgstr ""
-"നിങ്ങൾ ഏറ്റവും കൂടുതൽ സന്ദർശിച്ച സൈറ്റുകളുടെ ഒരു ലിസ്റ്റ് നിങ്ങളുടെ ബ്രൗസർ "
-"നൽകുന്നു."
+msgstr "നിങ്ങൾ ഏറ്റവും കൂടുതൽ സന്ദർശിച്ച സൈറ്റുകളുടെ ഒരു ലിസ്റ്റ് നിങ്ങളുടെ ബ്രൗസർ നൽകുന്നു."
 
 # smartling.placeholder_format=C
 #. Used as a description in a menu
@@ -23683,8 +24096,8 @@ msgid ""
 "Your browser provides a list of your most-visited sites. DuckDuckGo never "
 "has access to this data."
 msgstr ""
-"നിങ്ങൾ ഏറ്റവും കൂടുതൽ സന്ദർശിച്ച സൈറ്റുകളുടെ ഒരു ലിസ്റ്റ് നിങ്ങളുടെ ബ്രൗസർ "
-"നൽകുന്നു. DuckDuckGo-യ്ക്ക് ഒരിക്കലും ഈ ഡാറ്റയിലേക്ക് ആക്സസ് ഇല്ല."
+"നിങ്ങൾ ഏറ്റവും കൂടുതൽ സന്ദർശിച്ച സൈറ്റുകളുടെ ഒരു ലിസ്റ്റ് നിങ്ങളുടെ ബ്രൗസർ നൽകുന്നു. DuckDuckGo-"
+"യ്ക്ക് ഒരിക്കലും ഈ ഡാറ്റയിലേക്ക് ആക്സസ് ഇല്ല."
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
@@ -23692,8 +24105,8 @@ msgid ""
 "Your browser provides the list of most-visited sites. DuckDuckGo never has "
 "access to this data."
 msgstr ""
-"നിങ്ങളുടെ ബ്രൗസർ ഏറ്റവും കൂടുതൽ സന്ദർശിച്ച സൈറ്റുകളുടെ പട്ടിക നൽകുന്നു. "
-"DuckDuckGo-യ്ക്ക് ഒരിക്കലും ഈ ഡാറ്റയിലേക്ക് ആക്സസ് ഇല്ല."
+"നിങ്ങളുടെ ബ്രൗസർ ഏറ്റവും കൂടുതൽ സന്ദർശിച്ച സൈറ്റുകളുടെ പട്ടിക നൽകുന്നു. DuckDuckGo-യ്ക്ക് "
+"ഒരിക്കലും ഈ ഡാറ്റയിലേക്ക് ആക്സസ് ഇല്ല."
 
 # smartling.placeholder_format=C
 #. Disclaimer text shown bellow chat input. Example: 'You are chatting with GPT-3. AI chats may display inaccurate or offensive information.'
@@ -23702,8 +24115,8 @@ msgid ""
 "Your chat with %s is private. AI chats may display inaccurate or offensive "
 "information."
 msgstr ""
-"%1$s -നോടുള്ള നിങ്ങളുടെ ചാറ്റ് സ്വകാര്യമാണ്. AI ചാറ്റുകൾ കൃത്യമല്ലാത്തതോ "
-"കുറ്റകരമായതോ ആയ വിവരങ്ങൾ പ്രദർശിപ്പിച്ചേക്കാം."
+"%1$s -നോടുള്ള നിങ്ങളുടെ ചാറ്റ് സ്വകാര്യമാണ്. AI ചാറ്റുകൾ കൃത്യമല്ലാത്തതോ കുറ്റകരമായതോ ആയ "
+"വിവരങ്ങൾ പ്രദർശിപ്പിച്ചേക്കാം."
 
 # smartling.placeholder_format=C
 #. Body copy shown after Sync & Backup is enabled, confirming chats are now syncing.
@@ -23716,16 +24129,15 @@ msgstr "നിങ്ങളുടെ ചാറ്റുകൾ ഇപ്പോൾ 
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never saved or used to train AI models"
 msgstr ""
-"നിങ്ങളുടെ ചാറ്റുകൾ സ്വകാര്യമാണ്, മാത്രമല്ല AI മോഡലുകളെ പരിശീലിപ്പിക്കാൻ "
-"ഒരിക്കലും സംരക്ഷിക്കുകയോ ഉപയോഗിക്കുകയോ ചെയ്യുന്നില്ല"
+"നിങ്ങളുടെ ചാറ്റുകൾ സ്വകാര്യമാണ്, മാത്രമല്ല AI മോഡലുകളെ പരിശീലിപ്പിക്കാൻ ഒരിക്കലും "
+"സംരക്ഷിക്കുകയോ ഉപയോഗിക്കുകയോ ചെയ്യുന്നില്ല"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never used to train AI models"
 msgstr ""
-"നിങ്ങളുടെ ചാറ്റുകൾ സ്വകാര്യമാണ്, അവ AI മോഡലുകളെ പരിശീലിപ്പിക്കാൻ ഒരിക്കലും "
-"ഉപയോഗിക്കില്ല"
+"നിങ്ങളുടെ ചാറ്റുകൾ സ്വകാര്യമാണ്, അവ AI മോഡലുകളെ പരിശീലിപ്പിക്കാൻ ഒരിക്കലും ഉപയോഗിക്കില്ല"
 
 # smartling.placeholder_format=C
 #. Text for a description of the active privacy protection for DuckDuckGo's AI Chat feature.
@@ -23751,8 +24163,8 @@ msgctxt "Menu item description"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
 msgstr ""
-"നിങ്ങളുടെ ചാറ്റുകൾ സ്വകാര്യമാണ്, ഞങ്ങൾ ഒരിക്കലും സംരക്ഷിച്ചിട്ടില്ല, AI "
-"മോഡലുകളെ പരിശീലിപ്പിക്കാൻ ഉപയോഗിക്കുന്നില്ല."
+"നിങ്ങളുടെ ചാറ്റുകൾ സ്വകാര്യമാണ്, ഞങ്ങൾ ഒരിക്കലും സംരക്ഷിച്ചിട്ടില്ല, AI മോഡലുകളെ "
+"പരിശീലിപ്പിക്കാൻ ഉപയോഗിക്കുന്നില്ല."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the active privacy protection.
@@ -23760,8 +24172,8 @@ msgctxt "Modal body for privacy"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
 msgstr ""
-"നിങ്ങളുടെ ചാറ്റുകൾ സ്വകാര്യമാണ്, ഞങ്ങൾ ഒരിക്കലും സംരക്ഷിച്ചിട്ടില്ല, AI "
-"മോഡലുകളെ പരിശീലിപ്പിക്കാൻ ഉപയോഗിക്കുന്നില്ല."
+"നിങ്ങളുടെ ചാറ്റുകൾ സ്വകാര്യമാണ്, ഞങ്ങൾ ഒരിക്കലും സംരക്ഷിച്ചിട്ടില്ല, AI മോഡലുകളെ "
+"പരിശീലിപ്പിക്കാൻ ഉപയോഗിക്കുന്നില്ല."
 
 # smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that chats are stored locally on the user's device.
@@ -23776,9 +24188,9 @@ msgid ""
 "Your chats are still private, anonymized by us, and not used to train AI "
 "models. Follow these steps to keep your chat history."
 msgstr ""
-"നിങ്ങളുടെ ചാറ്റുകൾ ഇപ്പോഴും സ്വകാര്യമാണ്, ഞങ്ങൾ അത് "
-"അജ്ഞാതമാക്കിയിരിക്കുന്നു, കൂടാതെ അവയെ AI മോഡലുകളെ പരിശീലിപ്പിക്കാൻ "
-"ഉപയോഗിക്കാറില്ല. നിങ്ങളുടെ ചാറ്റ് ചരിത്രം സൂക്ഷിക്കാൻ ഈ ഘട്ടങ്ങൾ പാലിക്കൂ."
+"നിങ്ങളുടെ ചാറ്റുകൾ ഇപ്പോഴും സ്വകാര്യമാണ്, ഞങ്ങൾ അത് അജ്ഞാതമാക്കിയിരിക്കുന്നു, കൂടാതെ അവയെ AI "
+"മോഡലുകളെ പരിശീലിപ്പിക്കാൻ ഉപയോഗിക്കാറില്ല. നിങ്ങളുടെ ചാറ്റ് ചരിത്രം സൂക്ഷിക്കാൻ ഈ ഘട്ടങ്ങൾ "
+"പാലിക്കൂ."
 
 # smartling.placeholder_format=C
 #. Body shown after import completes.
@@ -23787,8 +24199,8 @@ msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
 msgstr ""
-"നിങ്ങളുടെ ചാറ്റുകൾ ഇംപോർട്ട് ചെയ്തിരിക്കുന്നു. നിങ്ങൾ മുന്നോട്ട് പോയി "
-"Duck.ai-ൽ നിർത്തിയിടത്ത് നിന്ന് തുടരൂ."
+"നിങ്ങളുടെ ചാറ്റുകൾ ഇംപോർട്ട് ചെയ്തിരിക്കുന്നു. നിങ്ങൾ മുന്നോട്ട് പോയി Duck.ai-ൽ നിർത്തിയിടത്ത് "
+"നിന്ന് തുടരൂ."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.
@@ -23836,8 +24248,8 @@ msgctxt ""
 "an AI response"
 msgid "Your feedback is anonymized and not used to train AI."
 msgstr ""
-"നിങ്ങളുടെ ഫീഡ്‌ബാക്ക് അജ്ഞാതമാക്കിയിരിക്കുന്നു, കൂടാതെ AI മോഡലുകളെ "
-"പരിശീലിപ്പിക്കാൻ ഉപയോഗിക്കാറില്ല."
+"നിങ്ങളുടെ ഫീഡ്‌ബാക്ക് അജ്ഞാതമാക്കിയിരിക്കുന്നു, കൂടാതെ AI മോഡലുകളെ പരിശീലിപ്പിക്കാൻ "
+"ഉപയോഗിക്കാറില്ല."
 
 # smartling.placeholder_format=C
 #. Explains that the User's Location is always private to DuckDuckGo.
@@ -23866,11 +24278,10 @@ msgid ""
 "browser. We save the settings file using the key as the name. DuckDuckGo "
 "never knows your passphrase."
 msgstr ""
-"%1$sSHA-2%2$s എന്നറിയപ്പെടുന്ന ഒരു സുരക്ഷിത ഹാഷ് അൽഗോരിതം ഉപയോഗിച്ച് "
-"നിങ്ങളുടെ പാസ്‌ഫ്രെയ്സ് ഒരു 512-ബിറ്റ് കീ സൃഷ്ടിക്കുന്നു. കീയും അനുബന്ധ "
-"ക്രമീകരണ ഫയലും മാത്രമേ നിങ്ങളുടെ ബ്രൗസർ ഉപേക്ഷിക്കുകയുള്ളൂ. പേരായി കീ "
-"ഉപയോഗിച്ചുകൊണ്ട് ക്രമീകരണ ഫയൽ ഞങ്ങൾ സംരക്ഷിക്കുന്നു. DuckDuckGo-യ്ക്ക് "
-"നിങ്ങളുടെ പാസ്‌ഫ്രെയ്സ് ഒരിക്കലും അറിയില്ല."
+"%1$sSHA-2%2$s എന്നറിയപ്പെടുന്ന ഒരു സുരക്ഷിത ഹാഷ് അൽഗോരിതം ഉപയോഗിച്ച് നിങ്ങളുടെ പാസ്‌ഫ്രെയ്സ് "
+"ഒരു 512-ബിറ്റ് കീ സൃഷ്ടിക്കുന്നു. കീയും അനുബന്ധ ക്രമീകരണ ഫയലും മാത്രമേ നിങ്ങളുടെ ബ്രൗസർ "
+"ഉപേക്ഷിക്കുകയുള്ളൂ. പേരായി കീ ഉപയോഗിച്ചുകൊണ്ട് ക്രമീകരണ ഫയൽ ഞങ്ങൾ സംരക്ഷിക്കുന്നു. DuckDuckGo-"
+"യ്ക്ക് നിങ്ങളുടെ പാസ്‌ഫ്രെയ്സ് ഒരിക്കലും അറിയില്ല."
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -23885,10 +24296,9 @@ msgid ""
 "personally identifiable metadata, so model providers can't tie your "
 "conversations back to you."
 msgstr ""
-"നിങ്ങളുടെ നിർദ്ദേശങ്ങൾ DuckDuckGo സെർവറുകളിലൂടെ കൈമാറുകയും വ്യക്തിപരമായി "
-"തിരിച്ചറിയാൻ കഴിയുന്ന മെറ്റാഡാറ്റ നീക്കം ചെയ്യുകയും ചെയ്യുന്നു, അതിനാൽ മോഡൽ "
-"ദാതാക്കൾക്ക് നിങ്ങളുടെ സംഭാഷണങ്ങൾ നിങ്ങളിലേക്ക് തിരികെ ബന്ധിപ്പിക്കാൻ "
-"കഴിയില്ല."
+"നിങ്ങളുടെ നിർദ്ദേശങ്ങൾ DuckDuckGo സെർവറുകളിലൂടെ കൈമാറുകയും വ്യക്തിപരമായി തിരിച്ചറിയാൻ "
+"കഴിയുന്ന മെറ്റാഡാറ്റ നീക്കം ചെയ്യുകയും ചെയ്യുന്നു, അതിനാൽ മോഡൽ ദാതാക്കൾക്ക് നിങ്ങളുടെ "
+"സംഭാഷണങ്ങൾ നിങ്ങളിലേക്ക് തിരികെ ബന്ധിപ്പിക്കാൻ കഴിയില്ല."
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -23902,8 +24312,8 @@ msgid ""
 "Your recent chats live here! You can refer to your chats or clear them "
 "anytime."
 msgstr ""
-"നിങ്ങളുടെ സമീപകാല ചാറ്റുകൾ ഇവിടെ കാണാം! നിങ്ങൾക്ക് നിങ്ങളുടെ ചാറ്റുകൾ "
-"പരിശോധിക്കാനോ എപ്പോൾ വേണമെങ്കിലും അവ മായ്ച്ചുകളയാനോ കഴിയും."
+"നിങ്ങളുടെ സമീപകാല ചാറ്റുകൾ ഇവിടെ കാണാം! നിങ്ങൾക്ക് നിങ്ങളുടെ ചാറ്റുകൾ പരിശോധിക്കാനോ "
+"എപ്പോൾ വേണമെങ്കിലും അവ മായ്ച്ചുകളയാനോ കഴിയും."
 
 # smartling.placeholder_format=C
 #. Message on a feedback form.
@@ -23946,9 +24356,8 @@ msgid ""
 "You’re now searching privately in Chrome. Use our browser instead of Chrome "
 "for more protection. It’s already installed and can:"
 msgstr ""
-"നിങ്ങൾ ഇപ്പോൾ Chrome-ൽ സ്വകാര്യമായി തിരയുന്നു. കൂടുതൽ സുരക്ഷയ്ക്കായി "
-"Chrome-ന് പകരം ഞങ്ങളുടെ ബ്രൗസർ ഉപയോഗിക്കുക. ഇത് ഇതിനകം ഇൻസ്റ്റാൾ "
-"ചെയ്തിട്ടുണ്ട്, ഇതിന് ഇവ ചെയ്യാനാകും:"
+"നിങ്ങൾ ഇപ്പോൾ Chrome-ൽ സ്വകാര്യമായി തിരയുന്നു. കൂടുതൽ സുരക്ഷയ്ക്കായി Chrome-ന് പകരം ഞങ്ങളുടെ "
+"ബ്രൗസർ ഉപയോഗിക്കുക. ഇത് ഇതിനകം ഇൻസ്റ്റാൾ ചെയ്തിട്ടുണ്ട്, ഇതിന് ഇവ ചെയ്യാനാകും:"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has exceeded the maximum message size.
@@ -23957,8 +24366,8 @@ msgid ""
 "You’ve exceeded the maximum message size. Please shorten your message and "
 "try again."
 msgstr ""
-"നിങ്ങൾ സന്ദേശത്തിൻ്റെ പരമാവധി വലുപ്പം കവിഞ്ഞു. ദയവായി നിങ്ങളുടെ സന്ദേശം "
-"ചുരുക്കി വീണ്ടും ശ്രമിക്കുക."
+"നിങ്ങൾ സന്ദേശത്തിൻ്റെ പരമാവധി വലുപ്പം കവിഞ്ഞു. ദയവായി നിങ്ങളുടെ സന്ദേശം ചുരുക്കി വീണ്ടും "
+"ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -23967,8 +24376,8 @@ msgid ""
 "You’ve reached the maximum chat length in this conversation. Clear this "
 "conversation with the Fire Button to continue."
 msgstr ""
-"ഈ സംഭാഷണത്തിൽ നിങ്ങൾ പരമാവധി ചാറ്റ് ദൈർഘ്യത്തിൽ എത്തി. തുടരാൻ Fire Button "
-"ഉപയോഗിച്ച് ഈ സംഭാഷണം മായ്ക്കുക."
+"ഈ സംഭാഷണത്തിൽ നിങ്ങൾ പരമാവധി ചാറ്റ് ദൈർഘ്യത്തിൽ എത്തി. തുടരാൻ Fire Button ഉപയോഗിച്ച് ഈ "
+"സംഭാഷണം മായ്ക്കുക."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -23977,8 +24386,7 @@ msgid ""
 "You’ve reached the maximum chat length in this conversation. Start a new "
 "chat to continue."
 msgstr ""
-"ഈ സംഭാഷണത്തിൽ നിങ്ങൾ പരമാവധി ചാറ്റ് ദൈർഘ്യത്തിൽ എത്തി. തുടരാൻ ഒരു പുതിയ "
-"ചാറ്റ് ആരംഭിക്കുക."
+"ഈ സംഭാഷണത്തിൽ നിങ്ങൾ പരമാവധി ചാറ്റ് ദൈർഘ്യത്തിൽ എത്തി. തുടരാൻ ഒരു പുതിയ ചാറ്റ് ആരംഭിക്കുക."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -23993,8 +24401,8 @@ msgid ""
 "You’ve reached the maximum number of messages for one day. Please continue "
 "this chat tomorrow."
 msgstr ""
-"ഒരു ദിവസത്തേക്കുള്ള പരമാവധി സന്ദേശങ്ങളുടെ എണ്ണത്തിൽ നിങ്ങൾ എത്തി. ദയവായി "
-"നാളെ ഈ ചാറ്റ് തുടരുക."
+"ഒരു ദിവസത്തേക്കുള്ള പരമാവധി സന്ദേശങ്ങളുടെ എണ്ണത്തിൽ നിങ്ങൾ എത്തി. ദയവായി നാളെ ഈ ചാറ്റ് "
+"തുടരുക."
 
 # smartling.placeholder_format=C
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
@@ -24297,8 +24705,8 @@ msgstr "ഔദ്യോഗിക വെബ്സൈറ്റ്"
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
 msgstr ""
-"അല്ലെങ്കിൽ നിങ്ങൾക്ക് വേണ്ട നിറത്തിനുള്ള കോഡ് എഴുതുക, ഉദാ. %1$s (%2$s ഒരു "
-"എന്‍കോഡ് ചെയ്ത %3$s പ്രതീകം ആണ്)."
+"അല്ലെങ്കിൽ നിങ്ങൾക്ക് വേണ്ട നിറത്തിനുള്ള കോഡ് എഴുതുക, ഉദാ. %1$s (%2$s ഒരു എന്‍കോഡ് ചെയ്ത %3$s "
+"പ്രതീകം ആണ്)."
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "

--- a/locales/mn_MN/LC_MESSAGES/duckduckgo.po
+++ b/locales/mn_MN/LC_MESSAGES/duckduckgo.po
@@ -1159,6 +1159,11 @@ msgctxt "feedback form"
 msgid "Address is incorrect"
 msgstr ""
 
+#. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Adjust the servings"
+msgstr ""
+
 #. as in multiple advertisements
 msgid "Ads"
 msgstr ""
@@ -1330,6 +1335,13 @@ msgstr ""
 #. Heading shown on the empty chat screen. The text between the two %s markers is displayed inside a clickable privacy button. First %s renders a shield icon, second %s is an invisible end marker. Keep the word 'private' between both %s markers.
 msgctxt "Empty state heading in Duck.ai chat mode"
 msgid "All chats are %sprivate%s"
+msgstr ""
+
+#. Paragraph in the Privacy & Terms section of the About & Legal page in Duck.ai settings, summarizing how chats are anonymized and are not stored or used to train chat models.
+msgctxt "Privacy & Terms section description on the Duck.ai settings page"
+msgid ""
+"All chats are anonymized by DuckDuckGo, and your conversations are not used "
+"to train chat models by DuckDuckGo or the model providers"
 msgstr ""
 
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1542,6 +1554,12 @@ msgstr ""
 #. Confirmation message after location service is enabled.
 msgctxt "precise_user_location"
 msgid "Anonymous location enabled"
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Anonymously generates answers for search queries based on web content. "
+"Choose how often you want it to appear, or disable it completely."
 msgstr ""
 
 #. Instant Answer tab name
@@ -1764,6 +1782,11 @@ msgstr ""
 
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse
 msgid "Ask a follow-up with Duck.ai"
+msgstr ""
+
+#. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
+msgctxt "Page suggestion chip label"
+msgid "Ask about this page"
 msgstr ""
 
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2088,6 +2111,11 @@ msgstr ""
 msgid "Barcode"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Based on this page, is this course worth taking?"
+msgstr ""
+
 msgctxt "settings"
 msgid "Basic"
 msgstr ""
@@ -2119,6 +2147,13 @@ msgstr ""
 #. Placeholder text displayed while the assistant waits for the user to choose an action.
 msgctxt "Assistant response placeholder"
 msgid "Before continuing..."
+msgstr ""
+
+#. Explains that before storing the report, DuckDuckGo will anonymize the conversation by removing PII like names, email addresses, and identifying metadata.
+msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
+msgid ""
+"Before storing this report, DuckDuckGo will anonymize your conversation by "
+"removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
 #. Label that's displayed next to a past start date below a web search result.
@@ -2377,6 +2412,11 @@ msgstr ""
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Break Points Won"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Break this down into clear, numbered steps."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -2736,6 +2776,11 @@ msgstr ""
 #. Text of a button that performs a search for the cast of a particular movie or tv show
 msgctxt "Movie/TV Show Title instant answer"
 msgid "Cast"
+msgstr ""
+
+#. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Cast & Crew"
 msgstr ""
 
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -4085,6 +4130,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Create a shopping list with quantities from this recipe."
+msgstr ""
+
 #. Placeholder text displayed in the input field when starting a new image generation session.
 msgctxt "Placeholder text for the image generation input field"
 msgid "Create an image of a cute duck..."
@@ -4611,6 +4661,10 @@ msgstr ""
 msgid "Dictation limit reached"
 msgstr ""
 
+#. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
+msgid "Dictation temporarily unavailable"
+msgstr ""
+
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
@@ -4855,6 +4909,20 @@ msgctxt "precise_user_location"
 msgid "Done"
 msgstr ""
 
+#. Message shown in a modal after DuckDuckGo browser users disable AI features in Settings. The first two placeholders bold noai.duckduckgo.com. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
+"filtered out. %sLearn More%s"
+msgstr ""
+
+#. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
+"and AI images filtered out. %sLearn more%s"
+msgstr ""
+
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Double Faults"
@@ -4945,6 +5013,16 @@ msgctxt "Full sentence for writing an email"
 msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
+msgstr ""
+
+#. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Draft a cover letter"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Draft a cover letter for this job."
 msgstr ""
 
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -5084,6 +5162,14 @@ msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
 msgstr ""
 
+#. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
+msgctxt "About section description on the Duck.ai settings page"
+msgid ""
+"Duck.ai is created by DuckDuckGo. We're an independent online protection "
+"company for anyone who wants to take back control of their personal "
+"information."
+msgstr ""
+
 #. Title shown when an update is required before proceeding.
 msgctxt "duckai_migration"
 msgid "Duck.ai is moving domains"
@@ -5117,6 +5203,12 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Duck.ai lets you chat privately with popular AI models. Disabling it hides "
+"Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
 
 msgctxt "settings"
@@ -5882,6 +5974,16 @@ msgstr ""
 msgid "Eritrea"
 msgstr ""
 
+#. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Estimate the nutrition"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Estimate the nutritional information for this recipe."
+msgstr ""
+
 msgid "Estonia"
 msgstr ""
 
@@ -5926,10 +6028,50 @@ msgctxt "merchant promotion product ad extension"
 msgid "Expires in 1 day"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain the accepted answer in simple terms."
+msgstr ""
+
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
+msgstr ""
+
+#. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain the top answer"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this in simple, plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this paper"
+msgstr ""
+
+#. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this repo"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this research paper in plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this simply"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain what this repository does and how to use it."
 msgstr ""
 
 #. Label to show if song lyrics contain explicit content
@@ -6158,6 +6300,11 @@ msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
 msgstr ""
 
+msgctxt "settings"
+msgid ""
+"Filters out known AI spam sites from image search results. %sLearn More%s"
+msgstr ""
+
 #. Label for the final score of a sporting event.
 msgid "Final"
 msgstr ""
@@ -6197,6 +6344,11 @@ msgstr ""
 #. Short description shown below the 'Web Search' label in the Tools dropdown.
 msgctxt "Subtitle for the Web Search tool entry in the Tools dropdown menu"
 msgid "Find current information"
+msgstr ""
+
+#. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Find me alternatives"
 msgstr ""
 
 #. Button that searches for results closer to the user's current location.
@@ -6587,6 +6739,11 @@ msgstr ""
 msgid "Generate More"
 msgstr ""
 
+#. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Generate a shopping list"
+msgstr ""
+
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
 msgid "Generate a short answer from the web"
 msgstr ""
@@ -6821,6 +6978,11 @@ msgstr ""
 #. Text for a button inviting users to give it a try for the Duck.ai product. On click, they're taken to the Duck.ai page.
 msgctxt "Onboarding welcome screen button text"
 msgid "Give it a Try"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Give me a quick background on this person."
 msgstr ""
 
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -7183,6 +7345,16 @@ msgstr ""
 
 #. Link to a page with information about sharing DuckDuckGo with friends.
 msgid "Help Spread Privacy"
+msgstr ""
+
+#. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Help me prep for the interview"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Help me tailor my resume for this job."
 msgstr ""
 
 #. Title of a SERP popup that invites users to take a survey (desktop only)
@@ -7602,6 +7774,13 @@ msgstr ""
 #. Text displayed on the button on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
 msgctxt "Onboarding terms screen button text"
 msgid "I Agree"
+msgstr ""
+
+#. Text for the button that takes the user to the external DuckDuckGo login subscription page.
+msgctxt ""
+"Text for the I already have a subscription button in the Duck.ai settings "
+"page"
+msgid "I Already Have a Subscription"
 msgstr ""
 
 #. Text for the button that takes the user to the login subscription page.
@@ -8052,6 +8231,11 @@ msgctxt "Sidemenu browser promo"
 msgid "Install Mac Browser"
 msgstr ""
 
+#. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
+msgctxt "settings"
+msgid "Install Now"
+msgstr ""
+
 #. Text of a button to install the DuckDuckGo app
 msgctxt "Serp footer content"
 msgid "Install Our App"
@@ -8131,9 +8315,36 @@ msgctxt "cloudsave"
 msgid "Is deleted data really deleted?"
 msgstr ""
 
+#. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is it worth taking?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this place any good?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"Is this place any good? Summarize its reputation based on reviews and "
+"ratings."
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "Is this video helpful?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this worth watching?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Is this worth watching? Give me a spoiler-free take."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -8630,6 +8841,11 @@ msgstr ""
 msgid "Links:"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "List the tools, materials, or prerequisites I need for this."
+msgstr ""
+
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
 msgid "Listen"
 msgstr ""
@@ -8962,6 +9178,11 @@ msgstr ""
 #. Label for linke navigating to site exclusion feature on Settings page
 msgctxt "Exclusion message manage sites button"
 msgid "Manage blocked sites"
+msgstr ""
+
+#. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
+msgctxt "setting"
+msgid "Manage in Browser Settings"
 msgstr ""
 
 #. Link to the site exclusion settings page
@@ -11259,6 +11480,11 @@ msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
+msgid "Please describe why the chat response is harmful or illegal. (optional)"
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
+msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
 msgstr ""
 
@@ -11277,6 +11503,13 @@ msgctxt "Modal disclaimer text"
 msgid ""
 "Please note: starting a new chat with any model will delete your current "
 "chat session."
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
+msgctxt "Feedback prompt"
+msgid ""
+"Please paste your prompt and the problematic output (with any personal "
+"information removed) and describe why the content is harmful or illegal."
 msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -11661,6 +11894,11 @@ msgctxt "settings"
 msgid "Privacy"
 msgstr ""
 
+#. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
+msgctxt "Section heading on the Duck.ai settings page"
+msgid "Privacy & Terms"
+msgstr ""
+
 msgid "Privacy Blog"
 msgstr ""
 
@@ -11714,6 +11952,11 @@ msgstr ""
 
 #. Text used in other strings to link to the Privacy Policy and Terms of Service content.
 msgctxt "Copy used to compose link in sentences"
+msgid "Privacy Policy and Terms of Service"
+msgstr ""
+
+#. Text for a button that links to the terms of use and privacy policy page.
+msgctxt "Secondary button text in active privacy modal"
 msgid "Privacy Policy and Terms of Service"
 msgstr ""
 
@@ -12122,6 +12365,26 @@ msgctxt "Brief for recommending a book"
 msgid "Recommend a book"
 msgstr ""
 
+#. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar books"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar books."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar movies or shows."
+msgstr ""
+
+#. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar titles"
+msgstr ""
+
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
 msgid "Recording failed. Please try again."
 msgstr ""
@@ -12441,6 +12704,14 @@ msgstr ""
 msgid "Republic of Moldova"
 msgstr ""
 
+#. Note indicating that sharing the conversation is mandatory when reporting harmful or illegal content. Rendered alongside the standard share label (DUCKCHAT_RESPONSE_FEEDBACK_SHARE_PROMPT_RESPONSE_LABEL), not replacing it.
+msgctxt ""
+"Note shown under the share-content switch label on the Duck.ai response "
+"feedback form when the user has selected Harmful or Illegal as the feedback "
+"reason"
+msgid "Required for harmful or illegal reports"
+msgstr ""
+
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
 msgctxt "Description for extended reasoning mode in Duck.ai"
 msgid "Researches before responding"
@@ -12626,6 +12897,11 @@ msgstr ""
 #. Label above a list of customer reviews of a business.
 msgctxt "maps_places"
 msgid "Reviews"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Rewrite this recipe scaled for a different number of servings."
 msgstr ""
 
 msgid "Romania"
@@ -13661,6 +13937,11 @@ msgctxt "Setup button for native sync flow"
 msgid "Set Up Now"
 msgstr ""
 
+#. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
+msgctxt "Encrypted storage setup button shown in native browsers"
+msgid "Set Up Sync & Backup"
+msgstr ""
+
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
 msgctxt "Title for the Sync & Backup intro screen"
 msgid "Set Up Sync & Backup"
@@ -13803,6 +14084,12 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
+msgctxt ""
+"Label beside the share-content switch on the Duck.ai response feedback form"
+msgid "Share this conversation with DuckDuckGo"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -14817,6 +15104,21 @@ msgctxt "Brief for suggesting a blog post title"
 msgid "Suggest a title for a blog post"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest related articles or topics worth exploring next."
+msgstr ""
+
+#. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Suggest related articles to explore"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest some alternatives to this product."
+msgstr ""
+
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
 msgctxt "directions"
 msgid "Suggestions:"
@@ -14826,9 +15128,84 @@ msgctxt "noresults"
 msgid "Suggestions:"
 msgstr ""
 
+#. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Sum up the reviews"
+msgstr ""
+
 #. A short title for the a message asking the AI to summarize a text.
 msgctxt "Title for the summarize message"
 msgid "Summarize"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize the Q&As"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the background and notable work of this person."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the key details of this event."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the questions and answers on this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize their background"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this book"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this book."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this discussion"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this discussion thread."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this video"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this video."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize what the reviews say."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -15083,6 +15460,11 @@ msgstr ""
 msgid "Syria"
 msgstr ""
 
+#. Text for a button that enables the theme to follow the operating system's color scheme preference.
+msgctxt "System theme button for theme selector"
+msgid "System"
+msgstr ""
+
 #. Abbreviation indicating this is the total score for a game
 msgctxt "Sports module"
 msgid "T"
@@ -15106,6 +15488,11 @@ msgctxt "language_name"
 msgid "Tahitian"
 msgstr ""
 
+#. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Tailor my resume"
+msgstr ""
+
 msgid "Taiwan"
 msgstr ""
 
@@ -15127,6 +15514,12 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "Take control of your personal data!"
+msgstr ""
+
+#. Description for the Feedback section of the Duck.ai settings page, asking the user to take an anonymous survey to let us know how we can make Duck.ai better.
+msgctxt "Feedback section description on the Duck.ai settings page"
+msgid ""
+"Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
 
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -15369,6 +15762,11 @@ msgstr ""
 
 #. Title for the theme menu:
 #. https://duck.co/media/files/theme.png
+msgid "Theme"
+msgstr ""
+
+#. Text for the theme selector label that allows users to switch between Light and dark theme.
+msgctxt "Label for the theme selector feature"
 msgid "Theme"
 msgstr ""
 
@@ -16022,6 +16420,16 @@ msgid ""
 "movie theatre?”"
 msgstr ""
 
+#. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Translate this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
+msgctxt "Page suggestion prompt"
+msgid "Translate this page into %s."
+msgstr ""
+
 #. Placeholder text for a region that will display translated text.
 msgctxt "translations_module"
 msgid "Translation"
@@ -16136,6 +16544,11 @@ msgstr ""
 #. Call-to-action button for the subscription promo in the SERP sidemenu.
 msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
+msgstr ""
+
+#. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
+msgctxt "settings"
+msgid "Try It Now"
 msgstr ""
 
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -16329,6 +16742,20 @@ msgstr ""
 #. Response a user can select in a feedback form, indicating that they're trying DuckDuckGo again.
 msgctxt "new user poll"
 msgid "Trying DuckDuckGo again"
+msgstr ""
+
+#. Message shown in a modal after supported third-party browser users disable AI features in Settings. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+#. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
 msgstr ""
 
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -16929,6 +17356,11 @@ msgstr ""
 msgid "Uruguay"
 msgstr ""
 
+#. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
+msgctxt "Navigation label on the Duck.ai settings page"
+msgid "Usage"
+msgstr ""
+
 #. A feedback suggestion
 msgctxt "Feedback prompt"
 msgid "Usage limit"
@@ -17277,6 +17709,11 @@ msgstr ""
 msgid "Wales"
 msgstr ""
 
+#. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Walk me through the steps"
+msgstr ""
+
 #. Label for walking directions on a map.
 msgctxt "directions"
 msgid "Walking"
@@ -17367,6 +17804,16 @@ msgstr ""
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
+msgstr ""
+
+#. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
+msgctxt ""
+"Inline warning shown below the share-content toggle when the user selects "
+"Harmful or Illegal but has not enabled sharing"
+msgid ""
+"We can only fix what we can see. To report a harmful or illegal response, "
+"please share this conversation with DuckDuckGo so we can investigate and "
+"address the issue."
 msgstr ""
 
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -17786,6 +18233,87 @@ msgid ""
 "experience."
 msgstr ""
 
+#. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the counterarguments?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the hours & location?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key contributions of this paper?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key contributions?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key details?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key points covered in this video?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key points?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key takeaways from this article?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key takeaways?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key things I will learn from this course?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main counterarguments or criticisms of this?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main questions this page answers?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the must-try dishes here?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"What are the opening hours, location, and contact details for this place?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the pros and cons of this product?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the pros and cons?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
 msgctxt "feedback form"
 msgid "What bothered you most?"
@@ -17869,6 +18397,11 @@ msgctxt "Full sentence for defining a term"
 msgid "What does atria mean in the context of a medical article?"
 msgstr ""
 
+#. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What does this answer?"
+msgstr ""
+
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
@@ -17877,6 +18410,11 @@ msgstr ""
 #. Header above a list of types of information that gets saved by the cloud save feature.
 msgctxt "cloudsave"
 msgid "What information gets saved?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What interview questions might come up for this role?"
 msgstr ""
 
 #. Text explaining how the cloud save feature works.
@@ -17889,6 +18427,11 @@ msgstr ""
 #. Text for a prompt suggestion for looking up the capital city of Albania.
 msgctxt "Full sentence for looking up basic facts"
 msgid "What is the capital city of Albania?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What is the overall verdict and rating for this?"
 msgstr ""
 
 #. Link to a page with additional information.
@@ -17909,6 +18452,11 @@ msgctxt "maps_places"
 msgid "What people say:"
 msgstr ""
 
+#. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What should I order?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
 msgctxt "feedback form"
 msgid "What stood out?"
@@ -17917,6 +18465,16 @@ msgstr ""
 #. Question on a feedback form for a negative feedback response.
 msgctxt "feedback form"
 msgid "What was wrong with the response? (optional)"
+msgstr ""
+
+#. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I learn?"
+msgstr ""
+
+#. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I need?"
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -17931,6 +18489,11 @@ msgstr ""
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
 msgctxt "SERP footer content"
 msgid "What's New"
+msgstr ""
+
+#. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What's the verdict?"
 msgstr ""
 
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -17972,6 +18535,11 @@ msgctxt "Feedback prompt"
 msgid "Which features are missing? (Optional)"
 msgstr ""
 
+#. An invitation for users to leave feedback
+msgctxt "Feedback prompt"
+msgid "Which features are missing? (optional)"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
 msgid "White"
 msgstr ""
@@ -17983,6 +18551,16 @@ msgstr ""
 
 #. Link to an about us page.
 msgid "Who We Are"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Who are the main cast and crew, and what else are they known for?"
+msgstr ""
+
+#. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Who is this person?"
 msgstr ""
 
 #. Header above a collection of privacy-related links.

--- a/locales/mr_IN/LC_MESSAGES/duckduckgo.po
+++ b/locales/mr_IN/LC_MESSAGES/duckduckgo.po
@@ -1161,6 +1161,11 @@ msgctxt "feedback form"
 msgid "Address is incorrect"
 msgstr ""
 
+#. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Adjust the servings"
+msgstr ""
+
 #. as in multiple advertisements
 msgid "Ads"
 msgstr ""
@@ -1332,6 +1337,13 @@ msgstr ""
 #. Heading shown on the empty chat screen. The text between the two %s markers is displayed inside a clickable privacy button. First %s renders a shield icon, second %s is an invisible end marker. Keep the word 'private' between both %s markers.
 msgctxt "Empty state heading in Duck.ai chat mode"
 msgid "All chats are %sprivate%s"
+msgstr ""
+
+#. Paragraph in the Privacy & Terms section of the About & Legal page in Duck.ai settings, summarizing how chats are anonymized and are not stored or used to train chat models.
+msgctxt "Privacy & Terms section description on the Duck.ai settings page"
+msgid ""
+"All chats are anonymized by DuckDuckGo, and your conversations are not used "
+"to train chat models by DuckDuckGo or the model providers"
 msgstr ""
 
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1544,6 +1556,12 @@ msgstr ""
 #. Confirmation message after location service is enabled.
 msgctxt "precise_user_location"
 msgid "Anonymous location enabled"
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Anonymously generates answers for search queries based on web content. "
+"Choose how often you want it to appear, or disable it completely."
 msgstr ""
 
 #. Instant Answer tab name
@@ -1766,6 +1784,11 @@ msgstr ""
 
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse
 msgid "Ask a follow-up with Duck.ai"
+msgstr ""
+
+#. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
+msgctxt "Page suggestion chip label"
+msgid "Ask about this page"
 msgstr ""
 
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2090,6 +2113,11 @@ msgstr ""
 msgid "Barcode"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Based on this page, is this course worth taking?"
+msgstr ""
+
 msgctxt "settings"
 msgid "Basic"
 msgstr ""
@@ -2121,6 +2149,13 @@ msgstr ""
 #. Placeholder text displayed while the assistant waits for the user to choose an action.
 msgctxt "Assistant response placeholder"
 msgid "Before continuing..."
+msgstr ""
+
+#. Explains that before storing the report, DuckDuckGo will anonymize the conversation by removing PII like names, email addresses, and identifying metadata.
+msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
+msgid ""
+"Before storing this report, DuckDuckGo will anonymize your conversation by "
+"removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
 #. Label that's displayed next to a past start date below a web search result.
@@ -2379,6 +2414,11 @@ msgstr ""
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Break Points Won"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Break this down into clear, numbered steps."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -2738,6 +2778,11 @@ msgstr ""
 #. Text of a button that performs a search for the cast of a particular movie or tv show
 msgctxt "Movie/TV Show Title instant answer"
 msgid "Cast"
+msgstr ""
+
+#. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Cast & Crew"
 msgstr ""
 
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -4088,6 +4133,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Create a shopping list with quantities from this recipe."
+msgstr ""
+
 #. Placeholder text displayed in the input field when starting a new image generation session.
 msgctxt "Placeholder text for the image generation input field"
 msgid "Create an image of a cute duck..."
@@ -4614,6 +4664,10 @@ msgstr ""
 msgid "Dictation limit reached"
 msgstr ""
 
+#. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
+msgid "Dictation temporarily unavailable"
+msgstr ""
+
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
@@ -4858,6 +4912,20 @@ msgctxt "precise_user_location"
 msgid "Done"
 msgstr ""
 
+#. Message shown in a modal after DuckDuckGo browser users disable AI features in Settings. The first two placeholders bold noai.duckduckgo.com. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
+"filtered out. %sLearn More%s"
+msgstr ""
+
+#. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
+"and AI images filtered out. %sLearn more%s"
+msgstr ""
+
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Double Faults"
@@ -4948,6 +5016,16 @@ msgctxt "Full sentence for writing an email"
 msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
+msgstr ""
+
+#. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Draft a cover letter"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Draft a cover letter for this job."
 msgstr ""
 
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -5087,6 +5165,14 @@ msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
 msgstr ""
 
+#. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
+msgctxt "About section description on the Duck.ai settings page"
+msgid ""
+"Duck.ai is created by DuckDuckGo. We're an independent online protection "
+"company for anyone who wants to take back control of their personal "
+"information."
+msgstr ""
+
 #. Title shown when an update is required before proceeding.
 msgctxt "duckai_migration"
 msgid "Duck.ai is moving domains"
@@ -5120,6 +5206,12 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Duck.ai lets you chat privately with popular AI models. Disabling it hides "
+"Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
 
 msgctxt "settings"
@@ -5893,6 +5985,16 @@ msgstr ""
 msgid "Eritrea"
 msgstr ""
 
+#. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Estimate the nutrition"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Estimate the nutritional information for this recipe."
+msgstr ""
+
 msgid "Estonia"
 msgstr ""
 
@@ -5937,10 +6039,50 @@ msgctxt "merchant promotion product ad extension"
 msgid "Expires in 1 day"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain the accepted answer in simple terms."
+msgstr ""
+
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
+msgstr ""
+
+#. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain the top answer"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this in simple, plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this paper"
+msgstr ""
+
+#. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this repo"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this research paper in plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this simply"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain what this repository does and how to use it."
 msgstr ""
 
 #. Label to show if song lyrics contain explicit content
@@ -6169,6 +6311,11 @@ msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
 msgstr ""
 
+msgctxt "settings"
+msgid ""
+"Filters out known AI spam sites from image search results. %sLearn More%s"
+msgstr ""
+
 #. Label for the final score of a sporting event.
 msgid "Final"
 msgstr "शेवटचे"
@@ -6208,6 +6355,11 @@ msgstr ""
 #. Short description shown below the 'Web Search' label in the Tools dropdown.
 msgctxt "Subtitle for the Web Search tool entry in the Tools dropdown menu"
 msgid "Find current information"
+msgstr ""
+
+#. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Find me alternatives"
 msgstr ""
 
 #. Button that searches for results closer to the user's current location.
@@ -6598,6 +6750,11 @@ msgstr ""
 msgid "Generate More"
 msgstr ""
 
+#. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Generate a shopping list"
+msgstr ""
+
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
 msgid "Generate a short answer from the web"
 msgstr ""
@@ -6832,6 +6989,11 @@ msgstr ""
 #. Text for a button inviting users to give it a try for the Duck.ai product. On click, they're taken to the Duck.ai page.
 msgctxt "Onboarding welcome screen button text"
 msgid "Give it a Try"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Give me a quick background on this person."
 msgstr ""
 
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -7194,6 +7356,16 @@ msgstr ""
 
 #. Link to a page with information about sharing DuckDuckGo with friends.
 msgid "Help Spread Privacy"
+msgstr ""
+
+#. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Help me prep for the interview"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Help me tailor my resume for this job."
 msgstr ""
 
 #. Title of a SERP popup that invites users to take a survey (desktop only)
@@ -7613,6 +7785,13 @@ msgstr ""
 #. Text displayed on the button on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
 msgctxt "Onboarding terms screen button text"
 msgid "I Agree"
+msgstr ""
+
+#. Text for the button that takes the user to the external DuckDuckGo login subscription page.
+msgctxt ""
+"Text for the I already have a subscription button in the Duck.ai settings "
+"page"
+msgid "I Already Have a Subscription"
 msgstr ""
 
 #. Text for the button that takes the user to the login subscription page.
@@ -8064,6 +8243,11 @@ msgctxt "Sidemenu browser promo"
 msgid "Install Mac Browser"
 msgstr ""
 
+#. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
+msgctxt "settings"
+msgid "Install Now"
+msgstr ""
+
 #. Text of a button to install the DuckDuckGo app
 msgctxt "Serp footer content"
 msgid "Install Our App"
@@ -8143,9 +8327,36 @@ msgctxt "cloudsave"
 msgid "Is deleted data really deleted?"
 msgstr "मिटवलॆली माहिती खरच मिट्ल्या जातॆ का?"
 
+#. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is it worth taking?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this place any good?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"Is this place any good? Summarize its reputation based on reviews and "
+"ratings."
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "Is this video helpful?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this worth watching?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Is this worth watching? Give me a spoiler-free take."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -8642,6 +8853,11 @@ msgstr "दुवा शैली:"
 msgid "Links:"
 msgstr "दुवे "
 
+#. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "List the tools, materials, or prerequisites I need for this."
+msgstr ""
+
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
 msgid "Listen"
 msgstr "ऐका"
@@ -8974,6 +9190,11 @@ msgstr ""
 #. Label for linke navigating to site exclusion feature on Settings page
 msgctxt "Exclusion message manage sites button"
 msgid "Manage blocked sites"
+msgstr ""
+
+#. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
+msgctxt "setting"
+msgid "Manage in Browser Settings"
 msgstr ""
 
 #. Link to the site exclusion settings page
@@ -11271,6 +11492,11 @@ msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
+msgid "Please describe why the chat response is harmful or illegal. (optional)"
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
+msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
 msgstr ""
 
@@ -11289,6 +11515,13 @@ msgctxt "Modal disclaimer text"
 msgid ""
 "Please note: starting a new chat with any model will delete your current "
 "chat session."
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
+msgctxt "Feedback prompt"
+msgid ""
+"Please paste your prompt and the problematic output (with any personal "
+"information removed) and describe why the content is harmful or illegal."
 msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -11673,6 +11906,11 @@ msgctxt "settings"
 msgid "Privacy"
 msgstr ""
 
+#. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
+msgctxt "Section heading on the Duck.ai settings page"
+msgid "Privacy & Terms"
+msgstr ""
+
 msgid "Privacy Blog"
 msgstr ""
 
@@ -11726,6 +11964,11 @@ msgstr ""
 
 #. Text used in other strings to link to the Privacy Policy and Terms of Service content.
 msgctxt "Copy used to compose link in sentences"
+msgid "Privacy Policy and Terms of Service"
+msgstr ""
+
+#. Text for a button that links to the terms of use and privacy policy page.
+msgctxt "Secondary button text in active privacy modal"
 msgid "Privacy Policy and Terms of Service"
 msgstr ""
 
@@ -12134,6 +12377,26 @@ msgctxt "Brief for recommending a book"
 msgid "Recommend a book"
 msgstr ""
 
+#. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar books"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar books."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar movies or shows."
+msgstr ""
+
+#. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar titles"
+msgstr ""
+
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
 msgid "Recording failed. Please try again."
 msgstr ""
@@ -12453,6 +12716,14 @@ msgstr ""
 msgid "Republic of Moldova"
 msgstr ""
 
+#. Note indicating that sharing the conversation is mandatory when reporting harmful or illegal content. Rendered alongside the standard share label (DUCKCHAT_RESPONSE_FEEDBACK_SHARE_PROMPT_RESPONSE_LABEL), not replacing it.
+msgctxt ""
+"Note shown under the share-content switch label on the Duck.ai response "
+"feedback form when the user has selected Harmful or Illegal as the feedback "
+"reason"
+msgid "Required for harmful or illegal reports"
+msgstr ""
+
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
 msgctxt "Description for extended reasoning mode in Duck.ai"
 msgid "Researches before responding"
@@ -12638,6 +12909,11 @@ msgstr "पुन्ह अवलोकन"
 #. Label above a list of customer reviews of a business.
 msgctxt "maps_places"
 msgid "Reviews"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Rewrite this recipe scaled for a different number of servings."
 msgstr ""
 
 msgid "Romania"
@@ -13675,6 +13951,11 @@ msgctxt "Setup button for native sync flow"
 msgid "Set Up Now"
 msgstr ""
 
+#. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
+msgctxt "Encrypted storage setup button shown in native browsers"
+msgid "Set Up Sync & Backup"
+msgstr ""
+
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
 msgctxt "Title for the Sync & Backup intro screen"
 msgid "Set Up Sync & Backup"
@@ -13817,6 +14098,12 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
+msgctxt ""
+"Label beside the share-content switch on the Duck.ai response feedback form"
+msgid "Share this conversation with DuckDuckGo"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -14831,6 +15118,21 @@ msgctxt "Brief for suggesting a blog post title"
 msgid "Suggest a title for a blog post"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest related articles or topics worth exploring next."
+msgstr ""
+
+#. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Suggest related articles to explore"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest some alternatives to this product."
+msgstr ""
+
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
 msgctxt "directions"
 msgid "Suggestions:"
@@ -14840,9 +15142,84 @@ msgctxt "noresults"
 msgid "Suggestions:"
 msgstr ""
 
+#. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Sum up the reviews"
+msgstr ""
+
 #. A short title for the a message asking the AI to summarize a text.
 msgctxt "Title for the summarize message"
 msgid "Summarize"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize the Q&As"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the background and notable work of this person."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the key details of this event."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the questions and answers on this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize their background"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this book"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this book."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this discussion"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this discussion thread."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this video"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this video."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize what the reviews say."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -15097,6 +15474,11 @@ msgstr ""
 msgid "Syria"
 msgstr ""
 
+#. Text for a button that enables the theme to follow the operating system's color scheme preference.
+msgctxt "System theme button for theme selector"
+msgid "System"
+msgstr ""
+
 #. Abbreviation indicating this is the total score for a game
 msgctxt "Sports module"
 msgid "T"
@@ -15120,6 +15502,11 @@ msgctxt "language_name"
 msgid "Tahitian"
 msgstr ""
 
+#. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Tailor my resume"
+msgstr ""
+
 msgid "Taiwan"
 msgstr ""
 
@@ -15141,6 +15528,12 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "Take control of your personal data!"
+msgstr ""
+
+#. Description for the Feedback section of the Duck.ai settings page, asking the user to take an anonymous survey to let us know how we can make Duck.ai better.
+msgctxt "Feedback section description on the Duck.ai settings page"
+msgid ""
+"Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
 
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -15383,6 +15776,11 @@ msgstr ""
 
 #. Title for the theme menu:
 #. https://duck.co/media/files/theme.png
+msgid "Theme"
+msgstr ""
+
+#. Text for the theme selector label that allows users to switch between Light and dark theme.
+msgctxt "Label for the theme selector feature"
 msgid "Theme"
 msgstr ""
 
@@ -16036,6 +16434,16 @@ msgid ""
 "movie theatre?”"
 msgstr ""
 
+#. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Translate this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
+msgctxt "Page suggestion prompt"
+msgid "Translate this page into %s."
+msgstr ""
+
 #. Placeholder text for a region that will display translated text.
 msgctxt "translations_module"
 msgid "Translation"
@@ -16150,6 +16558,11 @@ msgstr ""
 #. Call-to-action button for the subscription promo in the SERP sidemenu.
 msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
+msgstr ""
+
+#. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
+msgctxt "settings"
+msgid "Try It Now"
 msgstr ""
 
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -16343,6 +16756,20 @@ msgstr "%s वापरून पहा"
 #. Response a user can select in a feedback form, indicating that they're trying DuckDuckGo again.
 msgctxt "new user poll"
 msgid "Trying DuckDuckGo again"
+msgstr ""
+
+#. Message shown in a modal after supported third-party browser users disable AI features in Settings. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+#. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
 msgstr ""
 
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -16943,6 +17370,11 @@ msgstr ""
 msgid "Uruguay"
 msgstr ""
 
+#. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
+msgctxt "Navigation label on the Duck.ai settings page"
+msgid "Usage"
+msgstr ""
+
 #. A feedback suggestion
 msgctxt "Feedback prompt"
 msgid "Usage limit"
@@ -17291,6 +17723,11 @@ msgstr ""
 msgid "Wales"
 msgstr ""
 
+#. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Walk me through the steps"
+msgstr ""
+
 #. Label for walking directions on a map.
 msgctxt "directions"
 msgid "Walking"
@@ -17381,6 +17818,16 @@ msgstr ""
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
+msgstr ""
+
+#. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
+msgctxt ""
+"Inline warning shown below the share-content toggle when the user selects "
+"Harmful or Illegal but has not enabled sharing"
+msgid ""
+"We can only fix what we can see. To report a harmful or illegal response, "
+"please share this conversation with DuckDuckGo so we can investigate and "
+"address the issue."
 msgstr ""
 
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -17800,6 +18247,87 @@ msgid ""
 "experience."
 msgstr ""
 
+#. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the counterarguments?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the hours & location?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key contributions of this paper?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key contributions?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key details?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key points covered in this video?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key points?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key takeaways from this article?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key takeaways?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key things I will learn from this course?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main counterarguments or criticisms of this?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main questions this page answers?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the must-try dishes here?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"What are the opening hours, location, and contact details for this place?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the pros and cons of this product?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the pros and cons?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
 msgctxt "feedback form"
 msgid "What bothered you most?"
@@ -17883,6 +18411,11 @@ msgctxt "Full sentence for defining a term"
 msgid "What does atria mean in the context of a medical article?"
 msgstr ""
 
+#. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What does this answer?"
+msgstr ""
+
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
@@ -17892,6 +18425,11 @@ msgstr ""
 msgctxt "cloudsave"
 msgid "What information gets saved?"
 msgstr "कोणती माहिती जपून ठेवतो ?"
+
+#. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What interview questions might come up for this role?"
+msgstr ""
 
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
@@ -17903,6 +18441,11 @@ msgstr ""
 #. Text for a prompt suggestion for looking up the capital city of Albania.
 msgctxt "Full sentence for looking up basic facts"
 msgid "What is the capital city of Albania?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What is the overall verdict and rating for this?"
 msgstr ""
 
 #. Link to a page with additional information.
@@ -17923,6 +18466,11 @@ msgctxt "maps_places"
 msgid "What people say:"
 msgstr ""
 
+#. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What should I order?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
 msgctxt "feedback form"
 msgid "What stood out?"
@@ -17931,6 +18479,16 @@ msgstr ""
 #. Question on a feedback form for a negative feedback response.
 msgctxt "feedback form"
 msgid "What was wrong with the response? (optional)"
+msgstr ""
+
+#. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I learn?"
+msgstr ""
+
+#. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I need?"
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -17945,6 +18503,11 @@ msgstr ""
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
 msgctxt "SERP footer content"
 msgid "What's New"
+msgstr ""
+
+#. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What's the verdict?"
 msgstr ""
 
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -17986,6 +18549,11 @@ msgctxt "Feedback prompt"
 msgid "Which features are missing? (Optional)"
 msgstr ""
 
+#. An invitation for users to leave feedback
+msgctxt "Feedback prompt"
+msgid "Which features are missing? (optional)"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
 msgid "White"
 msgstr "पांढरा"
@@ -17997,6 +18565,16 @@ msgstr ""
 
 #. Link to an about us page.
 msgid "Who We Are"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Who are the main cast and crew, and what else are they known for?"
+msgstr ""
+
+#. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Who is this person?"
 msgstr ""
 
 #. Header above a collection of privacy-related links.

--- a/locales/ms_MY/LC_MESSAGES/duckduckgo.po
+++ b/locales/ms_MY/LC_MESSAGES/duckduckgo.po
@@ -1159,6 +1159,11 @@ msgctxt "feedback form"
 msgid "Address is incorrect"
 msgstr ""
 
+#. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Adjust the servings"
+msgstr ""
+
 #. as in multiple advertisements
 msgid "Ads"
 msgstr ""
@@ -1332,6 +1337,13 @@ msgstr ""
 #. Heading shown on the empty chat screen. The text between the two %s markers is displayed inside a clickable privacy button. First %s renders a shield icon, second %s is an invisible end marker. Keep the word 'private' between both %s markers.
 msgctxt "Empty state heading in Duck.ai chat mode"
 msgid "All chats are %sprivate%s"
+msgstr ""
+
+#. Paragraph in the Privacy & Terms section of the About & Legal page in Duck.ai settings, summarizing how chats are anonymized and are not stored or used to train chat models.
+msgctxt "Privacy & Terms section description on the Duck.ai settings page"
+msgid ""
+"All chats are anonymized by DuckDuckGo, and your conversations are not used "
+"to train chat models by DuckDuckGo or the model providers"
 msgstr ""
 
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1544,6 +1556,12 @@ msgstr ""
 #. Confirmation message after location service is enabled.
 msgctxt "precise_user_location"
 msgid "Anonymous location enabled"
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Anonymously generates answers for search queries based on web content. "
+"Choose how often you want it to appear, or disable it completely."
 msgstr ""
 
 #. Instant Answer tab name
@@ -1766,6 +1784,11 @@ msgstr ""
 
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse
 msgid "Ask a follow-up with Duck.ai"
+msgstr ""
+
+#. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
+msgctxt "Page suggestion chip label"
+msgid "Ask about this page"
 msgstr ""
 
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2090,6 +2113,11 @@ msgstr ""
 msgid "Barcode"
 msgstr "Kod Bar"
 
+#. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Based on this page, is this course worth taking?"
+msgstr ""
+
 msgctxt "settings"
 msgid "Basic"
 msgstr "Asas"
@@ -2121,6 +2149,13 @@ msgstr ""
 #. Placeholder text displayed while the assistant waits for the user to choose an action.
 msgctxt "Assistant response placeholder"
 msgid "Before continuing..."
+msgstr ""
+
+#. Explains that before storing the report, DuckDuckGo will anonymize the conversation by removing PII like names, email addresses, and identifying metadata.
+msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
+msgid ""
+"Before storing this report, DuckDuckGo will anonymize your conversation by "
+"removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
 #. Label that's displayed next to a past start date below a web search result.
@@ -2379,6 +2414,11 @@ msgstr ""
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Break Points Won"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Break this down into clear, numbered steps."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -2738,6 +2778,11 @@ msgstr ""
 #. Text of a button that performs a search for the cast of a particular movie or tv show
 msgctxt "Movie/TV Show Title instant answer"
 msgid "Cast"
+msgstr ""
+
+#. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Cast & Crew"
 msgstr ""
 
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -4096,6 +4141,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Create a shopping list with quantities from this recipe."
+msgstr ""
+
 #. Placeholder text displayed in the input field when starting a new image generation session.
 msgctxt "Placeholder text for the image generation input field"
 msgid "Create an image of a cute duck..."
@@ -4622,6 +4672,10 @@ msgstr ""
 msgid "Dictation limit reached"
 msgstr ""
 
+#. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
+msgid "Dictation temporarily unavailable"
+msgstr ""
+
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
@@ -4866,6 +4920,20 @@ msgctxt "precise_user_location"
 msgid "Done"
 msgstr ""
 
+#. Message shown in a modal after DuckDuckGo browser users disable AI features in Settings. The first two placeholders bold noai.duckduckgo.com. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
+"filtered out. %sLearn More%s"
+msgstr ""
+
+#. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
+"and AI images filtered out. %sLearn more%s"
+msgstr ""
+
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Double Faults"
@@ -4956,6 +5024,16 @@ msgctxt "Full sentence for writing an email"
 msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
+msgstr ""
+
+#. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Draft a cover letter"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Draft a cover letter for this job."
 msgstr ""
 
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -5095,6 +5173,14 @@ msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
 msgstr ""
 
+#. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
+msgctxt "About section description on the Duck.ai settings page"
+msgid ""
+"Duck.ai is created by DuckDuckGo. We're an independent online protection "
+"company for anyone who wants to take back control of their personal "
+"information."
+msgstr ""
+
 #. Title shown when an update is required before proceeding.
 msgctxt "duckai_migration"
 msgid "Duck.ai is moving domains"
@@ -5128,6 +5214,12 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Duck.ai lets you chat privately with popular AI models. Disabling it hides "
+"Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
 
 msgctxt "settings"
@@ -5893,6 +5985,16 @@ msgstr ""
 msgid "Eritrea"
 msgstr ""
 
+#. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Estimate the nutrition"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Estimate the nutritional information for this recipe."
+msgstr ""
+
 msgid "Estonia"
 msgstr ""
 
@@ -5937,10 +6039,50 @@ msgctxt "merchant promotion product ad extension"
 msgid "Expires in 1 day"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain the accepted answer in simple terms."
+msgstr ""
+
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
+msgstr ""
+
+#. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain the top answer"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this in simple, plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this paper"
+msgstr ""
+
+#. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this repo"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this research paper in plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this simply"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain what this repository does and how to use it."
 msgstr ""
 
 #. Label to show if song lyrics contain explicit content
@@ -6171,6 +6313,11 @@ msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
 msgstr ""
 
+msgctxt "settings"
+msgid ""
+"Filters out known AI spam sites from image search results. %sLearn More%s"
+msgstr ""
+
 #. Label for the final score of a sporting event.
 msgid "Final"
 msgstr "Akhir"
@@ -6211,6 +6358,11 @@ msgstr ""
 #. Short description shown below the 'Web Search' label in the Tools dropdown.
 msgctxt "Subtitle for the Web Search tool entry in the Tools dropdown menu"
 msgid "Find current information"
+msgstr ""
+
+#. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Find me alternatives"
 msgstr ""
 
 #. Button that searches for results closer to the user's current location.
@@ -6601,6 +6753,11 @@ msgstr ""
 msgid "Generate More"
 msgstr ""
 
+#. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Generate a shopping list"
+msgstr ""
+
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
 msgid "Generate a short answer from the web"
 msgstr ""
@@ -6835,6 +6992,11 @@ msgstr ""
 #. Text for a button inviting users to give it a try for the Duck.ai product. On click, they're taken to the Duck.ai page.
 msgctxt "Onboarding welcome screen button text"
 msgid "Give it a Try"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Give me a quick background on this person."
 msgstr ""
 
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -7197,6 +7359,16 @@ msgstr ""
 
 #. Link to a page with information about sharing DuckDuckGo with friends.
 msgid "Help Spread Privacy"
+msgstr ""
+
+#. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Help me prep for the interview"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Help me tailor my resume for this job."
 msgstr ""
 
 #. Title of a SERP popup that invites users to take a survey (desktop only)
@@ -7616,6 +7788,13 @@ msgstr ""
 #. Text displayed on the button on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
 msgctxt "Onboarding terms screen button text"
 msgid "I Agree"
+msgstr ""
+
+#. Text for the button that takes the user to the external DuckDuckGo login subscription page.
+msgctxt ""
+"Text for the I already have a subscription button in the Duck.ai settings "
+"page"
+msgid "I Already Have a Subscription"
 msgstr ""
 
 #. Text for the button that takes the user to the login subscription page.
@@ -8071,6 +8250,11 @@ msgctxt "Sidemenu browser promo"
 msgid "Install Mac Browser"
 msgstr ""
 
+#. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
+msgctxt "settings"
+msgid "Install Now"
+msgstr ""
+
 #. Text of a button to install the DuckDuckGo app
 msgctxt "Serp footer content"
 msgid "Install Our App"
@@ -8150,9 +8334,36 @@ msgctxt "cloudsave"
 msgid "Is deleted data really deleted?"
 msgstr "Adakah data yang dihapuskan benar-benar dihapuskan?"
 
+#. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is it worth taking?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this place any good?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"Is this place any good? Summarize its reputation based on reviews and "
+"ratings."
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "Is this video helpful?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this worth watching?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Is this worth watching? Give me a spoiler-free take."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -8649,6 +8860,11 @@ msgstr "Fon pautan:"
 msgid "Links:"
 msgstr "Pautan:"
 
+#. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "List the tools, materials, or prerequisites I need for this."
+msgstr ""
+
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
 msgid "Listen"
 msgstr "Dengar"
@@ -8982,6 +9198,11 @@ msgstr ""
 #. Label for linke navigating to site exclusion feature on Settings page
 msgctxt "Exclusion message manage sites button"
 msgid "Manage blocked sites"
+msgstr ""
+
+#. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
+msgctxt "setting"
+msgid "Manage in Browser Settings"
 msgstr ""
 
 #. Link to the site exclusion settings page
@@ -11285,6 +11506,11 @@ msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
+msgid "Please describe why the chat response is harmful or illegal. (optional)"
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
+msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
 msgstr ""
 
@@ -11303,6 +11529,13 @@ msgctxt "Modal disclaimer text"
 msgid ""
 "Please note: starting a new chat with any model will delete your current "
 "chat session."
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
+msgctxt "Feedback prompt"
+msgid ""
+"Please paste your prompt and the problematic output (with any personal "
+"information removed) and describe why the content is harmful or illegal."
 msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -11687,6 +11920,11 @@ msgctxt "settings"
 msgid "Privacy"
 msgstr "Kerahsiaan"
 
+#. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
+msgctxt "Section heading on the Duck.ai settings page"
+msgid "Privacy & Terms"
+msgstr ""
+
 msgid "Privacy Blog"
 msgstr ""
 
@@ -11740,6 +11978,11 @@ msgstr ""
 
 #. Text used in other strings to link to the Privacy Policy and Terms of Service content.
 msgctxt "Copy used to compose link in sentences"
+msgid "Privacy Policy and Terms of Service"
+msgstr ""
+
+#. Text for a button that links to the terms of use and privacy policy page.
+msgctxt "Secondary button text in active privacy modal"
 msgid "Privacy Policy and Terms of Service"
 msgstr ""
 
@@ -12148,6 +12391,26 @@ msgctxt "Brief for recommending a book"
 msgid "Recommend a book"
 msgstr ""
 
+#. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar books"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar books."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar movies or shows."
+msgstr ""
+
+#. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar titles"
+msgstr ""
+
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
 msgid "Recording failed. Please try again."
 msgstr ""
@@ -12467,6 +12730,14 @@ msgstr ""
 msgid "Republic of Moldova"
 msgstr ""
 
+#. Note indicating that sharing the conversation is mandatory when reporting harmful or illegal content. Rendered alongside the standard share label (DUCKCHAT_RESPONSE_FEEDBACK_SHARE_PROMPT_RESPONSE_LABEL), not replacing it.
+msgctxt ""
+"Note shown under the share-content switch label on the Duck.ai response "
+"feedback form when the user has selected Harmful or Illegal as the feedback "
+"reason"
+msgid "Required for harmful or illegal reports"
+msgstr ""
+
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
 msgctxt "Description for extended reasoning mode in Duck.ai"
 msgid "Researches before responding"
@@ -12652,6 +12923,11 @@ msgstr "Ulasan"
 #. Label above a list of customer reviews of a business.
 msgctxt "maps_places"
 msgid "Reviews"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Rewrite this recipe scaled for a different number of servings."
 msgstr ""
 
 msgid "Romania"
@@ -13693,6 +13969,11 @@ msgctxt "Setup button for native sync flow"
 msgid "Set Up Now"
 msgstr ""
 
+#. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
+msgctxt "Encrypted storage setup button shown in native browsers"
+msgid "Set Up Sync & Backup"
+msgstr ""
+
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
 msgctxt "Title for the Sync & Backup intro screen"
 msgid "Set Up Sync & Backup"
@@ -13835,6 +14116,12 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
+msgctxt ""
+"Label beside the share-content switch on the Duck.ai response feedback form"
+msgid "Share this conversation with DuckDuckGo"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -14849,6 +15136,21 @@ msgctxt "Brief for suggesting a blog post title"
 msgid "Suggest a title for a blog post"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest related articles or topics worth exploring next."
+msgstr ""
+
+#. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Suggest related articles to explore"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest some alternatives to this product."
+msgstr ""
+
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
 msgctxt "directions"
 msgid "Suggestions:"
@@ -14858,9 +15160,84 @@ msgctxt "noresults"
 msgid "Suggestions:"
 msgstr ""
 
+#. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Sum up the reviews"
+msgstr ""
+
 #. A short title for the a message asking the AI to summarize a text.
 msgctxt "Title for the summarize message"
 msgid "Summarize"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize the Q&As"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the background and notable work of this person."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the key details of this event."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the questions and answers on this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize their background"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this book"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this book."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this discussion"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this discussion thread."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this video"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this video."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize what the reviews say."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -15115,6 +15492,11 @@ msgstr ""
 msgid "Syria"
 msgstr ""
 
+#. Text for a button that enables the theme to follow the operating system's color scheme preference.
+msgctxt "System theme button for theme selector"
+msgid "System"
+msgstr ""
+
 #. Abbreviation indicating this is the total score for a game
 msgctxt "Sports module"
 msgid "T"
@@ -15138,6 +15520,11 @@ msgctxt "language_name"
 msgid "Tahitian"
 msgstr ""
 
+#. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Tailor my resume"
+msgstr ""
+
 msgid "Taiwan"
 msgstr ""
 
@@ -15159,6 +15546,12 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "Take control of your personal data!"
+msgstr ""
+
+#. Description for the Feedback section of the Duck.ai settings page, asking the user to take an anonymous survey to let us know how we can make Duck.ai better.
+msgctxt "Feedback section description on the Duck.ai settings page"
+msgid ""
+"Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
 
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -15403,6 +15796,11 @@ msgstr ""
 #. https://duck.co/media/files/theme.png
 msgid "Theme"
 msgstr "Tema"
+
+#. Text for the theme selector label that allows users to switch between Light and dark theme.
+msgctxt "Label for the theme selector feature"
+msgid "Theme"
+msgstr ""
 
 #. http://i.imgur.com/LpFhb1e.png
 msgctxt "settings"
@@ -16054,6 +16452,16 @@ msgid ""
 "movie theatre?”"
 msgstr ""
 
+#. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Translate this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
+msgctxt "Page suggestion prompt"
+msgid "Translate this page into %s."
+msgstr ""
+
 #. Placeholder text for a region that will display translated text.
 msgctxt "translations_module"
 msgid "Translation"
@@ -16168,6 +16576,11 @@ msgstr ""
 #. Call-to-action button for the subscription promo in the SERP sidemenu.
 msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
+msgstr ""
+
+#. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
+msgctxt "settings"
+msgid "Try It Now"
 msgstr ""
 
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -16361,6 +16774,20 @@ msgstr "Cuba: %s"
 #. Response a user can select in a feedback form, indicating that they're trying DuckDuckGo again.
 msgctxt "new user poll"
 msgid "Trying DuckDuckGo again"
+msgstr ""
+
+#. Message shown in a modal after supported third-party browser users disable AI features in Settings. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+#. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
 msgstr ""
 
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -16967,6 +17394,11 @@ msgstr ""
 msgid "Uruguay"
 msgstr ""
 
+#. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
+msgctxt "Navigation label on the Duck.ai settings page"
+msgid "Usage"
+msgstr ""
+
 #. A feedback suggestion
 msgctxt "Feedback prompt"
 msgid "Usage limit"
@@ -17315,6 +17747,11 @@ msgstr ""
 msgid "Wales"
 msgstr ""
 
+#. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Walk me through the steps"
+msgstr ""
+
 #. Label for walking directions on a map.
 msgctxt "directions"
 msgid "Walking"
@@ -17405,6 +17842,16 @@ msgstr ""
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
+msgstr ""
+
+#. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
+msgctxt ""
+"Inline warning shown below the share-content toggle when the user selects "
+"Harmful or Illegal but has not enabled sharing"
+msgid ""
+"We can only fix what we can see. To report a harmful or illegal response, "
+"please share this conversation with DuckDuckGo so we can investigate and "
+"address the issue."
 msgstr ""
 
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -17824,6 +18271,87 @@ msgid ""
 "experience."
 msgstr ""
 
+#. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the counterarguments?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the hours & location?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key contributions of this paper?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key contributions?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key details?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key points covered in this video?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key points?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key takeaways from this article?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key takeaways?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key things I will learn from this course?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main counterarguments or criticisms of this?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main questions this page answers?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the must-try dishes here?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"What are the opening hours, location, and contact details for this place?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the pros and cons of this product?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the pros and cons?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
 msgctxt "feedback form"
 msgid "What bothered you most?"
@@ -17907,6 +18435,11 @@ msgctxt "Full sentence for defining a term"
 msgid "What does atria mean in the context of a medical article?"
 msgstr ""
 
+#. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What does this answer?"
+msgstr ""
+
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
@@ -17916,6 +18449,11 @@ msgstr ""
 msgctxt "cloudsave"
 msgid "What information gets saved?"
 msgstr "Maklumat apakah yang disimpan?"
+
+#. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What interview questions might come up for this role?"
+msgstr ""
 
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
@@ -17927,6 +18465,11 @@ msgstr ""
 #. Text for a prompt suggestion for looking up the capital city of Albania.
 msgctxt "Full sentence for looking up basic facts"
 msgid "What is the capital city of Albania?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What is the overall verdict and rating for this?"
 msgstr ""
 
 #. Link to a page with additional information.
@@ -17947,6 +18490,11 @@ msgctxt "maps_places"
 msgid "What people say:"
 msgstr ""
 
+#. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What should I order?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
 msgctxt "feedback form"
 msgid "What stood out?"
@@ -17955,6 +18503,16 @@ msgstr ""
 #. Question on a feedback form for a negative feedback response.
 msgctxt "feedback form"
 msgid "What was wrong with the response? (optional)"
+msgstr ""
+
+#. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I learn?"
+msgstr ""
+
+#. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I need?"
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -17969,6 +18527,11 @@ msgstr ""
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
 msgctxt "SERP footer content"
 msgid "What's New"
+msgstr ""
+
+#. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What's the verdict?"
 msgstr ""
 
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -18010,6 +18573,11 @@ msgctxt "Feedback prompt"
 msgid "Which features are missing? (Optional)"
 msgstr ""
 
+#. An invitation for users to leave feedback
+msgctxt "Feedback prompt"
+msgid "Which features are missing? (optional)"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
 msgid "White"
 msgstr "Putih"
@@ -18021,6 +18589,16 @@ msgstr ""
 
 #. Link to an about us page.
 msgid "Who We Are"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Who are the main cast and crew, and what else are they known for?"
+msgstr ""
+
+#. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Who is this person?"
 msgstr ""
 
 #. Header above a collection of privacy-related links.

--- a/locales/nb_NO/LC_MESSAGES/duckduckgo.po
+++ b/locales/nb_NO/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: nb\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -473,7 +473,8 @@ msgstr "%1$sFinn ut hvordan du kan holde lokasjonen din privat%2$s."
 msgctxt "Footer text for About Sync modal"
 msgid ""
 "%sLearn more%s about how chats are stored privately on DuckDuckGo's server."
-msgstr "%1$sFinn ut mer%2$s om hvordan chatter lagres privat på DuckDuckGos server."
+msgstr ""
+"%1$sFinn ut mer%2$s om hvordan chatter lagres privat på DuckDuckGos server."
 
 # smartling.placeholder_format=C
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
@@ -808,7 +809,8 @@ msgstr "6 timers bruksgrense er nådd."
 #. Displayed when the user has reached a fixed 6-hour Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "6-hour usage limit reached. You can continue this chat after %s."
-msgstr "6 timers bruksgrense er nådd. Du kan fortsette denne chatten etter %1$s."
+msgstr ""
+"6 timers bruksgrense er nådd. Du kan fortsette denne chatten etter %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable 6-hour Duck.ai usage limit and can opt in to continue using the daily limit.
@@ -1434,6 +1436,12 @@ msgid "Address is incorrect"
 msgstr "Adressen er feil"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Adjust the servings"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. as in multiple advertisements
 msgid "Ads"
 msgstr "Annonser"
@@ -1647,6 +1655,14 @@ msgid "All chats are %sprivate%s"
 msgstr "Alle chatter er %1$sprivate%2$s"
 
 # smartling.placeholder_format=C
+#. Paragraph in the Privacy & Terms section of the About & Legal page in Duck.ai settings, summarizing how chats are anonymized and are not stored or used to train chat models.
+msgctxt "Privacy & Terms section description on the Duck.ai settings page"
+msgid ""
+"All chats are anonymized by DuckDuckGo, and your conversations are not used "
+"to train chat models by DuckDuckGo or the model providers"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
 msgctxt "Privacy modal header in Duck.ai chat"
 msgid "All chats are private"
@@ -1676,7 +1692,8 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "All model providers are prevented from training their AI on your "
 "conversations."
-msgstr "Alle modelleverandører er forhindret i å trene AI-ene sine på samtalene dine."
+msgstr ""
+"Alle modelleverandører er forhindret i å trene AI-ene sine på samtalene dine."
 
 # smartling.placeholder_format=C
 #. Text displayed in the subheader of the modal that allows the user to pick an AI chat model.
@@ -1717,7 +1734,8 @@ msgstr "Alle typer"
 msgctxt "voice chat"
 msgid ""
 "Allow DuckDuckGo microphone access in System Settings to use voice chat."
-msgstr "Gi DuckDuckGo mikrofontilgang i systeminnstillingene for å bruke talechat."
+msgstr ""
+"Gi DuckDuckGo mikrofontilgang i systeminnstillingene for å bruke talechat."
 
 # smartling.placeholder_format=C
 #. Tells users which icon to press in their browser. Part of a list of instructions on how to enable location service.
@@ -1733,7 +1751,8 @@ msgstr "Tillat annonser som respekterer personvernet"
 # smartling.placeholder_format=C
 #. Title in a dialog informing the user how to disable their ad blocker for DuckDuckGo
 msgid "Allow privacy-respecting ads on DuckDuckGo Private Search"
-msgstr "Tillat annonser som respekterer personvernet på DuckDuckGo Private Search"
+msgstr ""
+"Tillat annonser som respekterer personvernet på DuckDuckGo Private Search"
 
 # smartling.placeholder_format=C
 #. Description explaining privacy implications of enabling web search on encrypted models. The first two placeholders are the full model name (e.g. 'gpt-oss 120B'). The third and fourth placeholders wrap a clickable link reading 'zero provider visibility' that opens the privacy modal, please keep those around the link text in your translation. An example full sentence would be: Allows gpt-oss 120B to search the web to improve responses to relevant prompts. Only sends AI-generated queries to a search engine with limited data retention. Prompts and responses with gpt-oss 120B still have zero provider visibility.
@@ -1912,6 +1931,13 @@ msgid "Anonymous location enabled"
 msgstr "Skjult lokasjon er på"
 
 # smartling.placeholder_format=C
+msgctxt "settings"
+msgid ""
+"Anonymously generates answers for search queries based on web content. "
+"Choose how often you want it to appear, or disable it completely."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Instant Answer tab name
 msgid "Answer"
 msgstr "Svar"
@@ -2056,7 +2082,8 @@ msgstr "Er du der fortsatt?"
 msgctxt "Body text for clear all chats confirmation modal"
 msgid ""
 "Are you sure you want to clear all of your chats? This cannot be undone."
-msgstr "Er du sikker på at du vil fjerne alle chattene dine? Dette kan ikke angres."
+msgstr ""
+"Er du sikker på at du vil fjerne alle chattene dine? Dette kan ikke angres."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that asks the user if they want to clear the conversation.
@@ -2191,6 +2218,12 @@ msgid "Ask a follow-up with Duck.ai"
 msgstr "Still et oppfølgingsspørsmål med Duck.ai"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
+msgctxt "Page suggestion chip label"
+msgid "Ask about this page"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
 msgctxt "Title for the page context onboarding modal"
 msgid "Ask about this page"
@@ -2270,12 +2303,12 @@ msgid ""
 "to remember that responses are auto-generated from cited sources and based "
 "on %scrawling the web%s."
 msgstr ""
-"Assist er en valgfri funksjon i søkeresultatene våre, som kan generere "
-"KI-assisterte svar anonymt på søkeforespørsler. For å gjøre dette skanner "
-"den nettet etter relevant innhold, og bruker deretter KI-drevet naturlig "
-"språk-teknologi til å generere et kort svar basert på relevant informasjon "
-"den har funnet. Det er viktig å huske at svarene genereres automatisk fra "
-"siterte kilder og er basert på %1$sgjennomsøking av nettet%2$s."
+"Assist er en valgfri funksjon i søkeresultatene våre, som kan generere KI-"
+"assisterte svar anonymt på søkeforespørsler. For å gjøre dette skanner den "
+"nettet etter relevant innhold, og bruker deretter KI-drevet naturlig språk-"
+"teknologi til å generere et kort svar basert på relevant informasjon den har "
+"funnet. Det er viktig å huske at svarene genereres automatisk fra siterte "
+"kilder og er basert på %1$sgjennomsøking av nettet%2$s."
 
 # smartling.placeholder_format=C
 #. Title for the dropdown menu where users select the assistant's role. Example: 'Assistant role: Travel guide'
@@ -2366,7 +2399,8 @@ msgstr "Lyd lagres ikke av oss eller av OpenAI etter at chatten er avsluttet."
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat is transcribed."
-msgstr "Lyd lagres ikke av oss eller av OpenAI etter at chatten er transkribert."
+msgstr ""
+"Lyd lagres ikke av oss eller av OpenAI etter at chatten er transkribert."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when MediaRecorder API is unavailable.
@@ -2413,7 +2447,8 @@ msgstr "Autogenerert basert på oppførte kilder. Kan inneholde unøyaktigheter.
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid ""
 "Auto-generated based on listed sources. Responses may contain inaccuracies."
-msgstr "Autogenerert basert på oppførte kilder. Svarene kan inneholde unøyaktigheter."
+msgstr ""
+"Autogenerert basert på oppførte kilder. Svarene kan inneholde unøyaktigheter."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI) on mobile
@@ -2601,6 +2636,12 @@ msgid "Barcode"
 msgstr "Strekkode"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Based on this page, is this course worth taking?"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Basic"
 msgstr "Enkel"
@@ -2639,6 +2680,14 @@ msgstr "Batter"
 msgctxt "Assistant response placeholder"
 msgid "Before continuing..."
 msgstr "Før du fortsetter …"
+
+# smartling.placeholder_format=C
+#. Explains that before storing the report, DuckDuckGo will anonymize the conversation by removing PII like names, email addresses, and identifying metadata.
+msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
+msgid ""
+"Before storing this report, DuckDuckGo will anonymize your conversation by "
+"removing PII like names, email addresses, and identifying metadata."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -2957,6 +3006,12 @@ msgid "Break Points Won"
 msgstr "Antall bruddballer vunnet"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Break this down into clear, numbered steps."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
 msgctxt "Weather IA"
 msgid "Breezy"
@@ -3014,8 +3069,8 @@ msgid ""
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
 msgstr ""
 "Bruk nettleseren som vanlig, så legger vi til personvernbeskyttelse. Vi har "
-"samlet søkemotoren, sporingsblokkeren og krypteringsvakten i én "
-"%1$s%2$s-utvidelse%3$s."
+"samlet søkemotoren, sporingsblokkeren og krypteringsvakten i én %1$s%2$s-"
+"utvidelse%3$s."
 
 # smartling.placeholder_format=C
 msgid ""
@@ -3409,6 +3464,12 @@ msgid "Cast"
 msgstr "Rollebesetning"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Cast & Crew"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
 msgctxt "Tone option label for Casual"
 msgid "Casual"
@@ -3644,8 +3705,8 @@ msgid ""
 "off by visiting %shttps://duck.ai%s directly."
 msgstr ""
 "Med chatten (via Duck.ai-tjenesten vår) kan du ha anonyme samtaler med "
-"tredjeparts AI-chatmodeller. Disse støtter modeller fra OpenAI, Anthropic "
-"m.m. Hvis du slår av denne innstillingen, skjules chat-knapper og -lenker på "
+"tredjeparts AI-chatmodeller. Disse støtter modeller fra OpenAI, Anthropic m."
+"m. Hvis du slår av denne innstillingen, skjules chat-knapper og -lenker på "
 "DuckDuckGo Search. Men du kan likevel få tilgang til chatten når denne "
 "innstillingen er av, ved å gå til %1$shttps.://duck.ai%2$s direkte."
 
@@ -3702,7 +3763,8 @@ msgstr "Chat privat"
 #. Mobile variant of DUCKCHAT_BROWSER_UPSELL_PROMO_TEXT. Shorter version for the promotional card encouraging third-party browser users to download the DuckDuckGo browser.
 msgctxt "Promotional text (mobile)"
 msgid "Chat privately on any website with Duck.ai built into our free browser."
-msgstr "Chat privat på ethvert nettsted med Duck.ai innebygd i vår gratis nettleser."
+msgstr ""
+"Chat privat på ethvert nettsted med Duck.ai innebygd i vår gratis nettleser."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card encouraging third-party browser users to download the DuckDuckGo browser. Not shown in the DuckDuckGo browser or on Linux.
@@ -4244,7 +4306,8 @@ msgstr "Klikk %1$sher%2$s for å laste ned DuckDuckGo-utvidelsen"
 # smartling.placeholder_format=C
 #. Link to download the DuckDuckGo browser extension.
 msgid "Click %sOpen%s to download and open the DuckDuckGo Safari extension"
-msgstr "Klikk på %1$sÅpne%2$s for å laste ned og åpne DuckDuckGo sin Safari-utvidelse"
+msgstr ""
+"Klikk på %1$sÅpne%2$s for å laste ned og åpne DuckDuckGo sin Safari-utvidelse"
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -4277,7 +4340,8 @@ msgstr "Klikk på %1$sInnstillinger%2$s i nedtrekksmenyen."
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
-msgstr "Klikk på %1$sVelg nåværende sider%2$s, og %3$sklikk deretter på OK%4$s."
+msgstr ""
+"Klikk på %1$sVelg nåværende sider%2$s, og %3$sklikk deretter på OK%4$s."
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -5112,6 +5176,12 @@ msgid "Create Image"
 msgstr "Lag bilde"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Create a shopping list with quantities from this recipe."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text displayed in the input field when starting a new image generation session.
 msgctxt "Placeholder text for the image generation input field"
 msgid "Create an image of a cute duck..."
@@ -5633,7 +5703,8 @@ msgstr "Vil du slette de eldste chattene for å frigjøre lagringsplass?"
 #. Title shown when user has reached the file storage sync quota (5GB).
 msgctxt "Sync file storage limit modal title"
 msgid "Delete oldest chats with attachments to free up storage?"
-msgstr "Vil du slette de eldste chattene med vedlegg for å frigjøre lagringsplass?"
+msgstr ""
+"Vil du slette de eldste chattene med vedlegg for å frigjøre lagringsplass?"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to delete all recent chats.
@@ -5657,7 +5728,8 @@ msgstr "Slettede chatter"
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
 msgctxt "settings"
 msgid "Deleting cookies will reset these settings."
-msgstr "Hvis du sletter informasjonskapslene, blir disse innstillingene tilbakestilt."
+msgstr ""
+"Hvis du sletter informasjonskapslene, blir disse innstillingene tilbakestilt."
 
 # smartling.placeholder_format=C
 msgid "Democratic People's Republic of Korea"
@@ -5742,12 +5814,18 @@ msgstr "Diktering i Duck.ai"
 # smartling.placeholder_format=C
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
-msgstr "Diktering anonymiseres av oss, og brukes aldri til å trene AI-modeller."
+msgstr ""
+"Diktering anonymiseres av oss, og brukes aldri til å trene AI-modeller."
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
 msgid "Dictation limit reached"
 msgstr "Dikteringsgrensen er nådd"
+
+# smartling.placeholder_format=C
+#. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
+msgid "Dictation temporarily unavailable"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
@@ -6050,6 +6128,22 @@ msgid "Done"
 msgstr "Ferdig"
 
 # smartling.placeholder_format=C
+#. Message shown in a modal after DuckDuckGo browser users disable AI features in Settings. The first two placeholders bold noai.duckduckgo.com. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
+"filtered out. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
+"and AI images filtered out. %sLearn more%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Double Faults"
@@ -6162,6 +6256,18 @@ msgid ""
 msgstr ""
 "Skriv et konsist og detaljert utkast til en e-post til en leverandør der du "
 "ber om et prisanslag på reparasjon av kjøleskap hjemme."
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Draft a cover letter"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Draft a cover letter for this job."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -6340,6 +6446,15 @@ msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
 msgstr "Duck.ai er best i vår private og gratis DuckDuckGo-nettleser!"
 
 # smartling.placeholder_format=C
+#. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
+msgctxt "About section description on the Duck.ai settings page"
+msgid ""
+"Duck.ai is created by DuckDuckGo. We're an independent online protection "
+"company for anyone who wants to take back control of their personal "
+"information."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
 msgctxt "duckai_migration"
 msgid "Duck.ai is moving domains"
@@ -6387,6 +6502,13 @@ msgstr "Duck.ai er midlertidig utilgjengelig. Prøv igjen senere."
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
+"Duck.ai lets you chat privately with popular AI models. Disabling it hides "
+"Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
+msgstr ""
+
+# smartling.placeholder_format=C
+msgctxt "settings"
+msgid ""
 "Duck.ai lets you have anonymous conversations with 3rd-party AI chat models, "
 "including models from OpenAI, Anthropic, and others. Turning this setting "
 "off will hide Duck.ai buttons and links on DuckDuckGo Search. However, you "
@@ -6396,8 +6518,8 @@ msgstr ""
 "Med Duck.ai kan du ha anonyme samtaler med tredjeparts AI-chatmodeller, som "
 "OpenAI, Anthropic og andre. Hvis du slår av denne innstillingen, skjules "
 "Duck.ai-knapper og -lenker på DuckDuckGo Search. Men du kan likevel få "
-"tilgang til Duck.ai når denne innstillingen er av, ved å gå til "
-"%1$shttps://duck.ai%2$s direkte."
+"tilgang til Duck.ai når denne innstillingen er av, ved å gå til %1$shttps://"
+"duck.ai%2$s direkte."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
@@ -6755,8 +6877,8 @@ msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid ""
 "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to Duck.ai's %s."
 msgstr ""
-"DuckDuckGo anonymiserer chattene dine. Ved å klikke på «%1$s» godtar du "
-"Duck.ai's %2$s."
+"DuckDuckGo anonymiserer chattene dine. Ved å klikke på «%1$s» godtar du Duck."
+"ai's %2$s."
 
 # smartling.placeholder_format=C
 #. Shown below the input on the empty state when the user has not yet accepted the terms of service. The first %s is the action button label ('Ask' for chat, 'Create' for image generation). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. Clicking the action button both accepts the terms and submits the prompt.
@@ -6846,7 +6968,8 @@ msgctxt ""
 "Description of the DuckDuckGo subscription setting when it is not available "
 "in the user region"
 msgid "DuckDuckGo subscriptions are not available to purchase in this region."
-msgstr "DuckDuckGo-abonnementer er ikke tilgjengelige for kjøp i denne regionen."
+msgstr ""
+"DuckDuckGo-abonnementer er ikke tilgjengelige for kjøp i denne regionen."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use 'ducky' tone in its responses. When this option is selected, the AI assistant speaks like a duck.
@@ -7112,7 +7235,8 @@ msgstr "Aktiver diktering i Duck.ai"
 #. Prompt to enable location service so that search results can be displayed near the user's current location.
 msgctxt "precise_user_location"
 msgid "Enable location settings on your device to use anonymous location"
-msgstr "Aktiver posisjonsinnstillinger på enheten din for å bruke anonym posisjon"
+msgstr ""
+"Aktiver posisjonsinnstillinger på enheten din for å bruke anonym posisjon"
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -7376,6 +7500,18 @@ msgid "Eritrea"
 msgstr "Eritrea"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Estimate the nutrition"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Estimate the nutritional information for this recipe."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Estonia"
 msgstr "Estland"
 
@@ -7430,6 +7566,12 @@ msgid "Expires in 1 day"
 msgstr "Utløper om 1 dag"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain the accepted answer in simple terms."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
@@ -7437,6 +7579,48 @@ msgid ""
 msgstr ""
 "Forklar de grunnleggende konseptene om sorte hull for meg på nivå for "
 "videregående skole."
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain the top answer"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this in simple, plain language."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this paper"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this repo"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this research paper in plain language."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this simply"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain what this repository does and how to use it."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label to show if song lyrics contain explicit content
@@ -7718,7 +7902,14 @@ msgstr "Filtrerer ut AI-genererte bilder fra bildesøkresultater"
 msgctxt "settings"
 msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
-msgstr "Filtrerer ut AI-genererte bilder fra bildesøkresultater. %1$sFinn ut mer%2$s"
+msgstr ""
+"Filtrerer ut AI-genererte bilder fra bildesøkresultater. %1$sFinn ut mer%2$s"
+
+# smartling.placeholder_format=C
+msgctxt "settings"
+msgid ""
+"Filters out known AI spam sites from image search results. %sLearn More%s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the final score of a sporting event.
@@ -7774,6 +7965,12 @@ msgid "Find current information"
 msgstr "Finn oppdatert informasjon"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Find me alternatives"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Button that searches for results closer to the user's current location.
 msgctxt "precise_user_location"
 msgid "Find results closer to you"
@@ -7790,7 +7987,8 @@ msgstr "Søk nærmere der du er."
 msgctxt "Precise user location overlay"
 msgid ""
 "Find results near you. %sYour location stays private, secure, and anonymous."
-msgstr "Finn resultater nær deg. %1$sPosisjonen din forblir privat, sikker og anonym."
+msgstr ""
+"Finn resultater nær deg. %1$sPosisjonen din forblir privat, sikker og anonym."
 
 # smartling.placeholder_format=C
 #. Loading message shown while generating explore more follow-up questions
@@ -7996,7 +8194,8 @@ msgstr "Kan deles og brukes kommersielt"
 #. Description text explaining how to free up sync storage. Pinned chats are chats the user has explicitly marked to keep.
 msgctxt "Sync limit modal description"
 msgid "Free up space by deleting your chats. Pinned chats will not be deleted."
-msgstr "Frigjør plass ved å slette chattene dine. Festede chatter blir ikke slettet."
+msgstr ""
+"Frigjør plass ved å slette chattene dine. Festede chatter blir ikke slettet."
 
 # smartling.placeholder_format=C
 #. Indicates that this streaming service is free to watch but shows ads
@@ -8245,6 +8444,12 @@ msgstr "Generer bilde"
 #. Text for the button that generates more of an answer from duckassist when the answer has come from a collapsed state
 msgid "Generate More"
 msgstr "Generer mer"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Generate a shopping list"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
@@ -8536,6 +8741,12 @@ msgstr "Prøv det"
 msgctxt "Onboarding welcome screen button text"
 msgid "Give it a Try"
 msgstr "Prøv det"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Give me a quick background on this person."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -8982,6 +9193,18 @@ msgstr "Bidra til å spre DuckDuckGo!"
 #. Link to a page with information about sharing DuckDuckGo with friends.
 msgid "Help Spread Privacy"
 msgstr "Hjelp til å spre personvern"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Help me prep for the interview"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Help me tailor my resume for this job."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title of a SERP popup that invites users to take a survey (desktop only)
@@ -9499,6 +9722,14 @@ msgid "I Agree"
 msgstr "Jeg samtykker"
 
 # smartling.placeholder_format=C
+#. Text for the button that takes the user to the external DuckDuckGo login subscription page.
+msgctxt ""
+"Text for the I already have a subscription button in the Duck.ai settings "
+"page"
+msgid "I Already Have a Subscription"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for the button that takes the user to the login subscription page.
 msgctxt "Text for the I have a subscription button"
 msgid "I Have a Subscription"
@@ -9647,8 +9878,8 @@ msgid ""
 "If you have concerns about our chat providers or any particular chat "
 "response, you can also reach out directly to %s and %s support pages."
 msgstr ""
-"Hvis du har bekymringer om chat-leverandørene våre eller et bestemt "
-"chat-svar, kan du også kontakte støttesiden til %1$s og %2$s direkte."
+"Hvis du har bekymringer om chat-leverandørene våre eller et bestemt chat-"
+"svar, kan du også kontakte støttesiden til %1$s og %2$s direkte."
 
 # smartling.placeholder_format=C
 #. Body copy explaining what the recovery code is for and how it can be saved.
@@ -10075,6 +10306,12 @@ msgid "Install Mac Browser"
 msgstr "Installer Mac-nettleser"
 
 # smartling.placeholder_format=C
+#. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
+msgctxt "settings"
+msgid "Install Now"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of a button to install the DuckDuckGo app
 msgctxt "Serp footer content"
 msgid "Install Our App"
@@ -10172,10 +10409,42 @@ msgid "Is deleted data really deleted?"
 msgstr "Er slettet data virkelig slettet?"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is it worth taking?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this place any good?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"Is this place any good? Summarize its reputation based on reviews and "
+"ratings."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "Is this video helpful?"
 msgstr "Var denne videoen nyttig?"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this worth watching?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Is this worth watching? Give me a spoiler-free take."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -10787,6 +11056,12 @@ msgid "Links:"
 msgstr "Lenker:"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "List the tools, materials, or prerequisites I need for this."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
 msgid "Listen"
 msgstr "Lytt"
@@ -10895,7 +11170,8 @@ msgstr "Laster flere bilderesultater når du ruller"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Loads more results in Images, Videos, and Shopping when scrolling"
-msgstr "Laster inn flere resultater i Bilder, Videoer og Shopping når du ruller"
+msgstr ""
+"Laster inn flere resultater i Bilder, Videoer og Shopping når du ruller"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/WTkvs9I.png
@@ -11191,6 +11467,12 @@ msgstr "Administrer abonnementet ditt"
 msgctxt "Exclusion message manage sites button"
 msgid "Manage blocked sites"
 msgstr "Administrer blokkerte nettsteder"
+
+# smartling.placeholder_format=C
+#. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
+msgctxt "setting"
+msgid "Manage in Browser Settings"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to the site exclusion settings page
@@ -11640,7 +11922,8 @@ msgstr "Månedlig grense er nådd"
 #. Displayed when the user has reached a fixed monthly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Monthly usage limit reached. You can continue this chat after %s."
-msgstr "Månedlig bruksgrense er nådd. Du kan fortsette denne chatten etter %1$s."
+msgstr ""
+"Månedlig bruksgrense er nådd. Du kan fortsette denne chatten etter %1$s."
 
 # smartling.placeholder_format=C
 #. Used to point to additional social networking profiles (in results).
@@ -13034,8 +13317,8 @@ msgid ""
 "Only the settings that you have changed. They are detailed on the %sURL "
 "Parameters%s page."
 msgstr ""
-"Bare innstillingene du har endret. De er spesifisert på siden "
-"%1$sURL-parameter%2$s."
+"Bare innstillingene du har endret. De er spesifisert på siden %1$sURL-"
+"parameter%2$s."
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers only when the user clicks the Assist button.
@@ -14021,6 +14304,12 @@ msgstr "Fullfør denne testen for å bekrefte at søket ble gjort av et menneske
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
+msgid "Please describe why the chat response is harmful or illegal. (optional)"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
+msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
 msgstr "Beskriv hvorfor chatsvaret er ulovlig eller skadelig. (Valgfritt)"
 
@@ -14045,6 +14334,14 @@ msgid ""
 msgstr ""
 "Obs: En ny chat med en hvilken som helst modell vil slette den nåværende "
 "chat-økten din."
+
+# smartling.placeholder_format=C
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
+msgctxt "Feedback prompt"
+msgid ""
+"Please paste your prompt and the problematic output (with any personal "
+"information removed) and describe why the content is harmful or illegal."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -14514,6 +14811,12 @@ msgid "Privacy"
 msgstr "Personvern"
 
 # smartling.placeholder_format=C
+#. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
+msgctxt "Section heading on the Duck.ai settings page"
+msgid "Privacy & Terms"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Privacy Blog"
 msgstr "Personvernblogg"
 
@@ -14582,6 +14885,12 @@ msgstr "Personvernerklæring og vilkår for bruk"
 msgctxt "Copy used to compose link in sentences"
 msgid "Privacy Policy and Terms of Service"
 msgstr "Personvernerklæring og vilkår for bruk"
+
+# smartling.placeholder_format=C
+#. Text for a button that links to the terms of use and privacy policy page.
+msgctxt "Secondary button text in active privacy modal"
+msgid "Privacy Policy and Terms of Service"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title displayed on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
@@ -14755,7 +15064,8 @@ msgstr "Spør meg"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Prompt me to use my approximate location to get nearby results."
-msgstr "Spør meg om å bruke omtrentlig lokasjon for å få resultater i nærheten."
+msgstr ""
+"Spør meg om å bruke omtrentlig lokasjon for å få resultater i nærheten."
 
 # smartling.placeholder_format=C
 #. DuckDuckGo Email Protection removes trackers from emails
@@ -15036,8 +15346,8 @@ msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
 msgstr ""
-"Nylige chatter som lagres lokalt på enheten din, i stedet for på "
-"DuckDuckGo-servere eller andre eksterne servere."
+"Nylige chatter som lagres lokalt på enheten din, i stedet for på DuckDuckGo-"
+"servere eller andre eksterne servere."
 
 # smartling.placeholder_format=C
 #. Text explaining that recent chats are stored locally on the user's device.
@@ -15046,8 +15356,8 @@ msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
 msgstr ""
-"Nylige chatter lagres lokalt på enheten din i stedet for på "
-"DuckDuckGo-servere eller andre eksterne servere."
+"Nylige chatter lagres lokalt på enheten din i stedet for på DuckDuckGo-"
+"servere eller andre eksterne servere."
 
 # smartling.placeholder_format=C
 #. Text explaining how recent chats are stored locally on the user's device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection.
@@ -15081,6 +15391,30 @@ msgstr "Oppskrifter på %1$s%2$s%3$s"
 msgctxt "Brief for recommending a book"
 msgid "Recommend a book"
 msgstr "Anbefal en bok"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar books"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar books."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar movies or shows."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar titles"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
@@ -15483,6 +15817,15 @@ msgid "Republic of Moldova"
 msgstr "Republikken Moldova"
 
 # smartling.placeholder_format=C
+#. Note indicating that sharing the conversation is mandatory when reporting harmful or illegal content. Rendered alongside the standard share label (DUCKCHAT_RESPONSE_FEEDBACK_SHARE_PROMPT_RESPONSE_LABEL), not replacing it.
+msgctxt ""
+"Note shown under the share-content switch label on the Duck.ai response "
+"feedback form when the user has selected Harmful or Illegal as the feedback "
+"reason"
+msgid "Required for harmful or illegal reports"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
 msgctxt "Description for extended reasoning mode in Duck.ai"
 msgid "Researches before responding"
@@ -15717,6 +16060,12 @@ msgstr "Anmeldelser"
 msgctxt "maps_places"
 msgid "Reviews"
 msgstr "Anmeldelser"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Rewrite this recipe scaled for a different number of servings."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Romania"
@@ -16002,7 +16351,8 @@ msgstr "Lagre opptil 30 av de siste chattene lokalt på enheten din."
 msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
-msgstr "Lagre Duck.ai-chattene mellom enhetene dine med ende-til-ende-kryptering."
+msgstr ""
+"Lagre Duck.ai-chattene mellom enhetene dine med ende-til-ende-kryptering."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -16167,7 +16517,8 @@ msgstr "Rull ned til %1$sDuckDuckGo%2$s og la den bruke posisjonen din."
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down to the %sServices%s section and click %sAddress bar%s."
-msgstr "Rull ned til %1$sTjenester%2$s-delen, og klikk på %3$sAdresselinje%4$s."
+msgstr ""
+"Rull ned til %1$sTjenester%2$s-delen, og klikk på %3$sAdresselinje%4$s."
 
 # smartling.placeholder_format=C
 #. Rugby match stats
@@ -16391,8 +16742,8 @@ msgctxt "settings"
 msgid ""
 "Search queries are included in URL (if off, searches will use POST requests)"
 msgstr ""
-"Søkeforespørsler er inkludert i URL-en (hvis avslått, vil søkene bruke "
-"POST-forespørsler)"
+"Søkeforespørsler er inkludert i URL-en (hvis avslått, vil søkene bruke POST-"
+"forespørsler)"
 
 # smartling.placeholder_format=C
 #. Describes how cookies are used to store user settings privately and securely.
@@ -16505,8 +16856,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
 msgstr ""
-"Lagre nesten ubegrenset med chatter sikkert på serveren vår med "
-"ende-til-ende-kryptering, og få tilgang til dem fra alle enhetene dine."
+"Lagre nesten ubegrenset med chatter sikkert på serveren vår med ende-til-"
+"ende-kryptering, og få tilgang til dem fra alle enhetene dine."
 
 # smartling.placeholder_format=C
 #. Text explaining that the Encrypted Storage feature stores the user's chats encrypted on their device.
@@ -16515,8 +16866,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
 msgstr ""
-"Lagre nesten ubegrenset med chatter sikkert på serveren vår med "
-"ende-til-ende-kryptering, og få tilgang til dem fra alle enhetene dine."
+"Lagre nesten ubegrenset med chatter sikkert på serveren vår med ende-til-"
+"ende-kryptering, og få tilgang til dem fra alle enhetene dine."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -16664,7 +17015,8 @@ msgstr "Se noen av våre nyeste oppdateringer"
 #. Link to a page with more information about how user settings are stored in a URL.
 msgctxt "settings"
 msgid "See the %sURL Parameter Reference page%s for more details."
-msgstr "Se %1$sreferansesiden for nettadresseparametere%2$s for mer informasjon."
+msgstr ""
+"Se %1$sreferansesiden for nettadresseparametere%2$s for mer informasjon."
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the context menu of a chat in chat history, that allows the user to select the chat and begin batch selection mode.
@@ -16818,7 +17170,8 @@ msgstr "Velg %1$sInnstillinger%2$s fra nedtrekksmenyen."
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sAdvanced settings%s"
-msgstr "Velg %1$sInnstillinger%2$s, og deretter %3$sAvanserte innstillinger%4$s"
+msgstr ""
+"Velg %1$sInnstillinger%2$s, og deretter %3$sAvanserte innstillinger%4$s"
 
 # smartling.placeholder_format=C
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -16846,7 +17199,8 @@ msgstr ""
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %syour browser%s in the list and %sallow%s location access"
-msgstr "Velg %1$snettleseren din%2$s i listen og %3$stillat%4$s posisjonstilgang"
+msgstr ""
+"Velg %1$snettleseren din%2$s i listen og %3$stillat%4$s posisjonstilgang"
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the modal for deleting all recent chats, that allows the user to select the chats to delete.
@@ -17040,6 +17394,12 @@ msgid "Set Up Now"
 msgstr "Konfigurer nå"
 
 # smartling.placeholder_format=C
+#. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
+msgctxt "Encrypted storage setup button shown in native browsers"
+msgid "Set Up Sync & Backup"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
 msgctxt "Title for the Sync & Backup intro screen"
 msgid "Set Up Sync & Backup"
@@ -17159,8 +17519,8 @@ msgid ""
 "never reveals your precise location to us or AI models."
 msgstr ""
 "Del plassering så nær som nærmeste by med AI-modeller for å forbedre "
-"relevansen. Duck.ai avslører aldri din nøyaktige plassering til oss eller "
-"AI-modeller."
+"relevansen. Duck.ai avslører aldri din nøyaktige plassering til oss eller AI-"
+"modeller."
 
 # smartling.placeholder_format=C
 #. Menu option to share feedback about a result
@@ -17219,6 +17579,13 @@ msgstr "Del sidens nettadresse"
 msgctxt "feedback form"
 msgid "Share positive feedback"
 msgstr "Del positive tilbakemeldinger"
+
+# smartling.placeholder_format=C
+#. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
+msgctxt ""
+"Label beside the share-content switch on the Duck.ai response feedback form"
+msgid "Share this conversation with DuckDuckGo"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -17623,12 +17990,14 @@ msgstr "Viser de mest besøkte lenkene på ny fane"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your browser"
-msgstr "Viser sporadiske påminnelser om å legge til DuckDuckGo i nettleseren din"
+msgstr ""
+"Viser sporadiske påminnelser om å legge til DuckDuckGo i nettleseren din"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr "Viser sporadiske påminnelser om å legge til DuckDuckGo på enhetene dine"
+msgstr ""
+"Viser sporadiske påminnelser om å legge til DuckDuckGo på enhetene dine"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -17920,7 +18289,8 @@ msgstr "Noen ganger"
 #. Generic error message shown when the image generation model cannot process the user's request.
 msgctxt "Error message from the image generation model"
 msgid "Sorry I can't help, please describe your image in a different way."
-msgstr "Beklager at jeg ikke kan hjelpe deg. Prøv å beskrive bildet på en annen måte."
+msgstr ""
+"Beklager at jeg ikke kan hjelpe deg. Prøv å beskrive bildet på en annen måte."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -17994,7 +18364,8 @@ msgstr ""
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr "Beklager, vi kunne ikke sende inn tilbakemeldingen din. Prøv igjen senere."
+msgstr ""
+"Beklager, vi kunne ikke sende inn tilbakemeldingen din. Prøv igjen senere."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -18048,7 +18419,8 @@ msgstr "Kildetekst fjernet"
 msgctxt "Error message for summary selection input limit"
 msgid ""
 "Source text is too long to summarize. Try again with a shorter selection."
-msgstr "Kildeteksten er for lang til å oppsummere. Prøv igjen med en kortere tekst."
+msgstr ""
+"Kildeteksten er for lang til å oppsummere. Prøv igjen med en kortere tekst."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under Interface Settings.in the end. It is a header
@@ -18247,7 +18619,8 @@ msgstr "Bli på DuckDuckGo"
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletter."
-msgstr "Beskytt deg selv og hold deg informert med personvern-nyhetsbrevet vårt."
+msgstr ""
+"Beskytt deg selv og hold deg informert med personvern-nyhetsbrevet vårt."
 
 # smartling.placeholder_format=C
 #. Prompt to subscribe to a newsletter.
@@ -18472,6 +18845,24 @@ msgid "Suggest a title for a blog post"
 msgstr "Foreslå en tittel for et blogginnlegg"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest related articles or topics worth exploring next."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Suggest related articles to explore"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest some alternatives to this product."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
 msgctxt "directions"
 msgid "Suggestions:"
@@ -18483,10 +18874,100 @@ msgid "Suggestions:"
 msgstr "Forslag:"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Sum up the reviews"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A short title for the a message asking the AI to summarize a text.
 msgctxt "Title for the summarize message"
 msgid "Summarize"
 msgstr "Oppsummer"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize the Q&As"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the background and notable work of this person."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the key details of this event."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the questions and answers on this page."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize their background"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this book"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this book."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this discussion"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this discussion thread."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this page"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this page."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this video"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this video."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize what the reviews say."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -18703,7 +19184,8 @@ msgstr "Sync & Backup er aktivert!"
 #. Notice shown under the recovery code explaining that backup data has an inactivity expiration.
 msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
-msgstr "Sync & Backup-data kan ikke gjenopprettes etter 18 måneder med inaktivitet."
+msgstr ""
+"Sync & Backup-data kan ikke gjenopprettes etter 18 måneder med inaktivitet."
 
 # smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
@@ -18752,9 +19234,9 @@ msgid ""
 msgstr ""
 "Synkroniseringsgjenopprettingskode\n"
 "\n"
-"Gjenopprettingskoden lar deg synkronisere passord, autofylle data og "
-"Duck.ai-chatter på tvers av flere enheter, og gjenopprette synkroniserte "
-"data hvis du mister tilgangen til en enhet.\n"
+"Gjenopprettingskoden lar deg synkronisere passord, autofylle data og Duck.ai-"
+"chatter på tvers av flere enheter, og gjenopprette synkroniserte data hvis "
+"du mister tilgangen til en enhet.\n"
 "\n"
 "Ta godt vare på denne informasjonen.\n"
 "Alle som har tilgang til denne koden kan få tilgang til de synkroniserte "
@@ -18813,6 +19295,12 @@ msgid "Syria"
 msgstr "Syria"
 
 # smartling.placeholder_format=C
+#. Text for a button that enables the theme to follow the operating system's color scheme preference.
+msgctxt "System theme button for theme selector"
+msgid "System"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Abbreviation indicating this is the total score for a game
 msgctxt "Sports module"
 msgid "T"
@@ -18839,6 +19327,12 @@ msgstr "TV"
 msgctxt "language_name"
 msgid "Tahitian"
 msgstr "Tahitisk"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Tailor my resume"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Taiwan"
@@ -18868,6 +19362,13 @@ msgstr "Ta kontroll over personopplysningene dine"
 msgctxt "homepage ATB modal"
 msgid "Take control of your personal data!"
 msgstr "Ta kontroll over personopplysningene dine!"
+
+# smartling.placeholder_format=C
+#. Description for the Feedback section of the Duck.ai settings page, asking the user to take an anonymous survey to let us know how we can make Duck.ai better.
+msgctxt "Feedback section description on the Duck.ai settings page"
+msgid ""
+"Take this anonymous survey to let us know how we can make Duck.ai better."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -19111,7 +19612,8 @@ msgstr "De vedlagte filene overskrider den totale størrelsesgrensen på %1$s MB
 #. Error message displayed when the total size of all attached files in a conversation exceeds the allowed limit. Placeholder is the combined size limit in megabytes. E.g. The attached files exceed the total size limit of 5 MB
 msgctxt "Error message when combined file size exceeds the limit"
 msgid "The attached files exceed the total size limit of %s MB."
-msgstr "De vedlagte filene overskrider den totale størrelsesgrensen på %1$s MB."
+msgstr ""
+"De vedlagte filene overskrider den totale størrelsesgrensen på %1$s MB."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the server rejects corrupt or unrecognized audio.
@@ -19133,7 +19635,8 @@ msgstr ""
 msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider deletes any data associated with this chat within 30 days."
-msgstr "Modelleverandøren sletter alle data knyttet til denne chatten innen 30 dager."
+msgstr ""
+"Modelleverandøren sletter alle data knyttet til denne chatten innen 30 dager."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers.
@@ -19172,6 +19675,12 @@ msgstr "Serveren støtte på en feil og kunne ikke fullføre forespørselen din.
 #. https://duck.co/media/files/theme.png
 msgid "Theme"
 msgstr "Utseende"
+
+# smartling.placeholder_format=C
+#. Text for the theme selector label that allows users to switch between Light and dark theme.
+msgctxt "Label for the theme selector feature"
+msgid "Theme"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/LpFhb1e.png
@@ -19296,7 +19805,8 @@ msgstr ""
 #. Appears below a type of search results called 'Instant Answers'
 msgctxt "attribution"
 msgid "This Instant Answer was made by the %sDuckDuckHack%s Community."
-msgstr "Dette øyeblikkelige svaret ble laget av %1$sDuckDuckHack%2$s-samfunnet."
+msgstr ""
+"Dette øyeblikkelige svaret ble laget av %1$sDuckDuckHack%2$s-samfunnet."
 
 # smartling.placeholder_format=C
 #. Label for the monthly usage row in the Usage section of Duck.ai settings.
@@ -19317,9 +19827,9 @@ msgid ""
 "This conversation was generated with Duck.ai (%s) using %s's %s Model. AI "
 "chats may display inaccurate or offensive information (see %s for more info)."
 msgstr ""
-"Denne samtalen ble generert med Duck.ai (%1$s) ved hjelp av %2$ss "
-"%3$s-modell. KI-chatter kan vise feil eller støtende informasjon (se %4$s "
-"for mer informasjon)."
+"Denne samtalen ble generert med Duck.ai (%1$s) ved hjelp av %2$ss %3$s-"
+"modell. KI-chatter kan vise feil eller støtende informasjon (se %4$s for mer "
+"informasjon)."
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with multiple AI models in the same chat, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using multiple chat models. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -19424,14 +19934,16 @@ msgstr "Dette bildet kunne ikke opprettes."
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF"
-msgstr "Denne bildetypen støttes ikke. Legg ved en JPG-, PNG-, WebP- eller GIF-fil"
+msgstr ""
+"Denne bildetypen støttes ikke. Legg ved en JPG-, PNG-, WebP- eller GIF-fil"
 
 # smartling.placeholder_format=C
 #. Error message displayed when a file that the user tried to upload is not of a supported format
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF."
-msgstr "Denne bildetypen støttes ikke. Legg heller ved en JPG, PNG, WebP eller GIF."
+msgstr ""
+"Denne bildetypen støttes ikke. Legg heller ved en JPG, PNG, WebP eller GIF."
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
@@ -19553,7 +20065,8 @@ msgstr "Denne oversettelsen er feil"
 # smartling.placeholder_format=C
 #. Label indicating that the video can't be played on the current page, and only on the website that owns the vide. The placeholder is the name of the website that owns the video.
 msgid "This video is not yet able to be watched here. You can watch it on %s."
-msgstr "Videoen er ikke ennå i stand til å spilles av her. Du kan se den på %1$s."
+msgstr ""
+"Videoen er ikke ennå i stand til å spilles av her. Du kan se den på %1$s."
 
 # smartling.placeholder_format=C
 #. Message indicating that a website is not using an encrypted connection and is not secure.
@@ -19744,8 +20257,8 @@ msgid ""
 "To transfer your chat history to Duck.ai, please update your DuckDuckGo "
 "browser to the latest version and try again."
 msgstr ""
-"For å overføre chat-historikken din til Duck.ai, oppdater "
-"DuckDuckGo-nettleseren din til den nyeste versjonen og prøv igjen."
+"For å overføre chat-historikken din til Duck.ai, oppdater DuckDuckGo-"
+"nettleseren din til den nyeste versjonen og prøv igjen."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
@@ -20007,6 +20520,18 @@ msgstr ""
 "nærmeste kino?»"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Translate this page"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
+msgctxt "Page suggestion prompt"
+msgid "Translate this page into %s."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text for a region that will display translated text.
 msgctxt "translations_module"
 msgid "Translation"
@@ -20146,6 +20671,12 @@ msgstr "Prøv igjen"
 msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
 msgstr "Prøv gratis"
+
+# smartling.placeholder_format=C
+#. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
+msgctxt "settings"
+msgid "Try It Now"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -20382,6 +20913,22 @@ msgstr "Prøv: %1$s"
 msgctxt "new user poll"
 msgid "Trying DuckDuckGo again"
 msgstr "Prøver DuckDuckGo igjen"
+
+# smartling.placeholder_format=C
+#. Message shown in a modal after supported third-party browser users disable AI features in Settings. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -20704,8 +21251,8 @@ msgstr "Under %1$sÅpne med%2$s velger du %3$sEn spesifikk side eller sider%4$s"
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
 msgstr ""
-"Under %1$sOPPSTART > Startside%2$s startside skriver du inn: "
-"https://duckduckgo.com"
+"Under %1$sOPPSTART > Startside%2$s startside skriver du inn: https://"
+"duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -20727,7 +21274,8 @@ msgstr "Under %1$sSøke%2$sseksjon trykker du på %3$sBehandle søkemotorer …%
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under On startup select %sOpen a specific page or set of pages%s"
-msgstr "Under Ved oppstart velger du %1$sÅpne en spesifikk side eller flere sider%2$s"
+msgstr ""
+"Under Ved oppstart velger du %1$sÅpne en spesifikk side eller flere sider%2$s"
 
 #  Opera default search engine instruction
 # smartling.placeholder_format=C
@@ -20834,8 +21382,8 @@ msgctxt "voice chat limit modal"
 msgid ""
 "Unlock advanced AI models and higher limits with a DuckDuckGo Subscription"
 msgstr ""
-"Få tilgang til avanserte AI-modeller og høyere grenser med et "
-"DuckDuckGo-abonnement"
+"Få tilgang til avanserte AI-modeller og høyere grenser med et DuckDuckGo-"
+"abonnement"
 
 # smartling.placeholder_format=C
 #. Text informing the user that advanced AI models can be unlocked with a subscription. The variable is used to insert a link that opens the subscription modal. Example: Unlock advanced AI models with a DuckDuckGo subscription.
@@ -21130,6 +21678,12 @@ msgstr "Urdu"
 # smartling.placeholder_format=C
 msgid "Uruguay"
 msgstr "Uruguay"
+
+# smartling.placeholder_format=C
+#. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
+msgctxt "Navigation label on the Duck.ai settings page"
+msgid "Usage"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -21427,9 +21981,9 @@ msgid ""
 "Visit Duck.ai in your other browser and go to %sDuck.ai Settings%s > %sSync "
 "& Backup%s > %sManage%s then select %sSync With Another Device%s."
 msgstr ""
-"Gå til Duck.ai i den andre nettleseren din og så til "
-"%1$sDuck.ai-innstillinger%2$s > %3$sSync & Backup%4$s > %5$sAdministrer%6$s. "
-"Velg deretter %7$sSynkroniser med en annen enhet%8$s."
+"Gå til Duck.ai i den andre nettleseren din og så til %1$sDuck.ai-"
+"innstillinger%2$s > %3$sSync & Backup%4$s > %5$sAdministrer%6$s. Velg "
+"deretter %7$sSynkroniser med en annen enhet%8$s."
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -21465,8 +22019,8 @@ msgid ""
 msgstr ""
 "Gå til Duck.ai i nettleseren din eller i DuckDuckGo-appen, og åpne "
 "innstillingene for Duck.ai. Velg «Slå på» under Sync & Backup og velg "
-"«Synkroniser med en annen enhet». Eller skann QR-koden på "
-"gjenopprettings-PDF-en din."
+"«Synkroniser med en annen enhet». Eller skann QR-koden på gjenopprettings-"
+"PDF-en din."
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -21518,7 +22072,8 @@ msgstr "Talechatten er avsluttet"
 #. Description in consent disclaimer informing that voice chats with the AI (Artificial Intelligence) are anonymized by us, and are never used to train AI models.
 msgctxt "voice chat"
 msgid "Voice chat is anonymized by us, and never used to train AI models."
-msgstr "Talechatten anonymiseres av oss og brukes aldri til å trene AI-modeller."
+msgstr ""
+"Talechatten anonymiseres av oss og brukes aldri til å trene AI-modeller."
 
 # smartling.placeholder_format=C
 #. Title of the modal shown when the user has reached their daily voice chat limit.
@@ -21577,6 +22132,12 @@ msgstr "Venter på lokasjon …"
 # smartling.placeholder_format=C
 msgid "Wales"
 msgstr "Wales"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Walk me through the steps"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for walking directions on a map.
@@ -21697,6 +22258,17 @@ msgstr ""
 "resultater."
 
 # smartling.placeholder_format=C
+#. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
+msgctxt ""
+"Inline warning shown below the share-content toggle when the user selects "
+"Harmful or Illegal but has not enabled sharing"
+msgid ""
+"We can only fix what we can see. To report a harmful or illegal response, "
+"please share this conversation with DuckDuckGo so we can investigate and "
+"address the issue."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
 msgctxt ""
 "Inline warning shown below the share-content toggle when the user selects "
@@ -21734,7 +22306,8 @@ msgstr "Vi følger ikke etter deg med annonser."
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
 msgid "We don't store usernames or any personally identifiable information."
-msgstr "Vi lager hverken brukernavn eller informasjon som kan identifisere personer."
+msgstr ""
+"Vi lager hverken brukernavn eller informasjon som kan identifisere personer."
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -21894,7 +22467,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We stop anyone from getting your search history, including us."
-msgstr "Vi stopper alle fra å få tak i søkehistorikken din, inkludert oss selv."
+msgstr ""
+"Vi stopper alle fra å få tak i søkehistorikken din, inkludert oss selv."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -21917,7 +22491,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
-msgstr "Vi blokkerer sporere som prøver å samle inn dataene dine mens du surfer."
+msgstr ""
+"Vi blokkerer sporere som prøver å samle inn dataene dine mens du surfer."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -21951,7 +22526,8 @@ msgctxt "duckai_migration"
 msgid ""
 "We're sorry for this inconvenience. We’re working hard to make your "
 "experience better."
-msgstr "Vi beklager ulempen. Vi jobber hardt for å gjøre opplevelsen din bedre."
+msgstr ""
+"Vi beklager ulempen. Vi jobber hardt for å gjøre opplevelsen din bedre."
 
 # smartling.placeholder_format=C
 #. Body text explaining the service update requires a page reload.
@@ -22055,7 +22631,8 @@ msgstr "Ukentlig grense er nådd"
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Weekly usage limit reached. You can continue this chat after %s."
-msgstr "Ukentlig bruksgrense er nådd. Du kan fortsette denne chatten etter %1$s."
+msgstr ""
+"Ukentlig bruksgrense er nådd. Du kan fortsette denne chatten etter %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable weekly Duck.ai usage limit and can opt in to continue using the monthly limit.
@@ -22108,13 +22685,15 @@ msgstr ""
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai! You can now import your downloaded chats."
-msgstr "Velkommen til nye Duck.ai! Du kan nå importere de nedlastede chattene dine."
+msgstr ""
+"Velkommen til nye Duck.ai! Du kan nå importere de nedlastede chattene dine."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai, it's time to import your chats"
-msgstr "Velkommen til den nye Duck.ai, det er på tide å importere chattene dine"
+msgstr ""
+"Velkommen til den nye Duck.ai, det er på tide å importere chattene dine"
 
 # smartling.placeholder_format=C
 #. Welcome message for new DuckDuckGo users.
@@ -22241,6 +22820,103 @@ msgstr ""
 "dem som har erfaring med AI og teknologi, og dem som ikke har det."
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the counterarguments?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the hours & location?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key contributions of this paper?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key contributions?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key details?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key points covered in this video?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key points?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key takeaways from this article?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key takeaways?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key things I will learn from this course?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main counterarguments or criticisms of this?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main questions this page answers?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the must-try dishes here?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"What are the opening hours, location, and contact details for this place?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the pros and cons of this product?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the pros and cons?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
 msgctxt "feedback form"
 msgid "What bothered you most?"
@@ -22341,6 +23017,12 @@ msgid "What does atria mean in the context of a medical article?"
 msgstr "Hva betyr atrier i en medisinsk artikkel?"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What does this answer?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
@@ -22351,6 +23033,12 @@ msgstr "Hva slags funksjon vil du at vi skal legge til? (valgfritt)"
 msgctxt "cloudsave"
 msgid "What information gets saved?"
 msgstr "Hva slags informasjon blir lagret?"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What interview questions might come up for this role?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -22367,6 +23055,12 @@ msgstr ""
 msgctxt "Full sentence for looking up basic facts"
 msgid "What is the capital city of Albania?"
 msgstr "Hva er hovedstaden i Albania?"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What is the overall verdict and rating for this?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to a page with additional information.
@@ -22391,6 +23085,12 @@ msgid "What people say:"
 msgstr "Dette sier folk:"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What should I order?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
 msgctxt "feedback form"
 msgid "What stood out?"
@@ -22401,6 +23101,18 @@ msgstr "Hva var det som skilte seg ut?"
 msgctxt "feedback form"
 msgid "What was wrong with the response? (optional)"
 msgstr "Hva var galt med svaret? (valgfritt)"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I learn?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I need?"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -22418,6 +23130,12 @@ msgstr "Det du ser på DuckDuckGo, påvirker ikke anbefalingene dine på YouTube
 msgctxt "SERP footer content"
 msgid "What's New"
 msgstr "Dette er nytt"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What's the verdict?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -22470,6 +23188,12 @@ msgid "Which features are missing? (Optional)"
 msgstr "Hvilke funksjoner mangler? (Valgfritt)"
 
 # smartling.placeholder_format=C
+#. An invitation for users to leave feedback
+msgctxt "Feedback prompt"
+msgid "Which features are missing? (optional)"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
 msgid "White"
 msgstr "Hvit"
@@ -22484,6 +23208,18 @@ msgstr "Hvit"
 #. Link to an about us page.
 msgid "Who We Are"
 msgstr "Hvem vi er"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Who are the main cast and crew, and what else are they known for?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Who is this person?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Header above a collection of privacy-related links.
@@ -22854,7 +23590,8 @@ msgstr "Ja, ny bruker!"
 msgctxt "cloudsave"
 msgid ""
 "Yes, we throw away data when you’re done with it, and it cannot be recovered."
-msgstr "Ja, vi kaster data du er ferdig med, og dataene kan ikke gjenopprettes."
+msgstr ""
+"Ja, vi kaster data du er ferdig med, og dataene kan ikke gjenopprettes."
 
 # smartling.placeholder_format=C
 #. Option for the filter-by-date search.
@@ -22873,7 +23610,8 @@ msgctxt "Disclaimer bellow chat input - desktop"
 msgid ""
 "You are chatting with %s. AI chats may display inaccurate or offensive "
 "information."
-msgstr "Du chatter med %1$s. AI-chatter kan vise feil eller støtende informasjon."
+msgstr ""
+"Du chatter med %1$s. AI-chatter kan vise feil eller støtende informasjon."
 
 # smartling.placeholder_format=C
 #. Provide users with the ability to retry their search on a different search engine. First placeholder will be a link with the text "try your search again" OR "try your search later". Second is a URL to the !bangs page: https://duckduckgo.com/bangs.
@@ -23040,7 +23778,8 @@ msgstr ""
 #. Text explaining the benefits of the cloud save feature.
 msgctxt "cloudsave"
 msgid "You can restore your settings after deleting cookies."
-msgstr "Du kan gjenopprette innstillingene etter at informasjonskapslene er slettet."
+msgstr ""
+"Du kan gjenopprette innstillingene etter at informasjonskapslene er slettet."
 
 # smartling.placeholder_format=C
 #. Text explaining the benefits of the cloud save feature.
@@ -23177,7 +23916,8 @@ msgstr "Du søker nå med personvern!"
 msgid ""
 "You're now searching with privacy. %sGet tips to reduce your footprint even "
 "more."
-msgstr "Du søker nå med personvern. %1$sFå flere tips til å redusere ditt fotavtrykk."
+msgstr ""
+"Du søker nå med personvern. %1$sFå flere tips til å redusere ditt fotavtrykk."
 
 # smartling.placeholder_format=C
 #. Title of a notice thanking the user for turning off their adblocker
@@ -23220,7 +23960,8 @@ msgctxt "Error message for user limit"
 msgid ""
 "You've reached the maximum number of messages for the moment. Please try "
 "again later."
-msgstr "Du har nådd maksimalt antall meldinger for øyeblikket. Prøv igjen senere."
+msgstr ""
+"Du har nådd maksimalt antall meldinger for øyeblikket. Prøv igjen senere."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -23393,8 +24134,8 @@ msgstr "Chattene dine blir nå lagret."
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never saved or used to train AI models"
 msgstr ""
-"Chattene dine er private og verken lagres eller brukes til å trene opp "
-"AI-modeller"
+"Chattene dine er private og verken lagres eller brukes til å trene opp AI-"
+"modeller"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
@@ -23426,8 +24167,8 @@ msgctxt "Menu item description"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
 msgstr ""
-"Chattene dine er private, lagres aldri av oss og brukes ikke til å trene "
-"AI-modeller."
+"Chattene dine er private, lagres aldri av oss og brukes ikke til å trene AI-"
+"modeller."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the active privacy protection.
@@ -23435,8 +24176,8 @@ msgctxt "Modal body for privacy"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
 msgstr ""
-"Chattene dine er private, lagres aldri av oss og brukes ikke til å trene "
-"AI-modeller."
+"Chattene dine er private, lagres aldri av oss og brukes ikke til å trene AI-"
+"modeller."
 
 # smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that chats are stored locally on the user's device.
@@ -23537,11 +24278,10 @@ msgid ""
 "browser. We save the settings file using the key as the name. DuckDuckGo "
 "never knows your passphrase."
 msgstr ""
-"Passordet ditt genererer en 512-biters nøkkel ved hjelp av Secure "
-"Hash-algoritmen kjent som %1$sSHA-2%2$s. Det er kun nøkkelen og den "
-"tilhørende innstillingsfilen som forlater nettleseren din. Vi lagrer "
-"innstillingsfilen ved å bruke nøkkelen som navn. DuckDuckGo vet aldri "
-"passordet ditt."
+"Passordet ditt genererer en 512-biters nøkkel ved hjelp av Secure Hash-"
+"algoritmen kjent som %1$sSHA-2%2$s. Det er kun nøkkelen og den tilhørende "
+"innstillingsfilen som forlater nettleseren din. Vi lagrer innstillingsfilen "
+"ved å bruke nøkkelen som navn. DuckDuckGo vet aldri passordet ditt."
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -23965,7 +24705,8 @@ msgstr "det offisielle nettstedet"
 #. <em>%s</em> is for a hexadecimal color code as <em>#395323</em>, but it has to be safe encoded, and as <em>#</em> seems not safe, <em>%23</em> must be used in place of the sharp symbol, but they are the same for your browser.
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
-msgstr "eller skriv fargekoden du ønsker, f.eks. %1$s (%2$s er et kodet %3$s-tegn)."
+msgstr ""
+"eller skriv fargekoden du ønsker, f.eks. %1$s (%2$s er et kodet %3$s-tegn)."
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "

--- a/locales/nb_NO/LC_MESSAGES/duckduckgo.po
+++ b/locales/nb_NO/LC_MESSAGES/duckduckgo.po
@@ -6137,7 +6137,7 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
-"Vil du ikke ha AI? Visit %1$snoai.duckduckgo.com%2$s for å søke uten "
+"Vil du ikke ha AI? Besøk %1$snoai.duckduckgo.com%2$s for å søke uten "
 "AI-funksjoner og med AI-bilder filtrert ut. %3$sFinn ut mer%4$s"
 
 # smartling.placeholder_format=C
@@ -7970,7 +7970,7 @@ msgstr "Finn oppdatert informasjon"
 #. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Find me alternatives"
-msgstr "Finn alternativer til meg"
+msgstr "Finn alternativer"
 
 # smartling.placeholder_format=C
 #. Button that searches for results closer to the user's current location.

--- a/locales/nb_NO/LC_MESSAGES/duckduckgo.po
+++ b/locales/nb_NO/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: nb\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -473,8 +473,7 @@ msgstr "%1$sFinn ut hvordan du kan holde lokasjonen din privat%2$s."
 msgctxt "Footer text for About Sync modal"
 msgid ""
 "%sLearn more%s about how chats are stored privately on DuckDuckGo's server."
-msgstr ""
-"%1$sFinn ut mer%2$s om hvordan chatter lagres privat på DuckDuckGos server."
+msgstr "%1$sFinn ut mer%2$s om hvordan chatter lagres privat på DuckDuckGos server."
 
 # smartling.placeholder_format=C
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
@@ -809,8 +808,7 @@ msgstr "6 timers bruksgrense er nådd."
 #. Displayed when the user has reached a fixed 6-hour Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "6-hour usage limit reached. You can continue this chat after %s."
-msgstr ""
-"6 timers bruksgrense er nådd. Du kan fortsette denne chatten etter %1$s."
+msgstr "6 timers bruksgrense er nådd. Du kan fortsette denne chatten etter %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable 6-hour Duck.ai usage limit and can opt in to continue using the daily limit.
@@ -1439,7 +1437,7 @@ msgstr "Adressen er feil"
 #. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Adjust the servings"
-msgstr ""
+msgstr "Juster porsjonene"
 
 # smartling.placeholder_format=C
 #. as in multiple advertisements
@@ -1661,6 +1659,8 @@ msgid ""
 "All chats are anonymized by DuckDuckGo, and your conversations are not used "
 "to train chat models by DuckDuckGo or the model providers"
 msgstr ""
+"Alle chatter anonymiseres av DuckDuckGo, og samtalene dine brukes ikke til å "
+"trene opp chatmodeller av DuckDuckGo eller modelleverandørene"
 
 # smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1692,8 +1692,7 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "All model providers are prevented from training their AI on your "
 "conversations."
-msgstr ""
-"Alle modelleverandører er forhindret i å trene AI-ene sine på samtalene dine."
+msgstr "Alle modelleverandører er forhindret i å trene AI-ene sine på samtalene dine."
 
 # smartling.placeholder_format=C
 #. Text displayed in the subheader of the modal that allows the user to pick an AI chat model.
@@ -1734,8 +1733,7 @@ msgstr "Alle typer"
 msgctxt "voice chat"
 msgid ""
 "Allow DuckDuckGo microphone access in System Settings to use voice chat."
-msgstr ""
-"Gi DuckDuckGo mikrofontilgang i systeminnstillingene for å bruke talechat."
+msgstr "Gi DuckDuckGo mikrofontilgang i systeminnstillingene for å bruke talechat."
 
 # smartling.placeholder_format=C
 #. Tells users which icon to press in their browser. Part of a list of instructions on how to enable location service.
@@ -1751,8 +1749,7 @@ msgstr "Tillat annonser som respekterer personvernet"
 # smartling.placeholder_format=C
 #. Title in a dialog informing the user how to disable their ad blocker for DuckDuckGo
 msgid "Allow privacy-respecting ads on DuckDuckGo Private Search"
-msgstr ""
-"Tillat annonser som respekterer personvernet på DuckDuckGo Private Search"
+msgstr "Tillat annonser som respekterer personvernet på DuckDuckGo Private Search"
 
 # smartling.placeholder_format=C
 #. Description explaining privacy implications of enabling web search on encrypted models. The first two placeholders are the full model name (e.g. 'gpt-oss 120B'). The third and fourth placeholders wrap a clickable link reading 'zero provider visibility' that opens the privacy modal, please keep those around the link text in your translation. An example full sentence would be: Allows gpt-oss 120B to search the web to improve responses to relevant prompts. Only sends AI-generated queries to a search engine with limited data retention. Prompts and responses with gpt-oss 120B still have zero provider visibility.
@@ -1936,6 +1933,8 @@ msgid ""
 "Anonymously generates answers for search queries based on web content. "
 "Choose how often you want it to appear, or disable it completely."
 msgstr ""
+"Genererer svar automatisk for søk basert på nettinnhold. Velg hvor ofte du "
+"vil at det skal vises, eller deaktiver det helt."
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -2082,8 +2081,7 @@ msgstr "Er du der fortsatt?"
 msgctxt "Body text for clear all chats confirmation modal"
 msgid ""
 "Are you sure you want to clear all of your chats? This cannot be undone."
-msgstr ""
-"Er du sikker på at du vil fjerne alle chattene dine? Dette kan ikke angres."
+msgstr "Er du sikker på at du vil fjerne alle chattene dine? Dette kan ikke angres."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that asks the user if they want to clear the conversation.
@@ -2221,7 +2219,7 @@ msgstr "Still et oppfølgingsspørsmål med Duck.ai"
 #. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
 msgctxt "Page suggestion chip label"
 msgid "Ask about this page"
-msgstr ""
+msgstr "Spør om denne siden"
 
 # smartling.placeholder_format=C
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2303,12 +2301,12 @@ msgid ""
 "to remember that responses are auto-generated from cited sources and based "
 "on %scrawling the web%s."
 msgstr ""
-"Assist er en valgfri funksjon i søkeresultatene våre, som kan generere KI-"
-"assisterte svar anonymt på søkeforespørsler. For å gjøre dette skanner den "
-"nettet etter relevant innhold, og bruker deretter KI-drevet naturlig språk-"
-"teknologi til å generere et kort svar basert på relevant informasjon den har "
-"funnet. Det er viktig å huske at svarene genereres automatisk fra siterte "
-"kilder og er basert på %1$sgjennomsøking av nettet%2$s."
+"Assist er en valgfri funksjon i søkeresultatene våre, som kan generere "
+"KI-assisterte svar anonymt på søkeforespørsler. For å gjøre dette skanner "
+"den nettet etter relevant innhold, og bruker deretter KI-drevet naturlig "
+"språk-teknologi til å generere et kort svar basert på relevant informasjon "
+"den har funnet. Det er viktig å huske at svarene genereres automatisk fra "
+"siterte kilder og er basert på %1$sgjennomsøking av nettet%2$s."
 
 # smartling.placeholder_format=C
 #. Title for the dropdown menu where users select the assistant's role. Example: 'Assistant role: Travel guide'
@@ -2399,8 +2397,7 @@ msgstr "Lyd lagres ikke av oss eller av OpenAI etter at chatten er avsluttet."
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat is transcribed."
-msgstr ""
-"Lyd lagres ikke av oss eller av OpenAI etter at chatten er transkribert."
+msgstr "Lyd lagres ikke av oss eller av OpenAI etter at chatten er transkribert."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when MediaRecorder API is unavailable.
@@ -2447,8 +2444,7 @@ msgstr "Autogenerert basert på oppførte kilder. Kan inneholde unøyaktigheter.
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid ""
 "Auto-generated based on listed sources. Responses may contain inaccuracies."
-msgstr ""
-"Autogenerert basert på oppførte kilder. Svarene kan inneholde unøyaktigheter."
+msgstr "Autogenerert basert på oppførte kilder. Svarene kan inneholde unøyaktigheter."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI) on mobile
@@ -2639,7 +2635,7 @@ msgstr "Strekkode"
 #. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Based on this page, is this course worth taking?"
-msgstr ""
+msgstr "Er dette kurset verdt å ta, basert på denne siden?"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2688,6 +2684,9 @@ msgid ""
 "Before storing this report, DuckDuckGo will anonymize your conversation by "
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
+"Før denne rapporten blir lagret, anonymiserer DuckDuckGo samtalen din ved å "
+"fjerne personlig identifiserbar informasjon (PII) som navn, e-postadresser "
+"og identifiserende metadata."
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -3009,7 +3008,7 @@ msgstr "Antall bruddballer vunnet"
 #. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Break this down into clear, numbered steps."
-msgstr ""
+msgstr "Del dette opp i tydelige, nummererte trinn."
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -3069,8 +3068,8 @@ msgid ""
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
 msgstr ""
 "Bruk nettleseren som vanlig, så legger vi til personvernbeskyttelse. Vi har "
-"samlet søkemotoren, sporingsblokkeren og krypteringsvakten i én %1$s%2$s-"
-"utvidelse%3$s."
+"samlet søkemotoren, sporingsblokkeren og krypteringsvakten i én "
+"%1$s%2$s-utvidelse%3$s."
 
 # smartling.placeholder_format=C
 msgid ""
@@ -3467,7 +3466,7 @@ msgstr "Rollebesetning"
 #. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Cast & Crew"
-msgstr ""
+msgstr "Rollebesetning og stab"
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -3705,8 +3704,8 @@ msgid ""
 "off by visiting %shttps://duck.ai%s directly."
 msgstr ""
 "Med chatten (via Duck.ai-tjenesten vår) kan du ha anonyme samtaler med "
-"tredjeparts AI-chatmodeller. Disse støtter modeller fra OpenAI, Anthropic m."
-"m. Hvis du slår av denne innstillingen, skjules chat-knapper og -lenker på "
+"tredjeparts AI-chatmodeller. Disse støtter modeller fra OpenAI, Anthropic "
+"m.m. Hvis du slår av denne innstillingen, skjules chat-knapper og -lenker på "
 "DuckDuckGo Search. Men du kan likevel få tilgang til chatten når denne "
 "innstillingen er av, ved å gå til %1$shttps.://duck.ai%2$s direkte."
 
@@ -3763,8 +3762,7 @@ msgstr "Chat privat"
 #. Mobile variant of DUCKCHAT_BROWSER_UPSELL_PROMO_TEXT. Shorter version for the promotional card encouraging third-party browser users to download the DuckDuckGo browser.
 msgctxt "Promotional text (mobile)"
 msgid "Chat privately on any website with Duck.ai built into our free browser."
-msgstr ""
-"Chat privat på ethvert nettsted med Duck.ai innebygd i vår gratis nettleser."
+msgstr "Chat privat på ethvert nettsted med Duck.ai innebygd i vår gratis nettleser."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card encouraging third-party browser users to download the DuckDuckGo browser. Not shown in the DuckDuckGo browser or on Linux.
@@ -4306,8 +4304,7 @@ msgstr "Klikk %1$sher%2$s for å laste ned DuckDuckGo-utvidelsen"
 # smartling.placeholder_format=C
 #. Link to download the DuckDuckGo browser extension.
 msgid "Click %sOpen%s to download and open the DuckDuckGo Safari extension"
-msgstr ""
-"Klikk på %1$sÅpne%2$s for å laste ned og åpne DuckDuckGo sin Safari-utvidelse"
+msgstr "Klikk på %1$sÅpne%2$s for å laste ned og åpne DuckDuckGo sin Safari-utvidelse"
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -4340,8 +4337,7 @@ msgstr "Klikk på %1$sInnstillinger%2$s i nedtrekksmenyen."
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
-msgstr ""
-"Klikk på %1$sVelg nåværende sider%2$s, og %3$sklikk deretter på OK%4$s."
+msgstr "Klikk på %1$sVelg nåværende sider%2$s, og %3$sklikk deretter på OK%4$s."
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -5179,7 +5175,7 @@ msgstr "Lag bilde"
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
-msgstr ""
+msgstr "Skriv en handleliste med mengder basert på denne oppskriften."
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed in the input field when starting a new image generation session.
@@ -5703,8 +5699,7 @@ msgstr "Vil du slette de eldste chattene for å frigjøre lagringsplass?"
 #. Title shown when user has reached the file storage sync quota (5GB).
 msgctxt "Sync file storage limit modal title"
 msgid "Delete oldest chats with attachments to free up storage?"
-msgstr ""
-"Vil du slette de eldste chattene med vedlegg for å frigjøre lagringsplass?"
+msgstr "Vil du slette de eldste chattene med vedlegg for å frigjøre lagringsplass?"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to delete all recent chats.
@@ -5728,8 +5723,7 @@ msgstr "Slettede chatter"
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
 msgctxt "settings"
 msgid "Deleting cookies will reset these settings."
-msgstr ""
-"Hvis du sletter informasjonskapslene, blir disse innstillingene tilbakestilt."
+msgstr "Hvis du sletter informasjonskapslene, blir disse innstillingene tilbakestilt."
 
 # smartling.placeholder_format=C
 msgid "Democratic People's Republic of Korea"
@@ -5814,8 +5808,7 @@ msgstr "Diktering i Duck.ai"
 # smartling.placeholder_format=C
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
-msgstr ""
-"Diktering anonymiseres av oss, og brukes aldri til å trene AI-modeller."
+msgstr "Diktering anonymiseres av oss, og brukes aldri til å trene AI-modeller."
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
@@ -5825,7 +5818,7 @@ msgstr "Dikteringsgrensen er nådd"
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
 msgid "Dictation temporarily unavailable"
-msgstr ""
+msgstr "Diktering er midlertidig utilgjengelig"
 
 # smartling.placeholder_format=C
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
@@ -6134,6 +6127,8 @@ msgid ""
 "Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
 "filtered out. %sLearn More%s"
 msgstr ""
+"Vil du ikke ha AI? %1$snoai.duckduckgo.com%2$s tilbyr ingen AI-funksjoner, "
+"og AI-bilder filtreres ut. %3$sFinn ut mer%4$s"
 
 # smartling.placeholder_format=C
 #. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
@@ -6142,6 +6137,8 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
+"Vil du ikke ha AI? Visit %1$snoai.duckduckgo.com%2$s for å søke uten "
+"AI-funksjoner og med AI-bilder filtrert ut. %3$sFinn ut mer%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6261,13 +6258,13 @@ msgstr ""
 #. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Draft a cover letter"
-msgstr ""
+msgstr "Skriv et følgebrev"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Draft a cover letter for this job."
-msgstr ""
+msgstr "Skriv et følgebrev for denne stillingen."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -6453,6 +6450,9 @@ msgid ""
 "company for anyone who wants to take back control of their personal "
 "information."
 msgstr ""
+"Duck.ai er laget av DuckDuckGo. Vi er et uavhengig selskap som gir bedre "
+"personvern til alle som ønsker å ta tilbake kontrollen over "
+"personopplysninger på nettet."
 
 # smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
@@ -6505,6 +6505,9 @@ msgid ""
 "Duck.ai lets you chat privately with popular AI models. Disabling it hides "
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
+"Med Duck.ai kan du chatte privat med populære AI-modeller. Du kan deaktivere "
+"Duck.ai-knapper og -lenker, men du kan fortsatt gå til %1$sduck.ai%2$s "
+"direkte."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6518,8 +6521,8 @@ msgstr ""
 "Med Duck.ai kan du ha anonyme samtaler med tredjeparts AI-chatmodeller, som "
 "OpenAI, Anthropic og andre. Hvis du slår av denne innstillingen, skjules "
 "Duck.ai-knapper og -lenker på DuckDuckGo Search. Men du kan likevel få "
-"tilgang til Duck.ai når denne innstillingen er av, ved å gå til %1$shttps://"
-"duck.ai%2$s direkte."
+"tilgang til Duck.ai når denne innstillingen er av, ved å gå til "
+"%1$shttps://duck.ai%2$s direkte."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
@@ -6877,8 +6880,8 @@ msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid ""
 "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to Duck.ai's %s."
 msgstr ""
-"DuckDuckGo anonymiserer chattene dine. Ved å klikke på «%1$s» godtar du Duck."
-"ai's %2$s."
+"DuckDuckGo anonymiserer chattene dine. Ved å klikke på «%1$s» godtar du "
+"Duck.ai's %2$s."
 
 # smartling.placeholder_format=C
 #. Shown below the input on the empty state when the user has not yet accepted the terms of service. The first %s is the action button label ('Ask' for chat, 'Create' for image generation). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. Clicking the action button both accepts the terms and submits the prompt.
@@ -6968,8 +6971,7 @@ msgctxt ""
 "Description of the DuckDuckGo subscription setting when it is not available "
 "in the user region"
 msgid "DuckDuckGo subscriptions are not available to purchase in this region."
-msgstr ""
-"DuckDuckGo-abonnementer er ikke tilgjengelige for kjøp i denne regionen."
+msgstr "DuckDuckGo-abonnementer er ikke tilgjengelige for kjøp i denne regionen."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use 'ducky' tone in its responses. When this option is selected, the AI assistant speaks like a duck.
@@ -7235,8 +7237,7 @@ msgstr "Aktiver diktering i Duck.ai"
 #. Prompt to enable location service so that search results can be displayed near the user's current location.
 msgctxt "precise_user_location"
 msgid "Enable location settings on your device to use anonymous location"
-msgstr ""
-"Aktiver posisjonsinnstillinger på enheten din for å bruke anonym posisjon"
+msgstr "Aktiver posisjonsinnstillinger på enheten din for å bruke anonym posisjon"
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -7503,13 +7504,13 @@ msgstr "Eritrea"
 #. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Estimate the nutrition"
-msgstr ""
+msgstr "Beregn næringsinnholdet"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Estimate the nutritional information for this recipe."
-msgstr ""
+msgstr "Beregn næringsinnholdet i denne oppskriften."
 
 # smartling.placeholder_format=C
 msgid "Estonia"
@@ -7569,7 +7570,7 @@ msgstr "Utløper om 1 dag"
 #. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain the accepted answer in simple terms."
-msgstr ""
+msgstr "Forklar det godtatte svaret i enkle ord."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
@@ -7584,43 +7585,43 @@ msgstr ""
 #. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain the top answer"
-msgstr ""
+msgstr "Forklar det øverste svaret"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain this in simple, plain language."
-msgstr ""
+msgstr "Forklar dette i enkelt og forståelig språk."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain this paper"
-msgstr ""
+msgstr "Forklar denne artikkelen"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain this repo"
-msgstr ""
+msgstr "Forklar dette repositoriet"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain this research paper in plain language."
-msgstr ""
+msgstr "Forklar denne forskningsartikkelen på en forståelig måte."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain this simply"
-msgstr ""
+msgstr "Forklar dette enkelt"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain what this repository does and how to use it."
-msgstr ""
+msgstr "Forklar hva dette repositoriet gjør og hvordan man bruker det."
 
 # smartling.placeholder_format=C
 #. Label to show if song lyrics contain explicit content
@@ -7902,14 +7903,15 @@ msgstr "Filtrerer ut AI-genererte bilder fra bildesøkresultater"
 msgctxt "settings"
 msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
-msgstr ""
-"Filtrerer ut AI-genererte bilder fra bildesøkresultater. %1$sFinn ut mer%2$s"
+msgstr "Filtrerer ut AI-genererte bilder fra bildesøkresultater. %1$sFinn ut mer%2$s"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Filters out known AI spam sites from image search results. %sLearn More%s"
 msgstr ""
+"Filtrerer ut kjente AI-søppelnettsteder fra bildesøkresultater. %1$sLes "
+"mer%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the final score of a sporting event.
@@ -7968,7 +7970,7 @@ msgstr "Finn oppdatert informasjon"
 #. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Find me alternatives"
-msgstr ""
+msgstr "Finn alternativer til meg"
 
 # smartling.placeholder_format=C
 #. Button that searches for results closer to the user's current location.
@@ -7987,8 +7989,7 @@ msgstr "Søk nærmere der du er."
 msgctxt "Precise user location overlay"
 msgid ""
 "Find results near you. %sYour location stays private, secure, and anonymous."
-msgstr ""
-"Finn resultater nær deg. %1$sPosisjonen din forblir privat, sikker og anonym."
+msgstr "Finn resultater nær deg. %1$sPosisjonen din forblir privat, sikker og anonym."
 
 # smartling.placeholder_format=C
 #. Loading message shown while generating explore more follow-up questions
@@ -8194,8 +8195,7 @@ msgstr "Kan deles og brukes kommersielt"
 #. Description text explaining how to free up sync storage. Pinned chats are chats the user has explicitly marked to keep.
 msgctxt "Sync limit modal description"
 msgid "Free up space by deleting your chats. Pinned chats will not be deleted."
-msgstr ""
-"Frigjør plass ved å slette chattene dine. Festede chatter blir ikke slettet."
+msgstr "Frigjør plass ved å slette chattene dine. Festede chatter blir ikke slettet."
 
 # smartling.placeholder_format=C
 #. Indicates that this streaming service is free to watch but shows ads
@@ -8449,7 +8449,7 @@ msgstr "Generer mer"
 #. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Generate a shopping list"
-msgstr ""
+msgstr "Generer en handleliste"
 
 # smartling.placeholder_format=C
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
@@ -8746,7 +8746,7 @@ msgstr "Prøv det"
 #. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Give me a quick background on this person."
-msgstr ""
+msgstr "Gi meg litt bakgrunnsinformasjon om denne personen."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9198,13 +9198,13 @@ msgstr "Hjelp til å spre personvern"
 #. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Help me prep for the interview"
-msgstr ""
+msgstr "Hjelp meg å forberede meg til intervjuet"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Help me tailor my resume for this job."
-msgstr ""
+msgstr "Hjelp meg å tilpasse CV-en min til denne stillingen."
 
 # smartling.placeholder_format=C
 #. Title of a SERP popup that invites users to take a survey (desktop only)
@@ -9727,7 +9727,7 @@ msgctxt ""
 "Text for the I already have a subscription button in the Duck.ai settings "
 "page"
 msgid "I Already Have a Subscription"
-msgstr ""
+msgstr "Jeg har allerede et abonnement"
 
 # smartling.placeholder_format=C
 #. Text for the button that takes the user to the login subscription page.
@@ -9878,8 +9878,8 @@ msgid ""
 "If you have concerns about our chat providers or any particular chat "
 "response, you can also reach out directly to %s and %s support pages."
 msgstr ""
-"Hvis du har bekymringer om chat-leverandørene våre eller et bestemt chat-"
-"svar, kan du også kontakte støttesiden til %1$s og %2$s direkte."
+"Hvis du har bekymringer om chat-leverandørene våre eller et bestemt "
+"chat-svar, kan du også kontakte støttesiden til %1$s og %2$s direkte."
 
 # smartling.placeholder_format=C
 #. Body copy explaining what the recovery code is for and how it can be saved.
@@ -10309,7 +10309,7 @@ msgstr "Installer Mac-nettleser"
 #. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
 msgctxt "settings"
 msgid "Install Now"
-msgstr ""
+msgstr "Installer nå"
 
 # smartling.placeholder_format=C
 #. Text of a button to install the DuckDuckGo app
@@ -10412,13 +10412,13 @@ msgstr "Er slettet data virkelig slettet?"
 #. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Is it worth taking?"
-msgstr ""
+msgstr "Er dette verdt å ta?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Is this place any good?"
-msgstr ""
+msgstr "Er dette stedet bra?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
@@ -10427,6 +10427,8 @@ msgid ""
 "Is this place any good? Summarize its reputation based on reviews and "
 "ratings."
 msgstr ""
+"Er dette stedet bra? Oppsummer stedets omdømme basert på anmeldelser og "
+"vurderinger."
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -10438,13 +10440,13 @@ msgstr "Var denne videoen nyttig?"
 #. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Is this worth watching?"
-msgstr ""
+msgstr "Er dette verdt å se på?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Is this worth watching? Give me a spoiler-free take."
-msgstr ""
+msgstr "Er dette verdt å se på? Gi meg en vurdering uten spoilere."
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -11059,7 +11061,7 @@ msgstr "Lenker:"
 #. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
-msgstr ""
+msgstr "Si hvilke verktøy, materialer eller forutsetninger jeg trenger til dette."
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -11170,8 +11172,7 @@ msgstr "Laster flere bilderesultater når du ruller"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Loads more results in Images, Videos, and Shopping when scrolling"
-msgstr ""
-"Laster inn flere resultater i Bilder, Videoer og Shopping når du ruller"
+msgstr "Laster inn flere resultater i Bilder, Videoer og Shopping når du ruller"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/WTkvs9I.png
@@ -11472,7 +11473,7 @@ msgstr "Administrer blokkerte nettsteder"
 #. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
 msgctxt "setting"
 msgid "Manage in Browser Settings"
-msgstr ""
+msgstr "Administrer i nettleserinnstillingene"
 
 # smartling.placeholder_format=C
 #. Link to the site exclusion settings page
@@ -11922,8 +11923,7 @@ msgstr "Månedlig grense er nådd"
 #. Displayed when the user has reached a fixed monthly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Monthly usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Månedlig bruksgrense er nådd. Du kan fortsette denne chatten etter %1$s."
+msgstr "Månedlig bruksgrense er nådd. Du kan fortsette denne chatten etter %1$s."
 
 # smartling.placeholder_format=C
 #. Used to point to additional social networking profiles (in results).
@@ -13317,8 +13317,8 @@ msgid ""
 "Only the settings that you have changed. They are detailed on the %sURL "
 "Parameters%s page."
 msgstr ""
-"Bare innstillingene du har endret. De er spesifisert på siden %1$sURL-"
-"parameter%2$s."
+"Bare innstillingene du har endret. De er spesifisert på siden "
+"%1$sURL-parameter%2$s."
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers only when the user clicks the Assist button.
@@ -14305,7 +14305,7 @@ msgstr "Fullfør denne testen for å bekrefte at søket ble gjort av et menneske
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is harmful or illegal. (optional)"
-msgstr ""
+msgstr "Beskriv hvorfor chatsvaret er skadelig eller ulovlig. (valgfritt)"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
@@ -14342,6 +14342,8 @@ msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is harmful or illegal."
 msgstr ""
+"Lim inn ledeteksten din og det problematiske svaret (med all personlig "
+"informasjon fjernet) og beskriv hvorfor innholdet er skadelig eller ulovlig."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -14814,7 +14816,7 @@ msgstr "Personvern"
 #. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
 msgctxt "Section heading on the Duck.ai settings page"
 msgid "Privacy & Terms"
-msgstr ""
+msgstr "Personvern og vilkår"
 
 # smartling.placeholder_format=C
 msgid "Privacy Blog"
@@ -14890,7 +14892,7 @@ msgstr "Personvernerklæring og vilkår for bruk"
 #. Text for a button that links to the terms of use and privacy policy page.
 msgctxt "Secondary button text in active privacy modal"
 msgid "Privacy Policy and Terms of Service"
-msgstr ""
+msgstr "Personvernerklæring og vilkår for bruk"
 
 # smartling.placeholder_format=C
 #. Title displayed on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
@@ -15064,8 +15066,7 @@ msgstr "Spør meg"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Prompt me to use my approximate location to get nearby results."
-msgstr ""
-"Spør meg om å bruke omtrentlig lokasjon for å få resultater i nærheten."
+msgstr "Spør meg om å bruke omtrentlig lokasjon for å få resultater i nærheten."
 
 # smartling.placeholder_format=C
 #. DuckDuckGo Email Protection removes trackers from emails
@@ -15346,8 +15347,8 @@ msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
 msgstr ""
-"Nylige chatter som lagres lokalt på enheten din, i stedet for på DuckDuckGo-"
-"servere eller andre eksterne servere."
+"Nylige chatter som lagres lokalt på enheten din, i stedet for på "
+"DuckDuckGo-servere eller andre eksterne servere."
 
 # smartling.placeholder_format=C
 #. Text explaining that recent chats are stored locally on the user's device.
@@ -15356,8 +15357,8 @@ msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
 msgstr ""
-"Nylige chatter lagres lokalt på enheten din i stedet for på DuckDuckGo-"
-"servere eller andre eksterne servere."
+"Nylige chatter lagres lokalt på enheten din i stedet for på "
+"DuckDuckGo-servere eller andre eksterne servere."
 
 # smartling.placeholder_format=C
 #. Text explaining how recent chats are stored locally on the user's device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection.
@@ -15396,25 +15397,25 @@ msgstr "Anbefal en bok"
 #. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Recommend similar books"
-msgstr ""
+msgstr "Anbefal lignende bøker"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Recommend similar books."
-msgstr ""
+msgstr "Anbefal lignende bøker."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Recommend similar movies or shows."
-msgstr ""
+msgstr "Anbefal lignende filmer eller serier."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Recommend similar titles"
-msgstr ""
+msgstr "Anbefal lignende titler"
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
@@ -15823,7 +15824,7 @@ msgctxt ""
 "feedback form when the user has selected Harmful or Illegal as the feedback "
 "reason"
 msgid "Required for harmful or illegal reports"
-msgstr ""
+msgstr "Påkrevd for rapporter om skadelig eller ulovlig innhold"
 
 # smartling.placeholder_format=C
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
@@ -16065,7 +16066,7 @@ msgstr "Anmeldelser"
 #. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Rewrite this recipe scaled for a different number of servings."
-msgstr ""
+msgstr "Tilpass denne oppskriften til et annet antall porsjoner."
 
 # smartling.placeholder_format=C
 msgid "Romania"
@@ -16351,8 +16352,7 @@ msgstr "Lagre opptil 30 av de siste chattene lokalt på enheten din."
 msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
-msgstr ""
-"Lagre Duck.ai-chattene mellom enhetene dine med ende-til-ende-kryptering."
+msgstr "Lagre Duck.ai-chattene mellom enhetene dine med ende-til-ende-kryptering."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -16517,8 +16517,7 @@ msgstr "Rull ned til %1$sDuckDuckGo%2$s og la den bruke posisjonen din."
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down to the %sServices%s section and click %sAddress bar%s."
-msgstr ""
-"Rull ned til %1$sTjenester%2$s-delen, og klikk på %3$sAdresselinje%4$s."
+msgstr "Rull ned til %1$sTjenester%2$s-delen, og klikk på %3$sAdresselinje%4$s."
 
 # smartling.placeholder_format=C
 #. Rugby match stats
@@ -16742,8 +16741,8 @@ msgctxt "settings"
 msgid ""
 "Search queries are included in URL (if off, searches will use POST requests)"
 msgstr ""
-"Søkeforespørsler er inkludert i URL-en (hvis avslått, vil søkene bruke POST-"
-"forespørsler)"
+"Søkeforespørsler er inkludert i URL-en (hvis avslått, vil søkene bruke "
+"POST-forespørsler)"
 
 # smartling.placeholder_format=C
 #. Describes how cookies are used to store user settings privately and securely.
@@ -16856,8 +16855,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
 msgstr ""
-"Lagre nesten ubegrenset med chatter sikkert på serveren vår med ende-til-"
-"ende-kryptering, og få tilgang til dem fra alle enhetene dine."
+"Lagre nesten ubegrenset med chatter sikkert på serveren vår med "
+"ende-til-ende-kryptering, og få tilgang til dem fra alle enhetene dine."
 
 # smartling.placeholder_format=C
 #. Text explaining that the Encrypted Storage feature stores the user's chats encrypted on their device.
@@ -16866,8 +16865,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
 msgstr ""
-"Lagre nesten ubegrenset med chatter sikkert på serveren vår med ende-til-"
-"ende-kryptering, og få tilgang til dem fra alle enhetene dine."
+"Lagre nesten ubegrenset med chatter sikkert på serveren vår med "
+"ende-til-ende-kryptering, og få tilgang til dem fra alle enhetene dine."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17015,8 +17014,7 @@ msgstr "Se noen av våre nyeste oppdateringer"
 #. Link to a page with more information about how user settings are stored in a URL.
 msgctxt "settings"
 msgid "See the %sURL Parameter Reference page%s for more details."
-msgstr ""
-"Se %1$sreferansesiden for nettadresseparametere%2$s for mer informasjon."
+msgstr "Se %1$sreferansesiden for nettadresseparametere%2$s for mer informasjon."
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the context menu of a chat in chat history, that allows the user to select the chat and begin batch selection mode.
@@ -17170,8 +17168,7 @@ msgstr "Velg %1$sInnstillinger%2$s fra nedtrekksmenyen."
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sAdvanced settings%s"
-msgstr ""
-"Velg %1$sInnstillinger%2$s, og deretter %3$sAvanserte innstillinger%4$s"
+msgstr "Velg %1$sInnstillinger%2$s, og deretter %3$sAvanserte innstillinger%4$s"
 
 # smartling.placeholder_format=C
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -17199,8 +17196,7 @@ msgstr ""
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %syour browser%s in the list and %sallow%s location access"
-msgstr ""
-"Velg %1$snettleseren din%2$s i listen og %3$stillat%4$s posisjonstilgang"
+msgstr "Velg %1$snettleseren din%2$s i listen og %3$stillat%4$s posisjonstilgang"
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the modal for deleting all recent chats, that allows the user to select the chats to delete.
@@ -17397,7 +17393,7 @@ msgstr "Konfigurer nå"
 #. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
 msgctxt "Encrypted storage setup button shown in native browsers"
 msgid "Set Up Sync & Backup"
-msgstr ""
+msgstr "Konfigurer Sync & Backup"
 
 # smartling.placeholder_format=C
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
@@ -17519,8 +17515,8 @@ msgid ""
 "never reveals your precise location to us or AI models."
 msgstr ""
 "Del plassering så nær som nærmeste by med AI-modeller for å forbedre "
-"relevansen. Duck.ai avslører aldri din nøyaktige plassering til oss eller AI-"
-"modeller."
+"relevansen. Duck.ai avslører aldri din nøyaktige plassering til oss eller "
+"AI-modeller."
 
 # smartling.placeholder_format=C
 #. Menu option to share feedback about a result
@@ -17585,7 +17581,7 @@ msgstr "Del positive tilbakemeldinger"
 msgctxt ""
 "Label beside the share-content switch on the Duck.ai response feedback form"
 msgid "Share this conversation with DuckDuckGo"
-msgstr ""
+msgstr "Del denne samtalen med DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -17990,14 +17986,12 @@ msgstr "Viser de mest besøkte lenkene på ny fane"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your browser"
-msgstr ""
-"Viser sporadiske påminnelser om å legge til DuckDuckGo i nettleseren din"
+msgstr "Viser sporadiske påminnelser om å legge til DuckDuckGo i nettleseren din"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr ""
-"Viser sporadiske påminnelser om å legge til DuckDuckGo på enhetene dine"
+msgstr "Viser sporadiske påminnelser om å legge til DuckDuckGo på enhetene dine"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18289,8 +18283,7 @@ msgstr "Noen ganger"
 #. Generic error message shown when the image generation model cannot process the user's request.
 msgctxt "Error message from the image generation model"
 msgid "Sorry I can't help, please describe your image in a different way."
-msgstr ""
-"Beklager at jeg ikke kan hjelpe deg. Prøv å beskrive bildet på en annen måte."
+msgstr "Beklager at jeg ikke kan hjelpe deg. Prøv å beskrive bildet på en annen måte."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -18364,8 +18357,7 @@ msgstr ""
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr ""
-"Beklager, vi kunne ikke sende inn tilbakemeldingen din. Prøv igjen senere."
+msgstr "Beklager, vi kunne ikke sende inn tilbakemeldingen din. Prøv igjen senere."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -18419,8 +18411,7 @@ msgstr "Kildetekst fjernet"
 msgctxt "Error message for summary selection input limit"
 msgid ""
 "Source text is too long to summarize. Try again with a shorter selection."
-msgstr ""
-"Kildeteksten er for lang til å oppsummere. Prøv igjen med en kortere tekst."
+msgstr "Kildeteksten er for lang til å oppsummere. Prøv igjen med en kortere tekst."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under Interface Settings.in the end. It is a header
@@ -18619,8 +18610,7 @@ msgstr "Bli på DuckDuckGo"
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletter."
-msgstr ""
-"Beskytt deg selv og hold deg informert med personvern-nyhetsbrevet vårt."
+msgstr "Beskytt deg selv og hold deg informert med personvern-nyhetsbrevet vårt."
 
 # smartling.placeholder_format=C
 #. Prompt to subscribe to a newsletter.
@@ -18848,19 +18838,19 @@ msgstr "Foreslå en tittel for et blogginnlegg"
 #. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Suggest related articles or topics worth exploring next."
-msgstr ""
+msgstr "Foreslå relaterte artikler eller emner det er verdt å utforske videre."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Suggest related articles to explore"
-msgstr ""
+msgstr "Foreslå relaterte artikler jeg kan utforske"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Suggest some alternatives to this product."
-msgstr ""
+msgstr "Foreslå noen alternativer til dette produktet."
 
 # smartling.placeholder_format=C
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
@@ -18877,7 +18867,7 @@ msgstr "Forslag:"
 #. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Sum up the reviews"
-msgstr ""
+msgstr "Oppsummer anmeldelsene"
 
 # smartling.placeholder_format=C
 #. A short title for the a message asking the AI to summarize a text.
@@ -18889,85 +18879,85 @@ msgstr "Oppsummer"
 #. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize the Q&As"
-msgstr ""
+msgstr "Oppsummer spørsmålene og svarene"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the background and notable work of this person."
-msgstr ""
+msgstr "Oppsummer denne personens bakgrunn og viktigste arbeid."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the key details of this event."
-msgstr ""
+msgstr "Oppsummer de viktigste detaljene i denne begivenheten."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the questions and answers on this page."
-msgstr ""
+msgstr "Oppsummer spørsmålene og svarene på denne siden."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize their background"
-msgstr ""
+msgstr "Oppsummer denne personens bakgrunn"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this book"
-msgstr ""
+msgstr "Oppsummer denne boken"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this book."
-msgstr ""
+msgstr "Oppsummer denne boken."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this discussion"
-msgstr ""
+msgstr "Oppsummer denne diskusjonen"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this discussion thread."
-msgstr ""
+msgstr "Oppsummer denne diskusjonstråden."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this page"
-msgstr ""
+msgstr "Oppsummer denne siden"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this page."
-msgstr ""
+msgstr "Oppsummer denne siden."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this video"
-msgstr ""
+msgstr "Oppsummer denne videoen"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this video."
-msgstr ""
+msgstr "Oppsummer denne videoen."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize what the reviews say."
-msgstr ""
+msgstr "Oppsummer det som står i anmeldelsene."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -19184,8 +19174,7 @@ msgstr "Sync & Backup er aktivert!"
 #. Notice shown under the recovery code explaining that backup data has an inactivity expiration.
 msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
-msgstr ""
-"Sync & Backup-data kan ikke gjenopprettes etter 18 måneder med inaktivitet."
+msgstr "Sync & Backup-data kan ikke gjenopprettes etter 18 måneder med inaktivitet."
 
 # smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
@@ -19234,9 +19223,9 @@ msgid ""
 msgstr ""
 "Synkroniseringsgjenopprettingskode\n"
 "\n"
-"Gjenopprettingskoden lar deg synkronisere passord, autofylle data og Duck.ai-"
-"chatter på tvers av flere enheter, og gjenopprette synkroniserte data hvis "
-"du mister tilgangen til en enhet.\n"
+"Gjenopprettingskoden lar deg synkronisere passord, autofylle data og "
+"Duck.ai-chatter på tvers av flere enheter, og gjenopprette synkroniserte "
+"data hvis du mister tilgangen til en enhet.\n"
 "\n"
 "Ta godt vare på denne informasjonen.\n"
 "Alle som har tilgang til denne koden kan få tilgang til de synkroniserte "
@@ -19298,7 +19287,7 @@ msgstr "Syria"
 #. Text for a button that enables the theme to follow the operating system's color scheme preference.
 msgctxt "System theme button for theme selector"
 msgid "System"
-msgstr ""
+msgstr "System"
 
 # smartling.placeholder_format=C
 #. Abbreviation indicating this is the total score for a game
@@ -19332,7 +19321,7 @@ msgstr "Tahitisk"
 #. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Tailor my resume"
-msgstr ""
+msgstr "Skreddersy CV-en min"
 
 # smartling.placeholder_format=C
 msgid "Taiwan"
@@ -19369,6 +19358,8 @@ msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
+"Ta denne anonyme spørreundersøkelsen for å fortelle oss hvordan vi kan gjøre "
+"Duck.ai bedre."
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -19612,8 +19603,7 @@ msgstr "De vedlagte filene overskrider den totale størrelsesgrensen på %1$s MB
 #. Error message displayed when the total size of all attached files in a conversation exceeds the allowed limit. Placeholder is the combined size limit in megabytes. E.g. The attached files exceed the total size limit of 5 MB
 msgctxt "Error message when combined file size exceeds the limit"
 msgid "The attached files exceed the total size limit of %s MB."
-msgstr ""
-"De vedlagte filene overskrider den totale størrelsesgrensen på %1$s MB."
+msgstr "De vedlagte filene overskrider den totale størrelsesgrensen på %1$s MB."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the server rejects corrupt or unrecognized audio.
@@ -19635,8 +19625,7 @@ msgstr ""
 msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider deletes any data associated with this chat within 30 days."
-msgstr ""
-"Modelleverandøren sletter alle data knyttet til denne chatten innen 30 dager."
+msgstr "Modelleverandøren sletter alle data knyttet til denne chatten innen 30 dager."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers.
@@ -19680,7 +19669,7 @@ msgstr "Utseende"
 #. Text for the theme selector label that allows users to switch between Light and dark theme.
 msgctxt "Label for the theme selector feature"
 msgid "Theme"
-msgstr ""
+msgstr "Tema"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/LpFhb1e.png
@@ -19805,8 +19794,7 @@ msgstr ""
 #. Appears below a type of search results called 'Instant Answers'
 msgctxt "attribution"
 msgid "This Instant Answer was made by the %sDuckDuckHack%s Community."
-msgstr ""
-"Dette øyeblikkelige svaret ble laget av %1$sDuckDuckHack%2$s-samfunnet."
+msgstr "Dette øyeblikkelige svaret ble laget av %1$sDuckDuckHack%2$s-samfunnet."
 
 # smartling.placeholder_format=C
 #. Label for the monthly usage row in the Usage section of Duck.ai settings.
@@ -19827,9 +19815,9 @@ msgid ""
 "This conversation was generated with Duck.ai (%s) using %s's %s Model. AI "
 "chats may display inaccurate or offensive information (see %s for more info)."
 msgstr ""
-"Denne samtalen ble generert med Duck.ai (%1$s) ved hjelp av %2$ss %3$s-"
-"modell. KI-chatter kan vise feil eller støtende informasjon (se %4$s for mer "
-"informasjon)."
+"Denne samtalen ble generert med Duck.ai (%1$s) ved hjelp av %2$ss "
+"%3$s-modell. KI-chatter kan vise feil eller støtende informasjon (se %4$s "
+"for mer informasjon)."
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with multiple AI models in the same chat, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using multiple chat models. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -19934,16 +19922,14 @@ msgstr "Dette bildet kunne ikke opprettes."
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF"
-msgstr ""
-"Denne bildetypen støttes ikke. Legg ved en JPG-, PNG-, WebP- eller GIF-fil"
+msgstr "Denne bildetypen støttes ikke. Legg ved en JPG-, PNG-, WebP- eller GIF-fil"
 
 # smartling.placeholder_format=C
 #. Error message displayed when a file that the user tried to upload is not of a supported format
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF."
-msgstr ""
-"Denne bildetypen støttes ikke. Legg heller ved en JPG, PNG, WebP eller GIF."
+msgstr "Denne bildetypen støttes ikke. Legg heller ved en JPG, PNG, WebP eller GIF."
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
@@ -20065,8 +20051,7 @@ msgstr "Denne oversettelsen er feil"
 # smartling.placeholder_format=C
 #. Label indicating that the video can't be played on the current page, and only on the website that owns the vide. The placeholder is the name of the website that owns the video.
 msgid "This video is not yet able to be watched here. You can watch it on %s."
-msgstr ""
-"Videoen er ikke ennå i stand til å spilles av her. Du kan se den på %1$s."
+msgstr "Videoen er ikke ennå i stand til å spilles av her. Du kan se den på %1$s."
 
 # smartling.placeholder_format=C
 #. Message indicating that a website is not using an encrypted connection and is not secure.
@@ -20257,8 +20242,8 @@ msgid ""
 "To transfer your chat history to Duck.ai, please update your DuckDuckGo "
 "browser to the latest version and try again."
 msgstr ""
-"For å overføre chat-historikken din til Duck.ai, oppdater DuckDuckGo-"
-"nettleseren din til den nyeste versjonen og prøv igjen."
+"For å overføre chat-historikken din til Duck.ai, oppdater "
+"DuckDuckGo-nettleseren din til den nyeste versjonen og prøv igjen."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
@@ -20523,13 +20508,13 @@ msgstr ""
 #. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Translate this page"
-msgstr ""
+msgstr "Oversett denne siden"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
 msgctxt "Page suggestion prompt"
 msgid "Translate this page into %s."
-msgstr ""
+msgstr "Oversett denne siden til %1$s."
 
 # smartling.placeholder_format=C
 #. Placeholder text for a region that will display translated text.
@@ -20676,7 +20661,7 @@ msgstr "Prøv gratis"
 #. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
 msgctxt "settings"
 msgid "Try It Now"
-msgstr ""
+msgstr "Prøv det nå"
 
 # smartling.placeholder_format=C
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -20921,6 +20906,9 @@ msgid ""
 "Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
+"Prøver du å deaktivere AI-funksjonene? Installer søkeutvidelsen "
+"%1$sDuckDuckGo No AI%2$s, så innstillingene dine blir husket. %3$sFinn ut "
+"mer%4$s"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -20929,6 +20917,9 @@ msgid ""
 "Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
+"Prøver du å deaktivere AI-funksjonene? Bytt til søkeutvidelsen "
+"%1$sDuckDuckGo No AI%2$s, så innstillingene dine blir husket. %3$sFinn ut "
+"mer%4$s"
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -21251,8 +21242,8 @@ msgstr "Under %1$sÅpne med%2$s velger du %3$sEn spesifikk side eller sider%4$s"
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
 msgstr ""
-"Under %1$sOPPSTART > Startside%2$s startside skriver du inn: https://"
-"duckduckgo.com"
+"Under %1$sOPPSTART > Startside%2$s startside skriver du inn: "
+"https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -21274,8 +21265,7 @@ msgstr "Under %1$sSøke%2$sseksjon trykker du på %3$sBehandle søkemotorer …%
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under On startup select %sOpen a specific page or set of pages%s"
-msgstr ""
-"Under Ved oppstart velger du %1$sÅpne en spesifikk side eller flere sider%2$s"
+msgstr "Under Ved oppstart velger du %1$sÅpne en spesifikk side eller flere sider%2$s"
 
 #  Opera default search engine instruction
 # smartling.placeholder_format=C
@@ -21382,8 +21372,8 @@ msgctxt "voice chat limit modal"
 msgid ""
 "Unlock advanced AI models and higher limits with a DuckDuckGo Subscription"
 msgstr ""
-"Få tilgang til avanserte AI-modeller og høyere grenser med et DuckDuckGo-"
-"abonnement"
+"Få tilgang til avanserte AI-modeller og høyere grenser med et "
+"DuckDuckGo-abonnement"
 
 # smartling.placeholder_format=C
 #. Text informing the user that advanced AI models can be unlocked with a subscription. The variable is used to insert a link that opens the subscription modal. Example: Unlock advanced AI models with a DuckDuckGo subscription.
@@ -21683,7 +21673,7 @@ msgstr "Uruguay"
 #. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
 msgctxt "Navigation label on the Duck.ai settings page"
 msgid "Usage"
-msgstr ""
+msgstr "Bruk"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -21981,9 +21971,9 @@ msgid ""
 "Visit Duck.ai in your other browser and go to %sDuck.ai Settings%s > %sSync "
 "& Backup%s > %sManage%s then select %sSync With Another Device%s."
 msgstr ""
-"Gå til Duck.ai i den andre nettleseren din og så til %1$sDuck.ai-"
-"innstillinger%2$s > %3$sSync & Backup%4$s > %5$sAdministrer%6$s. Velg "
-"deretter %7$sSynkroniser med en annen enhet%8$s."
+"Gå til Duck.ai i den andre nettleseren din og så til "
+"%1$sDuck.ai-innstillinger%2$s > %3$sSync & Backup%4$s > %5$sAdministrer%6$s. "
+"Velg deretter %7$sSynkroniser med en annen enhet%8$s."
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -22019,8 +22009,8 @@ msgid ""
 msgstr ""
 "Gå til Duck.ai i nettleseren din eller i DuckDuckGo-appen, og åpne "
 "innstillingene for Duck.ai. Velg «Slå på» under Sync & Backup og velg "
-"«Synkroniser med en annen enhet». Eller skann QR-koden på gjenopprettings-"
-"PDF-en din."
+"«Synkroniser med en annen enhet». Eller skann QR-koden på "
+"gjenopprettings-PDF-en din."
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -22072,8 +22062,7 @@ msgstr "Talechatten er avsluttet"
 #. Description in consent disclaimer informing that voice chats with the AI (Artificial Intelligence) are anonymized by us, and are never used to train AI models.
 msgctxt "voice chat"
 msgid "Voice chat is anonymized by us, and never used to train AI models."
-msgstr ""
-"Talechatten anonymiseres av oss og brukes aldri til å trene AI-modeller."
+msgstr "Talechatten anonymiseres av oss og brukes aldri til å trene AI-modeller."
 
 # smartling.placeholder_format=C
 #. Title of the modal shown when the user has reached their daily voice chat limit.
@@ -22137,7 +22126,7 @@ msgstr "Wales"
 #. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Walk me through the steps"
-msgstr ""
+msgstr "Forklar meg fremgangsmåten"
 
 # smartling.placeholder_format=C
 #. Label for walking directions on a map.
@@ -22267,6 +22256,9 @@ msgid ""
 "please share this conversation with DuckDuckGo so we can investigate and "
 "address the issue."
 msgstr ""
+"Vi kan bare ordne opp i det vi kan se. For å rapportere et skadelig eller "
+"ulovlig svar må du dele denne samtalen med DuckDuckGo, så vi kan granske og "
+"løse problemet."
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -22306,8 +22298,7 @@ msgstr "Vi følger ikke etter deg med annonser."
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
 msgid "We don't store usernames or any personally identifiable information."
-msgstr ""
-"Vi lager hverken brukernavn eller informasjon som kan identifisere personer."
+msgstr "Vi lager hverken brukernavn eller informasjon som kan identifisere personer."
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -22467,8 +22458,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We stop anyone from getting your search history, including us."
-msgstr ""
-"Vi stopper alle fra å få tak i søkehistorikken din, inkludert oss selv."
+msgstr "Vi stopper alle fra å få tak i søkehistorikken din, inkludert oss selv."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -22491,8 +22481,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
-msgstr ""
-"Vi blokkerer sporere som prøver å samle inn dataene dine mens du surfer."
+msgstr "Vi blokkerer sporere som prøver å samle inn dataene dine mens du surfer."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -22526,8 +22515,7 @@ msgctxt "duckai_migration"
 msgid ""
 "We're sorry for this inconvenience. We’re working hard to make your "
 "experience better."
-msgstr ""
-"Vi beklager ulempen. Vi jobber hardt for å gjøre opplevelsen din bedre."
+msgstr "Vi beklager ulempen. Vi jobber hardt for å gjøre opplevelsen din bedre."
 
 # smartling.placeholder_format=C
 #. Body text explaining the service update requires a page reload.
@@ -22631,8 +22619,7 @@ msgstr "Ukentlig grense er nådd"
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Weekly usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Ukentlig bruksgrense er nådd. Du kan fortsette denne chatten etter %1$s."
+msgstr "Ukentlig bruksgrense er nådd. Du kan fortsette denne chatten etter %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable weekly Duck.ai usage limit and can opt in to continue using the monthly limit.
@@ -22685,15 +22672,13 @@ msgstr ""
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai! You can now import your downloaded chats."
-msgstr ""
-"Velkommen til nye Duck.ai! Du kan nå importere de nedlastede chattene dine."
+msgstr "Velkommen til nye Duck.ai! Du kan nå importere de nedlastede chattene dine."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai, it's time to import your chats"
-msgstr ""
-"Velkommen til den nye Duck.ai, det er på tide å importere chattene dine"
+msgstr "Velkommen til den nye Duck.ai, det er på tide å importere chattene dine"
 
 # smartling.placeholder_format=C
 #. Welcome message for new DuckDuckGo users.
@@ -22823,79 +22808,79 @@ msgstr ""
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the counterarguments?"
-msgstr ""
+msgstr "Hva er motargumentene?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the hours & location?"
-msgstr ""
+msgstr "Når er åpningstidene, og hvor er det?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key contributions of this paper?"
-msgstr ""
+msgstr "Hva er de viktigste bidragene i denne artikkelen?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key contributions?"
-msgstr ""
+msgstr "Hva er de viktigste bidragene?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key details?"
-msgstr ""
+msgstr "Hva er de viktigste detaljene?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key points covered in this video?"
-msgstr ""
+msgstr "Hvilke hovedpunkter dekker denne videoen?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key points?"
-msgstr ""
+msgstr "Hva er de viktigste detaljene?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key takeaways from this article?"
-msgstr ""
+msgstr "Hva er hovedpunktene i denne artikkelen?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key takeaways?"
-msgstr ""
+msgstr "Hva er hovedpunktene?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key things I will learn from this course?"
-msgstr ""
+msgstr "Hva er det viktigste jeg kommer til å lære i dette kurset?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the main counterarguments or criticisms of this?"
-msgstr ""
+msgstr "Hva er hovedargumentene eller -kritikken mot dette?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the main questions this page answers?"
-msgstr ""
+msgstr "Hvilke hovedspørsmål svarer denne siden på?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the must-try dishes here?"
-msgstr ""
+msgstr "Hvilke retter bør jeg prøve her?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
@@ -22903,18 +22888,20 @@ msgctxt "Page suggestion prompt"
 msgid ""
 "What are the opening hours, location, and contact details for this place?"
 msgstr ""
+"Når er åpningstidene for dette stedet, hvor ligger det, og hva er "
+"kontaktinformasjonen?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the pros and cons of this product?"
-msgstr ""
+msgstr "Hva er fordelene og ulempene med dette produktet?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the pros and cons?"
-msgstr ""
+msgstr "Hva er fordelene og ulempene?"
 
 # smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
@@ -23020,7 +23007,7 @@ msgstr "Hva betyr atrier i en medisinsk artikkel?"
 #. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What does this answer?"
-msgstr ""
+msgstr "Hva gir dette et svar på?"
 
 # smartling.placeholder_format=C
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
@@ -23038,7 +23025,7 @@ msgstr "Hva slags informasjon blir lagret?"
 #. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What interview questions might come up for this role?"
-msgstr ""
+msgstr "Hvilke intervjuspørsmål kan jeg bli stilt for denne stillingen?"
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -23060,7 +23047,7 @@ msgstr "Hva er hovedstaden i Albania?"
 #. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What is the overall verdict and rating for this?"
-msgstr ""
+msgstr "Hva er konklusjonen og den samlede vurderingen for dette?"
 
 # smartling.placeholder_format=C
 #. Link to a page with additional information.
@@ -23088,7 +23075,7 @@ msgstr "Dette sier folk:"
 #. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What should I order?"
-msgstr ""
+msgstr "Hva bør jeg bestille?"
 
 # smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
@@ -23106,13 +23093,13 @@ msgstr "Hva var galt med svaret? (valgfritt)"
 #. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What will I learn?"
-msgstr ""
+msgstr "Hva kommer jeg til å lære?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What will I need?"
-msgstr ""
+msgstr "Hva trenger jeg?"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -23135,7 +23122,7 @@ msgstr "Dette er nytt"
 #. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What's the verdict?"
-msgstr ""
+msgstr "Hva er konklusjonen?"
 
 # smartling.placeholder_format=C
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -23191,7 +23178,7 @@ msgstr "Hvilke funksjoner mangler? (Valgfritt)"
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Which features are missing? (optional)"
-msgstr ""
+msgstr "Hvilke funksjoner mangler? (valgfritt)"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
@@ -23214,12 +23201,14 @@ msgstr "Hvem vi er"
 msgctxt "Page suggestion prompt"
 msgid "Who are the main cast and crew, and what else are they known for?"
 msgstr ""
+"Hvem utgjør hovedrollelisten og produksjonsteamet, og hva mer er de kjent "
+"for?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Who is this person?"
-msgstr ""
+msgstr "Hvem er denne personen?"
 
 # smartling.placeholder_format=C
 #. Header above a collection of privacy-related links.
@@ -23590,8 +23579,7 @@ msgstr "Ja, ny bruker!"
 msgctxt "cloudsave"
 msgid ""
 "Yes, we throw away data when you’re done with it, and it cannot be recovered."
-msgstr ""
-"Ja, vi kaster data du er ferdig med, og dataene kan ikke gjenopprettes."
+msgstr "Ja, vi kaster data du er ferdig med, og dataene kan ikke gjenopprettes."
 
 # smartling.placeholder_format=C
 #. Option for the filter-by-date search.
@@ -23610,8 +23598,7 @@ msgctxt "Disclaimer bellow chat input - desktop"
 msgid ""
 "You are chatting with %s. AI chats may display inaccurate or offensive "
 "information."
-msgstr ""
-"Du chatter med %1$s. AI-chatter kan vise feil eller støtende informasjon."
+msgstr "Du chatter med %1$s. AI-chatter kan vise feil eller støtende informasjon."
 
 # smartling.placeholder_format=C
 #. Provide users with the ability to retry their search on a different search engine. First placeholder will be a link with the text "try your search again" OR "try your search later". Second is a URL to the !bangs page: https://duckduckgo.com/bangs.
@@ -23778,8 +23765,7 @@ msgstr ""
 #. Text explaining the benefits of the cloud save feature.
 msgctxt "cloudsave"
 msgid "You can restore your settings after deleting cookies."
-msgstr ""
-"Du kan gjenopprette innstillingene etter at informasjonskapslene er slettet."
+msgstr "Du kan gjenopprette innstillingene etter at informasjonskapslene er slettet."
 
 # smartling.placeholder_format=C
 #. Text explaining the benefits of the cloud save feature.
@@ -23916,8 +23902,7 @@ msgstr "Du søker nå med personvern!"
 msgid ""
 "You're now searching with privacy. %sGet tips to reduce your footprint even "
 "more."
-msgstr ""
-"Du søker nå med personvern. %1$sFå flere tips til å redusere ditt fotavtrykk."
+msgstr "Du søker nå med personvern. %1$sFå flere tips til å redusere ditt fotavtrykk."
 
 # smartling.placeholder_format=C
 #. Title of a notice thanking the user for turning off their adblocker
@@ -23960,8 +23945,7 @@ msgctxt "Error message for user limit"
 msgid ""
 "You've reached the maximum number of messages for the moment. Please try "
 "again later."
-msgstr ""
-"Du har nådd maksimalt antall meldinger for øyeblikket. Prøv igjen senere."
+msgstr "Du har nådd maksimalt antall meldinger for øyeblikket. Prøv igjen senere."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -24134,8 +24118,8 @@ msgstr "Chattene dine blir nå lagret."
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never saved or used to train AI models"
 msgstr ""
-"Chattene dine er private og verken lagres eller brukes til å trene opp AI-"
-"modeller"
+"Chattene dine er private og verken lagres eller brukes til å trene opp "
+"AI-modeller"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
@@ -24167,8 +24151,8 @@ msgctxt "Menu item description"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
 msgstr ""
-"Chattene dine er private, lagres aldri av oss og brukes ikke til å trene AI-"
-"modeller."
+"Chattene dine er private, lagres aldri av oss og brukes ikke til å trene "
+"AI-modeller."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the active privacy protection.
@@ -24176,8 +24160,8 @@ msgctxt "Modal body for privacy"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
 msgstr ""
-"Chattene dine er private, lagres aldri av oss og brukes ikke til å trene AI-"
-"modeller."
+"Chattene dine er private, lagres aldri av oss og brukes ikke til å trene "
+"AI-modeller."
 
 # smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that chats are stored locally on the user's device.
@@ -24278,10 +24262,11 @@ msgid ""
 "browser. We save the settings file using the key as the name. DuckDuckGo "
 "never knows your passphrase."
 msgstr ""
-"Passordet ditt genererer en 512-biters nøkkel ved hjelp av Secure Hash-"
-"algoritmen kjent som %1$sSHA-2%2$s. Det er kun nøkkelen og den tilhørende "
-"innstillingsfilen som forlater nettleseren din. Vi lagrer innstillingsfilen "
-"ved å bruke nøkkelen som navn. DuckDuckGo vet aldri passordet ditt."
+"Passordet ditt genererer en 512-biters nøkkel ved hjelp av Secure "
+"Hash-algoritmen kjent som %1$sSHA-2%2$s. Det er kun nøkkelen og den "
+"tilhørende innstillingsfilen som forlater nettleseren din. Vi lagrer "
+"innstillingsfilen ved å bruke nøkkelen som navn. DuckDuckGo vet aldri "
+"passordet ditt."
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -24705,8 +24690,7 @@ msgstr "det offisielle nettstedet"
 #. <em>%s</em> is for a hexadecimal color code as <em>#395323</em>, but it has to be safe encoded, and as <em>#</em> seems not safe, <em>%23</em> must be used in place of the sharp symbol, but they are the same for your browser.
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
-msgstr ""
-"eller skriv fargekoden du ønsker, f.eks. %1$s (%2$s er et kodet %3$s-tegn)."
+msgstr "eller skriv fargekoden du ønsker, f.eks. %1$s (%2$s er et kodet %3$s-tegn)."
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "

--- a/locales/ne_NP/LC_MESSAGES/duckduckgo.po
+++ b/locales/ne_NP/LC_MESSAGES/duckduckgo.po
@@ -1161,6 +1161,11 @@ msgctxt "feedback form"
 msgid "Address is incorrect"
 msgstr ""
 
+#. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Adjust the servings"
+msgstr ""
+
 #. as in multiple advertisements
 msgid "Ads"
 msgstr ""
@@ -1332,6 +1337,13 @@ msgstr ""
 #. Heading shown on the empty chat screen. The text between the two %s markers is displayed inside a clickable privacy button. First %s renders a shield icon, second %s is an invisible end marker. Keep the word 'private' between both %s markers.
 msgctxt "Empty state heading in Duck.ai chat mode"
 msgid "All chats are %sprivate%s"
+msgstr ""
+
+#. Paragraph in the Privacy & Terms section of the About & Legal page in Duck.ai settings, summarizing how chats are anonymized and are not stored or used to train chat models.
+msgctxt "Privacy & Terms section description on the Duck.ai settings page"
+msgid ""
+"All chats are anonymized by DuckDuckGo, and your conversations are not used "
+"to train chat models by DuckDuckGo or the model providers"
 msgstr ""
 
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1544,6 +1556,12 @@ msgstr ""
 #. Confirmation message after location service is enabled.
 msgctxt "precise_user_location"
 msgid "Anonymous location enabled"
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Anonymously generates answers for search queries based on web content. "
+"Choose how often you want it to appear, or disable it completely."
 msgstr ""
 
 #. Instant Answer tab name
@@ -1766,6 +1784,11 @@ msgstr ""
 
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse
 msgid "Ask a follow-up with Duck.ai"
+msgstr ""
+
+#. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
+msgctxt "Page suggestion chip label"
+msgid "Ask about this page"
 msgstr ""
 
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2090,6 +2113,11 @@ msgstr ""
 msgid "Barcode"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Based on this page, is this course worth taking?"
+msgstr ""
+
 msgctxt "settings"
 msgid "Basic"
 msgstr ""
@@ -2121,6 +2149,13 @@ msgstr ""
 #. Placeholder text displayed while the assistant waits for the user to choose an action.
 msgctxt "Assistant response placeholder"
 msgid "Before continuing..."
+msgstr ""
+
+#. Explains that before storing the report, DuckDuckGo will anonymize the conversation by removing PII like names, email addresses, and identifying metadata.
+msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
+msgid ""
+"Before storing this report, DuckDuckGo will anonymize your conversation by "
+"removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
 #. Label that's displayed next to a past start date below a web search result.
@@ -2379,6 +2414,11 @@ msgstr ""
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Break Points Won"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Break this down into clear, numbered steps."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -2738,6 +2778,11 @@ msgstr ""
 #. Text of a button that performs a search for the cast of a particular movie or tv show
 msgctxt "Movie/TV Show Title instant answer"
 msgid "Cast"
+msgstr ""
+
+#. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Cast & Crew"
 msgstr ""
 
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -4087,6 +4132,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Create a shopping list with quantities from this recipe."
+msgstr ""
+
 #. Placeholder text displayed in the input field when starting a new image generation session.
 msgctxt "Placeholder text for the image generation input field"
 msgid "Create an image of a cute duck..."
@@ -4613,6 +4663,10 @@ msgstr ""
 msgid "Dictation limit reached"
 msgstr ""
 
+#. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
+msgid "Dictation temporarily unavailable"
+msgstr ""
+
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
@@ -4857,6 +4911,20 @@ msgctxt "precise_user_location"
 msgid "Done"
 msgstr ""
 
+#. Message shown in a modal after DuckDuckGo browser users disable AI features in Settings. The first two placeholders bold noai.duckduckgo.com. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
+"filtered out. %sLearn More%s"
+msgstr ""
+
+#. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
+"and AI images filtered out. %sLearn more%s"
+msgstr ""
+
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Double Faults"
@@ -4947,6 +5015,16 @@ msgctxt "Full sentence for writing an email"
 msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
+msgstr ""
+
+#. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Draft a cover letter"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Draft a cover letter for this job."
 msgstr ""
 
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -5086,6 +5164,14 @@ msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
 msgstr ""
 
+#. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
+msgctxt "About section description on the Duck.ai settings page"
+msgid ""
+"Duck.ai is created by DuckDuckGo. We're an independent online protection "
+"company for anyone who wants to take back control of their personal "
+"information."
+msgstr ""
+
 #. Title shown when an update is required before proceeding.
 msgctxt "duckai_migration"
 msgid "Duck.ai is moving domains"
@@ -5119,6 +5205,12 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Duck.ai lets you chat privately with popular AI models. Disabling it hides "
+"Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
 
 msgctxt "settings"
@@ -5896,6 +5988,16 @@ msgstr ""
 msgid "Eritrea"
 msgstr ""
 
+#. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Estimate the nutrition"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Estimate the nutritional information for this recipe."
+msgstr ""
+
 msgid "Estonia"
 msgstr ""
 
@@ -5940,10 +6042,50 @@ msgctxt "merchant promotion product ad extension"
 msgid "Expires in 1 day"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain the accepted answer in simple terms."
+msgstr ""
+
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
+msgstr ""
+
+#. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain the top answer"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this in simple, plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this paper"
+msgstr ""
+
+#. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this repo"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this research paper in plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this simply"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain what this repository does and how to use it."
 msgstr ""
 
 #. Label to show if song lyrics contain explicit content
@@ -6172,6 +6314,11 @@ msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
 msgstr ""
 
+msgctxt "settings"
+msgid ""
+"Filters out known AI spam sites from image search results. %sLearn More%s"
+msgstr ""
+
 #. Label for the final score of a sporting event.
 msgid "Final"
 msgstr ""
@@ -6211,6 +6358,11 @@ msgstr ""
 #. Short description shown below the 'Web Search' label in the Tools dropdown.
 msgctxt "Subtitle for the Web Search tool entry in the Tools dropdown menu"
 msgid "Find current information"
+msgstr ""
+
+#. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Find me alternatives"
 msgstr ""
 
 #. Button that searches for results closer to the user's current location.
@@ -6601,6 +6753,11 @@ msgstr ""
 msgid "Generate More"
 msgstr ""
 
+#. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Generate a shopping list"
+msgstr ""
+
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
 msgid "Generate a short answer from the web"
 msgstr ""
@@ -6835,6 +6992,11 @@ msgstr ""
 #. Text for a button inviting users to give it a try for the Duck.ai product. On click, they're taken to the Duck.ai page.
 msgctxt "Onboarding welcome screen button text"
 msgid "Give it a Try"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Give me a quick background on this person."
 msgstr ""
 
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -7197,6 +7359,16 @@ msgstr ""
 
 #. Link to a page with information about sharing DuckDuckGo with friends.
 msgid "Help Spread Privacy"
+msgstr ""
+
+#. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Help me prep for the interview"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Help me tailor my resume for this job."
 msgstr ""
 
 #. Title of a SERP popup that invites users to take a survey (desktop only)
@@ -7616,6 +7788,13 @@ msgstr ""
 #. Text displayed on the button on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
 msgctxt "Onboarding terms screen button text"
 msgid "I Agree"
+msgstr ""
+
+#. Text for the button that takes the user to the external DuckDuckGo login subscription page.
+msgctxt ""
+"Text for the I already have a subscription button in the Duck.ai settings "
+"page"
+msgid "I Already Have a Subscription"
 msgstr ""
 
 #. Text for the button that takes the user to the login subscription page.
@@ -8070,6 +8249,11 @@ msgctxt "Sidemenu browser promo"
 msgid "Install Mac Browser"
 msgstr ""
 
+#. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
+msgctxt "settings"
+msgid "Install Now"
+msgstr ""
+
 #. Text of a button to install the DuckDuckGo app
 msgctxt "Serp footer content"
 msgid "Install Our App"
@@ -8149,9 +8333,36 @@ msgctxt "cloudsave"
 msgid "Is deleted data really deleted?"
 msgstr "के मेटिएको डाट़ा साँचिकै नष्ट भएको छ?"
 
+#. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is it worth taking?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this place any good?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"Is this place any good? Summarize its reputation based on reviews and "
+"ratings."
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "Is this video helpful?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this worth watching?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Is this worth watching? Give me a spoiler-free take."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -8648,6 +8859,11 @@ msgstr "लिङ्क फन्ट:"
 msgid "Links:"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "List the tools, materials, or prerequisites I need for this."
+msgstr ""
+
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
 msgid "Listen"
 msgstr "सुन"
@@ -8980,6 +9196,11 @@ msgstr ""
 #. Label for linke navigating to site exclusion feature on Settings page
 msgctxt "Exclusion message manage sites button"
 msgid "Manage blocked sites"
+msgstr ""
+
+#. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
+msgctxt "setting"
+msgid "Manage in Browser Settings"
 msgstr ""
 
 #. Link to the site exclusion settings page
@@ -11277,6 +11498,11 @@ msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
+msgid "Please describe why the chat response is harmful or illegal. (optional)"
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
+msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
 msgstr ""
 
@@ -11295,6 +11521,13 @@ msgctxt "Modal disclaimer text"
 msgid ""
 "Please note: starting a new chat with any model will delete your current "
 "chat session."
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
+msgctxt "Feedback prompt"
+msgid ""
+"Please paste your prompt and the problematic output (with any personal "
+"information removed) and describe why the content is harmful or illegal."
 msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -11679,6 +11912,11 @@ msgctxt "settings"
 msgid "Privacy"
 msgstr ""
 
+#. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
+msgctxt "Section heading on the Duck.ai settings page"
+msgid "Privacy & Terms"
+msgstr ""
+
 msgid "Privacy Blog"
 msgstr ""
 
@@ -11732,6 +11970,11 @@ msgstr ""
 
 #. Text used in other strings to link to the Privacy Policy and Terms of Service content.
 msgctxt "Copy used to compose link in sentences"
+msgid "Privacy Policy and Terms of Service"
+msgstr ""
+
+#. Text for a button that links to the terms of use and privacy policy page.
+msgctxt "Secondary button text in active privacy modal"
 msgid "Privacy Policy and Terms of Service"
 msgstr ""
 
@@ -12140,6 +12383,26 @@ msgctxt "Brief for recommending a book"
 msgid "Recommend a book"
 msgstr ""
 
+#. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar books"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar books."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar movies or shows."
+msgstr ""
+
+#. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar titles"
+msgstr ""
+
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
 msgid "Recording failed. Please try again."
 msgstr ""
@@ -12459,6 +12722,14 @@ msgstr ""
 msgid "Republic of Moldova"
 msgstr ""
 
+#. Note indicating that sharing the conversation is mandatory when reporting harmful or illegal content. Rendered alongside the standard share label (DUCKCHAT_RESPONSE_FEEDBACK_SHARE_PROMPT_RESPONSE_LABEL), not replacing it.
+msgctxt ""
+"Note shown under the share-content switch label on the Duck.ai response "
+"feedback form when the user has selected Harmful or Illegal as the feedback "
+"reason"
+msgid "Required for harmful or illegal reports"
+msgstr ""
+
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
 msgctxt "Description for extended reasoning mode in Duck.ai"
 msgid "Researches before responding"
@@ -12644,6 +12915,11 @@ msgstr "समीक्षा"
 #. Label above a list of customer reviews of a business.
 msgctxt "maps_places"
 msgid "Reviews"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Rewrite this recipe scaled for a different number of servings."
 msgstr ""
 
 msgid "Romania"
@@ -13681,6 +13957,11 @@ msgctxt "Setup button for native sync flow"
 msgid "Set Up Now"
 msgstr ""
 
+#. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
+msgctxt "Encrypted storage setup button shown in native browsers"
+msgid "Set Up Sync & Backup"
+msgstr ""
+
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
 msgctxt "Title for the Sync & Backup intro screen"
 msgid "Set Up Sync & Backup"
@@ -13823,6 +14104,12 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
+msgctxt ""
+"Label beside the share-content switch on the Duck.ai response feedback form"
+msgid "Share this conversation with DuckDuckGo"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -14837,6 +15124,21 @@ msgctxt "Brief for suggesting a blog post title"
 msgid "Suggest a title for a blog post"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest related articles or topics worth exploring next."
+msgstr ""
+
+#. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Suggest related articles to explore"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest some alternatives to this product."
+msgstr ""
+
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
 msgctxt "directions"
 msgid "Suggestions:"
@@ -14846,9 +15148,84 @@ msgctxt "noresults"
 msgid "Suggestions:"
 msgstr ""
 
+#. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Sum up the reviews"
+msgstr ""
+
 #. A short title for the a message asking the AI to summarize a text.
 msgctxt "Title for the summarize message"
 msgid "Summarize"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize the Q&As"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the background and notable work of this person."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the key details of this event."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the questions and answers on this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize their background"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this book"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this book."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this discussion"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this discussion thread."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this video"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this video."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize what the reviews say."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -15103,6 +15480,11 @@ msgstr ""
 msgid "Syria"
 msgstr ""
 
+#. Text for a button that enables the theme to follow the operating system's color scheme preference.
+msgctxt "System theme button for theme selector"
+msgid "System"
+msgstr ""
+
 #. Abbreviation indicating this is the total score for a game
 msgctxt "Sports module"
 msgid "T"
@@ -15126,6 +15508,11 @@ msgctxt "language_name"
 msgid "Tahitian"
 msgstr ""
 
+#. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Tailor my resume"
+msgstr ""
+
 msgid "Taiwan"
 msgstr ""
 
@@ -15147,6 +15534,12 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "Take control of your personal data!"
+msgstr ""
+
+#. Description for the Feedback section of the Duck.ai settings page, asking the user to take an anonymous survey to let us know how we can make Duck.ai better.
+msgctxt "Feedback section description on the Duck.ai settings page"
+msgid ""
+"Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
 
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -15389,6 +15782,11 @@ msgstr ""
 
 #. Title for the theme menu:
 #. https://duck.co/media/files/theme.png
+msgid "Theme"
+msgstr ""
+
+#. Text for the theme selector label that allows users to switch between Light and dark theme.
+msgctxt "Label for the theme selector feature"
 msgid "Theme"
 msgstr ""
 
@@ -16042,6 +16440,16 @@ msgid ""
 "movie theatre?”"
 msgstr ""
 
+#. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Translate this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
+msgctxt "Page suggestion prompt"
+msgid "Translate this page into %s."
+msgstr ""
+
 #. Placeholder text for a region that will display translated text.
 msgctxt "translations_module"
 msgid "Translation"
@@ -16156,6 +16564,11 @@ msgstr ""
 #. Call-to-action button for the subscription promo in the SERP sidemenu.
 msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
+msgstr ""
+
+#. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
+msgctxt "settings"
+msgid "Try It Now"
 msgstr ""
 
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -16349,6 +16762,20 @@ msgstr "%s प्रयास गर्नुहोस"
 #. Response a user can select in a feedback form, indicating that they're trying DuckDuckGo again.
 msgctxt "new user poll"
 msgid "Trying DuckDuckGo again"
+msgstr ""
+
+#. Message shown in a modal after supported third-party browser users disable AI features in Settings. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+#. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
 msgstr ""
 
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -16949,6 +17376,11 @@ msgstr ""
 msgid "Uruguay"
 msgstr ""
 
+#. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
+msgctxt "Navigation label on the Duck.ai settings page"
+msgid "Usage"
+msgstr ""
+
 #. A feedback suggestion
 msgctxt "Feedback prompt"
 msgid "Usage limit"
@@ -17297,6 +17729,11 @@ msgstr ""
 msgid "Wales"
 msgstr ""
 
+#. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Walk me through the steps"
+msgstr ""
+
 #. Label for walking directions on a map.
 msgctxt "directions"
 msgid "Walking"
@@ -17387,6 +17824,16 @@ msgstr ""
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
+msgstr ""
+
+#. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
+msgctxt ""
+"Inline warning shown below the share-content toggle when the user selects "
+"Harmful or Illegal but has not enabled sharing"
+msgid ""
+"We can only fix what we can see. To report a harmful or illegal response, "
+"please share this conversation with DuckDuckGo so we can investigate and "
+"address the issue."
 msgstr ""
 
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -17806,6 +18253,87 @@ msgid ""
 "experience."
 msgstr ""
 
+#. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the counterarguments?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the hours & location?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key contributions of this paper?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key contributions?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key details?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key points covered in this video?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key points?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key takeaways from this article?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key takeaways?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key things I will learn from this course?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main counterarguments or criticisms of this?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main questions this page answers?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the must-try dishes here?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"What are the opening hours, location, and contact details for this place?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the pros and cons of this product?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the pros and cons?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
 msgctxt "feedback form"
 msgid "What bothered you most?"
@@ -17889,6 +18417,11 @@ msgctxt "Full sentence for defining a term"
 msgid "What does atria mean in the context of a medical article?"
 msgstr ""
 
+#. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What does this answer?"
+msgstr ""
+
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
@@ -17897,6 +18430,11 @@ msgstr ""
 #. Header above a list of types of information that gets saved by the cloud save feature.
 msgctxt "cloudsave"
 msgid "What information gets saved?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What interview questions might come up for this role?"
 msgstr ""
 
 #. Text explaining how the cloud save feature works.
@@ -17909,6 +18447,11 @@ msgstr ""
 #. Text for a prompt suggestion for looking up the capital city of Albania.
 msgctxt "Full sentence for looking up basic facts"
 msgid "What is the capital city of Albania?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What is the overall verdict and rating for this?"
 msgstr ""
 
 #. Link to a page with additional information.
@@ -17929,6 +18472,11 @@ msgctxt "maps_places"
 msgid "What people say:"
 msgstr ""
 
+#. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What should I order?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
 msgctxt "feedback form"
 msgid "What stood out?"
@@ -17937,6 +18485,16 @@ msgstr ""
 #. Question on a feedback form for a negative feedback response.
 msgctxt "feedback form"
 msgid "What was wrong with the response? (optional)"
+msgstr ""
+
+#. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I learn?"
+msgstr ""
+
+#. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I need?"
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -17951,6 +18509,11 @@ msgstr ""
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
 msgctxt "SERP footer content"
 msgid "What's New"
+msgstr ""
+
+#. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What's the verdict?"
 msgstr ""
 
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -17992,6 +18555,11 @@ msgctxt "Feedback prompt"
 msgid "Which features are missing? (Optional)"
 msgstr ""
 
+#. An invitation for users to leave feedback
+msgctxt "Feedback prompt"
+msgid "Which features are missing? (optional)"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
 msgid "White"
 msgstr ""
@@ -18003,6 +18571,16 @@ msgstr ""
 
 #. Link to an about us page.
 msgid "Who We Are"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Who are the main cast and crew, and what else are they known for?"
+msgstr ""
+
+#. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Who is this person?"
 msgstr ""
 
 #. Header above a collection of privacy-related links.

--- a/locales/nl_BE/LC_MESSAGES/duckduckgo.po
+++ b/locales/nl_BE/LC_MESSAGES/duckduckgo.po
@@ -1159,6 +1159,11 @@ msgctxt "feedback form"
 msgid "Address is incorrect"
 msgstr ""
 
+#. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Adjust the servings"
+msgstr ""
+
 #. as in multiple advertisements
 msgid "Ads"
 msgstr ""
@@ -1332,6 +1337,13 @@ msgstr ""
 #. Heading shown on the empty chat screen. The text between the two %s markers is displayed inside a clickable privacy button. First %s renders a shield icon, second %s is an invisible end marker. Keep the word 'private' between both %s markers.
 msgctxt "Empty state heading in Duck.ai chat mode"
 msgid "All chats are %sprivate%s"
+msgstr ""
+
+#. Paragraph in the Privacy & Terms section of the About & Legal page in Duck.ai settings, summarizing how chats are anonymized and are not stored or used to train chat models.
+msgctxt "Privacy & Terms section description on the Duck.ai settings page"
+msgid ""
+"All chats are anonymized by DuckDuckGo, and your conversations are not used "
+"to train chat models by DuckDuckGo or the model providers"
 msgstr ""
 
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1544,6 +1556,12 @@ msgstr ""
 #. Confirmation message after location service is enabled.
 msgctxt "precise_user_location"
 msgid "Anonymous location enabled"
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Anonymously generates answers for search queries based on web content. "
+"Choose how often you want it to appear, or disable it completely."
 msgstr ""
 
 #. Instant Answer tab name
@@ -1766,6 +1784,11 @@ msgstr ""
 
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse
 msgid "Ask a follow-up with Duck.ai"
+msgstr ""
+
+#. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
+msgctxt "Page suggestion chip label"
+msgid "Ask about this page"
 msgstr ""
 
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2090,6 +2113,11 @@ msgstr ""
 msgid "Barcode"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Based on this page, is this course worth taking?"
+msgstr ""
+
 msgctxt "settings"
 msgid "Basic"
 msgstr "Basis"
@@ -2121,6 +2149,13 @@ msgstr ""
 #. Placeholder text displayed while the assistant waits for the user to choose an action.
 msgctxt "Assistant response placeholder"
 msgid "Before continuing..."
+msgstr ""
+
+#. Explains that before storing the report, DuckDuckGo will anonymize the conversation by removing PII like names, email addresses, and identifying metadata.
+msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
+msgid ""
+"Before storing this report, DuckDuckGo will anonymize your conversation by "
+"removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
 #. Label that's displayed next to a past start date below a web search result.
@@ -2379,6 +2414,11 @@ msgstr "Brazilië"
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Break Points Won"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Break this down into clear, numbered steps."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -2738,6 +2778,11 @@ msgstr "Baanmogelijkheden"
 #. Text of a button that performs a search for the cast of a particular movie or tv show
 msgctxt "Movie/TV Show Title instant answer"
 msgid "Cast"
+msgstr ""
+
+#. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Cast & Crew"
 msgstr ""
 
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -4098,6 +4143,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Create a shopping list with quantities from this recipe."
+msgstr ""
+
 #. Placeholder text displayed in the input field when starting a new image generation session.
 msgctxt "Placeholder text for the image generation input field"
 msgid "Create an image of a cute duck..."
@@ -4624,6 +4674,10 @@ msgstr ""
 msgid "Dictation limit reached"
 msgstr ""
 
+#. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
+msgid "Dictation temporarily unavailable"
+msgstr ""
+
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
@@ -4868,6 +4922,20 @@ msgctxt "precise_user_location"
 msgid "Done"
 msgstr "Klaar"
 
+#. Message shown in a modal after DuckDuckGo browser users disable AI features in Settings. The first two placeholders bold noai.duckduckgo.com. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
+"filtered out. %sLearn More%s"
+msgstr ""
+
+#. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
+"and AI images filtered out. %sLearn more%s"
+msgstr ""
+
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Double Faults"
@@ -4958,6 +5026,16 @@ msgctxt "Full sentence for writing an email"
 msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
+msgstr ""
+
+#. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Draft a cover letter"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Draft a cover letter for this job."
 msgstr ""
 
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -5097,6 +5175,14 @@ msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
 msgstr ""
 
+#. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
+msgctxt "About section description on the Duck.ai settings page"
+msgid ""
+"Duck.ai is created by DuckDuckGo. We're an independent online protection "
+"company for anyone who wants to take back control of their personal "
+"information."
+msgstr ""
+
 #. Title shown when an update is required before proceeding.
 msgctxt "duckai_migration"
 msgid "Duck.ai is moving domains"
@@ -5130,6 +5216,12 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Duck.ai lets you chat privately with popular AI models. Disabling it hides "
+"Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
 
 msgctxt "settings"
@@ -5896,6 +5988,16 @@ msgstr ""
 msgid "Eritrea"
 msgstr ""
 
+#. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Estimate the nutrition"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Estimate the nutritional information for this recipe."
+msgstr ""
+
 msgid "Estonia"
 msgstr "Estland"
 
@@ -5940,10 +6042,50 @@ msgctxt "merchant promotion product ad extension"
 msgid "Expires in 1 day"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain the accepted answer in simple terms."
+msgstr ""
+
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
+msgstr ""
+
+#. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain the top answer"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this in simple, plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this paper"
+msgstr ""
+
+#. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this repo"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this research paper in plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this simply"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain what this repository does and how to use it."
 msgstr ""
 
 #. Label to show if song lyrics contain explicit content
@@ -6174,6 +6316,11 @@ msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
 msgstr ""
 
+msgctxt "settings"
+msgid ""
+"Filters out known AI spam sites from image search results. %sLearn More%s"
+msgstr ""
+
 #. Label for the final score of a sporting event.
 msgid "Final"
 msgstr "Definitief"
@@ -6213,6 +6360,11 @@ msgstr ""
 #. Short description shown below the 'Web Search' label in the Tools dropdown.
 msgctxt "Subtitle for the Web Search tool entry in the Tools dropdown menu"
 msgid "Find current information"
+msgstr ""
+
+#. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Find me alternatives"
 msgstr ""
 
 #. Button that searches for results closer to the user's current location.
@@ -6603,6 +6755,11 @@ msgstr ""
 msgid "Generate More"
 msgstr ""
 
+#. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Generate a shopping list"
+msgstr ""
+
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
 msgid "Generate a short answer from the web"
 msgstr ""
@@ -6837,6 +6994,11 @@ msgstr ""
 #. Text for a button inviting users to give it a try for the Duck.ai product. On click, they're taken to the Duck.ai page.
 msgctxt "Onboarding welcome screen button text"
 msgid "Give it a Try"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Give me a quick background on this person."
 msgstr ""
 
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -7199,6 +7361,16 @@ msgstr ""
 
 #. Link to a page with information about sharing DuckDuckGo with friends.
 msgid "Help Spread Privacy"
+msgstr ""
+
+#. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Help me prep for the interview"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Help me tailor my resume for this job."
 msgstr ""
 
 #. Title of a SERP popup that invites users to take a survey (desktop only)
@@ -7618,6 +7790,13 @@ msgstr ""
 #. Text displayed on the button on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
 msgctxt "Onboarding terms screen button text"
 msgid "I Agree"
+msgstr ""
+
+#. Text for the button that takes the user to the external DuckDuckGo login subscription page.
+msgctxt ""
+"Text for the I already have a subscription button in the Duck.ai settings "
+"page"
+msgid "I Already Have a Subscription"
 msgstr ""
 
 #. Text for the button that takes the user to the login subscription page.
@@ -8072,6 +8251,11 @@ msgctxt "Sidemenu browser promo"
 msgid "Install Mac Browser"
 msgstr ""
 
+#. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
+msgctxt "settings"
+msgid "Install Now"
+msgstr ""
+
 #. Text of a button to install the DuckDuckGo app
 msgctxt "Serp footer content"
 msgid "Install Our App"
@@ -8151,9 +8335,36 @@ msgctxt "cloudsave"
 msgid "Is deleted data really deleted?"
 msgstr "Is verwijderde data echt verwijderd?"
 
+#. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is it worth taking?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this place any good?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"Is this place any good? Summarize its reputation based on reviews and "
+"ratings."
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "Is this video helpful?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this worth watching?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Is this worth watching? Give me a spoiler-free take."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -8650,6 +8861,11 @@ msgstr "Link lettertype:"
 msgid "Links:"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "List the tools, materials, or prerequisites I need for this."
+msgstr ""
+
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
 msgid "Listen"
 msgstr "Luister"
@@ -8982,6 +9198,11 @@ msgstr ""
 #. Label for linke navigating to site exclusion feature on Settings page
 msgctxt "Exclusion message manage sites button"
 msgid "Manage blocked sites"
+msgstr ""
+
+#. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
+msgctxt "setting"
+msgid "Manage in Browser Settings"
 msgstr ""
 
 #. Link to the site exclusion settings page
@@ -11287,6 +11508,11 @@ msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
+msgid "Please describe why the chat response is harmful or illegal. (optional)"
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
+msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
 msgstr ""
 
@@ -11305,6 +11531,13 @@ msgctxt "Modal disclaimer text"
 msgid ""
 "Please note: starting a new chat with any model will delete your current "
 "chat session."
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
+msgctxt "Feedback prompt"
+msgid ""
+"Please paste your prompt and the problematic output (with any personal "
+"information removed) and describe why the content is harmful or illegal."
 msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -11689,6 +11922,11 @@ msgctxt "settings"
 msgid "Privacy"
 msgstr ""
 
+#. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
+msgctxt "Section heading on the Duck.ai settings page"
+msgid "Privacy & Terms"
+msgstr ""
+
 msgid "Privacy Blog"
 msgstr ""
 
@@ -11742,6 +11980,11 @@ msgstr ""
 
 #. Text used in other strings to link to the Privacy Policy and Terms of Service content.
 msgctxt "Copy used to compose link in sentences"
+msgid "Privacy Policy and Terms of Service"
+msgstr ""
+
+#. Text for a button that links to the terms of use and privacy policy page.
+msgctxt "Secondary button text in active privacy modal"
 msgid "Privacy Policy and Terms of Service"
 msgstr ""
 
@@ -12150,6 +12393,26 @@ msgctxt "Brief for recommending a book"
 msgid "Recommend a book"
 msgstr ""
 
+#. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar books"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar books."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar movies or shows."
+msgstr ""
+
+#. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar titles"
+msgstr ""
+
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
 msgid "Recording failed. Please try again."
 msgstr ""
@@ -12469,6 +12732,14 @@ msgstr ""
 msgid "Republic of Moldova"
 msgstr ""
 
+#. Note indicating that sharing the conversation is mandatory when reporting harmful or illegal content. Rendered alongside the standard share label (DUCKCHAT_RESPONSE_FEEDBACK_SHARE_PROMPT_RESPONSE_LABEL), not replacing it.
+msgctxt ""
+"Note shown under the share-content switch label on the Duck.ai response "
+"feedback form when the user has selected Harmful or Illegal as the feedback "
+"reason"
+msgid "Required for harmful or illegal reports"
+msgstr ""
+
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
 msgctxt "Description for extended reasoning mode in Duck.ai"
 msgid "Researches before responding"
@@ -12654,6 +12925,11 @@ msgstr "Recensies"
 #. Label above a list of customer reviews of a business.
 msgctxt "maps_places"
 msgid "Reviews"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Rewrite this recipe scaled for a different number of servings."
 msgstr ""
 
 msgid "Romania"
@@ -13700,6 +13976,11 @@ msgctxt "Setup button for native sync flow"
 msgid "Set Up Now"
 msgstr ""
 
+#. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
+msgctxt "Encrypted storage setup button shown in native browsers"
+msgid "Set Up Sync & Backup"
+msgstr ""
+
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
 msgctxt "Title for the Sync & Backup intro screen"
 msgid "Set Up Sync & Backup"
@@ -13844,6 +14125,12 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
+msgctxt ""
+"Label beside the share-content switch on the Duck.ai response feedback form"
+msgid "Share this conversation with DuckDuckGo"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -14859,6 +15146,21 @@ msgctxt "Brief for suggesting a blog post title"
 msgid "Suggest a title for a blog post"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest related articles or topics worth exploring next."
+msgstr ""
+
+#. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Suggest related articles to explore"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest some alternatives to this product."
+msgstr ""
+
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
 msgctxt "directions"
 msgid "Suggestions:"
@@ -14868,9 +15170,84 @@ msgctxt "noresults"
 msgid "Suggestions:"
 msgstr ""
 
+#. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Sum up the reviews"
+msgstr ""
+
 #. A short title for the a message asking the AI to summarize a text.
 msgctxt "Title for the summarize message"
 msgid "Summarize"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize the Q&As"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the background and notable work of this person."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the key details of this event."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the questions and answers on this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize their background"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this book"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this book."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this discussion"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this discussion thread."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this video"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this video."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize what the reviews say."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -15125,6 +15502,11 @@ msgstr ""
 msgid "Syria"
 msgstr ""
 
+#. Text for a button that enables the theme to follow the operating system's color scheme preference.
+msgctxt "System theme button for theme selector"
+msgid "System"
+msgstr ""
+
 #. Abbreviation indicating this is the total score for a game
 msgctxt "Sports module"
 msgid "T"
@@ -15148,6 +15530,11 @@ msgctxt "language_name"
 msgid "Tahitian"
 msgstr ""
 
+#. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Tailor my resume"
+msgstr ""
+
 msgid "Taiwan"
 msgstr ""
 
@@ -15169,6 +15556,12 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "Take control of your personal data!"
+msgstr ""
+
+#. Description for the Feedback section of the Duck.ai settings page, asking the user to take an anonymous survey to let us know how we can make Duck.ai better.
+msgctxt "Feedback section description on the Duck.ai settings page"
+msgid ""
+"Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
 
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -15413,6 +15806,11 @@ msgstr ""
 #. https://duck.co/media/files/theme.png
 msgid "Theme"
 msgstr "Thema"
+
+#. Text for the theme selector label that allows users to switch between Light and dark theme.
+msgctxt "Label for the theme selector feature"
+msgid "Theme"
+msgstr ""
 
 #. http://i.imgur.com/LpFhb1e.png
 msgctxt "settings"
@@ -16065,6 +16463,16 @@ msgid ""
 "movie theatre?”"
 msgstr ""
 
+#. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Translate this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
+msgctxt "Page suggestion prompt"
+msgid "Translate this page into %s."
+msgstr ""
+
 #. Placeholder text for a region that will display translated text.
 msgctxt "translations_module"
 msgid "Translation"
@@ -16179,6 +16587,11 @@ msgstr ""
 #. Call-to-action button for the subscription promo in the SERP sidemenu.
 msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
+msgstr ""
+
+#. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
+msgctxt "settings"
+msgid "Try It Now"
 msgstr ""
 
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -16374,6 +16787,20 @@ msgstr "Probeer: %s"
 msgctxt "new user poll"
 msgid "Trying DuckDuckGo again"
 msgstr "Ik probeer DuckDuckGo opnieuw"
+
+#. Message shown in a modal after supported third-party browser users disable AI features in Settings. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+#. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
 
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
 msgctxt "Assistant response placeholder"
@@ -16979,6 +17406,11 @@ msgstr ""
 msgid "Uruguay"
 msgstr ""
 
+#. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
+msgctxt "Navigation label on the Duck.ai settings page"
+msgid "Usage"
+msgstr ""
+
 #. A feedback suggestion
 msgctxt "Feedback prompt"
 msgid "Usage limit"
@@ -17329,6 +17761,11 @@ msgstr ""
 msgid "Wales"
 msgstr ""
 
+#. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Walk me through the steps"
+msgstr ""
+
 #. Label for walking directions on a map.
 msgctxt "directions"
 msgid "Walking"
@@ -17419,6 +17856,16 @@ msgstr ""
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
+msgstr ""
+
+#. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
+msgctxt ""
+"Inline warning shown below the share-content toggle when the user selects "
+"Harmful or Illegal but has not enabled sharing"
+msgid ""
+"We can only fix what we can see. To report a harmful or illegal response, "
+"please share this conversation with DuckDuckGo so we can investigate and "
+"address the issue."
 msgstr ""
 
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -17844,6 +18291,87 @@ msgid ""
 "experience."
 msgstr ""
 
+#. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the counterarguments?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the hours & location?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key contributions of this paper?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key contributions?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key details?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key points covered in this video?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key points?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key takeaways from this article?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key takeaways?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key things I will learn from this course?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main counterarguments or criticisms of this?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main questions this page answers?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the must-try dishes here?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"What are the opening hours, location, and contact details for this place?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the pros and cons of this product?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the pros and cons?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
 msgctxt "feedback form"
 msgid "What bothered you most?"
@@ -17927,6 +18455,11 @@ msgctxt "Full sentence for defining a term"
 msgid "What does atria mean in the context of a medical article?"
 msgstr ""
 
+#. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What does this answer?"
+msgstr ""
+
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
@@ -17936,6 +18469,11 @@ msgstr ""
 msgctxt "cloudsave"
 msgid "What information gets saved?"
 msgstr "Welke informatie wordt bewaard?"
+
+#. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What interview questions might come up for this role?"
+msgstr ""
 
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
@@ -17947,6 +18485,11 @@ msgstr ""
 #. Text for a prompt suggestion for looking up the capital city of Albania.
 msgctxt "Full sentence for looking up basic facts"
 msgid "What is the capital city of Albania?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What is the overall verdict and rating for this?"
 msgstr ""
 
 #. Link to a page with additional information.
@@ -17967,6 +18510,11 @@ msgctxt "maps_places"
 msgid "What people say:"
 msgstr ""
 
+#. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What should I order?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
 msgctxt "feedback form"
 msgid "What stood out?"
@@ -17975,6 +18523,16 @@ msgstr ""
 #. Question on a feedback form for a negative feedback response.
 msgctxt "feedback form"
 msgid "What was wrong with the response? (optional)"
+msgstr ""
+
+#. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I learn?"
+msgstr ""
+
+#. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I need?"
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -17989,6 +18547,11 @@ msgstr ""
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
 msgctxt "SERP footer content"
 msgid "What's New"
+msgstr ""
+
+#. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What's the verdict?"
 msgstr ""
 
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -18030,6 +18593,11 @@ msgctxt "Feedback prompt"
 msgid "Which features are missing? (Optional)"
 msgstr ""
 
+#. An invitation for users to leave feedback
+msgctxt "Feedback prompt"
+msgid "Which features are missing? (optional)"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
 msgid "White"
 msgstr "Wit"
@@ -18041,6 +18609,16 @@ msgstr "Wit"
 
 #. Link to an about us page.
 msgid "Who We Are"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Who are the main cast and crew, and what else are they known for?"
+msgstr ""
+
+#. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Who is this person?"
 msgstr ""
 
 #. Header above a collection of privacy-related links.

--- a/locales/nl_NL/LC_MESSAGES/duckduckgo.po
+++ b/locales/nl_NL/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: nl_NL\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -87,8 +87,7 @@ msgstr "%1$s en %2$s AI-modellen"
 #. Message that appears above the search results encouraging them to filter results by domain. The placeholder string would include a the name of a website. E.g. 'Reddit appears in some of the top results for this search.'
 msgctxt "Site filter message"
 msgid "%s appears in some of the top results for this search."
-msgstr ""
-"%1$s komt voor in een aantal van de beste resultaten voor deze zoekopdracht."
+msgstr "%1$s komt voor in een aantal van de beste resultaten voor deze zoekopdracht."
 
 # smartling.placeholder_format=C
 #. Number of tracking attempts blocked, when there is more than 1. Eg: '2 attempts' or '302 attempts'
@@ -417,8 +416,7 @@ msgstr "%1$s woorden"
 #. Instructions on which buttons and options the user has to click in order to add the DuckDuckGo extension to their browser.
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
-msgstr ""
-"%1$sKlik op %2$sToevoegen%3$sSelecteer %4$sToestaan%5$s en klik op %6$sOK%7$s"
+msgstr "%1$sKlik op %2$sToevoegen%3$sSelecteer %4$sToestaan%5$s en klik op %6$sOK%7$s"
 
 # Firefox, obsolete
 # smartling.placeholder_format=C
@@ -481,8 +479,7 @@ msgstr ""
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "%sLearn more%s about how chats are stored privately on your device."
-msgstr ""
-"%1$sLees meer%2$s over hoe chats privé worden opgeslagen op je apparaat."
+msgstr "%1$sLees meer%2$s over hoe chats privé worden opgeslagen op je apparaat."
 
 # smartling.placeholder_format=C
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
@@ -815,8 +812,7 @@ msgstr "De 6-uurs gebruikslimiet is bereikt."
 #. Displayed when the user has reached a fixed 6-hour Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "6-hour usage limit reached. You can continue this chat after %s."
-msgstr ""
-"De 6-uurs gebruikslimiet is bereikt. Je kunt dit gesprek voortzetten na %1$s."
+msgstr "De 6-uurs gebruikslimiet is bereikt. Je kunt dit gesprek voortzetten na %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable 6-hour Duck.ai usage limit and can opt in to continue using the daily limit.
@@ -1445,7 +1441,7 @@ msgstr "Adres is onjuist"
 #. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Adjust the servings"
-msgstr ""
+msgstr "Aanpassen voor een ander aantal porties"
 
 # smartling.placeholder_format=C
 #. as in multiple advertisements
@@ -1665,6 +1661,9 @@ msgid ""
 "All chats are anonymized by DuckDuckGo, and your conversations are not used "
 "to train chat models by DuckDuckGo or the model providers"
 msgstr ""
+"Alle chats worden door DuckDuckGo geanonimiseerd en je gesprekken worden "
+"niet gebruikt om chatmodellen te trainen door DuckDuckGo of de "
+"modelaanbieders"
 
 # smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1755,8 +1754,7 @@ msgstr "Advertenties die de privacy respecteren toestaan"
 # smartling.placeholder_format=C
 #. Title in a dialog informing the user how to disable their ad blocker for DuckDuckGo
 msgid "Allow privacy-respecting ads on DuckDuckGo Private Search"
-msgstr ""
-"Advertenties die de privacy respecteren toestaan in DuckDuckGo Private Search"
+msgstr "Advertenties die de privacy respecteren toestaan in DuckDuckGo Private Search"
 
 # smartling.placeholder_format=C
 #. Description explaining privacy implications of enabling web search on encrypted models. The first two placeholders are the full model name (e.g. 'gpt-oss 120B'). The third and fourth placeholders wrap a clickable link reading 'zero provider visibility' that opens the privacy modal, please keep those around the link text in your translation. An example full sentence would be: Allows gpt-oss 120B to search the web to improve responses to relevant prompts. Only sends AI-generated queries to a search engine with limited data retention. Prompts and responses with gpt-oss 120B still have zero provider visibility.
@@ -1916,8 +1914,8 @@ msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
 msgstr ""
-"Anonieme toegang tot populaire AI-modellen, waaronder %1$s, %2$s, en open-"
-"source %3$s en %4$s."
+"Anonieme toegang tot populaire AI-modellen, waaronder %1$s, %2$s, en "
+"open-source %3$s en %4$s."
 
 # smartling.placeholder_format=C
 #. Text with information about Duck.ai and supported AI models, the placeholders list AI models. Example: 'Anonymous access to popular AI models, including GPT, Claude, and open-source Llama and Mistral.'
@@ -1926,8 +1924,8 @@ msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
 msgstr ""
-"Anonieme toegang tot populaire AI-modellen, waaronder %1$s, %2$s, en open-"
-"source %3$s en %4$s."
+"Anonieme toegang tot populaire AI-modellen, waaronder %1$s, %2$s, en "
+"open-source %3$s en %4$s."
 
 # smartling.placeholder_format=C
 #. Confirmation message after location service is enabled.
@@ -1941,6 +1939,8 @@ msgid ""
 "Anonymously generates answers for search queries based on web content. "
 "Choose how often you want it to appear, or disable it completely."
 msgstr ""
+"Genereert anoniem antwoorden voor zoekopdrachten op basis van webinhoud. "
+"Kies hoe vaak je wilt dat het verschijnt, of schakel het volledig uit."
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -2230,7 +2230,7 @@ msgstr "Stel een vervolgvraag aan Duck.ai"
 #. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
 msgctxt "Page suggestion chip label"
 msgid "Ask about this page"
-msgstr ""
+msgstr "Stel een vraag over deze pagina"
 
 # smartling.placeholder_format=C
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2298,8 +2298,8 @@ msgstr ""
 "relevante webinhoud samen te vatten. Je kunt kiezen hoe vaak je wilt dat "
 "Assist wordt weergegeven: 'Nooit' (de Assist-gebruikersinterface wordt "
 "helemaal uit de zoekresultaten verwijderd), 'Op verzoek' (AI-antwoorden "
-"worden alleen weergegeven als je op de Assist-knop klikt), 'Soms' (AI-"
-"antwoorden worden alleen weergegeven als ze zeer relevant zijn), of "
+"worden alleen weergegeven als je op de Assist-knop klikt), 'Soms' "
+"(AI-antwoorden worden alleen weergegeven als ze zeer relevant zijn), of "
 "'Vaak' (wordt vaker weergegeven bij een breder scala aan zoekopdrachten). "
 "Voorlopig zijn AI-antwoorden alleen beschikbaar in de Amerikaanse regio."
 
@@ -2313,8 +2313,8 @@ msgid ""
 "to remember that responses are auto-generated from cited sources and based "
 "on %scrawling the web%s."
 msgstr ""
-"Assist is een optionele functie in onze zoekresultaten die anoniem AI-"
-"ondersteunde antwoorden op zoekopdrachten kan genereren. De functie scant "
+"Assist is een optionele functie in onze zoekresultaten die anoniem "
+"AI-ondersteunde antwoorden op zoekopdrachten kan genereren. De functie scant "
 "het web op relevante inhoud en gebruikt vervolgens AI-technologie op basis "
 "van natuurlijke taal om een kort antwoord te genereren aan de hand van de "
 "gevonden relevante informatie. Het is belangrijk om te onthouden dat "
@@ -2660,7 +2660,7 @@ msgstr "Barcode"
 #. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Based on this page, is this course worth taking?"
-msgstr ""
+msgstr "Is deze cursus volgens deze pagina de moeite waard?"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2709,6 +2709,9 @@ msgid ""
 "Before storing this report, DuckDuckGo will anonymize your conversation by "
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
+"Voordat dit rapport wordt opgeslagen, maakt DuckDuckGo je gesprek anoniem "
+"door persoonlijk identificeerbare gegevens zoals namen, e-mailadressen en "
+"identificerende metadata te verwijderen."
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -3030,7 +3033,7 @@ msgstr "Breakpunten gewonnen"
 #. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Break this down into clear, numbered steps."
-msgstr ""
+msgstr "Deel dit op in duidelijke, genummerde stappen."
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -3491,7 +3494,7 @@ msgstr "Casten"
 #. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Cast & Crew"
-msgstr ""
+msgstr "Cast en crew"
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -3578,8 +3581,7 @@ msgstr "Wijzigt hoe URL's van resultaten worden weergegeven"
 #. This is the description of a user setting
 msgctxt "settings"
 msgid "Changes how the header is displayed and its behavior as you scroll"
-msgstr ""
-"Wijzigt de weergave van de header en bepaalt wat ermee gebeurt als je scrolt"
+msgstr "Wijzigt de weergave van de header en bepaalt wat ermee gebeurt als je scrolt"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/mcZdcaF.png
@@ -3790,16 +3792,14 @@ msgstr "Privé chatten"
 #. Mobile variant of DUCKCHAT_BROWSER_UPSELL_PROMO_TEXT. Shorter version for the promotional card encouraging third-party browser users to download the DuckDuckGo browser.
 msgctxt "Promotional text (mobile)"
 msgid "Chat privately on any website with Duck.ai built into our free browser."
-msgstr ""
-"Chat privé op elke website met Duck.ai, ingebouwd in onze gratis browser."
+msgstr "Chat privé op elke website met Duck.ai, ingebouwd in onze gratis browser."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card encouraging third-party browser users to download the DuckDuckGo browser. Not shown in the DuckDuckGo browser or on Linux.
 msgctxt "Promotional text"
 msgid ""
 "Chat privately on any website with the Duck.ai sidebar in our free browser."
-msgstr ""
-"Chat privé op elke website met de Duck.ai-zijbalk in onze gratis browser."
+msgstr "Chat privé op elke website met de Duck.ai-zijbalk in onze gratis browser."
 
 # smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
@@ -5158,8 +5158,7 @@ msgstr "Costa Rica"
 #. Inline error shown on the recovery code screen when exportSyncSettings rejects.
 msgctxt "Error message when the recovery code fails to generate"
 msgid "Couldn't load your recovery code. Please close this and try again."
-msgstr ""
-"Uw herstelcode kon niet worden geladen. Sluit dit en probeer het opnieuw."
+msgstr "Uw herstelcode kon niet worden geladen. Sluit dit en probeer het opnieuw."
 
 # smartling.placeholder_format=C
 #. Pairs with a Retry button. Shown after two consecutive failed attempts to load the device list.
@@ -5208,7 +5207,7 @@ msgstr "Afbeelding maken"
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
-msgstr ""
+msgstr "Maak een boodschappenlijst met de juiste hoeveelheden om dit recept te maken."
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed in the input field when starting a new image generation session.
@@ -5465,8 +5464,7 @@ msgstr "Dagelijkse limiet bereikt"
 #. Displayed when the user has reached a fixed daily Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Daily usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Dagelijkse gebruikslimiet bereikt. Je kunt dit gesprek voortzetten na %1$s."
+msgstr "Dagelijkse gebruikslimiet bereikt. Je kunt dit gesprek voortzetten na %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable daily Duck.ai usage limit and can opt in to continue using the weekly limit.
@@ -5854,7 +5852,7 @@ msgstr "Dicteerlimiet is bereikt"
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
 msgid "Dictation temporarily unavailable"
-msgstr ""
+msgstr "Dicteren tijdelijk niet beschikbaar"
 
 # smartling.placeholder_format=C
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
@@ -5943,8 +5941,7 @@ msgstr "Uitschakelen en loskoppelen"
 #. Title of a modal that asks the user if they want to turn off chat history and disconnect from Sync & Backup.
 msgctxt "Modal header for disabling chat history and disconnecting sync"
 msgid "Disable chat history and disconnect from Sync & Backup?"
-msgstr ""
-"Chatgeschiedenis uitschakelen en de verbinding met Sync & Backup verbreken?"
+msgstr "Chatgeschiedenis uitschakelen en de verbinding met Sync & Backup verbreken?"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to turn off the chat history feature.
@@ -6164,6 +6161,8 @@ msgid ""
 "Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
 "filtered out. %sLearn More%s"
 msgstr ""
+"Liever geen AI? %1$snoai.duckduckgo.com%2$s schakelt AI-functies uit en "
+"filtert AI-afbeeldingen weg. %3$sMeer informatie%4$s"
 
 # smartling.placeholder_format=C
 #. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
@@ -6172,6 +6171,8 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
+"Liever geen AI? Ga naar %1$snoai.duckduckgo.com%2$s om te zoeken zonder "
+"AI-functies en met AI-afbeeldingen weggefilterd. %3$sMeer informatie%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6291,13 +6292,13 @@ msgstr ""
 #. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Draft a cover letter"
-msgstr ""
+msgstr "Een sollicitatiebrief opstellen"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Draft a cover letter for this job."
-msgstr ""
+msgstr "Stel een sollicitatiebrief op voor deze baan."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -6387,8 +6388,7 @@ msgstr "Sleep je foto's of PDF-bestanden"
 # smartling.placeholder_format=C
 #. A title explaining what Duck Player (DDG's feature to watch youtube videos more privately) does
 msgid "Duck Player lets you watch YouTube without targeted ads"
-msgstr ""
-"Met Duck Player kun je YouTube-video's bekijken zonder gerichte advertenties"
+msgstr "Met Duck Player kun je YouTube-video's bekijken zonder gerichte advertenties"
 
 # smartling.placeholder_format=C
 #. This is the DDG version of "Google it", meaning "search it".
@@ -6485,6 +6485,10 @@ msgid ""
 "company for anyone who wants to take back control of their personal "
 "information."
 msgstr ""
+"Duck.ai is gemaakt door DuckDuckGo. We zijn een onafhankelijk online "
+"beveiligingsbedrijf voor iedereen die weer controle wil krijgen over zijn of "
+"haar persoonlijke gegevens.\n"
+"\n"
 
 # smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
@@ -6515,8 +6519,8 @@ msgid ""
 "Duck.ai is temporarily unavailable. If this persists, please email this "
 "anonymous code %s to %s"
 msgstr ""
-"Duck.ai is tijdelijk niet beschikbaar. Als dit aanhoudt, stuur dan een e-"
-"mail met deze anonieme code %1$s naar %2$s"
+"Duck.ai is tijdelijk niet beschikbaar. Als dit aanhoudt, stuur dan een "
+"e-mail met deze anonieme code %1$s naar %2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -6539,6 +6543,9 @@ msgid ""
 "Duck.ai lets you chat privately with popular AI models. Disabling it hides "
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
+"Met Duck.ai kun je privé chatten met populaire AI-modellen. Als je dit "
+"uitschakelt, worden de Duck.ai-knoppen en links verborgen, maar je kunt nog "
+"steeds %1$sduck.ai%2$s bezoeken ."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6575,8 +6582,7 @@ msgstr ""
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
 msgctxt "Promotional text for PDF upload feature"
 msgid "Duck.ai now can read and analyze PDFs. Give it a try!"
-msgstr ""
-"Duck.ai kan nu pdf-bestanden lezen en analyseren. Probeer het maar eens!"
+msgstr "Duck.ai kan nu pdf-bestanden lezen en analyseren. Probeer het maar eens!"
 
 # smartling.placeholder_format=C
 #. Disclaimer text shown above the chat input only when coming from a DuckAssist grounded response into ungrounded models.
@@ -6614,8 +6620,8 @@ msgid ""
 "models, privacy focused AI, no account AI chat"
 msgstr ""
 "Duck.ai, DuckDuckGo AI, privé AI-chatbot, gratis AI-chat, anonieme AI-chat, "
-"AI-chat zonder aanmelden, OpenAI, Anthropic, Llama, Mistral, open source  AI-"
-"modellen, privacy  AI, AI-chat zonder account"
+"AI-chat zonder aanmelden, OpenAI, Anthropic, Llama, Mistral, open "
+"source  AI-modellen, privacy  AI, AI-chat zonder account"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -6687,9 +6693,9 @@ msgid ""
 msgstr ""
 "DuckAssist is een nieuwe functie in onze zoekresultaten die anoniem "
 "antwoorden voor zoekopdrachten kan genereren. Hij scant daarvoor Wikipedia "
-"en gerelateerde sites op relevante inhoud en gebruikt vervolgens AI-"
-"technologie voor natuurlijke taal om die informatie samen te vatten. Let op: "
-"de antwoorden zijn op dit moment gebaseerd op Wikipedia en gerelateerde "
+"en gerelateerde sites op relevante inhoud en gebruikt vervolgens "
+"AI-technologie voor natuurlijke taal om die informatie samen te vatten. Let "
+"op: de antwoorden zijn op dit moment gebaseerd op Wikipedia en gerelateerde "
 "inhoud en worden niet gecontroleerd op juistheid."
 
 # smartling.placeholder_format=C
@@ -6787,8 +6793,7 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr ""
-"DuckDuckGo AI Chat is tijdelijk niet beschikbaar. Probeer het later opnieuw."
+msgstr "DuckDuckGo AI Chat is tijdelijk niet beschikbaar. Probeer het later opnieuw."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -7010,8 +7015,7 @@ msgctxt ""
 "Description of the DuckDuckGo subscription setting when it is not available "
 "in the user region"
 msgid "DuckDuckGo subscriptions are not available to purchase in this region."
-msgstr ""
-"DuckDuckGo-abonnementen zijn niet beschikbaar voor aankoop in deze regio."
+msgstr "DuckDuckGo-abonnementen zijn niet beschikbaar voor aankoop in deze regio."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use 'ducky' tone in its responses. When this option is selected, the AI assistant speaks like a duck.
@@ -7390,8 +7394,7 @@ msgstr "Ben je tevreden met Duck.ai?"
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure %s'Allow'%s is selected for the 'Location' setting."
-msgstr ""
-"Zorg dat %1$s'Toestaan'%2$s is geselecteerd voor de instelling 'Locatie'."
+msgstr "Zorg dat %1$s'Toestaan'%2$s is geselecteerd voor de instelling 'Locatie'."
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
@@ -7549,13 +7552,13 @@ msgstr "Eritrea"
 #. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Estimate the nutrition"
-msgstr ""
+msgstr "De voedingswaarde inschatten"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Estimate the nutritional information for this recipe."
-msgstr ""
+msgstr "Schat de voedingsinformatie voor dit recept in."
 
 # smartling.placeholder_format=C
 msgid "Estonia"
@@ -7591,8 +7594,7 @@ msgstr "Kaart uitvouwen"
 #. Subtitle for the Collaborations promotional card at the bottom of search results. Describes the branded merchandise line. 'Give a duck' is a wordplay on the DuckDuckGo brand name.
 msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
-msgstr ""
-"Vakkundig vervaardigde producten voor mensen die echt om privacy geven."
+msgstr "Vakkundig vervaardigde producten voor mensen die echt om privacy geven."
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
@@ -7616,7 +7618,7 @@ msgstr "Verloopt over 1 dag"
 #. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain the accepted answer in simple terms."
-msgstr ""
+msgstr "Leg het geaccepteerde antwoord in eenvoudige bewoordingen uit."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
@@ -7629,43 +7631,43 @@ msgstr "Leg me de basis van zwarte gaten uit op middelbare schoolniveau."
 #. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain the top answer"
-msgstr ""
+msgstr "Geef uitleg voor het beste antwoord"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain this in simple, plain language."
-msgstr ""
+msgstr "Leg dit uit in eenvoudige, gewone taal."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain this paper"
-msgstr ""
+msgstr "Dit artikel nader uitleggen"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain this repo"
-msgstr ""
+msgstr "Leg deze repo uit"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain this research paper in plain language."
-msgstr ""
+msgstr "Leg dit onderzoeksartikel uit in eenvoudige taal."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain this simply"
-msgstr ""
+msgstr "Leg dit eenvoudig uit"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain what this repository does and how to use it."
-msgstr ""
+msgstr "Leg uit wat deze repository doet en hoe je deze gebruikt."
 
 # smartling.placeholder_format=C
 #. Label to show if song lyrics contain explicit content
@@ -7941,8 +7943,7 @@ msgstr "Filters niet effectief"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Filters out AI-generated images from image search results"
-msgstr ""
-"Filtert AI-gegenereerde afbeeldingen uit de zoekresultaten van afbeeldingen."
+msgstr "Filtert AI-gegenereerde afbeeldingen uit de zoekresultaten van afbeeldingen."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -7957,6 +7958,8 @@ msgctxt "settings"
 msgid ""
 "Filters out known AI spam sites from image search results. %sLearn More%s"
 msgstr ""
+"Hiermee filter je bekende AI-spamsites uit de zoekresultaten voor "
+"afbeeldingen. %1$sMeer informatie%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the final score of a sporting event.
@@ -8017,7 +8020,7 @@ msgstr "Actuele informatie zoeken"
 #. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Find me alternatives"
-msgstr ""
+msgstr "Alternatieven zoeken"
 
 # smartling.placeholder_format=C
 #. Button that searches for results closer to the user's current location.
@@ -8327,9 +8330,9 @@ msgid ""
 "<strong>Check for Updates...</strong>, then select <strong>Install Update</"
 "strong>."
 msgstr ""
-"Selecteer in de menubalk van de app voor Mac de optie <strong>DuckDuckGo</"
-"strong> &gt; <strong>Controleren op updates...</strong> en selecteer "
-"vervolgens <strong>Update installeren</strong>."
+"Selecteer in de menubalk van de app voor Mac de optie "
+"<strong>DuckDuckGo</strong> &gt; <strong>Controleren op updates...</strong> "
+"en selecteer vervolgens <strong>Update installeren</strong>."
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -8500,7 +8503,7 @@ msgstr "Genereer meer"
 #. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Generate a shopping list"
-msgstr ""
+msgstr "Een boodschappenlijst genereren"
 
 # smartling.placeholder_format=C
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
@@ -8694,8 +8697,9 @@ msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"Krijg toegang tot geavanceerde AI-modellen in Duck.ai met een DuckDuckGo-"
-"abonnement, dat ook onze VPN en andere premium privacybeschermingen omvat."
+"Krijg toegang tot geavanceerde AI-modellen in Duck.ai met een "
+"DuckDuckGo-abonnement, dat ook onze VPN en andere premium "
+"privacybeschermingen omvat."
 
 # smartling.placeholder_format=C
 #. A button for users to generate an AI generated answer from their query on the duckassist module
@@ -8799,7 +8803,7 @@ msgstr "Proberen"
 #. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Give me a quick background on this person."
-msgstr ""
+msgstr "Geef me korte achtergrondinformatie over deze persoon."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9251,13 +9255,13 @@ msgstr "Help privacy verspreiden"
 #. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Help me prep for the interview"
-msgstr ""
+msgstr "Help me met de voorbereiding op het sollicitatiegesprek"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Help me tailor my resume for this job."
-msgstr ""
+msgstr "Help me mijn cv af te stemmen op deze vacature."
 
 # smartling.placeholder_format=C
 #. Title of a SERP popup that invites users to take a survey (desktop only)
@@ -9782,7 +9786,7 @@ msgctxt ""
 "Text for the I already have a subscription button in the Duck.ai settings "
 "page"
 msgid "I Already Have a Subscription"
-msgstr ""
+msgstr "Ik heb al een abonnement"
 
 # smartling.placeholder_format=C
 #. Text for the button that takes the user to the login subscription page.
@@ -10101,8 +10105,8 @@ msgctxt "settings"
 msgid ""
 "Improves result legibility with updated URL format, placement, and color"
 msgstr ""
-"Verbetert de leesbaarheid van het resultaat met een bijgewerkte URL-"
-"indeling, -plaatsing en -kleur"
+"Verbetert de leesbaarheid van het resultaat met een bijgewerkte "
+"URL-indeling, -plaatsing en -kleur"
 
 # smartling.placeholder_format=C
 #. A label that appears in front of the name of a company that DuckDuckGo has partnered with. For example, 'In partnership with Wikipedia'
@@ -10367,7 +10371,7 @@ msgstr "Mac-browser installeren"
 #. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
 msgctxt "settings"
 msgid "Install Now"
-msgstr ""
+msgstr "Nu installeren"
 
 # smartling.placeholder_format=C
 #. Text of a button to install the DuckDuckGo app
@@ -10470,13 +10474,13 @@ msgstr "Is verwijderde data echt verwijderd?"
 #. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Is it worth taking?"
-msgstr ""
+msgstr "Is het de moeite waard?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Is this place any good?"
-msgstr ""
+msgstr "Is dit een goede plek?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
@@ -10485,6 +10489,8 @@ msgid ""
 "Is this place any good? Summarize its reputation based on reviews and "
 "ratings."
 msgstr ""
+"Is dit een goede plek? Vat de reputatie samen op basis van beoordelingen en "
+"ratings."
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -10496,13 +10502,13 @@ msgstr "Is deze video nuttig?"
 #. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Is this worth watching?"
-msgstr ""
+msgstr "Is dit de moeite waard om te bekijken?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Is this worth watching? Give me a spoiler-free take."
-msgstr ""
+msgstr "Is dit de moeite waard? Geef me een mening zonder spoilers."
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -10975,8 +10981,7 @@ msgstr "Lees meer over hoe het werkt"
 # smartling.placeholder_format=C
 msgctxt "SERP footer content"
 msgid "Learn why reducing online tracking is important."
-msgstr ""
-"Informatie over waarom het terugdringen van online tracking belangrijk is."
+msgstr "Informatie over waarom het terugdringen van online tracking belangrijk is."
 
 # smartling.placeholder_format=C
 #. A link that takes users to a page where they can learn more about the dangers of online tracking.
@@ -11120,6 +11125,8 @@ msgstr "Links:"
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
 msgstr ""
+"Maak een lijst van het gereedschap, de materialen en andere dingen die ik "
+"hiervoor nodig heb."
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -11412,8 +11419,7 @@ msgstr "Zorg ervoor dat alle woorden correct gespeld zijn."
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Make sure to check %s\"Make this my default search provider\"%s"
-msgstr ""
-"Controleer of %1$s'Dit wordt mijn standaard zoekmachine'%2$s is aangevinkt"
+msgstr "Controleer of %1$s'Dit wordt mijn standaard zoekmachine'%2$s is aangevinkt"
 
 # smartling.placeholder_format=C
 #. Message prompting users to check the spelling of their search term.
@@ -11534,7 +11540,7 @@ msgstr "Geblokkeerde sites beheren"
 #. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
 msgctxt "setting"
 msgid "Manage in Browser Settings"
-msgstr ""
+msgstr "Beheren in browserinstellingen"
 
 # smartling.placeholder_format=C
 #. Link to the site exclusion settings page
@@ -12824,8 +12830,7 @@ msgstr "Geen resultaten gevonden."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the recording contains no audible speech.
 msgid "No speech detected. Please try again and speak into your microphone."
-msgstr ""
-"Geen spraak gedetecteerd. Probeer het nog eens en spreek in de microfoon."
+msgstr "Geen spraak gedetecteerd. Probeer het nog eens en spreek in de microfoon."
 
 # smartling.placeholder_format=C
 #. Button that dismisses a feedback form.
@@ -13453,8 +13458,7 @@ msgstr "%1$s-website openen"
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open %sLocation%s, and ensure location is %senabled%s"
-msgstr ""
-"Open %1$sLocatie%2$s en zorg ervoor dat locatie %3$sis ingeschakeld%4$s"
+msgstr "Open %1$sLocatie%2$s en zorg ervoor dat locatie %3$sis ingeschakeld%4$s"
 
 #  Chrome/Firefox on Android/iOS
 # smartling.placeholder_format=C
@@ -13617,8 +13621,7 @@ msgstr "Open het paneel 'Hoe Duck.ai werkt'"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open the Safari menu and select %sSettings for DuckDuckGo...%s"
-msgstr ""
-"Open het Safari-menu en selecteer %1$sInstellingen voor DuckDuckGo...%2$s"
+msgstr "Open het Safari-menu en selecteer %1$sInstellingen voor DuckDuckGo...%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the time a business opens. For example: 'Opens at 10am'
@@ -14377,7 +14380,7 @@ msgstr ""
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is harmful or illegal. (optional)"
-msgstr ""
+msgstr "Beschrijf waarom de chatreactie schadelijk of illegaal is. (optioneel)"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
@@ -14414,6 +14417,8 @@ msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is harmful or illegal."
 msgstr ""
+"Plak je prompt en de problematische uitvoer (zonder eventuele persoonlijke "
+"informatie) en beschrijf waarom de inhoud schadelijk of illegaal is."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -14853,8 +14858,7 @@ msgstr "Prijs"
 #. Category of feedback a user can select on a feedback form.
 msgctxt "feedback form"
 msgid "Price shown doesn't reflect merchant site"
-msgstr ""
-"De weergegeven prijs komt niet overeen met die op de site van de verkoper"
+msgstr "De weergegeven prijs komt niet overeen met die op de site van de verkoper"
 
 # smartling.placeholder_format=C
 #. A button that prints the contents of a page.
@@ -14887,7 +14891,7 @@ msgstr "Privacy"
 #. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
 msgctxt "Section heading on the Duck.ai settings page"
 msgid "Privacy & Terms"
-msgstr ""
+msgstr "Privacy en voorwaarden"
 
 # smartling.placeholder_format=C
 msgid "Privacy Blog"
@@ -14963,7 +14967,7 @@ msgstr "Privacybeleid en servicevoorwaarden"
 #. Text for a button that links to the terms of use and privacy policy page.
 msgctxt "Secondary button text in active privacy modal"
 msgid "Privacy Policy and Terms of Service"
-msgstr ""
+msgstr "Privacybeleid en servicevoorwaarden"
 
 # smartling.placeholder_format=C
 #. Title displayed on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
@@ -15137,8 +15141,7 @@ msgstr "Vraag het mij"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Prompt me to use my approximate location to get nearby results."
-msgstr ""
-"Vraag me om mijn geschatte locatie te gebruiken voor resultaten in de buurt."
+msgstr "Vraag me om mijn geschatte locatie te gebruiken voor resultaten in de buurt."
 
 # smartling.placeholder_format=C
 #. DuckDuckGo Email Protection removes trackers from emails
@@ -15470,25 +15473,25 @@ msgstr "Een boek aanbevelen"
 #. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Recommend similar books"
-msgstr ""
+msgstr "Vergelijkbare boeken aanbevelen"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Recommend similar books."
-msgstr ""
+msgstr "Beveel vergelijkbare boeken aan."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Recommend similar movies or shows."
-msgstr ""
+msgstr "Beveel soortgelijke films of series aan."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Recommend similar titles"
-msgstr ""
+msgstr "Beveel vergelijkbare titels aan"
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
@@ -15714,8 +15717,7 @@ msgstr "Mijn keuze onthouden"
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings
 msgid "Remember my choice (this can be changed in %s%s%sSettings%s)"
-msgstr ""
-"Onthoud mijn keuze (dit kun je wijzigen in de %1$s%2$s%3$sInstellingen%4$s)"
+msgstr "Onthoud mijn keuze (dit kun je wijzigen in de %1$s%2$s%3$sInstellingen%4$s)"
 
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
@@ -15901,7 +15903,7 @@ msgctxt ""
 "feedback form when the user has selected Harmful or Illegal as the feedback "
 "reason"
 msgid "Required for harmful or illegal reports"
-msgstr ""
+msgstr "Vereist voor meldingen van schadelijke of illegale inhoud"
 
 # smartling.placeholder_format=C
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
@@ -16144,7 +16146,7 @@ msgstr "Beoordelingen"
 #. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Rewrite this recipe scaled for a different number of servings."
-msgstr ""
+msgstr "Pas dit recept aan voor een ander aantal porties."
 
 # smartling.placeholder_format=C
 msgid "Romania"
@@ -16430,8 +16432,7 @@ msgstr "Bewaar maximaal 30 van je meest recente chats op je apparaat."
 msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
-msgstr ""
-"Bewaar je Duck.ai-chats tussen je apparaten met end-to-end-versleuteling."
+msgstr "Bewaar je Duck.ai-chats tussen je apparaten met end-to-end-versleuteling."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -16547,15 +16548,13 @@ msgstr "Schotland"
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Scroll down and click %sView advanced settings%s"
-msgstr ""
-"Scroll naar beneden en klik op %1$sGeavanceerde instellingen weergeven%2$s"
+msgstr "Scroll naar beneden en klik op %1$sGeavanceerde instellingen weergeven%2$s"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down and click %sView advanced settings%s."
-msgstr ""
-"Scroll naar beneden en klik op %1$sGeavanceerde instellingen weergeven%2$s."
+msgstr "Scroll naar beneden en klik op %1$sGeavanceerde instellingen weergeven%2$s."
 
 #  Edge Legacy default search engine instruction, obsolete?
 # smartling.placeholder_format=C
@@ -16798,8 +16797,8 @@ msgid ""
 "Search other sites with %s shortcuts: a search for ”!w ducks” will search "
 "for “ducks” directly on Wikipedia."
 msgstr ""
-"Zoek op andere sites met snelkoppelingen naar %1$s: een zoekopdracht naar \"!"
-"w ducks\" zal onmiddellijk op Wikipedia naar \"eenden\" zoeken."
+"Zoek op andere sites met snelkoppelingen naar %1$s: een zoekopdracht naar "
+"\"!w ducks\" zal onmiddellijk op Wikipedia naar \"eenden\" zoeken."
 
 # smartling.placeholder_format=C
 #. Placeholder text for the search form when no text has been entered
@@ -16978,8 +16977,7 @@ msgstr ""
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
 msgctxt "Sync feature benefit description"
 msgid "Securely stored on DuckDuckGo's server with end-to-end encryption."
-msgstr ""
-"Veilig opgeslagen op de server van DuckDuckGo met end-to-end-versleuteling."
+msgstr "Veilig opgeslagen op de server van DuckDuckGo met end-to-end-versleuteling."
 
 # smartling.placeholder_format=C
 #. List item explaining that synced chats are stored with end-to-end encryption on DuckDuckGo's server and only the user can access them.
@@ -17100,8 +17098,7 @@ msgstr "Bekijk enkele van onze nieuwste updates"
 #. Link to a page with more information about how user settings are stored in a URL.
 msgctxt "settings"
 msgid "See the %sURL Parameter Reference page%s for more details."
-msgstr ""
-"Kijk op de %1$sreferentiepagina voor URL-parameters%2$s voor meer informatie."
+msgstr "Kijk op de %1$sreferentiepagina voor URL-parameters%2$s voor meer informatie."
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the context menu of a chat in chat history, that allows the user to select the chat and begin batch selection mode.
@@ -17128,8 +17125,7 @@ msgstr "Selecteer %1$s%2$s%3$s en vervolgens %4$sZoekmachine%5$s"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %s'Setting for this Website...'%s from the Safari menu."
-msgstr ""
-"Selecteer %1$s'Instellingen voor deze website...'%2$s vanuit het Safari-menu."
+msgstr "Selecteer %1$s'Instellingen voor deze website...'%2$s vanuit het Safari-menu."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -17142,21 +17138,18 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
-msgstr ""
-"Selecteer %1$sDuckDuckGo%2$s en klik op %3$sToevoegen als standaard%4$s."
+msgstr "Selecteer %1$sDuckDuckGo%2$s en klik op %3$sToevoegen als standaard%4$s."
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s"
-msgstr ""
-"Selecteer %1$sDuckDuckGo%2$s en klik op %3$sInstellen als standaard%4$s"
+msgstr "Selecteer %1$sDuckDuckGo%2$s en klik op %3$sInstellen als standaard%4$s"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s."
-msgstr ""
-"Selecteer %1$sDuckDuckGo%2$s en klik op %3$sInstellen als standaard%4$s."
+msgstr "Selecteer %1$sDuckDuckGo%2$s en klik op %3$sInstellen als standaard%4$s."
 
 #  Firefox 33
 # smartling.placeholder_format=C
@@ -17168,8 +17161,7 @@ msgstr "Selecteer %1$sDuckDuckGo%2$s in het uitklapmenu Standaard zoekmachine"
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %sDuckDuckGo%s in the list and %sallow%s location access"
-msgstr ""
-"Selecteer %1$sDuckDuckGo%2$s in de lijst en geef %3$stoegang tot%4$s locatie"
+msgstr "Selecteer %1$sDuckDuckGo%2$s in de lijst en geef %3$stoegang tot%4$s locatie"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -17181,8 +17173,7 @@ msgstr "Selecteer %1$sDuckDuckGo%2$s in de lijst met zoekmachines"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s under the%sDefault Search Engine%s section"
-msgstr ""
-"Selecteer %1$sDuckDuckGo%2$s in het gedeelte %3$sStandaard zoekmachine%4$s"
+msgstr "Selecteer %1$sDuckDuckGo%2$s in het gedeelte %3$sStandaard zoekmachine%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user were in the settings menu they can change their default search engine.
@@ -17269,8 +17260,7 @@ msgstr ""
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sDefault search engine%s"
-msgstr ""
-"Selecteer %1$sInstellingen%2$s en vervolgens %3$sStandaard zoekmachine%4$s"
+msgstr "Selecteer %1$sInstellingen%2$s en vervolgens %3$sStandaard zoekmachine%4$s"
 
 #  Chrome/Firefox on Android
 # smartling.placeholder_format=C
@@ -17292,8 +17282,7 @@ msgstr ""
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %syour browser%s in the list and %sallow%s location access"
-msgstr ""
-"Selecteer %1$sje browser%2$s in de lijst en %3$slaat%4$s locatietoegang toe"
+msgstr "Selecteer %1$sje browser%2$s in de lijst en %3$slaat%4$s locatietoegang toe"
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the modal for deleting all recent chats, that allows the user to select the chats to delete.
@@ -17491,7 +17480,7 @@ msgstr "Nu instellen"
 #. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
 msgctxt "Encrypted storage setup button shown in native browsers"
 msgid "Set Up Sync & Backup"
-msgstr ""
+msgstr "Sync & Backup instellen"
 
 # smartling.placeholder_format=C
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
@@ -17613,8 +17602,8 @@ msgid ""
 "never reveals your precise location to us or AI models."
 msgstr ""
 "Deel een locatie op stadsniveau met AI-modellen om de relevantie te "
-"verbeteren. Duck.ai onthult nooit je precieze locatie aan ons of aan AI-"
-"modellen."
+"verbeteren. Duck.ai onthult nooit je precieze locatie aan ons of aan "
+"AI-modellen."
 
 # smartling.placeholder_format=C
 #. Menu option to share feedback about a result
@@ -17679,7 +17668,7 @@ msgstr "Deel positieve feedback"
 msgctxt ""
 "Label beside the share-content switch on the Duck.ai response feedback form"
 msgid "Share this conversation with DuckDuckGo"
-msgstr ""
+msgstr "Deel dit gesprek met DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -18086,8 +18075,7 @@ msgstr "Meest bezochte links weergeven op een nieuw tabblad"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your browser"
-msgstr ""
-"Geeft af en toe herinneringen weer om DuckDuckGo aan je browser toe te voegen"
+msgstr "Geeft af en toe herinneringen weer om DuckDuckGo aan je browser toe te voegen"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18101,8 +18089,8 @@ msgctxt "settings"
 msgid ""
 "Shows occasional reminders to sign up for the DuckDuckGo privacy newsletters"
 msgstr ""
-"Geeft af en toe herinneringen weer om je aan te melden voor de DuckDuckGo-"
-"nieuwsbrieven over privacy"
+"Geeft af en toe herinneringen weer om je aan te melden voor de "
+"DuckDuckGo-nieuwsbrieven over privacy"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18112,8 +18100,7 @@ msgstr "Geeft paginanummers weer naast resultaatpagina-einden"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows sign-up form for the DuckDuckGo privacy newsletters"
-msgstr ""
-"Geeft een inschrijfformulier weer voor de DuckDuckGo-privacynieuwsbrieven"
+msgstr "Geeft een inschrijfformulier weer voor de DuckDuckGo-privacynieuwsbrieven"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/94erFcS.png
@@ -18142,8 +18129,8 @@ msgstr "Geeft een welkomstbericht weer bovenaan de pagina met zoekresultaten"
 msgctxt "settings"
 msgid "Shows welcome message to EU Android preference menu users"
 msgstr ""
-"Geeft een welkomstbericht weer aan gebruikers van het EU-Android-"
-"voorkeursmenu"
+"Geeft een welkomstbericht weer aan gebruikers van het "
+"EU-Android-voorkeursmenu"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers sometimes.
@@ -18361,8 +18348,7 @@ msgstr "Er is iets misgegaan"
 #. Error message indicating that the user's settings weren't able to be saved.
 msgctxt "cloudsave"
 msgid "Something went wrong saving to the server, please try again."
-msgstr ""
-"Er is iets misgegaan tijdens het opslaan naar de server. Probeer het opnieuw."
+msgstr "Er is iets misgegaan tijdens het opslaan naar de server. Probeer het opnieuw."
 
 # smartling.placeholder_format=C
 #. Body copy displayed under the Set Up Now button when the sync setup call fails.
@@ -18394,8 +18380,7 @@ msgstr "Soms"
 #. Generic error message shown when the image generation model cannot process the user's request.
 msgctxt "Error message from the image generation model"
 msgid "Sorry I can't help, please describe your image in a different way."
-msgstr ""
-"Sorry, ik kan het niet helpen. Omschrijf je afbeelding op een andere manier."
+msgstr "Sorry, ik kan het niet helpen. Omschrijf je afbeelding op een andere manier."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -18469,8 +18454,7 @@ msgstr ""
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr ""
-"Sorry, we konden je feedback niet verzenden. Probeer het later opnieuw."
+msgstr "Sorry, we konden je feedback niet verzenden. Probeer het later opnieuw."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -18780,8 +18764,7 @@ msgstr "Stop verborgen trackers die op de loer liggen op andere websites."
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop most hidden trackers lurking on other websites."
-msgstr ""
-"Stop de meeste verborgen trackers die op de loer liggen op andere websites."
+msgstr "Stop de meeste verborgen trackers die op de loer liggen op andere websites."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18955,18 +18938,20 @@ msgstr "Stel een titel voor een blogpost voor"
 msgctxt "Page suggestion prompt"
 msgid "Suggest related articles or topics worth exploring next."
 msgstr ""
+"Stel gerelateerde artikelen of onderwerpen voor die de moeite waard zijn om "
+"verder te lezen."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Suggest related articles to explore"
-msgstr ""
+msgstr "Gerelateerde artikelen voorstellen om verder te lezen"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Suggest some alternatives to this product."
-msgstr ""
+msgstr "Stel een aantal alternatieven voor dit product voor."
 
 # smartling.placeholder_format=C
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
@@ -18983,7 +18968,7 @@ msgstr "Suggesties:"
 #. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Sum up the reviews"
-msgstr ""
+msgstr "De beoordelingen samenvatten"
 
 # smartling.placeholder_format=C
 #. A short title for the a message asking the AI to summarize a text.
@@ -18995,85 +18980,87 @@ msgstr "Samenvatting"
 #. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize the Q&As"
-msgstr ""
+msgstr "De Q&A's samenvatten"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the background and notable work of this person."
 msgstr ""
+"Geef een samenvatting van de achtergrond en het belangrijkste werk van deze "
+"persoon."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the key details of this event."
-msgstr ""
+msgstr "Vat de belangrijkste details van dit evenement samen."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the questions and answers on this page."
-msgstr ""
+msgstr "Vat de vragen en antwoorden op deze pagina samen."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize their background"
-msgstr ""
+msgstr "Hun achtergrond samenvatten"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this book"
-msgstr ""
+msgstr "Dit boek samenvatten"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this book."
-msgstr ""
+msgstr "Vat dit boek samen."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this discussion"
-msgstr ""
+msgstr "Deze discussie samenvatten"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this discussion thread."
-msgstr ""
+msgstr "Vat deze discussiethread samen."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this page"
-msgstr ""
+msgstr "Deze pagina samenvatten"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this page."
-msgstr ""
+msgstr "Deze pagina samenvatten."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this video"
-msgstr ""
+msgstr "Deze video samenvatten"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this video."
-msgstr ""
+msgstr "Vat deze video samen."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize what the reviews say."
-msgstr ""
+msgstr "Vat samen wat er in de beoordelingen staat."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -19406,7 +19393,7 @@ msgstr "Syrië"
 #. Text for a button that enables the theme to follow the operating system's color scheme preference.
 msgctxt "System theme button for theme selector"
 msgid "System"
-msgstr ""
+msgstr "Systeem"
 
 # smartling.placeholder_format=C
 #. Abbreviation indicating this is the total score for a game
@@ -19440,7 +19427,7 @@ msgstr "Tahitiaans"
 #. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Tailor my resume"
-msgstr ""
+msgstr "Mijn cv aanpassen"
 
 # smartling.placeholder_format=C
 msgid "Taiwan"
@@ -19477,6 +19464,8 @@ msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
+"Vul deze anonieme enquête in om ons te laten weten hoe we Duck.ai kunnen "
+"verbeteren."
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -19714,15 +19703,13 @@ msgstr "Gambia"
 #. Error message displayed when the total size of all attached files in a conversation exceeds the allowed limit. Placeholder is the combined size limit in megabytes. E.g. The attached files exceed the total size limit of 5 MB
 msgctxt "Error message when combined file size exceeds the limit"
 msgid "The attached files exceed the total size limit of %s MB"
-msgstr ""
-"De bijgevoegde bestanden overschrijden de totale groottelimiet van %1$sMB"
+msgstr "De bijgevoegde bestanden overschrijden de totale groottelimiet van %1$sMB"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the total size of all attached files in a conversation exceeds the allowed limit. Placeholder is the combined size limit in megabytes. E.g. The attached files exceed the total size limit of 5 MB
 msgctxt "Error message when combined file size exceeds the limit"
 msgid "The attached files exceed the total size limit of %s MB."
-msgstr ""
-"De bijgevoegde bestanden overschrijden de totale groottelimiet van %1$s MB."
+msgstr "De bijgevoegde bestanden overschrijden de totale groottelimiet van %1$s MB."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the server rejects corrupt or unrecognized audio.
@@ -19778,8 +19765,7 @@ msgstr "Het verzoek is verlopen. Probeer het opnieuw."
 #. Inform the users that "something" went wrong and we are unable to show any results.
 msgctxt "noresults"
 msgid "The server encountered an error and could not complete your request."
-msgstr ""
-"De server heeft een fout aangetroffen en kon je verzoek niet voltooien."
+msgstr "De server heeft een fout aangetroffen en kon je verzoek niet voltooien."
 
 # smartling.placeholder_format=C
 #. Title for the theme menu:
@@ -19791,7 +19777,7 @@ msgstr "Thema"
 #. Text for the theme selector label that allows users to switch between Light and dark theme.
 msgctxt "Label for the theme selector feature"
 msgid "Theme"
-msgstr ""
+msgstr "Thema"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/LpFhb1e.png
@@ -19919,8 +19905,7 @@ msgstr ""
 #. Appears below a type of search results called 'Instant Answers'
 msgctxt "attribution"
 msgid "This Instant Answer was made by the %sDuckDuckHack%s Community."
-msgstr ""
-"Dit directe antwoord is gemaakt door de %1$sDuckDuckHack%2$s-community."
+msgstr "Dit directe antwoord is gemaakt door de %1$sDuckDuckHack%2$s-community."
 
 # smartling.placeholder_format=C
 #. Label for the monthly usage row in the Usage section of Duck.ai settings.
@@ -20113,8 +20098,7 @@ msgstr "Voor deze pagina moet JavaScript zijn ingeschakeld."
 #. Information tooltip text explaining that the current page's content will be included with the chat message.
 msgctxt "Tooltip explaining that page content will be sent to Duck.ai"
 msgid "This page's content will be sent with your message to Duck.ai"
-msgstr ""
-"De inhoud van deze pagina wordt samen met je bericht naar Duck.ai gestuurd"
+msgstr "De inhoud van deze pagina wordt samen met je bericht naar Duck.ai gestuurd"
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -20183,15 +20167,13 @@ msgstr "Deze vertaling is onjuist"
 # smartling.placeholder_format=C
 #. Label indicating that the video can't be played on the current page, and only on the website that owns the vide. The placeholder is the name of the website that owns the video.
 msgid "This video is not yet able to be watched here. You can watch it on %s."
-msgstr ""
-"Deze video kan hier nog niet worden bekeken. Je kunt 'm bekijken op %1$s."
+msgstr "Deze video kan hier nog niet worden bekeken. Je kunt 'm bekijken op %1$s."
 
 # smartling.placeholder_format=C
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr ""
-"Deze webpagina gebruikt geen beveiligde, versleutelde verbinding (HTTPS)."
+msgstr "Deze webpagina gebruikt geen beveiligde, versleutelde verbinding (HTTPS)."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -20310,8 +20292,8 @@ msgstr "Tips"
 # smartling.placeholder_format=C
 msgid "Tired of being tracked online? %sWe can help.%s"
 msgstr ""
-"Ben je het zat om online te worden gevolgd? %1$sWij kunnen je hierbij helpen."
-"%2$s"
+"Ben je het zat om online te worden gevolgd? %1$sWij kunnen je hierbij "
+"helpen.%2$s"
 
 # smartling.placeholder_format=C
 #. This is the name of a user setting
@@ -20343,8 +20325,7 @@ msgstr ""
 msgctxt ""
 "Copy stating agreement to Duck.ai Privacy Policy and Terms of Service."
 msgid "To continue, you must agree to Duck.ai’s %s and %s"
-msgstr ""
-"Om door te gaan, moet je akkoord gaan met het %1$s en het %2$s van Duck.ai"
+msgstr "Om door te gaan, moet je akkoord gaan met het %1$s en het %2$s van Duck.ai"
 
 # smartling.placeholder_format=C
 #. Text stating agreement to AI Chat Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'To continue, you must agree to DuckDuckGo AI Chat’s Privacy Policy and Terms of Service'
@@ -20385,8 +20366,8 @@ msgid ""
 "To transfer your chat history to Duck.ai, please update your DuckDuckGo "
 "browser to the latest version and try again."
 msgstr ""
-"Opdate om je chatgeschiedenis over te zetten naar Duck.ai je DuckDuckGo-"
-"browser naar de nieuwste versie en probeer het opnieuw."
+"Opdate om je chatgeschiedenis over te zetten naar Duck.ai je "
+"DuckDuckGo-browser naar de nieuwste versie en probeer het opnieuw."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
@@ -20651,13 +20632,13 @@ msgstr ""
 #. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Translate this page"
-msgstr ""
+msgstr "Vertaal deze pagina"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
 msgctxt "Page suggestion prompt"
 msgid "Translate this page into %s."
-msgstr ""
+msgstr "Vertaal deze pagina naar %1$s."
 
 # smartling.placeholder_format=C
 #. Placeholder text for a region that will display translated text.
@@ -20759,8 +20740,7 @@ msgstr "Probeer %1$s om dit soort berichten niet meer te zien."
 #. Text for a promotional card that encourages users to try the encrypted AI model whose inference runs in a confidential environment so the model provider cannot access user data. %s is replaced with the model's full display name (e.g. 'GPT-OSS 120B').
 msgctxt "Promotional text for encrypted AI model"
 msgid "Try %s, our first model with zero provider visibility."
-msgstr ""
-"Probeer %1$s, ons eerste model zonder enige zichtbaarheid bij zorgverleners."
+msgstr "Probeer %1$s, ons eerste model zonder enige zichtbaarheid bij zorgverleners."
 
 # smartling.placeholder_format=C
 msgid "Try %sDuck.ai%s, our private AI chat service:"
@@ -20805,7 +20785,7 @@ msgstr "Probeer gratis"
 #. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
 msgctxt "settings"
 msgid "Try It Now"
-msgstr ""
+msgstr "Probeer het nu"
 
 # smartling.placeholder_format=C
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -20871,16 +20851,14 @@ msgstr ""
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
 msgctxt "precise_user_location"
 msgid "Try enabling anonymous location for more accurate results."
-msgstr ""
-"Probeer anonieme locatie in te schakelen voor nauwkeurigere resultaten."
+msgstr "Probeer anonieme locatie in te schakelen voor nauwkeurigere resultaten."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the screen of the onboarding where the user picks a chat model.
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr ""
-"Probeer met alle modellen te experimenteren. Ze reageren allemaal anders."
+msgstr "Probeer met alle modellen te experimenteren. Ze reageren allemaal anders."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
@@ -20908,8 +20886,7 @@ msgstr "Probeer het gratis"
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
-msgstr ""
-"Probeer het gratis! Een veilige VPN, geavanceerde en privé-AI, en meer."
+msgstr "Probeer het gratis! Een veilige VPN, geavanceerde en privé-AI, en meer."
 
 # smartling.placeholder_format=C
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -20936,8 +20913,7 @@ msgstr "Probeer onze browser"
 # smartling.placeholder_format=C
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
-msgstr ""
-"Probeer onze homepage, waar je deze berichten nooit te zien zult krijgen:"
+msgstr "Probeer onze homepage, waar je deze berichten nooit te zien zult krijgen:"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with different words to get more results.
@@ -21054,6 +21030,8 @@ msgid ""
 "Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
+"Wil je AI-functies uitschakelen? Installeer de zoekextensie %1$sDuckDuckGo "
+"No AI%2$s om je instellingen te laten onthouden. %3$sMeer informatie%4$s"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -21062,6 +21040,8 @@ msgid ""
 "Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
+"Wil je AI-functies uitschakelen? Stap over op de zoekextensie %1$sDuckDuckGo "
+"No AI%2$s om je instellingen te laten onthouden. %3$sMeer informatie%4$s"
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -21342,8 +21322,7 @@ msgstr ""
 #. Message shown to the user when there was an issue connecting to their microphone.
 msgctxt "voice chat"
 msgid "Unable to connect to your mic. Please try again."
-msgstr ""
-"Er kan geen verbinding worden gemaakt met je microfoon. Probeer het opnieuw."
+msgstr "Er kan geen verbinding worden gemaakt met je microfoon. Probeer het opnieuw."
 
 # smartling.placeholder_format=C
 #. Error message for explore more questions when answer fails to load
@@ -21384,8 +21363,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sOpen with%s select %sA specific page or pages%s"
-msgstr ""
-"Bij %1$sOpenen met%2$s selecteer je %3$sEen specifieke pagina of pagina's%4$s"
+msgstr "Bij %1$sOpenen met%2$s selecteer je %3$sEen specifieke pagina of pagina's%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -21400,15 +21378,13 @@ msgstr "Bij %1$sZoekinstellingen%2$s selecteer je %3$sDuckDuckGo%4$s"
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch in the address bar with%s select %sAdd New%s"
-msgstr ""
-"Bij %1$sZoek in de adresbalk met%2$s selecteer je %3$sNieuwe toevoegen%4$s"
+msgstr "Bij %1$sZoek in de adresbalk met%2$s selecteer je %3$sNieuwe toevoegen%4$s"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
-msgstr ""
-"Bij het gedeelte %1$sZoeken%2$s klik je op %3$sZoekmachines beheren...%4$s"
+msgstr "Bij het gedeelte %1$sZoeken%2$s klik je op %3$sZoekmachines beheren...%4$s"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -21422,8 +21398,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine
 msgid "Under Search click the drop down and select %sDuckDuckGo%s"
-msgstr ""
-"Bij Zoeken klik je op het uitklapmenu en selecteer je %1$sDuckDuckGo%2$s"
+msgstr "Bij Zoeken klik je op het uitklapmenu en selecteer je %1$sDuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings" header
@@ -21524,8 +21499,8 @@ msgctxt "voice chat limit modal"
 msgid ""
 "Unlock advanced AI models and higher limits with a DuckDuckGo Subscription"
 msgstr ""
-"Ontgrendel geavanceerde AI-modellen en hogere limieten met een DuckDuckGo-"
-"abonnement"
+"Ontgrendel geavanceerde AI-modellen en hogere limieten met een "
+"DuckDuckGo-abonnement"
 
 # smartling.placeholder_format=C
 #. Text informing the user that advanced AI models can be unlocked with a subscription. The variable is used to insert a link that opens the subscription modal. Example: Unlock advanced AI models with a DuckDuckGo subscription.
@@ -21773,8 +21748,7 @@ msgstr ""
 #. Upsell message shown in the voice chat limit and duration limit modals for Plus subscribers, encouraging them to upgrade to Pro.
 msgctxt "voice chat limit modal"
 msgid "Upgrade to Pro to unlock 2x higher usage limits than Plus"
-msgstr ""
-"Upgrade naar Pro om 2x hogere gebruikslimieten dan Plus te ontgrendelen"
+msgstr "Upgrade naar Pro om 2x hogere gebruikslimieten dan Plus te ontgrendelen"
 
 # smartling.placeholder_format=C
 #. Heading in a promotion for a desktop web browser
@@ -21826,7 +21800,7 @@ msgstr "Uruguay"
 #. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
 msgctxt "Navigation label on the Duck.ai settings page"
 msgid "Usage"
-msgstr ""
+msgstr "Gebruik"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -21884,8 +21858,7 @@ msgstr "Gebruik DuckDuckGo Private Search"
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Use DuckDuckGo private search on your iPad, iPhone, or Android!"
-msgstr ""
-"Gebruik DuckDuckGo Private Search op je iPad, iPhone of Android-apparaat."
+msgstr "Gebruik DuckDuckGo Private Search op je iPad, iPhone of Android-apparaat."
 
 # smartling.placeholder_format=C
 #. User clicks this button to share their device's location
@@ -22162,10 +22135,10 @@ msgid ""
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
 msgstr ""
-"Bezoek Duck.ai in je andere browser of de DuckDuckGo-app en open 'Duck.ai-"
-"instellingen'. Selecteer 'Inschakelen' onder Sync & Backup en selecteer "
-"'Synchroniseren met een ander apparaat'. Of scan de QR-code op je herstel-"
-"PDF."
+"Bezoek Duck.ai in je andere browser of de DuckDuckGo-app en open "
+"'Duck.ai-instellingen'. Selecteer 'Inschakelen' onder Sync & Backup en "
+"selecteer 'Synchroniseren met een ander apparaat'. Of scan de QR-code op je "
+"herstel-PDF."
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -22283,7 +22256,7 @@ msgstr "Wales"
 #. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Walk me through the steps"
-msgstr ""
+msgstr "Help me door de stappen"
 
 # smartling.placeholder_format=C
 #. Label for walking directions on a map.
@@ -22364,8 +22337,8 @@ msgid ""
 "viewing activity from influencing YouTube recommendations."
 msgstr ""
 "Kijk in Duck Player om gepersonaliseerde advertenties op YouTube te "
-"blokkeren en te voorkomen dat je kijkactiviteit invloed heeft op YouTube-"
-"aanbevelingen."
+"blokkeren en te voorkomen dat je kijkactiviteit invloed heeft op "
+"YouTube-aanbevelingen."
 
 # smartling.placeholder_format=C
 #. A button that takes a user to another site in order to watch a video. The placeholder is the name of the video site. For example: 'Watch on Vimeo'
@@ -22414,6 +22387,9 @@ msgid ""
 "please share this conversation with DuckDuckGo so we can investigate and "
 "address the issue."
 msgstr ""
+"We kunnen alleen oplossen wat we kunnen zien. Als je een schadelijke of "
+"illegale reactie wilt melden, deel dan dit gesprek met DuckDuckGo zodat we "
+"het probleem kunnen onderzoeken en oplossen."
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -22455,14 +22431,12 @@ msgstr "We achtervolgen je niet met advertenties."
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
 msgid "We don't store usernames or any personally identifiable information."
-msgstr ""
-"We slaan geen gebruikersnamen of persoonlijk identificeerbare informatie op."
+msgstr "We slaan geen gebruikersnamen of persoonlijk identificeerbare informatie op."
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don't store your personal info or track you. Ever."
-msgstr ""
-"We slaan je persoonlijke gegevens niet op en volgen je ook niet. Nooit."
+msgstr "We slaan je persoonlijke gegevens niet op en volgen je ook niet. Nooit."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -22488,8 +22462,7 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what brought you "
 "back today:"
-msgstr ""
-"We volgen je niet, dus we horen graag van je waarom je bij ons terugkeert:"
+msgstr "We volgen je niet, dus we horen graag van je waarom je bij ons terugkeert:"
 
 # smartling.placeholder_format=C
 #. Message prompting users to fill out a feedback form.
@@ -22497,8 +22470,7 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what convinced you "
 "to try us out today:"
-msgstr ""
-"We volgen je niet, dus we horen graag van je waarom je ons wilt uitproberen:"
+msgstr "We volgen je niet, dus we horen graag van je waarom je ons wilt uitproberen:"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -22585,8 +22557,7 @@ msgstr "De verbinding is verbroken. Probeer het later opnieuw."
 #. We store chats for 15 minutes in the BE. If the user tries to fetch it after the 15 minutes elapsed or if we had an issue saving it we show them this error message so they can re-submit their prompt.
 msgctxt "AI Chat: Error message for unsaved or expired chats saved in sync"
 msgid "We lost the connection. Please try sending your message again."
-msgstr ""
-"We hebben de verbinding verloren. Probeer je bericht opnieuw te verzenden."
+msgstr "We hebben de verbinding verloren. Probeer je bericht opnieuw te verzenden."
 
 # smartling.placeholder_format=C
 #. Message asking the user to disable their ad blocker, with a link to how our ads don't track you. The placeholders are for the start and end tags of that link (e.g. <a href="%">, </a>)
@@ -22618,8 +22589,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We stop anyone from getting your search history, including us."
-msgstr ""
-"We zorgen ervoor dat niemand je zoekgeschiedenis kan inzien, ook wij niet."
+msgstr "We zorgen ervoor dat niemand je zoekgeschiedenis kan inzien, ook wij niet."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -22642,8 +22612,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
-msgstr ""
-"We blokkeren trackers die je gegevens willen verzamelen terwijl je surft."
+msgstr "We blokkeren trackers die je gegevens willen verzamelen terwijl je surft."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -22677,8 +22646,7 @@ msgctxt "duckai_migration"
 msgid ""
 "We're sorry for this inconvenience. We’re working hard to make your "
 "experience better."
-msgstr ""
-"Onze excuses voor dit ongemak. We doen ons best om je ervaring te verbeteren."
+msgstr "Onze excuses voor dit ongemak. We doen ons best om je ervaring te verbeteren."
 
 # smartling.placeholder_format=C
 #. Body text explaining the service update requires a page reload.
@@ -22782,8 +22750,7 @@ msgstr "Wekelijkse limiet bereikt"
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Weekly usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Wekelijkse gebruikslimiet bereikt. Je kunt dit gesprek voortzetten na %1$s."
+msgstr "Wekelijkse gebruikslimiet bereikt. Je kunt dit gesprek voortzetten na %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable weekly Duck.ai usage limit and can opt in to continue using the monthly limit.
@@ -22836,8 +22803,7 @@ msgstr ""
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai! You can now import your downloaded chats."
-msgstr ""
-"Welkom bij de nieuwe Duck.ai! Je kunt nu je gedownloade chats importeren."
+msgstr "Welkom bij de nieuwe Duck.ai! Je kunt nu je gedownloade chats importeren."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -22976,98 +22942,98 @@ msgstr ""
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the counterarguments?"
-msgstr ""
+msgstr "Wat zijn de tegenargumenten?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the hours & location?"
-msgstr ""
+msgstr "Wat zijn de openingstijden en locatie?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key contributions of this paper?"
-msgstr ""
+msgstr "Wat zijn de belangrijkste bijdragen van dit artikel?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key contributions?"
-msgstr ""
+msgstr "Wat zijn de belangrijkste bijdragen?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key details?"
-msgstr ""
+msgstr "Wat zijn de belangrijkste details?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key points covered in this video?"
-msgstr ""
+msgstr "Wat zijn de belangrijkste punten die in deze video aan bod komen?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key points?"
-msgstr ""
+msgstr "Wat zijn de belangrijkste punten?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key takeaways from this article?"
-msgstr ""
+msgstr "Wat zijn de belangrijkste punten uit dit artikel?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key takeaways?"
-msgstr ""
+msgstr "Wat zijn de belangrijkste punten?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key things I will learn from this course?"
-msgstr ""
+msgstr "Wat zijn de belangrijkste dingen die ik in deze cursus kan leren?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the main counterarguments or criticisms of this?"
-msgstr ""
+msgstr "Wat zijn de belangrijkste tegenargumenten of kritiekpunten hierop?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the main questions this page answers?"
-msgstr ""
+msgstr "Wat zijn de belangrijkste vragen die deze pagina beantwoordt?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the must-try dishes here?"
-msgstr ""
+msgstr "Wat zijn de gerechten die hier aangeraden worden?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid ""
 "What are the opening hours, location, and contact details for this place?"
-msgstr ""
+msgstr "Wat zijn de openingstijden, locatie en contactgegevens van deze plek?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the pros and cons of this product?"
-msgstr ""
+msgstr "Wat zijn de voor- en nadelen van dit product?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the pros and cons?"
-msgstr ""
+msgstr "Wat zijn de voor- en nadelen?"
 
 # smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
@@ -23173,7 +23139,7 @@ msgstr "Wat betekent atria in de context van een medisch artikel?"
 #. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What does this answer?"
-msgstr ""
+msgstr "Welke vragen worden hier beantwoord?"
 
 # smartling.placeholder_format=C
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
@@ -23191,7 +23157,7 @@ msgstr "Welke informatie wordt er opgeslagen?"
 #. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What interview questions might come up for this role?"
-msgstr ""
+msgstr "Welke sollicitatievragen kan ik voor deze vacature verwachten?"
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -23213,7 +23179,7 @@ msgstr "Wat is de hoofdstad van Albanië?"
 #. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What is the overall verdict and rating for this?"
-msgstr ""
+msgstr "Wat is hiervan de beoordeling en de conclusie?"
 
 # smartling.placeholder_format=C
 #. Link to a page with additional information.
@@ -23241,7 +23207,7 @@ msgstr "Wat mensen zeggen:"
 #. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What should I order?"
-msgstr ""
+msgstr "Wat moet ik bestellen?"
 
 # smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
@@ -23259,13 +23225,13 @@ msgstr "Wat was er mis met het antwoord? (optioneel)"
 #. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What will I learn?"
-msgstr ""
+msgstr "Wat ga ik leren?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What will I need?"
-msgstr ""
+msgstr "Wat heb ik nodig?"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -23290,7 +23256,7 @@ msgstr "Wat is er nieuw?"
 #. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What's the verdict?"
-msgstr ""
+msgstr "Wat is het oordeel?"
 
 # smartling.placeholder_format=C
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -23346,7 +23312,7 @@ msgstr "Welke functies ontbreken? (Optioneel)"
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Which features are missing? (optional)"
-msgstr ""
+msgstr "Welke functies ontbreken? (optioneel)"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
@@ -23369,12 +23335,14 @@ msgstr "Wie zijn wij"
 msgctxt "Page suggestion prompt"
 msgid "Who are the main cast and crew, and what else are they known for?"
 msgstr ""
+"Wie zijn de belangrijkste leden in de cast en crew, en waar staan ze nog "
+"meer om bekend?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Who is this person?"
-msgstr ""
+msgstr "Wie is deze persoon?"
 
 # smartling.placeholder_format=C
 #. Header above a collection of privacy-related links.
@@ -24001,8 +23969,8 @@ msgid ""
 "DuckDuckGo subscription protections in the DuckDuckGo browser."
 msgstr ""
 "Je hebt nu toegang tot geavanceerde AI-modellen. Je hebt toegang tot de VPN "
-"en andere beveiligingen van het DuckDuckGo-abonnement in de DuckDuckGo-"
-"browser."
+"en andere beveiligingen van het DuckDuckGo-abonnement in de "
+"DuckDuckGo-browser."
 
 # smartling.placeholder_format=C
 #. Welcome message that appears after the DuckDuckGo extension is installed.
@@ -24142,8 +24110,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
 msgid "You've reached your dictation usage limit. Try again later."
-msgstr ""
-"Je hebt je limiet voor dicteergebruik bereikt. probeer het later opnieuw"
+msgstr "Je hebt je limiet voor dicteergebruik bereikt. probeer het later opnieuw"
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -24312,8 +24279,8 @@ msgctxt "Active Privacy protection description"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
 msgstr ""
-"Je chats zijn privé, geanonimiseerd door ons en worden niet gebruikt om AI-"
-"modellen te trainen."
+"Je chats zijn privé, geanonimiseerd door ons en worden niet gebruikt om "
+"AI-modellen te trainen."
 
 # smartling.placeholder_format=C
 #. Text explaining that user chats are private and not used for AI (Artificial Intelligence) training.
@@ -24321,8 +24288,8 @@ msgctxt "Body text for privacy protection modal"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
 msgstr ""
-"Je chats zijn privé, geanonimiseerd door ons en worden niet gebruikt om AI-"
-"modellen te trainen."
+"Je chats zijn privé, geanonimiseerd door ons en worden niet gebruikt om "
+"AI-modellen te trainen."
 
 # smartling.placeholder_format=C
 #. Text for a menu item that describes the privacy protection feature.
@@ -24355,8 +24322,8 @@ msgid ""
 "Your chats are still private, anonymized by us, and not used to train AI "
 "models. Follow these steps to keep your chat history."
 msgstr ""
-"Je chats zijn privé, geanonimiseerd door ons en worden niet gebruikt om AI-"
-"modellen te trainen. Volg deze stappen om je chatgeschiedenis te bewaren."
+"Je chats zijn privé, geanonimiseerd door ons en worden niet gebruikt om "
+"AI-modellen te trainen. Volg deze stappen om je chatgeschiedenis te bewaren."
 
 # smartling.placeholder_format=C
 #. Body shown after import completes.
@@ -24572,8 +24539,7 @@ msgstr ""
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
 msgctxt "voice chat limit modal"
 msgid "You’ve reached the voice chat limit for now. Please try again later."
-msgstr ""
-"Je hebt de limiet voor spraakchat voor nu bereikt. Probeer het later opnieuw."
+msgstr "Je hebt de limiet voor spraakchat voor nu bereikt. Probeer het later opnieuw."
 
 # smartling.placeholder_format=C
 #. The name of the Yucatec Maya language
@@ -24656,8 +24622,7 @@ msgstr "door %1$s"
 #. Trust line shown at the bottom of the explainer panel, summarizing DuckDuckGo's reputation for online protection.
 msgctxt "Footer banner text in the How Duck.ai Works panel"
 msgid "by DuckDuckGo — online protection trusted by millions every day."
-msgstr ""
-"Door DuckDuckGo — online bescherming vertrouwd door miljoenen elke dag."
+msgstr "Door DuckDuckGo — online bescherming vertrouwd door miljoenen elke dag."
 
 # smartling.placeholder_format=C
 #. An abreviated unit of time indicating an age, e.g. "2d"

--- a/locales/nl_NL/LC_MESSAGES/duckduckgo.po
+++ b/locales/nl_NL/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: nl_NL\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -87,7 +87,8 @@ msgstr "%1$s en %2$s AI-modellen"
 #. Message that appears above the search results encouraging them to filter results by domain. The placeholder string would include a the name of a website. E.g. 'Reddit appears in some of the top results for this search.'
 msgctxt "Site filter message"
 msgid "%s appears in some of the top results for this search."
-msgstr "%1$s komt voor in een aantal van de beste resultaten voor deze zoekopdracht."
+msgstr ""
+"%1$s komt voor in een aantal van de beste resultaten voor deze zoekopdracht."
 
 # smartling.placeholder_format=C
 #. Number of tracking attempts blocked, when there is more than 1. Eg: '2 attempts' or '302 attempts'
@@ -416,7 +417,8 @@ msgstr "%1$s woorden"
 #. Instructions on which buttons and options the user has to click in order to add the DuckDuckGo extension to their browser.
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
-msgstr "%1$sKlik op %2$sToevoegen%3$sSelecteer %4$sToestaan%5$s en klik op %6$sOK%7$s"
+msgstr ""
+"%1$sKlik op %2$sToevoegen%3$sSelecteer %4$sToestaan%5$s en klik op %6$sOK%7$s"
 
 # Firefox, obsolete
 # smartling.placeholder_format=C
@@ -479,7 +481,8 @@ msgstr ""
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "%sLearn more%s about how chats are stored privately on your device."
-msgstr "%1$sLees meer%2$s over hoe chats privé worden opgeslagen op je apparaat."
+msgstr ""
+"%1$sLees meer%2$s over hoe chats privé worden opgeslagen op je apparaat."
 
 # smartling.placeholder_format=C
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
@@ -812,7 +815,8 @@ msgstr "De 6-uurs gebruikslimiet is bereikt."
 #. Displayed when the user has reached a fixed 6-hour Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "6-hour usage limit reached. You can continue this chat after %s."
-msgstr "De 6-uurs gebruikslimiet is bereikt. Je kunt dit gesprek voortzetten na %1$s."
+msgstr ""
+"De 6-uurs gebruikslimiet is bereikt. Je kunt dit gesprek voortzetten na %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable 6-hour Duck.ai usage limit and can opt in to continue using the daily limit.
@@ -1438,6 +1442,12 @@ msgid "Address is incorrect"
 msgstr "Adres is onjuist"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Adjust the servings"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. as in multiple advertisements
 msgid "Ads"
 msgstr "Advertenties"
@@ -1649,6 +1659,14 @@ msgid "All chats are %sprivate%s"
 msgstr "Alle chats zijn %1$sprivé%2$s"
 
 # smartling.placeholder_format=C
+#. Paragraph in the Privacy & Terms section of the About & Legal page in Duck.ai settings, summarizing how chats are anonymized and are not stored or used to train chat models.
+msgctxt "Privacy & Terms section description on the Duck.ai settings page"
+msgid ""
+"All chats are anonymized by DuckDuckGo, and your conversations are not used "
+"to train chat models by DuckDuckGo or the model providers"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
 msgctxt "Privacy modal header in Duck.ai chat"
 msgid "All chats are private"
@@ -1737,7 +1755,8 @@ msgstr "Advertenties die de privacy respecteren toestaan"
 # smartling.placeholder_format=C
 #. Title in a dialog informing the user how to disable their ad blocker for DuckDuckGo
 msgid "Allow privacy-respecting ads on DuckDuckGo Private Search"
-msgstr "Advertenties die de privacy respecteren toestaan in DuckDuckGo Private Search"
+msgstr ""
+"Advertenties die de privacy respecteren toestaan in DuckDuckGo Private Search"
 
 # smartling.placeholder_format=C
 #. Description explaining privacy implications of enabling web search on encrypted models. The first two placeholders are the full model name (e.g. 'gpt-oss 120B'). The third and fourth placeholders wrap a clickable link reading 'zero provider visibility' that opens the privacy modal, please keep those around the link text in your translation. An example full sentence would be: Allows gpt-oss 120B to search the web to improve responses to relevant prompts. Only sends AI-generated queries to a search engine with limited data retention. Prompts and responses with gpt-oss 120B still have zero provider visibility.
@@ -1897,8 +1916,8 @@ msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
 msgstr ""
-"Anonieme toegang tot populaire AI-modellen, waaronder %1$s, %2$s, en "
-"open-source %3$s en %4$s."
+"Anonieme toegang tot populaire AI-modellen, waaronder %1$s, %2$s, en open-"
+"source %3$s en %4$s."
 
 # smartling.placeholder_format=C
 #. Text with information about Duck.ai and supported AI models, the placeholders list AI models. Example: 'Anonymous access to popular AI models, including GPT, Claude, and open-source Llama and Mistral.'
@@ -1907,14 +1926,21 @@ msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
 msgstr ""
-"Anonieme toegang tot populaire AI-modellen, waaronder %1$s, %2$s, en "
-"open-source %3$s en %4$s."
+"Anonieme toegang tot populaire AI-modellen, waaronder %1$s, %2$s, en open-"
+"source %3$s en %4$s."
 
 # smartling.placeholder_format=C
 #. Confirmation message after location service is enabled.
 msgctxt "precise_user_location"
 msgid "Anonymous location enabled"
 msgstr "Anonieme locatie ingeschakeld"
+
+# smartling.placeholder_format=C
+msgctxt "settings"
+msgid ""
+"Anonymously generates answers for search queries based on web content. "
+"Choose how often you want it to appear, or disable it completely."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -2201,6 +2227,12 @@ msgid "Ask a follow-up with Duck.ai"
 msgstr "Stel een vervolgvraag aan Duck.ai"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
+msgctxt "Page suggestion chip label"
+msgid "Ask about this page"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
 msgctxt "Title for the page context onboarding modal"
 msgid "Ask about this page"
@@ -2266,8 +2298,8 @@ msgstr ""
 "relevante webinhoud samen te vatten. Je kunt kiezen hoe vaak je wilt dat "
 "Assist wordt weergegeven: 'Nooit' (de Assist-gebruikersinterface wordt "
 "helemaal uit de zoekresultaten verwijderd), 'Op verzoek' (AI-antwoorden "
-"worden alleen weergegeven als je op de Assist-knop klikt), 'Soms' "
-"(AI-antwoorden worden alleen weergegeven als ze zeer relevant zijn), of "
+"worden alleen weergegeven als je op de Assist-knop klikt), 'Soms' (AI-"
+"antwoorden worden alleen weergegeven als ze zeer relevant zijn), of "
 "'Vaak' (wordt vaker weergegeven bij een breder scala aan zoekopdrachten). "
 "Voorlopig zijn AI-antwoorden alleen beschikbaar in de Amerikaanse regio."
 
@@ -2281,8 +2313,8 @@ msgid ""
 "to remember that responses are auto-generated from cited sources and based "
 "on %scrawling the web%s."
 msgstr ""
-"Assist is een optionele functie in onze zoekresultaten die anoniem "
-"AI-ondersteunde antwoorden op zoekopdrachten kan genereren. De functie scant "
+"Assist is een optionele functie in onze zoekresultaten die anoniem AI-"
+"ondersteunde antwoorden op zoekopdrachten kan genereren. De functie scant "
 "het web op relevante inhoud en gebruikt vervolgens AI-technologie op basis "
 "van natuurlijke taal om een kort antwoord te genereren aan de hand van de "
 "gevonden relevante informatie. Het is belangrijk om te onthouden dat "
@@ -2625,6 +2657,12 @@ msgid "Barcode"
 msgstr "Barcode"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Based on this page, is this course worth taking?"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Basic"
 msgstr "Normaal"
@@ -2663,6 +2701,14 @@ msgstr "Batter"
 msgctxt "Assistant response placeholder"
 msgid "Before continuing..."
 msgstr "Voordat we verder gaan ..."
+
+# smartling.placeholder_format=C
+#. Explains that before storing the report, DuckDuckGo will anonymize the conversation by removing PII like names, email addresses, and identifying metadata.
+msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
+msgid ""
+"Before storing this report, DuckDuckGo will anonymize your conversation by "
+"removing PII like names, email addresses, and identifying metadata."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -2979,6 +3025,12 @@ msgstr "Brazilië"
 msgctxt "Sports module"
 msgid "Break Points Won"
 msgstr "Breakpunten gewonnen"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Break this down into clear, numbered steps."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -3436,6 +3488,12 @@ msgid "Cast"
 msgstr "Casten"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Cast & Crew"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
 msgctxt "Tone option label for Casual"
 msgid "Casual"
@@ -3520,7 +3578,8 @@ msgstr "Wijzigt hoe URL's van resultaten worden weergegeven"
 #. This is the description of a user setting
 msgctxt "settings"
 msgid "Changes how the header is displayed and its behavior as you scroll"
-msgstr "Wijzigt de weergave van de header en bepaalt wat ermee gebeurt als je scrolt"
+msgstr ""
+"Wijzigt de weergave van de header en bepaalt wat ermee gebeurt als je scrolt"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/mcZdcaF.png
@@ -3731,14 +3790,16 @@ msgstr "Privé chatten"
 #. Mobile variant of DUCKCHAT_BROWSER_UPSELL_PROMO_TEXT. Shorter version for the promotional card encouraging third-party browser users to download the DuckDuckGo browser.
 msgctxt "Promotional text (mobile)"
 msgid "Chat privately on any website with Duck.ai built into our free browser."
-msgstr "Chat privé op elke website met Duck.ai, ingebouwd in onze gratis browser."
+msgstr ""
+"Chat privé op elke website met Duck.ai, ingebouwd in onze gratis browser."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card encouraging third-party browser users to download the DuckDuckGo browser. Not shown in the DuckDuckGo browser or on Linux.
 msgctxt "Promotional text"
 msgid ""
 "Chat privately on any website with the Duck.ai sidebar in our free browser."
-msgstr "Chat privé op elke website met de Duck.ai-zijbalk in onze gratis browser."
+msgstr ""
+"Chat privé op elke website met de Duck.ai-zijbalk in onze gratis browser."
 
 # smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
@@ -5097,7 +5158,8 @@ msgstr "Costa Rica"
 #. Inline error shown on the recovery code screen when exportSyncSettings rejects.
 msgctxt "Error message when the recovery code fails to generate"
 msgid "Couldn't load your recovery code. Please close this and try again."
-msgstr "Uw herstelcode kon niet worden geladen. Sluit dit en probeer het opnieuw."
+msgstr ""
+"Uw herstelcode kon niet worden geladen. Sluit dit en probeer het opnieuw."
 
 # smartling.placeholder_format=C
 #. Pairs with a Retry button. Shown after two consecutive failed attempts to load the device list.
@@ -5141,6 +5203,12 @@ msgstr "Afbeelding maken"
 msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr "Afbeelding maken"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Create a shopping list with quantities from this recipe."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed in the input field when starting a new image generation session.
@@ -5397,7 +5465,8 @@ msgstr "Dagelijkse limiet bereikt"
 #. Displayed when the user has reached a fixed daily Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Daily usage limit reached. You can continue this chat after %s."
-msgstr "Dagelijkse gebruikslimiet bereikt. Je kunt dit gesprek voortzetten na %1$s."
+msgstr ""
+"Dagelijkse gebruikslimiet bereikt. Je kunt dit gesprek voortzetten na %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable daily Duck.ai usage limit and can opt in to continue using the weekly limit.
@@ -5783,6 +5852,11 @@ msgid "Dictation limit reached"
 msgstr "Dicteerlimiet is bereikt"
 
 # smartling.placeholder_format=C
+#. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
+msgid "Dictation temporarily unavailable"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
@@ -5869,7 +5943,8 @@ msgstr "Uitschakelen en loskoppelen"
 #. Title of a modal that asks the user if they want to turn off chat history and disconnect from Sync & Backup.
 msgctxt "Modal header for disabling chat history and disconnecting sync"
 msgid "Disable chat history and disconnect from Sync & Backup?"
-msgstr "Chatgeschiedenis uitschakelen en de verbinding met Sync & Backup verbreken?"
+msgstr ""
+"Chatgeschiedenis uitschakelen en de verbinding met Sync & Backup verbreken?"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to turn off the chat history feature.
@@ -6083,6 +6158,22 @@ msgid "Done"
 msgstr "Klaar"
 
 # smartling.placeholder_format=C
+#. Message shown in a modal after DuckDuckGo browser users disable AI features in Settings. The first two placeholders bold noai.duckduckgo.com. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
+"filtered out. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
+"and AI images filtered out. %sLearn more%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Double Faults"
@@ -6197,6 +6288,18 @@ msgstr ""
 "om een offerte te maken voor de reparatie van een koelkast."
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Draft a cover letter"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Draft a cover letter for this job."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
 msgctxt "Full sentence for drafting a social media post"
 msgid ""
@@ -6284,7 +6387,8 @@ msgstr "Sleep je foto's of PDF-bestanden"
 # smartling.placeholder_format=C
 #. A title explaining what Duck Player (DDG's feature to watch youtube videos more privately) does
 msgid "Duck Player lets you watch YouTube without targeted ads"
-msgstr "Met Duck Player kun je YouTube-video's bekijken zonder gerichte advertenties"
+msgstr ""
+"Met Duck Player kun je YouTube-video's bekijken zonder gerichte advertenties"
 
 # smartling.placeholder_format=C
 #. This is the DDG version of "Google it", meaning "search it".
@@ -6374,6 +6478,15 @@ msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
 msgstr "Duck.ai werkt het beste in onze privé en gratis DuckDuckGo-browser!"
 
 # smartling.placeholder_format=C
+#. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
+msgctxt "About section description on the Duck.ai settings page"
+msgid ""
+"Duck.ai is created by DuckDuckGo. We're an independent online protection "
+"company for anyone who wants to take back control of their personal "
+"information."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
 msgctxt "duckai_migration"
 msgid "Duck.ai is moving domains"
@@ -6402,8 +6515,8 @@ msgid ""
 "Duck.ai is temporarily unavailable. If this persists, please email this "
 "anonymous code %s to %s"
 msgstr ""
-"Duck.ai is tijdelijk niet beschikbaar. Als dit aanhoudt, stuur dan een "
-"e-mail met deze anonieme code %1$s naar %2$s"
+"Duck.ai is tijdelijk niet beschikbaar. Als dit aanhoudt, stuur dan een e-"
+"mail met deze anonieme code %1$s naar %2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -6419,6 +6532,13 @@ msgstr ""
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
 msgstr "Duck.ai is tijdelijk niet beschikbaar. Probeer het later opnieuw."
+
+# smartling.placeholder_format=C
+msgctxt "settings"
+msgid ""
+"Duck.ai lets you chat privately with popular AI models. Disabling it hides "
+"Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6455,7 +6575,8 @@ msgstr ""
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
 msgctxt "Promotional text for PDF upload feature"
 msgid "Duck.ai now can read and analyze PDFs. Give it a try!"
-msgstr "Duck.ai kan nu pdf-bestanden lezen en analyseren. Probeer het maar eens!"
+msgstr ""
+"Duck.ai kan nu pdf-bestanden lezen en analyseren. Probeer het maar eens!"
 
 # smartling.placeholder_format=C
 #. Disclaimer text shown above the chat input only when coming from a DuckAssist grounded response into ungrounded models.
@@ -6493,8 +6614,8 @@ msgid ""
 "models, privacy focused AI, no account AI chat"
 msgstr ""
 "Duck.ai, DuckDuckGo AI, privé AI-chatbot, gratis AI-chat, anonieme AI-chat, "
-"AI-chat zonder aanmelden, OpenAI, Anthropic, Llama, Mistral, open "
-"source  AI-modellen, privacy  AI, AI-chat zonder account"
+"AI-chat zonder aanmelden, OpenAI, Anthropic, Llama, Mistral, open source  AI-"
+"modellen, privacy  AI, AI-chat zonder account"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -6566,9 +6687,9 @@ msgid ""
 msgstr ""
 "DuckAssist is een nieuwe functie in onze zoekresultaten die anoniem "
 "antwoorden voor zoekopdrachten kan genereren. Hij scant daarvoor Wikipedia "
-"en gerelateerde sites op relevante inhoud en gebruikt vervolgens "
-"AI-technologie voor natuurlijke taal om die informatie samen te vatten. Let "
-"op: de antwoorden zijn op dit moment gebaseerd op Wikipedia en gerelateerde "
+"en gerelateerde sites op relevante inhoud en gebruikt vervolgens AI-"
+"technologie voor natuurlijke taal om die informatie samen te vatten. Let op: "
+"de antwoorden zijn op dit moment gebaseerd op Wikipedia en gerelateerde "
 "inhoud en worden niet gecontroleerd op juistheid."
 
 # smartling.placeholder_format=C
@@ -6666,7 +6787,8 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr "DuckDuckGo AI Chat is tijdelijk niet beschikbaar. Probeer het later opnieuw."
+msgstr ""
+"DuckDuckGo AI Chat is tijdelijk niet beschikbaar. Probeer het later opnieuw."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -6888,7 +7010,8 @@ msgctxt ""
 "Description of the DuckDuckGo subscription setting when it is not available "
 "in the user region"
 msgid "DuckDuckGo subscriptions are not available to purchase in this region."
-msgstr "DuckDuckGo-abonnementen zijn niet beschikbaar voor aankoop in deze regio."
+msgstr ""
+"DuckDuckGo-abonnementen zijn niet beschikbaar voor aankoop in deze regio."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use 'ducky' tone in its responses. When this option is selected, the AI assistant speaks like a duck.
@@ -7267,7 +7390,8 @@ msgstr "Ben je tevreden met Duck.ai?"
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure %s'Allow'%s is selected for the 'Location' setting."
-msgstr "Zorg dat %1$s'Toestaan'%2$s is geselecteerd voor de instelling 'Locatie'."
+msgstr ""
+"Zorg dat %1$s'Toestaan'%2$s is geselecteerd voor de instelling 'Locatie'."
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
@@ -7422,6 +7546,18 @@ msgid "Eritrea"
 msgstr "Eritrea"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Estimate the nutrition"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Estimate the nutritional information for this recipe."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Estonia"
 msgstr "Estland"
 
@@ -7455,7 +7591,8 @@ msgstr "Kaart uitvouwen"
 #. Subtitle for the Collaborations promotional card at the bottom of search results. Describes the branded merchandise line. 'Give a duck' is a wordplay on the DuckDuckGo brand name.
 msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
-msgstr "Vakkundig vervaardigde producten voor mensen die echt om privacy geven."
+msgstr ""
+"Vakkundig vervaardigde producten voor mensen die echt om privacy geven."
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
@@ -7476,11 +7613,59 @@ msgid "Expires in 1 day"
 msgstr "Verloopt over 1 dag"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain the accepted answer in simple terms."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
 msgstr "Leg me de basis van zwarte gaten uit op middelbare schoolniveau."
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain the top answer"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this in simple, plain language."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this paper"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this repo"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this research paper in plain language."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this simply"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain what this repository does and how to use it."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label to show if song lyrics contain explicit content
@@ -7756,7 +7941,8 @@ msgstr "Filters niet effectief"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Filters out AI-generated images from image search results"
-msgstr "Filtert AI-gegenereerde afbeeldingen uit de zoekresultaten van afbeeldingen."
+msgstr ""
+"Filtert AI-gegenereerde afbeeldingen uit de zoekresultaten van afbeeldingen."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -7765,6 +7951,12 @@ msgid ""
 msgstr ""
 "Filtert door AI gegenereerde afbeeldingen uit de zoekresultaten van "
 "afbeeldingen. %1$sMeer informatie%2$s"
+
+# smartling.placeholder_format=C
+msgctxt "settings"
+msgid ""
+"Filters out known AI spam sites from image search results. %sLearn More%s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the final score of a sporting event.
@@ -7820,6 +8012,12 @@ msgstr "Zoek een beter woord"
 msgctxt "Subtitle for the Web Search tool entry in the Tools dropdown menu"
 msgid "Find current information"
 msgstr "Actuele informatie zoeken"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Find me alternatives"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button that searches for results closer to the user's current location.
@@ -8129,9 +8327,9 @@ msgid ""
 "<strong>Check for Updates...</strong>, then select <strong>Install Update</"
 "strong>."
 msgstr ""
-"Selecteer in de menubalk van de app voor Mac de optie "
-"<strong>DuckDuckGo</strong> &gt; <strong>Controleren op updates...</strong> "
-"en selecteer vervolgens <strong>Update installeren</strong>."
+"Selecteer in de menubalk van de app voor Mac de optie <strong>DuckDuckGo</"
+"strong> &gt; <strong>Controleren op updates...</strong> en selecteer "
+"vervolgens <strong>Update installeren</strong>."
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -8297,6 +8495,12 @@ msgstr "Afbeelding genereren"
 #. Text for the button that generates more of an answer from duckassist when the answer has come from a collapsed state
 msgid "Generate More"
 msgstr "Genereer meer"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Generate a shopping list"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
@@ -8490,9 +8694,8 @@ msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"Krijg toegang tot geavanceerde AI-modellen in Duck.ai met een "
-"DuckDuckGo-abonnement, dat ook onze VPN en andere premium "
-"privacybeschermingen omvat."
+"Krijg toegang tot geavanceerde AI-modellen in Duck.ai met een DuckDuckGo-"
+"abonnement, dat ook onze VPN en andere premium privacybeschermingen omvat."
 
 # smartling.placeholder_format=C
 #. A button for users to generate an AI generated answer from their query on the duckassist module
@@ -8591,6 +8794,12 @@ msgstr "Proberen"
 msgctxt "Onboarding welcome screen button text"
 msgid "Give it a Try"
 msgstr "Proberen"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Give me a quick background on this person."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9037,6 +9246,18 @@ msgstr "Help DuckDuckGo te verspreiden!"
 #. Link to a page with information about sharing DuckDuckGo with friends.
 msgid "Help Spread Privacy"
 msgstr "Help privacy verspreiden"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Help me prep for the interview"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Help me tailor my resume for this job."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title of a SERP popup that invites users to take a survey (desktop only)
@@ -9556,6 +9777,14 @@ msgid "I Agree"
 msgstr "Akkoord"
 
 # smartling.placeholder_format=C
+#. Text for the button that takes the user to the external DuckDuckGo login subscription page.
+msgctxt ""
+"Text for the I already have a subscription button in the Duck.ai settings "
+"page"
+msgid "I Already Have a Subscription"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for the button that takes the user to the login subscription page.
 msgctxt "Text for the I have a subscription button"
 msgid "I Have a Subscription"
@@ -9872,8 +10101,8 @@ msgctxt "settings"
 msgid ""
 "Improves result legibility with updated URL format, placement, and color"
 msgstr ""
-"Verbetert de leesbaarheid van het resultaat met een bijgewerkte "
-"URL-indeling, -plaatsing en -kleur"
+"Verbetert de leesbaarheid van het resultaat met een bijgewerkte URL-"
+"indeling, -plaatsing en -kleur"
 
 # smartling.placeholder_format=C
 #. A label that appears in front of the name of a company that DuckDuckGo has partnered with. For example, 'In partnership with Wikipedia'
@@ -10135,6 +10364,12 @@ msgid "Install Mac Browser"
 msgstr "Mac-browser installeren"
 
 # smartling.placeholder_format=C
+#. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
+msgctxt "settings"
+msgid "Install Now"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of a button to install the DuckDuckGo app
 msgctxt "Serp footer content"
 msgid "Install Our App"
@@ -10232,10 +10467,42 @@ msgid "Is deleted data really deleted?"
 msgstr "Is verwijderde data echt verwijderd?"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is it worth taking?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this place any good?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"Is this place any good? Summarize its reputation based on reviews and "
+"ratings."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "Is this video helpful?"
 msgstr "Is deze video nuttig?"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this worth watching?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Is this worth watching? Give me a spoiler-free take."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -10708,7 +10975,8 @@ msgstr "Lees meer over hoe het werkt"
 # smartling.placeholder_format=C
 msgctxt "SERP footer content"
 msgid "Learn why reducing online tracking is important."
-msgstr "Informatie over waarom het terugdringen van online tracking belangrijk is."
+msgstr ""
+"Informatie over waarom het terugdringen van online tracking belangrijk is."
 
 # smartling.placeholder_format=C
 #. A link that takes users to a page where they can learn more about the dangers of online tracking.
@@ -10846,6 +11114,12 @@ msgstr "Lettertype voor links:"
 #. https://duckduckgo.com/params under "Color Settings"
 msgid "Links:"
 msgstr "Links:"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "List the tools, materials, or prerequisites I need for this."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -11138,7 +11412,8 @@ msgstr "Zorg ervoor dat alle woorden correct gespeld zijn."
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Make sure to check %s\"Make this my default search provider\"%s"
-msgstr "Controleer of %1$s'Dit wordt mijn standaard zoekmachine'%2$s is aangevinkt"
+msgstr ""
+"Controleer of %1$s'Dit wordt mijn standaard zoekmachine'%2$s is aangevinkt"
 
 # smartling.placeholder_format=C
 #. Message prompting users to check the spelling of their search term.
@@ -11254,6 +11529,12 @@ msgstr "Je abonnement beheren"
 msgctxt "Exclusion message manage sites button"
 msgid "Manage blocked sites"
 msgstr "Geblokkeerde sites beheren"
+
+# smartling.placeholder_format=C
+#. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
+msgctxt "setting"
+msgid "Manage in Browser Settings"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to the site exclusion settings page
@@ -12543,7 +12824,8 @@ msgstr "Geen resultaten gevonden."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the recording contains no audible speech.
 msgid "No speech detected. Please try again and speak into your microphone."
-msgstr "Geen spraak gedetecteerd. Probeer het nog eens en spreek in de microfoon."
+msgstr ""
+"Geen spraak gedetecteerd. Probeer het nog eens en spreek in de microfoon."
 
 # smartling.placeholder_format=C
 #. Button that dismisses a feedback form.
@@ -13171,7 +13453,8 @@ msgstr "%1$s-website openen"
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open %sLocation%s, and ensure location is %senabled%s"
-msgstr "Open %1$sLocatie%2$s en zorg ervoor dat locatie %3$sis ingeschakeld%4$s"
+msgstr ""
+"Open %1$sLocatie%2$s en zorg ervoor dat locatie %3$sis ingeschakeld%4$s"
 
 #  Chrome/Firefox on Android/iOS
 # smartling.placeholder_format=C
@@ -13334,7 +13617,8 @@ msgstr "Open het paneel 'Hoe Duck.ai werkt'"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open the Safari menu and select %sSettings for DuckDuckGo...%s"
-msgstr "Open het Safari-menu en selecteer %1$sInstellingen voor DuckDuckGo...%2$s"
+msgstr ""
+"Open het Safari-menu en selecteer %1$sInstellingen voor DuckDuckGo...%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the time a business opens. For example: 'Opens at 10am'
@@ -14092,6 +14376,12 @@ msgstr ""
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
+msgid "Please describe why the chat response is harmful or illegal. (optional)"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
+msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
 msgstr "Beschrijf waarom de chatreactie illegaal of schadelijk is. (Optioneel)"
 
@@ -14116,6 +14406,14 @@ msgid ""
 msgstr ""
 "Let op: je huidige chatsessie wordt verwijderd als je een nieuwe chat in een "
 "ander chatmodel begint."
+
+# smartling.placeholder_format=C
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
+msgctxt "Feedback prompt"
+msgid ""
+"Please paste your prompt and the problematic output (with any personal "
+"information removed) and describe why the content is harmful or illegal."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -14555,7 +14853,8 @@ msgstr "Prijs"
 #. Category of feedback a user can select on a feedback form.
 msgctxt "feedback form"
 msgid "Price shown doesn't reflect merchant site"
-msgstr "De weergegeven prijs komt niet overeen met die op de site van de verkoper"
+msgstr ""
+"De weergegeven prijs komt niet overeen met die op de site van de verkoper"
 
 # smartling.placeholder_format=C
 #. A button that prints the contents of a page.
@@ -14583,6 +14882,12 @@ msgstr "Privacy"
 msgctxt "settings"
 msgid "Privacy"
 msgstr "Privacy"
+
+# smartling.placeholder_format=C
+#. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
+msgctxt "Section heading on the Duck.ai settings page"
+msgid "Privacy & Terms"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Privacy Blog"
@@ -14653,6 +14958,12 @@ msgstr "Privacybeleid en gebruiksvoorwaarden"
 msgctxt "Copy used to compose link in sentences"
 msgid "Privacy Policy and Terms of Service"
 msgstr "Privacybeleid en servicevoorwaarden"
+
+# smartling.placeholder_format=C
+#. Text for a button that links to the terms of use and privacy policy page.
+msgctxt "Secondary button text in active privacy modal"
+msgid "Privacy Policy and Terms of Service"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title displayed on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
@@ -14826,7 +15137,8 @@ msgstr "Vraag het mij"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Prompt me to use my approximate location to get nearby results."
-msgstr "Vraag me om mijn geschatte locatie te gebruiken voor resultaten in de buurt."
+msgstr ""
+"Vraag me om mijn geschatte locatie te gebruiken voor resultaten in de buurt."
 
 # smartling.placeholder_format=C
 #. DuckDuckGo Email Protection removes trackers from emails
@@ -15155,6 +15467,30 @@ msgid "Recommend a book"
 msgstr "Een boek aanbevelen"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar books"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar books."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar movies or shows."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar titles"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
 msgid "Recording failed. Please try again."
 msgstr "De opname is mislukt. Probeer het opnieuw."
@@ -15378,7 +15714,8 @@ msgstr "Mijn keuze onthouden"
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings
 msgid "Remember my choice (this can be changed in %s%s%sSettings%s)"
-msgstr "Onthoud mijn keuze (dit kun je wijzigen in de %1$s%2$s%3$sInstellingen%4$s)"
+msgstr ""
+"Onthoud mijn keuze (dit kun je wijzigen in de %1$s%2$s%3$sInstellingen%4$s)"
 
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
@@ -15556,6 +15893,15 @@ msgstr ""
 # smartling.placeholder_format=C
 msgid "Republic of Moldova"
 msgstr "Republiek Moldavië"
+
+# smartling.placeholder_format=C
+#. Note indicating that sharing the conversation is mandatory when reporting harmful or illegal content. Rendered alongside the standard share label (DUCKCHAT_RESPONSE_FEEDBACK_SHARE_PROMPT_RESPONSE_LABEL), not replacing it.
+msgctxt ""
+"Note shown under the share-content switch label on the Duck.ai response "
+"feedback form when the user has selected Harmful or Illegal as the feedback "
+"reason"
+msgid "Required for harmful or illegal reports"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
@@ -15793,6 +16139,12 @@ msgstr "Beoordelingen"
 msgctxt "maps_places"
 msgid "Reviews"
 msgstr "Beoordelingen"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Rewrite this recipe scaled for a different number of servings."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Romania"
@@ -16078,7 +16430,8 @@ msgstr "Bewaar maximaal 30 van je meest recente chats op je apparaat."
 msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
-msgstr "Bewaar je Duck.ai-chats tussen je apparaten met end-to-end-versleuteling."
+msgstr ""
+"Bewaar je Duck.ai-chats tussen je apparaten met end-to-end-versleuteling."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -16194,13 +16547,15 @@ msgstr "Schotland"
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Scroll down and click %sView advanced settings%s"
-msgstr "Scroll naar beneden en klik op %1$sGeavanceerde instellingen weergeven%2$s"
+msgstr ""
+"Scroll naar beneden en klik op %1$sGeavanceerde instellingen weergeven%2$s"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down and click %sView advanced settings%s."
-msgstr "Scroll naar beneden en klik op %1$sGeavanceerde instellingen weergeven%2$s."
+msgstr ""
+"Scroll naar beneden en klik op %1$sGeavanceerde instellingen weergeven%2$s."
 
 #  Edge Legacy default search engine instruction, obsolete?
 # smartling.placeholder_format=C
@@ -16443,8 +16798,8 @@ msgid ""
 "Search other sites with %s shortcuts: a search for ”!w ducks” will search "
 "for “ducks” directly on Wikipedia."
 msgstr ""
-"Zoek op andere sites met snelkoppelingen naar %1$s: een zoekopdracht naar "
-"\"!w ducks\" zal onmiddellijk op Wikipedia naar \"eenden\" zoeken."
+"Zoek op andere sites met snelkoppelingen naar %1$s: een zoekopdracht naar \"!"
+"w ducks\" zal onmiddellijk op Wikipedia naar \"eenden\" zoeken."
 
 # smartling.placeholder_format=C
 #. Placeholder text for the search form when no text has been entered
@@ -16623,7 +16978,8 @@ msgstr ""
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
 msgctxt "Sync feature benefit description"
 msgid "Securely stored on DuckDuckGo's server with end-to-end encryption."
-msgstr "Veilig opgeslagen op de server van DuckDuckGo met end-to-end-versleuteling."
+msgstr ""
+"Veilig opgeslagen op de server van DuckDuckGo met end-to-end-versleuteling."
 
 # smartling.placeholder_format=C
 #. List item explaining that synced chats are stored with end-to-end encryption on DuckDuckGo's server and only the user can access them.
@@ -16744,7 +17100,8 @@ msgstr "Bekijk enkele van onze nieuwste updates"
 #. Link to a page with more information about how user settings are stored in a URL.
 msgctxt "settings"
 msgid "See the %sURL Parameter Reference page%s for more details."
-msgstr "Kijk op de %1$sreferentiepagina voor URL-parameters%2$s voor meer informatie."
+msgstr ""
+"Kijk op de %1$sreferentiepagina voor URL-parameters%2$s voor meer informatie."
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the context menu of a chat in chat history, that allows the user to select the chat and begin batch selection mode.
@@ -16771,7 +17128,8 @@ msgstr "Selecteer %1$s%2$s%3$s en vervolgens %4$sZoekmachine%5$s"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %s'Setting for this Website...'%s from the Safari menu."
-msgstr "Selecteer %1$s'Instellingen voor deze website...'%2$s vanuit het Safari-menu."
+msgstr ""
+"Selecteer %1$s'Instellingen voor deze website...'%2$s vanuit het Safari-menu."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -16784,18 +17142,21 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
-msgstr "Selecteer %1$sDuckDuckGo%2$s en klik op %3$sToevoegen als standaard%4$s."
+msgstr ""
+"Selecteer %1$sDuckDuckGo%2$s en klik op %3$sToevoegen als standaard%4$s."
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s"
-msgstr "Selecteer %1$sDuckDuckGo%2$s en klik op %3$sInstellen als standaard%4$s"
+msgstr ""
+"Selecteer %1$sDuckDuckGo%2$s en klik op %3$sInstellen als standaard%4$s"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s."
-msgstr "Selecteer %1$sDuckDuckGo%2$s en klik op %3$sInstellen als standaard%4$s."
+msgstr ""
+"Selecteer %1$sDuckDuckGo%2$s en klik op %3$sInstellen als standaard%4$s."
 
 #  Firefox 33
 # smartling.placeholder_format=C
@@ -16807,7 +17168,8 @@ msgstr "Selecteer %1$sDuckDuckGo%2$s in het uitklapmenu Standaard zoekmachine"
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %sDuckDuckGo%s in the list and %sallow%s location access"
-msgstr "Selecteer %1$sDuckDuckGo%2$s in de lijst en geef %3$stoegang tot%4$s locatie"
+msgstr ""
+"Selecteer %1$sDuckDuckGo%2$s in de lijst en geef %3$stoegang tot%4$s locatie"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -16819,7 +17181,8 @@ msgstr "Selecteer %1$sDuckDuckGo%2$s in de lijst met zoekmachines"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s under the%sDefault Search Engine%s section"
-msgstr "Selecteer %1$sDuckDuckGo%2$s in het gedeelte %3$sStandaard zoekmachine%4$s"
+msgstr ""
+"Selecteer %1$sDuckDuckGo%2$s in het gedeelte %3$sStandaard zoekmachine%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user were in the settings menu they can change their default search engine.
@@ -16906,7 +17269,8 @@ msgstr ""
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sDefault search engine%s"
-msgstr "Selecteer %1$sInstellingen%2$s en vervolgens %3$sStandaard zoekmachine%4$s"
+msgstr ""
+"Selecteer %1$sInstellingen%2$s en vervolgens %3$sStandaard zoekmachine%4$s"
 
 #  Chrome/Firefox on Android
 # smartling.placeholder_format=C
@@ -16928,7 +17292,8 @@ msgstr ""
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %syour browser%s in the list and %sallow%s location access"
-msgstr "Selecteer %1$sje browser%2$s in de lijst en %3$slaat%4$s locatietoegang toe"
+msgstr ""
+"Selecteer %1$sje browser%2$s in de lijst en %3$slaat%4$s locatietoegang toe"
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the modal for deleting all recent chats, that allows the user to select the chats to delete.
@@ -17123,6 +17488,12 @@ msgid "Set Up Now"
 msgstr "Nu instellen"
 
 # smartling.placeholder_format=C
+#. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
+msgctxt "Encrypted storage setup button shown in native browsers"
+msgid "Set Up Sync & Backup"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
 msgctxt "Title for the Sync & Backup intro screen"
 msgid "Set Up Sync & Backup"
@@ -17242,8 +17613,8 @@ msgid ""
 "never reveals your precise location to us or AI models."
 msgstr ""
 "Deel een locatie op stadsniveau met AI-modellen om de relevantie te "
-"verbeteren. Duck.ai onthult nooit je precieze locatie aan ons of aan "
-"AI-modellen."
+"verbeteren. Duck.ai onthult nooit je precieze locatie aan ons of aan AI-"
+"modellen."
 
 # smartling.placeholder_format=C
 #. Menu option to share feedback about a result
@@ -17302,6 +17673,13 @@ msgstr "URL van pagina delen"
 msgctxt "feedback form"
 msgid "Share positive feedback"
 msgstr "Deel positieve feedback"
+
+# smartling.placeholder_format=C
+#. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
+msgctxt ""
+"Label beside the share-content switch on the Duck.ai response feedback form"
+msgid "Share this conversation with DuckDuckGo"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -17708,7 +18086,8 @@ msgstr "Meest bezochte links weergeven op een nieuw tabblad"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your browser"
-msgstr "Geeft af en toe herinneringen weer om DuckDuckGo aan je browser toe te voegen"
+msgstr ""
+"Geeft af en toe herinneringen weer om DuckDuckGo aan je browser toe te voegen"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -17722,8 +18101,8 @@ msgctxt "settings"
 msgid ""
 "Shows occasional reminders to sign up for the DuckDuckGo privacy newsletters"
 msgstr ""
-"Geeft af en toe herinneringen weer om je aan te melden voor de "
-"DuckDuckGo-nieuwsbrieven over privacy"
+"Geeft af en toe herinneringen weer om je aan te melden voor de DuckDuckGo-"
+"nieuwsbrieven over privacy"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -17733,7 +18112,8 @@ msgstr "Geeft paginanummers weer naast resultaatpagina-einden"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows sign-up form for the DuckDuckGo privacy newsletters"
-msgstr "Geeft een inschrijfformulier weer voor de DuckDuckGo-privacynieuwsbrieven"
+msgstr ""
+"Geeft een inschrijfformulier weer voor de DuckDuckGo-privacynieuwsbrieven"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/94erFcS.png
@@ -17762,8 +18142,8 @@ msgstr "Geeft een welkomstbericht weer bovenaan de pagina met zoekresultaten"
 msgctxt "settings"
 msgid "Shows welcome message to EU Android preference menu users"
 msgstr ""
-"Geeft een welkomstbericht weer aan gebruikers van het "
-"EU-Android-voorkeursmenu"
+"Geeft een welkomstbericht weer aan gebruikers van het EU-Android-"
+"voorkeursmenu"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers sometimes.
@@ -17981,7 +18361,8 @@ msgstr "Er is iets misgegaan"
 #. Error message indicating that the user's settings weren't able to be saved.
 msgctxt "cloudsave"
 msgid "Something went wrong saving to the server, please try again."
-msgstr "Er is iets misgegaan tijdens het opslaan naar de server. Probeer het opnieuw."
+msgstr ""
+"Er is iets misgegaan tijdens het opslaan naar de server. Probeer het opnieuw."
 
 # smartling.placeholder_format=C
 #. Body copy displayed under the Set Up Now button when the sync setup call fails.
@@ -18013,7 +18394,8 @@ msgstr "Soms"
 #. Generic error message shown when the image generation model cannot process the user's request.
 msgctxt "Error message from the image generation model"
 msgid "Sorry I can't help, please describe your image in a different way."
-msgstr "Sorry, ik kan het niet helpen. Omschrijf je afbeelding op een andere manier."
+msgstr ""
+"Sorry, ik kan het niet helpen. Omschrijf je afbeelding op een andere manier."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -18087,7 +18469,8 @@ msgstr ""
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr "Sorry, we konden je feedback niet verzenden. Probeer het later opnieuw."
+msgstr ""
+"Sorry, we konden je feedback niet verzenden. Probeer het later opnieuw."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -18397,7 +18780,8 @@ msgstr "Stop verborgen trackers die op de loer liggen op andere websites."
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop most hidden trackers lurking on other websites."
-msgstr "Stop de meeste verborgen trackers die op de loer liggen op andere websites."
+msgstr ""
+"Stop de meeste verborgen trackers die op de loer liggen op andere websites."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18567,6 +18951,24 @@ msgid "Suggest a title for a blog post"
 msgstr "Stel een titel voor een blogpost voor"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest related articles or topics worth exploring next."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Suggest related articles to explore"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest some alternatives to this product."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
 msgctxt "directions"
 msgid "Suggestions:"
@@ -18578,10 +18980,100 @@ msgid "Suggestions:"
 msgstr "Suggesties:"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Sum up the reviews"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A short title for the a message asking the AI to summarize a text.
 msgctxt "Title for the summarize message"
 msgid "Summarize"
 msgstr "Samenvatting"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize the Q&As"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the background and notable work of this person."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the key details of this event."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the questions and answers on this page."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize their background"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this book"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this book."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this discussion"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this discussion thread."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this page"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this page."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this video"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this video."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize what the reviews say."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -18911,6 +19403,12 @@ msgid "Syria"
 msgstr "Syrië"
 
 # smartling.placeholder_format=C
+#. Text for a button that enables the theme to follow the operating system's color scheme preference.
+msgctxt "System theme button for theme selector"
+msgid "System"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Abbreviation indicating this is the total score for a game
 msgctxt "Sports module"
 msgid "T"
@@ -18937,6 +19435,12 @@ msgstr "Televisie"
 msgctxt "language_name"
 msgid "Tahitian"
 msgstr "Tahitiaans"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Tailor my resume"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Taiwan"
@@ -18966,6 +19470,13 @@ msgstr "Houd controle over je persoonsgegevens"
 msgctxt "homepage ATB modal"
 msgid "Take control of your personal data!"
 msgstr "Houd controle over je persoonsgegevens!"
+
+# smartling.placeholder_format=C
+#. Description for the Feedback section of the Duck.ai settings page, asking the user to take an anonymous survey to let us know how we can make Duck.ai better.
+msgctxt "Feedback section description on the Duck.ai settings page"
+msgid ""
+"Take this anonymous survey to let us know how we can make Duck.ai better."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -19203,13 +19714,15 @@ msgstr "Gambia"
 #. Error message displayed when the total size of all attached files in a conversation exceeds the allowed limit. Placeholder is the combined size limit in megabytes. E.g. The attached files exceed the total size limit of 5 MB
 msgctxt "Error message when combined file size exceeds the limit"
 msgid "The attached files exceed the total size limit of %s MB"
-msgstr "De bijgevoegde bestanden overschrijden de totale groottelimiet van %1$sMB"
+msgstr ""
+"De bijgevoegde bestanden overschrijden de totale groottelimiet van %1$sMB"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the total size of all attached files in a conversation exceeds the allowed limit. Placeholder is the combined size limit in megabytes. E.g. The attached files exceed the total size limit of 5 MB
 msgctxt "Error message when combined file size exceeds the limit"
 msgid "The attached files exceed the total size limit of %s MB."
-msgstr "De bijgevoegde bestanden overschrijden de totale groottelimiet van %1$s MB."
+msgstr ""
+"De bijgevoegde bestanden overschrijden de totale groottelimiet van %1$s MB."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the server rejects corrupt or unrecognized audio.
@@ -19265,13 +19778,20 @@ msgstr "Het verzoek is verlopen. Probeer het opnieuw."
 #. Inform the users that "something" went wrong and we are unable to show any results.
 msgctxt "noresults"
 msgid "The server encountered an error and could not complete your request."
-msgstr "De server heeft een fout aangetroffen en kon je verzoek niet voltooien."
+msgstr ""
+"De server heeft een fout aangetroffen en kon je verzoek niet voltooien."
 
 # smartling.placeholder_format=C
 #. Title for the theme menu:
 #. https://duck.co/media/files/theme.png
 msgid "Theme"
 msgstr "Thema"
+
+# smartling.placeholder_format=C
+#. Text for the theme selector label that allows users to switch between Light and dark theme.
+msgctxt "Label for the theme selector feature"
+msgid "Theme"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/LpFhb1e.png
@@ -19399,7 +19919,8 @@ msgstr ""
 #. Appears below a type of search results called 'Instant Answers'
 msgctxt "attribution"
 msgid "This Instant Answer was made by the %sDuckDuckHack%s Community."
-msgstr "Dit directe antwoord is gemaakt door de %1$sDuckDuckHack%2$s-community."
+msgstr ""
+"Dit directe antwoord is gemaakt door de %1$sDuckDuckHack%2$s-community."
 
 # smartling.placeholder_format=C
 #. Label for the monthly usage row in the Usage section of Duck.ai settings.
@@ -19592,7 +20113,8 @@ msgstr "Voor deze pagina moet JavaScript zijn ingeschakeld."
 #. Information tooltip text explaining that the current page's content will be included with the chat message.
 msgctxt "Tooltip explaining that page content will be sent to Duck.ai"
 msgid "This page's content will be sent with your message to Duck.ai"
-msgstr "De inhoud van deze pagina wordt samen met je bericht naar Duck.ai gestuurd"
+msgstr ""
+"De inhoud van deze pagina wordt samen met je bericht naar Duck.ai gestuurd"
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -19661,13 +20183,15 @@ msgstr "Deze vertaling is onjuist"
 # smartling.placeholder_format=C
 #. Label indicating that the video can't be played on the current page, and only on the website that owns the vide. The placeholder is the name of the website that owns the video.
 msgid "This video is not yet able to be watched here. You can watch it on %s."
-msgstr "Deze video kan hier nog niet worden bekeken. Je kunt 'm bekijken op %1$s."
+msgstr ""
+"Deze video kan hier nog niet worden bekeken. Je kunt 'm bekijken op %1$s."
 
 # smartling.placeholder_format=C
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr "Deze webpagina gebruikt geen beveiligde, versleutelde verbinding (HTTPS)."
+msgstr ""
+"Deze webpagina gebruikt geen beveiligde, versleutelde verbinding (HTTPS)."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -19786,8 +20310,8 @@ msgstr "Tips"
 # smartling.placeholder_format=C
 msgid "Tired of being tracked online? %sWe can help.%s"
 msgstr ""
-"Ben je het zat om online te worden gevolgd? %1$sWij kunnen je hierbij "
-"helpen.%2$s"
+"Ben je het zat om online te worden gevolgd? %1$sWij kunnen je hierbij helpen."
+"%2$s"
 
 # smartling.placeholder_format=C
 #. This is the name of a user setting
@@ -19819,7 +20343,8 @@ msgstr ""
 msgctxt ""
 "Copy stating agreement to Duck.ai Privacy Policy and Terms of Service."
 msgid "To continue, you must agree to Duck.ai’s %s and %s"
-msgstr "Om door te gaan, moet je akkoord gaan met het %1$s en het %2$s van Duck.ai"
+msgstr ""
+"Om door te gaan, moet je akkoord gaan met het %1$s en het %2$s van Duck.ai"
 
 # smartling.placeholder_format=C
 #. Text stating agreement to AI Chat Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'To continue, you must agree to DuckDuckGo AI Chat’s Privacy Policy and Terms of Service'
@@ -19860,8 +20385,8 @@ msgid ""
 "To transfer your chat history to Duck.ai, please update your DuckDuckGo "
 "browser to the latest version and try again."
 msgstr ""
-"Opdate om je chatgeschiedenis over te zetten naar Duck.ai je "
-"DuckDuckGo-browser naar de nieuwste versie en probeer het opnieuw."
+"Opdate om je chatgeschiedenis over te zetten naar Duck.ai je DuckDuckGo-"
+"browser naar de nieuwste versie en probeer het opnieuw."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
@@ -20123,6 +20648,18 @@ msgstr ""
 "dichtstbijzijnde bioscoop?\""
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Translate this page"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
+msgctxt "Page suggestion prompt"
+msgid "Translate this page into %s."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text for a region that will display translated text.
 msgctxt "translations_module"
 msgid "Translation"
@@ -20222,7 +20759,8 @@ msgstr "Probeer %1$s om dit soort berichten niet meer te zien."
 #. Text for a promotional card that encourages users to try the encrypted AI model whose inference runs in a confidential environment so the model provider cannot access user data. %s is replaced with the model's full display name (e.g. 'GPT-OSS 120B').
 msgctxt "Promotional text for encrypted AI model"
 msgid "Try %s, our first model with zero provider visibility."
-msgstr "Probeer %1$s, ons eerste model zonder enige zichtbaarheid bij zorgverleners."
+msgstr ""
+"Probeer %1$s, ons eerste model zonder enige zichtbaarheid bij zorgverleners."
 
 # smartling.placeholder_format=C
 msgid "Try %sDuck.ai%s, our private AI chat service:"
@@ -20262,6 +20800,12 @@ msgstr "Probeer het opnieuw"
 msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
 msgstr "Probeer gratis"
+
+# smartling.placeholder_format=C
+#. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
+msgctxt "settings"
+msgid "Try It Now"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -20327,14 +20871,16 @@ msgstr ""
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
 msgctxt "precise_user_location"
 msgid "Try enabling anonymous location for more accurate results."
-msgstr "Probeer anonieme locatie in te schakelen voor nauwkeurigere resultaten."
+msgstr ""
+"Probeer anonieme locatie in te schakelen voor nauwkeurigere resultaten."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the screen of the onboarding where the user picks a chat model.
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr "Probeer met alle modellen te experimenteren. Ze reageren allemaal anders."
+msgstr ""
+"Probeer met alle modellen te experimenteren. Ze reageren allemaal anders."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
@@ -20362,7 +20908,8 @@ msgstr "Probeer het gratis"
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
-msgstr "Probeer het gratis! Een veilige VPN, geavanceerde en privé-AI, en meer."
+msgstr ""
+"Probeer het gratis! Een veilige VPN, geavanceerde en privé-AI, en meer."
 
 # smartling.placeholder_format=C
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -20389,7 +20936,8 @@ msgstr "Probeer onze browser"
 # smartling.placeholder_format=C
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
-msgstr "Probeer onze homepage, waar je deze berichten nooit te zien zult krijgen:"
+msgstr ""
+"Probeer onze homepage, waar je deze berichten nooit te zien zult krijgen:"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with different words to get more results.
@@ -20498,6 +21046,22 @@ msgstr "Probeer: %1$s"
 msgctxt "new user poll"
 msgid "Trying DuckDuckGo again"
 msgstr "DuckDuckGo wordt opnieuw geprobeerd"
+
+# smartling.placeholder_format=C
+#. Message shown in a modal after supported third-party browser users disable AI features in Settings. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -20778,7 +21342,8 @@ msgstr ""
 #. Message shown to the user when there was an issue connecting to their microphone.
 msgctxt "voice chat"
 msgid "Unable to connect to your mic. Please try again."
-msgstr "Er kan geen verbinding worden gemaakt met je microfoon. Probeer het opnieuw."
+msgstr ""
+"Er kan geen verbinding worden gemaakt met je microfoon. Probeer het opnieuw."
 
 # smartling.placeholder_format=C
 #. Error message for explore more questions when answer fails to load
@@ -20819,7 +21384,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sOpen with%s select %sA specific page or pages%s"
-msgstr "Bij %1$sOpenen met%2$s selecteer je %3$sEen specifieke pagina of pagina's%4$s"
+msgstr ""
+"Bij %1$sOpenen met%2$s selecteer je %3$sEen specifieke pagina of pagina's%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -20834,13 +21400,15 @@ msgstr "Bij %1$sZoekinstellingen%2$s selecteer je %3$sDuckDuckGo%4$s"
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch in the address bar with%s select %sAdd New%s"
-msgstr "Bij %1$sZoek in de adresbalk met%2$s selecteer je %3$sNieuwe toevoegen%4$s"
+msgstr ""
+"Bij %1$sZoek in de adresbalk met%2$s selecteer je %3$sNieuwe toevoegen%4$s"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
-msgstr "Bij het gedeelte %1$sZoeken%2$s klik je op %3$sZoekmachines beheren...%4$s"
+msgstr ""
+"Bij het gedeelte %1$sZoeken%2$s klik je op %3$sZoekmachines beheren...%4$s"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -20854,7 +21422,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine
 msgid "Under Search click the drop down and select %sDuckDuckGo%s"
-msgstr "Bij Zoeken klik je op het uitklapmenu en selecteer je %1$sDuckDuckGo%2$s"
+msgstr ""
+"Bij Zoeken klik je op het uitklapmenu en selecteer je %1$sDuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings" header
@@ -20955,8 +21524,8 @@ msgctxt "voice chat limit modal"
 msgid ""
 "Unlock advanced AI models and higher limits with a DuckDuckGo Subscription"
 msgstr ""
-"Ontgrendel geavanceerde AI-modellen en hogere limieten met een "
-"DuckDuckGo-abonnement"
+"Ontgrendel geavanceerde AI-modellen en hogere limieten met een DuckDuckGo-"
+"abonnement"
 
 # smartling.placeholder_format=C
 #. Text informing the user that advanced AI models can be unlocked with a subscription. The variable is used to insert a link that opens the subscription modal. Example: Unlock advanced AI models with a DuckDuckGo subscription.
@@ -21204,7 +21773,8 @@ msgstr ""
 #. Upsell message shown in the voice chat limit and duration limit modals for Plus subscribers, encouraging them to upgrade to Pro.
 msgctxt "voice chat limit modal"
 msgid "Upgrade to Pro to unlock 2x higher usage limits than Plus"
-msgstr "Upgrade naar Pro om 2x hogere gebruikslimieten dan Plus te ontgrendelen"
+msgstr ""
+"Upgrade naar Pro om 2x hogere gebruikslimieten dan Plus te ontgrendelen"
 
 # smartling.placeholder_format=C
 #. Heading in a promotion for a desktop web browser
@@ -21251,6 +21821,12 @@ msgstr "Urdu"
 # smartling.placeholder_format=C
 msgid "Uruguay"
 msgstr "Uruguay"
+
+# smartling.placeholder_format=C
+#. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
+msgctxt "Navigation label on the Duck.ai settings page"
+msgid "Usage"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -21308,7 +21884,8 @@ msgstr "Gebruik DuckDuckGo Private Search"
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Use DuckDuckGo private search on your iPad, iPhone, or Android!"
-msgstr "Gebruik DuckDuckGo Private Search op je iPad, iPhone of Android-apparaat."
+msgstr ""
+"Gebruik DuckDuckGo Private Search op je iPad, iPhone of Android-apparaat."
 
 # smartling.placeholder_format=C
 #. User clicks this button to share their device's location
@@ -21585,10 +22162,10 @@ msgid ""
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
 msgstr ""
-"Bezoek Duck.ai in je andere browser of de DuckDuckGo-app en open "
-"'Duck.ai-instellingen'. Selecteer 'Inschakelen' onder Sync & Backup en "
-"selecteer 'Synchroniseren met een ander apparaat'. Of scan de QR-code op je "
-"herstel-PDF."
+"Bezoek Duck.ai in je andere browser of de DuckDuckGo-app en open 'Duck.ai-"
+"instellingen'. Selecteer 'Inschakelen' onder Sync & Backup en selecteer "
+"'Synchroniseren met een ander apparaat'. Of scan de QR-code op je herstel-"
+"PDF."
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -21703,6 +22280,12 @@ msgid "Wales"
 msgstr "Wales"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Walk me through the steps"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for walking directions on a map.
 msgctxt "directions"
 msgid "Walking"
@@ -21781,8 +22364,8 @@ msgid ""
 "viewing activity from influencing YouTube recommendations."
 msgstr ""
 "Kijk in Duck Player om gepersonaliseerde advertenties op YouTube te "
-"blokkeren en te voorkomen dat je kijkactiviteit invloed heeft op "
-"YouTube-aanbevelingen."
+"blokkeren en te voorkomen dat je kijkactiviteit invloed heeft op YouTube-"
+"aanbevelingen."
 
 # smartling.placeholder_format=C
 #. A button that takes a user to another site in order to watch a video. The placeholder is the name of the video site. For example: 'Watch on Vimeo'
@@ -21820,6 +22403,17 @@ msgid "We can anonymize%s your location%s to show you more accurate results."
 msgstr ""
 "We kunnen%1$sje locatie%2$s anonimiseren om je nauwkeurigere resultaten te "
 "laten zien."
+
+# smartling.placeholder_format=C
+#. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
+msgctxt ""
+"Inline warning shown below the share-content toggle when the user selects "
+"Harmful or Illegal but has not enabled sharing"
+msgid ""
+"We can only fix what we can see. To report a harmful or illegal response, "
+"please share this conversation with DuckDuckGo so we can investigate and "
+"address the issue."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -21861,12 +22455,14 @@ msgstr "We achtervolgen je niet met advertenties."
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
 msgid "We don't store usernames or any personally identifiable information."
-msgstr "We slaan geen gebruikersnamen of persoonlijk identificeerbare informatie op."
+msgstr ""
+"We slaan geen gebruikersnamen of persoonlijk identificeerbare informatie op."
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don't store your personal info or track you. Ever."
-msgstr "We slaan je persoonlijke gegevens niet op en volgen je ook niet. Nooit."
+msgstr ""
+"We slaan je persoonlijke gegevens niet op en volgen je ook niet. Nooit."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -21892,7 +22488,8 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what brought you "
 "back today:"
-msgstr "We volgen je niet, dus we horen graag van je waarom je bij ons terugkeert:"
+msgstr ""
+"We volgen je niet, dus we horen graag van je waarom je bij ons terugkeert:"
 
 # smartling.placeholder_format=C
 #. Message prompting users to fill out a feedback form.
@@ -21900,7 +22497,8 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what convinced you "
 "to try us out today:"
-msgstr "We volgen je niet, dus we horen graag van je waarom je ons wilt uitproberen:"
+msgstr ""
+"We volgen je niet, dus we horen graag van je waarom je ons wilt uitproberen:"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -21987,7 +22585,8 @@ msgstr "De verbinding is verbroken. Probeer het later opnieuw."
 #. We store chats for 15 minutes in the BE. If the user tries to fetch it after the 15 minutes elapsed or if we had an issue saving it we show them this error message so they can re-submit their prompt.
 msgctxt "AI Chat: Error message for unsaved or expired chats saved in sync"
 msgid "We lost the connection. Please try sending your message again."
-msgstr "We hebben de verbinding verloren. Probeer je bericht opnieuw te verzenden."
+msgstr ""
+"We hebben de verbinding verloren. Probeer je bericht opnieuw te verzenden."
 
 # smartling.placeholder_format=C
 #. Message asking the user to disable their ad blocker, with a link to how our ads don't track you. The placeholders are for the start and end tags of that link (e.g. <a href="%">, </a>)
@@ -22019,7 +22618,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We stop anyone from getting your search history, including us."
-msgstr "We zorgen ervoor dat niemand je zoekgeschiedenis kan inzien, ook wij niet."
+msgstr ""
+"We zorgen ervoor dat niemand je zoekgeschiedenis kan inzien, ook wij niet."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -22042,7 +22642,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
-msgstr "We blokkeren trackers die je gegevens willen verzamelen terwijl je surft."
+msgstr ""
+"We blokkeren trackers die je gegevens willen verzamelen terwijl je surft."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -22076,7 +22677,8 @@ msgctxt "duckai_migration"
 msgid ""
 "We're sorry for this inconvenience. We’re working hard to make your "
 "experience better."
-msgstr "Onze excuses voor dit ongemak. We doen ons best om je ervaring te verbeteren."
+msgstr ""
+"Onze excuses voor dit ongemak. We doen ons best om je ervaring te verbeteren."
 
 # smartling.placeholder_format=C
 #. Body text explaining the service update requires a page reload.
@@ -22180,7 +22782,8 @@ msgstr "Wekelijkse limiet bereikt"
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Weekly usage limit reached. You can continue this chat after %s."
-msgstr "Wekelijkse gebruikslimiet bereikt. Je kunt dit gesprek voortzetten na %1$s."
+msgstr ""
+"Wekelijkse gebruikslimiet bereikt. Je kunt dit gesprek voortzetten na %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable weekly Duck.ai usage limit and can opt in to continue using the monthly limit.
@@ -22233,7 +22836,8 @@ msgstr ""
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai! You can now import your downloaded chats."
-msgstr "Welkom bij de nieuwe Duck.ai! Je kunt nu je gedownloade chats importeren."
+msgstr ""
+"Welkom bij de nieuwe Duck.ai! Je kunt nu je gedownloade chats importeren."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -22369,6 +22973,103 @@ msgstr ""
 "voor mensen met of zonder veel ervaring met AI of technische kennis."
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the counterarguments?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the hours & location?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key contributions of this paper?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key contributions?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key details?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key points covered in this video?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key points?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key takeaways from this article?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key takeaways?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key things I will learn from this course?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main counterarguments or criticisms of this?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main questions this page answers?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the must-try dishes here?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"What are the opening hours, location, and contact details for this place?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the pros and cons of this product?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the pros and cons?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
 msgctxt "feedback form"
 msgid "What bothered you most?"
@@ -22469,6 +23170,12 @@ msgid "What does atria mean in the context of a medical article?"
 msgstr "Wat betekent atria in de context van een medisch artikel?"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What does this answer?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
@@ -22479,6 +23186,12 @@ msgstr "Welke functie wil je dat we toevoegen? (optioneel)"
 msgctxt "cloudsave"
 msgid "What information gets saved?"
 msgstr "Welke informatie wordt er opgeslagen?"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What interview questions might come up for this role?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -22495,6 +23208,12 @@ msgstr ""
 msgctxt "Full sentence for looking up basic facts"
 msgid "What is the capital city of Albania?"
 msgstr "Wat is de hoofdstad van Albanië?"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What is the overall verdict and rating for this?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to a page with additional information.
@@ -22519,6 +23238,12 @@ msgid "What people say:"
 msgstr "Wat mensen zeggen:"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What should I order?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
 msgctxt "feedback form"
 msgid "What stood out?"
@@ -22529,6 +23254,18 @@ msgstr "Wat viel op?"
 msgctxt "feedback form"
 msgid "What was wrong with the response? (optional)"
 msgstr "Wat was er mis met het antwoord? (optioneel)"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I learn?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I need?"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -22548,6 +23285,12 @@ msgstr ""
 msgctxt "SERP footer content"
 msgid "What's New"
 msgstr "Wat is er nieuw?"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What's the verdict?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -22600,6 +23343,12 @@ msgid "Which features are missing? (Optional)"
 msgstr "Welke functies ontbreken? (Optioneel)"
 
 # smartling.placeholder_format=C
+#. An invitation for users to leave feedback
+msgctxt "Feedback prompt"
+msgid "Which features are missing? (optional)"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
 msgid "White"
 msgstr "Wit"
@@ -22614,6 +23363,18 @@ msgstr "Wit"
 #. Link to an about us page.
 msgid "Who We Are"
 msgstr "Wie zijn wij"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Who are the main cast and crew, and what else are they known for?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Who is this person?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Header above a collection of privacy-related links.
@@ -23240,8 +24001,8 @@ msgid ""
 "DuckDuckGo subscription protections in the DuckDuckGo browser."
 msgstr ""
 "Je hebt nu toegang tot geavanceerde AI-modellen. Je hebt toegang tot de VPN "
-"en andere beveiligingen van het DuckDuckGo-abonnement in de "
-"DuckDuckGo-browser."
+"en andere beveiligingen van het DuckDuckGo-abonnement in de DuckDuckGo-"
+"browser."
 
 # smartling.placeholder_format=C
 #. Welcome message that appears after the DuckDuckGo extension is installed.
@@ -23381,7 +24142,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
 msgid "You've reached your dictation usage limit. Try again later."
-msgstr "Je hebt je limiet voor dicteergebruik bereikt. probeer het later opnieuw"
+msgstr ""
+"Je hebt je limiet voor dicteergebruik bereikt. probeer het later opnieuw"
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -23550,8 +24312,8 @@ msgctxt "Active Privacy protection description"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
 msgstr ""
-"Je chats zijn privé, geanonimiseerd door ons en worden niet gebruikt om "
-"AI-modellen te trainen."
+"Je chats zijn privé, geanonimiseerd door ons en worden niet gebruikt om AI-"
+"modellen te trainen."
 
 # smartling.placeholder_format=C
 #. Text explaining that user chats are private and not used for AI (Artificial Intelligence) training.
@@ -23559,8 +24321,8 @@ msgctxt "Body text for privacy protection modal"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
 msgstr ""
-"Je chats zijn privé, geanonimiseerd door ons en worden niet gebruikt om "
-"AI-modellen te trainen."
+"Je chats zijn privé, geanonimiseerd door ons en worden niet gebruikt om AI-"
+"modellen te trainen."
 
 # smartling.placeholder_format=C
 #. Text for a menu item that describes the privacy protection feature.
@@ -23593,8 +24355,8 @@ msgid ""
 "Your chats are still private, anonymized by us, and not used to train AI "
 "models. Follow these steps to keep your chat history."
 msgstr ""
-"Je chats zijn privé, geanonimiseerd door ons en worden niet gebruikt om "
-"AI-modellen te trainen. Volg deze stappen om je chatgeschiedenis te bewaren."
+"Je chats zijn privé, geanonimiseerd door ons en worden niet gebruikt om AI-"
+"modellen te trainen. Volg deze stappen om je chatgeschiedenis te bewaren."
 
 # smartling.placeholder_format=C
 #. Body shown after import completes.
@@ -23810,7 +24572,8 @@ msgstr ""
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
 msgctxt "voice chat limit modal"
 msgid "You’ve reached the voice chat limit for now. Please try again later."
-msgstr "Je hebt de limiet voor spraakchat voor nu bereikt. Probeer het later opnieuw."
+msgstr ""
+"Je hebt de limiet voor spraakchat voor nu bereikt. Probeer het later opnieuw."
 
 # smartling.placeholder_format=C
 #. The name of the Yucatec Maya language
@@ -23893,7 +24656,8 @@ msgstr "door %1$s"
 #. Trust line shown at the bottom of the explainer panel, summarizing DuckDuckGo's reputation for online protection.
 msgctxt "Footer banner text in the How Duck.ai Works panel"
 msgid "by DuckDuckGo — online protection trusted by millions every day."
-msgstr "Door DuckDuckGo — online bescherming vertrouwd door miljoenen elke dag."
+msgstr ""
+"Door DuckDuckGo — online bescherming vertrouwd door miljoenen elke dag."
 
 # smartling.placeholder_format=C
 #. An abreviated unit of time indicating an age, e.g. "2d"

--- a/locales/nl_NL/LC_MESSAGES/duckduckgo.po
+++ b/locales/nl_NL/LC_MESSAGES/duckduckgo.po
@@ -6487,8 +6487,7 @@ msgid ""
 msgstr ""
 "Duck.ai is gemaakt door DuckDuckGo. We zijn een onafhankelijk online "
 "beveiligingsbedrijf voor iedereen die weer controle wil krijgen over zijn of "
-"haar persoonlijke gegevens.\n"
-"\n"
+"haar persoonlijke gegevens."
 
 # smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.

--- a/locales/nn_NO/LC_MESSAGES/duckduckgo.po
+++ b/locales/nn_NO/LC_MESSAGES/duckduckgo.po
@@ -1159,6 +1159,11 @@ msgctxt "feedback form"
 msgid "Address is incorrect"
 msgstr ""
 
+#. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Adjust the servings"
+msgstr ""
+
 #. as in multiple advertisements
 msgid "Ads"
 msgstr ""
@@ -1332,6 +1337,13 @@ msgstr ""
 #. Heading shown on the empty chat screen. The text between the two %s markers is displayed inside a clickable privacy button. First %s renders a shield icon, second %s is an invisible end marker. Keep the word 'private' between both %s markers.
 msgctxt "Empty state heading in Duck.ai chat mode"
 msgid "All chats are %sprivate%s"
+msgstr ""
+
+#. Paragraph in the Privacy & Terms section of the About & Legal page in Duck.ai settings, summarizing how chats are anonymized and are not stored or used to train chat models.
+msgctxt "Privacy & Terms section description on the Duck.ai settings page"
+msgid ""
+"All chats are anonymized by DuckDuckGo, and your conversations are not used "
+"to train chat models by DuckDuckGo or the model providers"
 msgstr ""
 
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1544,6 +1556,12 @@ msgstr ""
 #. Confirmation message after location service is enabled.
 msgctxt "precise_user_location"
 msgid "Anonymous location enabled"
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Anonymously generates answers for search queries based on web content. "
+"Choose how often you want it to appear, or disable it completely."
 msgstr ""
 
 #. Instant Answer tab name
@@ -1766,6 +1784,11 @@ msgstr ""
 
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse
 msgid "Ask a follow-up with Duck.ai"
+msgstr ""
+
+#. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
+msgctxt "Page suggestion chip label"
+msgid "Ask about this page"
 msgstr ""
 
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2090,6 +2113,11 @@ msgstr ""
 msgid "Barcode"
 msgstr "Strekkode"
 
+#. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Based on this page, is this course worth taking?"
+msgstr ""
+
 msgctxt "settings"
 msgid "Basic"
 msgstr "Grunnleggjande"
@@ -2121,6 +2149,13 @@ msgstr ""
 #. Placeholder text displayed while the assistant waits for the user to choose an action.
 msgctxt "Assistant response placeholder"
 msgid "Before continuing..."
+msgstr ""
+
+#. Explains that before storing the report, DuckDuckGo will anonymize the conversation by removing PII like names, email addresses, and identifying metadata.
+msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
+msgid ""
+"Before storing this report, DuckDuckGo will anonymize your conversation by "
+"removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
 #. Label that's displayed next to a past start date below a web search result.
@@ -2379,6 +2414,11 @@ msgstr "Brasil"
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Break Points Won"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Break this down into clear, numbered steps."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -2738,6 +2778,11 @@ msgstr "Karriere"
 #. Text of a button that performs a search for the cast of a particular movie or tv show
 msgctxt "Movie/TV Show Title instant answer"
 msgid "Cast"
+msgstr ""
+
+#. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Cast & Crew"
 msgstr ""
 
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -4096,6 +4141,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Create a shopping list with quantities from this recipe."
+msgstr ""
+
 #. Placeholder text displayed in the input field when starting a new image generation session.
 msgctxt "Placeholder text for the image generation input field"
 msgid "Create an image of a cute duck..."
@@ -4622,6 +4672,10 @@ msgstr ""
 msgid "Dictation limit reached"
 msgstr ""
 
+#. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
+msgid "Dictation temporarily unavailable"
+msgstr ""
+
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
@@ -4866,6 +4920,20 @@ msgctxt "precise_user_location"
 msgid "Done"
 msgstr ""
 
+#. Message shown in a modal after DuckDuckGo browser users disable AI features in Settings. The first two placeholders bold noai.duckduckgo.com. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
+"filtered out. %sLearn More%s"
+msgstr ""
+
+#. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
+"and AI images filtered out. %sLearn more%s"
+msgstr ""
+
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Double Faults"
@@ -4956,6 +5024,16 @@ msgctxt "Full sentence for writing an email"
 msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
+msgstr ""
+
+#. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Draft a cover letter"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Draft a cover letter for this job."
 msgstr ""
 
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -5095,6 +5173,14 @@ msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
 msgstr ""
 
+#. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
+msgctxt "About section description on the Duck.ai settings page"
+msgid ""
+"Duck.ai is created by DuckDuckGo. We're an independent online protection "
+"company for anyone who wants to take back control of their personal "
+"information."
+msgstr ""
+
 #. Title shown when an update is required before proceeding.
 msgctxt "duckai_migration"
 msgid "Duck.ai is moving domains"
@@ -5128,6 +5214,12 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Duck.ai lets you chat privately with popular AI models. Disabling it hides "
+"Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
 
 msgctxt "settings"
@@ -5895,6 +5987,16 @@ msgstr ""
 msgid "Eritrea"
 msgstr ""
 
+#. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Estimate the nutrition"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Estimate the nutritional information for this recipe."
+msgstr ""
+
 msgid "Estonia"
 msgstr "Estland"
 
@@ -5939,10 +6041,50 @@ msgctxt "merchant promotion product ad extension"
 msgid "Expires in 1 day"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain the accepted answer in simple terms."
+msgstr ""
+
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
+msgstr ""
+
+#. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain the top answer"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this in simple, plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this paper"
+msgstr ""
+
+#. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this repo"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this research paper in plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this simply"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain what this repository does and how to use it."
 msgstr ""
 
 #. Label to show if song lyrics contain explicit content
@@ -6173,6 +6315,11 @@ msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
 msgstr ""
 
+msgctxt "settings"
+msgid ""
+"Filters out known AI spam sites from image search results. %sLearn More%s"
+msgstr ""
+
 #. Label for the final score of a sporting event.
 msgid "Final"
 msgstr "Siste"
@@ -6212,6 +6359,11 @@ msgstr ""
 #. Short description shown below the 'Web Search' label in the Tools dropdown.
 msgctxt "Subtitle for the Web Search tool entry in the Tools dropdown menu"
 msgid "Find current information"
+msgstr ""
+
+#. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Find me alternatives"
 msgstr ""
 
 #. Button that searches for results closer to the user's current location.
@@ -6602,6 +6754,11 @@ msgstr ""
 msgid "Generate More"
 msgstr ""
 
+#. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Generate a shopping list"
+msgstr ""
+
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
 msgid "Generate a short answer from the web"
 msgstr ""
@@ -6836,6 +6993,11 @@ msgstr ""
 #. Text for a button inviting users to give it a try for the Duck.ai product. On click, they're taken to the Duck.ai page.
 msgctxt "Onboarding welcome screen button text"
 msgid "Give it a Try"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Give me a quick background on this person."
 msgstr ""
 
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -7198,6 +7360,16 @@ msgstr ""
 
 #. Link to a page with information about sharing DuckDuckGo with friends.
 msgid "Help Spread Privacy"
+msgstr ""
+
+#. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Help me prep for the interview"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Help me tailor my resume for this job."
 msgstr ""
 
 #. Title of a SERP popup that invites users to take a survey (desktop only)
@@ -7617,6 +7789,13 @@ msgstr ""
 #. Text displayed on the button on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
 msgctxt "Onboarding terms screen button text"
 msgid "I Agree"
+msgstr ""
+
+#. Text for the button that takes the user to the external DuckDuckGo login subscription page.
+msgctxt ""
+"Text for the I already have a subscription button in the Duck.ai settings "
+"page"
+msgid "I Already Have a Subscription"
 msgstr ""
 
 #. Text for the button that takes the user to the login subscription page.
@@ -8069,6 +8248,11 @@ msgctxt "Sidemenu browser promo"
 msgid "Install Mac Browser"
 msgstr ""
 
+#. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
+msgctxt "settings"
+msgid "Install Now"
+msgstr ""
+
 #. Text of a button to install the DuckDuckGo app
 msgctxt "Serp footer content"
 msgid "Install Our App"
@@ -8148,9 +8332,36 @@ msgctxt "cloudsave"
 msgid "Is deleted data really deleted?"
 msgstr "Er sletta data verkeleg sletta?"
 
+#. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is it worth taking?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this place any good?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"Is this place any good? Summarize its reputation based on reviews and "
+"ratings."
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "Is this video helpful?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this worth watching?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Is this worth watching? Give me a spoiler-free take."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -8647,6 +8858,11 @@ msgstr "Lenkjeskrift:"
 msgid "Links:"
 msgstr "Lenkjer:"
 
+#. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "List the tools, materials, or prerequisites I need for this."
+msgstr ""
+
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
 msgid "Listen"
 msgstr "Lytt"
@@ -8979,6 +9195,11 @@ msgstr ""
 #. Label for linke navigating to site exclusion feature on Settings page
 msgctxt "Exclusion message manage sites button"
 msgid "Manage blocked sites"
+msgstr ""
+
+#. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
+msgctxt "setting"
+msgid "Manage in Browser Settings"
 msgstr ""
 
 #. Link to the site exclusion settings page
@@ -11284,6 +11505,11 @@ msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
+msgid "Please describe why the chat response is harmful or illegal. (optional)"
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
+msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
 msgstr ""
 
@@ -11302,6 +11528,13 @@ msgctxt "Modal disclaimer text"
 msgid ""
 "Please note: starting a new chat with any model will delete your current "
 "chat session."
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
+msgctxt "Feedback prompt"
+msgid ""
+"Please paste your prompt and the problematic output (with any personal "
+"information removed) and describe why the content is harmful or illegal."
 msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -11686,6 +11919,11 @@ msgctxt "settings"
 msgid "Privacy"
 msgstr "Personvern"
 
+#. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
+msgctxt "Section heading on the Duck.ai settings page"
+msgid "Privacy & Terms"
+msgstr ""
+
 msgid "Privacy Blog"
 msgstr ""
 
@@ -11739,6 +11977,11 @@ msgstr ""
 
 #. Text used in other strings to link to the Privacy Policy and Terms of Service content.
 msgctxt "Copy used to compose link in sentences"
+msgid "Privacy Policy and Terms of Service"
+msgstr ""
+
+#. Text for a button that links to the terms of use and privacy policy page.
+msgctxt "Secondary button text in active privacy modal"
 msgid "Privacy Policy and Terms of Service"
 msgstr ""
 
@@ -12147,6 +12390,26 @@ msgctxt "Brief for recommending a book"
 msgid "Recommend a book"
 msgstr ""
 
+#. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar books"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar books."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar movies or shows."
+msgstr ""
+
+#. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar titles"
+msgstr ""
+
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
 msgid "Recording failed. Please try again."
 msgstr ""
@@ -12466,6 +12729,14 @@ msgstr ""
 msgid "Republic of Moldova"
 msgstr ""
 
+#. Note indicating that sharing the conversation is mandatory when reporting harmful or illegal content. Rendered alongside the standard share label (DUCKCHAT_RESPONSE_FEEDBACK_SHARE_PROMPT_RESPONSE_LABEL), not replacing it.
+msgctxt ""
+"Note shown under the share-content switch label on the Duck.ai response "
+"feedback form when the user has selected Harmful or Illegal as the feedback "
+"reason"
+msgid "Required for harmful or illegal reports"
+msgstr ""
+
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
 msgctxt "Description for extended reasoning mode in Duck.ai"
 msgid "Researches before responding"
@@ -12651,6 +12922,11 @@ msgstr "Omtalar"
 #. Label above a list of customer reviews of a business.
 msgctxt "maps_places"
 msgid "Reviews"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Rewrite this recipe scaled for a different number of servings."
 msgstr ""
 
 msgid "Romania"
@@ -13696,6 +13972,11 @@ msgctxt "Setup button for native sync flow"
 msgid "Set Up Now"
 msgstr ""
 
+#. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
+msgctxt "Encrypted storage setup button shown in native browsers"
+msgid "Set Up Sync & Backup"
+msgstr ""
+
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
 msgctxt "Title for the Sync & Backup intro screen"
 msgid "Set Up Sync & Backup"
@@ -13839,6 +14120,12 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
+msgctxt ""
+"Label beside the share-content switch on the Duck.ai response feedback form"
+msgid "Share this conversation with DuckDuckGo"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -14853,6 +15140,21 @@ msgctxt "Brief for suggesting a blog post title"
 msgid "Suggest a title for a blog post"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest related articles or topics worth exploring next."
+msgstr ""
+
+#. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Suggest related articles to explore"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest some alternatives to this product."
+msgstr ""
+
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
 msgctxt "directions"
 msgid "Suggestions:"
@@ -14862,9 +15164,84 @@ msgctxt "noresults"
 msgid "Suggestions:"
 msgstr ""
 
+#. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Sum up the reviews"
+msgstr ""
+
 #. A short title for the a message asking the AI to summarize a text.
 msgctxt "Title for the summarize message"
 msgid "Summarize"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize the Q&As"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the background and notable work of this person."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the key details of this event."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the questions and answers on this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize their background"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this book"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this book."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this discussion"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this discussion thread."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this video"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this video."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize what the reviews say."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -15119,6 +15496,11 @@ msgstr ""
 msgid "Syria"
 msgstr ""
 
+#. Text for a button that enables the theme to follow the operating system's color scheme preference.
+msgctxt "System theme button for theme selector"
+msgid "System"
+msgstr ""
+
 #. Abbreviation indicating this is the total score for a game
 msgctxt "Sports module"
 msgid "T"
@@ -15142,6 +15524,11 @@ msgctxt "language_name"
 msgid "Tahitian"
 msgstr ""
 
+#. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Tailor my resume"
+msgstr ""
+
 msgid "Taiwan"
 msgstr ""
 
@@ -15163,6 +15550,12 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "Take control of your personal data!"
+msgstr ""
+
+#. Description for the Feedback section of the Duck.ai settings page, asking the user to take an anonymous survey to let us know how we can make Duck.ai better.
+msgctxt "Feedback section description on the Duck.ai settings page"
+msgid ""
+"Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
 
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -15407,6 +15800,11 @@ msgstr ""
 #. https://duck.co/media/files/theme.png
 msgid "Theme"
 msgstr "Tema"
+
+#. Text for the theme selector label that allows users to switch between Light and dark theme.
+msgctxt "Label for the theme selector feature"
+msgid "Theme"
+msgstr ""
 
 #. http://i.imgur.com/LpFhb1e.png
 msgctxt "settings"
@@ -16060,6 +16458,16 @@ msgid ""
 "movie theatre?”"
 msgstr ""
 
+#. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Translate this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
+msgctxt "Page suggestion prompt"
+msgid "Translate this page into %s."
+msgstr ""
+
 #. Placeholder text for a region that will display translated text.
 msgctxt "translations_module"
 msgid "Translation"
@@ -16174,6 +16582,11 @@ msgstr ""
 #. Call-to-action button for the subscription promo in the SERP sidemenu.
 msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
+msgstr ""
+
+#. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
+msgctxt "settings"
+msgid "Try It Now"
 msgstr ""
 
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -16368,6 +16781,20 @@ msgstr "Prøv: %s"
 msgctxt "new user poll"
 msgid "Trying DuckDuckGo again"
 msgstr "Prøver DuckDuckGo igjen"
+
+#. Message shown in a modal after supported third-party browser users disable AI features in Settings. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+#. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
 
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
 msgctxt "Assistant response placeholder"
@@ -16971,6 +17398,11 @@ msgstr ""
 msgid "Uruguay"
 msgstr ""
 
+#. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
+msgctxt "Navigation label on the Duck.ai settings page"
+msgid "Usage"
+msgstr ""
+
 #. A feedback suggestion
 msgctxt "Feedback prompt"
 msgid "Usage limit"
@@ -17321,6 +17753,11 @@ msgstr ""
 msgid "Wales"
 msgstr ""
 
+#. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Walk me through the steps"
+msgstr ""
+
 #. Label for walking directions on a map.
 msgctxt "directions"
 msgid "Walking"
@@ -17411,6 +17848,16 @@ msgstr ""
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
+msgstr ""
+
+#. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
+msgctxt ""
+"Inline warning shown below the share-content toggle when the user selects "
+"Harmful or Illegal but has not enabled sharing"
+msgid ""
+"We can only fix what we can see. To report a harmful or illegal response, "
+"please share this conversation with DuckDuckGo so we can investigate and "
+"address the issue."
 msgstr ""
 
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -17838,6 +18285,87 @@ msgid ""
 "experience."
 msgstr ""
 
+#. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the counterarguments?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the hours & location?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key contributions of this paper?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key contributions?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key details?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key points covered in this video?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key points?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key takeaways from this article?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key takeaways?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key things I will learn from this course?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main counterarguments or criticisms of this?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main questions this page answers?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the must-try dishes here?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"What are the opening hours, location, and contact details for this place?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the pros and cons of this product?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the pros and cons?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
 msgctxt "feedback form"
 msgid "What bothered you most?"
@@ -17921,6 +18449,11 @@ msgctxt "Full sentence for defining a term"
 msgid "What does atria mean in the context of a medical article?"
 msgstr ""
 
+#. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What does this answer?"
+msgstr ""
+
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
@@ -17930,6 +18463,11 @@ msgstr ""
 msgctxt "cloudsave"
 msgid "What information gets saved?"
 msgstr "Kva slags informasjon vert lagra?"
+
+#. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What interview questions might come up for this role?"
+msgstr ""
 
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
@@ -17941,6 +18479,11 @@ msgstr ""
 #. Text for a prompt suggestion for looking up the capital city of Albania.
 msgctxt "Full sentence for looking up basic facts"
 msgid "What is the capital city of Albania?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What is the overall verdict and rating for this?"
 msgstr ""
 
 #. Link to a page with additional information.
@@ -17961,6 +18504,11 @@ msgctxt "maps_places"
 msgid "What people say:"
 msgstr ""
 
+#. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What should I order?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
 msgctxt "feedback form"
 msgid "What stood out?"
@@ -17969,6 +18517,16 @@ msgstr ""
 #. Question on a feedback form for a negative feedback response.
 msgctxt "feedback form"
 msgid "What was wrong with the response? (optional)"
+msgstr ""
+
+#. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I learn?"
+msgstr ""
+
+#. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I need?"
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -17983,6 +18541,11 @@ msgstr ""
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
 msgctxt "SERP footer content"
 msgid "What's New"
+msgstr ""
+
+#. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What's the verdict?"
 msgstr ""
 
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -18024,6 +18587,11 @@ msgctxt "Feedback prompt"
 msgid "Which features are missing? (Optional)"
 msgstr ""
 
+#. An invitation for users to leave feedback
+msgctxt "Feedback prompt"
+msgid "Which features are missing? (optional)"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
 msgid "White"
 msgstr "Kvit"
@@ -18036,6 +18604,16 @@ msgstr "Kvit"
 #. Link to an about us page.
 msgid "Who We Are"
 msgstr "Om oss"
+
+#. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Who are the main cast and crew, and what else are they known for?"
+msgstr ""
+
+#. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Who is this person?"
+msgstr ""
 
 #. Header above a collection of privacy-related links.
 msgid "Why Privacy"

--- a/locales/od_IN/LC_MESSAGES/duckduckgo.po
+++ b/locales/od_IN/LC_MESSAGES/duckduckgo.po
@@ -1162,6 +1162,11 @@ msgctxt "feedback form"
 msgid "Address is incorrect"
 msgstr ""
 
+#. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Adjust the servings"
+msgstr ""
+
 #. as in multiple advertisements
 msgid "Ads"
 msgstr ""
@@ -1333,6 +1338,13 @@ msgstr ""
 #. Heading shown on the empty chat screen. The text between the two %s markers is displayed inside a clickable privacy button. First %s renders a shield icon, second %s is an invisible end marker. Keep the word 'private' between both %s markers.
 msgctxt "Empty state heading in Duck.ai chat mode"
 msgid "All chats are %sprivate%s"
+msgstr ""
+
+#. Paragraph in the Privacy & Terms section of the About & Legal page in Duck.ai settings, summarizing how chats are anonymized and are not stored or used to train chat models.
+msgctxt "Privacy & Terms section description on the Duck.ai settings page"
+msgid ""
+"All chats are anonymized by DuckDuckGo, and your conversations are not used "
+"to train chat models by DuckDuckGo or the model providers"
 msgstr ""
 
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1545,6 +1557,12 @@ msgstr ""
 #. Confirmation message after location service is enabled.
 msgctxt "precise_user_location"
 msgid "Anonymous location enabled"
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Anonymously generates answers for search queries based on web content. "
+"Choose how often you want it to appear, or disable it completely."
 msgstr ""
 
 #. Instant Answer tab name
@@ -1769,6 +1787,11 @@ msgstr ""
 
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse
 msgid "Ask a follow-up with Duck.ai"
+msgstr ""
+
+#. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
+msgctxt "Page suggestion chip label"
+msgid "Ask about this page"
 msgstr ""
 
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2093,6 +2116,11 @@ msgstr ""
 msgid "Barcode"
 msgstr "ବାରକୋଡ଼"
 
+#. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Based on this page, is this course worth taking?"
+msgstr ""
+
 msgctxt "settings"
 msgid "Basic"
 msgstr "ମୂଳ"
@@ -2124,6 +2152,13 @@ msgstr ""
 #. Placeholder text displayed while the assistant waits for the user to choose an action.
 msgctxt "Assistant response placeholder"
 msgid "Before continuing..."
+msgstr ""
+
+#. Explains that before storing the report, DuckDuckGo will anonymize the conversation by removing PII like names, email addresses, and identifying metadata.
+msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
+msgid ""
+"Before storing this report, DuckDuckGo will anonymize your conversation by "
+"removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
 #. Label that's displayed next to a past start date below a web search result.
@@ -2382,6 +2417,11 @@ msgstr "ବ୍ରାଜିଲ"
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Break Points Won"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Break this down into clear, numbered steps."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -2741,6 +2781,11 @@ msgstr "କ୍ୟାରିୟର"
 #. Text of a button that performs a search for the cast of a particular movie or tv show
 msgctxt "Movie/TV Show Title instant answer"
 msgid "Cast"
+msgstr ""
+
+#. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Cast & Crew"
 msgstr ""
 
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -4092,6 +4137,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Create a shopping list with quantities from this recipe."
+msgstr ""
+
 #. Placeholder text displayed in the input field when starting a new image generation session.
 msgctxt "Placeholder text for the image generation input field"
 msgid "Create an image of a cute duck..."
@@ -4618,6 +4668,10 @@ msgstr ""
 msgid "Dictation limit reached"
 msgstr ""
 
+#. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
+msgid "Dictation temporarily unavailable"
+msgstr ""
+
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
@@ -4862,6 +4916,20 @@ msgctxt "precise_user_location"
 msgid "Done"
 msgstr ""
 
+#. Message shown in a modal after DuckDuckGo browser users disable AI features in Settings. The first two placeholders bold noai.duckduckgo.com. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
+"filtered out. %sLearn More%s"
+msgstr ""
+
+#. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
+"and AI images filtered out. %sLearn more%s"
+msgstr ""
+
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Double Faults"
@@ -4952,6 +5020,16 @@ msgctxt "Full sentence for writing an email"
 msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
+msgstr ""
+
+#. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Draft a cover letter"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Draft a cover letter for this job."
 msgstr ""
 
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -5091,6 +5169,14 @@ msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
 msgstr ""
 
+#. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
+msgctxt "About section description on the Duck.ai settings page"
+msgid ""
+"Duck.ai is created by DuckDuckGo. We're an independent online protection "
+"company for anyone who wants to take back control of their personal "
+"information."
+msgstr ""
+
 #. Title shown when an update is required before proceeding.
 msgctxt "duckai_migration"
 msgid "Duck.ai is moving domains"
@@ -5124,6 +5210,12 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Duck.ai lets you chat privately with popular AI models. Disabling it hides "
+"Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
 
 msgctxt "settings"
@@ -5890,6 +5982,16 @@ msgstr ""
 msgid "Eritrea"
 msgstr ""
 
+#. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Estimate the nutrition"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Estimate the nutritional information for this recipe."
+msgstr ""
+
 msgid "Estonia"
 msgstr "ଇସ୍ତୋନିଆ"
 
@@ -5934,10 +6036,50 @@ msgctxt "merchant promotion product ad extension"
 msgid "Expires in 1 day"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain the accepted answer in simple terms."
+msgstr ""
+
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
+msgstr ""
+
+#. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain the top answer"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this in simple, plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this paper"
+msgstr ""
+
+#. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this repo"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this research paper in plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this simply"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain what this repository does and how to use it."
 msgstr ""
 
 #. Label to show if song lyrics contain explicit content
@@ -6167,6 +6309,11 @@ msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
 msgstr ""
 
+msgctxt "settings"
+msgid ""
+"Filters out known AI spam sites from image search results. %sLearn More%s"
+msgstr ""
+
 #. Label for the final score of a sporting event.
 msgid "Final"
 msgstr "ଶେଷ"
@@ -6207,6 +6354,11 @@ msgstr ""
 #. Short description shown below the 'Web Search' label in the Tools dropdown.
 msgctxt "Subtitle for the Web Search tool entry in the Tools dropdown menu"
 msgid "Find current information"
+msgstr ""
+
+#. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Find me alternatives"
 msgstr ""
 
 #. Button that searches for results closer to the user's current location.
@@ -6597,6 +6749,11 @@ msgstr ""
 msgid "Generate More"
 msgstr ""
 
+#. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Generate a shopping list"
+msgstr ""
+
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
 msgid "Generate a short answer from the web"
 msgstr ""
@@ -6831,6 +6988,11 @@ msgstr ""
 #. Text for a button inviting users to give it a try for the Duck.ai product. On click, they're taken to the Duck.ai page.
 msgctxt "Onboarding welcome screen button text"
 msgid "Give it a Try"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Give me a quick background on this person."
 msgstr ""
 
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -7194,6 +7356,16 @@ msgstr ""
 #. Link to a page with information about sharing DuckDuckGo with friends.
 msgid "Help Spread Privacy"
 msgstr "ଗୋପନୀୟତା ପ୍ରଚାରରେ ସାହାର୍ଯ୍ୟ କରନ୍ତୁ"
+
+#. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Help me prep for the interview"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Help me tailor my resume for this job."
+msgstr ""
 
 #. Title of a SERP popup that invites users to take a survey (desktop only)
 msgctxt "User survey popup"
@@ -7614,6 +7786,13 @@ msgstr ""
 #. Text displayed on the button on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
 msgctxt "Onboarding terms screen button text"
 msgid "I Agree"
+msgstr ""
+
+#. Text for the button that takes the user to the external DuckDuckGo login subscription page.
+msgctxt ""
+"Text for the I already have a subscription button in the Duck.ai settings "
+"page"
+msgid "I Already Have a Subscription"
 msgstr ""
 
 #. Text for the button that takes the user to the login subscription page.
@@ -8068,6 +8247,11 @@ msgctxt "Sidemenu browser promo"
 msgid "Install Mac Browser"
 msgstr ""
 
+#. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
+msgctxt "settings"
+msgid "Install Now"
+msgstr ""
+
 #. Text of a button to install the DuckDuckGo app
 msgctxt "Serp footer content"
 msgid "Install Our App"
@@ -8147,9 +8331,36 @@ msgctxt "cloudsave"
 msgid "Is deleted data really deleted?"
 msgstr "କଣ ଲିଭାଯାଇଥିବା ତଥ୍ୟ ସତରେ ଲିଭାଯାଇସାରିଛି?"
 
+#. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is it worth taking?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this place any good?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"Is this place any good? Summarize its reputation based on reviews and "
+"ratings."
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "Is this video helpful?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this worth watching?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Is this worth watching? Give me a spoiler-free take."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -8646,6 +8857,11 @@ msgstr "ଫଣ୍ଟ ଯୋଡ଼ନ୍ତୁ:"
 msgid "Links:"
 msgstr "ଲିଙ୍କଗୁଡ଼ିକ:"
 
+#. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "List the tools, materials, or prerequisites I need for this."
+msgstr ""
+
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
 msgid "Listen"
 msgstr "ଶୁଣନ୍ତୁ"
@@ -8978,6 +9194,11 @@ msgstr ""
 #. Label for linke navigating to site exclusion feature on Settings page
 msgctxt "Exclusion message manage sites button"
 msgid "Manage blocked sites"
+msgstr ""
+
+#. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
+msgctxt "setting"
+msgid "Manage in Browser Settings"
 msgstr ""
 
 #. Link to the site exclusion settings page
@@ -11279,6 +11500,11 @@ msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
+msgid "Please describe why the chat response is harmful or illegal. (optional)"
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
+msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
 msgstr ""
 
@@ -11297,6 +11523,13 @@ msgctxt "Modal disclaimer text"
 msgid ""
 "Please note: starting a new chat with any model will delete your current "
 "chat session."
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
+msgctxt "Feedback prompt"
+msgid ""
+"Please paste your prompt and the problematic output (with any personal "
+"information removed) and describe why the content is harmful or illegal."
 msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -11681,6 +11914,11 @@ msgctxt "settings"
 msgid "Privacy"
 msgstr "ଗୁପ୍ତତା"
 
+#. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
+msgctxt "Section heading on the Duck.ai settings page"
+msgid "Privacy & Terms"
+msgstr ""
+
 msgid "Privacy Blog"
 msgstr "ଗୋପନୀୟତାର ବ୍ଲଗ ।"
 
@@ -11734,6 +11972,11 @@ msgstr ""
 
 #. Text used in other strings to link to the Privacy Policy and Terms of Service content.
 msgctxt "Copy used to compose link in sentences"
+msgid "Privacy Policy and Terms of Service"
+msgstr ""
+
+#. Text for a button that links to the terms of use and privacy policy page.
+msgctxt "Secondary button text in active privacy modal"
 msgid "Privacy Policy and Terms of Service"
 msgstr ""
 
@@ -12142,6 +12385,26 @@ msgctxt "Brief for recommending a book"
 msgid "Recommend a book"
 msgstr ""
 
+#. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar books"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar books."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar movies or shows."
+msgstr ""
+
+#. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar titles"
+msgstr ""
+
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
 msgid "Recording failed. Please try again."
 msgstr ""
@@ -12461,6 +12724,14 @@ msgstr ""
 msgid "Republic of Moldova"
 msgstr ""
 
+#. Note indicating that sharing the conversation is mandatory when reporting harmful or illegal content. Rendered alongside the standard share label (DUCKCHAT_RESPONSE_FEEDBACK_SHARE_PROMPT_RESPONSE_LABEL), not replacing it.
+msgctxt ""
+"Note shown under the share-content switch label on the Duck.ai response "
+"feedback form when the user has selected Harmful or Illegal as the feedback "
+"reason"
+msgid "Required for harmful or illegal reports"
+msgstr ""
+
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
 msgctxt "Description for extended reasoning mode in Duck.ai"
 msgid "Researches before responding"
@@ -12647,6 +12918,11 @@ msgstr "ସମୀକ୍ଷା"
 msgctxt "maps_places"
 msgid "Reviews"
 msgstr "ସମୀକ୍ଷାଗୁଡ଼ିକ "
+
+#. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Rewrite this recipe scaled for a different number of servings."
+msgstr ""
 
 msgid "Romania"
 msgstr "ରୋମାନିଆ"
@@ -13690,6 +13966,11 @@ msgctxt "Setup button for native sync flow"
 msgid "Set Up Now"
 msgstr ""
 
+#. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
+msgctxt "Encrypted storage setup button shown in native browsers"
+msgid "Set Up Sync & Backup"
+msgstr ""
+
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
 msgctxt "Title for the Sync & Backup intro screen"
 msgid "Set Up Sync & Backup"
@@ -13834,6 +14115,12 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
+msgctxt ""
+"Label beside the share-content switch on the Duck.ai response feedback form"
+msgid "Share this conversation with DuckDuckGo"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -14848,6 +15135,21 @@ msgctxt "Brief for suggesting a blog post title"
 msgid "Suggest a title for a blog post"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest related articles or topics worth exploring next."
+msgstr ""
+
+#. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Suggest related articles to explore"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest some alternatives to this product."
+msgstr ""
+
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
 msgctxt "directions"
 msgid "Suggestions:"
@@ -14857,9 +15159,84 @@ msgctxt "noresults"
 msgid "Suggestions:"
 msgstr "ମତାମତଗୁଡ଼ିକ:"
 
+#. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Sum up the reviews"
+msgstr ""
+
 #. A short title for the a message asking the AI to summarize a text.
 msgctxt "Title for the summarize message"
 msgid "Summarize"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize the Q&As"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the background and notable work of this person."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the key details of this event."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the questions and answers on this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize their background"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this book"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this book."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this discussion"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this discussion thread."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this video"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this video."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize what the reviews say."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -15114,6 +15491,11 @@ msgstr ""
 msgid "Syria"
 msgstr ""
 
+#. Text for a button that enables the theme to follow the operating system's color scheme preference.
+msgctxt "System theme button for theme selector"
+msgid "System"
+msgstr ""
+
 #. Abbreviation indicating this is the total score for a game
 msgctxt "Sports module"
 msgid "T"
@@ -15137,6 +15519,11 @@ msgctxt "language_name"
 msgid "Tahitian"
 msgstr ""
 
+#. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Tailor my resume"
+msgstr ""
+
 msgid "Taiwan"
 msgstr "ତାଇୱାନ"
 
@@ -15158,6 +15545,12 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "Take control of your personal data!"
+msgstr ""
+
+#. Description for the Feedback section of the Duck.ai settings page, asking the user to take an anonymous survey to let us know how we can make Duck.ai better.
+msgctxt "Feedback section description on the Duck.ai settings page"
+msgid ""
+"Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
 
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -15405,6 +15798,11 @@ msgstr ""
 #. https://duck.co/media/files/theme.png
 msgid "Theme"
 msgstr "ଥିମ"
+
+#. Text for the theme selector label that allows users to switch between Light and dark theme.
+msgctxt "Label for the theme selector feature"
+msgid "Theme"
+msgstr ""
 
 #. http://i.imgur.com/LpFhb1e.png
 msgctxt "settings"
@@ -16059,6 +16457,16 @@ msgid ""
 "movie theatre?”"
 msgstr ""
 
+#. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Translate this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
+msgctxt "Page suggestion prompt"
+msgid "Translate this page into %s."
+msgstr ""
+
 #. Placeholder text for a region that will display translated text.
 msgctxt "translations_module"
 msgid "Translation"
@@ -16173,6 +16581,11 @@ msgstr ""
 #. Call-to-action button for the subscription promo in the SERP sidemenu.
 msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
+msgstr ""
+
+#. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
+msgctxt "settings"
+msgid "Try It Now"
 msgstr ""
 
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -16367,6 +16780,20 @@ msgstr "ଚେଷ୍ଟା କରନ୍ତୁ: %s"
 msgctxt "new user poll"
 msgid "Trying DuckDuckGo again"
 msgstr "ପୁଣିଥରେ DuckDuckGo କୁ ବ୍ୟବହାର କରିବାକୁ ଚେଷ୍ଟା କରୁଛନ୍ତି"
+
+#. Message shown in a modal after supported third-party browser users disable AI features in Settings. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+#. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
 
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
 msgctxt "Assistant response placeholder"
@@ -16969,6 +17396,11 @@ msgstr ""
 msgid "Uruguay"
 msgstr ""
 
+#. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
+msgctxt "Navigation label on the Duck.ai settings page"
+msgid "Usage"
+msgstr ""
+
 #. A feedback suggestion
 msgctxt "Feedback prompt"
 msgid "Usage limit"
@@ -17320,6 +17752,11 @@ msgstr ""
 msgid "Wales"
 msgstr ""
 
+#. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Walk me through the steps"
+msgstr ""
+
 #. Label for walking directions on a map.
 msgctxt "directions"
 msgid "Walking"
@@ -17410,6 +17847,16 @@ msgstr ""
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
+msgstr ""
+
+#. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
+msgctxt ""
+"Inline warning shown below the share-content toggle when the user selects "
+"Harmful or Illegal but has not enabled sharing"
+msgid ""
+"We can only fix what we can see. To report a harmful or illegal response, "
+"please share this conversation with DuckDuckGo so we can investigate and "
+"address the issue."
 msgstr ""
 
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -17835,6 +18282,87 @@ msgid ""
 "experience."
 msgstr ""
 
+#. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the counterarguments?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the hours & location?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key contributions of this paper?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key contributions?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key details?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key points covered in this video?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key points?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key takeaways from this article?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key takeaways?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key things I will learn from this course?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main counterarguments or criticisms of this?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main questions this page answers?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the must-try dishes here?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"What are the opening hours, location, and contact details for this place?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the pros and cons of this product?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the pros and cons?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
 msgctxt "feedback form"
 msgid "What bothered you most?"
@@ -17918,6 +18446,11 @@ msgctxt "Full sentence for defining a term"
 msgid "What does atria mean in the context of a medical article?"
 msgstr ""
 
+#. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What does this answer?"
+msgstr ""
+
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
@@ -17927,6 +18460,11 @@ msgstr ""
 msgctxt "cloudsave"
 msgid "What information gets saved?"
 msgstr "କେଉଁ ସବୁ ତଥ୍ୟ ସଞ୍ଚିତ ହୋଇରହିଥାଏ?"
+
+#. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What interview questions might come up for this role?"
+msgstr ""
 
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
@@ -17938,6 +18476,11 @@ msgstr ""
 #. Text for a prompt suggestion for looking up the capital city of Albania.
 msgctxt "Full sentence for looking up basic facts"
 msgid "What is the capital city of Albania?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What is the overall verdict and rating for this?"
 msgstr ""
 
 #. Link to a page with additional information.
@@ -17958,6 +18501,11 @@ msgctxt "maps_places"
 msgid "What people say:"
 msgstr ""
 
+#. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What should I order?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
 msgctxt "feedback form"
 msgid "What stood out?"
@@ -17966,6 +18514,16 @@ msgstr ""
 #. Question on a feedback form for a negative feedback response.
 msgctxt "feedback form"
 msgid "What was wrong with the response? (optional)"
+msgstr ""
+
+#. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I learn?"
+msgstr ""
+
+#. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I need?"
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -17980,6 +18538,11 @@ msgstr ""
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
 msgctxt "SERP footer content"
 msgid "What's New"
+msgstr ""
+
+#. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What's the verdict?"
 msgstr ""
 
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -18021,6 +18584,11 @@ msgctxt "Feedback prompt"
 msgid "Which features are missing? (Optional)"
 msgstr ""
 
+#. An invitation for users to leave feedback
+msgctxt "Feedback prompt"
+msgid "Which features are missing? (optional)"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
 msgid "White"
 msgstr "ଧଳା"
@@ -18033,6 +18601,16 @@ msgstr "ଧଳା"
 #. Link to an about us page.
 msgid "Who We Are"
 msgstr "ଆମେ କିଏ"
+
+#. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Who are the main cast and crew, and what else are they known for?"
+msgstr ""
+
+#. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Who is this person?"
+msgstr ""
 
 #. Header above a collection of privacy-related links.
 msgid "Why Privacy"

--- a/locales/pl_PL/LC_MESSAGES/duckduckgo.po
+++ b/locales/pl_PL/LC_MESSAGES/duckduckgo.po
@@ -2,15 +2,16 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: pl_PL\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 "
+"|| n%100>=20) ? 1 : 2;\n"
 
 # smartling.gettext_line_width = normalized : 79
 # smartling.placeholder_format=C
@@ -489,7 +490,8 @@ msgstr ""
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "%sLong-press%s the DuckDuckGo app icon on the home screen"
-msgstr "%1$sNaciśnij i przytrzymaj%2$s ikonę aplikacji DuckDuckGo na ekranie głównym"
+msgstr ""
+"%1$sNaciśnij i przytrzymaj%2$s ikonę aplikacji DuckDuckGo na ekranie głównym"
 
 # smartling.placeholder_format=C
 #. A message displayed when there is an error loading content or no results on requery
@@ -812,7 +814,8 @@ msgstr "Osiągnięto limit 6 godzin użytkowania."
 #. Displayed when the user has reached a fixed 6-hour Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "6-hour usage limit reached. You can continue this chat after %s."
-msgstr "Osiągnięto limit 6 godzin użytkowania. Możesz kontynuować tę rozmowę po %1$s."
+msgstr ""
+"Osiągnięto limit 6 godzin użytkowania. Możesz kontynuować tę rozmowę po %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable 6-hour Duck.ai usage limit and can opt in to continue using the daily limit.
@@ -933,8 +936,8 @@ msgstr ""
 "Funkcja AI Chat umożliwia prowadzenie anonimowych rozmów z modelami czatu AI "
 "oferowanymi przez inne firmy. Wyłączenie tej opcji spowoduje ukrycie funkcji "
 "AI Chat w DuckDuckGo Search. Nawet w przypadku wyłączenia tego ustawienia "
-"możesz uzyskać dostęp do funkcji AI Chat na stronie "
-"%1$sduckduckgo.com/aichat%2$s."
+"możesz uzyskać dostęp do funkcji AI Chat na stronie %1$sduckduckgo.com/"
+"aichat%2$s."
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -1438,6 +1441,12 @@ msgid "Address is incorrect"
 msgstr "Adres jest nieprawidłowy"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Adjust the servings"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. as in multiple advertisements
 msgid "Ads"
 msgstr "Reklamy"
@@ -1651,6 +1660,14 @@ msgid "All chats are %sprivate%s"
 msgstr "Wszystkie czaty są %1$sprywatne%2$s"
 
 # smartling.placeholder_format=C
+#. Paragraph in the Privacy & Terms section of the About & Legal page in Duck.ai settings, summarizing how chats are anonymized and are not stored or used to train chat models.
+msgctxt "Privacy & Terms section description on the Duck.ai settings page"
+msgid ""
+"All chats are anonymized by DuckDuckGo, and your conversations are not used "
+"to train chat models by DuckDuckGo or the model providers"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
 msgctxt "Privacy modal header in Duck.ai chat"
 msgid "All chats are private"
@@ -1793,7 +1810,8 @@ msgstr "To urządzenie jest już zsynchronizowane."
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Also search privately on your iPad, iPhone, or Android!"
-msgstr "Możesz też wyszukiwać prywatnie na swoim iPadzie, iPhonie oraz Androidzie!"
+msgstr ""
+"Możesz też wyszukiwać prywatnie na swoim iPadzie, iPhonie oraz Androidzie!"
 
 # smartling.placeholder_format=C
 #. Keyboard shortcut for Duck.ai
@@ -1919,6 +1937,13 @@ msgstr ""
 msgctxt "precise_user_location"
 msgid "Anonymous location enabled"
 msgstr "Włączono lokalizację anonimową"
+
+# smartling.placeholder_format=C
+msgctxt "settings"
+msgid ""
+"Anonymously generates answers for search queries based on web content. "
+"Choose how often you want it to appear, or disable it completely."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -2202,6 +2227,12 @@ msgid "Ask a follow-up with Duck.ai"
 msgstr "Poproś o kontynuację z Duck.ai"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
+msgctxt "Page suggestion chip label"
+msgid "Ask about this page"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
 msgctxt "Title for the page context onboarding modal"
 msgid "Ask about this page"
@@ -2444,7 +2475,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI) on mobile
 msgid "Auto-generated from sources. May be inaccurate."
-msgstr "Generowane automatycznie na podstawie źródeł. Może zawierać nieścisłości."
+msgstr ""
+"Generowane automatycznie na podstawie źródeł. Może zawierać nieścisłości."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2629,6 +2661,12 @@ msgid "Barcode"
 msgstr "Kod kreskowy"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Based on this page, is this course worth taking?"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Basic"
 msgstr "Podstawowy"
@@ -2667,6 +2705,14 @@ msgstr "Pałkarz"
 msgctxt "Assistant response placeholder"
 msgid "Before continuing..."
 msgstr "Zanim przejdziesz dalej..."
+
+# smartling.placeholder_format=C
+#. Explains that before storing the report, DuckDuckGo will anonymize the conversation by removing PII like names, email addresses, and identifying metadata.
+msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
+msgid ""
+"Before storing this report, DuckDuckGo will anonymize your conversation by "
+"removing PII like names, email addresses, and identifying metadata."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -2808,7 +2854,8 @@ msgstr "Zablokuj tę witrynę we wszystkich wynikach"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Block trackers and take control of your personal data"
-msgstr "Zablokuj skrypty śledzące i przejmij kontrolę nad swoimi danymi osobowymi"
+msgstr ""
+"Zablokuj skrypty śledzące i przejmij kontrolę nad swoimi danymi osobowymi"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -2985,6 +3032,12 @@ msgid "Break Points Won"
 msgstr "Zdobyte break pointy"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Break this down into clear, numbered steps."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
 msgctxt "Weather IA"
 msgid "Breezy"
@@ -3142,7 +3195,8 @@ msgstr "Burundi"
 #. The first %s is the action button label ('Continue'). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab.
 msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid "By clicking '%s' you agree to our %s."
-msgstr "Klikając przycisk „%1$s”, akceptujesz postanowienia naszego dokumentu %2$s."
+msgstr ""
+"Klikając przycisk „%1$s”, akceptujesz postanowienia naszego dokumentu %2$s."
 
 # smartling.placeholder_format=C
 #. Text stating agreement to Duck.ai Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'By clicking “Agree and Continue,” you accept Duck.ai’s Privacy Policy and Terms of Service.'
@@ -3443,6 +3497,12 @@ msgid "Cast"
 msgstr "Obsada"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Cast & Crew"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
 msgctxt "Tone option label for Casual"
 msgid "Casual"
@@ -3527,7 +3587,8 @@ msgstr "Zmienia sposób wyświetlania adresów URL wyników"
 #. This is the description of a user setting
 msgctxt "settings"
 msgid "Changes how the header is displayed and its behavior as you scroll"
-msgstr "Zmienia sposób wyświetlania nagłówka i jego zachowanie podczas przewijania"
+msgstr ""
+"Zmienia sposób wyświetlania nagłówka i jego zachowanie podczas przewijania"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/mcZdcaF.png
@@ -3546,7 +3607,8 @@ msgstr "Zmienia kolor tła na całej stronie"
 msgctxt "settings"
 msgid ""
 "Changes the background color of results on hover, modules, and dropdown menus"
-msgstr "Zmienia kolor tła wyników po najechaniu kursorem, modułów i rozwijanych menu"
+msgstr ""
+"Zmienia kolor tła wyników po najechaniu kursorem, modułów i rozwijanych menu"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/NdpkbY0.png
@@ -3679,8 +3741,8 @@ msgstr ""
 "rozmów z zewnętrznymi modelami czatu AI, obsługującymi modele OpenAI, "
 "Anthropic i inne. Wyłączenie tej opcji spowoduje ukrycie przycisków czatu i "
 "linków w DuckDuckGo Search. Nawet w przypadku wyłączenia tego ustawienia "
-"możesz uzyskać dostęp do czatu, przechodząc pod adres "
-"%1$shttps://duck.ai%2$s bezpośrednio."
+"możesz uzyskać dostęp do czatu, przechodząc pod adres %1$shttps://duck."
+"ai%2$s bezpośrednio."
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -5159,6 +5221,12 @@ msgid "Create Image"
 msgstr "Utwórz obraz"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Create a shopping list with quantities from this recipe."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text displayed in the input field when starting a new image generation session.
 msgctxt "Placeholder text for the image generation input field"
 msgid "Create an image of a cute duck..."
@@ -5413,7 +5481,8 @@ msgstr "Osiągnięto dzienny limit"
 #. Displayed when the user has reached a fixed daily Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Daily usage limit reached. You can continue this chat after %s."
-msgstr "Osiągnięto dzienny limit użycia. Możesz kontynuować tę rozmowę po %1$s."
+msgstr ""
+"Osiągnięto dzienny limit użycia. Możesz kontynuować tę rozmowę po %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable daily Duck.ai usage limit and can opt in to continue using the weekly limit.
@@ -5799,6 +5868,11 @@ msgid "Dictation limit reached"
 msgstr "Osiągnięto limit dyktowania"
 
 # smartling.placeholder_format=C
+#. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
+msgid "Dictation temporarily unavailable"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
@@ -6099,6 +6173,22 @@ msgid "Done"
 msgstr "Gotowe"
 
 # smartling.placeholder_format=C
+#. Message shown in a modal after DuckDuckGo browser users disable AI features in Settings. The first two placeholders bold noai.duckduckgo.com. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
+"filtered out. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
+"and AI images filtered out. %sLearn more%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Double Faults"
@@ -6211,6 +6301,18 @@ msgid ""
 msgstr ""
 "Przygotuj zwięzłą i szczegółową wiadomość e-mail do sprzedawcy z prośbą o "
 "wycenę usługi naprawy domowej lodówki."
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Draft a cover letter"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Draft a cover letter for this job."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -6394,6 +6496,15 @@ msgstr ""
 "DuckDuckGo!"
 
 # smartling.placeholder_format=C
+#. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
+msgctxt "About section description on the Duck.ai settings page"
+msgid ""
+"Duck.ai is created by DuckDuckGo. We're an independent online protection "
+"company for anyone who wants to take back control of their personal "
+"information."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
 msgctxt "duckai_migration"
 msgid "Duck.ai is moving domains"
@@ -6430,13 +6541,21 @@ msgstr ""
 msgctxt "Error message for VQD error"
 msgid ""
 "Duck.ai is temporarily unavailable. Please refresh the page and try again."
-msgstr "Funkcja Duck.ai jest chwilowo niedostępna. Odśwież stronę i spróbuj ponownie."
+msgstr ""
+"Funkcja Duck.ai jest chwilowo niedostępna. Odśwież stronę i spróbuj ponownie."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
 msgstr "Funkcja Duck.ai jest chwilowo niedostępna. Spróbuj ponownie później."
+
+# smartling.placeholder_format=C
+msgctxt "settings"
+msgid ""
+"Duck.ai lets you chat privately with popular AI models. Disabling it hides "
+"Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6687,7 +6806,8 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr "DuckDuckGo AI Chat jest chwilowo niedostępny. Spróbuj ponownie później."
+msgstr ""
+"DuckDuckGo AI Chat jest chwilowo niedostępny. Spróbuj ponownie później."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -7307,7 +7427,8 @@ msgstr "Upewnij się, że opcja „Lokalizacja” jest ustawiona na %1$szezwalaj
 #. Tells users how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location' is set to %sallow%s."
-msgstr "Upewnij się, że opcja „Lokalizacja” jest ustawiona na %1$szezwalaj%2$s."
+msgstr ""
+"Upewnij się, że opcja „Lokalizacja” jest ustawiona na %1$szezwalaj%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -7441,11 +7562,24 @@ msgstr "Gwinea Równikowa"
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Erase your browsing data in a flash with our %sFire Button%s"
-msgstr "Błyskawicznie usuń dane przeglądania za pomocą przycisku %1$sFire Button%2$s"
+msgstr ""
+"Błyskawicznie usuń dane przeglądania za pomocą przycisku %1$sFire Button%2$s"
 
 # smartling.placeholder_format=C
 msgid "Eritrea"
 msgstr "Erytrea"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Estimate the nutrition"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Estimate the nutritional information for this recipe."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Estonia"
@@ -7481,7 +7615,8 @@ msgstr "Rozwiń mapę"
 #. Subtitle for the Collaborations promotional card at the bottom of search results. Describes the branded merchandise line. 'Give a duck' is a wordplay on the DuckDuckGo brand name.
 msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
-msgstr "Profesjonalnie wykonane produkty dla osób, które naprawdę dbają o prywatność."
+msgstr ""
+"Profesjonalnie wykonane produkty dla osób, które naprawdę dbają o prywatność."
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
@@ -7502,6 +7637,12 @@ msgid "Expires in 1 day"
 msgstr "Wygasa za 1 dzień"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain the accepted answer in simple terms."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
@@ -7509,6 +7650,48 @@ msgid ""
 msgstr ""
 "Wyjaśnij mi podstawowe pojęcia dotyczące czarnych dziur na poziomie szkoły "
 "średniej."
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain the top answer"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this in simple, plain language."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this paper"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this repo"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this research paper in plain language."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this simply"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain what this repository does and how to use it."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label to show if song lyrics contain explicit content
@@ -7795,6 +7978,12 @@ msgstr ""
 "%1$sDowiedz się więcej%2$s"
 
 # smartling.placeholder_format=C
+msgctxt "settings"
+msgid ""
+"Filters out known AI spam sites from image search results. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the final score of a sporting event.
 msgid "Final"
 msgstr "Finałowy"
@@ -7848,6 +8037,12 @@ msgstr "Znajdź lepsze słowo"
 msgctxt "Subtitle for the Web Search tool entry in the Tools dropdown menu"
 msgid "Find current information"
 msgstr "Znajdź aktualne informacje"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Find me alternatives"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button that searches for results closer to the user's current location.
@@ -8044,7 +8239,8 @@ msgstr "Bezpłatne i prywatne czaty anonimizowane przez nas"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr "Darmowe i prywatne czaty, anonimizowane przez nas. Nie trzeba zakładać konta."
+msgstr ""
+"Darmowe i prywatne czaty, anonimizowane przez nas. Nie trzeba zakładać konta."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -8288,19 +8484,22 @@ msgstr "Ogólnego przeznaczenia"
 #. Text with short description for an AI (Artificial Intelligence) Model that has a high moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "General purpose AI with high built-in moderation"
-msgstr "Sztuczna inteligencja ogólnego przeznaczenia z wysoką wbudowaną moderacją"
+msgstr ""
+"Sztuczna inteligencja ogólnego przeznaczenia z wysoką wbudowaną moderacją"
 
 # smartling.placeholder_format=C
 #. Text with short description for an AI (Artificial Intelligence) Model that has a low moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "General purpose AI with low built-in moderation"
-msgstr "Sztuczna inteligencja ogólnego przeznaczenia z niską wbudowaną moderacją"
+msgstr ""
+"Sztuczna inteligencja ogólnego przeznaczenia z niską wbudowaną moderacją"
 
 # smartling.placeholder_format=C
 #. Text with short description for an AI (Artificial Intelligence) Model that has a medium moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "General purpose AI with medium built-in moderation"
-msgstr "Sztuczna inteligencja ogólnego przeznaczenia ze średnią wbudowaną moderacją"
+msgstr ""
+"Sztuczna inteligencja ogólnego przeznaczenia ze średnią wbudowaną moderacją"
 
 # smartling.placeholder_format=C
 #. Text indicating that the AI (Artificial Intelligence) model is a model for general purpose use. General-purpose AI refers to AI systems that can perform a wide range of tasks, rather than being specialized for a specific task.
@@ -8323,6 +8522,12 @@ msgstr "Generuj obraz"
 #. Text for the button that generates more of an answer from duckassist when the answer has come from a collapsed state
 msgid "Generate More"
 msgstr "Generuj więcej"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Generate a shopping list"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
@@ -8618,10 +8823,17 @@ msgid "Give it a Try"
 msgstr "Wypróbuj"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Give me a quick background on this person."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
-msgstr "Wybierz kolejno %1$sPrywatność i bezpieczeństwo > Usługi lokalizacji%2$s"
+msgstr ""
+"Wybierz kolejno %1$sPrywatność i bezpieczeństwo > Usługi lokalizacji%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9064,6 +9276,18 @@ msgid "Help Spread Privacy"
 msgstr "Pomóż promować prywatność"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Help me prep for the interview"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Help me tailor my resume for this job."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title of a SERP popup that invites users to take a survey (desktop only)
 msgctxt "User survey popup"
 msgid "Help us improve DuckDuckGo"
@@ -9125,7 +9349,8 @@ msgstr "Podaj powód negatywnej oceny"
 #. A subtitle of a page that encourages users to share DuckDuckGo with their friends.
 msgctxt "showcase_spread"
 msgid "Help your friends and family join the Duck Side!"
-msgstr "Pomóż swoim przyjaciołom oraz rodzinie dołączyć do społeczności DuckDuckGo!"
+msgstr ""
+"Pomóż swoim przyjaciołom oraz rodzinie dołączyć do społeczności DuckDuckGo!"
 
 # smartling.placeholder_format=C
 #. Text description for the Spread card in the SERP footer
@@ -9583,6 +9808,14 @@ msgid "I Agree"
 msgstr "Zgadzam się"
 
 # smartling.placeholder_format=C
+#. Text for the button that takes the user to the external DuckDuckGo login subscription page.
+msgctxt ""
+"Text for the I already have a subscription button in the Duck.ai settings "
+"page"
+msgid "I Already Have a Subscription"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for the button that takes the user to the login subscription page.
 msgctxt "Text for the I have a subscription button"
 msgid "I Have a Subscription"
@@ -9758,7 +9991,8 @@ msgstr "Jeśli chcesz nas wesprzeć, %1$spomóż nam rozpowszechnić DuckDuckGo%
 msgid ""
 "If you want to use DuckDuckGo without JavaScript, please use our %s or %s "
 "versions."
-msgstr "Jeśli chcesz używać DuckDuckGo bez JavaScript, użyj wersji %1$s lub %2$s."
+msgstr ""
+"Jeśli chcesz używać DuckDuckGo bez JavaScript, użyj wersji %1$s lub %2$s."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -9950,7 +10184,8 @@ msgstr "W menu na górze ekranu wybierz %1$sNarzędzia%2$s > %3$sUstawienia%4$s"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "In the popup, check %sMake this my default search provider%s"
-msgstr "W wyskakującym okienku zaznacz %1$sUstaw jako domyślną wyszukiwarkę%2$s"
+msgstr ""
+"W wyskakującym okienku zaznacz %1$sUstaw jako domyślną wyszukiwarkę%2$s"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -10156,6 +10391,12 @@ msgid "Install Mac Browser"
 msgstr "Zainstaluj przeglądarkę Mac"
 
 # smartling.placeholder_format=C
+#. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
+msgctxt "settings"
+msgid "Install Now"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of a button to install the DuckDuckGo app
 msgctxt "Serp footer content"
 msgid "Install Our App"
@@ -10253,10 +10494,42 @@ msgid "Is deleted data really deleted?"
 msgstr "Czy usuwane dane są naprawdę usuwane?"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is it worth taking?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this place any good?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"Is this place any good? Summarize its reputation based on reviews and "
+"ratings."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "Is this video helpful?"
 msgstr "Czy ten film jest pomocny?"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this worth watching?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Is this worth watching? Give me a spoiler-free take."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -10288,7 +10561,8 @@ msgstr "Jest szybki, bezpłatny i zapewnia Ci jeszcze większą ochronę online.
 msgctxt "settings"
 msgid ""
 "It's okay to (very infrequently) ask me about my experience using DuckDuckGo"
-msgstr "Zgadzam się na (bardzo rzadkie) pytania o moje doświadczenia z DuckDuckGo"
+msgstr ""
+"Zgadzam się na (bardzo rzadkie) pytania o moje doświadczenia z DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. The name of the Italian language
@@ -10353,7 +10627,8 @@ msgstr "Dołącz do nas!"
 # smartling.placeholder_format=C
 msgctxt "showcase_donate"
 msgid "Join our $500,000 Privacy Challenge"
-msgstr "Dołącz do naszego konkursu na ochronę prywatności w wysokości 500 000 USD"
+msgstr ""
+"Dołącz do naszego konkursu na ochronę prywatności w wysokości 500 000 USD"
 
 # smartling.placeholder_format=C
 msgid "Jordan"
@@ -10869,6 +11144,12 @@ msgid "Links:"
 msgstr "Linki:"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "List the tools, materials, or prerequisites I need for this."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
 msgid "Listen"
 msgstr "Słuchaj"
@@ -10977,7 +11258,8 @@ msgstr "Ładuj więcej obrazów podczas przewijania"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Loads more results in Images, Videos, and Shopping when scrolling"
-msgstr "Automatycznie wczytuje więcej obrazów, filmów i zakupów podczas przewijania"
+msgstr ""
+"Automatycznie wczytuje więcej obrazów, filmów i zakupów podczas przewijania"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/WTkvs9I.png
@@ -11273,6 +11555,12 @@ msgstr "Zarządzaj swoją subskrypcją"
 msgctxt "Exclusion message manage sites button"
 msgid "Manage blocked sites"
 msgstr "Zarządzaj zablokowanymi witrynami"
+
+# smartling.placeholder_format=C
+#. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
+msgctxt "setting"
+msgid "Manage in Browser Settings"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to the site exclusion settings page
@@ -11724,7 +12012,8 @@ msgstr "Osiągnięty limit miesięczny"
 #. Displayed when the user has reached a fixed monthly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Monthly usage limit reached. You can continue this chat after %s."
-msgstr "Osiągnięto miesięczny limit użycia. Możesz kontynuować tę rozmowę po %1$s."
+msgstr ""
+"Osiągnięto miesięczny limit użycia. Możesz kontynuować tę rozmowę po %1$s."
 
 # smartling.placeholder_format=C
 #. Used to point to additional social networking profiles (in results).
@@ -14112,6 +14401,12 @@ msgstr ""
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
+msgid "Please describe why the chat response is harmful or illegal. (optional)"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
+msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
 msgstr ""
 "Opisz, dlaczego odpowiedź w czacie jest nielegalna lub szkodliwa. "
@@ -14138,6 +14433,14 @@ msgid ""
 msgstr ""
 "Uwaga: rozpoczęcie nowego czatu z dowolnym modelem spowoduje usunięcie "
 "bieżącej sesji czatu."
+
+# smartling.placeholder_format=C
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
+msgctxt "Feedback prompt"
+msgid ""
+"Please paste your prompt and the problematic output (with any personal "
+"information removed) and describe why the content is harmful or illegal."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -14607,6 +14910,12 @@ msgid "Privacy"
 msgstr "Prywatność"
 
 # smartling.placeholder_format=C
+#. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
+msgctxt "Section heading on the Duck.ai settings page"
+msgid "Privacy & Terms"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Privacy Blog"
 msgstr "Blog o prywatności"
 
@@ -14675,6 +14984,12 @@ msgstr "Polityka prywatności i warunki użytkowania"
 msgctxt "Copy used to compose link in sentences"
 msgid "Privacy Policy and Terms of Service"
 msgstr "Polityka prywatności i warunki użytkowania"
+
+# smartling.placeholder_format=C
+#. Text for a button that links to the terms of use and privacy policy page.
+msgctxt "Secondary button text in active privacy modal"
+msgid "Privacy Policy and Terms of Service"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title displayed on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
@@ -14868,7 +15183,8 @@ msgstr "Chroń swoje dane podczas wyszukiwania i przeglądania."
 #. Shown on the Mac and Windows browser promo cards. DuckDuckGo's desktop browser protects your data across search, browsing, and AI chat.
 msgctxt "SERP footer content"
 msgid "Protect your data as you search, browse, and use AI."
-msgstr "Chroń swoje dane podczas wyszukiwania, przeglądania i korzystania z AI."
+msgstr ""
+"Chroń swoje dane podczas wyszukiwania, przeglądania i korzystania z AI."
 
 # smartling.placeholder_format=C
 #. A title above links to download the DuckDuckGo apps.
@@ -15075,19 +15391,22 @@ msgstr "Wnioskowanie AI"
 #. Text with short description for a reasoning AI (Artificial Intelligence) Model that has a high moderation level. Reasoning refers to the AI ability to think logically to draw conclusions before providing an answer. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with high built-in moderation"
-msgstr "Rozumująca sztuczna inteligencja z wysokim poziomem wbudowanej moderacji"
+msgstr ""
+"Rozumująca sztuczna inteligencja z wysokim poziomem wbudowanej moderacji"
 
 # smartling.placeholder_format=C
 #. Text with short description for a reasoning AI (Artificial Intelligence) Model that has a low moderation level. Reasoning refers to the AI ability to think logically to draw conclusions before providing an answer. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with low built-in moderation"
-msgstr "Rozumująca sztuczna inteligencja z niskim poziomem wbudowanej moderacji"
+msgstr ""
+"Rozumująca sztuczna inteligencja z niskim poziomem wbudowanej moderacji"
 
 # smartling.placeholder_format=C
 #. Text with short description for a reasoning AI (Artificial Intelligence) Model that has a medium moderation level. Reasoning refers to the AI ability to think logically to draw conclusions before providing an answer. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with medium built-in moderation"
-msgstr "Rozumująca sztuczna inteligencja ze średnim poziomem wbudowanej moderacji"
+msgstr ""
+"Rozumująca sztuczna inteligencja ze średnim poziomem wbudowanej moderacji"
 
 # smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
@@ -15177,6 +15496,30 @@ msgstr "Przepisy dla %1$s%2$s%3$s"
 msgctxt "Brief for recommending a book"
 msgid "Recommend a book"
 msgstr "Poleć książkę"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar books"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar books."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar movies or shows."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar titles"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
@@ -15582,6 +15925,15 @@ msgid "Republic of Moldova"
 msgstr "Republika Mołdawii"
 
 # smartling.placeholder_format=C
+#. Note indicating that sharing the conversation is mandatory when reporting harmful or illegal content. Rendered alongside the standard share label (DUCKCHAT_RESPONSE_FEEDBACK_SHARE_PROMPT_RESPONSE_LABEL), not replacing it.
+msgctxt ""
+"Note shown under the share-content switch label on the Duck.ai response "
+"feedback form when the user has selected Harmful or Illegal as the feedback "
+"reason"
+msgid "Required for harmful or illegal reports"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
 msgctxt "Description for extended reasoning mode in Duck.ai"
 msgid "Researches before responding"
@@ -15818,6 +16170,12 @@ msgstr "Recenzje"
 msgctxt "maps_places"
 msgid "Reviews"
 msgstr "Recenzje"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Rewrite this recipe scaled for a different number of servings."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Romania"
@@ -16106,8 +16464,8 @@ msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
 msgstr ""
-"Zapisuj swoje czaty Duck.ai między urządzeniami dzięki szyfrowaniu typu "
-"end-to-end."
+"Zapisuj swoje czaty Duck.ai między urządzeniami dzięki szyfrowaniu typu end-"
+"to-end."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -16655,7 +17013,8 @@ msgstr ""
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
 msgctxt "Sync feature benefit description"
 msgid "Securely stored on DuckDuckGo's server with end-to-end encryption."
-msgstr "Bezpieczne przechowywanie na serwerze DuckDuckGo z kompleksowym szyfrowaniem."
+msgstr ""
+"Bezpieczne przechowywanie na serwerze DuckDuckGo z kompleksowym szyfrowaniem."
 
 # smartling.placeholder_format=C
 #. List item explaining that synced chats are stored with end-to-end encryption on DuckDuckGo's server and only the user can access them.
@@ -16837,13 +17196,15 @@ msgstr "Wybierz %1$sDuckDuckGo%2$s i kliknij %3$sUstaw jako domyślną%4$s."
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Select %sDuckDuckGo%s in the Default Search Engine drop down"
-msgstr "Wybierz %1$sDuckDuckGo%2$s w rozwijanym menu jako domyślną wyszukiwarkę"
+msgstr ""
+"Wybierz %1$sDuckDuckGo%2$s w rozwijanym menu jako domyślną wyszukiwarkę"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %sDuckDuckGo%s in the list and %sallow%s location access"
-msgstr "Wybierz %1$sDuckDuckGo%2$s z listy i %3$szezwól%4$s na dostęp do lokalizacji"
+msgstr ""
+"Wybierz %1$sDuckDuckGo%2$s z listy i %3$szezwól%4$s na dostęp do lokalizacji"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -16934,7 +17295,8 @@ msgstr "Wybierz %1$sUstawienia%2$s z rozwijanego menu."
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sAdvanced settings%s"
-msgstr "Wybierz %1$sUstawienia%2$s, a następnie %3$sUstawienia zaawansowane%4$s"
+msgstr ""
+"Wybierz %1$sUstawienia%2$s, a następnie %3$sUstawienia zaawansowane%4$s"
 
 # smartling.placeholder_format=C
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -17158,6 +17520,12 @@ msgid "Set Up Now"
 msgstr "Skonfiguruj teraz"
 
 # smartling.placeholder_format=C
+#. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
+msgctxt "Encrypted storage setup button shown in native browsers"
+msgid "Set Up Sync & Backup"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
 msgctxt "Title for the Sync & Backup intro screen"
 msgid "Set Up Sync & Backup"
@@ -17249,7 +17617,8 @@ msgstr "Udostępnij"
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "Share DuckDuckGo and help friends take their privacy back!"
-msgstr "Udostępniaj informacje o DuckDuckGo i pomóż znajomym odzyskać prywatność!"
+msgstr ""
+"Udostępniaj informacje o DuckDuckGo i pomóż znajomym odzyskać prywatność!"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button that opens a feedback modal when clicked.
@@ -17337,6 +17706,13 @@ msgstr "Udostępnij adres URL strony"
 msgctxt "feedback form"
 msgid "Share positive feedback"
 msgstr "Podziel się pozytywną opinią"
+
+# smartling.placeholder_format=C
+#. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
+msgctxt ""
+"Label beside the share-content switch on the Duck.ai response feedback form"
+msgid "Share this conversation with DuckDuckGo"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -17725,7 +18101,8 @@ msgstr "Wyświetla poziome linie pomiędzy stronami z wynikami wyszukiwania"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows links to instructions for how to add DuckDuckGo to your browser"
-msgstr "Wyświetla łącza do instrukcji dodawania DuckDuckGo do Twojej przeglądarki"
+msgstr ""
+"Wyświetla łącza do instrukcji dodawania DuckDuckGo do Twojej przeglądarki"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers more frequently.
@@ -17741,7 +18118,8 @@ msgstr "Wyświetla najczęściej odwiedzane łącza na stronie nowej karty"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your browser"
-msgstr "Wyświetla sporadyczne przypomnienia o dodaniu DuckDuckGo do przeglądarki"
+msgstr ""
+"Wyświetla sporadyczne przypomnienia o dodaniu DuckDuckGo do przeglądarki"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18429,7 +18807,8 @@ msgstr "Zatrzymaj generowanie"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop hidden trackers lurking on other websites."
-msgstr "Blokowanie mechanizmów śledzących ukrytych na innych stronach internetowych."
+msgstr ""
+"Blokowanie mechanizmów śledzących ukrytych na innych stronach internetowych."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -18606,6 +18985,24 @@ msgid "Suggest a title for a blog post"
 msgstr "Zaproponuj tytuł wpisu na blogu"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest related articles or topics worth exploring next."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Suggest related articles to explore"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest some alternatives to this product."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
 msgctxt "directions"
 msgid "Suggestions:"
@@ -18617,10 +19014,100 @@ msgid "Suggestions:"
 msgstr "Sugestie:"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Sum up the reviews"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A short title for the a message asking the AI to summarize a text.
 msgctxt "Title for the summarize message"
 msgid "Summarize"
 msgstr "Podsumuj"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize the Q&As"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the background and notable work of this person."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the key details of this event."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the questions and answers on this page."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize their background"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this book"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this book."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this discussion"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this discussion thread."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this page"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this page."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this video"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this video."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize what the reviews say."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -18837,7 +19324,8 @@ msgstr "Sync & Backup włączone!"
 #. Notice shown under the recovery code explaining that backup data has an inactivity expiration.
 msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
-msgstr "Danych Sync & Backup nie można odzyskać po 18 miesiącach braku aktywności."
+msgstr ""
+"Danych Sync & Backup nie można odzyskać po 18 miesiącach braku aktywności."
 
 # smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
@@ -18948,6 +19436,12 @@ msgid "Syria"
 msgstr "Syria"
 
 # smartling.placeholder_format=C
+#. Text for a button that enables the theme to follow the operating system's color scheme preference.
+msgctxt "System theme button for theme selector"
+msgid "System"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Abbreviation indicating this is the total score for a game
 msgctxt "Sports module"
 msgid "T"
@@ -18974,6 +19468,12 @@ msgstr "TV"
 msgctxt "language_name"
 msgid "Tahitian"
 msgstr "tahitański"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Tailor my resume"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Taiwan"
@@ -19003,6 +19503,13 @@ msgstr "Przejmij kontrolę nad swoimi danymi osobowymi"
 msgctxt "homepage ATB modal"
 msgid "Take control of your personal data!"
 msgstr "Przejmij kontrolę nad swoimi danymi osobowymi."
+
+# smartling.placeholder_format=C
+#. Description for the Feedback section of the Duck.ai settings page, asking the user to take an anonymous survey to let us know how we can make Duck.ai better.
+msgctxt "Feedback section description on the Duck.ai settings page"
+msgid ""
+"Take this anonymous survey to let us know how we can make Duck.ai better."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -19267,7 +19774,8 @@ msgstr ""
 msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider deletes any data associated with this chat within 30 days."
-msgstr "Dostawca modelu usuwa wszelkie dane związane z tym czatem w ciągu 30 dni."
+msgstr ""
+"Dostawca modelu usuwa wszelkie dane związane z tym czatem w ciągu 30 dni."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers.
@@ -19306,6 +19814,12 @@ msgstr "Wystąpił błąd serwera i nie można zrealizować żądania."
 #. https://duck.co/media/files/theme.png
 msgid "Theme"
 msgstr "Motyw"
+
+# smartling.placeholder_format=C
+#. Text for the theme selector label that allows users to switch between Light and dark theme.
+msgctxt "Label for the theme selector feature"
+msgid "Theme"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/LpFhb1e.png
@@ -19561,14 +20075,16 @@ msgstr "Tego obrazu nie dało się stworzyć."
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF"
-msgstr "Ten typ obrazu nie jest obsługiwany, dołącz plik JPG, PNG, WebP lub GIF"
+msgstr ""
+"Ten typ obrazu nie jest obsługiwany, dołącz plik JPG, PNG, WebP lub GIF"
 
 # smartling.placeholder_format=C
 #. Error message displayed when a file that the user tried to upload is not of a supported format
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF."
-msgstr "Ten typ obrazu nie jest obsługiwany, dołącz plik JPG, PNG, WebP lub GIF."
+msgstr ""
+"Ten typ obrazu nie jest obsługiwany, dołącz plik JPG, PNG, WebP lub GIF."
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
@@ -19621,7 +20137,8 @@ msgstr "Ta strona do działania wymaga włączonego Javascriptu."
 #. Information tooltip text explaining that the current page's content will be included with the chat message.
 msgctxt "Tooltip explaining that page content will be sent to Duck.ai"
 msgid "This page's content will be sent with your message to Duck.ai"
-msgstr "Zawartość tej strony zostanie wysłana wraz z Twoją wiadomością do Duck.ai"
+msgstr ""
+"Zawartość tej strony zostanie wysłana wraz z Twoją wiadomością do Duck.ai"
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -19729,7 +20246,8 @@ msgstr ""
 #. Message explaining what will happen when the user deletes an image.
 msgctxt "Confirmation message in delete image modal"
 msgid "This will delete your selected image. This cannot be undone."
-msgstr "Spowoduje to usunięcie wybranego obrazu. Tej czynności nie można cofnąć."
+msgstr ""
+"Spowoduje to usunięcie wybranego obrazu. Tej czynności nie można cofnąć."
 
 # smartling.placeholder_format=C
 #. Confirmation message asking if the user is sure they want to reset all of their settings.
@@ -19854,7 +20372,8 @@ msgstr "Aby kontynuować, musisz wyrazić zgodę na %1$s i %2$s Duck.ai"
 msgctxt ""
 "Copy stating agreement to AI Chat Privacy Policy and Terms of Service."
 msgid "To continue, you must agree to DuckDuckGo AI Chat’s %s and %s"
-msgstr "Aby kontynuować, musisz wyrazić zgodę na %1$s i %2$s DuckDuckGo AI Chat"
+msgstr ""
+"Aby kontynuować, musisz wyrazić zgodę na %1$s i %2$s DuckDuckGo AI Chat"
 
 # smartling.placeholder_format=C
 #. Instructions for how to print driving directions.
@@ -20149,6 +20668,18 @@ msgstr ""
 "kina?”"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Translate this page"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
+msgctxt "Page suggestion prompt"
+msgid "Translate this page into %s."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text for a region that will display translated text.
 msgctxt "translations_module"
 msgid "Translation"
@@ -20290,6 +20821,12 @@ msgid "Try Free"
 msgstr "Wypróbuj za darmo"
 
 # smartling.placeholder_format=C
+#. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
+msgctxt "settings"
+msgid "Try It Now"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
 msgctxt "Promotional CTA for new AI models"
 msgid "Try Now"
@@ -20345,20 +20882,23 @@ msgstr "Spróbuj innych słów kluczowych."
 # smartling.placeholder_format=C
 #. Prompt encouraging the user to turn off their ad blocker to see more results for their query.
 msgid "Try disabling your ad blocker on DuckDuckGo to see more results."
-msgstr "Spróbuj wyłączyć blokadę reklam w DuckDuckGo, aby zobaczyć więcej wyników."
+msgstr ""
+"Spróbuj wyłączyć blokadę reklam w DuckDuckGo, aby zobaczyć więcej wyników."
 
 # smartling.placeholder_format=C
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
 msgctxt "precise_user_location"
 msgid "Try enabling anonymous location for more accurate results."
-msgstr "Spróbuj włączyć anonimową lokalizację, aby uzyskać dokładniejsze wyniki."
+msgstr ""
+"Spróbuj włączyć anonimową lokalizację, aby uzyskać dokładniejsze wyniki."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the screen of the onboarding where the user picks a chat model.
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr "Spróbuj poeksperymentować z każdym modelem — otrzymasz różne odpowiedzi."
+msgstr ""
+"Spróbuj poeksperymentować z każdym modelem — otrzymasz różne odpowiedzi."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
@@ -20528,6 +21068,22 @@ msgid "Trying DuckDuckGo again"
 msgstr "Sprawdzam DuckDuckGo jeszcze raz"
 
 # smartling.placeholder_format=C
+#. Message shown in a modal after supported third-party browser users disable AI features in Settings. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
 msgctxt "Assistant response placeholder"
 msgid "Trying with %s"
@@ -20627,7 +21183,8 @@ msgstr "Wyłącz:"
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on %sPrecise Location%s for more accurate results"
-msgstr "Włącz opcję %1$sDokładna lokalizacja%2$s, aby uzyskać dokładniejsze wyniki."
+msgstr ""
+"Włącz opcję %1$sDokładna lokalizacja%2$s, aby uzyskać dokładniejsze wyniki."
 
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
@@ -20845,14 +21402,15 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sOpen with%s select %sA specific page or pages%s"
-msgstr "Pod %1$sOtwórz za pomocą%2$s wybierz %3$sKonkretna strona lub strony%4$s"
+msgstr ""
+"Pod %1$sOtwórz za pomocą%2$s wybierz %3$sKonkretna strona lub strony%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
 msgstr ""
-"Pod %1$sPrzy uruchomieniu > Strona główna \\%2$s wprowadź: "
-"https://duckduckgo.com"
+"Pod %1$sPrzy uruchomieniu > Strona główna \\%2$s wprowadź: https://"
+"duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -20862,13 +21420,15 @@ msgstr "Pod %1$sUstawienia wyszukiwania%2$s wybierz %3$sDuckDuckGo%4$s"
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch in the address bar with%s select %sAdd New%s"
-msgstr "Pod %1$sWyszukaj w pasku adresu za pomocą%2$s wybierz %3$sDodaj nową%4$s"
+msgstr ""
+"Pod %1$sWyszukaj w pasku adresu za pomocą%2$s wybierz %3$sDodaj nową%4$s"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
-msgstr "W dziale %1$sWyszukiwanie%2$s kliknij %3$sZarządzaj wyszukiwarkami…%4$s"
+msgstr ""
+"W dziale %1$sWyszukiwanie%2$s kliknij %3$sZarządzaj wyszukiwarkami…%4$s"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -20982,7 +21542,8 @@ msgstr "Odblokuj za pomocą subskrypcji DuckDuckGo"
 msgctxt "voice chat limit modal"
 msgid ""
 "Unlock advanced AI models and higher limits with a DuckDuckGo Subscription"
-msgstr "Odblokuj zaawansowane modele AI i wyższe limity dzięki subskrypcji DuckDuckGo"
+msgstr ""
+"Odblokuj zaawansowane modele AI i wyższe limity dzięki subskrypcji DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Text informing the user that advanced AI models can be unlocked with a subscription. The variable is used to insert a link that opens the subscription modal. Example: Unlock advanced AI models with a DuckDuckGo subscription.
@@ -21015,7 +21576,8 @@ msgctxt ""
 "Text shown in the subscription promo card, with a trailing call-to-action "
 "link."
 msgid "Unlock more capable AI models with a DuckDuckGo subscription. %s"
-msgstr "Odblokuj bardziej wydajne modele AI dzięki subskrypcji DuckDuckGo. %1$s"
+msgstr ""
+"Odblokuj bardziej wydajne modele AI dzięki subskrypcji DuckDuckGo. %1$s"
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to unmute the microphone.
@@ -21279,6 +21841,12 @@ msgid "Uruguay"
 msgstr "Urugwaj"
 
 # smartling.placeholder_format=C
+#. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
+msgctxt "Navigation label on the Duck.ai settings page"
+msgid "Usage"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A feedback suggestion
 msgctxt "Feedback prompt"
 msgid "Usage limit"
@@ -21373,7 +21941,8 @@ msgstr ""
 #. Prompt to ask the user if they want to use their approximate location for more accurate results
 msgctxt "DuckChat location prompt"
 msgid "Use your approximate location for more accurate results?"
-msgstr "Czy użyć Twojej przybliżonej lokalizacji, aby uzyskać dokładniejsze wyniki?"
+msgstr ""
+"Czy użyć Twojej przybliżonej lokalizacji, aby uzyskać dokładniejsze wyniki?"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes before every user message in the downloaded file, indicating which message it is out of the total number of messages. Example: 'User prompt 3 of 5'
@@ -21730,6 +22299,12 @@ msgid "Wales"
 msgstr "Walia"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Walk me through the steps"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for walking directions on a map.
 msgctxt "directions"
 msgid "Walking"
@@ -21849,6 +22424,17 @@ msgstr ""
 "wyniki."
 
 # smartling.placeholder_format=C
+#. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
+msgctxt ""
+"Inline warning shown below the share-content toggle when the user selects "
+"Harmful or Illegal but has not enabled sharing"
+msgid ""
+"We can only fix what we can see. To report a harmful or illegal response, "
+"please share this conversation with DuckDuckGo so we can investigate and "
+"address the issue."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
 msgctxt ""
 "Inline warning shown below the share-content toggle when the user selects "
@@ -21895,7 +22481,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don't store your personal info or track you. Ever."
-msgstr "Nie przechowujemy informacji na Twój temat ani Cię nie śledzimy. Nigdy."
+msgstr ""
+"Nie przechowujemy informacji na Twój temat ani Cię nie śledzimy. Nigdy."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -21979,7 +22566,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don’t track you in or out of private browsing mode."
-msgstr "Nie śledzimy Cię, niezależnie od tego czy używasz trybu incognito, czy nie."
+msgstr ""
+"Nie śledzimy Cię, niezależnie od tego czy używasz trybu incognito, czy nie."
 
 # smartling.placeholder_format=C
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with an Agree button is shown below.
@@ -21991,7 +22579,8 @@ msgstr "Nie śledzimy Cię. To jest nasza polityka prywatności w skrócie…"
 #. Displayed when the user's voice chat session is ended because of being inactive for too long.
 msgctxt "voice chat error"
 msgid "We ended the chat due to inactivity. Want to try again?"
-msgstr "Zakończyliśmy czat z powodu braku aktywności. Chcesz spróbować ponownie?"
+msgstr ""
+"Zakończyliśmy czat z powodu braku aktywności. Chcesz spróbować ponownie?"
 
 # smartling.placeholder_format=C
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
@@ -22216,7 +22805,8 @@ msgstr "Osiągnięto limit tygodniowy"
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Weekly usage limit reached. You can continue this chat after %s."
-msgstr "Osiągnięto tygodniowy limit użycia. Możesz kontynuować tę rozmowę po %1$s."
+msgstr ""
+"Osiągnięto tygodniowy limit użycia. Możesz kontynuować tę rozmowę po %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable weekly Duck.ai usage limit and can opt in to continue using the monthly limit.
@@ -22404,6 +22994,103 @@ msgstr ""
 "inteligencji."
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the counterarguments?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the hours & location?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key contributions of this paper?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key contributions?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key details?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key points covered in this video?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key points?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key takeaways from this article?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key takeaways?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key things I will learn from this course?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main counterarguments or criticisms of this?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main questions this page answers?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the must-try dishes here?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"What are the opening hours, location, and contact details for this place?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the pros and cons of this product?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the pros and cons?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
 msgctxt "feedback form"
 msgid "What bothered you most?"
@@ -22504,6 +23191,12 @@ msgid "What does atria mean in the context of a medical article?"
 msgstr "Co oznaczają przedsionki w artykule medycznym?"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What does this answer?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
@@ -22516,18 +23209,31 @@ msgid "What information gets saved?"
 msgstr "Jakie informacje są zapisywane?"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What interview questions might come up for this role?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
 msgid ""
 "What is the Cloud Save bookmarklet and how does it differ from the URL "
 "parameter bookmarklet?"
-msgstr "Czym jest skryptozakładka Cloud Save i czym różni się od skryptozakładki URL?"
+msgstr ""
+"Czym jest skryptozakładka Cloud Save i czym różni się od skryptozakładki URL?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for looking up the capital city of Albania.
 msgctxt "Full sentence for looking up basic facts"
 msgid "What is the capital city of Albania?"
 msgstr "Jakie miasto jest stolicą Albanii?"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What is the overall verdict and rating for this?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to a page with additional information.
@@ -22552,6 +23258,12 @@ msgid "What people say:"
 msgstr "Opinie innych osób:"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What should I order?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
 msgctxt "feedback form"
 msgid "What stood out?"
@@ -22564,6 +23276,18 @@ msgid "What was wrong with the response? (optional)"
 msgstr "Co było nie tak z odpowiedzią? (opcjonalnie)"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I learn?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I need?"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid "What would you like to provide feedback on?"
 msgstr "Na jaki temat chcesz przekazać opinię?"
@@ -22572,13 +23296,20 @@ msgstr "Na jaki temat chcesz przekazać opinię?"
 #. Explains the benefits of using our custom video player, the Duck Player
 msgid ""
 "What you watch in DuckDuckGo won't influence your recommendations on YouTube."
-msgstr "To, co oglądasz w DuckDuckGo, nie wpłynie na rekomendacje w serwisie YouTube."
+msgstr ""
+"To, co oglądasz w DuckDuckGo, nie wpłynie na rekomendacje w serwisie YouTube."
 
 # smartling.placeholder_format=C
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
 msgctxt "SERP footer content"
 msgid "What's New"
 msgstr "Co nowego"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What's the verdict?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -22633,6 +23364,12 @@ msgid "Which features are missing? (Optional)"
 msgstr "Jakich funkcji brakuje? (opcjonalnie)"
 
 # smartling.placeholder_format=C
+#. An invitation for users to leave feedback
+msgctxt "Feedback prompt"
+msgid "Which features are missing? (optional)"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
 msgid "White"
 msgstr "Biały"
@@ -22647,6 +23384,18 @@ msgstr "Biały"
 #. Link to an about us page.
 msgid "Who We Are"
 msgstr "Kim jesteśmy"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Who are the main cast and crew, and what else are they known for?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Who is this person?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Header above a collection of privacy-related links.
@@ -23054,7 +23803,8 @@ msgstr ""
 #. Text informing the user that they can access DuckDuckGo AI Chat directly at a specific URL. The placeholder %s will be replaced with the link. Example: 'You can access DuckDuckGo AI Chat directly at duck.ai.'
 msgctxt "Information about direct access to DuckDuckGo AI Chat"
 msgid "You can access DuckDuckGo AI Chat directly at %s."
-msgstr "Możesz uzyskać dostęp do DuckDuckGo AI Chat bezpośrednio pod adresem %1$s."
+msgstr ""
+"Możesz uzyskać dostęp do DuckDuckGo AI Chat bezpośrednio pod adresem %1$s."
 
 # smartling.placeholder_format=C
 #. Search Assist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate Search Assist.
@@ -23108,7 +23858,8 @@ msgstr ""
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
 msgctxt "Third party map app picker feedback dialog"
 msgid "You can change this any time in %sSearch Settings%s"
-msgstr "Możesz to zmienić w dowolnym momencie w %1$sustawieniach wyszukiwania%2$s"
+msgstr ""
+"Możesz to zmienić w dowolnym momencie w %1$sustawieniach wyszukiwania%2$s"
 
 # smartling.placeholder_format=C
 #. Text explaning how to change a passphrase.
@@ -23141,7 +23892,8 @@ msgstr "Możesz ukryć to przypomnienie w %1$sustawieniach wyszukiwania%2$s"
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
-msgstr "Teraz możesz zapisać do 100 czatów na tym urządzeniu. Rozmawiajcie śmiało!"
+msgstr ""
+"Teraz możesz zapisać do 100 czatów na tym urządzeniu. Rozmawiajcie śmiało!"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -23211,7 +23963,8 @@ msgstr "Można przywrócić swoje ustawienia po usunięciu plików cookie."
 #. Text explaining the benefits of the cloud save feature.
 msgctxt "cloudsave"
 msgid "You can share your settings among computers and browsers."
-msgstr "Możesz używać tych samych ustawień na różnych komputerach i przeglądarkach."
+msgstr ""
+"Możesz używać tych samych ustawień na różnych komputerach i przeglądarkach."
 
 # smartling.placeholder_format=C
 #. Alternative option description on export screen.
@@ -23397,7 +24150,8 @@ msgstr ""
 #. Description shown when the user has reached the maximum voice chat duration.
 msgctxt "voice chat duration limit modal"
 msgid "You've reached the maximum voice chat duration for a single session."
-msgstr "Osiągnięto maksymalny czas trwania czatu głosowego w ramach jednej sesji."
+msgstr ""
+"Osiągnięto maksymalny czas trwania czatu głosowego w ramach jednej sesji."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the daily voice chat limit.
@@ -23530,8 +24284,8 @@ msgid ""
 "Your browser provides a list of your most-visited sites. DuckDuckGo never "
 "has access to this data."
 msgstr ""
-"Twoja przeglądarka udostępnia listę najczęściej odwiedzanych "
-"witryn.DuckDuckGo nigdy nie ma dostępu do tych danych."
+"Twoja przeglądarka udostępnia listę najczęściej odwiedzanych witryn."
+"DuckDuckGo nigdy nie ma dostępu do tych danych."
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
@@ -23570,7 +24324,8 @@ msgstr ""
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never used to train AI models"
-msgstr "Twoje czaty są prywatne i nigdy nie są wykorzystywane do trenowania modeli AI"
+msgstr ""
+"Twoje czaty są prywatne i nigdy nie są wykorzystywane do trenowania modeli AI"
 
 # smartling.placeholder_format=C
 #. Text for a description of the active privacy protection for DuckDuckGo's AI Chat feature.

--- a/locales/pl_PL/LC_MESSAGES/duckduckgo.po
+++ b/locales/pl_PL/LC_MESSAGES/duckduckgo.po
@@ -2,16 +2,15 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: pl_PL\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 "
-"|| n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 
 # smartling.gettext_line_width = normalized : 79
 # smartling.placeholder_format=C
@@ -490,8 +489,7 @@ msgstr ""
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "%sLong-press%s the DuckDuckGo app icon on the home screen"
-msgstr ""
-"%1$sNaciśnij i przytrzymaj%2$s ikonę aplikacji DuckDuckGo na ekranie głównym"
+msgstr "%1$sNaciśnij i przytrzymaj%2$s ikonę aplikacji DuckDuckGo na ekranie głównym"
 
 # smartling.placeholder_format=C
 #. A message displayed when there is an error loading content or no results on requery
@@ -814,8 +812,7 @@ msgstr "Osiągnięto limit 6 godzin użytkowania."
 #. Displayed when the user has reached a fixed 6-hour Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "6-hour usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Osiągnięto limit 6 godzin użytkowania. Możesz kontynuować tę rozmowę po %1$s."
+msgstr "Osiągnięto limit 6 godzin użytkowania. Możesz kontynuować tę rozmowę po %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable 6-hour Duck.ai usage limit and can opt in to continue using the daily limit.
@@ -936,8 +933,8 @@ msgstr ""
 "Funkcja AI Chat umożliwia prowadzenie anonimowych rozmów z modelami czatu AI "
 "oferowanymi przez inne firmy. Wyłączenie tej opcji spowoduje ukrycie funkcji "
 "AI Chat w DuckDuckGo Search. Nawet w przypadku wyłączenia tego ustawienia "
-"możesz uzyskać dostęp do funkcji AI Chat na stronie %1$sduckduckgo.com/"
-"aichat%2$s."
+"możesz uzyskać dostęp do funkcji AI Chat na stronie "
+"%1$sduckduckgo.com/aichat%2$s."
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -1444,7 +1441,7 @@ msgstr "Adres jest nieprawidłowy"
 #. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Adjust the servings"
-msgstr ""
+msgstr "Dostosuj porcje"
 
 # smartling.placeholder_format=C
 #. as in multiple advertisements
@@ -1666,6 +1663,9 @@ msgid ""
 "All chats are anonymized by DuckDuckGo, and your conversations are not used "
 "to train chat models by DuckDuckGo or the model providers"
 msgstr ""
+"Wszystkie czaty są anonimizowane przez DuckDuckGo, a Twoje rozmowy nie są "
+"wykorzystywane do trenowania modeli czatów przez DuckDuckGo ani dostawców "
+"modeli"
 
 # smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1810,8 +1810,7 @@ msgstr "To urządzenie jest już zsynchronizowane."
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Also search privately on your iPad, iPhone, or Android!"
-msgstr ""
-"Możesz też wyszukiwać prywatnie na swoim iPadzie, iPhonie oraz Androidzie!"
+msgstr "Możesz też wyszukiwać prywatnie na swoim iPadzie, iPhonie oraz Androidzie!"
 
 # smartling.placeholder_format=C
 #. Keyboard shortcut for Duck.ai
@@ -1944,6 +1943,9 @@ msgid ""
 "Anonymously generates answers for search queries based on web content. "
 "Choose how often you want it to appear, or disable it completely."
 msgstr ""
+"Anonimowo generuje odpowiedzi na zapytania wyszukiwania w oparciu o treści "
+"internetowe. Wybierz, jak często ma się pojawiać, lub wyłącz tę funkcję "
+"całkowicie."
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -2230,7 +2232,7 @@ msgstr "Poproś o kontynuację z Duck.ai"
 #. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
 msgctxt "Page suggestion chip label"
 msgid "Ask about this page"
-msgstr ""
+msgstr "Zapytaj o tę stronę"
 
 # smartling.placeholder_format=C
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2475,8 +2477,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI) on mobile
 msgid "Auto-generated from sources. May be inaccurate."
-msgstr ""
-"Generowane automatycznie na podstawie źródeł. Może zawierać nieścisłości."
+msgstr "Generowane automatycznie na podstawie źródeł. Może zawierać nieścisłości."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2664,7 +2665,7 @@ msgstr "Kod kreskowy"
 #. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Based on this page, is this course worth taking?"
-msgstr ""
+msgstr "Czy na podstawie tej strony warto wziąć udział w tym kursie?"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2713,6 +2714,9 @@ msgid ""
 "Before storing this report, DuckDuckGo will anonymize your conversation by "
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
+"Przed zapisaniem tego raportu DuckDuckGo zanonimizuje Twoją konwersację, "
+"usuwając dane osobowe, takie jak nazwiska, adresy e-mail i identyfikujące "
+"metadane."
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -2854,8 +2858,7 @@ msgstr "Zablokuj tę witrynę we wszystkich wynikach"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Block trackers and take control of your personal data"
-msgstr ""
-"Zablokuj skrypty śledzące i przejmij kontrolę nad swoimi danymi osobowymi"
+msgstr "Zablokuj skrypty śledzące i przejmij kontrolę nad swoimi danymi osobowymi"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -3035,7 +3038,7 @@ msgstr "Zdobyte break pointy"
 #. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Break this down into clear, numbered steps."
-msgstr ""
+msgstr "Podziel to na jasne, ponumerowane kroki."
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -3195,8 +3198,7 @@ msgstr "Burundi"
 #. The first %s is the action button label ('Continue'). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab.
 msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid "By clicking '%s' you agree to our %s."
-msgstr ""
-"Klikając przycisk „%1$s”, akceptujesz postanowienia naszego dokumentu %2$s."
+msgstr "Klikając przycisk „%1$s”, akceptujesz postanowienia naszego dokumentu %2$s."
 
 # smartling.placeholder_format=C
 #. Text stating agreement to Duck.ai Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'By clicking “Agree and Continue,” you accept Duck.ai’s Privacy Policy and Terms of Service.'
@@ -3500,7 +3502,7 @@ msgstr "Obsada"
 #. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Cast & Crew"
-msgstr ""
+msgstr "Obsada & ekipa"
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -3587,8 +3589,7 @@ msgstr "Zmienia sposób wyświetlania adresów URL wyników"
 #. This is the description of a user setting
 msgctxt "settings"
 msgid "Changes how the header is displayed and its behavior as you scroll"
-msgstr ""
-"Zmienia sposób wyświetlania nagłówka i jego zachowanie podczas przewijania"
+msgstr "Zmienia sposób wyświetlania nagłówka i jego zachowanie podczas przewijania"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/mcZdcaF.png
@@ -3607,8 +3608,7 @@ msgstr "Zmienia kolor tła na całej stronie"
 msgctxt "settings"
 msgid ""
 "Changes the background color of results on hover, modules, and dropdown menus"
-msgstr ""
-"Zmienia kolor tła wyników po najechaniu kursorem, modułów i rozwijanych menu"
+msgstr "Zmienia kolor tła wyników po najechaniu kursorem, modułów i rozwijanych menu"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/NdpkbY0.png
@@ -3741,8 +3741,8 @@ msgstr ""
 "rozmów z zewnętrznymi modelami czatu AI, obsługującymi modele OpenAI, "
 "Anthropic i inne. Wyłączenie tej opcji spowoduje ukrycie przycisków czatu i "
 "linków w DuckDuckGo Search. Nawet w przypadku wyłączenia tego ustawienia "
-"możesz uzyskać dostęp do czatu, przechodząc pod adres %1$shttps://duck."
-"ai%2$s bezpośrednio."
+"możesz uzyskać dostęp do czatu, przechodząc pod adres "
+"%1$shttps://duck.ai%2$s bezpośrednio."
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -5224,7 +5224,7 @@ msgstr "Utwórz obraz"
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
-msgstr ""
+msgstr "Utwórz listę zakupów z ilościami produktów z tego przepisu."
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed in the input field when starting a new image generation session.
@@ -5481,8 +5481,7 @@ msgstr "Osiągnięto dzienny limit"
 #. Displayed when the user has reached a fixed daily Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Daily usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Osiągnięto dzienny limit użycia. Możesz kontynuować tę rozmowę po %1$s."
+msgstr "Osiągnięto dzienny limit użycia. Możesz kontynuować tę rozmowę po %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable daily Duck.ai usage limit and can opt in to continue using the weekly limit.
@@ -5870,7 +5869,7 @@ msgstr "Osiągnięto limit dyktowania"
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
 msgid "Dictation temporarily unavailable"
-msgstr ""
+msgstr "Funkcja dyktowania jest tymczasowo niedostępna"
 
 # smartling.placeholder_format=C
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
@@ -6179,6 +6178,8 @@ msgid ""
 "Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
 "filtered out. %sLearn More%s"
 msgstr ""
+"Nie chcesz AI? %1$snoai.duckduckgo.com%2$s nie oferuje funkcji AI i "
+"odfiltrowuje obrazy generowane przez AI. %3$sDowiedz się więcej%4$s"
 
 # smartling.placeholder_format=C
 #. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
@@ -6187,6 +6188,8 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
+"Nie chcesz AI? Odwiedź %1$snoai.duckduckgo.com%2$s aby wyszukiwać bez "
+"funkcji AI i z odfiltrowanymi obrazami AI. %3$sDowiedz się więcej%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6306,13 +6309,13 @@ msgstr ""
 #. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Draft a cover letter"
-msgstr ""
+msgstr "Napisz list motywacy"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Draft a cover letter for this job."
-msgstr ""
+msgstr "Napisz list motywacyjny na to stanowisko."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -6503,6 +6506,9 @@ msgid ""
 "company for anyone who wants to take back control of their personal "
 "information."
 msgstr ""
+"Duck.ai jest tworzony przez DuckDuckGo. Jesteśmy niezależną firmą oferującą "
+"ochronę w Internecie użytkownikom, którzy chcą odzyskać kontrolę nad swoimi "
+"danymi osobowymi."
 
 # smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
@@ -6541,8 +6547,7 @@ msgstr ""
 msgctxt "Error message for VQD error"
 msgid ""
 "Duck.ai is temporarily unavailable. Please refresh the page and try again."
-msgstr ""
-"Funkcja Duck.ai jest chwilowo niedostępna. Odśwież stronę i spróbuj ponownie."
+msgstr "Funkcja Duck.ai jest chwilowo niedostępna. Odśwież stronę i spróbuj ponownie."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -6556,6 +6561,9 @@ msgid ""
 "Duck.ai lets you chat privately with popular AI models. Disabling it hides "
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
+"Duck.ai umożliwia prywatne czatowanie z popularnymi modelami AI. Wyłączenie "
+"tej opcji ukryje przyciski i linki Duck.ai, ale nadal możesz odwiedzić "
+"%1$sduck.ai%2$s bezpośrednio."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6806,8 +6814,7 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr ""
-"DuckDuckGo AI Chat jest chwilowo niedostępny. Spróbuj ponownie później."
+msgstr "DuckDuckGo AI Chat jest chwilowo niedostępny. Spróbuj ponownie później."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -7427,8 +7434,7 @@ msgstr "Upewnij się, że opcja „Lokalizacja” jest ustawiona na %1$szezwalaj
 #. Tells users how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location' is set to %sallow%s."
-msgstr ""
-"Upewnij się, że opcja „Lokalizacja” jest ustawiona na %1$szezwalaj%2$s."
+msgstr "Upewnij się, że opcja „Lokalizacja” jest ustawiona na %1$szezwalaj%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -7562,8 +7568,7 @@ msgstr "Gwinea Równikowa"
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Erase your browsing data in a flash with our %sFire Button%s"
-msgstr ""
-"Błyskawicznie usuń dane przeglądania za pomocą przycisku %1$sFire Button%2$s"
+msgstr "Błyskawicznie usuń dane przeglądania za pomocą przycisku %1$sFire Button%2$s"
 
 # smartling.placeholder_format=C
 msgid "Eritrea"
@@ -7573,13 +7578,13 @@ msgstr "Erytrea"
 #. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Estimate the nutrition"
-msgstr ""
+msgstr "Oszacuj wartości odżywcze"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Estimate the nutritional information for this recipe."
-msgstr ""
+msgstr "Oszacuj wartość odżywczą tego przepisu."
 
 # smartling.placeholder_format=C
 msgid "Estonia"
@@ -7615,8 +7620,7 @@ msgstr "Rozwiń mapę"
 #. Subtitle for the Collaborations promotional card at the bottom of search results. Describes the branded merchandise line. 'Give a duck' is a wordplay on the DuckDuckGo brand name.
 msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
-msgstr ""
-"Profesjonalnie wykonane produkty dla osób, które naprawdę dbają o prywatność."
+msgstr "Profesjonalnie wykonane produkty dla osób, które naprawdę dbają o prywatność."
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
@@ -7640,7 +7644,7 @@ msgstr "Wygasa za 1 dzień"
 #. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain the accepted answer in simple terms."
-msgstr ""
+msgstr "Wyjaśnij zaakceptowaną odpowiedź w prostych słowach."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
@@ -7655,43 +7659,43 @@ msgstr ""
 #. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain the top answer"
-msgstr ""
+msgstr "Wyjaśnij najlepszą odpowiedź"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain this in simple, plain language."
-msgstr ""
+msgstr "Wyjaśnij to prostym, zrozumiałym językiem."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain this paper"
-msgstr ""
+msgstr "Wyjaśnij ten artykuł"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain this repo"
-msgstr ""
+msgstr "Wyjaśnij to repozytorium"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain this research paper in plain language."
-msgstr ""
+msgstr "Wyjaśnij ten artykuł naukowy zwykłym językiem."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain this simply"
-msgstr ""
+msgstr "Wyjaśnij to prosto"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain what this repository does and how to use it."
-msgstr ""
+msgstr "Wyjaśnij, co robi to repozytorium i jak z niego korzystać."
 
 # smartling.placeholder_format=C
 #. Label to show if song lyrics contain explicit content
@@ -7982,6 +7986,8 @@ msgctxt "settings"
 msgid ""
 "Filters out known AI spam sites from image search results. %sLearn More%s"
 msgstr ""
+"Odfiltrowuje znane strony ze spamem AI z wyników wyszukiwania obrazów. "
+"%1$sDowiedz się więcej%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the final score of a sporting event.
@@ -8042,7 +8048,7 @@ msgstr "Znajdź aktualne informacje"
 #. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Find me alternatives"
-msgstr ""
+msgstr "Znajdź alternatywy"
 
 # smartling.placeholder_format=C
 #. Button that searches for results closer to the user's current location.
@@ -8239,8 +8245,7 @@ msgstr "Bezpłatne i prywatne czaty anonimizowane przez nas"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr ""
-"Darmowe i prywatne czaty, anonimizowane przez nas. Nie trzeba zakładać konta."
+msgstr "Darmowe i prywatne czaty, anonimizowane przez nas. Nie trzeba zakładać konta."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -8484,22 +8489,19 @@ msgstr "Ogólnego przeznaczenia"
 #. Text with short description for an AI (Artificial Intelligence) Model that has a high moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "General purpose AI with high built-in moderation"
-msgstr ""
-"Sztuczna inteligencja ogólnego przeznaczenia z wysoką wbudowaną moderacją"
+msgstr "Sztuczna inteligencja ogólnego przeznaczenia z wysoką wbudowaną moderacją"
 
 # smartling.placeholder_format=C
 #. Text with short description for an AI (Artificial Intelligence) Model that has a low moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "General purpose AI with low built-in moderation"
-msgstr ""
-"Sztuczna inteligencja ogólnego przeznaczenia z niską wbudowaną moderacją"
+msgstr "Sztuczna inteligencja ogólnego przeznaczenia z niską wbudowaną moderacją"
 
 # smartling.placeholder_format=C
 #. Text with short description for an AI (Artificial Intelligence) Model that has a medium moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "General purpose AI with medium built-in moderation"
-msgstr ""
-"Sztuczna inteligencja ogólnego przeznaczenia ze średnią wbudowaną moderacją"
+msgstr "Sztuczna inteligencja ogólnego przeznaczenia ze średnią wbudowaną moderacją"
 
 # smartling.placeholder_format=C
 #. Text indicating that the AI (Artificial Intelligence) model is a model for general purpose use. General-purpose AI refers to AI systems that can perform a wide range of tasks, rather than being specialized for a specific task.
@@ -8527,7 +8529,7 @@ msgstr "Generuj więcej"
 #. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Generate a shopping list"
-msgstr ""
+msgstr "Wygeneruj listę zakupów"
 
 # smartling.placeholder_format=C
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
@@ -8826,14 +8828,13 @@ msgstr "Wypróbuj"
 #. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Give me a quick background on this person."
-msgstr ""
+msgstr "Podaj mi krótkie informacje o tej osobie."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
-msgstr ""
-"Wybierz kolejno %1$sPrywatność i bezpieczeństwo > Usługi lokalizacji%2$s"
+msgstr "Wybierz kolejno %1$sPrywatność i bezpieczeństwo > Usługi lokalizacji%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9279,13 +9280,13 @@ msgstr "Pomóż promować prywatność"
 #. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Help me prep for the interview"
-msgstr ""
+msgstr "Pomóż mi przygotować się do rozmowy kwalifikacyjnej"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Help me tailor my resume for this job."
-msgstr ""
+msgstr "Pomóż mi dopasować moje CV do tej oferty pracy."
 
 # smartling.placeholder_format=C
 #. Title of a SERP popup that invites users to take a survey (desktop only)
@@ -9349,8 +9350,7 @@ msgstr "Podaj powód negatywnej oceny"
 #. A subtitle of a page that encourages users to share DuckDuckGo with their friends.
 msgctxt "showcase_spread"
 msgid "Help your friends and family join the Duck Side!"
-msgstr ""
-"Pomóż swoim przyjaciołom oraz rodzinie dołączyć do społeczności DuckDuckGo!"
+msgstr "Pomóż swoim przyjaciołom oraz rodzinie dołączyć do społeczności DuckDuckGo!"
 
 # smartling.placeholder_format=C
 #. Text description for the Spread card in the SERP footer
@@ -9813,7 +9813,7 @@ msgctxt ""
 "Text for the I already have a subscription button in the Duck.ai settings "
 "page"
 msgid "I Already Have a Subscription"
-msgstr ""
+msgstr "Mam już subskrypcję"
 
 # smartling.placeholder_format=C
 #. Text for the button that takes the user to the login subscription page.
@@ -9991,8 +9991,7 @@ msgstr "Jeśli chcesz nas wesprzeć, %1$spomóż nam rozpowszechnić DuckDuckGo%
 msgid ""
 "If you want to use DuckDuckGo without JavaScript, please use our %s or %s "
 "versions."
-msgstr ""
-"Jeśli chcesz używać DuckDuckGo bez JavaScript, użyj wersji %1$s lub %2$s."
+msgstr "Jeśli chcesz używać DuckDuckGo bez JavaScript, użyj wersji %1$s lub %2$s."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -10184,8 +10183,7 @@ msgstr "W menu na górze ekranu wybierz %1$sNarzędzia%2$s > %3$sUstawienia%4$s"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "In the popup, check %sMake this my default search provider%s"
-msgstr ""
-"W wyskakującym okienku zaznacz %1$sUstaw jako domyślną wyszukiwarkę%2$s"
+msgstr "W wyskakującym okienku zaznacz %1$sUstaw jako domyślną wyszukiwarkę%2$s"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -10394,7 +10392,7 @@ msgstr "Zainstaluj przeglądarkę Mac"
 #. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
 msgctxt "settings"
 msgid "Install Now"
-msgstr ""
+msgstr "Zainstaluj teraz"
 
 # smartling.placeholder_format=C
 #. Text of a button to install the DuckDuckGo app
@@ -10497,13 +10495,13 @@ msgstr "Czy usuwane dane są naprawdę usuwane?"
 #. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Is it worth taking?"
-msgstr ""
+msgstr "Warto to brać?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Is this place any good?"
-msgstr ""
+msgstr "Czy to miejsce jest dobre?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
@@ -10512,6 +10510,8 @@ msgid ""
 "Is this place any good? Summarize its reputation based on reviews and "
 "ratings."
 msgstr ""
+"Czy to miejsce jest dobre? Podsumuj jego reputację na podstawie recenzji i "
+"ocen."
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -10523,13 +10523,13 @@ msgstr "Czy ten film jest pomocny?"
 #. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Is this worth watching?"
-msgstr ""
+msgstr "Warto to obejrzeć?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Is this worth watching? Give me a spoiler-free take."
-msgstr ""
+msgstr "Warto to obejrzeć? Daj mi opinię bez spoilerów."
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -10561,8 +10561,7 @@ msgstr "Jest szybki, bezpłatny i zapewnia Ci jeszcze większą ochronę online.
 msgctxt "settings"
 msgid ""
 "It's okay to (very infrequently) ask me about my experience using DuckDuckGo"
-msgstr ""
-"Zgadzam się na (bardzo rzadkie) pytania o moje doświadczenia z DuckDuckGo"
+msgstr "Zgadzam się na (bardzo rzadkie) pytania o moje doświadczenia z DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. The name of the Italian language
@@ -10627,8 +10626,7 @@ msgstr "Dołącz do nas!"
 # smartling.placeholder_format=C
 msgctxt "showcase_donate"
 msgid "Join our $500,000 Privacy Challenge"
-msgstr ""
-"Dołącz do naszego konkursu na ochronę prywatności w wysokości 500 000 USD"
+msgstr "Dołącz do naszego konkursu na ochronę prywatności w wysokości 500 000 USD"
 
 # smartling.placeholder_format=C
 msgid "Jordan"
@@ -11147,7 +11145,7 @@ msgstr "Linki:"
 #. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
-msgstr ""
+msgstr "Wymień narzędzia, materiały lub warunki wstępne, których do tego potrzebuję."
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -11258,8 +11256,7 @@ msgstr "Ładuj więcej obrazów podczas przewijania"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Loads more results in Images, Videos, and Shopping when scrolling"
-msgstr ""
-"Automatycznie wczytuje więcej obrazów, filmów i zakupów podczas przewijania"
+msgstr "Automatycznie wczytuje więcej obrazów, filmów i zakupów podczas przewijania"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/WTkvs9I.png
@@ -11560,7 +11557,7 @@ msgstr "Zarządzaj zablokowanymi witrynami"
 #. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
 msgctxt "setting"
 msgid "Manage in Browser Settings"
-msgstr ""
+msgstr "Zarządzaj w ustawieniach przeglądarki"
 
 # smartling.placeholder_format=C
 #. Link to the site exclusion settings page
@@ -12012,8 +12009,7 @@ msgstr "Osiągnięty limit miesięczny"
 #. Displayed when the user has reached a fixed monthly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Monthly usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Osiągnięto miesięczny limit użycia. Możesz kontynuować tę rozmowę po %1$s."
+msgstr "Osiągnięto miesięczny limit użycia. Możesz kontynuować tę rozmowę po %1$s."
 
 # smartling.placeholder_format=C
 #. Used to point to additional social networking profiles (in results).
@@ -14403,6 +14399,8 @@ msgstr ""
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is harmful or illegal. (optional)"
 msgstr ""
+"Opisz, dlaczego odpowiedź na czacie jest szkodliwa lub nielegalna. "
+"(opcjonalnie)"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
@@ -14441,6 +14439,8 @@ msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is harmful or illegal."
 msgstr ""
+"Wklej zapytanie i problematyczne dane wyjściowe (z usuniętymi danymi "
+"osobowymi) i opisz, dlaczego treść jest szkodliwa lub nielegalna."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -14913,7 +14913,7 @@ msgstr "Prywatność"
 #. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
 msgctxt "Section heading on the Duck.ai settings page"
 msgid "Privacy & Terms"
-msgstr ""
+msgstr "Prywatność i warunki"
 
 # smartling.placeholder_format=C
 msgid "Privacy Blog"
@@ -14989,7 +14989,7 @@ msgstr "Polityka prywatności i warunki użytkowania"
 #. Text for a button that links to the terms of use and privacy policy page.
 msgctxt "Secondary button text in active privacy modal"
 msgid "Privacy Policy and Terms of Service"
-msgstr ""
+msgstr "Polityka prywatności i warunki użytkowania"
 
 # smartling.placeholder_format=C
 #. Title displayed on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
@@ -15183,8 +15183,7 @@ msgstr "Chroń swoje dane podczas wyszukiwania i przeglądania."
 #. Shown on the Mac and Windows browser promo cards. DuckDuckGo's desktop browser protects your data across search, browsing, and AI chat.
 msgctxt "SERP footer content"
 msgid "Protect your data as you search, browse, and use AI."
-msgstr ""
-"Chroń swoje dane podczas wyszukiwania, przeglądania i korzystania z AI."
+msgstr "Chroń swoje dane podczas wyszukiwania, przeglądania i korzystania z AI."
 
 # smartling.placeholder_format=C
 #. A title above links to download the DuckDuckGo apps.
@@ -15391,22 +15390,19 @@ msgstr "Wnioskowanie AI"
 #. Text with short description for a reasoning AI (Artificial Intelligence) Model that has a high moderation level. Reasoning refers to the AI ability to think logically to draw conclusions before providing an answer. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with high built-in moderation"
-msgstr ""
-"Rozumująca sztuczna inteligencja z wysokim poziomem wbudowanej moderacji"
+msgstr "Rozumująca sztuczna inteligencja z wysokim poziomem wbudowanej moderacji"
 
 # smartling.placeholder_format=C
 #. Text with short description for a reasoning AI (Artificial Intelligence) Model that has a low moderation level. Reasoning refers to the AI ability to think logically to draw conclusions before providing an answer. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with low built-in moderation"
-msgstr ""
-"Rozumująca sztuczna inteligencja z niskim poziomem wbudowanej moderacji"
+msgstr "Rozumująca sztuczna inteligencja z niskim poziomem wbudowanej moderacji"
 
 # smartling.placeholder_format=C
 #. Text with short description for a reasoning AI (Artificial Intelligence) Model that has a medium moderation level. Reasoning refers to the AI ability to think logically to draw conclusions before providing an answer. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with medium built-in moderation"
-msgstr ""
-"Rozumująca sztuczna inteligencja ze średnim poziomem wbudowanej moderacji"
+msgstr "Rozumująca sztuczna inteligencja ze średnim poziomem wbudowanej moderacji"
 
 # smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
@@ -15501,25 +15497,25 @@ msgstr "Poleć książkę"
 #. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Recommend similar books"
-msgstr ""
+msgstr "Poleć podobne książki"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Recommend similar books."
-msgstr ""
+msgstr "Poleć podobne książki."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Recommend similar movies or shows."
-msgstr ""
+msgstr "Poleć podobne filmy lub programy."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Recommend similar titles"
-msgstr ""
+msgstr "Poleć podobne tytuły"
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
@@ -15931,7 +15927,7 @@ msgctxt ""
 "feedback form when the user has selected Harmful or Illegal as the feedback "
 "reason"
 msgid "Required for harmful or illegal reports"
-msgstr ""
+msgstr "Wymagane przy zgłaszaniu szkodliwych lub nielegalnych treści"
 
 # smartling.placeholder_format=C
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
@@ -16175,7 +16171,7 @@ msgstr "Recenzje"
 #. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Rewrite this recipe scaled for a different number of servings."
-msgstr ""
+msgstr "Przepisz ten przepis z inną liczbą porcji."
 
 # smartling.placeholder_format=C
 msgid "Romania"
@@ -16464,8 +16460,8 @@ msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
 msgstr ""
-"Zapisuj swoje czaty Duck.ai między urządzeniami dzięki szyfrowaniu typu end-"
-"to-end."
+"Zapisuj swoje czaty Duck.ai między urządzeniami dzięki szyfrowaniu typu "
+"end-to-end."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -17013,8 +17009,7 @@ msgstr ""
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
 msgctxt "Sync feature benefit description"
 msgid "Securely stored on DuckDuckGo's server with end-to-end encryption."
-msgstr ""
-"Bezpieczne przechowywanie na serwerze DuckDuckGo z kompleksowym szyfrowaniem."
+msgstr "Bezpieczne przechowywanie na serwerze DuckDuckGo z kompleksowym szyfrowaniem."
 
 # smartling.placeholder_format=C
 #. List item explaining that synced chats are stored with end-to-end encryption on DuckDuckGo's server and only the user can access them.
@@ -17196,15 +17191,13 @@ msgstr "Wybierz %1$sDuckDuckGo%2$s i kliknij %3$sUstaw jako domyślną%4$s."
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Select %sDuckDuckGo%s in the Default Search Engine drop down"
-msgstr ""
-"Wybierz %1$sDuckDuckGo%2$s w rozwijanym menu jako domyślną wyszukiwarkę"
+msgstr "Wybierz %1$sDuckDuckGo%2$s w rozwijanym menu jako domyślną wyszukiwarkę"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %sDuckDuckGo%s in the list and %sallow%s location access"
-msgstr ""
-"Wybierz %1$sDuckDuckGo%2$s z listy i %3$szezwól%4$s na dostęp do lokalizacji"
+msgstr "Wybierz %1$sDuckDuckGo%2$s z listy i %3$szezwól%4$s na dostęp do lokalizacji"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -17295,8 +17288,7 @@ msgstr "Wybierz %1$sUstawienia%2$s z rozwijanego menu."
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sAdvanced settings%s"
-msgstr ""
-"Wybierz %1$sUstawienia%2$s, a następnie %3$sUstawienia zaawansowane%4$s"
+msgstr "Wybierz %1$sUstawienia%2$s, a następnie %3$sUstawienia zaawansowane%4$s"
 
 # smartling.placeholder_format=C
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -17523,7 +17515,7 @@ msgstr "Skonfiguruj teraz"
 #. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
 msgctxt "Encrypted storage setup button shown in native browsers"
 msgid "Set Up Sync & Backup"
-msgstr ""
+msgstr "Konfigurowanie funkcji Sync & Backup"
 
 # smartling.placeholder_format=C
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
@@ -17617,8 +17609,7 @@ msgstr "Udostępnij"
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "Share DuckDuckGo and help friends take their privacy back!"
-msgstr ""
-"Udostępniaj informacje o DuckDuckGo i pomóż znajomym odzyskać prywatność!"
+msgstr "Udostępniaj informacje o DuckDuckGo i pomóż znajomym odzyskać prywatność!"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button that opens a feedback modal when clicked.
@@ -17712,7 +17703,7 @@ msgstr "Podziel się pozytywną opinią"
 msgctxt ""
 "Label beside the share-content switch on the Duck.ai response feedback form"
 msgid "Share this conversation with DuckDuckGo"
-msgstr ""
+msgstr "Podziel się tą konwersacją z DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -18101,8 +18092,7 @@ msgstr "Wyświetla poziome linie pomiędzy stronami z wynikami wyszukiwania"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows links to instructions for how to add DuckDuckGo to your browser"
-msgstr ""
-"Wyświetla łącza do instrukcji dodawania DuckDuckGo do Twojej przeglądarki"
+msgstr "Wyświetla łącza do instrukcji dodawania DuckDuckGo do Twojej przeglądarki"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers more frequently.
@@ -18118,8 +18108,7 @@ msgstr "Wyświetla najczęściej odwiedzane łącza na stronie nowej karty"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your browser"
-msgstr ""
-"Wyświetla sporadyczne przypomnienia o dodaniu DuckDuckGo do przeglądarki"
+msgstr "Wyświetla sporadyczne przypomnienia o dodaniu DuckDuckGo do przeglądarki"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18807,8 +18796,7 @@ msgstr "Zatrzymaj generowanie"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop hidden trackers lurking on other websites."
-msgstr ""
-"Blokowanie mechanizmów śledzących ukrytych na innych stronach internetowych."
+msgstr "Blokowanie mechanizmów śledzących ukrytych na innych stronach internetowych."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -18989,18 +18977,20 @@ msgstr "Zaproponuj tytuł wpisu na blogu"
 msgctxt "Page suggestion prompt"
 msgid "Suggest related articles or topics worth exploring next."
 msgstr ""
+"Sugeruj powiązane artykuły lub tematy, które warto sprawdzić w następnej "
+"kolejności."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Suggest related articles to explore"
-msgstr ""
+msgstr "Zaproponuj powiązane artykuły do przejrzenia"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Suggest some alternatives to this product."
-msgstr ""
+msgstr "Zaproponuj jakieś alternatywy dla tego produktu."
 
 # smartling.placeholder_format=C
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
@@ -19017,7 +19007,7 @@ msgstr "Sugestie:"
 #. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Sum up the reviews"
-msgstr ""
+msgstr "Podsumuj recenzje"
 
 # smartling.placeholder_format=C
 #. A short title for the a message asking the AI to summarize a text.
@@ -19029,85 +19019,85 @@ msgstr "Podsumuj"
 #. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize the Q&As"
-msgstr ""
+msgstr "Podsumuj pytania i odpowiedzi"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the background and notable work of this person."
-msgstr ""
+msgstr "Podsumuj życiorys i najważniejsze osiągnięcia tej osoby."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the key details of this event."
-msgstr ""
+msgstr "Podsumuj najważniejsze szczegóły tego wydarzenia."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the questions and answers on this page."
-msgstr ""
+msgstr "Podsumuj pytania i odpowiedzi na tej stronie."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize their background"
-msgstr ""
+msgstr "Podsumuj ich tło"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this book"
-msgstr ""
+msgstr "Podsumuj tę książkę"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this book."
-msgstr ""
+msgstr "Podsumuj tę książkę."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this discussion"
-msgstr ""
+msgstr "Podsumuj tę dyskusję"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this discussion thread."
-msgstr ""
+msgstr "Podsumuj ten wątek dyskusji."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this page"
-msgstr ""
+msgstr "Podsumuj tę stronę"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this page."
-msgstr ""
+msgstr "Podsumuj tę stronę."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this video"
-msgstr ""
+msgstr "Podsumuj ten film"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this video."
-msgstr ""
+msgstr "Podsumuj ten film."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize what the reviews say."
-msgstr ""
+msgstr "Podsumuj, co mówią opinie."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -19324,8 +19314,7 @@ msgstr "Sync & Backup włączone!"
 #. Notice shown under the recovery code explaining that backup data has an inactivity expiration.
 msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
-msgstr ""
-"Danych Sync & Backup nie można odzyskać po 18 miesiącach braku aktywności."
+msgstr "Danych Sync & Backup nie można odzyskać po 18 miesiącach braku aktywności."
 
 # smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
@@ -19439,7 +19428,7 @@ msgstr "Syria"
 #. Text for a button that enables the theme to follow the operating system's color scheme preference.
 msgctxt "System theme button for theme selector"
 msgid "System"
-msgstr ""
+msgstr "Systemowy"
 
 # smartling.placeholder_format=C
 #. Abbreviation indicating this is the total score for a game
@@ -19473,7 +19462,7 @@ msgstr "tahitański"
 #. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Tailor my resume"
-msgstr ""
+msgstr "Dopasuj moje CV"
 
 # smartling.placeholder_format=C
 msgid "Taiwan"
@@ -19510,6 +19499,8 @@ msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
+"Weź udział w tej anonimowej ankiecie i daj nam znać, jak możemy ulepszyć "
+"Duck.ai."
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -19774,8 +19765,7 @@ msgstr ""
 msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider deletes any data associated with this chat within 30 days."
-msgstr ""
-"Dostawca modelu usuwa wszelkie dane związane z tym czatem w ciągu 30 dni."
+msgstr "Dostawca modelu usuwa wszelkie dane związane z tym czatem w ciągu 30 dni."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers.
@@ -19819,7 +19809,7 @@ msgstr "Motyw"
 #. Text for the theme selector label that allows users to switch between Light and dark theme.
 msgctxt "Label for the theme selector feature"
 msgid "Theme"
-msgstr ""
+msgstr "Motyw"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/LpFhb1e.png
@@ -20075,16 +20065,14 @@ msgstr "Tego obrazu nie dało się stworzyć."
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF"
-msgstr ""
-"Ten typ obrazu nie jest obsługiwany, dołącz plik JPG, PNG, WebP lub GIF"
+msgstr "Ten typ obrazu nie jest obsługiwany, dołącz plik JPG, PNG, WebP lub GIF"
 
 # smartling.placeholder_format=C
 #. Error message displayed when a file that the user tried to upload is not of a supported format
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF."
-msgstr ""
-"Ten typ obrazu nie jest obsługiwany, dołącz plik JPG, PNG, WebP lub GIF."
+msgstr "Ten typ obrazu nie jest obsługiwany, dołącz plik JPG, PNG, WebP lub GIF."
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
@@ -20137,8 +20125,7 @@ msgstr "Ta strona do działania wymaga włączonego Javascriptu."
 #. Information tooltip text explaining that the current page's content will be included with the chat message.
 msgctxt "Tooltip explaining that page content will be sent to Duck.ai"
 msgid "This page's content will be sent with your message to Duck.ai"
-msgstr ""
-"Zawartość tej strony zostanie wysłana wraz z Twoją wiadomością do Duck.ai"
+msgstr "Zawartość tej strony zostanie wysłana wraz z Twoją wiadomością do Duck.ai"
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -20246,8 +20233,7 @@ msgstr ""
 #. Message explaining what will happen when the user deletes an image.
 msgctxt "Confirmation message in delete image modal"
 msgid "This will delete your selected image. This cannot be undone."
-msgstr ""
-"Spowoduje to usunięcie wybranego obrazu. Tej czynności nie można cofnąć."
+msgstr "Spowoduje to usunięcie wybranego obrazu. Tej czynności nie można cofnąć."
 
 # smartling.placeholder_format=C
 #. Confirmation message asking if the user is sure they want to reset all of their settings.
@@ -20372,8 +20358,7 @@ msgstr "Aby kontynuować, musisz wyrazić zgodę na %1$s i %2$s Duck.ai"
 msgctxt ""
 "Copy stating agreement to AI Chat Privacy Policy and Terms of Service."
 msgid "To continue, you must agree to DuckDuckGo AI Chat’s %s and %s"
-msgstr ""
-"Aby kontynuować, musisz wyrazić zgodę na %1$s i %2$s DuckDuckGo AI Chat"
+msgstr "Aby kontynuować, musisz wyrazić zgodę na %1$s i %2$s DuckDuckGo AI Chat"
 
 # smartling.placeholder_format=C
 #. Instructions for how to print driving directions.
@@ -20671,13 +20656,13 @@ msgstr ""
 #. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Translate this page"
-msgstr ""
+msgstr "Przetłumacz tę stronę"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
 msgctxt "Page suggestion prompt"
 msgid "Translate this page into %s."
-msgstr ""
+msgstr "Przetłumacz tę stronę na język %1$s."
 
 # smartling.placeholder_format=C
 #. Placeholder text for a region that will display translated text.
@@ -20824,7 +20809,7 @@ msgstr "Wypróbuj za darmo"
 #. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
 msgctxt "settings"
 msgid "Try It Now"
-msgstr ""
+msgstr "Wypróbuj teraz"
 
 # smartling.placeholder_format=C
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -20882,23 +20867,20 @@ msgstr "Spróbuj innych słów kluczowych."
 # smartling.placeholder_format=C
 #. Prompt encouraging the user to turn off their ad blocker to see more results for their query.
 msgid "Try disabling your ad blocker on DuckDuckGo to see more results."
-msgstr ""
-"Spróbuj wyłączyć blokadę reklam w DuckDuckGo, aby zobaczyć więcej wyników."
+msgstr "Spróbuj wyłączyć blokadę reklam w DuckDuckGo, aby zobaczyć więcej wyników."
 
 # smartling.placeholder_format=C
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
 msgctxt "precise_user_location"
 msgid "Try enabling anonymous location for more accurate results."
-msgstr ""
-"Spróbuj włączyć anonimową lokalizację, aby uzyskać dokładniejsze wyniki."
+msgstr "Spróbuj włączyć anonimową lokalizację, aby uzyskać dokładniejsze wyniki."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the screen of the onboarding where the user picks a chat model.
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr ""
-"Spróbuj poeksperymentować z każdym modelem — otrzymasz różne odpowiedzi."
+msgstr "Spróbuj poeksperymentować z każdym modelem — otrzymasz różne odpowiedzi."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
@@ -21074,6 +21056,9 @@ msgid ""
 "Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
+"Chcesz wyłączyć funkcje AI? Zainstaluj rozszerzenie wyszukiwania "
+"%1$sDuckDuckGo No AI%2$s, aby zapamiętać swoje ustawienia. %3$sDowiedz się "
+"więcej%4$s"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -21082,6 +21067,9 @@ msgid ""
 "Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
+"Chcesz wyłączyć funkcje AI? Przełącz się na rozszerzenie wyszukiwania "
+"%1$sDuckDuckGo No AI%2$s, aby zapamiętać swoje ustawienia. %3$sDowiedz się "
+"więcej%4$s"
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -21183,8 +21171,7 @@ msgstr "Wyłącz:"
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on %sPrecise Location%s for more accurate results"
-msgstr ""
-"Włącz opcję %1$sDokładna lokalizacja%2$s, aby uzyskać dokładniejsze wyniki."
+msgstr "Włącz opcję %1$sDokładna lokalizacja%2$s, aby uzyskać dokładniejsze wyniki."
 
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
@@ -21402,15 +21389,14 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sOpen with%s select %sA specific page or pages%s"
-msgstr ""
-"Pod %1$sOtwórz za pomocą%2$s wybierz %3$sKonkretna strona lub strony%4$s"
+msgstr "Pod %1$sOtwórz za pomocą%2$s wybierz %3$sKonkretna strona lub strony%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
 msgstr ""
-"Pod %1$sPrzy uruchomieniu > Strona główna \\%2$s wprowadź: https://"
-"duckduckgo.com"
+"Pod %1$sPrzy uruchomieniu > Strona główna \\%2$s wprowadź: "
+"https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -21420,15 +21406,13 @@ msgstr "Pod %1$sUstawienia wyszukiwania%2$s wybierz %3$sDuckDuckGo%4$s"
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch in the address bar with%s select %sAdd New%s"
-msgstr ""
-"Pod %1$sWyszukaj w pasku adresu za pomocą%2$s wybierz %3$sDodaj nową%4$s"
+msgstr "Pod %1$sWyszukaj w pasku adresu za pomocą%2$s wybierz %3$sDodaj nową%4$s"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
-msgstr ""
-"W dziale %1$sWyszukiwanie%2$s kliknij %3$sZarządzaj wyszukiwarkami…%4$s"
+msgstr "W dziale %1$sWyszukiwanie%2$s kliknij %3$sZarządzaj wyszukiwarkami…%4$s"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -21542,8 +21526,7 @@ msgstr "Odblokuj za pomocą subskrypcji DuckDuckGo"
 msgctxt "voice chat limit modal"
 msgid ""
 "Unlock advanced AI models and higher limits with a DuckDuckGo Subscription"
-msgstr ""
-"Odblokuj zaawansowane modele AI i wyższe limity dzięki subskrypcji DuckDuckGo"
+msgstr "Odblokuj zaawansowane modele AI i wyższe limity dzięki subskrypcji DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Text informing the user that advanced AI models can be unlocked with a subscription. The variable is used to insert a link that opens the subscription modal. Example: Unlock advanced AI models with a DuckDuckGo subscription.
@@ -21576,8 +21559,7 @@ msgctxt ""
 "Text shown in the subscription promo card, with a trailing call-to-action "
 "link."
 msgid "Unlock more capable AI models with a DuckDuckGo subscription. %s"
-msgstr ""
-"Odblokuj bardziej wydajne modele AI dzięki subskrypcji DuckDuckGo. %1$s"
+msgstr "Odblokuj bardziej wydajne modele AI dzięki subskrypcji DuckDuckGo. %1$s"
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to unmute the microphone.
@@ -21844,7 +21826,7 @@ msgstr "Urugwaj"
 #. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
 msgctxt "Navigation label on the Duck.ai settings page"
 msgid "Usage"
-msgstr ""
+msgstr "Zastosowanie"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -21941,8 +21923,7 @@ msgstr ""
 #. Prompt to ask the user if they want to use their approximate location for more accurate results
 msgctxt "DuckChat location prompt"
 msgid "Use your approximate location for more accurate results?"
-msgstr ""
-"Czy użyć Twojej przybliżonej lokalizacji, aby uzyskać dokładniejsze wyniki?"
+msgstr "Czy użyć Twojej przybliżonej lokalizacji, aby uzyskać dokładniejsze wyniki?"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes before every user message in the downloaded file, indicating which message it is out of the total number of messages. Example: 'User prompt 3 of 5'
@@ -22302,7 +22283,7 @@ msgstr "Walia"
 #. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Walk me through the steps"
-msgstr ""
+msgstr "Przeprowadź mnie przez kolejne kroki"
 
 # smartling.placeholder_format=C
 #. Label for walking directions on a map.
@@ -22433,6 +22414,9 @@ msgid ""
 "please share this conversation with DuckDuckGo so we can investigate and "
 "address the issue."
 msgstr ""
+"Możemy naprawić tylko to, co widzimy. Aby zgłosić szkodliwą lub niezgodną z "
+"prawem odpowiedź, udostępnij tę rozmowę DuckDuckGo, abyśmy mogli zbadać "
+"sprawę i zająć się nią."
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -22481,8 +22465,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don't store your personal info or track you. Ever."
-msgstr ""
-"Nie przechowujemy informacji na Twój temat ani Cię nie śledzimy. Nigdy."
+msgstr "Nie przechowujemy informacji na Twój temat ani Cię nie śledzimy. Nigdy."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -22566,8 +22549,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don’t track you in or out of private browsing mode."
-msgstr ""
-"Nie śledzimy Cię, niezależnie od tego czy używasz trybu incognito, czy nie."
+msgstr "Nie śledzimy Cię, niezależnie od tego czy używasz trybu incognito, czy nie."
 
 # smartling.placeholder_format=C
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with an Agree button is shown below.
@@ -22579,8 +22561,7 @@ msgstr "Nie śledzimy Cię. To jest nasza polityka prywatności w skrócie…"
 #. Displayed when the user's voice chat session is ended because of being inactive for too long.
 msgctxt "voice chat error"
 msgid "We ended the chat due to inactivity. Want to try again?"
-msgstr ""
-"Zakończyliśmy czat z powodu braku aktywności. Chcesz spróbować ponownie?"
+msgstr "Zakończyliśmy czat z powodu braku aktywności. Chcesz spróbować ponownie?"
 
 # smartling.placeholder_format=C
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
@@ -22805,8 +22786,7 @@ msgstr "Osiągnięto limit tygodniowy"
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Weekly usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Osiągnięto tygodniowy limit użycia. Możesz kontynuować tę rozmowę po %1$s."
+msgstr "Osiągnięto tygodniowy limit użycia. Możesz kontynuować tę rozmowę po %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable weekly Duck.ai usage limit and can opt in to continue using the monthly limit.
@@ -22997,98 +22977,98 @@ msgstr ""
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the counterarguments?"
-msgstr ""
+msgstr "Jakie są argumenty przeciw?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the hours & location?"
-msgstr ""
+msgstr "Jakie są godziny otwarcia i lokalizacja?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key contributions of this paper?"
-msgstr ""
+msgstr "Jakie są najważniejsze wnioski zawarte w tym artykule?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key contributions?"
-msgstr ""
+msgstr "Jakie są najważniejsze wnioski?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key details?"
-msgstr ""
+msgstr "Jakie są najważniejsze szczegóły?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key points covered in this video?"
-msgstr ""
+msgstr "Jakie są najważniejsze punkty omówione w tym filmie?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key points?"
-msgstr ""
+msgstr "Jakie są najważniejsze punkty?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key takeaways from this article?"
-msgstr ""
+msgstr "Jakie są najważniejsze wnioski z tego artykułu?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key takeaways?"
-msgstr ""
+msgstr "Jakie są najważniejsze wnioski?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key things I will learn from this course?"
-msgstr ""
+msgstr "Jakie są najważniejsze rzeczy, których dowiem się z tego kursu?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the main counterarguments or criticisms of this?"
-msgstr ""
+msgstr "Jakie są główne kontrargumenty i zarzuty wobec tego stwierdzenia?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the main questions this page answers?"
-msgstr ""
+msgstr "Na jakie główne pytania odpowiada ta strona?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the must-try dishes here?"
-msgstr ""
+msgstr "Jakie dania warto tu zjeść?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid ""
 "What are the opening hours, location, and contact details for this place?"
-msgstr ""
+msgstr "Jakie są godziny otwarcia, lokalizacja i dane kontaktowe tego miejsca?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the pros and cons of this product?"
-msgstr ""
+msgstr "Jakie są zalety i wady tego produktu?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the pros and cons?"
-msgstr ""
+msgstr "Jakie są zalety i wady?"
 
 # smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
@@ -23194,7 +23174,7 @@ msgstr "Co oznaczają przedsionki w artykule medycznym?"
 #. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What does this answer?"
-msgstr ""
+msgstr "Na co to odpowiada?"
 
 # smartling.placeholder_format=C
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
@@ -23213,6 +23193,8 @@ msgstr "Jakie informacje są zapisywane?"
 msgctxt "Page suggestion prompt"
 msgid "What interview questions might come up for this role?"
 msgstr ""
+"Jakie pytania mogą pojawić się podczas rozmowy kwalifikacyjnej na to "
+"stanowisko?"
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -23220,8 +23202,7 @@ msgctxt "cloudsave"
 msgid ""
 "What is the Cloud Save bookmarklet and how does it differ from the URL "
 "parameter bookmarklet?"
-msgstr ""
-"Czym jest skryptozakładka Cloud Save i czym różni się od skryptozakładki URL?"
+msgstr "Czym jest skryptozakładka Cloud Save i czym różni się od skryptozakładki URL?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for looking up the capital city of Albania.
@@ -23233,7 +23214,7 @@ msgstr "Jakie miasto jest stolicą Albanii?"
 #. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What is the overall verdict and rating for this?"
-msgstr ""
+msgstr "Jaki jest ogólny werdykt i ocena tego?"
 
 # smartling.placeholder_format=C
 #. Link to a page with additional information.
@@ -23261,7 +23242,7 @@ msgstr "Opinie innych osób:"
 #. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What should I order?"
-msgstr ""
+msgstr "Co powinienem zamówić?"
 
 # smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
@@ -23279,13 +23260,13 @@ msgstr "Co było nie tak z odpowiedzią? (opcjonalnie)"
 #. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What will I learn?"
-msgstr ""
+msgstr "Czego się dowiem?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What will I need?"
-msgstr ""
+msgstr "Czego będę potrzebować?"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -23296,8 +23277,7 @@ msgstr "Na jaki temat chcesz przekazać opinię?"
 #. Explains the benefits of using our custom video player, the Duck Player
 msgid ""
 "What you watch in DuckDuckGo won't influence your recommendations on YouTube."
-msgstr ""
-"To, co oglądasz w DuckDuckGo, nie wpłynie na rekomendacje w serwisie YouTube."
+msgstr "To, co oglądasz w DuckDuckGo, nie wpłynie na rekomendacje w serwisie YouTube."
 
 # smartling.placeholder_format=C
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
@@ -23309,7 +23289,7 @@ msgstr "Co nowego"
 #. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What's the verdict?"
-msgstr ""
+msgstr "Jaki werdykt?"
 
 # smartling.placeholder_format=C
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -23367,7 +23347,7 @@ msgstr "Jakich funkcji brakuje? (opcjonalnie)"
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Which features are missing? (optional)"
-msgstr ""
+msgstr "Jakich funkcji brakuje? (opcjonalnie)"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
@@ -23389,13 +23369,13 @@ msgstr "Kim jesteśmy"
 #. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Who are the main cast and crew, and what else are they known for?"
-msgstr ""
+msgstr "Kto należy do głównej obsady i ekipy oraz z czego jeszcze są znani?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Who is this person?"
-msgstr ""
+msgstr "Kim jest ta osoba?"
 
 # smartling.placeholder_format=C
 #. Header above a collection of privacy-related links.
@@ -23803,8 +23783,7 @@ msgstr ""
 #. Text informing the user that they can access DuckDuckGo AI Chat directly at a specific URL. The placeholder %s will be replaced with the link. Example: 'You can access DuckDuckGo AI Chat directly at duck.ai.'
 msgctxt "Information about direct access to DuckDuckGo AI Chat"
 msgid "You can access DuckDuckGo AI Chat directly at %s."
-msgstr ""
-"Możesz uzyskać dostęp do DuckDuckGo AI Chat bezpośrednio pod adresem %1$s."
+msgstr "Możesz uzyskać dostęp do DuckDuckGo AI Chat bezpośrednio pod adresem %1$s."
 
 # smartling.placeholder_format=C
 #. Search Assist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate Search Assist.
@@ -23858,8 +23837,7 @@ msgstr ""
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
 msgctxt "Third party map app picker feedback dialog"
 msgid "You can change this any time in %sSearch Settings%s"
-msgstr ""
-"Możesz to zmienić w dowolnym momencie w %1$sustawieniach wyszukiwania%2$s"
+msgstr "Możesz to zmienić w dowolnym momencie w %1$sustawieniach wyszukiwania%2$s"
 
 # smartling.placeholder_format=C
 #. Text explaning how to change a passphrase.
@@ -23892,8 +23870,7 @@ msgstr "Możesz ukryć to przypomnienie w %1$sustawieniach wyszukiwania%2$s"
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
-msgstr ""
-"Teraz możesz zapisać do 100 czatów na tym urządzeniu. Rozmawiajcie śmiało!"
+msgstr "Teraz możesz zapisać do 100 czatów na tym urządzeniu. Rozmawiajcie śmiało!"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -23963,8 +23940,7 @@ msgstr "Można przywrócić swoje ustawienia po usunięciu plików cookie."
 #. Text explaining the benefits of the cloud save feature.
 msgctxt "cloudsave"
 msgid "You can share your settings among computers and browsers."
-msgstr ""
-"Możesz używać tych samych ustawień na różnych komputerach i przeglądarkach."
+msgstr "Możesz używać tych samych ustawień na różnych komputerach i przeglądarkach."
 
 # smartling.placeholder_format=C
 #. Alternative option description on export screen.
@@ -24150,8 +24126,7 @@ msgstr ""
 #. Description shown when the user has reached the maximum voice chat duration.
 msgctxt "voice chat duration limit modal"
 msgid "You've reached the maximum voice chat duration for a single session."
-msgstr ""
-"Osiągnięto maksymalny czas trwania czatu głosowego w ramach jednej sesji."
+msgstr "Osiągnięto maksymalny czas trwania czatu głosowego w ramach jednej sesji."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the daily voice chat limit.
@@ -24284,8 +24259,8 @@ msgid ""
 "Your browser provides a list of your most-visited sites. DuckDuckGo never "
 "has access to this data."
 msgstr ""
-"Twoja przeglądarka udostępnia listę najczęściej odwiedzanych witryn."
-"DuckDuckGo nigdy nie ma dostępu do tych danych."
+"Twoja przeglądarka udostępnia listę najczęściej odwiedzanych "
+"witryn.DuckDuckGo nigdy nie ma dostępu do tych danych."
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
@@ -24324,8 +24299,7 @@ msgstr ""
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never used to train AI models"
-msgstr ""
-"Twoje czaty są prywatne i nigdy nie są wykorzystywane do trenowania modeli AI"
+msgstr "Twoje czaty są prywatne i nigdy nie są wykorzystywane do trenowania modeli AI"
 
 # smartling.placeholder_format=C
 #. Text for a description of the active privacy protection for DuckDuckGo's AI Chat feature.

--- a/locales/ps_AF/LC_MESSAGES/duckduckgo.po
+++ b/locales/ps_AF/LC_MESSAGES/duckduckgo.po
@@ -1159,6 +1159,11 @@ msgctxt "feedback form"
 msgid "Address is incorrect"
 msgstr ""
 
+#. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Adjust the servings"
+msgstr ""
+
 #. as in multiple advertisements
 msgid "Ads"
 msgstr ""
@@ -1330,6 +1335,13 @@ msgstr ""
 #. Heading shown on the empty chat screen. The text between the two %s markers is displayed inside a clickable privacy button. First %s renders a shield icon, second %s is an invisible end marker. Keep the word 'private' between both %s markers.
 msgctxt "Empty state heading in Duck.ai chat mode"
 msgid "All chats are %sprivate%s"
+msgstr ""
+
+#. Paragraph in the Privacy & Terms section of the About & Legal page in Duck.ai settings, summarizing how chats are anonymized and are not stored or used to train chat models.
+msgctxt "Privacy & Terms section description on the Duck.ai settings page"
+msgid ""
+"All chats are anonymized by DuckDuckGo, and your conversations are not used "
+"to train chat models by DuckDuckGo or the model providers"
 msgstr ""
 
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1542,6 +1554,12 @@ msgstr ""
 #. Confirmation message after location service is enabled.
 msgctxt "precise_user_location"
 msgid "Anonymous location enabled"
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Anonymously generates answers for search queries based on web content. "
+"Choose how often you want it to appear, or disable it completely."
 msgstr ""
 
 #. Instant Answer tab name
@@ -1764,6 +1782,11 @@ msgstr ""
 
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse
 msgid "Ask a follow-up with Duck.ai"
+msgstr ""
+
+#. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
+msgctxt "Page suggestion chip label"
+msgid "Ask about this page"
 msgstr ""
 
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2088,6 +2111,11 @@ msgstr ""
 msgid "Barcode"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Based on this page, is this course worth taking?"
+msgstr ""
+
 msgctxt "settings"
 msgid "Basic"
 msgstr ""
@@ -2119,6 +2147,13 @@ msgstr ""
 #. Placeholder text displayed while the assistant waits for the user to choose an action.
 msgctxt "Assistant response placeholder"
 msgid "Before continuing..."
+msgstr ""
+
+#. Explains that before storing the report, DuckDuckGo will anonymize the conversation by removing PII like names, email addresses, and identifying metadata.
+msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
+msgid ""
+"Before storing this report, DuckDuckGo will anonymize your conversation by "
+"removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
 #. Label that's displayed next to a past start date below a web search result.
@@ -2377,6 +2412,11 @@ msgstr ""
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Break Points Won"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Break this down into clear, numbered steps."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -2736,6 +2776,11 @@ msgstr ""
 #. Text of a button that performs a search for the cast of a particular movie or tv show
 msgctxt "Movie/TV Show Title instant answer"
 msgid "Cast"
+msgstr ""
+
+#. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Cast & Crew"
 msgstr ""
 
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -4085,6 +4130,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Create a shopping list with quantities from this recipe."
+msgstr ""
+
 #. Placeholder text displayed in the input field when starting a new image generation session.
 msgctxt "Placeholder text for the image generation input field"
 msgid "Create an image of a cute duck..."
@@ -4611,6 +4661,10 @@ msgstr ""
 msgid "Dictation limit reached"
 msgstr ""
 
+#. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
+msgid "Dictation temporarily unavailable"
+msgstr ""
+
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
@@ -4855,6 +4909,20 @@ msgctxt "precise_user_location"
 msgid "Done"
 msgstr ""
 
+#. Message shown in a modal after DuckDuckGo browser users disable AI features in Settings. The first two placeholders bold noai.duckduckgo.com. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
+"filtered out. %sLearn More%s"
+msgstr ""
+
+#. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
+"and AI images filtered out. %sLearn more%s"
+msgstr ""
+
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Double Faults"
@@ -4945,6 +5013,16 @@ msgctxt "Full sentence for writing an email"
 msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
+msgstr ""
+
+#. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Draft a cover letter"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Draft a cover letter for this job."
 msgstr ""
 
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -5084,6 +5162,14 @@ msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
 msgstr ""
 
+#. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
+msgctxt "About section description on the Duck.ai settings page"
+msgid ""
+"Duck.ai is created by DuckDuckGo. We're an independent online protection "
+"company for anyone who wants to take back control of their personal "
+"information."
+msgstr ""
+
 #. Title shown when an update is required before proceeding.
 msgctxt "duckai_migration"
 msgid "Duck.ai is moving domains"
@@ -5117,6 +5203,12 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Duck.ai lets you chat privately with popular AI models. Disabling it hides "
+"Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
 
 msgctxt "settings"
@@ -5882,6 +5974,16 @@ msgstr ""
 msgid "Eritrea"
 msgstr ""
 
+#. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Estimate the nutrition"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Estimate the nutritional information for this recipe."
+msgstr ""
+
 msgid "Estonia"
 msgstr ""
 
@@ -5926,10 +6028,50 @@ msgctxt "merchant promotion product ad extension"
 msgid "Expires in 1 day"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain the accepted answer in simple terms."
+msgstr ""
+
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
+msgstr ""
+
+#. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain the top answer"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this in simple, plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this paper"
+msgstr ""
+
+#. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this repo"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this research paper in plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this simply"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain what this repository does and how to use it."
 msgstr ""
 
 #. Label to show if song lyrics contain explicit content
@@ -6158,6 +6300,11 @@ msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
 msgstr ""
 
+msgctxt "settings"
+msgid ""
+"Filters out known AI spam sites from image search results. %sLearn More%s"
+msgstr ""
+
 #. Label for the final score of a sporting event.
 msgid "Final"
 msgstr ""
@@ -6197,6 +6344,11 @@ msgstr ""
 #. Short description shown below the 'Web Search' label in the Tools dropdown.
 msgctxt "Subtitle for the Web Search tool entry in the Tools dropdown menu"
 msgid "Find current information"
+msgstr ""
+
+#. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Find me alternatives"
 msgstr ""
 
 #. Button that searches for results closer to the user's current location.
@@ -6587,6 +6739,11 @@ msgstr ""
 msgid "Generate More"
 msgstr ""
 
+#. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Generate a shopping list"
+msgstr ""
+
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
 msgid "Generate a short answer from the web"
 msgstr ""
@@ -6821,6 +6978,11 @@ msgstr ""
 #. Text for a button inviting users to give it a try for the Duck.ai product. On click, they're taken to the Duck.ai page.
 msgctxt "Onboarding welcome screen button text"
 msgid "Give it a Try"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Give me a quick background on this person."
 msgstr ""
 
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -7183,6 +7345,16 @@ msgstr ""
 
 #. Link to a page with information about sharing DuckDuckGo with friends.
 msgid "Help Spread Privacy"
+msgstr ""
+
+#. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Help me prep for the interview"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Help me tailor my resume for this job."
 msgstr ""
 
 #. Title of a SERP popup that invites users to take a survey (desktop only)
@@ -7602,6 +7774,13 @@ msgstr ""
 #. Text displayed on the button on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
 msgctxt "Onboarding terms screen button text"
 msgid "I Agree"
+msgstr ""
+
+#. Text for the button that takes the user to the external DuckDuckGo login subscription page.
+msgctxt ""
+"Text for the I already have a subscription button in the Duck.ai settings "
+"page"
+msgid "I Already Have a Subscription"
 msgstr ""
 
 #. Text for the button that takes the user to the login subscription page.
@@ -8052,6 +8231,11 @@ msgctxt "Sidemenu browser promo"
 msgid "Install Mac Browser"
 msgstr ""
 
+#. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
+msgctxt "settings"
+msgid "Install Now"
+msgstr ""
+
 #. Text of a button to install the DuckDuckGo app
 msgctxt "Serp footer content"
 msgid "Install Our App"
@@ -8131,9 +8315,36 @@ msgctxt "cloudsave"
 msgid "Is deleted data really deleted?"
 msgstr ""
 
+#. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is it worth taking?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this place any good?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"Is this place any good? Summarize its reputation based on reviews and "
+"ratings."
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "Is this video helpful?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this worth watching?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Is this worth watching? Give me a spoiler-free take."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -8630,6 +8841,11 @@ msgstr ""
 msgid "Links:"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "List the tools, materials, or prerequisites I need for this."
+msgstr ""
+
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
 msgid "Listen"
 msgstr ""
@@ -8962,6 +9178,11 @@ msgstr ""
 #. Label for linke navigating to site exclusion feature on Settings page
 msgctxt "Exclusion message manage sites button"
 msgid "Manage blocked sites"
+msgstr ""
+
+#. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
+msgctxt "setting"
+msgid "Manage in Browser Settings"
 msgstr ""
 
 #. Link to the site exclusion settings page
@@ -11259,6 +11480,11 @@ msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
+msgid "Please describe why the chat response is harmful or illegal. (optional)"
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
+msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
 msgstr ""
 
@@ -11277,6 +11503,13 @@ msgctxt "Modal disclaimer text"
 msgid ""
 "Please note: starting a new chat with any model will delete your current "
 "chat session."
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
+msgctxt "Feedback prompt"
+msgid ""
+"Please paste your prompt and the problematic output (with any personal "
+"information removed) and describe why the content is harmful or illegal."
 msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -11661,6 +11894,11 @@ msgctxt "settings"
 msgid "Privacy"
 msgstr ""
 
+#. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
+msgctxt "Section heading on the Duck.ai settings page"
+msgid "Privacy & Terms"
+msgstr ""
+
 msgid "Privacy Blog"
 msgstr ""
 
@@ -11714,6 +11952,11 @@ msgstr ""
 
 #. Text used in other strings to link to the Privacy Policy and Terms of Service content.
 msgctxt "Copy used to compose link in sentences"
+msgid "Privacy Policy and Terms of Service"
+msgstr ""
+
+#. Text for a button that links to the terms of use and privacy policy page.
+msgctxt "Secondary button text in active privacy modal"
 msgid "Privacy Policy and Terms of Service"
 msgstr ""
 
@@ -12122,6 +12365,26 @@ msgctxt "Brief for recommending a book"
 msgid "Recommend a book"
 msgstr ""
 
+#. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar books"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar books."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar movies or shows."
+msgstr ""
+
+#. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar titles"
+msgstr ""
+
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
 msgid "Recording failed. Please try again."
 msgstr ""
@@ -12441,6 +12704,14 @@ msgstr ""
 msgid "Republic of Moldova"
 msgstr ""
 
+#. Note indicating that sharing the conversation is mandatory when reporting harmful or illegal content. Rendered alongside the standard share label (DUCKCHAT_RESPONSE_FEEDBACK_SHARE_PROMPT_RESPONSE_LABEL), not replacing it.
+msgctxt ""
+"Note shown under the share-content switch label on the Duck.ai response "
+"feedback form when the user has selected Harmful or Illegal as the feedback "
+"reason"
+msgid "Required for harmful or illegal reports"
+msgstr ""
+
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
 msgctxt "Description for extended reasoning mode in Duck.ai"
 msgid "Researches before responding"
@@ -12626,6 +12897,11 @@ msgstr ""
 #. Label above a list of customer reviews of a business.
 msgctxt "maps_places"
 msgid "Reviews"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Rewrite this recipe scaled for a different number of servings."
 msgstr ""
 
 msgid "Romania"
@@ -13661,6 +13937,11 @@ msgctxt "Setup button for native sync flow"
 msgid "Set Up Now"
 msgstr ""
 
+#. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
+msgctxt "Encrypted storage setup button shown in native browsers"
+msgid "Set Up Sync & Backup"
+msgstr ""
+
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
 msgctxt "Title for the Sync & Backup intro screen"
 msgid "Set Up Sync & Backup"
@@ -13803,6 +14084,12 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
+msgctxt ""
+"Label beside the share-content switch on the Duck.ai response feedback form"
+msgid "Share this conversation with DuckDuckGo"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -14817,6 +15104,21 @@ msgctxt "Brief for suggesting a blog post title"
 msgid "Suggest a title for a blog post"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest related articles or topics worth exploring next."
+msgstr ""
+
+#. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Suggest related articles to explore"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest some alternatives to this product."
+msgstr ""
+
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
 msgctxt "directions"
 msgid "Suggestions:"
@@ -14826,9 +15128,84 @@ msgctxt "noresults"
 msgid "Suggestions:"
 msgstr ""
 
+#. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Sum up the reviews"
+msgstr ""
+
 #. A short title for the a message asking the AI to summarize a text.
 msgctxt "Title for the summarize message"
 msgid "Summarize"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize the Q&As"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the background and notable work of this person."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the key details of this event."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the questions and answers on this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize their background"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this book"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this book."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this discussion"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this discussion thread."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this video"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this video."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize what the reviews say."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -15083,6 +15460,11 @@ msgstr ""
 msgid "Syria"
 msgstr ""
 
+#. Text for a button that enables the theme to follow the operating system's color scheme preference.
+msgctxt "System theme button for theme selector"
+msgid "System"
+msgstr ""
+
 #. Abbreviation indicating this is the total score for a game
 msgctxt "Sports module"
 msgid "T"
@@ -15106,6 +15488,11 @@ msgctxt "language_name"
 msgid "Tahitian"
 msgstr ""
 
+#. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Tailor my resume"
+msgstr ""
+
 msgid "Taiwan"
 msgstr ""
 
@@ -15127,6 +15514,12 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "Take control of your personal data!"
+msgstr ""
+
+#. Description for the Feedback section of the Duck.ai settings page, asking the user to take an anonymous survey to let us know how we can make Duck.ai better.
+msgctxt "Feedback section description on the Duck.ai settings page"
+msgid ""
+"Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
 
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -15369,6 +15762,11 @@ msgstr ""
 
 #. Title for the theme menu:
 #. https://duck.co/media/files/theme.png
+msgid "Theme"
+msgstr ""
+
+#. Text for the theme selector label that allows users to switch between Light and dark theme.
+msgctxt "Label for the theme selector feature"
 msgid "Theme"
 msgstr ""
 
@@ -16022,6 +16420,16 @@ msgid ""
 "movie theatre?”"
 msgstr ""
 
+#. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Translate this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
+msgctxt "Page suggestion prompt"
+msgid "Translate this page into %s."
+msgstr ""
+
 #. Placeholder text for a region that will display translated text.
 msgctxt "translations_module"
 msgid "Translation"
@@ -16136,6 +16544,11 @@ msgstr ""
 #. Call-to-action button for the subscription promo in the SERP sidemenu.
 msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
+msgstr ""
+
+#. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
+msgctxt "settings"
+msgid "Try It Now"
 msgstr ""
 
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -16329,6 +16742,20 @@ msgstr ""
 #. Response a user can select in a feedback form, indicating that they're trying DuckDuckGo again.
 msgctxt "new user poll"
 msgid "Trying DuckDuckGo again"
+msgstr ""
+
+#. Message shown in a modal after supported third-party browser users disable AI features in Settings. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+#. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
 msgstr ""
 
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -16929,6 +17356,11 @@ msgstr ""
 msgid "Uruguay"
 msgstr ""
 
+#. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
+msgctxt "Navigation label on the Duck.ai settings page"
+msgid "Usage"
+msgstr ""
+
 #. A feedback suggestion
 msgctxt "Feedback prompt"
 msgid "Usage limit"
@@ -17277,6 +17709,11 @@ msgstr ""
 msgid "Wales"
 msgstr ""
 
+#. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Walk me through the steps"
+msgstr ""
+
 #. Label for walking directions on a map.
 msgctxt "directions"
 msgid "Walking"
@@ -17367,6 +17804,16 @@ msgstr ""
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
+msgstr ""
+
+#. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
+msgctxt ""
+"Inline warning shown below the share-content toggle when the user selects "
+"Harmful or Illegal but has not enabled sharing"
+msgid ""
+"We can only fix what we can see. To report a harmful or illegal response, "
+"please share this conversation with DuckDuckGo so we can investigate and "
+"address the issue."
 msgstr ""
 
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -17786,6 +18233,87 @@ msgid ""
 "experience."
 msgstr ""
 
+#. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the counterarguments?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the hours & location?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key contributions of this paper?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key contributions?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key details?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key points covered in this video?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key points?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key takeaways from this article?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key takeaways?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key things I will learn from this course?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main counterarguments or criticisms of this?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main questions this page answers?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the must-try dishes here?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"What are the opening hours, location, and contact details for this place?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the pros and cons of this product?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the pros and cons?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
 msgctxt "feedback form"
 msgid "What bothered you most?"
@@ -17869,6 +18397,11 @@ msgctxt "Full sentence for defining a term"
 msgid "What does atria mean in the context of a medical article?"
 msgstr ""
 
+#. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What does this answer?"
+msgstr ""
+
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
@@ -17877,6 +18410,11 @@ msgstr ""
 #. Header above a list of types of information that gets saved by the cloud save feature.
 msgctxt "cloudsave"
 msgid "What information gets saved?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What interview questions might come up for this role?"
 msgstr ""
 
 #. Text explaining how the cloud save feature works.
@@ -17889,6 +18427,11 @@ msgstr ""
 #. Text for a prompt suggestion for looking up the capital city of Albania.
 msgctxt "Full sentence for looking up basic facts"
 msgid "What is the capital city of Albania?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What is the overall verdict and rating for this?"
 msgstr ""
 
 #. Link to a page with additional information.
@@ -17909,6 +18452,11 @@ msgctxt "maps_places"
 msgid "What people say:"
 msgstr ""
 
+#. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What should I order?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
 msgctxt "feedback form"
 msgid "What stood out?"
@@ -17917,6 +18465,16 @@ msgstr ""
 #. Question on a feedback form for a negative feedback response.
 msgctxt "feedback form"
 msgid "What was wrong with the response? (optional)"
+msgstr ""
+
+#. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I learn?"
+msgstr ""
+
+#. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I need?"
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -17931,6 +18489,11 @@ msgstr ""
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
 msgctxt "SERP footer content"
 msgid "What's New"
+msgstr ""
+
+#. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What's the verdict?"
 msgstr ""
 
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -17972,6 +18535,11 @@ msgctxt "Feedback prompt"
 msgid "Which features are missing? (Optional)"
 msgstr ""
 
+#. An invitation for users to leave feedback
+msgctxt "Feedback prompt"
+msgid "Which features are missing? (optional)"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
 msgid "White"
 msgstr ""
@@ -17983,6 +18551,16 @@ msgstr ""
 
 #. Link to an about us page.
 msgid "Who We Are"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Who are the main cast and crew, and what else are they known for?"
+msgstr ""
+
+#. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Who is this person?"
 msgstr ""
 
 #. Header above a collection of privacy-related links.

--- a/locales/pt_BR/LC_MESSAGES/duckduckgo.po
+++ b/locales/pt_BR/LC_MESSAGES/duckduckgo.po
@@ -1169,6 +1169,11 @@ msgctxt "feedback form"
 msgid "Address is incorrect"
 msgstr ""
 
+#. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Adjust the servings"
+msgstr ""
+
 #. as in multiple advertisements
 msgid "Ads"
 msgstr "Anúncios"
@@ -1342,6 +1347,13 @@ msgstr ""
 #. Heading shown on the empty chat screen. The text between the two %s markers is displayed inside a clickable privacy button. First %s renders a shield icon, second %s is an invisible end marker. Keep the word 'private' between both %s markers.
 msgctxt "Empty state heading in Duck.ai chat mode"
 msgid "All chats are %sprivate%s"
+msgstr ""
+
+#. Paragraph in the Privacy & Terms section of the About & Legal page in Duck.ai settings, summarizing how chats are anonymized and are not stored or used to train chat models.
+msgctxt "Privacy & Terms section description on the Duck.ai settings page"
+msgid ""
+"All chats are anonymized by DuckDuckGo, and your conversations are not used "
+"to train chat models by DuckDuckGo or the model providers"
 msgstr ""
 
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1557,6 +1569,12 @@ msgstr ""
 msgctxt "precise_user_location"
 msgid "Anonymous location enabled"
 msgstr "Localização anônima habilitada"
+
+msgctxt "settings"
+msgid ""
+"Anonymously generates answers for search queries based on web content. "
+"Choose how often you want it to appear, or disable it completely."
+msgstr ""
 
 #. Instant Answer tab name
 msgid "Answer"
@@ -1781,6 +1799,11 @@ msgstr ""
 
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse
 msgid "Ask a follow-up with Duck.ai"
+msgstr ""
+
+#. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
+msgctxt "Page suggestion chip label"
+msgid "Ask about this page"
 msgstr ""
 
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2105,6 +2128,11 @@ msgstr ""
 msgid "Barcode"
 msgstr "Código de barras"
 
+#. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Based on this page, is this course worth taking?"
+msgstr ""
+
 msgctxt "settings"
 msgid "Basic"
 msgstr "Básico"
@@ -2136,6 +2164,13 @@ msgstr ""
 #. Placeholder text displayed while the assistant waits for the user to choose an action.
 msgctxt "Assistant response placeholder"
 msgid "Before continuing..."
+msgstr ""
+
+#. Explains that before storing the report, DuckDuckGo will anonymize the conversation by removing PII like names, email addresses, and identifying metadata.
+msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
+msgid ""
+"Before storing this report, DuckDuckGo will anonymize your conversation by "
+"removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
 #. Label that's displayed next to a past start date below a web search result.
@@ -2394,6 +2429,11 @@ msgstr "Brasil"
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Break Points Won"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Break this down into clear, numbered steps."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -2767,6 +2807,11 @@ msgstr "Carreiras"
 #. Text of a button that performs a search for the cast of a particular movie or tv show
 msgctxt "Movie/TV Show Title instant answer"
 msgid "Cast"
+msgstr ""
+
+#. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Cast & Crew"
 msgstr ""
 
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -4132,6 +4177,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Create a shopping list with quantities from this recipe."
+msgstr ""
+
 #. Placeholder text displayed in the input field when starting a new image generation session.
 msgctxt "Placeholder text for the image generation input field"
 msgid "Create an image of a cute duck..."
@@ -4658,6 +4708,10 @@ msgstr ""
 msgid "Dictation limit reached"
 msgstr ""
 
+#. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
+msgid "Dictation temporarily unavailable"
+msgstr ""
+
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
@@ -4903,6 +4957,20 @@ msgctxt "precise_user_location"
 msgid "Done"
 msgstr "Feito"
 
+#. Message shown in a modal after DuckDuckGo browser users disable AI features in Settings. The first two placeholders bold noai.duckduckgo.com. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
+"filtered out. %sLearn More%s"
+msgstr ""
+
+#. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
+"and AI images filtered out. %sLearn more%s"
+msgstr ""
+
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Double Faults"
@@ -4993,6 +5061,16 @@ msgctxt "Full sentence for writing an email"
 msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
+msgstr ""
+
+#. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Draft a cover letter"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Draft a cover letter for this job."
 msgstr ""
 
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -5132,6 +5210,14 @@ msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
 msgstr ""
 
+#. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
+msgctxt "About section description on the Duck.ai settings page"
+msgid ""
+"Duck.ai is created by DuckDuckGo. We're an independent online protection "
+"company for anyone who wants to take back control of their personal "
+"information."
+msgstr ""
+
 #. Title shown when an update is required before proceeding.
 msgctxt "duckai_migration"
 msgid "Duck.ai is moving domains"
@@ -5165,6 +5251,12 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Duck.ai lets you chat privately with popular AI models. Disabling it hides "
+"Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
 
 msgctxt "settings"
@@ -5956,6 +6048,16 @@ msgstr ""
 msgid "Eritrea"
 msgstr ""
 
+#. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Estimate the nutrition"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Estimate the nutritional information for this recipe."
+msgstr ""
+
 msgid "Estonia"
 msgstr "Estônia"
 
@@ -6000,10 +6102,50 @@ msgctxt "merchant promotion product ad extension"
 msgid "Expires in 1 day"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain the accepted answer in simple terms."
+msgstr ""
+
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
+msgstr ""
+
+#. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain the top answer"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this in simple, plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this paper"
+msgstr ""
+
+#. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this repo"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this research paper in plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this simply"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain what this repository does and how to use it."
 msgstr ""
 
 #. Label to show if song lyrics contain explicit content
@@ -6234,6 +6376,11 @@ msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
 msgstr ""
 
+msgctxt "settings"
+msgid ""
+"Filters out known AI spam sites from image search results. %sLearn More%s"
+msgstr ""
+
 #. Label for the final score of a sporting event.
 msgid "Final"
 msgstr "Final"
@@ -6273,6 +6420,11 @@ msgstr ""
 #. Short description shown below the 'Web Search' label in the Tools dropdown.
 msgctxt "Subtitle for the Web Search tool entry in the Tools dropdown menu"
 msgid "Find current information"
+msgstr ""
+
+#. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Find me alternatives"
 msgstr ""
 
 #. Button that searches for results closer to the user's current location.
@@ -6663,6 +6815,11 @@ msgstr ""
 msgid "Generate More"
 msgstr ""
 
+#. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Generate a shopping list"
+msgstr ""
+
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
 msgid "Generate a short answer from the web"
 msgstr ""
@@ -6899,6 +7056,11 @@ msgstr ""
 #. Text for a button inviting users to give it a try for the Duck.ai product. On click, they're taken to the Duck.ai page.
 msgctxt "Onboarding welcome screen button text"
 msgid "Give it a Try"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Give me a quick background on this person."
 msgstr ""
 
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -7262,6 +7424,16 @@ msgstr ""
 #. Link to a page with information about sharing DuckDuckGo with friends.
 msgid "Help Spread Privacy"
 msgstr "Ajude a espalhar privacidade"
+
+#. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Help me prep for the interview"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Help me tailor my resume for this job."
+msgstr ""
 
 #. Title of a SERP popup that invites users to take a survey (desktop only)
 msgctxt "User survey popup"
@@ -7686,6 +7858,13 @@ msgstr ""
 #. Text displayed on the button on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
 msgctxt "Onboarding terms screen button text"
 msgid "I Agree"
+msgstr ""
+
+#. Text for the button that takes the user to the external DuckDuckGo login subscription page.
+msgctxt ""
+"Text for the I already have a subscription button in the Duck.ai settings "
+"page"
+msgid "I Already Have a Subscription"
 msgstr ""
 
 #. Text for the button that takes the user to the login subscription page.
@@ -8153,6 +8332,11 @@ msgctxt "Sidemenu browser promo"
 msgid "Install Mac Browser"
 msgstr ""
 
+#. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
+msgctxt "settings"
+msgid "Install Now"
+msgstr ""
+
 #. Text of a button to install the DuckDuckGo app
 msgctxt "Serp footer content"
 msgid "Install Our App"
@@ -8232,10 +8416,37 @@ msgctxt "cloudsave"
 msgid "Is deleted data really deleted?"
 msgstr "Os dados excluídos são realmente excluídos?"
 
+#. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is it worth taking?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this place any good?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"Is this place any good? Summarize its reputation based on reviews and "
+"ratings."
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "Is this video helpful?"
 msgstr "Este video é útil?"
+
+#. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this worth watching?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Is this worth watching? Give me a spoiler-free take."
+msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
 msgctxt "Weather IA"
@@ -8735,6 +8946,11 @@ msgstr "Fonte do link:"
 msgid "Links:"
 msgstr "Links:"
 
+#. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "List the tools, materials, or prerequisites I need for this."
+msgstr ""
+
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
 msgid "Listen"
 msgstr "Ouvir"
@@ -9070,6 +9286,11 @@ msgstr ""
 #. Label for linke navigating to site exclusion feature on Settings page
 msgctxt "Exclusion message manage sites button"
 msgid "Manage blocked sites"
+msgstr ""
+
+#. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
+msgctxt "setting"
+msgid "Manage in Browser Settings"
 msgstr ""
 
 #. Link to the site exclusion settings page
@@ -11382,6 +11603,11 @@ msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
+msgid "Please describe why the chat response is harmful or illegal. (optional)"
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
+msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
 msgstr ""
 
@@ -11400,6 +11626,13 @@ msgctxt "Modal disclaimer text"
 msgid ""
 "Please note: starting a new chat with any model will delete your current "
 "chat session."
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
+msgctxt "Feedback prompt"
+msgid ""
+"Please paste your prompt and the problematic output (with any personal "
+"information removed) and describe why the content is harmful or illegal."
 msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -11784,6 +12017,11 @@ msgctxt "settings"
 msgid "Privacy"
 msgstr "Privacidade"
 
+#. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
+msgctxt "Section heading on the Duck.ai settings page"
+msgid "Privacy & Terms"
+msgstr ""
+
 msgid "Privacy Blog"
 msgstr "Blogue da privacidade"
 
@@ -11837,6 +12075,11 @@ msgstr ""
 
 #. Text used in other strings to link to the Privacy Policy and Terms of Service content.
 msgctxt "Copy used to compose link in sentences"
+msgid "Privacy Policy and Terms of Service"
+msgstr ""
+
+#. Text for a button that links to the terms of use and privacy policy page.
+msgctxt "Secondary button text in active privacy modal"
 msgid "Privacy Policy and Terms of Service"
 msgstr ""
 
@@ -12247,6 +12490,26 @@ msgctxt "Brief for recommending a book"
 msgid "Recommend a book"
 msgstr ""
 
+#. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar books"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar books."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar movies or shows."
+msgstr ""
+
+#. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar titles"
+msgstr ""
+
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
 msgid "Recording failed. Please try again."
 msgstr ""
@@ -12566,6 +12829,14 @@ msgstr ""
 msgid "Republic of Moldova"
 msgstr ""
 
+#. Note indicating that sharing the conversation is mandatory when reporting harmful or illegal content. Rendered alongside the standard share label (DUCKCHAT_RESPONSE_FEEDBACK_SHARE_PROMPT_RESPONSE_LABEL), not replacing it.
+msgctxt ""
+"Note shown under the share-content switch label on the Duck.ai response "
+"feedback form when the user has selected Harmful or Illegal as the feedback "
+"reason"
+msgid "Required for harmful or illegal reports"
+msgstr ""
+
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
 msgctxt "Description for extended reasoning mode in Duck.ai"
 msgid "Researches before responding"
@@ -12752,6 +13023,11 @@ msgstr "Avaliações"
 msgctxt "maps_places"
 msgid "Reviews"
 msgstr "Avaliações"
+
+#. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Rewrite this recipe scaled for a different number of servings."
+msgstr ""
 
 msgid "Romania"
 msgstr "Romênia"
@@ -13808,6 +14084,11 @@ msgctxt "Setup button for native sync flow"
 msgid "Set Up Now"
 msgstr ""
 
+#. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
+msgctxt "Encrypted storage setup button shown in native browsers"
+msgid "Set Up Sync & Backup"
+msgstr ""
+
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
 msgctxt "Title for the Sync & Backup intro screen"
 msgid "Set Up Sync & Backup"
@@ -13954,6 +14235,12 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
+msgctxt ""
+"Label beside the share-content switch on the Duck.ai response feedback form"
+msgid "Share this conversation with DuckDuckGo"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -14978,6 +15265,21 @@ msgctxt "Brief for suggesting a blog post title"
 msgid "Suggest a title for a blog post"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest related articles or topics worth exploring next."
+msgstr ""
+
+#. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Suggest related articles to explore"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest some alternatives to this product."
+msgstr ""
+
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
 msgctxt "directions"
 msgid "Suggestions:"
@@ -14987,9 +15289,84 @@ msgctxt "noresults"
 msgid "Suggestions:"
 msgstr "Sugestões:"
 
+#. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Sum up the reviews"
+msgstr ""
+
 #. A short title for the a message asking the AI to summarize a text.
 msgctxt "Title for the summarize message"
 msgid "Summarize"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize the Q&As"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the background and notable work of this person."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the key details of this event."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the questions and answers on this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize their background"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this book"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this book."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this discussion"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this discussion thread."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this video"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this video."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize what the reviews say."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -15244,6 +15621,11 @@ msgstr ""
 msgid "Syria"
 msgstr ""
 
+#. Text for a button that enables the theme to follow the operating system's color scheme preference.
+msgctxt "System theme button for theme selector"
+msgid "System"
+msgstr ""
+
 #. Abbreviation indicating this is the total score for a game
 msgctxt "Sports module"
 msgid "T"
@@ -15267,6 +15649,11 @@ msgctxt "language_name"
 msgid "Tahitian"
 msgstr "Taitiano"
 
+#. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Tailor my resume"
+msgstr ""
+
 msgid "Taiwan"
 msgstr "Taiwan"
 
@@ -15288,6 +15675,12 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "Take control of your personal data!"
+msgstr ""
+
+#. Description for the Feedback section of the Duck.ai settings page, asking the user to take an anonymous survey to let us know how we can make Duck.ai better.
+msgctxt "Feedback section description on the Duck.ai settings page"
+msgid ""
+"Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
 
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -15537,6 +15930,11 @@ msgstr ""
 #. https://duck.co/media/files/theme.png
 msgid "Theme"
 msgstr "Tema"
+
+#. Text for the theme selector label that allows users to switch between Light and dark theme.
+msgctxt "Label for the theme selector feature"
+msgid "Theme"
+msgstr ""
 
 #. http://i.imgur.com/LpFhb1e.png
 msgctxt "settings"
@@ -16195,6 +16593,16 @@ msgid ""
 "movie theatre?”"
 msgstr ""
 
+#. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Translate this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
+msgctxt "Page suggestion prompt"
+msgid "Translate this page into %s."
+msgstr ""
+
 #. Placeholder text for a region that will display translated text.
 msgctxt "translations_module"
 msgid "Translation"
@@ -16309,6 +16717,11 @@ msgstr ""
 #. Call-to-action button for the subscription promo in the SERP sidemenu.
 msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
+msgstr ""
+
+#. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
+msgctxt "settings"
+msgid "Try It Now"
 msgstr ""
 
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -16504,6 +16917,20 @@ msgstr "Experimente: %s"
 msgctxt "new user poll"
 msgid "Trying DuckDuckGo again"
 msgstr "Experimentando o DuckDuckGo novamente"
+
+#. Message shown in a modal after supported third-party browser users disable AI features in Settings. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+#. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
 
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
 msgctxt "Assistant response placeholder"
@@ -17110,6 +17537,11 @@ msgstr "Urdu"
 msgid "Uruguay"
 msgstr ""
 
+#. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
+msgctxt "Navigation label on the Duck.ai settings page"
+msgid "Usage"
+msgstr ""
+
 #. A feedback suggestion
 msgctxt "Feedback prompt"
 msgid "Usage limit"
@@ -17460,6 +17892,11 @@ msgstr "Esperando pela localização..."
 msgid "Wales"
 msgstr ""
 
+#. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Walk me through the steps"
+msgstr ""
+
 #. Label for walking directions on a map.
 msgctxt "directions"
 msgid "Walking"
@@ -17550,6 +17987,16 @@ msgstr ""
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
+msgstr ""
+
+#. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
+msgctxt ""
+"Inline warning shown below the share-content toggle when the user selects "
+"Harmful or Illegal but has not enabled sharing"
+msgid ""
+"We can only fix what we can see. To report a harmful or illegal response, "
+"please share this conversation with DuckDuckGo so we can investigate and "
+"address the issue."
 msgstr ""
 
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -17983,6 +18430,87 @@ msgid ""
 "experience."
 msgstr ""
 
+#. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the counterarguments?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the hours & location?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key contributions of this paper?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key contributions?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key details?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key points covered in this video?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key points?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key takeaways from this article?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key takeaways?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key things I will learn from this course?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main counterarguments or criticisms of this?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main questions this page answers?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the must-try dishes here?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"What are the opening hours, location, and contact details for this place?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the pros and cons of this product?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the pros and cons?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
 msgctxt "feedback form"
 msgid "What bothered you most?"
@@ -18066,6 +18594,11 @@ msgctxt "Full sentence for defining a term"
 msgid "What does atria mean in the context of a medical article?"
 msgstr ""
 
+#. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What does this answer?"
+msgstr ""
+
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
@@ -18075,6 +18608,11 @@ msgstr ""
 msgctxt "cloudsave"
 msgid "What information gets saved?"
 msgstr "Quais informações são salvas?"
+
+#. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What interview questions might come up for this role?"
+msgstr ""
 
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
@@ -18088,6 +18626,11 @@ msgstr ""
 #. Text for a prompt suggestion for looking up the capital city of Albania.
 msgctxt "Full sentence for looking up basic facts"
 msgid "What is the capital city of Albania?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What is the overall verdict and rating for this?"
 msgstr ""
 
 #. Link to a page with additional information.
@@ -18108,6 +18651,11 @@ msgctxt "maps_places"
 msgid "What people say:"
 msgstr "O que as pessoas dizem:"
 
+#. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What should I order?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
 msgctxt "feedback form"
 msgid "What stood out?"
@@ -18116,6 +18664,16 @@ msgstr ""
 #. Question on a feedback form for a negative feedback response.
 msgctxt "feedback form"
 msgid "What was wrong with the response? (optional)"
+msgstr ""
+
+#. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I learn?"
+msgstr ""
+
+#. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I need?"
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -18130,6 +18688,11 @@ msgstr ""
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
 msgctxt "SERP footer content"
 msgid "What's New"
+msgstr ""
+
+#. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What's the verdict?"
 msgstr ""
 
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -18171,6 +18734,11 @@ msgctxt "Feedback prompt"
 msgid "Which features are missing? (Optional)"
 msgstr ""
 
+#. An invitation for users to leave feedback
+msgctxt "Feedback prompt"
+msgid "Which features are missing? (optional)"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
 msgid "White"
 msgstr "Branco"
@@ -18183,6 +18751,16 @@ msgstr "Branco"
 #. Link to an about us page.
 msgid "Who We Are"
 msgstr "Quem somos"
+
+#. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Who are the main cast and crew, and what else are they known for?"
+msgstr ""
+
+#. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Who is this person?"
+msgstr ""
 
 #. Header above a collection of privacy-related links.
 msgid "Why Privacy"

--- a/locales/pt_PT/LC_MESSAGES/duckduckgo.po
+++ b/locales/pt_PT/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: pt_PT\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -489,8 +489,7 @@ msgstr ""
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "%sLong-press%s the DuckDuckGo app icon on the home screen"
-msgstr ""
-"%1$sPrime sem soltar%2$s o ícone da aplicação DuckDuckGo no ecrã inicial"
+msgstr "%1$sPrime sem soltar%2$s o ícone da aplicação DuckDuckGo no ecrã inicial"
 
 # smartling.placeholder_format=C
 #. A message displayed when there is an error loading content or no results on requery
@@ -1240,8 +1239,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. An item in the ads tooltip that explains that ad clicks aren’t used to profile you.
 msgid "Ad clicks aren’t used to profile you"
-msgstr ""
-"Os cliques em anúncios não são usados para criar perfis de utilizadores"
+msgstr "Os cliques em anúncios não são usados para criar perfis de utilizadores"
 
 # smartling.placeholder_format=C
 #. Category of problem a user can select on a feedback form.
@@ -1446,7 +1444,7 @@ msgstr "O endereço está incorreto"
 #. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Adjust the servings"
-msgstr ""
+msgstr "Ajusta as doses"
 
 # smartling.placeholder_format=C
 #. as in multiple advertisements
@@ -1668,6 +1666,9 @@ msgid ""
 "All chats are anonymized by DuckDuckGo, and your conversations are not used "
 "to train chat models by DuckDuckGo or the model providers"
 msgstr ""
+"Todos os chats são anonimizados pelo DuckDuckGo, e as tuas conversas não são "
+"usadas para treinar modelos de chat pelo DuckDuckGo ou pelos fornecedores "
+"dos modelos"
 
 # smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1760,8 +1761,7 @@ msgstr "Permitir anúncios que respeitam a privacidade"
 # smartling.placeholder_format=C
 #. Title in a dialog informing the user how to disable their ad blocker for DuckDuckGo
 msgid "Allow privacy-respecting ads on DuckDuckGo Private Search"
-msgstr ""
-"Permitir anúncios que respeitam a privacidade na Private Search do DuckDuckGo"
+msgstr "Permitir anúncios que respeitam a privacidade na Private Search do DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Description explaining privacy implications of enabling web search on encrypted models. The first two placeholders are the full model name (e.g. 'gpt-oss 120B'). The third and fourth placeholders wrap a clickable link reading 'zero provider visibility' that opens the privacy modal, please keep those around the link text in your translation. An example full sentence would be: Allows gpt-oss 120B to search the web to improve responses to relevant prompts. Only sends AI-generated queries to a search engine with limited data retention. Prompts and responses with gpt-oss 120B still have zero provider visibility.
@@ -1946,6 +1946,9 @@ msgid ""
 "Anonymously generates answers for search queries based on web content. "
 "Choose how often you want it to appear, or disable it completely."
 msgstr ""
+"Gera anonimamente respostas para consultas de pesquisa com base em conteúdo "
+"web. Escolhe a frequência com que queres que apareça, ou desativa-o "
+"completamente."
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -2234,7 +2237,7 @@ msgstr "Faz uma pergunta de seguimento com Duck.ai"
 #. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
 msgctxt "Page suggestion chip label"
 msgid "Ask about this page"
-msgstr ""
+msgstr "Pergunta sobre esta página"
 
 # smartling.placeholder_format=C
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2457,8 +2460,7 @@ msgstr "Resposta automática"
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid "Auto-generated based on listed sources. May contain inaccuracies."
-msgstr ""
-"Gerada automaticamente com base nas fontes listadas. Pode conter imprecisões."
+msgstr "Gerada automaticamente com base nas fontes listadas. Pode conter imprecisões."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
@@ -2657,7 +2659,7 @@ msgstr "Código de barras"
 #. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Based on this page, is this course worth taking?"
-msgstr ""
+msgstr "Com base nesta página, vale a pena fazer este curso?"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2706,6 +2708,9 @@ msgid ""
 "Before storing this report, DuckDuckGo will anonymize your conversation by "
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
+"Antes de guardar este relatório, o DuckDuckGo irá anonimizar a tua conversa "
+"removendo informações de identificação pessoal, como nomes, endereços de "
+"e-mail e metadados identificativos."
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -3027,7 +3032,7 @@ msgstr "Pontos de quebra ganhos"
 #. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Break this down into clear, numbered steps."
-msgstr ""
+msgstr "Divide isto em passos claros e numerados."
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -3488,7 +3493,7 @@ msgstr "Elenco"
 #. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Cast & Crew"
-msgstr ""
+msgstr "Elenco e equipa técnica"
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -3596,8 +3601,7 @@ msgstr "Modifica a cor de fundo em todo o site"
 msgctxt "settings"
 msgid ""
 "Changes the background color of results on hover, modules, and dropdown menus"
-msgstr ""
-"Altera a cor de fundo dos resultados em menus suspensos, hovers e módulos"
+msgstr "Altera a cor de fundo dos resultados em menus suspensos, hovers e módulos"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/NdpkbY0.png
@@ -3963,8 +3967,7 @@ msgstr ""
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
 msgctxt "noresults"
 msgid "Check the status page for updates on this outage."
-msgstr ""
-"Consulta a página de estado para atualizações sobre esta indisponibilidade."
+msgstr "Consulta a página de estado para atualizações sobre esta indisponibilidade."
 
 # smartling.placeholder_format=C
 #. Title shown to the host device (the one that is logged in) after it sends the pairing code. The host can't confirm the peer applied it, so this is a title-only screen (no body) prompting the user to finish on the other device.
@@ -4425,8 +4428,7 @@ msgstr "Clica em %1$sFornecedores de Pesquisa%2$s em tipos de Add-on"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click on the %sTools icon%s in the top-right of the browser"
-msgstr ""
-"No canto superior direito do navegador, clica no %1$sícone de Ferramentas%2$s"
+msgstr "No canto superior direito do navegador, clica no %1$sícone de Ferramentas%2$s"
 
 #  Firefox default search engine instruction
 # smartling.placeholder_format=C
@@ -5210,7 +5212,7 @@ msgstr "Criar imagem"
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
-msgstr ""
+msgstr "Cria uma lista de compras com as quantidades desta receita."
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed in the input field when starting a new image generation session.
@@ -5467,8 +5469,7 @@ msgstr "Limite diário atingido"
 #. Displayed when the user has reached a fixed daily Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Daily usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Limite de utilização diária atingido. Podes continuar este chat após %1$s."
+msgstr "Limite de utilização diária atingido. Podes continuar este chat após %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable daily Duck.ai usage limit and can opt in to continue using the weekly limit.
@@ -5856,7 +5857,7 @@ msgstr "Limite de ditado atingido"
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
 msgid "Dictation temporarily unavailable"
-msgstr ""
+msgstr "Ditado temporariamente indisponível"
 
 # smartling.placeholder_format=C
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
@@ -6165,6 +6166,8 @@ msgid ""
 "Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
 "filtered out. %sLearn More%s"
 msgstr ""
+"Não queres IA? %1$snoai.duckduckgo.com%2$s não oferece funcionalidades de IA "
+"e filtra imagens geradas por IA. %3$sSabe mais%4$s"
 
 # smartling.placeholder_format=C
 #. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
@@ -6173,6 +6176,9 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
+"Não queres IA? Visita %1$snoai.duckduckgo.com%2$s para pesquisar sem "
+"funcionalidades de IA e com as imagens geradas por IA filtradas e excluídas. "
+"%3$sSabe mais%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6292,13 +6298,13 @@ msgstr ""
 #. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Draft a cover letter"
-msgstr ""
+msgstr "Escreve uma carta de apresentação"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Draft a cover letter for this job."
-msgstr ""
+msgstr "Escreve uma carta de apresentação para este trabalho."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -6486,6 +6492,9 @@ msgid ""
 "company for anyone who wants to take back control of their personal "
 "information."
 msgstr ""
+"O Duck.ai foi criado pela DuckDuckGo. Somos uma empresa independente de "
+"proteção online para quem quer recuperar o controlo das suas informações "
+"pessoais."
 
 # smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
@@ -6532,8 +6541,7 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
-msgstr ""
-"O Duck.ai está temporariamente indisponível. Tenta novamente mais tarde."
+msgstr "O Duck.ai está temporariamente indisponível. Tenta novamente mais tarde."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6541,6 +6549,9 @@ msgid ""
 "Duck.ai lets you chat privately with popular AI models. Disabling it hides "
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
+"O Duck.ai permite-te conversar em privado com modelos de IA populares. "
+"Desativá-lo oculta os botões e links do Duck.ai, mas podes continuar a "
+"visitar %1$sduck.ai%2$s diretamente."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6604,8 +6615,7 @@ msgstr "Duck.ai atualizado!"
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
-msgstr ""
-"O Duck.ai funciona melhor na nossa aplicação privada e gratuita DuckDuckGo!"
+msgstr "O Duck.ai funciona melhor na nossa aplicação privada e gratuita DuckDuckGo!"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -7013,8 +7023,7 @@ msgctxt ""
 "Description of the DuckDuckGo subscription setting when it is not available "
 "in the user region"
 msgid "DuckDuckGo subscriptions are not available to purchase in this region."
-msgstr ""
-"As subscrições da DuckDuckGo não estão disponíveis para compra nesta região."
+msgstr "As subscrições da DuckDuckGo não estão disponíveis para compra nesta região."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use 'ducky' tone in its responses. When this option is selected, the AI assistant speaks like a duck.
@@ -7401,22 +7410,19 @@ msgstr ""
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location Services' is %senabled%s."
-msgstr ""
-"Certifica-te de que os \"Serviços de Localização\" estão %1$sativos%2$s."
+msgstr "Certifica-te de que os \"Serviços de Localização\" estão %1$sativos%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location' is set to %sallow%s"
-msgstr ""
-"Certifica-te de que a \"Localização\" está definida como %1$spermitir%2$s"
+msgstr "Certifica-te de que a \"Localização\" está definida como %1$spermitir%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location' is set to %sallow%s."
-msgstr ""
-"Certifica-te de que a \"Localização\" está definida para %1$spermitir%2$s."
+msgstr "Certifica-te de que a \"Localização\" está definida para %1$spermitir%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -7456,15 +7462,13 @@ msgstr ""
 #. Tells how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed location access"
-msgstr ""
-"Certifica-te de que o teu navegador tem permissão para aceder à localização"
+msgstr "Certifica-te de que o teu navegador tem permissão para aceder à localização"
 
 # smartling.placeholder_format=C
 #. Tells how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed location access."
-msgstr ""
-"Certifica-te de que o teu navegador tem permissão para aceder à localização."
+msgstr "Certifica-te de que o teu navegador tem permissão para aceder à localização."
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -7564,13 +7568,13 @@ msgstr "Eritreia"
 #. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Estimate the nutrition"
-msgstr ""
+msgstr "Faz uma estimativa da nutrição"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Estimate the nutritional information for this recipe."
-msgstr ""
+msgstr "Faz uma estimativa das informações nutricionais desta receita."
 
 # smartling.placeholder_format=C
 msgid "Estonia"
@@ -7632,7 +7636,7 @@ msgstr "Expira em 1 dia"
 #. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain the accepted answer in simple terms."
-msgstr ""
+msgstr "Explica a resposta aceite de forma simples."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
@@ -7647,43 +7651,43 @@ msgstr ""
 #. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain the top answer"
-msgstr ""
+msgstr "Explica a resposta principal"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain this in simple, plain language."
-msgstr ""
+msgstr "Explica esta informação numa linguagem simples e clara."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain this paper"
-msgstr ""
+msgstr "Explica este artigo"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain this repo"
-msgstr ""
+msgstr "Explica este repositório"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain this research paper in plain language."
-msgstr ""
+msgstr "Explica este artigo de investigação numa linguagem simples."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain this simply"
-msgstr ""
+msgstr "Explica isto de forma simples"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain what this repository does and how to use it."
-msgstr ""
+msgstr "Explica o que este repositório faz e como utilizá-lo."
 
 # smartling.placeholder_format=C
 #. Label to show if song lyrics contain explicit content
@@ -7976,6 +7980,8 @@ msgctxt "settings"
 msgid ""
 "Filters out known AI spam sites from image search results. %sLearn More%s"
 msgstr ""
+"Filtra sites conhecidos de spam gerado por IA nos resultados de pesquisa de "
+"imagens. %1$sSabe mais%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the final score of a sporting event.
@@ -8034,7 +8040,7 @@ msgstr "Encontra informações atuais"
 #. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Find me alternatives"
-msgstr ""
+msgstr "Encontra alternativas"
 
 # smartling.placeholder_format=C
 #. Button that searches for results closer to the user's current location.
@@ -8231,8 +8237,7 @@ msgstr "Chats gratuitos e privados, anonimizados por nós"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr ""
-"Chats gratuitos e privados, anonimizados por nós. Não é necessária conta."
+msgstr "Chats gratuitos e privados, anonimizados por nós. Não é necessária conta."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -8518,7 +8523,7 @@ msgstr "Gerar mais"
 #. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Generate a shopping list"
-msgstr ""
+msgstr "Gera uma lista de compras"
 
 # smartling.placeholder_format=C
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
@@ -8817,7 +8822,7 @@ msgstr "Experimentar"
 #. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Give me a quick background on this person."
-msgstr ""
+msgstr "Dá-me um historial rápido sobre esta pessoa."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9270,13 +9275,13 @@ msgstr "Ajuda a divulgar a privacidade"
 #. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Help me prep for the interview"
-msgstr ""
+msgstr "Ajuda-me a preparar-me para a entrevista"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Help me tailor my resume for this job."
-msgstr ""
+msgstr "Ajuda-me a adaptar o meu currículo a este emprego."
 
 # smartling.placeholder_format=C
 #. Title of a SERP popup that invites users to take a survey (desktop only)
@@ -9799,7 +9804,7 @@ msgctxt ""
 "Text for the I already have a subscription button in the Duck.ai settings "
 "page"
 msgid "I Already Have a Subscription"
-msgstr ""
+msgstr "Já tenho uma subscrição"
 
 # smartling.placeholder_format=C
 #. Text for the button that takes the user to the login subscription page.
@@ -10380,7 +10385,7 @@ msgstr "Instalar navegador para Mac"
 #. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
 msgctxt "settings"
 msgid "Install Now"
-msgstr ""
+msgstr "Instalar agora"
 
 # smartling.placeholder_format=C
 #. Text of a button to install the DuckDuckGo app
@@ -10483,13 +10488,13 @@ msgstr "Os dados apagados são mesmo apagados?"
 #. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Is it worth taking?"
-msgstr ""
+msgstr "Vale a pena fazer?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Is this place any good?"
-msgstr ""
+msgstr "Este local é bom?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
@@ -10498,6 +10503,8 @@ msgid ""
 "Is this place any good? Summarize its reputation based on reviews and "
 "ratings."
 msgstr ""
+"Este local é bom? Resume a reputação do local com base em comentários e "
+"classificações."
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -10509,13 +10516,13 @@ msgstr "Este vídeo é útil?"
 #. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Is this worth watching?"
-msgstr ""
+msgstr "Vale a pena ver?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Is this worth watching? Give me a spoiler-free take."
-msgstr ""
+msgstr "Vale a pena ver? Dá-me uma opinião sem spoilers."
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -10547,8 +10554,7 @@ msgstr "É rápido, gratuito e oferece ainda mais proteção online."
 msgctxt "settings"
 msgid ""
 "It's okay to (very infrequently) ask me about my experience using DuckDuckGo"
-msgstr ""
-"Inquéritos (pouco frequentes) acerca da minha experiência com o DuckDuckGo"
+msgstr "Inquéritos (pouco frequentes) acerca da minha experiência com o DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. The name of the Italian language
@@ -10935,8 +10941,7 @@ msgstr "Saber mais sobre a Proteção de privacidade ativa"
 # smartling.placeholder_format=C
 msgctxt "showcase_newsletter"
 msgid "Learn about online privacy right in your inbox."
-msgstr ""
-"Sabe mais sobre privacidade online diretamente na tua caixa de entrada."
+msgstr "Sabe mais sobre privacidade online diretamente na tua caixa de entrada."
 
 # smartling.placeholder_format=C
 #. Link to a page with more information about how DuckDuckGo settings are managed.
@@ -11131,7 +11136,7 @@ msgstr "Ligações:"
 #. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
-msgstr ""
+msgstr "Lista as ferramentas, materiais ou pré-requisitos de que preciso para isto."
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -11423,8 +11428,8 @@ msgstr "Certifica-te de que todas as palavras estão escritas corretamente."
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Make sure to check %s\"Make this my default search provider\"%s"
 msgstr ""
-"Certifica-te de marcar %1$s\"Tornar este no meu motor de buscar pré-"
-"definido\"%2$s"
+"Certifica-te de marcar %1$s\"Tornar este no meu motor de buscar "
+"pré-definido\"%2$s"
 
 # smartling.placeholder_format=C
 #. Message prompting users to check the spelling of their search term.
@@ -11545,7 +11550,7 @@ msgstr "Gerir sites bloqueados"
 #. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
 msgctxt "setting"
 msgid "Manage in Browser Settings"
-msgstr ""
+msgstr "Gerir nas definições do navegador"
 
 # smartling.placeholder_format=C
 #. Link to the site exclusion settings page
@@ -11938,8 +11943,7 @@ msgstr "Capitalização do mercado"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Mobile Instructions (not displayed on settings page)"
-msgstr ""
-"Instruções para dispositivos móveis (não disponível na página de definições)"
+msgstr "Instruções para dispositivos móveis (não disponível na página de definições)"
 
 # smartling.placeholder_format=C
 #. A short label indicating that a user is a moderator of a discussion.
@@ -11998,8 +12002,7 @@ msgstr "Limite mensal atingido"
 #. Displayed when the user has reached a fixed monthly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Monthly usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Limite de utilização mensal atingido. Podes continuar este chat após %1$s."
+msgstr "Limite de utilização mensal atingido. Podes continuar este chat após %1$s."
 
 # smartling.placeholder_format=C
 #. Used to point to additional social networking profiles (in results).
@@ -14391,7 +14394,7 @@ msgstr ""
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is harmful or illegal. (optional)"
-msgstr ""
+msgstr "Indica por que motivo a resposta do chat é prejudicial ou ilegal. (opcional)"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
@@ -14428,6 +14431,9 @@ msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is harmful or illegal."
 msgstr ""
+"Cola o teu pedido e o resultado problemático (com todas as informações "
+"pessoais removidas) e indica por que motivo o conteúdo é prejudicial ou "
+"ilegal."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -14901,7 +14907,7 @@ msgstr "Privacidade"
 #. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
 msgctxt "Section heading on the Duck.ai settings page"
 msgid "Privacy & Terms"
-msgstr ""
+msgstr "Privacidade & Termos"
 
 # smartling.placeholder_format=C
 msgid "Privacy Blog"
@@ -14977,7 +14983,7 @@ msgstr "Política de Privacidade e Termos de Serviço"
 #. Text for a button that links to the terms of use and privacy policy page.
 msgctxt "Secondary button text in active privacy modal"
 msgid "Privacy Policy and Terms of Service"
-msgstr ""
+msgstr "Política de Privacidade e Termos de Serviço"
 
 # smartling.placeholder_format=C
 #. Title displayed on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
@@ -15485,25 +15491,25 @@ msgstr "Recomendar um livro"
 #. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Recommend similar books"
-msgstr ""
+msgstr "Recomenda livros semelhantes"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Recommend similar books."
-msgstr ""
+msgstr "Recomenda livros semelhantes."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Recommend similar movies or shows."
-msgstr ""
+msgstr "Recomenda filmes ou séries semelhantes."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Recommend similar titles"
-msgstr ""
+msgstr "Recomenda títulos semelhantes"
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
@@ -15718,8 +15724,8 @@ msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
 msgstr ""
-"Recarrega o DuckDuckGo seguindo as instruções ou clicando no botão &quot;"
-"Atualizar&quot; ou &quot;Recarregar&quot; do teu navegador."
+"Recarrega o DuckDuckGo seguindo as instruções ou clicando no botão "
+"&quot;Atualizar&quot; ou &quot;Recarregar&quot; do teu navegador."
 
 # smartling.placeholder_format=C
 #. checkbox label that allows the user to save the setting
@@ -15729,8 +15735,7 @@ msgstr "Memorizar a minha opção"
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings
 msgid "Remember my choice (this can be changed in %s%s%sSettings%s)"
-msgstr ""
-"Lembrar escolha (isto pode ser alterado nas %1$s%2$s%3$sDefinições%4$s)"
+msgstr "Lembrar escolha (isto pode ser alterado nas %1$s%2$s%3$sDefinições%4$s)"
 
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
@@ -15915,7 +15920,7 @@ msgctxt ""
 "feedback form when the user has selected Harmful or Illegal as the feedback "
 "reason"
 msgid "Required for harmful or illegal reports"
-msgstr ""
+msgstr "Obrigatório em denúncias de conteúdos prejudiciais ou ilegais"
 
 # smartling.placeholder_format=C
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
@@ -16087,8 +16092,7 @@ msgstr "Os resultados excluem informações de sites bloqueados."
 #. Message that appears when results exclude blocked sites
 msgctxt "Blocked sites filter disclaimer"
 msgid "Results exclude your blocked sites, which you can manage in your %s."
-msgstr ""
-"Os resultados excluem os teus sites bloqueados, que podes gerir no teu %1$s."
+msgstr "Os resultados excluem os teus sites bloqueados, que podes gerir no teu %1$s."
 
 # smartling.placeholder_format=C
 #. A label showing the source of the results, e.g. "Results from Reddit"
@@ -16159,7 +16163,7 @@ msgstr "Comentários"
 #. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Rewrite this recipe scaled for a different number of servings."
-msgstr ""
+msgstr "Reescreve esta receita ajustada para um número diferente de doses."
 
 # smartling.placeholder_format=C
 msgid "Romania"
@@ -16440,8 +16444,7 @@ msgstr ""
 #. Short text for native DDG browser users explaining how Chat History stores up to 30 of their most recent chats locally on their device.
 msgctxt "Short description for Chat History feature on native DDG browsers"
 msgid "Save up to 30 of your most recent chats locally on your device."
-msgstr ""
-"Guarda até 30 das tuas conversas mais recentes localmente no teu dispositivo."
+msgstr "Guarda até 30 das tuas conversas mais recentes localmente no teu dispositivo."
 
 # smartling.placeholder_format=C
 #. Desktop/mobile intro modal body under the title per Sync Chats Figma (choose step).
@@ -16609,8 +16612,7 @@ msgstr "Desce na página e localiza %1$so teu navegador%2$s na lista."
 #. Tells users which setting to change to enable location service.
 msgctxt "precise_user_location"
 msgid "Scroll down to %sDuckDuckGo%s and allow it to use your location."
-msgstr ""
-"Desce até %1$sDuckDuckGo%2$s e autoriza a utilização da tua localização."
+msgstr "Desce até %1$sDuckDuckGo%2$s e autoriza a utilização da tua localização."
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -17165,8 +17167,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
-msgstr ""
-"Seleciona %1$sDuckDuckGo%2$s e clica em %3$sAdicionar como predefinido%4$s!"
+msgstr "Seleciona %1$sDuckDuckGo%2$s e clica em %3$sAdicionar como predefinido%4$s!"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
@@ -17183,8 +17184,7 @@ msgstr "Seleciona %1$sDuckDuckGo%2$s e clica em %3$sPredefinir%4$s."
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Select %sDuckDuckGo%s in the Default Search Engine drop down"
-msgstr ""
-"Seleciona %1$sDuckDuckGo%2$s no menu suspenso de motor de busca predefinido"
+msgstr "Seleciona %1$sDuckDuckGo%2$s no menu suspenso de motor de busca predefinido"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
@@ -17204,8 +17204,7 @@ msgstr "Seleciona %1$sDuckDuckGo%2$s na lista de fornecedores de pesquisa"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s under the%sDefault Search Engine%s section"
-msgstr ""
-"Seleciona %1$sDuckDuckGo%2$s na secção%3$sMotor de busca predefinido%4$s"
+msgstr "Seleciona %1$sDuckDuckGo%2$s na secção%3$sMotor de busca predefinido%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user were in the settings menu they can change their default search engine.
@@ -17290,8 +17289,7 @@ msgstr "Seleciona %1$sDefinições%2$s e depois %3$sDefinições Avançadas%4$s"
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sDefault search engine%s"
-msgstr ""
-"Seleciona %1$sDefinições%2$s e depois %3$sMotor de busca predefinido%4$s"
+msgstr "Seleciona %1$sDefinições%2$s e depois %3$sMotor de busca predefinido%4$s"
 
 #  Chrome/Firefox on Android
 # smartling.placeholder_format=C
@@ -17514,7 +17512,7 @@ msgstr "Configura agora"
 #. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
 msgctxt "Encrypted storage setup button shown in native browsers"
 msgid "Set Up Sync & Backup"
-msgstr ""
+msgstr "Configurar Sincronização e cópia de segurança"
 
 # smartling.placeholder_format=C
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
@@ -17608,8 +17606,7 @@ msgstr "Partilhar"
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "Share DuckDuckGo and help friends take their privacy back!"
-msgstr ""
-"Partilha o DuckDuckGo e ajuda os teus amigos a recuperar a sua privacidade!"
+msgstr "Partilha o DuckDuckGo e ajuda os teus amigos a recuperar a sua privacidade!"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button that opens a feedback modal when clicked.
@@ -17703,7 +17700,7 @@ msgstr "Partilhar comentário positivo"
 msgctxt ""
 "Label beside the share-content switch on the Duck.ai response feedback form"
 msgid "Share this conversation with DuckDuckGo"
-msgstr ""
+msgstr "Partilhar esta conversa com a DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -17961,8 +17958,7 @@ msgstr "Mostrar todos os resultados"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show answers more often. (You can also %sturn them off%s.)"
-msgstr ""
-"Mostra as respostas com mais frequência. (Também podes %1$sdesativá-las%2$s.)"
+msgstr "Mostra as respostas com mais frequência. (Também podes %1$sdesativá-las%2$s.)"
 
 # smartling.placeholder_format=C
 #. Accessible label for the button that reveals a popover listing multiple citation sources in Duck.ai chat responses.
@@ -18092,8 +18088,7 @@ msgstr "Mostrar linhas horizontais nas quebras de página de resultados"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows links to instructions for how to add DuckDuckGo to your browser"
-msgstr ""
-"Mostra links para instruções de como adicionar o DuckDuckGo ao teu navegador"
+msgstr "Mostra links para instruções de como adicionar o DuckDuckGo ao teu navegador"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers more frequently.
@@ -18109,14 +18104,12 @@ msgstr "Mostra os links mais visitados na página de um novo separador"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your browser"
-msgstr ""
-"Mostra lembretes ocasionais para adicionar o DuckDuckGo ao teu navegador"
+msgstr "Mostra lembretes ocasionais para adicionar o DuckDuckGo ao teu navegador"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr ""
-"Mostra lembretes ocasionais para adicionar o DuckDuckGo aos teus dispositivos"
+msgstr "Mostra lembretes ocasionais para adicionar o DuckDuckGo aos teus dispositivos"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18147,8 +18140,7 @@ msgstr "Mostra sugestões na caixa de pesquisa enquanto digitas"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows the privacy benefits of using DuckDuckGo on the homepage"
-msgstr ""
-"Mostra os benefícios de privacidade do uso do DuckDuckGo na página inicial"
+msgstr "Mostra os benefícios de privacidade do uso do DuckDuckGo na página inicial"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18158,8 +18150,7 @@ msgstr "Mostra o fundo do botão de pesquisa"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message on top of the search results page"
-msgstr ""
-"Mostra a mensagem de boas-vindas no topo da página dos resultados de pesquisa"
+msgstr "Mostra a mensagem de boas-vindas no topo da página dos resultados de pesquisa"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18466,8 +18457,7 @@ msgctxt "Description for the wrong code error screen"
 msgid ""
 "Sorry, this code is invalid. Please make sure the correct code was entered "
 "or scanned."
-msgstr ""
-"Este código é inválido. Confirma que introduziste ou leste o código correto."
+msgstr "Este código é inválido. Confirma que introduziste ou leste o código correto."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -18748,22 +18738,19 @@ msgstr "Fica no DuckDuckGo"
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletter."
-msgstr ""
-"Mantém-te protegido e informado com a nossa newsletter sobre privacidade."
+msgstr "Mantém-te protegido e informado com a nossa newsletter sobre privacidade."
 
 # smartling.placeholder_format=C
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletters."
-msgstr ""
-"Mantém-te protegido e informado com as nossas newsletters sobre privacidade."
+msgstr "Mantém-te protegido e informado com as nossas newsletters sobre privacidade."
 
 # smartling.placeholder_format=C
 #. Text on the page where users can subscribe to DuckDuckGo's privacy newsletter
 msgctxt "showcase_newsletter"
 msgid "Stay protected and informed with our privacy newsletters."
-msgstr ""
-"Mantém-te protegido e informado com as nossas newsletters sobre privacidade."
+msgstr "Mantém-te protegido e informado com as nossas newsletters sobre privacidade."
 
 # smartling.placeholder_format=C
 #. Loading message shown when image generation is taking longer than usual.
@@ -18806,8 +18793,7 @@ msgstr "Bloqueia os rastreadores ocultos que se escondem noutros sites."
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop most hidden trackers lurking on other websites."
-msgstr ""
-"Bloqueia a maioria dos rastreadores ocultos que se escondem noutros sites."
+msgstr "Bloqueia a maioria dos rastreadores ocultos que se escondem noutros sites."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18980,19 +18966,19 @@ msgstr "Sugere um título para uma publicação num blog"
 #. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Suggest related articles or topics worth exploring next."
-msgstr ""
+msgstr "Sugere artigos ou tópicos relacionados que valha a pena explorar a seguir."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Suggest related articles to explore"
-msgstr ""
+msgstr "Sugere artigos relacionados para explorar"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Suggest some alternatives to this product."
-msgstr ""
+msgstr "Sugere algumas alternativas a este produto."
 
 # smartling.placeholder_format=C
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
@@ -19009,7 +18995,7 @@ msgstr "Sugestões:"
 #. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Sum up the reviews"
-msgstr ""
+msgstr "Resume os comentários"
 
 # smartling.placeholder_format=C
 #. A short title for the a message asking the AI to summarize a text.
@@ -19021,85 +19007,85 @@ msgstr "Resumir"
 #. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize the Q&As"
-msgstr ""
+msgstr "Resume as perguntas e respostas"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the background and notable work of this person."
-msgstr ""
+msgstr "Resume o historial e o trabalho notável desta pessoa."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the key details of this event."
-msgstr ""
+msgstr "Resume os detalhes principais deste evento."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the questions and answers on this page."
-msgstr ""
+msgstr "Resume as perguntas e respostas nesta página."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize their background"
-msgstr ""
+msgstr "Resume o historial deles"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this book"
-msgstr ""
+msgstr "Resume este livro"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this book."
-msgstr ""
+msgstr "Resume este livro."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this discussion"
-msgstr ""
+msgstr "Resume esta discussão"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this discussion thread."
-msgstr ""
+msgstr "Resume este tópico de discussão."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this page"
-msgstr ""
+msgstr "Resume esta página"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this page."
-msgstr ""
+msgstr "Resumir esta página."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this video"
-msgstr ""
+msgstr "Resume este vídeo"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this video."
-msgstr ""
+msgstr "Resume este vídeo."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize what the reviews say."
-msgstr ""
+msgstr "Resume o que dizem os comentários."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -19433,7 +19419,7 @@ msgstr "Síria"
 #. Text for a button that enables the theme to follow the operating system's color scheme preference.
 msgctxt "System theme button for theme selector"
 msgid "System"
-msgstr ""
+msgstr "Sistema"
 
 # smartling.placeholder_format=C
 #. Abbreviation indicating this is the total score for a game
@@ -19467,7 +19453,7 @@ msgstr "Taitiano"
 #. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Tailor my resume"
-msgstr ""
+msgstr "Personaliza o meu CV"
 
 # smartling.placeholder_format=C
 msgid "Taiwan"
@@ -19504,6 +19490,8 @@ msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
+"Responde a este inquérito anónimo para nos dizeres como podemos melhorar o "
+"Duck.ai."
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -19814,7 +19802,7 @@ msgstr "Tema"
 #. Text for the theme selector label that allows users to switch between Light and dark theme.
 msgctxt "Label for the theme selector feature"
 msgid "Theme"
-msgstr ""
+msgstr "Tema"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/LpFhb1e.png
@@ -19940,8 +19928,7 @@ msgstr ""
 #. Appears below a type of search results called 'Instant Answers'
 msgctxt "attribution"
 msgid "This Instant Answer was made by the %sDuckDuckHack%s Community."
-msgstr ""
-"Esta resposta instantânea foi dada pela Comunidade %1$sDuckDuckHack%2$s."
+msgstr "Esta resposta instantânea foi dada pela Comunidade %1$sDuckDuckHack%2$s."
 
 # smartling.placeholder_format=C
 #. Label for the monthly usage row in the Usage section of Duck.ai settings.
@@ -20005,15 +19992,13 @@ msgstr ""
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
-msgstr ""
-"Este ficheiro é demasiado grande. O tamanho máximo do ficheiro é %1$s MB"
+msgstr "Este ficheiro é demasiado grande. O tamanho máximo do ficheiro é %1$s MB"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB."
-msgstr ""
-"Este ficheiro é demasiado grande. O tamanho máximo do ficheiro é %1$s MB."
+msgstr "Este ficheiro é demasiado grande. O tamanho máximo do ficheiro é %1$s MB."
 
 # smartling.placeholder_format=C
 #. Generic error message displayed when the user tries to upload an unsupported file type and we cannot determine the accepted types
@@ -20204,8 +20189,7 @@ msgstr "Esta tradução está errada"
 # smartling.placeholder_format=C
 #. Label indicating that the video can't be played on the current page, and only on the website that owns the vide. The placeholder is the name of the website that owns the video.
 msgid "This video is not yet able to be watched here. You can watch it on %s."
-msgstr ""
-"Ainda não é possível visualizar este vídeo aqui. Podes visualizá-lo em %1$s."
+msgstr "Ainda não é possível visualizar este vídeo aqui. Podes visualizá-lo em %1$s."
 
 # smartling.placeholder_format=C
 #. Message indicating that a website is not using an encrypted connection and is not secure.
@@ -20239,8 +20223,7 @@ msgstr ""
 #. Message explaining what will happen when the user deletes an image.
 msgctxt "Confirmation message in delete image modal"
 msgid "This will delete your selected image. This cannot be undone."
-msgstr ""
-"Isto irá eliminar a imagem selecionada. Esta ação não pode ser anulada."
+msgstr "Isto irá eliminar a imagem selecionada. Esta ação não pode ser anulada."
 
 # smartling.placeholder_format=C
 #. Confirmation message asking if the user is sure they want to reset all of their settings.
@@ -20367,8 +20350,7 @@ msgstr "Para continuar, tens de concordar com a %1$s e os %2$sdo Duck.ai"
 msgctxt ""
 "Copy stating agreement to AI Chat Privacy Policy and Terms of Service."
 msgid "To continue, you must agree to DuckDuckGo AI Chat’s %s and %s"
-msgstr ""
-"Para continuar, tens de concordar com a %1$s e os %2$s do DuckDuckGo AI Chat"
+msgstr "Para continuar, tens de concordar com a %1$s e os %2$s do DuckDuckGo AI Chat"
 
 # smartling.placeholder_format=C
 #. Instructions for how to print driving directions.
@@ -20666,13 +20648,13 @@ msgstr ""
 #. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Translate this page"
-msgstr ""
+msgstr "Traduz esta página"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
 msgctxt "Page suggestion prompt"
 msgid "Translate this page into %s."
-msgstr ""
+msgstr "Traduz esta página para %1$s."
 
 # smartling.placeholder_format=C
 #. Placeholder text for a region that will display translated text.
@@ -20774,8 +20756,7 @@ msgstr "Experimenta %1$s para deixar de ver mensagens como esta."
 #. Text for a promotional card that encourages users to try the encrypted AI model whose inference runs in a confidential environment so the model provider cannot access user data. %s is replaced with the model's full display name (e.g. 'GPT-OSS 120B').
 msgctxt "Promotional text for encrypted AI model"
 msgid "Try %s, our first model with zero provider visibility."
-msgstr ""
-"Experimenta %1$s, o nosso primeiro modelo sem visibilidade para o fornecedor."
+msgstr "Experimenta %1$s, o nosso primeiro modelo sem visibilidade para o fornecedor."
 
 # smartling.placeholder_format=C
 msgid "Try %sDuck.ai%s, our private AI chat service:"
@@ -20820,7 +20801,7 @@ msgstr "Experimentar gratuitamente"
 #. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
 msgctxt "settings"
 msgid "Try It Now"
-msgstr ""
+msgstr "Experimenta agora"
 
 # smartling.placeholder_format=C
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -20886,8 +20867,7 @@ msgstr ""
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
 msgctxt "precise_user_location"
 msgid "Try enabling anonymous location for more accurate results."
-msgstr ""
-"Tenta permitir a localização anónima para obter resultados mais específicos."
+msgstr "Tenta permitir a localização anónima para obter resultados mais específicos."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the screen of the onboarding where the user picks a chat model.
@@ -21020,8 +21000,7 @@ msgstr "Experimenta o novo chat privado de voz em tempo real!"
 #. Text for a promotional card that encourages users to try the recently added open-source AI models. The placeholders are the names of AI models like 'Try the recently added open-source Llama 3.1 and Mistral.'
 msgctxt "Promotional text for new AI models"
 msgid "Try the recently added open-source %s and %s"
-msgstr ""
-"Experimenta o %1$s e o %2$s, de código aberto, adicionados recentemente"
+msgstr "Experimenta o %1$s e o %2$s, de código aberto, adicionados recentemente"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that encourages users to try the recently added open-source AI models Llama 3.1 and Mixtral.
@@ -21071,6 +21050,9 @@ msgid ""
 "Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
+"Estás a tentar desativar as funcionalidades de IA? Instala a extensão de "
+"pesquisa %1$sDuckDuckGo No AI%2$s para memorizar as tuas definições. "
+"%3$sSabe mais%4$s"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -21079,6 +21061,9 @@ msgid ""
 "Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
+"Estás a tentar desativar as funcionalidades de IA? Muda para a extensão de "
+"pesquisa %1$sDuckDuckGo No AI%2$s para guardar as tuas definições. %3$sSabe "
+"mais%4$s"
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -21396,14 +21381,12 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sOpen with%s select %sA specific page or pages%s"
-msgstr ""
-"Em %1$s\"Abrir com\"%2$s, seleciona %3$sUma página específica ou várias%4$s"
+msgstr "Em %1$s\"Abrir com\"%2$s, seleciona %3$sUma página específica ou várias%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
-msgstr ""
-"Em %1$sNo arranque > Página inicial%2$s, introduz: https://duckduckgo.com"
+msgstr "Em %1$sNo arranque > Página inicial%2$s, introduz: https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -21562,8 +21545,7 @@ msgstr "Desbloqueia a IA avançada com a tua subscrição!"
 #. Upsell message shown in the voice chat duration limit modal for free users.
 msgctxt "voice chat duration limit modal"
 msgid "Unlock longer voice chats with a DuckDuckGo Subscription"
-msgstr ""
-"Desbloqueia conversas de voz mais longas com uma subscrição da DuckDuckGo"
+msgstr "Desbloqueia conversas de voz mais longas com uma subscrição da DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Text informing the user that more capable AI models can be unlocked with a subscription, with a trailing call-to-action link. %s is replaced with either the 'Try for free' link (for unauthenticated users) or the 'Learn more' link (for authenticated users). The link opens the subscription modal. Example: Unlock more capable AI models with a DuckDuckGo subscription. Try for free
@@ -21840,7 +21822,7 @@ msgstr "Uruguai"
 #. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
 msgctxt "Navigation label on the Duck.ai settings page"
 msgid "Usage"
-msgstr ""
+msgstr "Uso"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -22121,8 +22103,7 @@ msgctxt "mobile promotion on desktop"
 msgid ""
 "Visit %sDuckDuckGo.com%s on your tablet or phone and follow the provided "
 "instructions."
-msgstr ""
-"Vai a %1$sDuckDuckGo.com%2$s no tablet ou smartphone e segue as instruções."
+msgstr "Vai a %1$sDuckDuckGo.com%2$s no tablet ou smartphone e segue as instruções."
 
 # smartling.placeholder_format=C
 #. Primary button to visit Duck.ai.
@@ -22294,7 +22275,7 @@ msgstr "País de Gales"
 #. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Walk me through the steps"
-msgstr ""
+msgstr "Guia-me pelos passos"
 
 # smartling.placeholder_format=C
 #. Label for walking directions on a map.
@@ -22425,6 +22406,9 @@ msgid ""
 "please share this conversation with DuckDuckGo so we can investigate and "
 "address the issue."
 msgstr ""
+"Só podemos corrigir o que conseguimos ver. Para denunciares uma resposta "
+"prejudicial ou ilegal, partilha esta conversa com a DuckDuckGo para "
+"investigarmos e resolvermos o problema."
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -22795,8 +22779,7 @@ msgstr "Limite semanal atingido"
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Weekly usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Limite de utilização semanal atingido. Podes continuar este chat após %1$s."
+msgstr "Limite de utilização semanal atingido. Podes continuar este chat após %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable weekly Duck.ai usage limit and can opt in to continue using the monthly limit.
@@ -22941,15 +22924,13 @@ msgstr ""
 #. Text for a prompt suggestion for considering factors when purchasing a computer monitor.
 msgctxt "Full sentence for preparing for a purchase"
 msgid "What are some factors to consider when purchasing a computer monitor?"
-msgstr ""
-"Quais são alguns fatores a considerar ao comprar um monitor de computador?"
+msgstr "Quais são alguns fatores a considerar ao comprar um monitor de computador?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for asking about must-see attractions in Paris for a first-time visitor.
 msgctxt "Full sentence for planning a trip"
 msgid "What are some must-see attractions in Paris for a first-time visitor?"
-msgstr ""
-"Quais são algumas das atrações imperdíveis em Paris para a primeira visita?"
+msgstr "Quais são algumas das atrações imperdíveis em Paris para a primeira visita?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for finding options for the word 'better' in a specific context.
@@ -22989,98 +22970,98 @@ msgstr ""
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the counterarguments?"
-msgstr ""
+msgstr "Quais são os contra-argumentos?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the hours & location?"
-msgstr ""
+msgstr "Quais são os horários e a localização?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key contributions of this paper?"
-msgstr ""
+msgstr "Quais são os principais contributos deste artigo?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key contributions?"
-msgstr ""
+msgstr "Quais são as principais contribuições?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key details?"
-msgstr ""
+msgstr "Quais são os detalhes principais?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key points covered in this video?"
-msgstr ""
+msgstr "Quais são os pontos principais abordados neste vídeo?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key points?"
-msgstr ""
+msgstr "Quais são os pontos-chave?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key takeaways from this article?"
-msgstr ""
+msgstr "Quais são as principais conclusões deste artigo?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key takeaways?"
-msgstr ""
+msgstr "Quais são as principais conclusões?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key things I will learn from this course?"
-msgstr ""
+msgstr "Quais são as principais coisas que vou aprender neste curso?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the main counterarguments or criticisms of this?"
-msgstr ""
+msgstr "Quais são os principais contra-argumentos ou críticas a isto?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the main questions this page answers?"
-msgstr ""
+msgstr "Quais são as principais perguntas que esta página responde?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the must-try dishes here?"
-msgstr ""
+msgstr "Quais são os pratos que tens de experimentar aqui?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid ""
 "What are the opening hours, location, and contact details for this place?"
-msgstr ""
+msgstr "Quais são os horários de funcionamento, localização e contactos deste local?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the pros and cons of this product?"
-msgstr ""
+msgstr "Quais são os prós e contras deste produto?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the pros and cons?"
-msgstr ""
+msgstr "Quais são os prós e contras?"
 
 # smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
@@ -23186,7 +23167,7 @@ msgstr "O que significa aurícula no contexto de um artigo médico?"
 #. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What does this answer?"
-msgstr ""
+msgstr "O que é que isto responde?"
 
 # smartling.placeholder_format=C
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
@@ -23204,7 +23185,7 @@ msgstr "Que informações são guardadas?"
 #. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What interview questions might come up for this role?"
-msgstr ""
+msgstr "O que me podem perguntar na entrevista para esta função?"
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -23212,8 +23193,7 @@ msgctxt "cloudsave"
 msgid ""
 "What is the Cloud Save bookmarklet and how does it differ from the URL "
 "parameter bookmarklet?"
-msgstr ""
-"O que é o marcador Cloud Save e como é que difere do de parâmetros de URL?"
+msgstr "O que é o marcador Cloud Save e como é que difere do de parâmetros de URL?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for looking up the capital city of Albania.
@@ -23225,7 +23205,7 @@ msgstr "Qual é a capital da Albânia?"
 #. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What is the overall verdict and rating for this?"
-msgstr ""
+msgstr "Qual é o veredito e a classificação geral disto?"
 
 # smartling.placeholder_format=C
 #. Link to a page with additional information.
@@ -23253,7 +23233,7 @@ msgstr "O que as pessoas dizem:"
 #. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What should I order?"
-msgstr ""
+msgstr "O que devo pedir?"
 
 # smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
@@ -23271,13 +23251,13 @@ msgstr "Qual o problema da resposta? (opcional)"
 #. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What will I learn?"
-msgstr ""
+msgstr "O que vou aprender?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What will I need?"
-msgstr ""
+msgstr "Do que vou precisar?"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -23288,8 +23268,7 @@ msgstr "Sobre o que gostarias de dar feedback?"
 #. Explains the benefits of using our custom video player, the Duck Player
 msgid ""
 "What you watch in DuckDuckGo won't influence your recommendations on YouTube."
-msgstr ""
-"O que vês no DuckDuckGo não influencia as tuas recomendações no YouTube."
+msgstr "O que vês no DuckDuckGo não influencia as tuas recomendações no YouTube."
 
 # smartling.placeholder_format=C
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
@@ -23301,7 +23280,7 @@ msgstr "Novidades"
 #. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What's the verdict?"
-msgstr ""
+msgstr "Qual é o veredito?"
 
 # smartling.placeholder_format=C
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -23357,7 +23336,7 @@ msgstr "Que funcionalidades estão em falta? (Opcional)"
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Which features are missing? (optional)"
-msgstr ""
+msgstr "Que funcionalidades estão em falta? (opcional)"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
@@ -23380,12 +23359,14 @@ msgstr "Quem somos"
 msgctxt "Page suggestion prompt"
 msgid "Who are the main cast and crew, and what else are they known for?"
 msgstr ""
+"Quem são os principais membros do elenco e da equipa técnica, e por que "
+"outros projetos são conhecidos?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Who is this person?"
-msgstr ""
+msgstr "Quem é esta pessoa?"
 
 # smartling.placeholder_format=C
 #. Header above a collection of privacy-related links.
@@ -23849,8 +23830,7 @@ msgstr ""
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
 msgctxt "Third party map app picker feedback dialog"
 msgid "You can change this any time in %sSearch Settings%s"
-msgstr ""
-"Podes alterar isto em qualquer altura nas %1$sDefinições de pesquisa%2$s"
+msgstr "Podes alterar isto em qualquer altura nas %1$sDefinições de pesquisa%2$s"
 
 # smartling.placeholder_format=C
 #. Text explaning how to change a passphrase.
@@ -23883,8 +23863,7 @@ msgstr "Podes ocultar este lembrete em %1$sDefinições de pesquisa%2$s"
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
-msgstr ""
-"Agora podes guardar até 100 chats neste dispositivo. Conversa à vontade!"
+msgstr "Agora podes guardar até 100 chats neste dispositivo. Conversa à vontade!"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -24150,8 +24129,7 @@ msgstr "Atingiste o limite de chat de voz para hoje. Tente novamente amanhã."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
 msgid "You've reached your dictation usage limit. Try again later."
-msgstr ""
-"Atingiste o limite de utilização de ditado. tentar novamente mais tarde"
+msgstr "Atingiste o limite de utilização de ditado. tentar novamente mais tarde"
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -24376,8 +24354,7 @@ msgctxt "duckai_migration"
 msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
-msgstr ""
-"Os teus chats foram importados. Continua a partir de onde ficaste no Duck.ai."
+msgstr "Os teus chats foram importados. Continua a partir de onde ficaste no Duck.ai."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.
@@ -24576,15 +24553,13 @@ msgctxt "Error message for user limit"
 msgid ""
 "You’ve reached the maximum number of messages for one day. Please continue "
 "this chat tomorrow."
-msgstr ""
-"Atingiste o número máximo de mensagens para um dia. Continua o chat amanhã."
+msgstr "Atingiste o número máximo de mensagens para um dia. Continua o chat amanhã."
 
 # smartling.placeholder_format=C
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
 msgctxt "voice chat limit modal"
 msgid "You’ve reached the voice chat limit for now. Please try again later."
-msgstr ""
-"Atingiste o limite do chat de voz por agora. Tenta novamente mais tarde."
+msgstr "Atingiste o limite do chat de voz por agora. Tenta novamente mais tarde."
 
 # smartling.placeholder_format=C
 #. The name of the Yucatec Maya language
@@ -24667,8 +24642,7 @@ msgstr "por %1$s"
 #. Trust line shown at the bottom of the explainer panel, summarizing DuckDuckGo's reputation for online protection.
 msgctxt "Footer banner text in the How Duck.ai Works panel"
 msgid "by DuckDuckGo — online protection trusted by millions every day."
-msgstr ""
-"DuckDuckGo — proteção online em que milhões de pessoas confiam todos os dias."
+msgstr "DuckDuckGo — proteção online em que milhões de pessoas confiam todos os dias."
 
 # smartling.placeholder_format=C
 #. An abreviated unit of time indicating an age, e.g. "2d"

--- a/locales/pt_PT/LC_MESSAGES/duckduckgo.po
+++ b/locales/pt_PT/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: pt_PT\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -489,7 +489,8 @@ msgstr ""
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "%sLong-press%s the DuckDuckGo app icon on the home screen"
-msgstr "%1$sPrime sem soltar%2$s o ícone da aplicação DuckDuckGo no ecrã inicial"
+msgstr ""
+"%1$sPrime sem soltar%2$s o ícone da aplicação DuckDuckGo no ecrã inicial"
 
 # smartling.placeholder_format=C
 #. A message displayed when there is an error loading content or no results on requery
@@ -1239,7 +1240,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. An item in the ads tooltip that explains that ad clicks aren’t used to profile you.
 msgid "Ad clicks aren’t used to profile you"
-msgstr "Os cliques em anúncios não são usados para criar perfis de utilizadores"
+msgstr ""
+"Os cliques em anúncios não são usados para criar perfis de utilizadores"
 
 # smartling.placeholder_format=C
 #. Category of problem a user can select on a feedback form.
@@ -1439,6 +1441,12 @@ msgstr "Barra de endereço:"
 msgctxt "feedback form"
 msgid "Address is incorrect"
 msgstr "O endereço está incorreto"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Adjust the servings"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. as in multiple advertisements
@@ -1654,6 +1662,14 @@ msgid "All chats are %sprivate%s"
 msgstr "Todos os chats são %1$sprivados%2$s"
 
 # smartling.placeholder_format=C
+#. Paragraph in the Privacy & Terms section of the About & Legal page in Duck.ai settings, summarizing how chats are anonymized and are not stored or used to train chat models.
+msgctxt "Privacy & Terms section description on the Duck.ai settings page"
+msgid ""
+"All chats are anonymized by DuckDuckGo, and your conversations are not used "
+"to train chat models by DuckDuckGo or the model providers"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
 msgctxt "Privacy modal header in Duck.ai chat"
 msgid "All chats are private"
@@ -1744,7 +1760,8 @@ msgstr "Permitir anúncios que respeitam a privacidade"
 # smartling.placeholder_format=C
 #. Title in a dialog informing the user how to disable their ad blocker for DuckDuckGo
 msgid "Allow privacy-respecting ads on DuckDuckGo Private Search"
-msgstr "Permitir anúncios que respeitam a privacidade na Private Search do DuckDuckGo"
+msgstr ""
+"Permitir anúncios que respeitam a privacidade na Private Search do DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Description explaining privacy implications of enabling web search on encrypted models. The first two placeholders are the full model name (e.g. 'gpt-oss 120B'). The third and fourth placeholders wrap a clickable link reading 'zero provider visibility' that opens the privacy modal, please keep those around the link text in your translation. An example full sentence would be: Allows gpt-oss 120B to search the web to improve responses to relevant prompts. Only sends AI-generated queries to a search engine with limited data retention. Prompts and responses with gpt-oss 120B still have zero provider visibility.
@@ -1922,6 +1939,13 @@ msgstr ""
 msgctxt "precise_user_location"
 msgid "Anonymous location enabled"
 msgstr "Localização anónima ativada"
+
+# smartling.placeholder_format=C
+msgctxt "settings"
+msgid ""
+"Anonymously generates answers for search queries based on web content. "
+"Choose how often you want it to appear, or disable it completely."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -2207,6 +2231,12 @@ msgid "Ask a follow-up with Duck.ai"
 msgstr "Faz uma pergunta de seguimento com Duck.ai"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
+msgctxt "Page suggestion chip label"
+msgid "Ask about this page"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
 msgctxt "Title for the page context onboarding modal"
 msgid "Ask about this page"
@@ -2427,7 +2457,8 @@ msgstr "Resposta automática"
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid "Auto-generated based on listed sources. May contain inaccuracies."
-msgstr "Gerada automaticamente com base nas fontes listadas. Pode conter imprecisões."
+msgstr ""
+"Gerada automaticamente com base nas fontes listadas. Pode conter imprecisões."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
@@ -2623,6 +2654,12 @@ msgid "Barcode"
 msgstr "Código de barras"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Based on this page, is this course worth taking?"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Basic"
 msgstr "Básico"
@@ -2661,6 +2698,14 @@ msgstr "Batedor"
 msgctxt "Assistant response placeholder"
 msgid "Before continuing..."
 msgstr "Antes de continuar..."
+
+# smartling.placeholder_format=C
+#. Explains that before storing the report, DuckDuckGo will anonymize the conversation by removing PII like names, email addresses, and identifying metadata.
+msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
+msgid ""
+"Before storing this report, DuckDuckGo will anonymize your conversation by "
+"removing PII like names, email addresses, and identifying metadata."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -2977,6 +3022,12 @@ msgstr "Brasil"
 msgctxt "Sports module"
 msgid "Break Points Won"
 msgstr "Pontos de quebra ganhos"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Break this down into clear, numbered steps."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -3434,6 +3485,12 @@ msgid "Cast"
 msgstr "Elenco"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Cast & Crew"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
 msgctxt "Tone option label for Casual"
 msgid "Casual"
@@ -3539,7 +3596,8 @@ msgstr "Modifica a cor de fundo em todo o site"
 msgctxt "settings"
 msgid ""
 "Changes the background color of results on hover, modules, and dropdown menus"
-msgstr "Altera a cor de fundo dos resultados em menus suspensos, hovers e módulos"
+msgstr ""
+"Altera a cor de fundo dos resultados em menus suspensos, hovers e módulos"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/NdpkbY0.png
@@ -3905,7 +3963,8 @@ msgstr ""
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
 msgctxt "noresults"
 msgid "Check the status page for updates on this outage."
-msgstr "Consulta a página de estado para atualizações sobre esta indisponibilidade."
+msgstr ""
+"Consulta a página de estado para atualizações sobre esta indisponibilidade."
 
 # smartling.placeholder_format=C
 #. Title shown to the host device (the one that is logged in) after it sends the pairing code. The host can't confirm the peer applied it, so this is a title-only screen (no body) prompting the user to finish on the other device.
@@ -4366,7 +4425,8 @@ msgstr "Clica em %1$sFornecedores de Pesquisa%2$s em tipos de Add-on"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click on the %sTools icon%s in the top-right of the browser"
-msgstr "No canto superior direito do navegador, clica no %1$sícone de Ferramentas%2$s"
+msgstr ""
+"No canto superior direito do navegador, clica no %1$sícone de Ferramentas%2$s"
 
 #  Firefox default search engine instruction
 # smartling.placeholder_format=C
@@ -5147,6 +5207,12 @@ msgid "Create Image"
 msgstr "Criar imagem"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Create a shopping list with quantities from this recipe."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text displayed in the input field when starting a new image generation session.
 msgctxt "Placeholder text for the image generation input field"
 msgid "Create an image of a cute duck..."
@@ -5401,7 +5467,8 @@ msgstr "Limite diário atingido"
 #. Displayed when the user has reached a fixed daily Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Daily usage limit reached. You can continue this chat after %s."
-msgstr "Limite de utilização diária atingido. Podes continuar este chat após %1$s."
+msgstr ""
+"Limite de utilização diária atingido. Podes continuar este chat após %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable daily Duck.ai usage limit and can opt in to continue using the weekly limit.
@@ -5787,6 +5854,11 @@ msgid "Dictation limit reached"
 msgstr "Limite de ditado atingido"
 
 # smartling.placeholder_format=C
+#. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
+msgid "Dictation temporarily unavailable"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
@@ -6087,6 +6159,22 @@ msgid "Done"
 msgstr "Feito"
 
 # smartling.placeholder_format=C
+#. Message shown in a modal after DuckDuckGo browser users disable AI features in Settings. The first two placeholders bold noai.duckduckgo.com. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
+"filtered out. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
+"and AI images filtered out. %sLearn more%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Double Faults"
@@ -6199,6 +6287,18 @@ msgid ""
 msgstr ""
 "Escreve um e-mail breve e detalhado para um fornecedor a pedir um orçamento "
 "para serviços de reparação de frigoríficos domésticos."
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Draft a cover letter"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Draft a cover letter for this job."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -6379,6 +6479,15 @@ msgstr ""
 "gratuito!"
 
 # smartling.placeholder_format=C
+#. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
+msgctxt "About section description on the Duck.ai settings page"
+msgid ""
+"Duck.ai is created by DuckDuckGo. We're an independent online protection "
+"company for anyone who wants to take back control of their personal "
+"information."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
 msgctxt "duckai_migration"
 msgid "Duck.ai is moving domains"
@@ -6423,7 +6532,15 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
-msgstr "O Duck.ai está temporariamente indisponível. Tenta novamente mais tarde."
+msgstr ""
+"O Duck.ai está temporariamente indisponível. Tenta novamente mais tarde."
+
+# smartling.placeholder_format=C
+msgctxt "settings"
+msgid ""
+"Duck.ai lets you chat privately with popular AI models. Disabling it hides "
+"Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6487,7 +6604,8 @@ msgstr "Duck.ai atualizado!"
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
-msgstr "O Duck.ai funciona melhor na nossa aplicação privada e gratuita DuckDuckGo!"
+msgstr ""
+"O Duck.ai funciona melhor na nossa aplicação privada e gratuita DuckDuckGo!"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -6895,7 +7013,8 @@ msgctxt ""
 "Description of the DuckDuckGo subscription setting when it is not available "
 "in the user region"
 msgid "DuckDuckGo subscriptions are not available to purchase in this region."
-msgstr "As subscrições da DuckDuckGo não estão disponíveis para compra nesta região."
+msgstr ""
+"As subscrições da DuckDuckGo não estão disponíveis para compra nesta região."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use 'ducky' tone in its responses. When this option is selected, the AI assistant speaks like a duck.
@@ -7282,19 +7401,22 @@ msgstr ""
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location Services' is %senabled%s."
-msgstr "Certifica-te de que os \"Serviços de Localização\" estão %1$sativos%2$s."
+msgstr ""
+"Certifica-te de que os \"Serviços de Localização\" estão %1$sativos%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location' is set to %sallow%s"
-msgstr "Certifica-te de que a \"Localização\" está definida como %1$spermitir%2$s"
+msgstr ""
+"Certifica-te de que a \"Localização\" está definida como %1$spermitir%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location' is set to %sallow%s."
-msgstr "Certifica-te de que a \"Localização\" está definida para %1$spermitir%2$s."
+msgstr ""
+"Certifica-te de que a \"Localização\" está definida para %1$spermitir%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -7334,13 +7456,15 @@ msgstr ""
 #. Tells how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed location access"
-msgstr "Certifica-te de que o teu navegador tem permissão para aceder à localização"
+msgstr ""
+"Certifica-te de que o teu navegador tem permissão para aceder à localização"
 
 # smartling.placeholder_format=C
 #. Tells how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed location access."
-msgstr "Certifica-te de que o teu navegador tem permissão para aceder à localização."
+msgstr ""
+"Certifica-te de que o teu navegador tem permissão para aceder à localização."
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -7437,6 +7561,18 @@ msgid "Eritrea"
 msgstr "Eritreia"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Estimate the nutrition"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Estimate the nutritional information for this recipe."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Estonia"
 msgstr "Estónia"
 
@@ -7493,6 +7629,12 @@ msgid "Expires in 1 day"
 msgstr "Expira em 1 dia"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain the accepted answer in simple terms."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
@@ -7500,6 +7642,48 @@ msgid ""
 msgstr ""
 "Explica-me os conceitos fundamentais dos buracos negros a um nível de ensino "
 "secundário."
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain the top answer"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this in simple, plain language."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this paper"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this repo"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this research paper in plain language."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this simply"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain what this repository does and how to use it."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label to show if song lyrics contain explicit content
@@ -7788,6 +7972,12 @@ msgstr ""
 "%1$sSabe mais%2$s"
 
 # smartling.placeholder_format=C
+msgctxt "settings"
+msgid ""
+"Filters out known AI spam sites from image search results. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the final score of a sporting event.
 msgid "Final"
 msgstr "Final"
@@ -7839,6 +8029,12 @@ msgstr "Encontrar uma palavra melhor"
 msgctxt "Subtitle for the Web Search tool entry in the Tools dropdown menu"
 msgid "Find current information"
 msgstr "Encontra informações atuais"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Find me alternatives"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button that searches for results closer to the user's current location.
@@ -8035,7 +8231,8 @@ msgstr "Chats gratuitos e privados, anonimizados por nós"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr "Chats gratuitos e privados, anonimizados por nós. Não é necessária conta."
+msgstr ""
+"Chats gratuitos e privados, anonimizados por nós. Não é necessária conta."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -8316,6 +8513,12 @@ msgstr "Gerar imagem"
 #. Text for the button that generates more of an answer from duckassist when the answer has come from a collapsed state
 msgid "Generate More"
 msgstr "Gerar mais"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Generate a shopping list"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
@@ -8609,6 +8812,12 @@ msgstr "Experimentar"
 msgctxt "Onboarding welcome screen button text"
 msgid "Give it a Try"
 msgstr "Experimentar"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Give me a quick background on this person."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9056,6 +9265,18 @@ msgstr "Divulga o DuckDuckGo!"
 #. Link to a page with information about sharing DuckDuckGo with friends.
 msgid "Help Spread Privacy"
 msgstr "Ajuda a divulgar a privacidade"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Help me prep for the interview"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Help me tailor my resume for this job."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title of a SERP popup that invites users to take a survey (desktop only)
@@ -9571,6 +9792,14 @@ msgstr "Furacão"
 msgctxt "Onboarding terms screen button text"
 msgid "I Agree"
 msgstr "Concordo"
+
+# smartling.placeholder_format=C
+#. Text for the button that takes the user to the external DuckDuckGo login subscription page.
+msgctxt ""
+"Text for the I already have a subscription button in the Duck.ai settings "
+"page"
+msgid "I Already Have a Subscription"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the button that takes the user to the login subscription page.
@@ -10148,6 +10377,12 @@ msgid "Install Mac Browser"
 msgstr "Instalar navegador para Mac"
 
 # smartling.placeholder_format=C
+#. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
+msgctxt "settings"
+msgid "Install Now"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of a button to install the DuckDuckGo app
 msgctxt "Serp footer content"
 msgid "Install Our App"
@@ -10245,10 +10480,42 @@ msgid "Is deleted data really deleted?"
 msgstr "Os dados apagados são mesmo apagados?"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is it worth taking?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this place any good?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"Is this place any good? Summarize its reputation based on reviews and "
+"ratings."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "Is this video helpful?"
 msgstr "Este vídeo é útil?"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this worth watching?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Is this worth watching? Give me a spoiler-free take."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -10280,7 +10547,8 @@ msgstr "É rápido, gratuito e oferece ainda mais proteção online."
 msgctxt "settings"
 msgid ""
 "It's okay to (very infrequently) ask me about my experience using DuckDuckGo"
-msgstr "Inquéritos (pouco frequentes) acerca da minha experiência com o DuckDuckGo"
+msgstr ""
+"Inquéritos (pouco frequentes) acerca da minha experiência com o DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. The name of the Italian language
@@ -10667,7 +10935,8 @@ msgstr "Saber mais sobre a Proteção de privacidade ativa"
 # smartling.placeholder_format=C
 msgctxt "showcase_newsletter"
 msgid "Learn about online privacy right in your inbox."
-msgstr "Sabe mais sobre privacidade online diretamente na tua caixa de entrada."
+msgstr ""
+"Sabe mais sobre privacidade online diretamente na tua caixa de entrada."
 
 # smartling.placeholder_format=C
 #. Link to a page with more information about how DuckDuckGo settings are managed.
@@ -10857,6 +11126,12 @@ msgstr "Tipo de letra das ligações:"
 #. https://duckduckgo.com/params under "Color Settings"
 msgid "Links:"
 msgstr "Ligações:"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "List the tools, materials, or prerequisites I need for this."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -11148,8 +11423,8 @@ msgstr "Certifica-te de que todas as palavras estão escritas corretamente."
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Make sure to check %s\"Make this my default search provider\"%s"
 msgstr ""
-"Certifica-te de marcar %1$s\"Tornar este no meu motor de buscar "
-"pré-definido\"%2$s"
+"Certifica-te de marcar %1$s\"Tornar este no meu motor de buscar pré-"
+"definido\"%2$s"
 
 # smartling.placeholder_format=C
 #. Message prompting users to check the spelling of their search term.
@@ -11265,6 +11540,12 @@ msgstr "Gerir a subscrição"
 msgctxt "Exclusion message manage sites button"
 msgid "Manage blocked sites"
 msgstr "Gerir sites bloqueados"
+
+# smartling.placeholder_format=C
+#. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
+msgctxt "setting"
+msgid "Manage in Browser Settings"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to the site exclusion settings page
@@ -11657,7 +11938,8 @@ msgstr "Capitalização do mercado"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Mobile Instructions (not displayed on settings page)"
-msgstr "Instruções para dispositivos móveis (não disponível na página de definições)"
+msgstr ""
+"Instruções para dispositivos móveis (não disponível na página de definições)"
 
 # smartling.placeholder_format=C
 #. A short label indicating that a user is a moderator of a discussion.
@@ -11716,7 +11998,8 @@ msgstr "Limite mensal atingido"
 #. Displayed when the user has reached a fixed monthly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Monthly usage limit reached. You can continue this chat after %s."
-msgstr "Limite de utilização mensal atingido. Podes continuar este chat após %1$s."
+msgstr ""
+"Limite de utilização mensal atingido. Podes continuar este chat após %1$s."
 
 # smartling.placeholder_format=C
 #. Used to point to additional social networking profiles (in results).
@@ -14107,6 +14390,12 @@ msgstr ""
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
+msgid "Please describe why the chat response is harmful or illegal. (optional)"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
+msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
 msgstr "Indica por que motivo a resposta é ilegal ou prejudicial. (Opcional)"
 
@@ -14131,6 +14420,14 @@ msgid ""
 msgstr ""
 "Nota: se começares uma nova conversa com qualquer modelo, a tua sessão de "
 "chat atual será eliminada."
+
+# smartling.placeholder_format=C
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
+msgctxt "Feedback prompt"
+msgid ""
+"Please paste your prompt and the problematic output (with any personal "
+"information removed) and describe why the content is harmful or illegal."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -14601,6 +14898,12 @@ msgid "Privacy"
 msgstr "Privacidade"
 
 # smartling.placeholder_format=C
+#. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
+msgctxt "Section heading on the Duck.ai settings page"
+msgid "Privacy & Terms"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Privacy Blog"
 msgstr "Blog da privacidade"
 
@@ -14669,6 +14972,12 @@ msgstr "Política de Privacidade e Termos de Utilização"
 msgctxt "Copy used to compose link in sentences"
 msgid "Privacy Policy and Terms of Service"
 msgstr "Política de Privacidade e Termos de Serviço"
+
+# smartling.placeholder_format=C
+#. Text for a button that links to the terms of use and privacy policy page.
+msgctxt "Secondary button text in active privacy modal"
+msgid "Privacy Policy and Terms of Service"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title displayed on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
@@ -15173,6 +15482,30 @@ msgid "Recommend a book"
 msgstr "Recomendar um livro"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar books"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar books."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar movies or shows."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar titles"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
 msgid "Recording failed. Please try again."
 msgstr "A gravação falhou. Tenta novamente."
@@ -15385,8 +15718,8 @@ msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
 msgstr ""
-"Recarrega o DuckDuckGo seguindo as instruções ou clicando no botão "
-"&quot;Atualizar&quot; ou &quot;Recarregar&quot; do teu navegador."
+"Recarrega o DuckDuckGo seguindo as instruções ou clicando no botão &quot;"
+"Atualizar&quot; ou &quot;Recarregar&quot; do teu navegador."
 
 # smartling.placeholder_format=C
 #. checkbox label that allows the user to save the setting
@@ -15396,7 +15729,8 @@ msgstr "Memorizar a minha opção"
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings
 msgid "Remember my choice (this can be changed in %s%s%sSettings%s)"
-msgstr "Lembrar escolha (isto pode ser alterado nas %1$s%2$s%3$sDefinições%4$s)"
+msgstr ""
+"Lembrar escolha (isto pode ser alterado nas %1$s%2$s%3$sDefinições%4$s)"
 
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
@@ -15575,6 +15909,15 @@ msgid "Republic of Moldova"
 msgstr "República da Moldávia"
 
 # smartling.placeholder_format=C
+#. Note indicating that sharing the conversation is mandatory when reporting harmful or illegal content. Rendered alongside the standard share label (DUCKCHAT_RESPONSE_FEEDBACK_SHARE_PROMPT_RESPONSE_LABEL), not replacing it.
+msgctxt ""
+"Note shown under the share-content switch label on the Duck.ai response "
+"feedback form when the user has selected Harmful or Illegal as the feedback "
+"reason"
+msgid "Required for harmful or illegal reports"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
 msgctxt "Description for extended reasoning mode in Duck.ai"
 msgid "Researches before responding"
@@ -15744,7 +16087,8 @@ msgstr "Os resultados excluem informações de sites bloqueados."
 #. Message that appears when results exclude blocked sites
 msgctxt "Blocked sites filter disclaimer"
 msgid "Results exclude your blocked sites, which you can manage in your %s."
-msgstr "Os resultados excluem os teus sites bloqueados, que podes gerir no teu %1$s."
+msgstr ""
+"Os resultados excluem os teus sites bloqueados, que podes gerir no teu %1$s."
 
 # smartling.placeholder_format=C
 #. A label showing the source of the results, e.g. "Results from Reddit"
@@ -15810,6 +16154,12 @@ msgstr "Comentários"
 msgctxt "maps_places"
 msgid "Reviews"
 msgstr "Comentários"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Rewrite this recipe scaled for a different number of servings."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Romania"
@@ -16090,7 +16440,8 @@ msgstr ""
 #. Short text for native DDG browser users explaining how Chat History stores up to 30 of their most recent chats locally on their device.
 msgctxt "Short description for Chat History feature on native DDG browsers"
 msgid "Save up to 30 of your most recent chats locally on your device."
-msgstr "Guarda até 30 das tuas conversas mais recentes localmente no teu dispositivo."
+msgstr ""
+"Guarda até 30 das tuas conversas mais recentes localmente no teu dispositivo."
 
 # smartling.placeholder_format=C
 #. Desktop/mobile intro modal body under the title per Sync Chats Figma (choose step).
@@ -16258,7 +16609,8 @@ msgstr "Desce na página e localiza %1$so teu navegador%2$s na lista."
 #. Tells users which setting to change to enable location service.
 msgctxt "precise_user_location"
 msgid "Scroll down to %sDuckDuckGo%s and allow it to use your location."
-msgstr "Desce até %1$sDuckDuckGo%2$s e autoriza a utilização da tua localização."
+msgstr ""
+"Desce até %1$sDuckDuckGo%2$s e autoriza a utilização da tua localização."
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -16813,7 +17165,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
-msgstr "Seleciona %1$sDuckDuckGo%2$s e clica em %3$sAdicionar como predefinido%4$s!"
+msgstr ""
+"Seleciona %1$sDuckDuckGo%2$s e clica em %3$sAdicionar como predefinido%4$s!"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
@@ -16830,7 +17183,8 @@ msgstr "Seleciona %1$sDuckDuckGo%2$s e clica em %3$sPredefinir%4$s."
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Select %sDuckDuckGo%s in the Default Search Engine drop down"
-msgstr "Seleciona %1$sDuckDuckGo%2$s no menu suspenso de motor de busca predefinido"
+msgstr ""
+"Seleciona %1$sDuckDuckGo%2$s no menu suspenso de motor de busca predefinido"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
@@ -16850,7 +17204,8 @@ msgstr "Seleciona %1$sDuckDuckGo%2$s na lista de fornecedores de pesquisa"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s under the%sDefault Search Engine%s section"
-msgstr "Seleciona %1$sDuckDuckGo%2$s na secção%3$sMotor de busca predefinido%4$s"
+msgstr ""
+"Seleciona %1$sDuckDuckGo%2$s na secção%3$sMotor de busca predefinido%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user were in the settings menu they can change their default search engine.
@@ -16935,7 +17290,8 @@ msgstr "Seleciona %1$sDefinições%2$s e depois %3$sDefinições Avançadas%4$s"
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sDefault search engine%s"
-msgstr "Seleciona %1$sDefinições%2$s e depois %3$sMotor de busca predefinido%4$s"
+msgstr ""
+"Seleciona %1$sDefinições%2$s e depois %3$sMotor de busca predefinido%4$s"
 
 #  Chrome/Firefox on Android
 # smartling.placeholder_format=C
@@ -17155,6 +17511,12 @@ msgid "Set Up Now"
 msgstr "Configura agora"
 
 # smartling.placeholder_format=C
+#. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
+msgctxt "Encrypted storage setup button shown in native browsers"
+msgid "Set Up Sync & Backup"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
 msgctxt "Title for the Sync & Backup intro screen"
 msgid "Set Up Sync & Backup"
@@ -17246,7 +17608,8 @@ msgstr "Partilhar"
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "Share DuckDuckGo and help friends take their privacy back!"
-msgstr "Partilha o DuckDuckGo e ajuda os teus amigos a recuperar a sua privacidade!"
+msgstr ""
+"Partilha o DuckDuckGo e ajuda os teus amigos a recuperar a sua privacidade!"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button that opens a feedback modal when clicked.
@@ -17334,6 +17697,13 @@ msgstr "Partilhar URL da página"
 msgctxt "feedback form"
 msgid "Share positive feedback"
 msgstr "Partilhar comentário positivo"
+
+# smartling.placeholder_format=C
+#. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
+msgctxt ""
+"Label beside the share-content switch on the Duck.ai response feedback form"
+msgid "Share this conversation with DuckDuckGo"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -17591,7 +17961,8 @@ msgstr "Mostrar todos os resultados"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show answers more often. (You can also %sturn them off%s.)"
-msgstr "Mostra as respostas com mais frequência. (Também podes %1$sdesativá-las%2$s.)"
+msgstr ""
+"Mostra as respostas com mais frequência. (Também podes %1$sdesativá-las%2$s.)"
 
 # smartling.placeholder_format=C
 #. Accessible label for the button that reveals a popover listing multiple citation sources in Duck.ai chat responses.
@@ -17721,7 +18092,8 @@ msgstr "Mostrar linhas horizontais nas quebras de página de resultados"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows links to instructions for how to add DuckDuckGo to your browser"
-msgstr "Mostra links para instruções de como adicionar o DuckDuckGo ao teu navegador"
+msgstr ""
+"Mostra links para instruções de como adicionar o DuckDuckGo ao teu navegador"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers more frequently.
@@ -17737,12 +18109,14 @@ msgstr "Mostra os links mais visitados na página de um novo separador"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your browser"
-msgstr "Mostra lembretes ocasionais para adicionar o DuckDuckGo ao teu navegador"
+msgstr ""
+"Mostra lembretes ocasionais para adicionar o DuckDuckGo ao teu navegador"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr "Mostra lembretes ocasionais para adicionar o DuckDuckGo aos teus dispositivos"
+msgstr ""
+"Mostra lembretes ocasionais para adicionar o DuckDuckGo aos teus dispositivos"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -17773,7 +18147,8 @@ msgstr "Mostra sugestões na caixa de pesquisa enquanto digitas"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows the privacy benefits of using DuckDuckGo on the homepage"
-msgstr "Mostra os benefícios de privacidade do uso do DuckDuckGo na página inicial"
+msgstr ""
+"Mostra os benefícios de privacidade do uso do DuckDuckGo na página inicial"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -17783,7 +18158,8 @@ msgstr "Mostra o fundo do botão de pesquisa"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message on top of the search results page"
-msgstr "Mostra a mensagem de boas-vindas no topo da página dos resultados de pesquisa"
+msgstr ""
+"Mostra a mensagem de boas-vindas no topo da página dos resultados de pesquisa"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18090,7 +18466,8 @@ msgctxt "Description for the wrong code error screen"
 msgid ""
 "Sorry, this code is invalid. Please make sure the correct code was entered "
 "or scanned."
-msgstr "Este código é inválido. Confirma que introduziste ou leste o código correto."
+msgstr ""
+"Este código é inválido. Confirma que introduziste ou leste o código correto."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -18371,19 +18748,22 @@ msgstr "Fica no DuckDuckGo"
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletter."
-msgstr "Mantém-te protegido e informado com a nossa newsletter sobre privacidade."
+msgstr ""
+"Mantém-te protegido e informado com a nossa newsletter sobre privacidade."
 
 # smartling.placeholder_format=C
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletters."
-msgstr "Mantém-te protegido e informado com as nossas newsletters sobre privacidade."
+msgstr ""
+"Mantém-te protegido e informado com as nossas newsletters sobre privacidade."
 
 # smartling.placeholder_format=C
 #. Text on the page where users can subscribe to DuckDuckGo's privacy newsletter
 msgctxt "showcase_newsletter"
 msgid "Stay protected and informed with our privacy newsletters."
-msgstr "Mantém-te protegido e informado com as nossas newsletters sobre privacidade."
+msgstr ""
+"Mantém-te protegido e informado com as nossas newsletters sobre privacidade."
 
 # smartling.placeholder_format=C
 #. Loading message shown when image generation is taking longer than usual.
@@ -18426,7 +18806,8 @@ msgstr "Bloqueia os rastreadores ocultos que se escondem noutros sites."
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop most hidden trackers lurking on other websites."
-msgstr "Bloqueia a maioria dos rastreadores ocultos que se escondem noutros sites."
+msgstr ""
+"Bloqueia a maioria dos rastreadores ocultos que se escondem noutros sites."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18596,6 +18977,24 @@ msgid "Suggest a title for a blog post"
 msgstr "Sugere um título para uma publicação num blog"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest related articles or topics worth exploring next."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Suggest related articles to explore"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest some alternatives to this product."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
 msgctxt "directions"
 msgid "Suggestions:"
@@ -18607,10 +19006,100 @@ msgid "Suggestions:"
 msgstr "Sugestões:"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Sum up the reviews"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A short title for the a message asking the AI to summarize a text.
 msgctxt "Title for the summarize message"
 msgid "Summarize"
 msgstr "Resumir"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize the Q&As"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the background and notable work of this person."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the key details of this event."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the questions and answers on this page."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize their background"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this book"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this book."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this discussion"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this discussion thread."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this page"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this page."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this video"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this video."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize what the reviews say."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -18941,6 +19430,12 @@ msgid "Syria"
 msgstr "Síria"
 
 # smartling.placeholder_format=C
+#. Text for a button that enables the theme to follow the operating system's color scheme preference.
+msgctxt "System theme button for theme selector"
+msgid "System"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Abbreviation indicating this is the total score for a game
 msgctxt "Sports module"
 msgid "T"
@@ -18967,6 +19462,12 @@ msgstr "Televisão"
 msgctxt "language_name"
 msgid "Tahitian"
 msgstr "Taitiano"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Tailor my resume"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Taiwan"
@@ -18996,6 +19497,13 @@ msgstr "Assume o controlo dos teus dados pessoais"
 msgctxt "homepage ATB modal"
 msgid "Take control of your personal data!"
 msgstr "Assume o controlo dos teus dados pessoais!"
+
+# smartling.placeholder_format=C
+#. Description for the Feedback section of the Duck.ai settings page, asking the user to take an anonymous survey to let us know how we can make Duck.ai better.
+msgctxt "Feedback section description on the Duck.ai settings page"
+msgid ""
+"Take this anonymous survey to let us know how we can make Duck.ai better."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -19303,6 +19811,12 @@ msgid "Theme"
 msgstr "Tema"
 
 # smartling.placeholder_format=C
+#. Text for the theme selector label that allows users to switch between Light and dark theme.
+msgctxt "Label for the theme selector feature"
+msgid "Theme"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. http://i.imgur.com/LpFhb1e.png
 msgctxt "settings"
 msgid "Theme"
@@ -19426,7 +19940,8 @@ msgstr ""
 #. Appears below a type of search results called 'Instant Answers'
 msgctxt "attribution"
 msgid "This Instant Answer was made by the %sDuckDuckHack%s Community."
-msgstr "Esta resposta instantânea foi dada pela Comunidade %1$sDuckDuckHack%2$s."
+msgstr ""
+"Esta resposta instantânea foi dada pela Comunidade %1$sDuckDuckHack%2$s."
 
 # smartling.placeholder_format=C
 #. Label for the monthly usage row in the Usage section of Duck.ai settings.
@@ -19490,13 +20005,15 @@ msgstr ""
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
-msgstr "Este ficheiro é demasiado grande. O tamanho máximo do ficheiro é %1$s MB"
+msgstr ""
+"Este ficheiro é demasiado grande. O tamanho máximo do ficheiro é %1$s MB"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB."
-msgstr "Este ficheiro é demasiado grande. O tamanho máximo do ficheiro é %1$s MB."
+msgstr ""
+"Este ficheiro é demasiado grande. O tamanho máximo do ficheiro é %1$s MB."
 
 # smartling.placeholder_format=C
 #. Generic error message displayed when the user tries to upload an unsupported file type and we cannot determine the accepted types
@@ -19687,7 +20204,8 @@ msgstr "Esta tradução está errada"
 # smartling.placeholder_format=C
 #. Label indicating that the video can't be played on the current page, and only on the website that owns the vide. The placeholder is the name of the website that owns the video.
 msgid "This video is not yet able to be watched here. You can watch it on %s."
-msgstr "Ainda não é possível visualizar este vídeo aqui. Podes visualizá-lo em %1$s."
+msgstr ""
+"Ainda não é possível visualizar este vídeo aqui. Podes visualizá-lo em %1$s."
 
 # smartling.placeholder_format=C
 #. Message indicating that a website is not using an encrypted connection and is not secure.
@@ -19721,7 +20239,8 @@ msgstr ""
 #. Message explaining what will happen when the user deletes an image.
 msgctxt "Confirmation message in delete image modal"
 msgid "This will delete your selected image. This cannot be undone."
-msgstr "Isto irá eliminar a imagem selecionada. Esta ação não pode ser anulada."
+msgstr ""
+"Isto irá eliminar a imagem selecionada. Esta ação não pode ser anulada."
 
 # smartling.placeholder_format=C
 #. Confirmation message asking if the user is sure they want to reset all of their settings.
@@ -19848,7 +20367,8 @@ msgstr "Para continuar, tens de concordar com a %1$s e os %2$sdo Duck.ai"
 msgctxt ""
 "Copy stating agreement to AI Chat Privacy Policy and Terms of Service."
 msgid "To continue, you must agree to DuckDuckGo AI Chat’s %s and %s"
-msgstr "Para continuar, tens de concordar com a %1$s e os %2$s do DuckDuckGo AI Chat"
+msgstr ""
+"Para continuar, tens de concordar com a %1$s e os %2$s do DuckDuckGo AI Chat"
 
 # smartling.placeholder_format=C
 #. Instructions for how to print driving directions.
@@ -20143,6 +20663,18 @@ msgstr ""
 "próximo?\""
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Translate this page"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
+msgctxt "Page suggestion prompt"
+msgid "Translate this page into %s."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text for a region that will display translated text.
 msgctxt "translations_module"
 msgid "Translation"
@@ -20242,7 +20774,8 @@ msgstr "Experimenta %1$s para deixar de ver mensagens como esta."
 #. Text for a promotional card that encourages users to try the encrypted AI model whose inference runs in a confidential environment so the model provider cannot access user data. %s is replaced with the model's full display name (e.g. 'GPT-OSS 120B').
 msgctxt "Promotional text for encrypted AI model"
 msgid "Try %s, our first model with zero provider visibility."
-msgstr "Experimenta %1$s, o nosso primeiro modelo sem visibilidade para o fornecedor."
+msgstr ""
+"Experimenta %1$s, o nosso primeiro modelo sem visibilidade para o fornecedor."
 
 # smartling.placeholder_format=C
 msgid "Try %sDuck.ai%s, our private AI chat service:"
@@ -20282,6 +20815,12 @@ msgstr "Tentar novamente"
 msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
 msgstr "Experimentar gratuitamente"
+
+# smartling.placeholder_format=C
+#. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
+msgctxt "settings"
+msgid "Try It Now"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -20347,7 +20886,8 @@ msgstr ""
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
 msgctxt "precise_user_location"
 msgid "Try enabling anonymous location for more accurate results."
-msgstr "Tenta permitir a localização anónima para obter resultados mais específicos."
+msgstr ""
+"Tenta permitir a localização anónima para obter resultados mais específicos."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the screen of the onboarding where the user picks a chat model.
@@ -20480,7 +21020,8 @@ msgstr "Experimenta o novo chat privado de voz em tempo real!"
 #. Text for a promotional card that encourages users to try the recently added open-source AI models. The placeholders are the names of AI models like 'Try the recently added open-source Llama 3.1 and Mistral.'
 msgctxt "Promotional text for new AI models"
 msgid "Try the recently added open-source %s and %s"
-msgstr "Experimenta o %1$s e o %2$s, de código aberto, adicionados recentemente"
+msgstr ""
+"Experimenta o %1$s e o %2$s, de código aberto, adicionados recentemente"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that encourages users to try the recently added open-source AI models Llama 3.1 and Mixtral.
@@ -20522,6 +21063,22 @@ msgstr "Tenta: %1$s"
 msgctxt "new user poll"
 msgid "Trying DuckDuckGo again"
 msgstr "Experimentar outra vez o DuckDuckGo"
+
+# smartling.placeholder_format=C
+#. Message shown in a modal after supported third-party browser users disable AI features in Settings. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -20839,12 +21396,14 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sOpen with%s select %sA specific page or pages%s"
-msgstr "Em %1$s\"Abrir com\"%2$s, seleciona %3$sUma página específica ou várias%4$s"
+msgstr ""
+"Em %1$s\"Abrir com\"%2$s, seleciona %3$sUma página específica ou várias%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
-msgstr "Em %1$sNo arranque > Página inicial%2$s, introduz: https://duckduckgo.com"
+msgstr ""
+"Em %1$sNo arranque > Página inicial%2$s, introduz: https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -21003,7 +21562,8 @@ msgstr "Desbloqueia a IA avançada com a tua subscrição!"
 #. Upsell message shown in the voice chat duration limit modal for free users.
 msgctxt "voice chat duration limit modal"
 msgid "Unlock longer voice chats with a DuckDuckGo Subscription"
-msgstr "Desbloqueia conversas de voz mais longas com uma subscrição da DuckDuckGo"
+msgstr ""
+"Desbloqueia conversas de voz mais longas com uma subscrição da DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Text informing the user that more capable AI models can be unlocked with a subscription, with a trailing call-to-action link. %s is replaced with either the 'Try for free' link (for unauthenticated users) or the 'Learn more' link (for authenticated users). The link opens the subscription modal. Example: Unlock more capable AI models with a DuckDuckGo subscription. Try for free
@@ -21275,6 +21835,12 @@ msgstr "Urdu"
 # smartling.placeholder_format=C
 msgid "Uruguay"
 msgstr "Uruguai"
+
+# smartling.placeholder_format=C
+#. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
+msgctxt "Navigation label on the Duck.ai settings page"
+msgid "Usage"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -21555,7 +22121,8 @@ msgctxt "mobile promotion on desktop"
 msgid ""
 "Visit %sDuckDuckGo.com%s on your tablet or phone and follow the provided "
 "instructions."
-msgstr "Vai a %1$sDuckDuckGo.com%2$s no tablet ou smartphone e segue as instruções."
+msgstr ""
+"Vai a %1$sDuckDuckGo.com%2$s no tablet ou smartphone e segue as instruções."
 
 # smartling.placeholder_format=C
 #. Primary button to visit Duck.ai.
@@ -21724,6 +22291,12 @@ msgid "Wales"
 msgstr "País de Gales"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Walk me through the steps"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for walking directions on a map.
 msgctxt "directions"
 msgid "Walking"
@@ -21841,6 +22414,17 @@ msgid "We can anonymize%s your location%s to show you more accurate results."
 msgstr ""
 "Podemos anonimizar%1$s a tua localização%2$s para te mostrar resultados mais "
 "precisos."
+
+# smartling.placeholder_format=C
+#. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
+msgctxt ""
+"Inline warning shown below the share-content toggle when the user selects "
+"Harmful or Illegal but has not enabled sharing"
+msgid ""
+"We can only fix what we can see. To report a harmful or illegal response, "
+"please share this conversation with DuckDuckGo so we can investigate and "
+"address the issue."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -22211,7 +22795,8 @@ msgstr "Limite semanal atingido"
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Weekly usage limit reached. You can continue this chat after %s."
-msgstr "Limite de utilização semanal atingido. Podes continuar este chat após %1$s."
+msgstr ""
+"Limite de utilização semanal atingido. Podes continuar este chat após %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable weekly Duck.ai usage limit and can opt in to continue using the monthly limit.
@@ -22356,13 +22941,15 @@ msgstr ""
 #. Text for a prompt suggestion for considering factors when purchasing a computer monitor.
 msgctxt "Full sentence for preparing for a purchase"
 msgid "What are some factors to consider when purchasing a computer monitor?"
-msgstr "Quais são alguns fatores a considerar ao comprar um monitor de computador?"
+msgstr ""
+"Quais são alguns fatores a considerar ao comprar um monitor de computador?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for asking about must-see attractions in Paris for a first-time visitor.
 msgctxt "Full sentence for planning a trip"
 msgid "What are some must-see attractions in Paris for a first-time visitor?"
-msgstr "Quais são algumas das atrações imperdíveis em Paris para a primeira visita?"
+msgstr ""
+"Quais são algumas das atrações imperdíveis em Paris para a primeira visita?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for finding options for the word 'better' in a specific context.
@@ -22397,6 +22984,103 @@ msgstr ""
 "integrações do Duck.ai e a proteção da privacidade. Mantém a resposta "
 "bastante curta, simples e fácil de perceber para pessoas com muita ou pouca "
 "experiência em IA ou em questões técnicas."
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the counterarguments?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the hours & location?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key contributions of this paper?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key contributions?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key details?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key points covered in this video?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key points?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key takeaways from this article?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key takeaways?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key things I will learn from this course?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main counterarguments or criticisms of this?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main questions this page answers?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the must-try dishes here?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"What are the opening hours, location, and contact details for this place?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the pros and cons of this product?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the pros and cons?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
@@ -22499,6 +23183,12 @@ msgid "What does atria mean in the context of a medical article?"
 msgstr "O que significa aurícula no contexto de um artigo médico?"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What does this answer?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
@@ -22511,18 +23201,31 @@ msgid "What information gets saved?"
 msgstr "Que informações são guardadas?"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What interview questions might come up for this role?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
 msgid ""
 "What is the Cloud Save bookmarklet and how does it differ from the URL "
 "parameter bookmarklet?"
-msgstr "O que é o marcador Cloud Save e como é que difere do de parâmetros de URL?"
+msgstr ""
+"O que é o marcador Cloud Save e como é que difere do de parâmetros de URL?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for looking up the capital city of Albania.
 msgctxt "Full sentence for looking up basic facts"
 msgid "What is the capital city of Albania?"
 msgstr "Qual é a capital da Albânia?"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What is the overall verdict and rating for this?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to a page with additional information.
@@ -22547,6 +23250,12 @@ msgid "What people say:"
 msgstr "O que as pessoas dizem:"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What should I order?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
 msgctxt "feedback form"
 msgid "What stood out?"
@@ -22559,6 +23268,18 @@ msgid "What was wrong with the response? (optional)"
 msgstr "Qual o problema da resposta? (opcional)"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I learn?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I need?"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid "What would you like to provide feedback on?"
 msgstr "Sobre o que gostarias de dar feedback?"
@@ -22567,13 +23288,20 @@ msgstr "Sobre o que gostarias de dar feedback?"
 #. Explains the benefits of using our custom video player, the Duck Player
 msgid ""
 "What you watch in DuckDuckGo won't influence your recommendations on YouTube."
-msgstr "O que vês no DuckDuckGo não influencia as tuas recomendações no YouTube."
+msgstr ""
+"O que vês no DuckDuckGo não influencia as tuas recomendações no YouTube."
 
 # smartling.placeholder_format=C
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
 msgctxt "SERP footer content"
 msgid "What's New"
 msgstr "Novidades"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What's the verdict?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -22626,6 +23354,12 @@ msgid "Which features are missing? (Optional)"
 msgstr "Que funcionalidades estão em falta? (Opcional)"
 
 # smartling.placeholder_format=C
+#. An invitation for users to leave feedback
+msgctxt "Feedback prompt"
+msgid "Which features are missing? (optional)"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
 msgid "White"
 msgstr "Branco"
@@ -22640,6 +23374,18 @@ msgstr "Branco"
 #. Link to an about us page.
 msgid "Who We Are"
 msgstr "Quem somos"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Who are the main cast and crew, and what else are they known for?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Who is this person?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Header above a collection of privacy-related links.
@@ -23103,7 +23849,8 @@ msgstr ""
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
 msgctxt "Third party map app picker feedback dialog"
 msgid "You can change this any time in %sSearch Settings%s"
-msgstr "Podes alterar isto em qualquer altura nas %1$sDefinições de pesquisa%2$s"
+msgstr ""
+"Podes alterar isto em qualquer altura nas %1$sDefinições de pesquisa%2$s"
 
 # smartling.placeholder_format=C
 #. Text explaning how to change a passphrase.
@@ -23136,7 +23883,8 @@ msgstr "Podes ocultar este lembrete em %1$sDefinições de pesquisa%2$s"
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
-msgstr "Agora podes guardar até 100 chats neste dispositivo. Conversa à vontade!"
+msgstr ""
+"Agora podes guardar até 100 chats neste dispositivo. Conversa à vontade!"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -23402,7 +24150,8 @@ msgstr "Atingiste o limite de chat de voz para hoje. Tente novamente amanhã."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
 msgid "You've reached your dictation usage limit. Try again later."
-msgstr "Atingiste o limite de utilização de ditado. tentar novamente mais tarde"
+msgstr ""
+"Atingiste o limite de utilização de ditado. tentar novamente mais tarde"
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -23627,7 +24376,8 @@ msgctxt "duckai_migration"
 msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
-msgstr "Os teus chats foram importados. Continua a partir de onde ficaste no Duck.ai."
+msgstr ""
+"Os teus chats foram importados. Continua a partir de onde ficaste no Duck.ai."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.
@@ -23826,13 +24576,15 @@ msgctxt "Error message for user limit"
 msgid ""
 "You’ve reached the maximum number of messages for one day. Please continue "
 "this chat tomorrow."
-msgstr "Atingiste o número máximo de mensagens para um dia. Continua o chat amanhã."
+msgstr ""
+"Atingiste o número máximo de mensagens para um dia. Continua o chat amanhã."
 
 # smartling.placeholder_format=C
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
 msgctxt "voice chat limit modal"
 msgid "You’ve reached the voice chat limit for now. Please try again later."
-msgstr "Atingiste o limite do chat de voz por agora. Tenta novamente mais tarde."
+msgstr ""
+"Atingiste o limite do chat de voz por agora. Tenta novamente mais tarde."
 
 # smartling.placeholder_format=C
 #. The name of the Yucatec Maya language
@@ -23915,7 +24667,8 @@ msgstr "por %1$s"
 #. Trust line shown at the bottom of the explainer panel, summarizing DuckDuckGo's reputation for online protection.
 msgctxt "Footer banner text in the How Duck.ai Works panel"
 msgid "by DuckDuckGo — online protection trusted by millions every day."
-msgstr "DuckDuckGo — proteção online em que milhões de pessoas confiam todos os dias."
+msgstr ""
+"DuckDuckGo — proteção online em que milhões de pessoas confiam todos os dias."
 
 # smartling.placeholder_format=C
 #. An abreviated unit of time indicating an age, e.g. "2d"

--- a/locales/ro_RO/LC_MESSAGES/duckduckgo.po
+++ b/locales/ro_RO/LC_MESSAGES/duckduckgo.po
@@ -2,16 +2,15 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: ro_RO\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n==1 ? 0 : (n==0 || (n%100 > 0 && n%100 < "
-"20)) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n==1 ? 0 : (n==0 || (n%100 > 0 && n%100 < 20)) ? 1 : 2;\n"
 
 # smartling.gettext_line_width = normalized : 79
 # smartling.placeholder_format=C
@@ -490,8 +489,7 @@ msgstr ""
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "%sLong-press%s the DuckDuckGo app icon on the home screen"
-msgstr ""
-"%1$sApasă lung%2$s pe pictograma aplicației DuckDuckGo din pagina de pornire"
+msgstr "%1$sApasă lung%2$s pe pictograma aplicației DuckDuckGo din pagina de pornire"
 
 # smartling.placeholder_format=C
 #. A message displayed when there is an error loading content or no results on requery
@@ -1450,7 +1448,7 @@ msgstr "Adresa este incorectă"
 #. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Adjust the servings"
-msgstr ""
+msgstr "Ajustează porțiile"
 
 # smartling.placeholder_format=C
 #. as in multiple advertisements
@@ -1672,6 +1670,9 @@ msgid ""
 "All chats are anonymized by DuckDuckGo, and your conversations are not used "
 "to train chat models by DuckDuckGo or the model providers"
 msgstr ""
+"Toate chaturile sunt anonimizate de DuckDuckGo, iar conversațiile tale nu "
+"sunt folosite pentru a antrena modele de chat de către DuckDuckGo sau "
+"furnizorii de modele"
 
 # smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1926,8 +1927,8 @@ msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
 msgstr ""
-"Acces anonim la modele AI populare, inclusiv %1$s, %2$s și %3$s și %4$s open-"
-"source."
+"Acces anonim la modele AI populare, inclusiv %1$s, %2$s și %3$s și %4$s "
+"open-source."
 
 # smartling.placeholder_format=C
 #. Text with information about Duck.ai and supported AI models, the placeholders list AI models. Example: 'Anonymous access to popular AI models, including GPT, Claude, and open-source Llama and Mistral.'
@@ -1936,8 +1937,8 @@ msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
 msgstr ""
-"Acces anonim la modele AI populare, inclusiv %1$s, %2$s și %3$s și %4$s open-"
-"source."
+"Acces anonim la modele AI populare, inclusiv %1$s, %2$s și %3$s și %4$s "
+"open-source."
 
 # smartling.placeholder_format=C
 #. Confirmation message after location service is enabled.
@@ -1951,6 +1952,8 @@ msgid ""
 "Anonymously generates answers for search queries based on web content. "
 "Choose how often you want it to appear, or disable it completely."
 msgstr ""
+"Generează anonim răspunsuri la interogările de căutare pe baza conținutului "
+"web. Alege cât de des vrei să apară sau dezactivează-l complet."
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -2097,8 +2100,7 @@ msgstr "Ești încă acolo?"
 msgctxt "Body text for clear all chats confirmation modal"
 msgid ""
 "Are you sure you want to clear all of your chats? This cannot be undone."
-msgstr ""
-"Sigur dorești să ștergi toate chaturile tale? Acest lucru nu poate fi anulat."
+msgstr "Sigur dorești să ștergi toate chaturile tale? Acest lucru nu poate fi anulat."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that asks the user if they want to clear the conversation.
@@ -2236,7 +2238,7 @@ msgstr "Adresează o întrebare suplimentară cu Duck.ai"
 #. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
 msgctxt "Page suggestion chip label"
 msgid "Ask about this page"
-msgstr ""
+msgstr "Întreabă despre această pagină"
 
 # smartling.placeholder_format=C
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2418,8 +2420,7 @@ msgstr "Sunetul nu este stocat de noi sau de OpenAI după încheierea chatului."
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat is transcribed."
-msgstr ""
-"Sunetul nu este stocat de noi sau de OpenAI după ce chatul este transcris."
+msgstr "Sunetul nu este stocat de noi sau de OpenAI după ce chatul este transcris."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when MediaRecorder API is unavailable.
@@ -2460,8 +2461,7 @@ msgstr "Răspuns automat"
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid "Auto-generated based on listed sources. May contain inaccuracies."
-msgstr ""
-"Generat automat pe baza surselor menționate. Poate conține inexactități."
+msgstr "Generat automat pe baza surselor menționate. Poate conține inexactități."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
@@ -2660,7 +2660,7 @@ msgstr "Cod de bare"
 #. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Based on this page, is this course worth taking?"
-msgstr ""
+msgstr "Pe baza acestei pagini, merită să urmezi acest curs?"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2709,6 +2709,9 @@ msgid ""
 "Before storing this report, DuckDuckGo will anonymize your conversation by "
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
+"Înainte de a stoca acest raport, DuckDuckGo îți va anonimiza conversația "
+"prin eliminarea informațiilor de identificare personală, cum ar fi numele, "
+"adresele de e-mail și metadatele de identificare."
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -2829,8 +2832,7 @@ msgstr "Blochează ferestrele pop-up enervante privind modulele cookie"
 #. DuckDuckGo Email Protection offers the ability to generate random email addresses to protect your personal email address
 msgctxt "SERP footer content"
 msgid "Block email trackers and hide your address."
-msgstr ""
-"Blochează modulele cookie de urmărire pentru e-mail și ascunde-ți adresa."
+msgstr "Blochează modulele cookie de urmărire pentru e-mail și ascunde-ți adresa."
 
 # smartling.placeholder_format=C
 #. A disclaimer about AI-generated images in search results
@@ -2916,8 +2918,7 @@ msgstr "Blocat:"
 #. shown after the DuckDuckGo extension is installed
 msgctxt "welcome message"
 msgid "Blocks trackers on websites you visit"
-msgstr ""
-"Blochează instrumentele de urmărire pe site-urile web pe care le vizitezi"
+msgstr "Blochează instrumentele de urmărire pe site-urile web pe care le vizitezi"
 
 # smartling.placeholder_format=C
 msgid "Blog"
@@ -3034,7 +3035,7 @@ msgstr "Puncte de break câștigate"
 #. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Break this down into clear, numbered steps."
-msgstr ""
+msgstr "Împarte acest lucru în pași clari, numerotați."
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -3495,7 +3496,7 @@ msgstr "Distribuție"
 #. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Cast & Crew"
-msgstr ""
+msgstr "Distribuție și echipă"
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -3971,8 +3972,7 @@ msgstr ""
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
 msgctxt "noresults"
 msgid "Check the status page for updates on this outage."
-msgstr ""
-"Verifică pagina de stare pentru actualizări despre această întrerupere."
+msgstr "Verifică pagina de stare pentru actualizări despre această întrerupere."
 
 # smartling.placeholder_format=C
 #. Title shown to the host device (the one that is logged in) after it sends the pairing code. The host can't confirm the peer applied it, so this is a title-only screen (no body) prompting the user to finish on the other device.
@@ -4352,8 +4352,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click %sPrivacy and Services%s in the left sidebar."
-msgstr ""
-"Fă click pe %1$sConfidențialitate și Servicii%2$s în bara laterală stângă."
+msgstr "Fă click pe %1$sConfidențialitate și Servicii%2$s în bara laterală stângă."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -4380,8 +4379,7 @@ msgstr "Fă click pe %1$sSetări%2$s în meniul vertical."
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
-msgstr ""
-"Fă click pe %1$sUtilizează paginile curente%2$s apoi %3$sfă click pe OK%4$s."
+msgstr "Fă click pe %1$sUtilizează paginile curente%2$s apoi %3$sfă click pe OK%4$s."
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -4437,8 +4435,7 @@ msgstr "Fă click pe %1$sFurnizori căutare%2$s sub Tipuri Add-on-uri"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click on the %sTools icon%s in the top-right of the browser"
-msgstr ""
-"Fă click pe %1$spictograma Instrumente%2$s din dreapta sus a browserului"
+msgstr "Fă click pe %1$spictograma Instrumente%2$s din dreapta sus a browserului"
 
 #  Firefox default search engine instruction
 # smartling.placeholder_format=C
@@ -4513,8 +4510,7 @@ msgstr "Apasă pe pictograma %1$spermisiuni%2$s din bara de adrese"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to search using DuckDuckGo.
 msgid "Click the Duck icon at the top of your browser to search!"
-msgstr ""
-"Fă click pe pictograma Duck din partea de sus a browserului pentru a căuta!"
+msgstr "Fă click pe pictograma Duck din partea de sus a browserului pentru a căuta!"
 
 #  UC Browser on Android
 # smartling.placeholder_format=C
@@ -4566,8 +4562,7 @@ msgstr "Fă click pe lupa din bara de căutare"
 #. Tells users what icon to click in order to make DuckDuckGo the default engine in their browser.
 msgid ""
 "Click the magnifying glass in the search box (at the top of the browser)"
-msgstr ""
-"Fă click pe lupa din căsuța de căutare (în partea de sus a browserului)"
+msgstr "Fă click pe lupa din căsuța de căutare (în partea de sus a browserului)"
 
 #  IE default search engine instruction
 # smartling.placeholder_format=C
@@ -5173,8 +5168,7 @@ msgstr "Costa Rica"
 #. Inline error shown on the recovery code screen when exportSyncSettings rejects.
 msgctxt "Error message when the recovery code fails to generate"
 msgid "Couldn't load your recovery code. Please close this and try again."
-msgstr ""
-"Codul tău de recuperare nu s-a putut încărca. Închide și încearcă din nou."
+msgstr "Codul tău de recuperare nu s-a putut încărca. Închide și încearcă din nou."
 
 # smartling.placeholder_format=C
 #. Pairs with a Retry button. Shown after two consecutive failed attempts to load the device list.
@@ -5223,7 +5217,7 @@ msgstr "Creează imaginea"
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
-msgstr ""
+msgstr "Creează o listă de cumpărături cu cantități din această rețetă."
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed in the input field when starting a new image generation session.
@@ -5872,7 +5866,7 @@ msgstr "Limita de dictare a fost atinsă"
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
 msgid "Dictation temporarily unavailable"
-msgstr ""
+msgstr "Funcția de dictare este temporar indisponibilă"
 
 # smartling.placeholder_format=C
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
@@ -5961,8 +5955,7 @@ msgstr "Dezactivare și deconectare"
 #. Title of a modal that asks the user if they want to turn off chat history and disconnect from Sync & Backup.
 msgctxt "Modal header for disabling chat history and disconnecting sync"
 msgid "Disable chat history and disconnect from Sync & Backup?"
-msgstr ""
-"Dezactivezi istoricul chaturilor și te deconectezi de la Sync & Backup?"
+msgstr "Dezactivezi istoricul chaturilor și te deconectezi de la Sync & Backup?"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to turn off the chat history feature.
@@ -6182,6 +6175,8 @@ msgid ""
 "Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
 "filtered out. %sLearn More%s"
 msgstr ""
+"Nu vrei IA? %1$snoai.duckduckgo.com%2$s nu oferă funcții IA, iar imaginile "
+"IA sunt filtrate. %3$sAflă mai multe%4$s"
 
 # smartling.placeholder_format=C
 #. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
@@ -6190,6 +6185,8 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
+"Nu vrei IA? Vizitează %1$snoai.duckduckgo.com%2$s pentru a căuta fără "
+"funcții IA și cu imaginile IA filtrate. %3$sAflă mai multe%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6309,13 +6306,13 @@ msgstr ""
 #. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Draft a cover letter"
-msgstr ""
+msgstr "Redactează o scrisoare de intenție"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Draft a cover letter for this job."
-msgstr ""
+msgstr "Redactează o scrisoare de intenție pentru acest job."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -6428,8 +6425,8 @@ msgstr "Duck.ai"
 msgctxt "Text on link to the Duck.ai Privacy Policy & Terms of Service page."
 msgid "Duck.ai Privacy Policy and Terms of Service"
 msgstr ""
-"Politica de confidențialitate și Condițiile de utilizare a serviciului Duck."
-"ai"
+"Politica de confidențialitate și Condițiile de utilizare a serviciului "
+"Duck.ai"
 
 # smartling.placeholder_format=C
 #. Title of the modal that contains settings for Duck.ai.
@@ -6453,8 +6450,7 @@ msgstr "Condiții de utilizare Duck.ai"
 #. The HTML <title> for Duck.ai.
 msgctxt "duckai_seo"
 msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
-msgstr ""
-"Duck.ai de la DuckDuckGo. Chat privat cu inteligență artificială. Gratuit."
+msgstr "Duck.ai de la DuckDuckGo. Chat privat cu inteligență artificială. Gratuit."
 
 # smartling.placeholder_format=C
 #. Description explaining how the page context feature works in Duck.ai sidebar.
@@ -6506,6 +6502,9 @@ msgid ""
 "company for anyone who wants to take back control of their personal "
 "information."
 msgstr ""
+"Duck.ai este creat de DuckDuckGo. Suntem o companie independentă din "
+"domeniul protecției online care se adresează oricărei persoane care dorește "
+"să recâștige controlul asupra informațiilor sale personale."
 
 # smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
@@ -6560,6 +6559,9 @@ msgid ""
 "Duck.ai lets you chat privately with popular AI models. Disabling it hides "
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
+"Duck.ai îți permite să discuți în privat cu modele IA populare. Dezactivarea "
+"acesteia ascunde butoanele și linkurile Duck.ai, dar poți vizita în "
+"continuare %1$sduck.ai%2$s direct."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6808,8 +6810,7 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr ""
-"DuckDuckGo AI Chat este temporar indisponibil. Încearcă din nou mai târziu."
+msgstr "DuckDuckGo AI Chat este temporar indisponibil. Încearcă din nou mai târziu."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -7154,8 +7155,7 @@ msgstr "Se editează imaginea..."
 msgctxt "Info text for the editing message feature"
 msgid ""
 "Editing your message will remove the response below and generate a new one."
-msgstr ""
-"Editarea mesajului tău va elimina răspunsul de mai jos și va genera unul nou."
+msgstr "Editarea mesajului tău va elimina răspunsul de mai jos și va genera unul nou."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of an editor in its responses.
@@ -7454,8 +7454,7 @@ msgstr "Asigură-te că accesul la locație este %1$spermis%2$s."
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed %slocation access%s"
-msgstr ""
-"Asigură-te că browserul tău are permisiunea de a %1$saccesa locația%2$s"
+msgstr "Asigură-te că browserul tău are permisiunea de a %1$saccesa locația%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service.
@@ -7571,13 +7570,13 @@ msgstr "Eritreea"
 #. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Estimate the nutrition"
-msgstr ""
+msgstr "Estimează nutriția"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Estimate the nutritional information for this recipe."
-msgstr ""
+msgstr "Estimează informațiile nutriționale pentru această rețetă."
 
 # smartling.placeholder_format=C
 msgid "Estonia"
@@ -7639,57 +7638,56 @@ msgstr "Expiră peste 1 zi"
 #. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain the accepted answer in simple terms."
-msgstr ""
+msgstr "Explică răspunsul acceptat în termeni simpli."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
-msgstr ""
-"Explică-mi conceptele fundamentale ale găurilor negre la nivel de liceu."
+msgstr "Explică-mi conceptele fundamentale ale găurilor negre la nivel de liceu."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain the top answer"
-msgstr ""
+msgstr "Explică răspunsul de sus"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain this in simple, plain language."
-msgstr ""
+msgstr "Explică asta pe înțelesul tuturor."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain this paper"
-msgstr ""
+msgstr "Explică această lucrare"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain this repo"
-msgstr ""
+msgstr "Explică acest depozit"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain this research paper in plain language."
-msgstr ""
+msgstr "Explică această lucrare de cercetare pe înțelesul tuturor."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain this simply"
-msgstr ""
+msgstr "Explică simplu"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain what this repository does and how to use it."
-msgstr ""
+msgstr "Explică ce face acest depozit și cum să-l folosești."
 
 # smartling.placeholder_format=C
 #. Label to show if song lyrics contain explicit content
@@ -7982,6 +7980,8 @@ msgctxt "settings"
 msgid ""
 "Filters out known AI spam sites from image search results. %sLearn More%s"
 msgstr ""
+"Filtrează site-urile spam cunoscute, bazate pe IA, din rezultatele căutării "
+"de imagini. %1$sAflă mai multe%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the final score of a sporting event.
@@ -8042,7 +8042,7 @@ msgstr "Găsește informații actuale"
 #. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Find me alternatives"
-msgstr ""
+msgstr "Găsește-mi alternative"
 
 # smartling.placeholder_format=C
 #. Button that searches for results closer to the user's current location.
@@ -8240,8 +8240,7 @@ msgstr "Chaturi gratuite și private, anonimizate de noi"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr ""
-"Chaturi gratuite și private, anonimizate de noi. Nu este nevoie de un cont."
+msgstr "Chaturi gratuite și private, anonimizate de noi. Nu este nevoie de un cont."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -8271,8 +8270,7 @@ msgstr "Fără restricții de distrubuire și utilizare comercială"
 #. Description text explaining how to free up sync storage. Pinned chats are chats the user has explicitly marked to keep.
 msgctxt "Sync limit modal description"
 msgid "Free up space by deleting your chats. Pinned chats will not be deleted."
-msgstr ""
-"Eliberează spațiu ștergând chaturile. Chaturile fixate nu vor fi șterse."
+msgstr "Eliberează spațiu ștergând chaturile. Chaturile fixate nu vor fi șterse."
 
 # smartling.placeholder_format=C
 #. Indicates that this streaming service is free to watch but shows ads
@@ -8353,9 +8351,9 @@ msgid ""
 "<strong>Check for Updates...</strong>, then select <strong>Install Update</"
 "strong>."
 msgstr ""
-"Din bara de meniu a aplicației pe Mac, selectează <strong>DuckDuckGo</"
-"strong> &gt; <strong>Caută actualizări...</strong>, apoi selectează "
-"<strong>Instalează actualizările</strong>."
+"Din bara de meniu a aplicației pe Mac, selectează "
+"<strong>DuckDuckGo</strong> &gt; <strong>Caută actualizări...</strong>, apoi "
+"selectează <strong>Instalează actualizările</strong>."
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -8526,7 +8524,7 @@ msgstr "Generează mai mult"
 #. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Generate a shopping list"
-msgstr ""
+msgstr "Generează o listă de cumpărături"
 
 # smartling.placeholder_format=C
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
@@ -8827,14 +8825,13 @@ msgstr "Încearcă"
 #. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Give me a quick background on this person."
-msgstr ""
+msgstr "Dă-mi rapid câteva informații de fundal despre această persoană."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
-msgstr ""
-"Accesează %1$sConfidențialitate și securitate > Servicii de localizare%2$s"
+msgstr "Accesează %1$sConfidențialitate și securitate > Servicii de localizare%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9099,8 +9096,7 @@ msgstr "Guatemala"
 #. Text for a prompt suggestion for guiding through the basic steps of replacing a window wiper.
 msgctxt "Full sentence for learning a new skill"
 msgid "Guide me through the basic steps of replacing a window wiper."
-msgstr ""
-"Ghidează-mă prin pașii de bază ai înlocuirii unui ștergător de ferestre."
+msgstr "Ghidează-mă prin pașii de bază ai înlocuirii unui ștergător de ferestre."
 
 # smartling.placeholder_format=C
 msgid "Guinea"
@@ -9282,13 +9278,13 @@ msgstr "Ajută la promovarea confidențialității"
 #. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Help me prep for the interview"
-msgstr ""
+msgstr "Ajută-mă să mă pregătesc pentru interviu"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Help me tailor my resume for this job."
-msgstr ""
+msgstr "Ajută-mă să-mi adaptez CV-ul pentru acest job."
 
 # smartling.placeholder_format=C
 #. Title of a SERP popup that invites users to take a survey (desktop only)
@@ -9737,8 +9733,7 @@ msgstr "Cât de mult vrei să apară răspunsurile asistate de AI?"
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
 msgctxt "Duck.ai settings usage section"
 msgid "How much of your daily and weekly limits you've used so far."
-msgstr ""
-"Ce proporție din limitele tale zilnice și săptămânale ai utilizat până acum."
+msgstr "Ce proporție din limitele tale zilnice și săptămânale ai utilizat până acum."
 
 # smartling.placeholder_format=C
 #. A header for the feedback form in the assist negative feedback flow. The user is being asked to update how often they want AI-assisted answers to appear.
@@ -9812,7 +9807,7 @@ msgctxt ""
 "Text for the I already have a subscription button in the Duck.ai settings "
 "page"
 msgid "I Already Have a Subscription"
-msgstr ""
+msgstr "Am deja un abonament"
 
 # smartling.placeholder_format=C
 #. Text for the button that takes the user to the login subscription page.
@@ -9980,8 +9975,7 @@ msgstr ""
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
-msgstr ""
-"Dacă încă dorești să ne susții, %1$sajută-ne să promovăm DuckDuckGo%2$s"
+msgstr "Dacă încă dorești să ne susții, %1$sajută-ne să promovăm DuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -10393,7 +10387,7 @@ msgstr "Instalează browserul pentru Mac"
 #. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
 msgctxt "settings"
 msgid "Install Now"
-msgstr ""
+msgstr "Instalează acum"
 
 # smartling.placeholder_format=C
 #. Text of a button to install the DuckDuckGo app
@@ -10496,13 +10490,13 @@ msgstr "Datele șterse sunt cu adevărat șterse?"
 #. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Is it worth taking?"
-msgstr ""
+msgstr "Merită să-l iei?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Is this place any good?"
-msgstr ""
+msgstr "E bun acest loc?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
@@ -10510,7 +10504,7 @@ msgctxt "Page suggestion prompt"
 msgid ""
 "Is this place any good? Summarize its reputation based on reviews and "
 "ratings."
-msgstr ""
+msgstr "E bun acest loc? Rezumă-i reputația pe baza recenziilor și a evaluărilor."
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -10522,13 +10516,13 @@ msgstr "Este de ajutor acest clip?"
 #. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Is this worth watching?"
-msgstr ""
+msgstr "Merită vizionat?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Is this worth watching? Give me a spoiler-free take."
-msgstr ""
+msgstr "Merită vizionat? Dă-mi o părere fără spoilere."
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -11143,6 +11137,8 @@ msgstr "Linkuri:"
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
 msgstr ""
+"Enumeră instrumentele, materialele sau condițiile prealabile de care am "
+"nevoie pentru asta."
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -11253,8 +11249,7 @@ msgstr "Încarcă mai multe imagini rezultate când derulezi"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Loads more results in Images, Videos, and Shopping when scrolling"
-msgstr ""
-"Încarcă mai multe rezultate în imagini, clipuri și cumpărături la derulare"
+msgstr "Încarcă mai multe rezultate în imagini, clipuri și cumpărături la derulare"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/WTkvs9I.png
@@ -11555,7 +11550,7 @@ msgstr "Gestionează site-urile blocate"
 #. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
 msgctxt "setting"
 msgid "Manage in Browser Settings"
-msgstr ""
+msgstr "Gestionează în setările browserului"
 
 # smartling.placeholder_format=C
 #. Link to the site exclusion settings page
@@ -12007,8 +12002,7 @@ msgstr "Limita lunară a fost atinsă"
 #. Displayed when the user has reached a fixed monthly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Monthly usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Limita lunară de utilizare a fost atinsă. Poți continua acest chat după %1$s."
+msgstr "Limita lunară de utilizare a fost atinsă. Poți continua acest chat după %1$s."
 
 # smartling.placeholder_format=C
 #. Used to point to additional social networking profiles (in results).
@@ -12392,8 +12386,7 @@ msgstr "Namibia"
 #. Title of the divisional championship series for the National League division of Major League Baseball
 msgctxt "Sports module"
 msgid "National League Championship Series"
-msgstr ""
-"National League Championship Series (Seria Campionatului Ligii Naționale)"
+msgstr "National League Championship Series (Seria Campionatului Ligii Naționale)"
 
 # smartling.placeholder_format=C
 #. Title of the divisional semi-final series for the National League division of Major League Baseball
@@ -13473,8 +13466,7 @@ msgstr "Deschide website-ul %1$s"
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open %sLocation%s, and ensure location is %senabled%s"
-msgstr ""
-"Deschide %1$sLocație%2$s și asigură-te că locația este %3$sactivată%4$s"
+msgstr "Deschide %1$sLocație%2$s și asigură-te că locația este %3$sactivată%4$s"
 
 #  Chrome/Firefox on Android/iOS
 # smartling.placeholder_format=C
@@ -14395,7 +14387,7 @@ msgstr ""
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is harmful or illegal. (optional)"
-msgstr ""
+msgstr "Descrie de ce răspunsul din chat este dăunător sau ilegal. (opțional)"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
@@ -14432,6 +14424,8 @@ msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is harmful or illegal."
 msgstr ""
+"Lipește solicitarea și rezultatul problematic (cu eventualele informații "
+"personale eliminate) și descrie de ce conținutul este dăunător sau ilegal."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -14904,7 +14898,7 @@ msgstr "Confidențialitate"
 #. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
 msgctxt "Section heading on the Duck.ai settings page"
 msgid "Privacy & Terms"
-msgstr ""
+msgstr "Confidențialitate și condiții"
 
 # smartling.placeholder_format=C
 msgid "Privacy Blog"
@@ -14980,7 +14974,7 @@ msgstr "Politica de confidențialitate și Condițiile de prestare a serviciului
 #. Text for a button that links to the terms of use and privacy policy page.
 msgctxt "Secondary button text in active privacy modal"
 msgid "Privacy Policy and Terms of Service"
-msgstr ""
+msgstr "Politica de confidențialitate și Condițiile de prestare a serviciului"
 
 # smartling.placeholder_format=C
 #. Title displayed on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
@@ -15488,25 +15482,25 @@ msgstr "Recomandă o carte"
 #. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Recommend similar books"
-msgstr ""
+msgstr "Recomandă cărți similare"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Recommend similar books."
-msgstr ""
+msgstr "Recomandă cărți similare."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Recommend similar movies or shows."
-msgstr ""
+msgstr "Recomandă filme sau emisiuni similare."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Recommend similar titles"
-msgstr ""
+msgstr "Recomandă titluri similare"
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
@@ -15732,8 +15726,7 @@ msgstr "Reține alegerea mea"
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings
 msgid "Remember my choice (this can be changed in %s%s%sSettings%s)"
-msgstr ""
-"Ține minte alegerea mea (poate fi modificată în %1$s%2$s%3$sSetări%4$s)"
+msgstr "Ține minte alegerea mea (poate fi modificată în %1$s%2$s%3$sSetări%4$s)"
 
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
@@ -15919,7 +15912,7 @@ msgctxt ""
 "feedback form when the user has selected Harmful or Illegal as the feedback "
 "reason"
 msgid "Required for harmful or illegal reports"
-msgstr ""
+msgstr "Necesar pentru raportările de conținut dăunător sau ilegal"
 
 # smartling.placeholder_format=C
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
@@ -16090,8 +16083,7 @@ msgstr "Rezultatele exclud informațiile de pe site-urile blocate."
 #. Message that appears when results exclude blocked sites
 msgctxt "Blocked sites filter disclaimer"
 msgid "Results exclude your blocked sites, which you can manage in your %s."
-msgstr ""
-"Rezultatele exclud site-urile blocate, pe care le poți gestiona în %1$s."
+msgstr "Rezultatele exclud site-urile blocate, pe care le poți gestiona în %1$s."
 
 # smartling.placeholder_format=C
 #. A label showing the source of the results, e.g. "Results from Reddit"
@@ -16162,7 +16154,7 @@ msgstr "Recenzii"
 #. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Rewrite this recipe scaled for a different number of servings."
-msgstr ""
+msgstr "Rescrie această rețetă adaptată pentru un număr diferit de porții."
 
 # smartling.placeholder_format=C
 msgid "Romania"
@@ -16441,16 +16433,14 @@ msgstr ""
 #. Short text for native DDG browser users explaining how Chat History stores up to 30 of their most recent chats locally on their device.
 msgctxt "Short description for Chat History feature on native DDG browsers"
 msgid "Save up to 30 of your most recent chats locally on your device."
-msgstr ""
-"Salvează local pe dispozitiv până la 30 dintre cele mai recente chaturi."
+msgstr "Salvează local pe dispozitiv până la 30 dintre cele mai recente chaturi."
 
 # smartling.placeholder_format=C
 #. Desktop/mobile intro modal body under the title per Sync Chats Figma (choose step).
 msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
-msgstr ""
-"Salvează-ți chaturile Duck.ai între dispozitive cu criptare end-to-end."
+msgstr "Salvează-ți chaturile Duck.ai între dispozitive cu criptare end-to-end."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -16949,8 +16939,7 @@ msgstr "Săptămâni din sezon"
 #. Description shown in the Sync & Backup settings section when sync is not yet enabled, explaining the feature.
 msgctxt "Description for sync and backup feature"
 msgid "Securely save and sync your chats across all your devices."
-msgstr ""
-"Salvează și sincronizează-ți în siguranță chaturile pe toate dispozitivele."
+msgstr "Salvează și sincronizează-ți în siguranță chaturile pe toate dispozitivele."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17102,8 +17091,7 @@ msgstr "Vezi mai multe pe %1$s"
 # smartling.placeholder_format=C
 #. Title of a notice that DuckDuckGo has noticed the user is blocking its non-tracking ads
 msgid "See more shopping results from popular retailers"
-msgstr ""
-"Vezi mai multe rezultate privind cumpărăturile, de la comercianți populari"
+msgstr "Vezi mai multe rezultate privind cumpărăturile, de la comercianți populari"
 
 # smartling.placeholder_format=C
 #. Text for tooltip shown on hover when displaying the number of reviews the product has on an ad, indicating that users can see more ratings on bing.com
@@ -17121,8 +17109,7 @@ msgstr "Vezi câteva dintre cele mai recente actualizări ale noastre"
 #. Link to a page with more information about how user settings are stored in a URL.
 msgctxt "settings"
 msgid "See the %sURL Parameter Reference page%s for more details."
-msgstr ""
-"Vezi %1$spagina de referință a parametrilor URL%2$s pentru mai multe detalii."
+msgstr "Vezi %1$spagina de referință a parametrilor URL%2$s pentru mai multe detalii."
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the context menu of a chat in chat history, that allows the user to select the chat and begin batch selection mode.
@@ -17149,8 +17136,7 @@ msgstr "Selectează %1$s%2$s%3$s, apoi %4$sMotor de căutare%5$s"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %s'Setting for this Website...'%s from the Safari menu."
-msgstr ""
-"Selectează %1$s„Setare pentru acest site web...”%2$s din meniul Safari."
+msgstr "Selectează %1$s„Setare pentru acest site web...”%2$s din meniul Safari."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -17163,35 +17149,30 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
-msgstr ""
-"Selectează %1$sDuckDuckGo%2$s și fă click pe %3$sAdaugă ca implicit%4$s!"
+msgstr "Selectează %1$sDuckDuckGo%2$s și fă click pe %3$sAdaugă ca implicit%4$s!"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s"
-msgstr ""
-"Selectează %1$sDuckDuckGo%2$s și fă click pe %3$sSetează ca implicit%4$s"
+msgstr "Selectează %1$sDuckDuckGo%2$s și fă click pe %3$sSetează ca implicit%4$s"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s."
-msgstr ""
-"Selectează %1$sDuckDuckGo%2$s și fă click pe %3$sSetează ca implicit%4$s."
+msgstr "Selectează %1$sDuckDuckGo%2$s și fă click pe %3$sSetează ca implicit%4$s."
 
 #  Firefox 33
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Select %sDuckDuckGo%s in the Default Search Engine drop down"
-msgstr ""
-"Selectează %1$sDuckDuckGo%2$s în meniul vertical Motor de căutare implicit"
+msgstr "Selectează %1$sDuckDuckGo%2$s în meniul vertical Motor de căutare implicit"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %sDuckDuckGo%s in the list and %sallow%s location access"
-msgstr ""
-"Selectează %1$sDuckDuckGo%2$s din listă și %3$spermite%4$s accesul la locație"
+msgstr "Selectează %1$sDuckDuckGo%2$s din listă și %3$spermite%4$s accesul la locație"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -17203,8 +17184,7 @@ msgstr "Selectează %1$sDuckDuckGo%2$s din lista de furnizori de căutare"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s under the%sDefault Search Engine%s section"
-msgstr ""
-"Selectează %1$sDuckDuckGo%2$s sub%3$ssecțiunea Motor de căutare implicit%4$s"
+msgstr "Selectează %1$sDuckDuckGo%2$s sub%3$ssecțiunea Motor de căutare implicit%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user were in the settings menu they can change their default search engine.
@@ -17215,8 +17195,7 @@ msgstr "Selectează %1$sDuckDuckGo%2$s!"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Select %sEdit Search Engines...%sin the dropdown"
-msgstr ""
-"Selectează %1$sEditează motoarele de căutare...%2$s din meniul vertical"
+msgstr "Selectează %1$sEditează motoarele de căutare...%2$s din meniul vertical"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -17312,8 +17291,7 @@ msgstr ""
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %syour browser%s in the list and %sallow%s location access"
-msgstr ""
-"Selectează %1$sbrowserul%2$s din listă și %3$spermite%4$s accesul la locație"
+msgstr "Selectează %1$sbrowserul%2$s din listă și %3$spermite%4$s accesul la locație"
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the modal for deleting all recent chats, that allows the user to select the chats to delete.
@@ -17385,8 +17363,7 @@ msgstr "Text selectat din %1$s"
 #. Displayed when the user's text selection exceeds the maximum message size for AI tools (summary, translation, etc.).
 msgctxt "Error message for selection input limit"
 msgid "Selected text is too long. Try again with a shorter selection."
-msgstr ""
-"Textul selectat este prea lung. Încearcă din nou cu o selecție mai scurtă."
+msgstr "Textul selectat este prea lung. Încearcă din nou cu o selecție mai scurtă."
 
 # smartling.placeholder_format=C
 #. Label for the semi-finals knockout stage in e.g. the soccer World Cup
@@ -17511,7 +17488,7 @@ msgstr "Configurează acum"
 #. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
 msgctxt "Encrypted storage setup button shown in native browsers"
 msgid "Set Up Sync & Backup"
-msgstr ""
+msgstr "Configurează Sync & Backup"
 
 # smartling.placeholder_format=C
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
@@ -17701,7 +17678,7 @@ msgstr "Distribuie feedback pozitiv"
 msgctxt ""
 "Label beside the share-content switch on the Duck.ai response feedback form"
 msgid "Share this conversation with DuckDuckGo"
-msgstr ""
+msgstr "Distribuie această conversație cu DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -17840,8 +17817,7 @@ msgstr "Afișează DuckAssist <sup>BETA</sup>"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show DuckAssist more often. (You can also completely %sturn it off%s.)"
-msgstr ""
-"Arată DuckAssist mai des. (De asemenea, îl poți %1$sdezactiva%2$s complet.)"
+msgstr "Arată DuckAssist mai des. (De asemenea, îl poți %1$sdezactiva%2$s complet.)"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
@@ -18089,8 +18065,7 @@ msgstr "Afișează linii orizontale la sfârșitul paginilor de rezultate"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows links to instructions for how to add DuckDuckGo to your browser"
-msgstr ""
-"Afișează linkuri spre instrucțiuni pentru a adăuga DuckDuckGo în browser"
+msgstr "Afișează linkuri spre instrucțiuni pentru a adăuga DuckDuckGo în browser"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers more frequently.
@@ -18244,8 +18219,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Sites you block will be hidden from all your search results"
-msgstr ""
-"Site-urile pe care le blochezi vor fi ascunse din toate rezultatele căutării."
+msgstr "Site-urile pe care le blochezi vor fi ascunse din toate rezultatele căutării."
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes full name (tooltip)
@@ -18390,8 +18364,7 @@ msgstr "Ceva nu a funcționat, te rugăm să încerci din nou."
 #. Body copy displayed under the Set Up Now button when the sync setup call fails.
 msgctxt "Generic error shown when sync setup fails"
 msgid "Something went wrong while enabling Sync & Backup. Please try again."
-msgstr ""
-"A apărut o eroare la activarea funcției Sync & Backup. Încearcă din nou."
+msgstr "A apărut o eroare la activarea funcției Sync & Backup. Încearcă din nou."
 
 # smartling.placeholder_format=C
 #. Displayed when the voice chat session ends with an unknown error.
@@ -18440,8 +18413,7 @@ msgstr "Ne pare rău, a survenit o eroare neașteptată."
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
 msgid "Sorry, no relevant information was found in our search."
-msgstr ""
-"Ne pare rău, nu au fost găsite informații relevante în căutarea noastră."
+msgstr "Ne pare rău, nu au fost găsite informații relevante în căutarea noastră."
 
 # smartling.placeholder_format=C
 #. Indicates that there were no search results for a user's search.
@@ -18490,8 +18462,7 @@ msgstr ""
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr ""
-"Ne pare rău, nu am putut trimite feedbackul tău. Încearcă din nou mai târziu."
+msgstr "Ne pare rău, nu am putut trimite feedbackul tău. Încearcă din nou mai târziu."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -18754,15 +18725,13 @@ msgstr ""
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletters."
-msgstr ""
-"Rămâi protejat și informat cu newsletterele noastre despre confidențialitate."
+msgstr "Rămâi protejat și informat cu newsletterele noastre despre confidențialitate."
 
 # smartling.placeholder_format=C
 #. Text on the page where users can subscribe to DuckDuckGo's privacy newsletter
 msgctxt "showcase_newsletter"
 msgid "Stay protected and informed with our privacy newsletters."
-msgstr ""
-"Rămâi protejat și informat cu newsletterele noastre despre confidențialitate."
+msgstr "Rămâi protejat și informat cu newsletterele noastre despre confidențialitate."
 
 # smartling.placeholder_format=C
 #. Loading message shown when image generation is taking longer than usual.
@@ -18805,8 +18774,7 @@ msgstr "Oprește instrumentele de urmărire ascunse de pe alte site-uri."
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop most hidden trackers lurking on other websites."
-msgstr ""
-"Oprește majoritatea instrumentelor de urmărire ascunse de pe alte site-uri."
+msgstr "Oprește majoritatea instrumentelor de urmărire ascunse de pe alte site-uri."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18980,19 +18948,19 @@ msgstr "Sugerează un titlu pentru o postare pe blog"
 #. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Suggest related articles or topics worth exploring next."
-msgstr ""
+msgstr "Sugerează articole sau subiecte similare care merită explorate în continuare."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Suggest related articles to explore"
-msgstr ""
+msgstr "Sugerează articole conexe de explorat"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Suggest some alternatives to this product."
-msgstr ""
+msgstr "Sugerează câteva alternative pentru acest produs."
 
 # smartling.placeholder_format=C
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
@@ -19009,7 +18977,7 @@ msgstr "Sugestii:"
 #. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Sum up the reviews"
-msgstr ""
+msgstr "Rezumă recenziile"
 
 # smartling.placeholder_format=C
 #. A short title for the a message asking the AI to summarize a text.
@@ -19021,85 +18989,85 @@ msgstr "Rezumă"
 #. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize the Q&As"
-msgstr ""
+msgstr "Rezumă întrebările și răspunsurile"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the background and notable work of this person."
-msgstr ""
+msgstr "Rezumă istoricul și activitatea notabilă a acestei persoane."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the key details of this event."
-msgstr ""
+msgstr "Rezumă principalele detalii ale acestui eveniment."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the questions and answers on this page."
-msgstr ""
+msgstr "Rezumă întrebările și răspunsurile de pe această pagină."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize their background"
-msgstr ""
+msgstr "Rezumă istoricul lor"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this book"
-msgstr ""
+msgstr "Rezumă această carte"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this book."
-msgstr ""
+msgstr "Rezumă această carte."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this discussion"
-msgstr ""
+msgstr "Rezumă această discuție"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this discussion thread."
-msgstr ""
+msgstr "Rezumă acest fir de discuție."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this page"
-msgstr ""
+msgstr "Rezumă această pagină"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this page."
-msgstr ""
+msgstr "Rezumă această pagină."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this video"
-msgstr ""
+msgstr "Rezumă acest videoclip"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this video."
-msgstr ""
+msgstr "Rezumă acest videoclip."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize what the reviews say."
-msgstr ""
+msgstr "Rezumă ce spun recenziile."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -19316,8 +19284,7 @@ msgstr "Sync & Backup activat!"
 #. Notice shown under the recovery code explaining that backup data has an inactivity expiration.
 msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
-msgstr ""
-"Datele Sync & Backup nu pot fi recuperate după 18 luni de inactivitate."
+msgstr "Datele Sync & Backup nu pot fi recuperate după 18 luni de inactivitate."
 
 # smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
@@ -19430,7 +19397,7 @@ msgstr "Siria"
 #. Text for a button that enables the theme to follow the operating system's color scheme preference.
 msgctxt "System theme button for theme selector"
 msgid "System"
-msgstr ""
+msgstr "Sistem"
 
 # smartling.placeholder_format=C
 #. Abbreviation indicating this is the total score for a game
@@ -19464,7 +19431,7 @@ msgstr "Tahitiană"
 #. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Tailor my resume"
-msgstr ""
+msgstr "Adaptează-mi CV-ul"
 
 # smartling.placeholder_format=C
 msgid "Taiwan"
@@ -19501,6 +19468,8 @@ msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
+"Completează acest sondaj anonim pentru a ne spune cum putem îmbunătăți "
+"Duck.ai."
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -19749,8 +19718,7 @@ msgstr "Fișierele atașate depășesc limita totală de %1$s MB."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the server rejects corrupt or unrecognized audio.
 msgid "The audio could not be processed. Please try recording again."
-msgstr ""
-"Materialul audio nu a putut fi prelucrat. Încearcă să înregistrezi din nou."
+msgstr "Materialul audio nu a putut fi prelucrat. Încearcă să înregistrezi din nou."
 
 # smartling.placeholder_format=C
 #. Second paragraph explaining where the encryption key is stored on the entry screen.
@@ -19813,7 +19781,7 @@ msgstr "Temă"
 #. Text for the theme selector label that allows users to switch between Light and dark theme.
 msgctxt "Label for the theme selector feature"
 msgid "Theme"
-msgstr ""
+msgstr "Temă"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/LpFhb1e.png
@@ -19938,8 +19906,7 @@ msgstr ""
 #. Appears below a type of search results called 'Instant Answers'
 msgctxt "attribution"
 msgid "This Instant Answer was made by the %sDuckDuckHack%s Community."
-msgstr ""
-"Acest răspuns instant a fost creat de Comunitatea %1$sDuckDuckHack%2$s."
+msgstr "Acest răspuns instant a fost creat de Comunitatea %1$sDuckDuckHack%2$s."
 
 # smartling.placeholder_format=C
 #. Label for the monthly usage row in the Usage section of Duck.ai settings.
@@ -20003,15 +19970,13 @@ msgstr ""
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
-msgstr ""
-"Fișierul acesta e prea mare. Dimensiunea maximă a fișierului este de %1$s MB"
+msgstr "Fișierul acesta e prea mare. Dimensiunea maximă a fișierului este de %1$s MB"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB."
-msgstr ""
-"Fișierul acesta e prea mare. Dimensiunea maximă a fișierului este de %1$s MB."
+msgstr "Fișierul acesta e prea mare. Dimensiunea maximă a fișierului este de %1$s MB."
 
 # smartling.placeholder_format=C
 #. Generic error message displayed when the user tries to upload an unsupported file type and we cannot determine the accepted types
@@ -20135,8 +20100,7 @@ msgstr "Această pagină necesită JavaScript pentru a funcționa."
 #. Information tooltip text explaining that the current page's content will be included with the chat message.
 msgctxt "Tooltip explaining that page content will be sent to Duck.ai"
 msgid "This page's content will be sent with your message to Duck.ai"
-msgstr ""
-"Conținutul acestei pagini va fi trimis împreună cu mesajul tău către Duck.ai"
+msgstr "Conținutul acestei pagini va fi trimis împreună cu mesajul tău către Duck.ai"
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -20239,8 +20203,7 @@ msgstr ""
 #. Message explaining what will happen when the user deletes an image.
 msgctxt "Confirmation message in delete image modal"
 msgid "This will delete your selected image. This cannot be undone."
-msgstr ""
-"Aceasta va șterge imaginea selectată de tine. Acest lucru nu poate fi anulat."
+msgstr "Aceasta va șterge imaginea selectată de tine. Acest lucru nu poate fi anulat."
 
 # smartling.placeholder_format=C
 #. Confirmation message asking if the user is sure they want to reset all of their settings.
@@ -20376,8 +20339,8 @@ msgid ""
 "To print directions:%sGo back to the map.%sSelect the route you want to "
 "print.%sClick the print icon.%s"
 msgstr ""
-"Pentru a tipări indicații de orientare:%1$sîntoarce-te la hartă."
-"%2$sSelectează ruta pe care dorești să o tipărești.%3$sFă click pe "
+"Pentru a tipări indicații de orientare:%1$sîntoarce-te la "
+"hartă.%2$sSelectează ruta pe care dorești să o tipărești.%3$sFă click pe "
 "pictograma de tipărire.%4$s"
 
 # smartling.placeholder_format=C
@@ -20591,8 +20554,7 @@ msgstr "Instrumente de urmărire blocate în ultima oră"
 #. Placeholder for when we cannot report any blocked trackers yet
 msgctxt "tracker_stats"
 msgid "Trackers that DuckDuckGo blocks will appear here"
-msgstr ""
-"Instrumentele de urmărire pe care DuckDuckGo le blochează vor apărea aici"
+msgstr "Instrumentele de urmărire pe care DuckDuckGo le blochează vor apărea aici"
 
 # smartling.placeholder_format=C
 #. Placeholder for when we cannot report any blocked trackers yet
@@ -20667,13 +20629,13 @@ msgstr ""
 #. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Translate this page"
-msgstr ""
+msgstr "Tradu această pagină"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
 msgctxt "Page suggestion prompt"
 msgid "Translate this page into %s."
-msgstr ""
+msgstr "Tradu această pagină în %1$s."
 
 # smartling.placeholder_format=C
 #. Placeholder text for a region that will display translated text.
@@ -20822,7 +20784,7 @@ msgstr "Încearcă gratuit"
 #. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
 msgctxt "settings"
 msgid "Try It Now"
-msgstr ""
+msgstr "Încearcă acum"
 
 # smartling.placeholder_format=C
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -20925,8 +20887,7 @@ msgstr "Încearcă gratis"
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
-msgstr ""
-"Încearcă gratuit! Un VPN securizat, AI avansată și privată și multe altele."
+msgstr "Încearcă gratuit! Un VPN securizat, AI avansată și privată și multe altele."
 
 # smartling.placeholder_format=C
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -20953,8 +20914,7 @@ msgstr "Încearcă browserul nostru"
 # smartling.placeholder_format=C
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
-msgstr ""
-"Încearcă pagina noastră de pornire care nu afișează niciodată aceste mesaje:"
+msgstr "Încearcă pagina noastră de pornire care nu afișează niciodată aceste mesaje:"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with different words to get more results.
@@ -21071,6 +21031,8 @@ msgid ""
 "Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
+"Încerci să dezactivezi caracteristicile IA? Instalează extensia de căutare "
+"%1$sDuckDuckGo No AI%2$s pentru a-ți reține setările. %3$sAflă mai multe%4$s"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -21079,6 +21041,8 @@ msgid ""
 "Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
+"Încerci să dezactivezi caracteristicile IA? Comută la extensia de căutare "
+"%1$sDuckDuckGo No AI%2$s pentru a-ți reține setările. %3$sAflă mai multe%4$s"
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -21185,8 +21149,7 @@ msgstr "Activează %1$sLocație precisă%2$s pentru rezultate mai precise"
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
-msgstr ""
-"Activează Duck Player pentru a viziona pe YouTube fără reclame direcționate"
+msgstr "Activează Duck Player pentru a viziona pe YouTube fără reclame direcționate"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service.
@@ -21397,14 +21360,12 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sOpen with%s select %sA specific page or pages%s"
-msgstr ""
-"Sub %1$sDeschide cu%2$s selectează %3$sUna sau mai multe pagini specifice%4$s"
+msgstr "Sub %1$sDeschide cu%2$s selectează %3$sUna sau mai multe pagini specifice%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
-msgstr ""
-"Sub %1$sPORNIRE > Pagina de pornire%2$s introdu: https://duckduckgo.com"
+msgstr "Sub %1$sPORNIRE > Pagina de pornire%2$s introdu: https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -21414,8 +21375,7 @@ msgstr "Sub %1$sSetări de căutare%2$s selectează %3$sDuckDuckGo%4$s"
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch in the address bar with%s select %sAdd New%s"
-msgstr ""
-"Sub %1$sCaută în bara de adrese cu%2$s selectează %3$sAdăugare nouă%4$s"
+msgstr "Sub %1$sCaută în bara de adrese cu%2$s selectează %3$sAdăugare nouă%4$s"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -21429,15 +21389,13 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under On startup select %sOpen a specific page or set of pages%s"
-msgstr ""
-"Sub Pornire, selectează %1$sDeschide una sau mai multe pagini specifice%2$s"
+msgstr "Sub Pornire, selectează %1$sDeschide una sau mai multe pagini specifice%2$s"
 
 #  Opera default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine
 msgid "Under Search click the drop down and select %sDuckDuckGo%s"
-msgstr ""
-"Sub Căutare, fă click pe meniul vertical și selectează %1$sDuckDuckGo%2$s"
+msgstr "Sub Căutare, fă click pe meniul vertical și selectează %1$sDuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings" header
@@ -21843,7 +21801,7 @@ msgstr "Uruguay"
 #. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
 msgctxt "Navigation label on the Duck.ai settings page"
 msgid "Usage"
-msgstr ""
+msgstr "Utilizare"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -21887,9 +21845,9 @@ msgid ""
 "Use ChatGPT, Claude, and other AIs, privately. Protect chats from hackers, "
 "scammers, and companies. Keep info confidential. Free. No account required."
 msgstr ""
-"Folosește ChatGPT, Claude și alte platforme de IA, în mod privat. Protejează-"
-"ți chaturile împotriva hackerilor, a escrocilor și a companiilor. Păstrează "
-"informațiile confidențiale. Gratuit. Nu este nevoie de un cont."
+"Folosește ChatGPT, Claude și alte platforme de IA, în mod privat. "
+"Protejează-ți chaturile împotriva hackerilor, a escrocilor și a companiilor. "
+"Păstrează informațiile confidențiale. Gratuit. Nu este nevoie de un cont."
 
 # smartling.placeholder_format=C
 #. Header above instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -22303,7 +22261,7 @@ msgstr "Țara Galilor"
 #. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Walk me through the steps"
-msgstr ""
+msgstr "Ghidează-mă prin pași"
 
 # smartling.placeholder_format=C
 #. Label for walking directions on a map.
@@ -22420,8 +22378,7 @@ msgstr "Anonimizăm"
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
-msgstr ""
-"Putem anonimiza%1$s locația ta%2$s pentru a-ți afișa rezultate mai precise."
+msgstr "Putem anonimiza%1$s locația ta%2$s pentru a-ți afișa rezultate mai precise."
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
@@ -22433,6 +22390,9 @@ msgid ""
 "please share this conversation with DuckDuckGo so we can investigate and "
 "address the issue."
 msgstr ""
+"Putem remedia doar ceea ce putem vedea. Pentru a raporta un răspuns dăunător "
+"sau ilegal, distribuie această conversație cu DuckDuckGo, astfel încât să "
+"putem investiga și remedia problema."
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -22565,8 +22525,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don’t track you in or out of private browsing mode."
-msgstr ""
-"Noi nu te monitorizăm în interiorul sau în afara modului de navigare privată."
+msgstr "Noi nu te monitorizăm în interiorul sau în afara modului de navigare privată."
 
 # smartling.placeholder_format=C
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with an Agree button is shown below.
@@ -22580,8 +22539,7 @@ msgstr ""
 #. Displayed when the user's voice chat session is ended because of being inactive for too long.
 msgctxt "voice chat error"
 msgid "We ended the chat due to inactivity. Want to try again?"
-msgstr ""
-"Am încheiat chatul din cauza inactivității. Dorești să încerci din nou?"
+msgstr "Am încheiat chatul din cauza inactivității. Dorești să încerci din nou?"
 
 # smartling.placeholder_format=C
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
@@ -22641,8 +22599,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We stop anyone from getting your search history, including us."
-msgstr ""
-"Împiedicăm pe oricine, inclusiv pe noi, să obțină istoricul căutărilor tale."
+msgstr "Împiedicăm pe oricine, inclusiv pe noi, să obțină istoricul căutărilor tale."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -22931,8 +22888,8 @@ msgid ""
 "We’re really sorry, but it seems there was a problem loading Duck.ai. Try "
 "reloading the page."
 msgstr ""
-"Ne pare foarte rău, dar se pare că a apărut o problemă la încărcarea Duck."
-"ai. Încearcă să reîncarci pagina."
+"Ne pare foarte rău, dar se pare că a apărut o problemă la încărcarea "
+"Duck.ai. Încearcă să reîncarci pagina."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to suggest an AI (Artificial Intelligence) model to be added to the product, and this field is optional.
@@ -22995,88 +22952,88 @@ msgid ""
 msgstr ""
 "Care sunt beneficiile descărcării browserului DuckDuckGo pentru tine, dacă "
 "vrei să folosești Duck.ai? Citește doar surse oficiale DuckDuckGo. Împarte "
-"răspunsul în secțiuni clare cu titluri, concentrându-te pe integrările Duck."
-"ai și pe protecția confidențialității. Păstrează-l destul de scurt, simplu "
-"și ușor de înțeles pentru cei care au (sau nu) experiență în IA sau în "
-"domeniul tehnic."
+"răspunsul în secțiuni clare cu titluri, concentrându-te pe integrările "
+"Duck.ai și pe protecția confidențialității. Păstrează-l destul de scurt, "
+"simplu și ușor de înțeles pentru cei care au (sau nu) experiență în IA sau "
+"în domeniul tehnic."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the counterarguments?"
-msgstr ""
+msgstr "Care sunt contraargumentele?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the hours & location?"
-msgstr ""
+msgstr "Care sunt programul și locația?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key contributions of this paper?"
-msgstr ""
+msgstr "Care sunt contribuțiile principale ale acestei lucrări?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key contributions?"
-msgstr ""
+msgstr "Care sunt principalele contribuții?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key details?"
-msgstr ""
+msgstr "Care sunt detaliile principale?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key points covered in this video?"
-msgstr ""
+msgstr "Care sunt punctele principale acoperite în acest videoclip?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key points?"
-msgstr ""
+msgstr "Care sunt punctele principale?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key takeaways from this article?"
-msgstr ""
+msgstr "Care sunt principalele idei ale acestui articol?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key takeaways?"
-msgstr ""
+msgstr "Care sunt ideile principale?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key things I will learn from this course?"
-msgstr ""
+msgstr "Care sunt principalele lucruri pe care le voi învăța din acest curs?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the main counterarguments or criticisms of this?"
-msgstr ""
+msgstr "Care sunt principalele contraargumente sau critici la adresa acestui lucru?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the main questions this page answers?"
-msgstr ""
+msgstr "Care sunt principalele întrebări la care răspunde această pagină?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the must-try dishes here?"
-msgstr ""
+msgstr "Care sunt preparatele pe care trebuie să le încerc aici?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
@@ -23084,18 +23041,20 @@ msgctxt "Page suggestion prompt"
 msgid ""
 "What are the opening hours, location, and contact details for this place?"
 msgstr ""
+"Care sunt programul de funcționare, locația și detaliile de contact pentru "
+"acest loc?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the pros and cons of this product?"
-msgstr ""
+msgstr "Care sunt argumentele pro și contra pentru acest produs?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the pros and cons?"
-msgstr ""
+msgstr "Care sunt argumentele pro și contra?"
 
 # smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
@@ -23201,7 +23160,7 @@ msgstr "Ce înseamnă „atrii” în contextul unui articol medical?"
 #. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What does this answer?"
-msgstr ""
+msgstr "La ce răspunde aceasta?"
 
 # smartling.placeholder_format=C
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
@@ -23219,7 +23178,7 @@ msgstr "Ce informație se salvează?"
 #. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What interview questions might come up for this role?"
-msgstr ""
+msgstr "Ce întrebări de interviu ar putea apărea pentru acest post?"
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -23228,8 +23187,8 @@ msgid ""
 "What is the Cloud Save bookmarklet and how does it differ from the URL "
 "parameter bookmarklet?"
 msgstr ""
-"Ce este bookmarklet-ul Cloud Save și cum se diferențiază el de bookmarklet-"
-"ul cu parametri URL?"
+"Ce este bookmarklet-ul Cloud Save și cum se diferențiază el de "
+"bookmarklet-ul cu parametri URL?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for looking up the capital city of Albania.
@@ -23241,7 +23200,7 @@ msgstr "Care este capitala Albaniei?"
 #. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What is the overall verdict and rating for this?"
-msgstr ""
+msgstr "Care este verdictul și evaluarea generală pentru acest lucru?"
 
 # smartling.placeholder_format=C
 #. Link to a page with additional information.
@@ -23269,7 +23228,7 @@ msgstr "Ce spun oamenii:"
 #. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What should I order?"
-msgstr ""
+msgstr "Ce ar trebui să comand?"
 
 # smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
@@ -23287,13 +23246,13 @@ msgstr "Ce a fost în neregulă cu răspunsul? (opțional)"
 #. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What will I learn?"
-msgstr ""
+msgstr "Ce voi învăța?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What will I need?"
-msgstr ""
+msgstr "De ce am nevoie?"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -23318,7 +23277,7 @@ msgstr "Noutăți"
 #. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What's the verdict?"
-msgstr ""
+msgstr "Care e verdictul?"
 
 # smartling.placeholder_format=C
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -23338,8 +23297,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "When enabled, Duck.ai will show instant answers in the chat."
-msgstr ""
-"Când este activat, Duck.ai va afișa răspunsuri instantanee în conversație."
+msgstr "Când este activat, Duck.ai va afișa răspunsuri instantanee în conversație."
 
 # smartling.placeholder_format=C
 #. Text of a button that performs a search for the available streaming services that show a particular movie or tv show
@@ -23357,8 +23315,7 @@ msgstr "Unde să urmărești <strong>%1$s</strong>"
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Where it says Homepage click %sSet to Current Page%s."
-msgstr ""
-"Fă click pe %1$sSetează ca pagină curentă%2$s unde scrie Pagină de pornire."
+msgstr "Fă click pe %1$sSetează ca pagină curentă%2$s unde scrie Pagină de pornire."
 
 # smartling.placeholder_format=C
 #. Heading of a module showing what streaming services are showing a movie or series, e.g. Where to Watch The Matrix
@@ -23376,7 +23333,7 @@ msgstr "Ce funcții lipsesc? (Opțional)"
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Which features are missing? (optional)"
-msgstr ""
+msgstr "Ce funcții lipsesc? (opțional)"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
@@ -23399,12 +23356,14 @@ msgstr "Cine suntem noi"
 msgctxt "Page suggestion prompt"
 msgid "Who are the main cast and crew, and what else are they known for?"
 msgstr ""
+"Cine sunt principalii actori și membri ai echipei de producție și pentru ce "
+"altceva mai sunt cunoscuți?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Who is this person?"
-msgstr ""
+msgstr "Cine este această persoană?"
 
 # smartling.placeholder_format=C
 #. Header above a collection of privacy-related links.
@@ -24145,8 +24104,7 @@ msgctxt "Error message for user limit"
 msgid ""
 "You've reached the maximum number of messages for the moment. Please try "
 "again later."
-msgstr ""
-"Pentru moment, ai atins numărul maxim de mesaje. Încearcă din nou mai târziu."
+msgstr "Pentru moment, ai atins numărul maxim de mesaje. Încearcă din nou mai târziu."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -24173,8 +24131,8 @@ msgid ""
 "You've run out of Sync & Backup storage for Duck.ai chats with attachments. "
 "Delete the %s oldest chats to resume Sync. Pinned chats will not be deleted."
 msgstr ""
-"Ai rămas fără spațiu de stocare pentru Sync & Backup pentru chaturile Duck."
-"ai cu atașări. Șterge cele mai vechi %1$s chaturi pentru a relua "
+"Ai rămas fără spațiu de stocare pentru Sync & Backup pentru chaturile "
+"Duck.ai cu atașări. Șterge cele mai vechi %1$s chaturi pentru a relua "
 "sincronizarea. Chaturile fixate nu vor fi șterse."
 
 # smartling.placeholder_format=C
@@ -24389,8 +24347,7 @@ msgctxt "duckai_migration"
 msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
-msgstr ""
-"Chaturile tale au fost importate. Continuă de unde ai rămas în Duck.ai."
+msgstr "Chaturile tale au fost importate. Continuă de unde ai rămas în Duck.ai."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.
@@ -24437,8 +24394,7 @@ msgctxt ""
 "Subtitle of the one-time popover shown above the thumbs up/down buttons on "
 "an AI response"
 msgid "Your feedback is anonymized and not used to train AI."
-msgstr ""
-"Feedbackul tău este anonimizat și nu este folosit pentru antrenarea IA."
+msgstr "Feedbackul tău este anonimizat și nu este folosit pentru antrenarea IA."
 
 # smartling.placeholder_format=C
 #. Explains that the User's Location is always private to DuckDuckGo.
@@ -24591,15 +24547,13 @@ msgctxt "Error message for user limit"
 msgid ""
 "You’ve reached the maximum number of messages for one day. Please continue "
 "this chat tomorrow."
-msgstr ""
-"Ai atins numărul maxim de mesaje pentru o zi. Continuă acest chat mâine."
+msgstr "Ai atins numărul maxim de mesaje pentru o zi. Continuă acest chat mâine."
 
 # smartling.placeholder_format=C
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
 msgctxt "voice chat limit modal"
 msgid "You’ve reached the voice chat limit for now. Please try again later."
-msgstr ""
-"Ai atins limita de chat vocal pentru moment. Încearcă din nou mai târziu."
+msgstr "Ai atins limita de chat vocal pentru moment. Încearcă din nou mai târziu."
 
 # smartling.placeholder_format=C
 #. The name of the Yucatec Maya language

--- a/locales/ro_RO/LC_MESSAGES/duckduckgo.po
+++ b/locales/ro_RO/LC_MESSAGES/duckduckgo.po
@@ -2,15 +2,16 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: ro_RO\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n==1 ? 0 : (n==0 || (n%100 > 0 && n%100 < 20)) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n==1 ? 0 : (n==0 || (n%100 > 0 && n%100 < "
+"20)) ? 1 : 2;\n"
 
 # smartling.gettext_line_width = normalized : 79
 # smartling.placeholder_format=C
@@ -489,7 +490,8 @@ msgstr ""
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "%sLong-press%s the DuckDuckGo app icon on the home screen"
-msgstr "%1$sApasă lung%2$s pe pictograma aplicației DuckDuckGo din pagina de pornire"
+msgstr ""
+"%1$sApasă lung%2$s pe pictograma aplicației DuckDuckGo din pagina de pornire"
 
 # smartling.placeholder_format=C
 #. A message displayed when there is an error loading content or no results on requery
@@ -1445,6 +1447,12 @@ msgid "Address is incorrect"
 msgstr "Adresa este incorectă"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Adjust the servings"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. as in multiple advertisements
 msgid "Ads"
 msgstr "Reclame"
@@ -1656,6 +1664,14 @@ msgstr "Toate chaturile sunt %1$s. IA poate face greșeli."
 msgctxt "Empty state heading in Duck.ai chat mode"
 msgid "All chats are %sprivate%s"
 msgstr "Toate chaturile sunt %1$sprivate%2$s"
+
+# smartling.placeholder_format=C
+#. Paragraph in the Privacy & Terms section of the About & Legal page in Duck.ai settings, summarizing how chats are anonymized and are not stored or used to train chat models.
+msgctxt "Privacy & Terms section description on the Duck.ai settings page"
+msgid ""
+"All chats are anonymized by DuckDuckGo, and your conversations are not used "
+"to train chat models by DuckDuckGo or the model providers"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1910,8 +1926,8 @@ msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
 msgstr ""
-"Acces anonim la modele AI populare, inclusiv %1$s, %2$s și %3$s și %4$s "
-"open-source."
+"Acces anonim la modele AI populare, inclusiv %1$s, %2$s și %3$s și %4$s open-"
+"source."
 
 # smartling.placeholder_format=C
 #. Text with information about Duck.ai and supported AI models, the placeholders list AI models. Example: 'Anonymous access to popular AI models, including GPT, Claude, and open-source Llama and Mistral.'
@@ -1920,14 +1936,21 @@ msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
 msgstr ""
-"Acces anonim la modele AI populare, inclusiv %1$s, %2$s și %3$s și %4$s "
-"open-source."
+"Acces anonim la modele AI populare, inclusiv %1$s, %2$s și %3$s și %4$s open-"
+"source."
 
 # smartling.placeholder_format=C
 #. Confirmation message after location service is enabled.
 msgctxt "precise_user_location"
 msgid "Anonymous location enabled"
 msgstr "Locație anonimă activată"
+
+# smartling.placeholder_format=C
+msgctxt "settings"
+msgid ""
+"Anonymously generates answers for search queries based on web content. "
+"Choose how often you want it to appear, or disable it completely."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -2074,7 +2097,8 @@ msgstr "Ești încă acolo?"
 msgctxt "Body text for clear all chats confirmation modal"
 msgid ""
 "Are you sure you want to clear all of your chats? This cannot be undone."
-msgstr "Sigur dorești să ștergi toate chaturile tale? Acest lucru nu poate fi anulat."
+msgstr ""
+"Sigur dorești să ștergi toate chaturile tale? Acest lucru nu poate fi anulat."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that asks the user if they want to clear the conversation.
@@ -2207,6 +2231,12 @@ msgstr "Pune o întrebare suplimentară"
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse
 msgid "Ask a follow-up with Duck.ai"
 msgstr "Adresează o întrebare suplimentară cu Duck.ai"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
+msgctxt "Page suggestion chip label"
+msgid "Ask about this page"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2388,7 +2418,8 @@ msgstr "Sunetul nu este stocat de noi sau de OpenAI după încheierea chatului."
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat is transcribed."
-msgstr "Sunetul nu este stocat de noi sau de OpenAI după ce chatul este transcris."
+msgstr ""
+"Sunetul nu este stocat de noi sau de OpenAI după ce chatul este transcris."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when MediaRecorder API is unavailable.
@@ -2429,7 +2460,8 @@ msgstr "Răspuns automat"
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid "Auto-generated based on listed sources. May contain inaccuracies."
-msgstr "Generat automat pe baza surselor menționate. Poate conține inexactități."
+msgstr ""
+"Generat automat pe baza surselor menționate. Poate conține inexactități."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
@@ -2625,6 +2657,12 @@ msgid "Barcode"
 msgstr "Cod de bare"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Based on this page, is this course worth taking?"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Basic"
 msgstr "Primar"
@@ -2663,6 +2701,14 @@ msgstr "Jucător cu bâta"
 msgctxt "Assistant response placeholder"
 msgid "Before continuing..."
 msgstr "Înainte de a continua..."
+
+# smartling.placeholder_format=C
+#. Explains that before storing the report, DuckDuckGo will anonymize the conversation by removing PII like names, email addresses, and identifying metadata.
+msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
+msgid ""
+"Before storing this report, DuckDuckGo will anonymize your conversation by "
+"removing PII like names, email addresses, and identifying metadata."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -2783,7 +2829,8 @@ msgstr "Blochează ferestrele pop-up enervante privind modulele cookie"
 #. DuckDuckGo Email Protection offers the ability to generate random email addresses to protect your personal email address
 msgctxt "SERP footer content"
 msgid "Block email trackers and hide your address."
-msgstr "Blochează modulele cookie de urmărire pentru e-mail și ascunde-ți adresa."
+msgstr ""
+"Blochează modulele cookie de urmărire pentru e-mail și ascunde-ți adresa."
 
 # smartling.placeholder_format=C
 #. A disclaimer about AI-generated images in search results
@@ -2869,7 +2916,8 @@ msgstr "Blocat:"
 #. shown after the DuckDuckGo extension is installed
 msgctxt "welcome message"
 msgid "Blocks trackers on websites you visit"
-msgstr "Blochează instrumentele de urmărire pe site-urile web pe care le vizitezi"
+msgstr ""
+"Blochează instrumentele de urmărire pe site-urile web pe care le vizitezi"
 
 # smartling.placeholder_format=C
 msgid "Blog"
@@ -2981,6 +3029,12 @@ msgstr "Brazilia"
 msgctxt "Sports module"
 msgid "Break Points Won"
 msgstr "Puncte de break câștigate"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Break this down into clear, numbered steps."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -3436,6 +3490,12 @@ msgstr "Cariere"
 msgctxt "Movie/TV Show Title instant answer"
 msgid "Cast"
 msgstr "Distribuție"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Cast & Crew"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -3911,7 +3971,8 @@ msgstr ""
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
 msgctxt "noresults"
 msgid "Check the status page for updates on this outage."
-msgstr "Verifică pagina de stare pentru actualizări despre această întrerupere."
+msgstr ""
+"Verifică pagina de stare pentru actualizări despre această întrerupere."
 
 # smartling.placeholder_format=C
 #. Title shown to the host device (the one that is logged in) after it sends the pairing code. The host can't confirm the peer applied it, so this is a title-only screen (no body) prompting the user to finish on the other device.
@@ -4291,7 +4352,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click %sPrivacy and Services%s in the left sidebar."
-msgstr "Fă click pe %1$sConfidențialitate și Servicii%2$s în bara laterală stângă."
+msgstr ""
+"Fă click pe %1$sConfidențialitate și Servicii%2$s în bara laterală stângă."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -4318,7 +4380,8 @@ msgstr "Fă click pe %1$sSetări%2$s în meniul vertical."
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
-msgstr "Fă click pe %1$sUtilizează paginile curente%2$s apoi %3$sfă click pe OK%4$s."
+msgstr ""
+"Fă click pe %1$sUtilizează paginile curente%2$s apoi %3$sfă click pe OK%4$s."
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -4374,7 +4437,8 @@ msgstr "Fă click pe %1$sFurnizori căutare%2$s sub Tipuri Add-on-uri"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click on the %sTools icon%s in the top-right of the browser"
-msgstr "Fă click pe %1$spictograma Instrumente%2$s din dreapta sus a browserului"
+msgstr ""
+"Fă click pe %1$spictograma Instrumente%2$s din dreapta sus a browserului"
 
 #  Firefox default search engine instruction
 # smartling.placeholder_format=C
@@ -4449,7 +4513,8 @@ msgstr "Apasă pe pictograma %1$spermisiuni%2$s din bara de adrese"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to search using DuckDuckGo.
 msgid "Click the Duck icon at the top of your browser to search!"
-msgstr "Fă click pe pictograma Duck din partea de sus a browserului pentru a căuta!"
+msgstr ""
+"Fă click pe pictograma Duck din partea de sus a browserului pentru a căuta!"
 
 #  UC Browser on Android
 # smartling.placeholder_format=C
@@ -4501,7 +4566,8 @@ msgstr "Fă click pe lupa din bara de căutare"
 #. Tells users what icon to click in order to make DuckDuckGo the default engine in their browser.
 msgid ""
 "Click the magnifying glass in the search box (at the top of the browser)"
-msgstr "Fă click pe lupa din căsuța de căutare (în partea de sus a browserului)"
+msgstr ""
+"Fă click pe lupa din căsuța de căutare (în partea de sus a browserului)"
 
 #  IE default search engine instruction
 # smartling.placeholder_format=C
@@ -5107,7 +5173,8 @@ msgstr "Costa Rica"
 #. Inline error shown on the recovery code screen when exportSyncSettings rejects.
 msgctxt "Error message when the recovery code fails to generate"
 msgid "Couldn't load your recovery code. Please close this and try again."
-msgstr "Codul tău de recuperare nu s-a putut încărca. Închide și încearcă din nou."
+msgstr ""
+"Codul tău de recuperare nu s-a putut încărca. Închide și încearcă din nou."
 
 # smartling.placeholder_format=C
 #. Pairs with a Retry button. Shown after two consecutive failed attempts to load the device list.
@@ -5151,6 +5218,12 @@ msgstr "Creează imaginea"
 msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr "Creează imaginea"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Create a shopping list with quantities from this recipe."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed in the input field when starting a new image generation session.
@@ -5797,6 +5870,11 @@ msgid "Dictation limit reached"
 msgstr "Limita de dictare a fost atinsă"
 
 # smartling.placeholder_format=C
+#. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
+msgid "Dictation temporarily unavailable"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
@@ -5883,7 +5961,8 @@ msgstr "Dezactivare și deconectare"
 #. Title of a modal that asks the user if they want to turn off chat history and disconnect from Sync & Backup.
 msgctxt "Modal header for disabling chat history and disconnecting sync"
 msgid "Disable chat history and disconnect from Sync & Backup?"
-msgstr "Dezactivezi istoricul chaturilor și te deconectezi de la Sync & Backup?"
+msgstr ""
+"Dezactivezi istoricul chaturilor și te deconectezi de la Sync & Backup?"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to turn off the chat history feature.
@@ -6097,6 +6176,22 @@ msgid "Done"
 msgstr "Terminat"
 
 # smartling.placeholder_format=C
+#. Message shown in a modal after DuckDuckGo browser users disable AI features in Settings. The first two placeholders bold noai.duckduckgo.com. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
+"filtered out. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
+"and AI images filtered out. %sLearn more%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Double Faults"
@@ -6211,6 +6306,18 @@ msgstr ""
 "solicită o ofertă de preț pentru servicii de reparații de frigidere casnice."
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Draft a cover letter"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Draft a cover letter for this job."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
 msgctxt "Full sentence for drafting a social media post"
 msgid ""
@@ -6321,8 +6428,8 @@ msgstr "Duck.ai"
 msgctxt "Text on link to the Duck.ai Privacy Policy & Terms of Service page."
 msgid "Duck.ai Privacy Policy and Terms of Service"
 msgstr ""
-"Politica de confidențialitate și Condițiile de utilizare a serviciului "
-"Duck.ai"
+"Politica de confidențialitate și Condițiile de utilizare a serviciului Duck."
+"ai"
 
 # smartling.placeholder_format=C
 #. Title of the modal that contains settings for Duck.ai.
@@ -6346,7 +6453,8 @@ msgstr "Condiții de utilizare Duck.ai"
 #. The HTML <title> for Duck.ai.
 msgctxt "duckai_seo"
 msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
-msgstr "Duck.ai de la DuckDuckGo. Chat privat cu inteligență artificială. Gratuit."
+msgstr ""
+"Duck.ai de la DuckDuckGo. Chat privat cu inteligență artificială. Gratuit."
 
 # smartling.placeholder_format=C
 #. Description explaining how the page context feature works in Duck.ai sidebar.
@@ -6389,6 +6497,15 @@ msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
 msgstr ""
 "Duck.ai funcționează cel mai bine în browserul nostru privat și gratuit "
 "DuckDuckGo!"
+
+# smartling.placeholder_format=C
+#. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
+msgctxt "About section description on the Duck.ai settings page"
+msgid ""
+"Duck.ai is created by DuckDuckGo. We're an independent online protection "
+"company for anyone who wants to take back control of their personal "
+"information."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
@@ -6436,6 +6553,13 @@ msgstr ""
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
 msgstr "Duck.ai este temporar indisponibil. Încearcă din nou mai târziu."
+
+# smartling.placeholder_format=C
+msgctxt "settings"
+msgid ""
+"Duck.ai lets you chat privately with popular AI models. Disabling it hides "
+"Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6684,7 +6808,8 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr "DuckDuckGo AI Chat este temporar indisponibil. Încearcă din nou mai târziu."
+msgstr ""
+"DuckDuckGo AI Chat este temporar indisponibil. Încearcă din nou mai târziu."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -7029,7 +7154,8 @@ msgstr "Se editează imaginea..."
 msgctxt "Info text for the editing message feature"
 msgid ""
 "Editing your message will remove the response below and generate a new one."
-msgstr "Editarea mesajului tău va elimina răspunsul de mai jos și va genera unul nou."
+msgstr ""
+"Editarea mesajului tău va elimina răspunsul de mai jos și va genera unul nou."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of an editor in its responses.
@@ -7328,7 +7454,8 @@ msgstr "Asigură-te că accesul la locație este %1$spermis%2$s."
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed %slocation access%s"
-msgstr "Asigură-te că browserul tău are permisiunea de a %1$saccesa locația%2$s"
+msgstr ""
+"Asigură-te că browserul tău are permisiunea de a %1$saccesa locația%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service.
@@ -7441,6 +7568,18 @@ msgid "Eritrea"
 msgstr "Eritreea"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Estimate the nutrition"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Estimate the nutritional information for this recipe."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Estonia"
 msgstr "Estonia"
 
@@ -7497,11 +7636,60 @@ msgid "Expires in 1 day"
 msgstr "Expiră peste 1 zi"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain the accepted answer in simple terms."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
-msgstr "Explică-mi conceptele fundamentale ale găurilor negre la nivel de liceu."
+msgstr ""
+"Explică-mi conceptele fundamentale ale găurilor negre la nivel de liceu."
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain the top answer"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this in simple, plain language."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this paper"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this repo"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this research paper in plain language."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this simply"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain what this repository does and how to use it."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label to show if song lyrics contain explicit content
@@ -7790,6 +7978,12 @@ msgstr ""
 "%1$sAflă mai multe%2$s"
 
 # smartling.placeholder_format=C
+msgctxt "settings"
+msgid ""
+"Filters out known AI spam sites from image search results. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the final score of a sporting event.
 msgid "Final"
 msgstr "Final"
@@ -7843,6 +8037,12 @@ msgstr "Găsește un cuvânt mai bun"
 msgctxt "Subtitle for the Web Search tool entry in the Tools dropdown menu"
 msgid "Find current information"
 msgstr "Găsește informații actuale"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Find me alternatives"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button that searches for results closer to the user's current location.
@@ -8040,7 +8240,8 @@ msgstr "Chaturi gratuite și private, anonimizate de noi"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr "Chaturi gratuite și private, anonimizate de noi. Nu este nevoie de un cont."
+msgstr ""
+"Chaturi gratuite și private, anonimizate de noi. Nu este nevoie de un cont."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -8070,7 +8271,8 @@ msgstr "Fără restricții de distrubuire și utilizare comercială"
 #. Description text explaining how to free up sync storage. Pinned chats are chats the user has explicitly marked to keep.
 msgctxt "Sync limit modal description"
 msgid "Free up space by deleting your chats. Pinned chats will not be deleted."
-msgstr "Eliberează spațiu ștergând chaturile. Chaturile fixate nu vor fi șterse."
+msgstr ""
+"Eliberează spațiu ștergând chaturile. Chaturile fixate nu vor fi șterse."
 
 # smartling.placeholder_format=C
 #. Indicates that this streaming service is free to watch but shows ads
@@ -8151,9 +8353,9 @@ msgid ""
 "<strong>Check for Updates...</strong>, then select <strong>Install Update</"
 "strong>."
 msgstr ""
-"Din bara de meniu a aplicației pe Mac, selectează "
-"<strong>DuckDuckGo</strong> &gt; <strong>Caută actualizări...</strong>, apoi "
-"selectează <strong>Instalează actualizările</strong>."
+"Din bara de meniu a aplicației pe Mac, selectează <strong>DuckDuckGo</"
+"strong> &gt; <strong>Caută actualizări...</strong>, apoi selectează "
+"<strong>Instalează actualizările</strong>."
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -8319,6 +8521,12 @@ msgstr "Generează imaginea"
 #. Text for the button that generates more of an answer from duckassist when the answer has come from a collapsed state
 msgid "Generate More"
 msgstr "Generează mai mult"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Generate a shopping list"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
@@ -8616,10 +8824,17 @@ msgid "Give it a Try"
 msgstr "Încearcă"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Give me a quick background on this person."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
-msgstr "Accesează %1$sConfidențialitate și securitate > Servicii de localizare%2$s"
+msgstr ""
+"Accesează %1$sConfidențialitate și securitate > Servicii de localizare%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -8884,7 +9099,8 @@ msgstr "Guatemala"
 #. Text for a prompt suggestion for guiding through the basic steps of replacing a window wiper.
 msgctxt "Full sentence for learning a new skill"
 msgid "Guide me through the basic steps of replacing a window wiper."
-msgstr "Ghidează-mă prin pașii de bază ai înlocuirii unui ștergător de ferestre."
+msgstr ""
+"Ghidează-mă prin pașii de bază ai înlocuirii unui ștergător de ferestre."
 
 # smartling.placeholder_format=C
 msgid "Guinea"
@@ -9061,6 +9277,18 @@ msgstr "Spune și altora despre DuckDuckGo!"
 #. Link to a page with information about sharing DuckDuckGo with friends.
 msgid "Help Spread Privacy"
 msgstr "Ajută la promovarea confidențialității"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Help me prep for the interview"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Help me tailor my resume for this job."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title of a SERP popup that invites users to take a survey (desktop only)
@@ -9509,7 +9737,8 @@ msgstr "Cât de mult vrei să apară răspunsurile asistate de AI?"
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
 msgctxt "Duck.ai settings usage section"
 msgid "How much of your daily and weekly limits you've used so far."
-msgstr "Ce proporție din limitele tale zilnice și săptămânale ai utilizat până acum."
+msgstr ""
+"Ce proporție din limitele tale zilnice și săptămânale ai utilizat până acum."
 
 # smartling.placeholder_format=C
 #. A header for the feedback form in the assist negative feedback flow. The user is being asked to update how often they want AI-assisted answers to appear.
@@ -9576,6 +9805,14 @@ msgstr "Uragan"
 msgctxt "Onboarding terms screen button text"
 msgid "I Agree"
 msgstr "Sunt de acord"
+
+# smartling.placeholder_format=C
+#. Text for the button that takes the user to the external DuckDuckGo login subscription page.
+msgctxt ""
+"Text for the I already have a subscription button in the Duck.ai settings "
+"page"
+msgid "I Already Have a Subscription"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the button that takes the user to the login subscription page.
@@ -9743,7 +9980,8 @@ msgstr ""
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
-msgstr "Dacă încă dorești să ne susții, %1$sajută-ne să promovăm DuckDuckGo%2$s"
+msgstr ""
+"Dacă încă dorești să ne susții, %1$sajută-ne să promovăm DuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -10152,6 +10390,12 @@ msgid "Install Mac Browser"
 msgstr "Instalează browserul pentru Mac"
 
 # smartling.placeholder_format=C
+#. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
+msgctxt "settings"
+msgid "Install Now"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of a button to install the DuckDuckGo app
 msgctxt "Serp footer content"
 msgid "Install Our App"
@@ -10249,10 +10493,42 @@ msgid "Is deleted data really deleted?"
 msgstr "Datele șterse sunt cu adevărat șterse?"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is it worth taking?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this place any good?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"Is this place any good? Summarize its reputation based on reviews and "
+"ratings."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "Is this video helpful?"
 msgstr "Este de ajutor acest clip?"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this worth watching?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Is this worth watching? Give me a spoiler-free take."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -10863,6 +11139,12 @@ msgid "Links:"
 msgstr "Linkuri:"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "List the tools, materials, or prerequisites I need for this."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
 msgid "Listen"
 msgstr "Ascultă"
@@ -10971,7 +11253,8 @@ msgstr "Încarcă mai multe imagini rezultate când derulezi"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Loads more results in Images, Videos, and Shopping when scrolling"
-msgstr "Încarcă mai multe rezultate în imagini, clipuri și cumpărături la derulare"
+msgstr ""
+"Încarcă mai multe rezultate în imagini, clipuri și cumpărături la derulare"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/WTkvs9I.png
@@ -11267,6 +11550,12 @@ msgstr "Gestionează-ți abonamentul"
 msgctxt "Exclusion message manage sites button"
 msgid "Manage blocked sites"
 msgstr "Gestionează site-urile blocate"
+
+# smartling.placeholder_format=C
+#. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
+msgctxt "setting"
+msgid "Manage in Browser Settings"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to the site exclusion settings page
@@ -11718,7 +12007,8 @@ msgstr "Limita lunară a fost atinsă"
 #. Displayed when the user has reached a fixed monthly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Monthly usage limit reached. You can continue this chat after %s."
-msgstr "Limita lunară de utilizare a fost atinsă. Poți continua acest chat după %1$s."
+msgstr ""
+"Limita lunară de utilizare a fost atinsă. Poți continua acest chat după %1$s."
 
 # smartling.placeholder_format=C
 #. Used to point to additional social networking profiles (in results).
@@ -12102,7 +12392,8 @@ msgstr "Namibia"
 #. Title of the divisional championship series for the National League division of Major League Baseball
 msgctxt "Sports module"
 msgid "National League Championship Series"
-msgstr "National League Championship Series (Seria Campionatului Ligii Naționale)"
+msgstr ""
+"National League Championship Series (Seria Campionatului Ligii Naționale)"
 
 # smartling.placeholder_format=C
 #. Title of the divisional semi-final series for the National League division of Major League Baseball
@@ -13182,7 +13473,8 @@ msgstr "Deschide website-ul %1$s"
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open %sLocation%s, and ensure location is %senabled%s"
-msgstr "Deschide %1$sLocație%2$s și asigură-te că locația este %3$sactivată%4$s"
+msgstr ""
+"Deschide %1$sLocație%2$s și asigură-te că locația este %3$sactivată%4$s"
 
 #  Chrome/Firefox on Android/iOS
 # smartling.placeholder_format=C
@@ -14102,6 +14394,12 @@ msgstr ""
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
+msgid "Please describe why the chat response is harmful or illegal. (optional)"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
+msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
 msgstr "Descrie de ce răspunsul din chat este ilegal sau dăunător. (Opțional)"
 
@@ -14126,6 +14424,14 @@ msgid ""
 msgstr ""
 "Reține: începerea unui chat nou cu orice model va șterge sesiunea de chat "
 "curentă."
+
+# smartling.placeholder_format=C
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
+msgctxt "Feedback prompt"
+msgid ""
+"Please paste your prompt and the problematic output (with any personal "
+"information removed) and describe why the content is harmful or illegal."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -14595,6 +14901,12 @@ msgid "Privacy"
 msgstr "Confidențialitate"
 
 # smartling.placeholder_format=C
+#. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
+msgctxt "Section heading on the Duck.ai settings page"
+msgid "Privacy & Terms"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Privacy Blog"
 msgstr "Blog despre confidențialitate"
 
@@ -14663,6 +14975,12 @@ msgstr "Politica de confidențialitate și Condițiile de utilizare"
 msgctxt "Copy used to compose link in sentences"
 msgid "Privacy Policy and Terms of Service"
 msgstr "Politica de confidențialitate și Condițiile de prestare a serviciului"
+
+# smartling.placeholder_format=C
+#. Text for a button that links to the terms of use and privacy policy page.
+msgctxt "Secondary button text in active privacy modal"
+msgid "Privacy Policy and Terms of Service"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title displayed on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
@@ -15167,6 +15485,30 @@ msgid "Recommend a book"
 msgstr "Recomandă o carte"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar books"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar books."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar movies or shows."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar titles"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
 msgid "Recording failed. Please try again."
 msgstr "Înregistrarea nu a reușit. Încearcă din nou."
@@ -15390,7 +15732,8 @@ msgstr "Reține alegerea mea"
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings
 msgid "Remember my choice (this can be changed in %s%s%sSettings%s)"
-msgstr "Ține minte alegerea mea (poate fi modificată în %1$s%2$s%3$sSetări%4$s)"
+msgstr ""
+"Ține minte alegerea mea (poate fi modificată în %1$s%2$s%3$sSetări%4$s)"
 
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
@@ -15570,6 +15913,15 @@ msgid "Republic of Moldova"
 msgstr "Republica Moldova"
 
 # smartling.placeholder_format=C
+#. Note indicating that sharing the conversation is mandatory when reporting harmful or illegal content. Rendered alongside the standard share label (DUCKCHAT_RESPONSE_FEEDBACK_SHARE_PROMPT_RESPONSE_LABEL), not replacing it.
+msgctxt ""
+"Note shown under the share-content switch label on the Duck.ai response "
+"feedback form when the user has selected Harmful or Illegal as the feedback "
+"reason"
+msgid "Required for harmful or illegal reports"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
 msgctxt "Description for extended reasoning mode in Duck.ai"
 msgid "Researches before responding"
@@ -15738,7 +16090,8 @@ msgstr "Rezultatele exclud informațiile de pe site-urile blocate."
 #. Message that appears when results exclude blocked sites
 msgctxt "Blocked sites filter disclaimer"
 msgid "Results exclude your blocked sites, which you can manage in your %s."
-msgstr "Rezultatele exclud site-urile blocate, pe care le poți gestiona în %1$s."
+msgstr ""
+"Rezultatele exclud site-urile blocate, pe care le poți gestiona în %1$s."
 
 # smartling.placeholder_format=C
 #. A label showing the source of the results, e.g. "Results from Reddit"
@@ -15804,6 +16157,12 @@ msgstr "Recenzii"
 msgctxt "maps_places"
 msgid "Reviews"
 msgstr "Recenzii"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Rewrite this recipe scaled for a different number of servings."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Romania"
@@ -16082,14 +16441,16 @@ msgstr ""
 #. Short text for native DDG browser users explaining how Chat History stores up to 30 of their most recent chats locally on their device.
 msgctxt "Short description for Chat History feature on native DDG browsers"
 msgid "Save up to 30 of your most recent chats locally on your device."
-msgstr "Salvează local pe dispozitiv până la 30 dintre cele mai recente chaturi."
+msgstr ""
+"Salvează local pe dispozitiv până la 30 dintre cele mai recente chaturi."
 
 # smartling.placeholder_format=C
 #. Desktop/mobile intro modal body under the title per Sync Chats Figma (choose step).
 msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
-msgstr "Salvează-ți chaturile Duck.ai între dispozitive cu criptare end-to-end."
+msgstr ""
+"Salvează-ți chaturile Duck.ai între dispozitive cu criptare end-to-end."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -16588,7 +16949,8 @@ msgstr "Săptămâni din sezon"
 #. Description shown in the Sync & Backup settings section when sync is not yet enabled, explaining the feature.
 msgctxt "Description for sync and backup feature"
 msgid "Securely save and sync your chats across all your devices."
-msgstr "Salvează și sincronizează-ți în siguranță chaturile pe toate dispozitivele."
+msgstr ""
+"Salvează și sincronizează-ți în siguranță chaturile pe toate dispozitivele."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -16740,7 +17102,8 @@ msgstr "Vezi mai multe pe %1$s"
 # smartling.placeholder_format=C
 #. Title of a notice that DuckDuckGo has noticed the user is blocking its non-tracking ads
 msgid "See more shopping results from popular retailers"
-msgstr "Vezi mai multe rezultate privind cumpărăturile, de la comercianți populari"
+msgstr ""
+"Vezi mai multe rezultate privind cumpărăturile, de la comercianți populari"
 
 # smartling.placeholder_format=C
 #. Text for tooltip shown on hover when displaying the number of reviews the product has on an ad, indicating that users can see more ratings on bing.com
@@ -16758,7 +17121,8 @@ msgstr "Vezi câteva dintre cele mai recente actualizări ale noastre"
 #. Link to a page with more information about how user settings are stored in a URL.
 msgctxt "settings"
 msgid "See the %sURL Parameter Reference page%s for more details."
-msgstr "Vezi %1$spagina de referință a parametrilor URL%2$s pentru mai multe detalii."
+msgstr ""
+"Vezi %1$spagina de referință a parametrilor URL%2$s pentru mai multe detalii."
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the context menu of a chat in chat history, that allows the user to select the chat and begin batch selection mode.
@@ -16785,7 +17149,8 @@ msgstr "Selectează %1$s%2$s%3$s, apoi %4$sMotor de căutare%5$s"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %s'Setting for this Website...'%s from the Safari menu."
-msgstr "Selectează %1$s„Setare pentru acest site web...”%2$s din meniul Safari."
+msgstr ""
+"Selectează %1$s„Setare pentru acest site web...”%2$s din meniul Safari."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -16798,30 +17163,35 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
-msgstr "Selectează %1$sDuckDuckGo%2$s și fă click pe %3$sAdaugă ca implicit%4$s!"
+msgstr ""
+"Selectează %1$sDuckDuckGo%2$s și fă click pe %3$sAdaugă ca implicit%4$s!"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s"
-msgstr "Selectează %1$sDuckDuckGo%2$s și fă click pe %3$sSetează ca implicit%4$s"
+msgstr ""
+"Selectează %1$sDuckDuckGo%2$s și fă click pe %3$sSetează ca implicit%4$s"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s."
-msgstr "Selectează %1$sDuckDuckGo%2$s și fă click pe %3$sSetează ca implicit%4$s."
+msgstr ""
+"Selectează %1$sDuckDuckGo%2$s și fă click pe %3$sSetează ca implicit%4$s."
 
 #  Firefox 33
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Select %sDuckDuckGo%s in the Default Search Engine drop down"
-msgstr "Selectează %1$sDuckDuckGo%2$s în meniul vertical Motor de căutare implicit"
+msgstr ""
+"Selectează %1$sDuckDuckGo%2$s în meniul vertical Motor de căutare implicit"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %sDuckDuckGo%s in the list and %sallow%s location access"
-msgstr "Selectează %1$sDuckDuckGo%2$s din listă și %3$spermite%4$s accesul la locație"
+msgstr ""
+"Selectează %1$sDuckDuckGo%2$s din listă și %3$spermite%4$s accesul la locație"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -16833,7 +17203,8 @@ msgstr "Selectează %1$sDuckDuckGo%2$s din lista de furnizori de căutare"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s under the%sDefault Search Engine%s section"
-msgstr "Selectează %1$sDuckDuckGo%2$s sub%3$ssecțiunea Motor de căutare implicit%4$s"
+msgstr ""
+"Selectează %1$sDuckDuckGo%2$s sub%3$ssecțiunea Motor de căutare implicit%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user were in the settings menu they can change their default search engine.
@@ -16844,7 +17215,8 @@ msgstr "Selectează %1$sDuckDuckGo%2$s!"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Select %sEdit Search Engines...%sin the dropdown"
-msgstr "Selectează %1$sEditează motoarele de căutare...%2$s din meniul vertical"
+msgstr ""
+"Selectează %1$sEditează motoarele de căutare...%2$s din meniul vertical"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -16940,7 +17312,8 @@ msgstr ""
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %syour browser%s in the list and %sallow%s location access"
-msgstr "Selectează %1$sbrowserul%2$s din listă și %3$spermite%4$s accesul la locație"
+msgstr ""
+"Selectează %1$sbrowserul%2$s din listă și %3$spermite%4$s accesul la locație"
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the modal for deleting all recent chats, that allows the user to select the chats to delete.
@@ -17012,7 +17385,8 @@ msgstr "Text selectat din %1$s"
 #. Displayed when the user's text selection exceeds the maximum message size for AI tools (summary, translation, etc.).
 msgctxt "Error message for selection input limit"
 msgid "Selected text is too long. Try again with a shorter selection."
-msgstr "Textul selectat este prea lung. Încearcă din nou cu o selecție mai scurtă."
+msgstr ""
+"Textul selectat este prea lung. Încearcă din nou cu o selecție mai scurtă."
 
 # smartling.placeholder_format=C
 #. Label for the semi-finals knockout stage in e.g. the soccer World Cup
@@ -17132,6 +17506,12 @@ msgstr "Configurează acum"
 msgctxt "Setup button for native sync flow"
 msgid "Set Up Now"
 msgstr "Configurează acum"
+
+# smartling.placeholder_format=C
+#. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
+msgctxt "Encrypted storage setup button shown in native browsers"
+msgid "Set Up Sync & Backup"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
@@ -17317,6 +17697,13 @@ msgid "Share positive feedback"
 msgstr "Distribuie feedback pozitiv"
 
 # smartling.placeholder_format=C
+#. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
+msgctxt ""
+"Label beside the share-content switch on the Duck.ai response feedback form"
+msgid "Share this conversation with DuckDuckGo"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
 msgctxt ""
 "Label beside the share-content switch on the Duck.ai response feedback form"
@@ -17453,7 +17840,8 @@ msgstr "Afișează DuckAssist <sup>BETA</sup>"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show DuckAssist more often. (You can also completely %sturn it off%s.)"
-msgstr "Arată DuckAssist mai des. (De asemenea, îl poți %1$sdezactiva%2$s complet.)"
+msgstr ""
+"Arată DuckAssist mai des. (De asemenea, îl poți %1$sdezactiva%2$s complet.)"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
@@ -17701,7 +18089,8 @@ msgstr "Afișează linii orizontale la sfârșitul paginilor de rezultate"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows links to instructions for how to add DuckDuckGo to your browser"
-msgstr "Afișează linkuri spre instrucțiuni pentru a adăuga DuckDuckGo în browser"
+msgstr ""
+"Afișează linkuri spre instrucțiuni pentru a adăuga DuckDuckGo în browser"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers more frequently.
@@ -17855,7 +18244,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Sites you block will be hidden from all your search results"
-msgstr "Site-urile pe care le blochezi vor fi ascunse din toate rezultatele căutării."
+msgstr ""
+"Site-urile pe care le blochezi vor fi ascunse din toate rezultatele căutării."
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes full name (tooltip)
@@ -18000,7 +18390,8 @@ msgstr "Ceva nu a funcționat, te rugăm să încerci din nou."
 #. Body copy displayed under the Set Up Now button when the sync setup call fails.
 msgctxt "Generic error shown when sync setup fails"
 msgid "Something went wrong while enabling Sync & Backup. Please try again."
-msgstr "A apărut o eroare la activarea funcției Sync & Backup. Încearcă din nou."
+msgstr ""
+"A apărut o eroare la activarea funcției Sync & Backup. Încearcă din nou."
 
 # smartling.placeholder_format=C
 #. Displayed when the voice chat session ends with an unknown error.
@@ -18049,7 +18440,8 @@ msgstr "Ne pare rău, a survenit o eroare neașteptată."
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
 msgid "Sorry, no relevant information was found in our search."
-msgstr "Ne pare rău, nu au fost găsite informații relevante în căutarea noastră."
+msgstr ""
+"Ne pare rău, nu au fost găsite informații relevante în căutarea noastră."
 
 # smartling.placeholder_format=C
 #. Indicates that there were no search results for a user's search.
@@ -18098,7 +18490,8 @@ msgstr ""
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr "Ne pare rău, nu am putut trimite feedbackul tău. Încearcă din nou mai târziu."
+msgstr ""
+"Ne pare rău, nu am putut trimite feedbackul tău. Încearcă din nou mai târziu."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -18361,13 +18754,15 @@ msgstr ""
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletters."
-msgstr "Rămâi protejat și informat cu newsletterele noastre despre confidențialitate."
+msgstr ""
+"Rămâi protejat și informat cu newsletterele noastre despre confidențialitate."
 
 # smartling.placeholder_format=C
 #. Text on the page where users can subscribe to DuckDuckGo's privacy newsletter
 msgctxt "showcase_newsletter"
 msgid "Stay protected and informed with our privacy newsletters."
-msgstr "Rămâi protejat și informat cu newsletterele noastre despre confidențialitate."
+msgstr ""
+"Rămâi protejat și informat cu newsletterele noastre despre confidențialitate."
 
 # smartling.placeholder_format=C
 #. Loading message shown when image generation is taking longer than usual.
@@ -18410,7 +18805,8 @@ msgstr "Oprește instrumentele de urmărire ascunse de pe alte site-uri."
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop most hidden trackers lurking on other websites."
-msgstr "Oprește majoritatea instrumentelor de urmărire ascunse de pe alte site-uri."
+msgstr ""
+"Oprește majoritatea instrumentelor de urmărire ascunse de pe alte site-uri."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18581,6 +18977,24 @@ msgid "Suggest a title for a blog post"
 msgstr "Sugerează un titlu pentru o postare pe blog"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest related articles or topics worth exploring next."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Suggest related articles to explore"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest some alternatives to this product."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
 msgctxt "directions"
 msgid "Suggestions:"
@@ -18592,10 +19006,100 @@ msgid "Suggestions:"
 msgstr "Sugestii:"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Sum up the reviews"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A short title for the a message asking the AI to summarize a text.
 msgctxt "Title for the summarize message"
 msgid "Summarize"
 msgstr "Rezumă"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize the Q&As"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the background and notable work of this person."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the key details of this event."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the questions and answers on this page."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize their background"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this book"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this book."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this discussion"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this discussion thread."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this page"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this page."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this video"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this video."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize what the reviews say."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -18812,7 +19316,8 @@ msgstr "Sync & Backup activat!"
 #. Notice shown under the recovery code explaining that backup data has an inactivity expiration.
 msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
-msgstr "Datele Sync & Backup nu pot fi recuperate după 18 luni de inactivitate."
+msgstr ""
+"Datele Sync & Backup nu pot fi recuperate după 18 luni de inactivitate."
 
 # smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
@@ -18922,6 +19427,12 @@ msgid "Syria"
 msgstr "Siria"
 
 # smartling.placeholder_format=C
+#. Text for a button that enables the theme to follow the operating system's color scheme preference.
+msgctxt "System theme button for theme selector"
+msgid "System"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Abbreviation indicating this is the total score for a game
 msgctxt "Sports module"
 msgid "T"
@@ -18948,6 +19459,12 @@ msgstr "TV"
 msgctxt "language_name"
 msgid "Tahitian"
 msgstr "Tahitiană"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Tailor my resume"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Taiwan"
@@ -18977,6 +19494,13 @@ msgstr "Preia controlul asupra datelor tale cu caracter personal"
 msgctxt "homepage ATB modal"
 msgid "Take control of your personal data!"
 msgstr "Preia controlul asupra datelor tale cu caracter personal!"
+
+# smartling.placeholder_format=C
+#. Description for the Feedback section of the Duck.ai settings page, asking the user to take an anonymous survey to let us know how we can make Duck.ai better.
+msgctxt "Feedback section description on the Duck.ai settings page"
+msgid ""
+"Take this anonymous survey to let us know how we can make Duck.ai better."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -19225,7 +19749,8 @@ msgstr "Fișierele atașate depășesc limita totală de %1$s MB."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the server rejects corrupt or unrecognized audio.
 msgid "The audio could not be processed. Please try recording again."
-msgstr "Materialul audio nu a putut fi prelucrat. Încearcă să înregistrezi din nou."
+msgstr ""
+"Materialul audio nu a putut fi prelucrat. Încearcă să înregistrezi din nou."
 
 # smartling.placeholder_format=C
 #. Second paragraph explaining where the encryption key is stored on the entry screen.
@@ -19283,6 +19808,12 @@ msgstr "Serverul a întâmpinat o eroare și nu a putut finaliza cererea ta."
 #. https://duck.co/media/files/theme.png
 msgid "Theme"
 msgstr "Temă"
+
+# smartling.placeholder_format=C
+#. Text for the theme selector label that allows users to switch between Light and dark theme.
+msgctxt "Label for the theme selector feature"
+msgid "Theme"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/LpFhb1e.png
@@ -19407,7 +19938,8 @@ msgstr ""
 #. Appears below a type of search results called 'Instant Answers'
 msgctxt "attribution"
 msgid "This Instant Answer was made by the %sDuckDuckHack%s Community."
-msgstr "Acest răspuns instant a fost creat de Comunitatea %1$sDuckDuckHack%2$s."
+msgstr ""
+"Acest răspuns instant a fost creat de Comunitatea %1$sDuckDuckHack%2$s."
 
 # smartling.placeholder_format=C
 #. Label for the monthly usage row in the Usage section of Duck.ai settings.
@@ -19471,13 +20003,15 @@ msgstr ""
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
-msgstr "Fișierul acesta e prea mare. Dimensiunea maximă a fișierului este de %1$s MB"
+msgstr ""
+"Fișierul acesta e prea mare. Dimensiunea maximă a fișierului este de %1$s MB"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB."
-msgstr "Fișierul acesta e prea mare. Dimensiunea maximă a fișierului este de %1$s MB."
+msgstr ""
+"Fișierul acesta e prea mare. Dimensiunea maximă a fișierului este de %1$s MB."
 
 # smartling.placeholder_format=C
 #. Generic error message displayed when the user tries to upload an unsupported file type and we cannot determine the accepted types
@@ -19601,7 +20135,8 @@ msgstr "Această pagină necesită JavaScript pentru a funcționa."
 #. Information tooltip text explaining that the current page's content will be included with the chat message.
 msgctxt "Tooltip explaining that page content will be sent to Duck.ai"
 msgid "This page's content will be sent with your message to Duck.ai"
-msgstr "Conținutul acestei pagini va fi trimis împreună cu mesajul tău către Duck.ai"
+msgstr ""
+"Conținutul acestei pagini va fi trimis împreună cu mesajul tău către Duck.ai"
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -19704,7 +20239,8 @@ msgstr ""
 #. Message explaining what will happen when the user deletes an image.
 msgctxt "Confirmation message in delete image modal"
 msgid "This will delete your selected image. This cannot be undone."
-msgstr "Aceasta va șterge imaginea selectată de tine. Acest lucru nu poate fi anulat."
+msgstr ""
+"Aceasta va șterge imaginea selectată de tine. Acest lucru nu poate fi anulat."
 
 # smartling.placeholder_format=C
 #. Confirmation message asking if the user is sure they want to reset all of their settings.
@@ -19840,8 +20376,8 @@ msgid ""
 "To print directions:%sGo back to the map.%sSelect the route you want to "
 "print.%sClick the print icon.%s"
 msgstr ""
-"Pentru a tipări indicații de orientare:%1$sîntoarce-te la "
-"hartă.%2$sSelectează ruta pe care dorești să o tipărești.%3$sFă click pe "
+"Pentru a tipări indicații de orientare:%1$sîntoarce-te la hartă."
+"%2$sSelectează ruta pe care dorești să o tipărești.%3$sFă click pe "
 "pictograma de tipărire.%4$s"
 
 # smartling.placeholder_format=C
@@ -20055,7 +20591,8 @@ msgstr "Instrumente de urmărire blocate în ultima oră"
 #. Placeholder for when we cannot report any blocked trackers yet
 msgctxt "tracker_stats"
 msgid "Trackers that DuckDuckGo blocks will appear here"
-msgstr "Instrumentele de urmărire pe care DuckDuckGo le blochează vor apărea aici"
+msgstr ""
+"Instrumentele de urmărire pe care DuckDuckGo le blochează vor apărea aici"
 
 # smartling.placeholder_format=C
 #. Placeholder for when we cannot report any blocked trackers yet
@@ -20125,6 +20662,18 @@ msgid ""
 msgstr ""
 "Traduci această propoziție din română în engleză: „Cum ajung la cel mai "
 "apropiat cinematograf?”"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Translate this page"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
+msgctxt "Page suggestion prompt"
+msgid "Translate this page into %s."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder text for a region that will display translated text.
@@ -20270,6 +20819,12 @@ msgid "Try Free"
 msgstr "Încearcă gratuit"
 
 # smartling.placeholder_format=C
+#. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
+msgctxt "settings"
+msgid "Try It Now"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
 msgctxt "Promotional CTA for new AI models"
 msgid "Try Now"
@@ -20370,7 +20925,8 @@ msgstr "Încearcă gratis"
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
-msgstr "Încearcă gratuit! Un VPN securizat, AI avansată și privată și multe altele."
+msgstr ""
+"Încearcă gratuit! Un VPN securizat, AI avansată și privată și multe altele."
 
 # smartling.placeholder_format=C
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -20397,7 +20953,8 @@ msgstr "Încearcă browserul nostru"
 # smartling.placeholder_format=C
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
-msgstr "Încearcă pagina noastră de pornire care nu afișează niciodată aceste mesaje:"
+msgstr ""
+"Încearcă pagina noastră de pornire care nu afișează niciodată aceste mesaje:"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with different words to get more results.
@@ -20508,6 +21065,22 @@ msgid "Trying DuckDuckGo again"
 msgstr "Încearcă DuckDuckGo din nou"
 
 # smartling.placeholder_format=C
+#. Message shown in a modal after supported third-party browser users disable AI features in Settings. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
 msgctxt "Assistant response placeholder"
 msgid "Trying with %s"
@@ -20612,7 +21185,8 @@ msgstr "Activează %1$sLocație precisă%2$s pentru rezultate mai precise"
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
-msgstr "Activează Duck Player pentru a viziona pe YouTube fără reclame direcționate"
+msgstr ""
+"Activează Duck Player pentru a viziona pe YouTube fără reclame direcționate"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service.
@@ -20823,12 +21397,14 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sOpen with%s select %sA specific page or pages%s"
-msgstr "Sub %1$sDeschide cu%2$s selectează %3$sUna sau mai multe pagini specifice%4$s"
+msgstr ""
+"Sub %1$sDeschide cu%2$s selectează %3$sUna sau mai multe pagini specifice%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
-msgstr "Sub %1$sPORNIRE > Pagina de pornire%2$s introdu: https://duckduckgo.com"
+msgstr ""
+"Sub %1$sPORNIRE > Pagina de pornire%2$s introdu: https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -20838,7 +21414,8 @@ msgstr "Sub %1$sSetări de căutare%2$s selectează %3$sDuckDuckGo%4$s"
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch in the address bar with%s select %sAdd New%s"
-msgstr "Sub %1$sCaută în bara de adrese cu%2$s selectează %3$sAdăugare nouă%4$s"
+msgstr ""
+"Sub %1$sCaută în bara de adrese cu%2$s selectează %3$sAdăugare nouă%4$s"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -20852,13 +21429,15 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under On startup select %sOpen a specific page or set of pages%s"
-msgstr "Sub Pornire, selectează %1$sDeschide una sau mai multe pagini specifice%2$s"
+msgstr ""
+"Sub Pornire, selectează %1$sDeschide una sau mai multe pagini specifice%2$s"
 
 #  Opera default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine
 msgid "Under Search click the drop down and select %sDuckDuckGo%s"
-msgstr "Sub Căutare, fă click pe meniul vertical și selectează %1$sDuckDuckGo%2$s"
+msgstr ""
+"Sub Căutare, fă click pe meniul vertical și selectează %1$sDuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings" header
@@ -21261,6 +21840,12 @@ msgid "Uruguay"
 msgstr "Uruguay"
 
 # smartling.placeholder_format=C
+#. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
+msgctxt "Navigation label on the Duck.ai settings page"
+msgid "Usage"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A feedback suggestion
 msgctxt "Feedback prompt"
 msgid "Usage limit"
@@ -21302,9 +21887,9 @@ msgid ""
 "Use ChatGPT, Claude, and other AIs, privately. Protect chats from hackers, "
 "scammers, and companies. Keep info confidential. Free. No account required."
 msgstr ""
-"Folosește ChatGPT, Claude și alte platforme de IA, în mod privat. "
-"Protejează-ți chaturile împotriva hackerilor, a escrocilor și a companiilor. "
-"Păstrează informațiile confidențiale. Gratuit. Nu este nevoie de un cont."
+"Folosește ChatGPT, Claude și alte platforme de IA, în mod privat. Protejează-"
+"ți chaturile împotriva hackerilor, a escrocilor și a companiilor. Păstrează "
+"informațiile confidențiale. Gratuit. Nu este nevoie de un cont."
 
 # smartling.placeholder_format=C
 #. Header above instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -21715,6 +22300,12 @@ msgid "Wales"
 msgstr "Țara Galilor"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Walk me through the steps"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for walking directions on a map.
 msgctxt "directions"
 msgid "Walking"
@@ -21829,7 +22420,19 @@ msgstr "Anonimizăm"
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
-msgstr "Putem anonimiza%1$s locația ta%2$s pentru a-ți afișa rezultate mai precise."
+msgstr ""
+"Putem anonimiza%1$s locația ta%2$s pentru a-ți afișa rezultate mai precise."
+
+# smartling.placeholder_format=C
+#. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
+msgctxt ""
+"Inline warning shown below the share-content toggle when the user selects "
+"Harmful or Illegal but has not enabled sharing"
+msgid ""
+"We can only fix what we can see. To report a harmful or illegal response, "
+"please share this conversation with DuckDuckGo so we can investigate and "
+"address the issue."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -21962,7 +22565,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don’t track you in or out of private browsing mode."
-msgstr "Noi nu te monitorizăm în interiorul sau în afara modului de navigare privată."
+msgstr ""
+"Noi nu te monitorizăm în interiorul sau în afara modului de navigare privată."
 
 # smartling.placeholder_format=C
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with an Agree button is shown below.
@@ -21976,7 +22580,8 @@ msgstr ""
 #. Displayed when the user's voice chat session is ended because of being inactive for too long.
 msgctxt "voice chat error"
 msgid "We ended the chat due to inactivity. Want to try again?"
-msgstr "Am încheiat chatul din cauza inactivității. Dorești să încerci din nou?"
+msgstr ""
+"Am încheiat chatul din cauza inactivității. Dorești să încerci din nou?"
 
 # smartling.placeholder_format=C
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
@@ -22036,7 +22641,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We stop anyone from getting your search history, including us."
-msgstr "Împiedicăm pe oricine, inclusiv pe noi, să obțină istoricul căutărilor tale."
+msgstr ""
+"Împiedicăm pe oricine, inclusiv pe noi, să obțină istoricul căutărilor tale."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -22325,8 +22931,8 @@ msgid ""
 "We’re really sorry, but it seems there was a problem loading Duck.ai. Try "
 "reloading the page."
 msgstr ""
-"Ne pare foarte rău, dar se pare că a apărut o problemă la încărcarea "
-"Duck.ai. Încearcă să reîncarci pagina."
+"Ne pare foarte rău, dar se pare că a apărut o problemă la încărcarea Duck."
+"ai. Încearcă să reîncarci pagina."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to suggest an AI (Artificial Intelligence) model to be added to the product, and this field is optional.
@@ -22389,10 +22995,107 @@ msgid ""
 msgstr ""
 "Care sunt beneficiile descărcării browserului DuckDuckGo pentru tine, dacă "
 "vrei să folosești Duck.ai? Citește doar surse oficiale DuckDuckGo. Împarte "
-"răspunsul în secțiuni clare cu titluri, concentrându-te pe integrările "
-"Duck.ai și pe protecția confidențialității. Păstrează-l destul de scurt, "
-"simplu și ușor de înțeles pentru cei care au (sau nu) experiență în IA sau "
-"în domeniul tehnic."
+"răspunsul în secțiuni clare cu titluri, concentrându-te pe integrările Duck."
+"ai și pe protecția confidențialității. Păstrează-l destul de scurt, simplu "
+"și ușor de înțeles pentru cei care au (sau nu) experiență în IA sau în "
+"domeniul tehnic."
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the counterarguments?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the hours & location?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key contributions of this paper?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key contributions?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key details?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key points covered in this video?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key points?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key takeaways from this article?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key takeaways?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key things I will learn from this course?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main counterarguments or criticisms of this?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main questions this page answers?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the must-try dishes here?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"What are the opening hours, location, and contact details for this place?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the pros and cons of this product?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the pros and cons?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
@@ -22495,6 +23198,12 @@ msgid "What does atria mean in the context of a medical article?"
 msgstr "Ce înseamnă „atrii” în contextul unui articol medical?"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What does this answer?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
@@ -22507,20 +23216,32 @@ msgid "What information gets saved?"
 msgstr "Ce informație se salvează?"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What interview questions might come up for this role?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
 msgid ""
 "What is the Cloud Save bookmarklet and how does it differ from the URL "
 "parameter bookmarklet?"
 msgstr ""
-"Ce este bookmarklet-ul Cloud Save și cum se diferențiază el de "
-"bookmarklet-ul cu parametri URL?"
+"Ce este bookmarklet-ul Cloud Save și cum se diferențiază el de bookmarklet-"
+"ul cu parametri URL?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for looking up the capital city of Albania.
 msgctxt "Full sentence for looking up basic facts"
 msgid "What is the capital city of Albania?"
 msgstr "Care este capitala Albaniei?"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What is the overall verdict and rating for this?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to a page with additional information.
@@ -22545,6 +23266,12 @@ msgid "What people say:"
 msgstr "Ce spun oamenii:"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What should I order?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
 msgctxt "feedback form"
 msgid "What stood out?"
@@ -22555,6 +23282,18 @@ msgstr "Ce a ieșit în evidență?"
 msgctxt "feedback form"
 msgid "What was wrong with the response? (optional)"
 msgstr "Ce a fost în neregulă cu răspunsul? (opțional)"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I learn?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I need?"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -22576,6 +23315,12 @@ msgid "What's New"
 msgstr "Noutăți"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What's the verdict?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to a page featuring the most recent updates from DuckDuckGo.
 msgid "What’s New"
 msgstr "Ce este nou"
@@ -22593,7 +23338,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "When enabled, Duck.ai will show instant answers in the chat."
-msgstr "Când este activat, Duck.ai va afișa răspunsuri instantanee în conversație."
+msgstr ""
+"Când este activat, Duck.ai va afișa răspunsuri instantanee în conversație."
 
 # smartling.placeholder_format=C
 #. Text of a button that performs a search for the available streaming services that show a particular movie or tv show
@@ -22611,7 +23357,8 @@ msgstr "Unde să urmărești <strong>%1$s</strong>"
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Where it says Homepage click %sSet to Current Page%s."
-msgstr "Fă click pe %1$sSetează ca pagină curentă%2$s unde scrie Pagină de pornire."
+msgstr ""
+"Fă click pe %1$sSetează ca pagină curentă%2$s unde scrie Pagină de pornire."
 
 # smartling.placeholder_format=C
 #. Heading of a module showing what streaming services are showing a movie or series, e.g. Where to Watch The Matrix
@@ -22624,6 +23371,12 @@ msgstr "Unde să urmărești <strong>%1$s</strong>"
 msgctxt "Feedback prompt"
 msgid "Which features are missing? (Optional)"
 msgstr "Ce funcții lipsesc? (Opțional)"
+
+# smartling.placeholder_format=C
+#. An invitation for users to leave feedback
+msgctxt "Feedback prompt"
+msgid "Which features are missing? (optional)"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
@@ -22640,6 +23393,18 @@ msgstr "Alb"
 #. Link to an about us page.
 msgid "Who We Are"
 msgstr "Cine suntem noi"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Who are the main cast and crew, and what else are they known for?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Who is this person?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Header above a collection of privacy-related links.
@@ -23380,7 +24145,8 @@ msgctxt "Error message for user limit"
 msgid ""
 "You've reached the maximum number of messages for the moment. Please try "
 "again later."
-msgstr "Pentru moment, ai atins numărul maxim de mesaje. Încearcă din nou mai târziu."
+msgstr ""
+"Pentru moment, ai atins numărul maxim de mesaje. Încearcă din nou mai târziu."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -23407,8 +24173,8 @@ msgid ""
 "You've run out of Sync & Backup storage for Duck.ai chats with attachments. "
 "Delete the %s oldest chats to resume Sync. Pinned chats will not be deleted."
 msgstr ""
-"Ai rămas fără spațiu de stocare pentru Sync & Backup pentru chaturile "
-"Duck.ai cu atașări. Șterge cele mai vechi %1$s chaturi pentru a relua "
+"Ai rămas fără spațiu de stocare pentru Sync & Backup pentru chaturile Duck."
+"ai cu atașări. Șterge cele mai vechi %1$s chaturi pentru a relua "
 "sincronizarea. Chaturile fixate nu vor fi șterse."
 
 # smartling.placeholder_format=C
@@ -23623,7 +24389,8 @@ msgctxt "duckai_migration"
 msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
-msgstr "Chaturile tale au fost importate. Continuă de unde ai rămas în Duck.ai."
+msgstr ""
+"Chaturile tale au fost importate. Continuă de unde ai rămas în Duck.ai."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.
@@ -23670,7 +24437,8 @@ msgctxt ""
 "Subtitle of the one-time popover shown above the thumbs up/down buttons on "
 "an AI response"
 msgid "Your feedback is anonymized and not used to train AI."
-msgstr "Feedbackul tău este anonimizat și nu este folosit pentru antrenarea IA."
+msgstr ""
+"Feedbackul tău este anonimizat și nu este folosit pentru antrenarea IA."
 
 # smartling.placeholder_format=C
 #. Explains that the User's Location is always private to DuckDuckGo.
@@ -23823,13 +24591,15 @@ msgctxt "Error message for user limit"
 msgid ""
 "You’ve reached the maximum number of messages for one day. Please continue "
 "this chat tomorrow."
-msgstr "Ai atins numărul maxim de mesaje pentru o zi. Continuă acest chat mâine."
+msgstr ""
+"Ai atins numărul maxim de mesaje pentru o zi. Continuă acest chat mâine."
 
 # smartling.placeholder_format=C
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
 msgctxt "voice chat limit modal"
 msgid "You’ve reached the voice chat limit for now. Please try again later."
-msgstr "Ai atins limita de chat vocal pentru moment. Încearcă din nou mai târziu."
+msgstr ""
+"Ai atins limita de chat vocal pentru moment. Încearcă din nou mai târziu."
 
 # smartling.placeholder_format=C
 #. The name of the Yucatec Maya language

--- a/locales/ru_RU/LC_MESSAGES/duckduckgo.po
+++ b/locales/ru_RU/LC_MESSAGES/duckduckgo.po
@@ -2,16 +2,15 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: ru_RU\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
-"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 
 # smartling.gettext_line_width = normalized : 79
 # smartling.placeholder_format=C
@@ -242,8 +241,7 @@ msgstr "Лайков: %1$s"
 #. Disclaimer text shown bellow chat input on mobile, avoid long text if possible. Example: 'GPT-3 may display inaccurate or offensive information.'
 msgctxt "Disclaimer bellow chat input - mobile"
 msgid "%s may display inaccurate or offensive information."
-msgstr ""
-"ИИ-модель %1$s может предложить неточную или оскорбительную информацию."
+msgstr "ИИ-модель %1$s может предложить неточную или оскорбительную информацию."
 
 # smartling.placeholder_format=C
 #. Label showing how many members a discussion has. To be displayed on a card about that discussion.
@@ -475,15 +473,13 @@ msgstr "%1$sКак мы сохраняем конфиденциальность 
 msgctxt "Footer text for About Sync modal"
 msgid ""
 "%sLearn more%s about how chats are stored privately on DuckDuckGo's server."
-msgstr ""
-"%1$sПодробнее%2$s о конфиденциальном хранении чатов на сервере DuckDuckGo."
+msgstr "%1$sПодробнее%2$s о конфиденциальном хранении чатов на сервере DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "%sLearn more%s about how chats are stored privately on your device."
-msgstr ""
-"%1$sПодробнее%2$s о том, как чаты хранятся в тайне на вашем устройстве."
+msgstr "%1$sПодробнее%2$s о том, как чаты хранятся в тайне на вашем устройстве."
 
 # smartling.placeholder_format=C
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
@@ -934,8 +930,8 @@ msgid ""
 msgstr ""
 "Функция AI Chat позволяет анонимно общаться с нашим чат-ботом на базе "
 "сторонних моделей ИИ. Если отключить эту функцию, она не будет отображаться "
-"в поиске DuckDuckGo Search, но останется доступной по ссылке %1$sduckduckgo."
-"com/aichat%2$s."
+"в поиске DuckDuckGo Search, но останется доступной по ссылке "
+"%1$sduckduckgo.com/aichat%2$s."
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -1051,8 +1047,7 @@ msgstr "Не добавлять в браузер"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "ATB related (not displayed on settings page)"
-msgstr ""
-"Связано с параметром «Добавить в браузер» (отсутствует на странице настроек)"
+msgstr "Связано с параметром «Добавить в браузер» (отсутствует на странице настроек)"
 
 # smartling.placeholder_format=C
 #. Golf rankings column: average points
@@ -1443,7 +1438,7 @@ msgstr "Неверно указан адрес"
 #. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Adjust the servings"
-msgstr ""
+msgstr "Измени количество порций"
 
 # smartling.placeholder_format=C
 #. as in multiple advertisements
@@ -1665,6 +1660,8 @@ msgid ""
 "All chats are anonymized by DuckDuckGo, and your conversations are not used "
 "to train chat models by DuckDuckGo or the model providers"
 msgstr ""
+"Все чаты анонимизируются DuckDuckGo, а содержимое бесед не применяется для "
+"обучения ИИ-моделей DuckDuckGo или сторонних поставщиков"
 
 # smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1769,8 +1766,8 @@ msgid ""
 msgstr ""
 "Позволяет %1$s выполнить поиск в Интернете, чтобы улучшить ответы на "
 "релевантные запросы. Отправляет в поисковую систему только сгенерированные "
-"ИИ запросы с ограниченным сроком хранения данных. Запросы и ответы %2$s по-"
-"прежнему имеют %3$sнулевую видимость провайдера%4$s."
+"ИИ запросы с ограниченным сроком хранения данных. Запросы и ответы %2$s "
+"по-прежнему имеют %3$sнулевую видимость провайдера%4$s."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -1942,6 +1939,9 @@ msgid ""
 "Anonymously generates answers for search queries based on web content. "
 "Choose how often you want it to appear, or disable it completely."
 msgstr ""
+"Анонимно генерирует ответы на поисковые запросы на основе веб-содержимого. "
+"Выберите, как часто вы хотите видеть его в результатах поиска, или полностью "
+"отключите эту функцию."
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -2226,7 +2226,7 @@ msgstr "Задавайте Duck.ai дальнейшие вопросы"
 #. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
 msgctxt "Page suggestion chip label"
 msgid "Ask about this page"
-msgstr ""
+msgstr "Задать вопрос об этой странице"
 
 # smartling.placeholder_format=C
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2295,10 +2295,9 @@ msgstr ""
 "интеллекта. Вы можете самостоятельно проконтролировать, как часто будут "
 "появляться ответы Assist: «никогда» (интерфейс Assist полностью исключается "
 "из поисковых запросов), «по запросу» (ответы ИИ отображаются при нажатии "
-"кнопки «Ассистент»), «иногда» (только при высокой релевантности) или "
-"«часто» (чаще и в отношении более широкого спектра запросов). Пока что "
-"ответы на базе ИИ предоставляются только на территории США (на английском "
-"языке)."
+"кнопки «Ассистент»), «иногда» (только при высокой релевантности) или «часто» "
+"(чаще и в отношении более широкого спектра запросов). Пока что ответы на "
+"базе ИИ предоставляются только на территории США (на английском языке)."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2651,7 +2650,7 @@ msgstr "Штрихкод"
 #. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Based on this page, is this course worth taking?"
-msgstr ""
+msgstr "Стоит ли проходить этот курс, судя по этой странице?"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2700,6 +2699,9 @@ msgid ""
 "Before storing this report, DuckDuckGo will anonymize your conversation by "
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
+"Перед сохранением этого отчета DuckDuckGo анонимизирует ваш чат, удалив "
+"персональные данные, такие как имена, адреса электронной почты и "
+"идентифицирующие метаданные."
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -2825,8 +2827,7 @@ msgstr "Блокировка почтовых трекеров и скрытие
 # smartling.placeholder_format=C
 #. A disclaimer about AI-generated images in search results
 msgid "Block list is not exhaustive and may contain inaccuracies."
-msgstr ""
-"Список блокировки не является исчерпывающим и может содержать неточности."
+msgstr "Список блокировки не является исчерпывающим и может содержать неточности."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -3022,7 +3023,7 @@ msgstr "Выигранные брейк-пойнты"
 #. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Break this down into clear, numbered steps."
-msgstr ""
+msgstr "Разбей это на понятные пронумерованные шаги."
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -3485,7 +3486,7 @@ msgstr "Актеры"
 #. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Cast & Crew"
-msgstr ""
+msgstr "Актеры и съемочная группа"
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -3724,11 +3725,11 @@ msgid ""
 "DuckDuckGo Search. However, you can still access Chat when this setting is "
 "off by visiting %shttps://duck.ai%s directly."
 msgstr ""
-"Чат (на сервисе Duck.ai) позволяет анонимно общаться со сторонними чат-"
-"моделями на базе ИИ от OpenAI, Anthropic и других компаний. При отключении "
-"этой настройки из интерфейса DuckDuckGo Search исчезнут кнопка «Чат» и "
-"ссылки на чат-сервис. Вы по-прежнему можете воспользоваться чатом, посетив "
-"его страницу напрямую: %1$shttps://duck.ai%2$s."
+"Чат (на сервисе Duck.ai) позволяет анонимно общаться со сторонними "
+"чат-моделями на базе ИИ от OpenAI, Anthropic и других компаний. При "
+"отключении этой настройки из интерфейса DuckDuckGo Search исчезнут кнопка "
+"«Чат» и ссылки на чат-сервис. Вы по-прежнему можете воспользоваться чатом, "
+"посетив его страницу напрямую: %1$shttps://duck.ai%2$s."
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -3950,8 +3951,7 @@ msgstr "Проверьте орфографию"
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
 msgctxt "noresults"
 msgid "Check the DuckDuckGo subreddit for updates on this outage."
-msgstr ""
-"Последнюю информацию по этому сбою можно отследить в сабреддите DuckDuckGo."
+msgstr "Последнюю информацию по этому сбою можно отследить в сабреддите DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
@@ -4367,8 +4367,7 @@ msgstr "Нажмите %1$sНастройки%2$s в выпадающем мен
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
-msgstr ""
-"Выберите %1$sИспользовать текущие страницы%2$s, затем %3$sНажмите OK%4$s."
+msgstr "Выберите %1$sИспользовать текущие страницы%2$s, затем %3$sНажмите OK%4$s."
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -5087,8 +5086,7 @@ msgstr "Копировать"
 # smartling.placeholder_format=C
 #. Instructions on how to change the default search engine
 msgid "Copy &amp; paste %sabout:preferences#search%s into the address bar"
-msgstr ""
-"Скопируйте и вставьте %1$sabout:preferences#search%2$s в адресную строку"
+msgstr "Скопируйте и вставьте %1$sabout:preferences#search%2$s в адресную строку"
 
 # smartling.placeholder_format=C
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
@@ -5209,7 +5207,7 @@ msgstr "Создать изображение"
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
-msgstr ""
+msgstr "Создай список покупок с указанием количества ингредиентов из этого рецепта."
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed in the input field when starting a new image generation session.
@@ -5844,8 +5842,7 @@ msgstr "Диктовка в Duck.ai"
 # smartling.placeholder_format=C
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
-msgstr ""
-"Диктовка анонимизируется и никогда не используется для обучения моделей ИИ."
+msgstr "Диктовка анонимизируется и никогда не используется для обучения моделей ИИ."
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
@@ -5855,7 +5852,7 @@ msgstr "Достигнут лимит диктовки"
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
 msgid "Dictation temporarily unavailable"
-msgstr ""
+msgstr "Функция диктовки временно недоступна"
 
 # smartling.placeholder_format=C
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
@@ -6164,6 +6161,8 @@ msgid ""
 "Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
 "filtered out. %sLearn More%s"
 msgstr ""
+"Не нужен ИИ? %1$snoai.duckduckgo.com%2$s — отсутствие ИИ-функций и "
+"фильтрация изображений, сгенерированных ИИ. %3$sПодробнее%4$s"
 
 # smartling.placeholder_format=C
 #. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
@@ -6172,6 +6171,9 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
+"Не нужен ИИ? Перейдите на страницу %1$snoai.duckduckgo.com%2$s и пользуйтесь "
+"поиском без ИИ и с исключением из результатов сгенерированных ИИ "
+"изображений. %3$sПодробнее%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6291,13 +6293,13 @@ msgstr ""
 #. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Draft a cover letter"
-msgstr ""
+msgstr "Подготовь сопроводительное письмо"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Draft a cover letter for this job."
-msgstr ""
+msgstr "Подготовь сопроводительное письмо для этой вакансии."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -6305,8 +6307,7 @@ msgctxt "Full sentence for drafting a social media post"
 msgid ""
 "Draft a few options for a social media post inviting people to my upcoming "
 "party."
-msgstr ""
-"Предложи несколько вариантов поста для соцсетей с приглашением на вечеринку."
+msgstr "Предложи несколько вариантов поста для соцсетей с приглашением на вечеринку."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a few options for a blog post title about strategies to increase team collaboration.
@@ -6328,8 +6329,7 @@ msgstr "Подготовь пост для соцсетей"
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Drag %sThis Button%s on top of the home icon:"
-msgstr ""
-"Переместите %1$sЭту кнопку%2$s на верхнюю часть значка домашней страницы:"
+msgstr "Переместите %1$sЭту кнопку%2$s на верхнюю часть значка домашней страницы:"
 
 # smartling.placeholder_format=C
 #. Indicates this is the number of draws for this team in e.g. soccer
@@ -6486,6 +6486,9 @@ msgid ""
 "company for anyone who wants to take back control of their personal "
 "information."
 msgstr ""
+"Duck.ai создан компанией DuckDuckGo. Мы — независимая компания, которая "
+"обеспечивает защиту личной информации в Интернете тем, кто хочет вернуть "
+"себе контроль над собственными данными."
 
 # smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
@@ -6540,6 +6543,10 @@ msgid ""
 "Duck.ai lets you chat privately with popular AI models. Disabling it hides "
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
+"Duck.ai позволяет вести приватные беседы с популярными ИИ-моделями. При "
+"отключении этой настройки кнопки Duck.ai и ссылки будут скрыты, но вы "
+"по-прежнему можете перейти на %1$sduck.ai%2$s и использовать инструмент "
+"напрямую."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6616,8 +6623,8 @@ msgid ""
 "models, privacy focused AI, no account AI chat"
 msgstr ""
 "Duck.ai, DuckDuckGo AI, приватный чат-бот, бесплатный чат с ИИ, анонимный "
-"чат с ИИ, ИИ-чат без регистрации, OpenAI, Anthropic, Llama, Mistral, ИИ-"
-"модели с открытым кодом, конфиденциальный ИИ, чат с ИИ без учетной записи"
+"чат с ИИ, ИИ-чат без регистрации, OpenAI, Anthropic, Llama, Mistral, "
+"ИИ-модели с открытым кодом, конфиденциальный ИИ, чат с ИИ без учетной записи"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -6793,8 +6800,7 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr ""
-"Сервис DuckDuckGo AI Chat временно недоступен. Повторите попытку позже."
+msgstr "Сервис DuckDuckGo AI Chat временно недоступен. Повторите попытку позже."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -7071,8 +7077,8 @@ msgid ""
 msgstr ""
 "Каждый раз, когда вы просите нас порекомендовать парольную фразу, мы "
 "запрашиваем с серверов DuckDuckGo длинный список случайных слов. Затем в "
-"браузере мы наугад выбираем из списка 4–5 составных слов длиной минимум 18–"
-"20 символов."
+"браузере мы наугад выбираем из списка 4–5 составных слов длиной минимум "
+"18–20 символов."
 
 # smartling.placeholder_format=C
 msgctxt "Sports module"
@@ -7556,13 +7562,13 @@ msgstr "Эритрея"
 #. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Estimate the nutrition"
-msgstr ""
+msgstr "Оцени пищевую ценность"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Estimate the nutritional information for this recipe."
-msgstr ""
+msgstr "Оцени пищевую ценность блюда по рецепту."
 
 # smartling.placeholder_format=C
 msgid "Estonia"
@@ -7624,7 +7630,7 @@ msgstr "Остался 1 день"
 #. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain the accepted answer in simple terms."
-msgstr ""
+msgstr "Объясни принятый ответ простыми словами."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
@@ -7637,43 +7643,43 @@ msgstr "Объясни основные принципы теории черны
 #. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain the top answer"
-msgstr ""
+msgstr "Объясни ответ вверху"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain this in simple, plain language."
-msgstr ""
+msgstr "Объясни это простым и понятным языком."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain this paper"
-msgstr ""
+msgstr "Объясни эту статью"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain this repo"
-msgstr ""
+msgstr "Расскажи про этот репозиторий"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain this research paper in plain language."
-msgstr ""
+msgstr "Объясни эту научную статью простым языком."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain this simply"
-msgstr ""
+msgstr "Объясни это просто"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain what this repository does and how to use it."
-msgstr ""
+msgstr "Объясни, что делает этот репозиторий и как им пользоваться."
 
 # smartling.placeholder_format=C
 #. Label to show if song lyrics contain explicit content
@@ -7964,6 +7970,8 @@ msgctxt "settings"
 msgid ""
 "Filters out known AI spam sites from image search results. %sLearn More%s"
 msgstr ""
+"Исключает из результатов поиска изображений известные сайты с ИИ-спамом. "
+"%1$sПодробнее%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the final score of a sporting event.
@@ -8024,7 +8032,7 @@ msgstr "Найдите актуальную информацию"
 #. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Find me alternatives"
-msgstr ""
+msgstr "Найди альтернативы"
 
 # smartling.placeholder_format=C
 #. Button that searches for results closer to the user's current location.
@@ -8507,7 +8515,7 @@ msgstr "Создавай больше"
 #. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Generate a shopping list"
-msgstr ""
+msgstr "Составь список покупок"
 
 # smartling.placeholder_format=C
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
@@ -8804,7 +8812,7 @@ msgstr "Попробовать"
 #. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Give me a quick background on this person."
-msgstr ""
+msgstr "Расскажи вкратце об этом человеке."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9258,13 +9266,13 @@ msgstr "Помогите в распространении конфиденци�
 #. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Help me prep for the interview"
-msgstr ""
+msgstr "Помоги подготовиться к собеседованию"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Help me tailor my resume for this job."
-msgstr ""
+msgstr "Помоги мне адаптировать мое резюме для этой вакансии."
 
 # smartling.placeholder_format=C
 #. Title of a SERP popup that invites users to take a survey (desktop only)
@@ -9346,8 +9354,7 @@ msgstr "Ответ пригодился"
 #. The title of a menu that shows other applications DuckDuckGo has made.
 msgctxt "showcase_aria_dropdown"
 msgid "Here are some things that we made that you might like."
-msgstr ""
-"Мы сделали несколько приложений, которые могут вас заинтересовать. Вот они!"
+msgstr "Мы сделали несколько приложений, которые могут вас заинтересовать. Вот они!"
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -9790,7 +9797,7 @@ msgctxt ""
 "Text for the I already have a subscription button in the Duck.ai settings "
 "page"
 msgid "I Already Have a Subscription"
-msgstr ""
+msgstr "У меня уже есть подписка"
 
 # smartling.placeholder_format=C
 #. Text for the button that takes the user to the login subscription page.
@@ -10060,8 +10067,7 @@ msgstr "Изображения по запросу «%1$s»"
 # smartling.placeholder_format=C
 #. A label that indicates a specific search result for images has been blocked by the safe search filter. The placeholder value is the name of the search result that was blocked.
 msgid "Images for %s blocked by safe search"
-msgstr ""
-"Изображения по запросу «%1$s» заблокированы в рамках безопасного поиска."
+msgstr "Изображения по запросу «%1$s» заблокированы в рамках безопасного поиска."
 
 # smartling.placeholder_format=C
 #. Title for the section that showcases the image results for a certain query, ex. Images for <b>beach</b>
@@ -10374,7 +10380,7 @@ msgstr "Установить браузер для Mac"
 #. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
 msgctxt "settings"
 msgid "Install Now"
-msgstr ""
+msgstr "Установить"
 
 # smartling.placeholder_format=C
 #. Text of a button to install the DuckDuckGo app
@@ -10477,13 +10483,13 @@ msgstr "Удалены ли данные на самом деле?"
 #. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Is it worth taking?"
-msgstr ""
+msgstr "Стоит попробовать?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Is this place any good?"
-msgstr ""
+msgstr "Это хорошее место?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
@@ -10492,6 +10498,8 @@ msgid ""
 "Is this place any good? Summarize its reputation based on reviews and "
 "ratings."
 msgstr ""
+"Это хорошее место? Кратко изложи, какая у него репутация на основе отзывов и "
+"оценок."
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -10503,13 +10511,13 @@ msgstr "Видео пригодилось?"
 #. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Is this worth watching?"
-msgstr ""
+msgstr "Стоит ли это смотреть?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Is this worth watching? Give me a spoiler-free take."
-msgstr ""
+msgstr "Стоит ли это смотреть? Дай отзыв без спойлеров."
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -10934,8 +10942,7 @@ msgstr "Подробнее об активной защите конфиденц
 # smartling.placeholder_format=C
 msgctxt "showcase_newsletter"
 msgid "Learn about online privacy right in your inbox."
-msgstr ""
-"Получайте рекомендации о защите персональных данных на электронную почту."
+msgstr "Получайте рекомендации о защите персональных данных на электронную почту."
 
 # smartling.placeholder_format=C
 #. Link to a page with more information about how DuckDuckGo settings are managed.
@@ -10989,8 +10996,7 @@ msgstr "Подробнее о работе этой функции"
 # smartling.placeholder_format=C
 msgctxt "SERP footer content"
 msgid "Learn why reducing online tracking is important."
-msgstr ""
-"Узнайте, почему важно ограничивать отслеживание ваших действий в интернете."
+msgstr "Узнайте, почему важно ограничивать отслеживание ваших действий в интернете."
 
 # smartling.placeholder_format=C
 #. A link that takes users to a page where they can learn more about the dangers of online tracking.
@@ -11132,6 +11138,8 @@ msgstr "Ссылки:"
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
 msgstr ""
+"Перечисли инструменты, материалы или условия, которые мне для этого "
+"понадобятся."
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -11545,7 +11553,7 @@ msgstr "Настроить блокировку"
 #. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
 msgctxt "setting"
 msgid "Manage in Browser Settings"
-msgstr ""
+msgstr "Управлять в настройках браузера"
 
 # smartling.placeholder_format=C
 #. Link to the site exclusion settings page
@@ -13303,8 +13311,7 @@ msgstr "Оман"
 #. http://i.imgur.com/zQWKLIm.png
 msgctxt "settings"
 msgid "Omits objectionable (mostly adult) material"
-msgstr ""
-"Исключает из выдачи нежелательные материалы (в основном — \"для взрослых\")"
+msgstr "Исключает из выдачи нежелательные материалы (в основном — \"для взрослых\")"
 
 # smartling.placeholder_format=C
 msgid "On"
@@ -13463,8 +13470,7 @@ msgstr "Открыть сайт %1$s"
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open %sLocation%s, and ensure location is %senabled%s"
-msgstr ""
-"Убедитесь, что %1$sгеолокация%2$s (в одноименном разделе) %3$sвключена%4$s."
+msgstr "Убедитесь, что %1$sгеолокация%2$s (в одноименном разделе) %3$sвключена%4$s."
 
 #  Chrome/Firefox on Android/iOS
 # smartling.placeholder_format=C
@@ -13627,8 +13633,7 @@ msgstr "Открыть панель «Как работает Duck.ai»"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open the Safari menu and select %sSettings for DuckDuckGo...%s"
-msgstr ""
-"Откройте меню Safari и выберите пункт «%1$sНастройки для DuckDuckGo...%2$s»"
+msgstr "Откройте меню Safari и выберите пункт «%1$sНастройки для DuckDuckGo...%2$s»"
 
 # smartling.placeholder_format=C
 #. Label for the time a business opens. For example: 'Opens at 10am'
@@ -14384,6 +14389,8 @@ msgstr ""
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is harmful or illegal. (optional)"
 msgstr ""
+"Опишите, почему ответ чата является вредоносным или незаконным. "
+"(Необязательно)"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
@@ -14422,6 +14429,8 @@ msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is harmful or illegal."
 msgstr ""
+"Скопируйте и вставьте свой запрос и полученный ответ (удалите всю личную "
+"информацию). Опишите проблему с контентом."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -14894,7 +14903,7 @@ msgstr "Настройки конфиденциальности"
 #. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
 msgctxt "Section heading on the Duck.ai settings page"
 msgid "Privacy & Terms"
-msgstr ""
+msgstr "Конфиденциальность и условия"
 
 # smartling.placeholder_format=C
 msgid "Privacy Blog"
@@ -14970,7 +14979,7 @@ msgstr "Политика конфиденциальности и условия 
 #. Text for a button that links to the terms of use and privacy policy page.
 msgctxt "Secondary button text in active privacy modal"
 msgid "Privacy Policy and Terms of Service"
-msgstr ""
+msgstr "Политика конфиденциальности и Условия использования"
 
 # smartling.placeholder_format=C
 #. Title displayed on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
@@ -15072,8 +15081,7 @@ msgstr "Приватные чаты без сохранения"
 #. The device location shared is is not logged by us
 msgctxt "precise_user_location"
 msgid "Private to us and secured on your device"
-msgstr ""
-"Ваши данные остаются конфиденциальными и надежно хранятся на вашем устройстве"
+msgstr "Ваши данные остаются конфиденциальными и надежно хранятся на вашем устройстве"
 
 # smartling.placeholder_format=C
 #. Heading above the group of Pro-tier locked models in the model picker dropdown, when the user is on the Plus tier.
@@ -15478,25 +15486,25 @@ msgstr "Порекомендовать книгу"
 #. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Recommend similar books"
-msgstr ""
+msgstr "Посоветуй похожие книги"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Recommend similar books."
-msgstr ""
+msgstr "Посоветуй похожие книги."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Recommend similar movies or shows."
-msgstr ""
+msgstr "Посоветуй похожие фильмы или сериалы."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Recommend similar titles"
-msgstr ""
+msgstr "Посоветуй похожее"
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
@@ -15906,7 +15914,7 @@ msgctxt ""
 "feedback form when the user has selected Harmful or Illegal as the feedback "
 "reason"
 msgid "Required for harmful or illegal reports"
-msgstr ""
+msgstr "Обязательно для сообщений о незаконном или вредоносном контенте"
 
 # smartling.placeholder_format=C
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
@@ -16151,7 +16159,7 @@ msgstr "Отзывы"
 #. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Rewrite this recipe scaled for a different number of servings."
-msgstr ""
+msgstr "Пересчитай этот рецепт на другое количество порций."
 
 # smartling.placeholder_format=C
 msgid "Romania"
@@ -16985,8 +16993,7 @@ msgstr ""
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
 msgctxt "Sync feature benefit description"
 msgid "Securely stored on DuckDuckGo's server with end-to-end encryption."
-msgstr ""
-"Надежно хранится на сервере DuckDuckGo с применением сквозного шифрования."
+msgstr "Надежно хранится на сервере DuckDuckGo с применением сквозного шифрования."
 
 # smartling.placeholder_format=C
 #. List item explaining that synced chats are stored with end-to-end encryption on DuckDuckGo's server and only the user can access them.
@@ -17164,8 +17171,7 @@ msgstr "Выберите %1$sDuckDuckGo%2$s и нажмите %3$sУстанов
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Select %sDuckDuckGo%s in the Default Search Engine drop down"
-msgstr ""
-"Выберите %1$sDuckDuckGo%2$s поисковой системой по умолчанию в выпадающем меню"
+msgstr "Выберите %1$sDuckDuckGo%2$s поисковой системой по умолчанию в выпадающем меню"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
@@ -17185,8 +17191,7 @@ msgstr "Выберите %1$sDuckDuckGo%2$s в списке поисковых �
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s under the%sDefault Search Engine%s section"
-msgstr ""
-"Выберите %1$sDuckDuckGo%2$s в разделе%3$sПоисковая система по умолчанию%4$s"
+msgstr "Выберите %1$sDuckDuckGo%2$s в разделе%3$sПоисковая система по умолчанию%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user were in the settings menu they can change their default search engine.
@@ -17271,8 +17276,7 @@ msgstr "Выберите %1$sНастройки%2$s, затем %3$sДополн
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sDefault search engine%s"
-msgstr ""
-"Выберите %1$sНастройки%2$s, а затем %3$sПоисковая система по умолчанию%4$s"
+msgstr "Выберите %1$sНастройки%2$s, а затем %3$sПоисковая система по умолчанию%4$s"
 
 #  Chrome/Firefox on Android
 # smartling.placeholder_format=C
@@ -17368,8 +17372,7 @@ msgstr "Выбранный текст со страницы %1$s"
 #. Displayed when the user's text selection exceeds the maximum message size for AI tools (summary, translation, etc.).
 msgctxt "Error message for selection input limit"
 msgid "Selected text is too long. Try again with a shorter selection."
-msgstr ""
-"Выделенный текст слишком длинный. Попробуйте выбрать фрагмент покороче."
+msgstr "Выделенный текст слишком длинный. Попробуйте выбрать фрагмент покороче."
 
 # smartling.placeholder_format=C
 #. Label for the semi-finals knockout stage in e.g. the soccer World Cup
@@ -17493,7 +17496,7 @@ msgstr "Настрой сейчас"
 #. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
 msgctxt "Encrypted storage setup button shown in native browsers"
 msgid "Set Up Sync & Backup"
-msgstr ""
+msgstr "Настройка Sync & Backup"
 
 # smartling.placeholder_format=C
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
@@ -17587,8 +17590,7 @@ msgstr "Поделиться"
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "Share DuckDuckGo and help friends take their privacy back!"
-msgstr ""
-"Поделитесь DuckDuckGo и помогите друзьям вернуть свою конфиденциальность!"
+msgstr "Поделитесь DuckDuckGo и помогите друзьям вернуть свою конфиденциальность!"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button that opens a feedback modal when clicked.
@@ -17682,7 +17684,7 @@ msgstr "Отправить положительный отзыв"
 msgctxt ""
 "Label beside the share-content switch on the Duck.ai response feedback form"
 msgid "Share this conversation with DuckDuckGo"
-msgstr ""
+msgstr "Поделиться этим чатом с DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -18123,8 +18125,7 @@ msgstr "Показывает поисковые подсказки при вво
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows the privacy benefits of using DuckDuckGo on the homepage"
-msgstr ""
-"Показывает преимущества приватного поиска с DuckDuckGo на стартовой странице"
+msgstr "Показывает преимущества приватного поиска с DuckDuckGo на стартовой странице"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18218,8 +18219,7 @@ msgstr "Поиск по сайту временно недоступен. Мы �
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Sites you block will be hidden from all your search results"
-msgstr ""
-"Сайты, которые ты заблокируешь, будут скрыты из всех твоих результатов поиска"
+msgstr "Сайты, которые ты заблокируешь, будут скрыты из всех твоих результатов поиска"
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes full name (tooltip)
@@ -18358,8 +18358,7 @@ msgstr "Что-то пошло не так"
 #. Error message indicating that the user's settings weren't able to be saved.
 msgctxt "cloudsave"
 msgid "Something went wrong saving to the server, please try again."
-msgstr ""
-"Что-то пошло не так при сохранении на сервер, пожалуйста, попробуйте снова."
+msgstr "Что-то пошло не так при сохранении на сервер, пожалуйста, попробуйте снова."
 
 # smartling.placeholder_format=C
 #. Body copy displayed under the Set Up Now button when the sync setup call fails.
@@ -18455,8 +18454,7 @@ msgctxt "noresults"
 msgid ""
 "Sorry, we ran into an error displaying these results. %sClick here%s to try "
 "again."
-msgstr ""
-"При отображении результатов произошла ошибка. %1$sПовторить попытку%2$s"
+msgstr "При отображении результатов произошла ошибка. %1$sПовторить попытку%2$s"
 
 # smartling.placeholder_format=C
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
@@ -18945,19 +18943,19 @@ msgstr "Предложи заголовок для статьи в блоге"
 #. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Suggest related articles or topics worth exploring next."
-msgstr ""
+msgstr "Предложи похожие статьи или темы, которые стоит рассмотреть далее."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Suggest related articles to explore"
-msgstr ""
+msgstr "Предложи похожие статьи"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Suggest some alternatives to this product."
-msgstr ""
+msgstr "Предложи альтернативы этому продукту."
 
 # smartling.placeholder_format=C
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
@@ -18974,7 +18972,7 @@ msgstr "Рекомендации:"
 #. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Sum up the reviews"
-msgstr ""
+msgstr "Подытожь отзывы"
 
 # smartling.placeholder_format=C
 #. A short title for the a message asking the AI to summarize a text.
@@ -18986,85 +18984,85 @@ msgstr "Краткий пересказ"
 #. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize the Q&As"
-msgstr ""
+msgstr "Кратко изложи вопросы и ответы"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the background and notable work of this person."
-msgstr ""
+msgstr "Расскажи вкратце об этом человеке и его известных работах."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the key details of this event."
-msgstr ""
+msgstr "Кратко изложи основные детали этого события."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the questions and answers on this page."
-msgstr ""
+msgstr "Кратко изложи вопросы и ответы на этой странице."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize their background"
-msgstr ""
+msgstr "Кратко изложи биографию этого человека"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this book"
-msgstr ""
+msgstr "Кратко изложи содержимое книги"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this book."
-msgstr ""
+msgstr "Кратко изложи содержимое книги."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this discussion"
-msgstr ""
+msgstr "Кратко изложи суть обсуждения"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this discussion thread."
-msgstr ""
+msgstr "Кратко изложи суть этой ветки обсуждения."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this page"
-msgstr ""
+msgstr "Кратко изложи содержимое страницы"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this page."
-msgstr ""
+msgstr "Кратко изложи содержимое страницы."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this video"
-msgstr ""
+msgstr "Кратко изложи содержимое видео"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this video."
-msgstr ""
+msgstr "Кратко изложи содержимое видео."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize what the reviews say."
-msgstr ""
+msgstr "Обобщи, что пишут в отзывах."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -19397,7 +19395,7 @@ msgstr "Сирия"
 #. Text for a button that enables the theme to follow the operating system's color scheme preference.
 msgctxt "System theme button for theme selector"
 msgid "System"
-msgstr ""
+msgstr "Тема системы"
 
 # smartling.placeholder_format=C
 #. Abbreviation indicating this is the total score for a game
@@ -19431,7 +19429,7 @@ msgstr "Таитянский"
 #. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Tailor my resume"
-msgstr ""
+msgstr "Адаптируй мое резюме"
 
 # smartling.placeholder_format=C
 msgid "Taiwan"
@@ -19467,7 +19465,7 @@ msgstr "Ваши личные данные — под вашим контрол�
 msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
-msgstr ""
+msgstr "Пройди этот анонимный опрос и помоги нам улучшить Duck.ai."
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -19749,8 +19747,7 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider does not save this chat or any associated data on their "
 "servers."
-msgstr ""
-"Поставщик не хранит этот чат и связанные с ним данные на своих серверах."
+msgstr "Поставщик не хранит этот чат и связанные с ним данные на своих серверах."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19778,7 +19775,7 @@ msgstr "Тема"
 #. Text for the theme selector label that allows users to switch between Light and dark theme.
 msgctxt "Label for the theme selector feature"
 msgid "Theme"
-msgstr ""
+msgstr "Тема"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/LpFhb1e.png
@@ -19885,8 +19882,7 @@ msgctxt "AI Chat: Error message for when a model is removed"
 msgid ""
 "This AI model is no longer available. Try starting a new chat with a "
 "different model."
-msgstr ""
-"Эта ИИ-модель больше недоступна. Попробуйте запустить чат с другой моделью."
+msgstr "Эта ИИ-модель больше недоступна. Попробуйте запустить чат с другой моделью."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is no longer supported because it has been upgraded to a newest version.
@@ -20039,8 +20035,7 @@ msgstr ""
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF."
-msgstr ""
-"Формат не поддерживается. Прикрепите изображение в JPG, PNG, WebP или GIF."
+msgstr "Формат не поддерживается. Прикрепите изображение в JPG, PNG, WebP или GIF."
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
@@ -20093,8 +20088,7 @@ msgstr "Для нормальной работы данной странице �
 #. Information tooltip text explaining that the current page's content will be included with the chat message.
 msgctxt "Tooltip explaining that page content will be sent to Duck.ai"
 msgid "This page's content will be sent with your message to Duck.ai"
-msgstr ""
-"Содержимое страницы будет отправлено в Duck.ai вместе с вашим сообщением."
+msgstr "Содержимое страницы будет отправлено в Duck.ai вместе с вашим сообщением."
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -20170,8 +20164,7 @@ msgstr "Здесь это видео пока недоступно. Его мо�
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr ""
-"Эта страница не использует безопасное зашифрованное соединение (HTTPS)."
+msgstr "Эта страница не использует безопасное зашифрованное соединение (HTTPS)."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -20318,8 +20311,7 @@ msgstr ""
 msgctxt ""
 "Copy stating agreement to Duck.ai Privacy Policy and Terms of Service."
 msgid "To continue, you must agree to Duck.ai’s %s and %s"
-msgstr ""
-"Чтобы продолжить, примите положения разделов «%1$s» и «%2$s» сервиса Duck.ai."
+msgstr "Чтобы продолжить, примите положения разделов «%1$s» и «%2$s» сервиса Duck.ai."
 
 # smartling.placeholder_format=C
 #. Text stating agreement to AI Chat Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'To continue, you must agree to DuckDuckGo AI Chat’s Privacy Policy and Terms of Service'
@@ -20626,13 +20618,13 @@ msgstr ""
 #. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Translate this page"
-msgstr ""
+msgstr "Переведи эту страницу"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
 msgctxt "Page suggestion prompt"
 msgid "Translate this page into %s."
-msgstr ""
+msgstr "Переведи эту страницу на %1$s."
 
 # smartling.placeholder_format=C
 #. Placeholder text for a region that will display translated text.
@@ -20734,13 +20726,11 @@ msgstr "Чтобы не получать подобные сообщения, п
 #. Text for a promotional card that encourages users to try the encrypted AI model whose inference runs in a confidential environment so the model provider cannot access user data. %s is replaced with the model's full display name (e.g. 'GPT-OSS 120B').
 msgctxt "Promotional text for encrypted AI model"
 msgid "Try %s, our first model with zero provider visibility."
-msgstr ""
-"Попробуйте %1$s — нашу первую ИИ-модель с нулевой видимостью для поставщика."
+msgstr "Попробуйте %1$s — нашу первую ИИ-модель с нулевой видимостью для поставщика."
 
 # smartling.placeholder_format=C
 msgid "Try %sDuck.ai%s, our private AI chat service:"
-msgstr ""
-"Попробуйте %1$sDuck.ai%2$s — приватный чат с искусственным интеллектом:"
+msgstr "Попробуйте %1$sDuck.ai%2$s — приватный чат с искусственным интеллектом:"
 
 # smartling.placeholder_format=C
 #. Button text to retry loading an explore more question that failed
@@ -20781,7 +20771,7 @@ msgstr "Попробовать бесплатно"
 #. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
 msgctxt "settings"
 msgid "Try It Now"
-msgstr ""
+msgstr "Попробуй сейчас"
 
 # smartling.placeholder_format=C
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -20847,16 +20837,14 @@ msgstr ""
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
 msgctxt "precise_user_location"
 msgid "Try enabling anonymous location for more accurate results."
-msgstr ""
-"Для более точных результатов попробуйте использовать анонимную геопозицию."
+msgstr "Для более точных результатов попробуйте использовать анонимную геопозицию."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the screen of the onboarding where the user picks a chat model.
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr ""
-"Попробуйте поэкспериментировать с каждой моделью: они дадут разные ответы."
+msgstr "Попробуйте поэкспериментировать с каждой моделью: они дадут разные ответы."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
@@ -20996,8 +20984,7 @@ msgstr "Новинки платформы: ИИ-модели с открытым
 #. Message displayed to suggest the user to try the provided prompts or enter their own.
 msgctxt "Prompt suggestion message"
 msgid "Try these prompts to get started or enter your own prompt below"
-msgstr ""
-"Попробуйте начать с готовых запросов или введите собственный вариант ниже."
+msgstr "Попробуйте начать с готовых запросов или введите собственный вариант ниже."
 
 # smartling.placeholder_format=C
 #. Description for the empty state displayed when searching recent chats in Duck.ai returns no results, suggesting the user rephrase their search query.
@@ -21031,6 +21018,8 @@ msgid ""
 "Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
+"Хотите отключить функции ИИ? Установите расширение %1$sDuckDuckGo No AI%2$s "
+"для браузера, чтобы сохранить настройки. %3$sПодробнее%4$s"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -21039,6 +21028,8 @@ msgid ""
 "Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
+"Хотите отключить функции ИИ? Переключитесь на расширение %1$sDuckDuckGo No "
+"AI%2$s для браузера, чтобы сохранить свои настройки. %3$sПодробнее%4$s"
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -21153,8 +21144,7 @@ msgstr "Duck Player — просмотр YouTube без целевой рекл�
 #. Tells users which setting to change to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on “Precise Location” for more accurate results."
-msgstr ""
-"Для получения более точных результатов выберите вариант «Точная геопозиция»."
+msgstr "Для получения более точных результатов выберите вариант «Точная геопозиция»."
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -21361,15 +21351,14 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sOpen with%s select %sA specific page or pages%s"
-msgstr ""
-"Под %1$sОткрыть с%2$s выберите %3$sОпределенная страница или страницы%4$s"
+msgstr "Под %1$sОткрыть с%2$s выберите %3$sОпределенная страница или страницы%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
 msgstr ""
-"В меню %1$sПри запуске > Домашняя страница%2$s введите: https://duckduckgo."
-"com"
+"В меню %1$sПри запуске > Домашняя страница%2$s введите: "
+"https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -21379,16 +21368,15 @@ msgstr "В меню %1$sНастройки поиска%2$s выберите %3$
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch in the address bar with%s select %sAdd New%s"
-msgstr ""
-"В разделе %1$sпоиска в адресной строке%2$s выберите %3$sДобавить новый%4$s"
+msgstr "В разделе %1$sпоиска в адресной строке%2$s выберите %3$sДобавить новый%4$s"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
 msgstr ""
-"Под разделом %1$sПоиск%2$s нажмите на %3$sУправление поисковыми системами..."
-"%4$s"
+"Под разделом %1$sПоиск%2$s нажмите на %3$sУправление поисковыми "
+"системами...%4$s"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -21402,8 +21390,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine
 msgid "Under Search click the drop down and select %sDuckDuckGo%s"
-msgstr ""
-"В разделе поиска нажмите на выпадающий список и выберите %1$sDuckDuckGo%2$s"
+msgstr "В разделе поиска нажмите на выпадающий список и выберите %1$sDuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings" header
@@ -21620,8 +21607,8 @@ msgid ""
 "Update the DuckDuckGo browser to activate your subscription in Duck.ai and "
 "access advanced models"
 msgstr ""
-"Чтобы активировать подписку в Duck.ai и пользоваться продвинутыми ИИ-"
-"моделями, обновите браузер DuckDuckGo."
+"Чтобы активировать подписку в Duck.ai и пользоваться продвинутыми "
+"ИИ-моделями, обновите браузер DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. The placeholder indicates a formatted date (e.g., 'Updated 2 days ago')
@@ -21805,7 +21792,7 @@ msgstr "Уругвай"
 #. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
 msgctxt "Navigation label on the Duck.ai settings page"
 msgid "Usage"
-msgstr ""
+msgstr "Применение"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -21863,8 +21850,7 @@ msgstr "Используйте DuckDuckGo Private Search"
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Use DuckDuckGo private search on your iPad, iPhone, or Android!"
-msgstr ""
-"Пользуйтесь DuckDuckGo Private Search на вашем iPad, iPhone, или Android!"
+msgstr "Пользуйтесь DuckDuckGo Private Search на вашем iPad, iPhone, или Android!"
 
 # smartling.placeholder_format=C
 #. User clicks this button to share their device's location
@@ -21976,8 +21962,7 @@ msgstr "Видеоролики заблокированы в рамках без
 # smartling.placeholder_format=C
 #. A label that indicates a specific search result for videos has been blocked by the safe search filter. The placeholder value is the name of the search result that was blocked.
 msgid "Videos for %s blocked by safe search"
-msgstr ""
-"Видеоролики по запросу «%1$s» заблокированы в рамках безопасного поиска."
+msgstr "Видеоролики по запросу «%1$s» заблокированы в рамках безопасного поиска."
 
 # smartling.placeholder_format=C
 #. Title for the section that showcases the video results for a certain query, ex. Videos for <b>japan</b>
@@ -22266,7 +22251,7 @@ msgstr "Уэльс"
 #. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Walk me through the steps"
-msgstr ""
+msgstr "Поэтапно проведи меня по инструкции"
 
 # smartling.placeholder_format=C
 #. Label for walking directions on a map.
@@ -22396,6 +22381,9 @@ msgid ""
 "please share this conversation with DuckDuckGo so we can investigate and "
 "address the issue."
 msgstr ""
+"Мы можем исправить только то, что можем проверить. Чтобы сообщить о "
+"вредоносном или незаконном контенте в ответе, поделитесь этим чатом с "
+"DuckDuckGo, чтобы мы могли расследовать проблему и принять меры."
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -22493,8 +22481,7 @@ msgstr "Мы не отслеживаем вас. Никогда."
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with a Continue button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don't track you. That's our Privacy Policy in a nutshell."
-msgstr ""
-"Никакой слежки за вами. Вот краткий обзор нашей Политики конфиденциальности."
+msgstr "Никакой слежки за вами. Вот краткий обзор нашей Политики конфиденциальности."
 
 # smartling.placeholder_format=C
 #. Description for the audio identification highlight in the dictation consent modal.
@@ -22535,8 +22522,7 @@ msgstr "Мы не следим за вами, ни в режиме приват�
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with an Agree button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don’t track you. That’s our Privacy Policy in a nutshell…"
-msgstr ""
-"Мы не шпионим за вами. Вот краткий обзор нашей политики конфиденциальности…"
+msgstr "Мы не шпионим за вами. Вот краткий обзор нашей политики конфиденциальности…"
 
 # smartling.placeholder_format=C
 #. Displayed when the user's voice chat session is ended because of being inactive for too long.
@@ -22622,8 +22608,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
-msgstr ""
-"Пока вы гуляете по Интернету, мы не даем трекерам собирать ваши данные."
+msgstr "Пока вы гуляете по Интернету, мы не даем трекерам собирать ваши данные."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -22947,98 +22932,98 @@ msgstr ""
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the counterarguments?"
-msgstr ""
+msgstr "Какие есть контраргументы?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the hours & location?"
-msgstr ""
+msgstr "Где находится это место и каков его график работы?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key contributions of this paper?"
-msgstr ""
+msgstr "Каковы основные положения этой статьи?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key contributions?"
-msgstr ""
+msgstr "Каковы основные положения?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key details?"
-msgstr ""
+msgstr "Каковы основные детали?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key points covered in this video?"
-msgstr ""
+msgstr "Какие основные моменты освещаются в этом видео?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key points?"
-msgstr ""
+msgstr "Какие основные моменты?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key takeaways from this article?"
-msgstr ""
+msgstr "Какие основные выводы из этой статьи?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key takeaways?"
-msgstr ""
+msgstr "Какие основные выводы?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key things I will learn from this course?"
-msgstr ""
+msgstr "Чему я научусь на этом курсе?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the main counterarguments or criticisms of this?"
-msgstr ""
+msgstr "Каковы основные контраргументы или критические замечания по этому поводу?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the main questions this page answers?"
-msgstr ""
+msgstr "На какие основные вопросы отвечает эта страница?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the must-try dishes here?"
-msgstr ""
+msgstr "Что здесь стоит попробовать?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid ""
 "What are the opening hours, location, and contact details for this place?"
-msgstr ""
+msgstr "Какие здесь часы работы, адрес и контактные данные?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the pros and cons of this product?"
-msgstr ""
+msgstr "В чем плюсы и минусы этого продукта?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the pros and cons?"
-msgstr ""
+msgstr "В чем плюсы и минусы?"
 
 # smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
@@ -23144,7 +23129,7 @@ msgstr "Что значит «атриум» в контексте медици�
 #. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What does this answer?"
-msgstr ""
+msgstr "Ответы на какие вопросы здесь можно найти?"
 
 # smartling.placeholder_format=C
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
@@ -23162,7 +23147,7 @@ msgstr "Какая информация сохраняется?"
 #. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What interview questions might come up for this role?"
-msgstr ""
+msgstr "Какие вопросы могут возникнуть на собеседовании на эту должность?"
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -23184,7 +23169,7 @@ msgstr "Как называется столица Албании?"
 #. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What is the overall verdict and rating for this?"
-msgstr ""
+msgstr "Каков общий вердикт и оценка?"
 
 # smartling.placeholder_format=C
 #. Link to a page with additional information.
@@ -23212,7 +23197,7 @@ msgstr "Мнения других:"
 #. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What should I order?"
-msgstr ""
+msgstr "Что мне заказать?"
 
 # smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
@@ -23230,13 +23215,13 @@ msgstr "Какая проблема возникла с ответом? (Нео�
 #. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What will I learn?"
-msgstr ""
+msgstr "Чему я научусь?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What will I need?"
-msgstr ""
+msgstr "Что мне понадобится?"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -23261,7 +23246,7 @@ msgstr "Что нового"
 #. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What's the verdict?"
-msgstr ""
+msgstr "Каков вердикт?"
 
 # smartling.placeholder_format=C
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -23279,8 +23264,7 @@ msgstr "На какие бренды обратить внимание нови�
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "When enabled, Duck.ai will show instant answers in the chat."
-msgstr ""
-"При активации этой настройки Duck.ai будет показывать быстрые ответы в чате."
+msgstr "При активации этой настройки Duck.ai будет показывать быстрые ответы в чате."
 
 # smartling.placeholder_format=C
 #. Text of a button that performs a search for the available streaming services that show a particular movie or tv show
@@ -23316,7 +23300,7 @@ msgstr "Каких функций не хватает? (по желанию)"
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Which features are missing? (optional)"
-msgstr ""
+msgstr "Каких функций не хватает? (Необязательно)"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
@@ -23339,12 +23323,14 @@ msgstr "Кто мы"
 msgctxt "Page suggestion prompt"
 msgid "Who are the main cast and crew, and what else are they known for?"
 msgstr ""
+"Кто входит в основной актерский состав и съемочную группу и чем еще они "
+"известны?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Who is this person?"
-msgstr ""
+msgstr "Кто этот человек?"
 
 # smartling.placeholder_format=C
 #. Header above a collection of privacy-related links.
@@ -23777,8 +23763,7 @@ msgstr ""
 
 # smartling.placeholder_format=C
 msgid "You can also use %sDuck.ai%s to answer questions or summarize text."
-msgstr ""
-"Сервис %1$sDuck.ai%2$s также умеет отвечать на вопросы и резюмировать текст."
+msgstr "Сервис %1$sDuck.ai%2$s также умеет отвечать на вопросы и резюмировать текст."
 
 # smartling.placeholder_format=C
 msgid ""
@@ -23807,8 +23792,7 @@ msgstr ""
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
 msgctxt "Third party map app picker feedback dialog"
 msgid "You can change this any time in %sSearch Settings%s"
-msgstr ""
-"Вы в любой момент можете изменить свой выбор в %1$sнастройках поиска%2$s"
+msgstr "Вы в любой момент можете изменить свой выбор в %1$sнастройках поиска%2$s"
 
 # smartling.placeholder_format=C
 #. Text explaning how to change a passphrase.
@@ -23841,8 +23825,7 @@ msgstr "Это напоминание можно скрыть в %1$sнастр�
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
-msgstr ""
-"Теперь на этом устройстве можно хранить до 100 чатов. Общайтесь больше!"
+msgstr "Теперь на этом устройстве можно хранить до 100 чатов. Общайтесь больше!"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -23860,29 +23843,25 @@ msgstr "Число файлов, прикрепляемых к одной бес
 #. Error message displayed when the user has select more images than are allowed to be uploaded. Placeholder is the number of images that are allowed. E.g. You can only attach 3 images per chat
 msgctxt "Error message when input exceeds image upload limit"
 msgid "You can only attach %s images at a time"
-msgstr ""
-"Число изображений, прикрепляемых за один раз, ограничено: максимум %1$s."
+msgstr "Число изображений, прикрепляемых за один раз, ограничено: максимум %1$s."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has select more images than are allowed to be uploaded. Placeholder is the number of images that are allowed. E.g. You can only attach 3 images per chat
 msgctxt "Error message when input exceeds image upload limit"
 msgid "You can only attach %s images at a time."
-msgstr ""
-"Число изображений, прикрепляемых за один раз, ограничено: максимум %1$s."
+msgstr "Число изображений, прикрепляемых за один раз, ограничено: максимум %1$s."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more images across the conversation than allowed. Placeholder is the maximum number of images. E.g. You can only attach 5 images per conversation
 msgctxt "Error message when total image count exceeds conversation limit"
 msgid "You can only attach %s images per conversation"
-msgstr ""
-"Число изображений, прикрепляемых к одной беседе, ограничено: максимум %1$s."
+msgstr "Число изображений, прикрепляемых к одной беседе, ограничено: максимум %1$s."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more images across the conversation than allowed. Placeholder is the maximum number of images. E.g. You can only attach 5 images per conversation
 msgctxt "Error message when total image count exceeds conversation limit"
 msgid "You can only attach %s images per conversation."
-msgstr ""
-"Число изображений, прикрепляемых к одной беседе, ограничено: максимум %1$s."
+msgstr "Число изображений, прикрепляемых к одной беседе, ограничено: максимум %1$s."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
@@ -24109,8 +24088,7 @@ msgstr "Вы исчерпали голосовой лимит на сегодн�
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
 msgid "You've reached your dictation usage limit. Try again later."
-msgstr ""
-"Вы достигли лимита использования функции диктовки. Повторите попытку позже."
+msgstr "Вы достигли лимита использования функции диктовки. Повторите попытку позже."
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -24271,8 +24249,7 @@ msgstr ""
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never used to train AI models"
-msgstr ""
-"Ваши чаты сохраняются в секрете и не используются для обучения моделей ИИ"
+msgstr "Ваши чаты сохраняются в секрете и не используются для обучения моделей ИИ"
 
 # smartling.placeholder_format=C
 #. Text for a description of the active privacy protection for DuckDuckGo's AI Chat feature.
@@ -24294,8 +24271,8 @@ msgctxt "Menu item description"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
 msgstr ""
-"Ваши чаты конфиденциальны. Мы не храним их и не используем для обучения ИИ-"
-"моделей."
+"Ваши чаты конфиденциальны. Мы не храним их и не используем для обучения "
+"ИИ-моделей."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the active privacy protection.
@@ -24329,8 +24306,8 @@ msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
 msgstr ""
-"Ваши чаты импортированы. Продолжай с того места, где ты остановился, в Duck."
-"ai."
+"Ваши чаты импортированы. Продолжай с того места, где ты остановился, в "
+"Duck.ai."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.

--- a/locales/ru_RU/LC_MESSAGES/duckduckgo.po
+++ b/locales/ru_RU/LC_MESSAGES/duckduckgo.po
@@ -2,15 +2,16 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: ru_RU\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 
 # smartling.gettext_line_width = normalized : 79
 # smartling.placeholder_format=C
@@ -241,7 +242,8 @@ msgstr "Лайков: %1$s"
 #. Disclaimer text shown bellow chat input on mobile, avoid long text if possible. Example: 'GPT-3 may display inaccurate or offensive information.'
 msgctxt "Disclaimer bellow chat input - mobile"
 msgid "%s may display inaccurate or offensive information."
-msgstr "ИИ-модель %1$s может предложить неточную или оскорбительную информацию."
+msgstr ""
+"ИИ-модель %1$s может предложить неточную или оскорбительную информацию."
 
 # smartling.placeholder_format=C
 #. Label showing how many members a discussion has. To be displayed on a card about that discussion.
@@ -473,13 +475,15 @@ msgstr "%1$sКак мы сохраняем конфиденциальность 
 msgctxt "Footer text for About Sync modal"
 msgid ""
 "%sLearn more%s about how chats are stored privately on DuckDuckGo's server."
-msgstr "%1$sПодробнее%2$s о конфиденциальном хранении чатов на сервере DuckDuckGo."
+msgstr ""
+"%1$sПодробнее%2$s о конфиденциальном хранении чатов на сервере DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "%sLearn more%s about how chats are stored privately on your device."
-msgstr "%1$sПодробнее%2$s о том, как чаты хранятся в тайне на вашем устройстве."
+msgstr ""
+"%1$sПодробнее%2$s о том, как чаты хранятся в тайне на вашем устройстве."
 
 # smartling.placeholder_format=C
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
@@ -930,8 +934,8 @@ msgid ""
 msgstr ""
 "Функция AI Chat позволяет анонимно общаться с нашим чат-ботом на базе "
 "сторонних моделей ИИ. Если отключить эту функцию, она не будет отображаться "
-"в поиске DuckDuckGo Search, но останется доступной по ссылке "
-"%1$sduckduckgo.com/aichat%2$s."
+"в поиске DuckDuckGo Search, но останется доступной по ссылке %1$sduckduckgo."
+"com/aichat%2$s."
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -1047,7 +1051,8 @@ msgstr "Не добавлять в браузер"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "ATB related (not displayed on settings page)"
-msgstr "Связано с параметром «Добавить в браузер» (отсутствует на странице настроек)"
+msgstr ""
+"Связано с параметром «Добавить в браузер» (отсутствует на странице настроек)"
 
 # smartling.placeholder_format=C
 #. Golf rankings column: average points
@@ -1435,6 +1440,12 @@ msgid "Address is incorrect"
 msgstr "Неверно указан адрес"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Adjust the servings"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. as in multiple advertisements
 msgid "Ads"
 msgstr "Реклама"
@@ -1648,6 +1659,14 @@ msgid "All chats are %sprivate%s"
 msgstr "Все чаты %1$sконфиденциальны%2$s"
 
 # smartling.placeholder_format=C
+#. Paragraph in the Privacy & Terms section of the About & Legal page in Duck.ai settings, summarizing how chats are anonymized and are not stored or used to train chat models.
+msgctxt "Privacy & Terms section description on the Duck.ai settings page"
+msgid ""
+"All chats are anonymized by DuckDuckGo, and your conversations are not used "
+"to train chat models by DuckDuckGo or the model providers"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
 msgctxt "Privacy modal header in Duck.ai chat"
 msgid "All chats are private"
@@ -1750,8 +1769,8 @@ msgid ""
 msgstr ""
 "Позволяет %1$s выполнить поиск в Интернете, чтобы улучшить ответы на "
 "релевантные запросы. Отправляет в поисковую систему только сгенерированные "
-"ИИ запросы с ограниченным сроком хранения данных. Запросы и ответы %2$s "
-"по-прежнему имеют %3$sнулевую видимость провайдера%4$s."
+"ИИ запросы с ограниченным сроком хранения данных. Запросы и ответы %2$s по-"
+"прежнему имеют %3$sнулевую видимость провайдера%4$s."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -1916,6 +1935,13 @@ msgstr ""
 msgctxt "precise_user_location"
 msgid "Anonymous location enabled"
 msgstr "Включено «Анонимное местоположение»"
+
+# smartling.placeholder_format=C
+msgctxt "settings"
+msgid ""
+"Anonymously generates answers for search queries based on web content. "
+"Choose how often you want it to appear, or disable it completely."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -2197,6 +2223,12 @@ msgid "Ask a follow-up with Duck.ai"
 msgstr "Задавайте Duck.ai дальнейшие вопросы"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
+msgctxt "Page suggestion chip label"
+msgid "Ask about this page"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
 msgctxt "Title for the page context onboarding modal"
 msgid "Ask about this page"
@@ -2263,9 +2295,10 @@ msgstr ""
 "интеллекта. Вы можете самостоятельно проконтролировать, как часто будут "
 "появляться ответы Assist: «никогда» (интерфейс Assist полностью исключается "
 "из поисковых запросов), «по запросу» (ответы ИИ отображаются при нажатии "
-"кнопки «Ассистент»), «иногда» (только при высокой релевантности) или «часто» "
-"(чаще и в отношении более широкого спектра запросов). Пока что ответы на "
-"базе ИИ предоставляются только на территории США (на английском языке)."
+"кнопки «Ассистент»), «иногда» (только при высокой релевантности) или "
+"«часто» (чаще и в отношении более широкого спектра запросов). Пока что "
+"ответы на базе ИИ предоставляются только на территории США (на английском "
+"языке)."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2615,6 +2648,12 @@ msgid "Barcode"
 msgstr "Штрихкод"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Based on this page, is this course worth taking?"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Basic"
 msgstr "Основные"
@@ -2653,6 +2692,14 @@ msgstr "Отбивающий"
 msgctxt "Assistant response placeholder"
 msgid "Before continuing..."
 msgstr "Прежде чем продолжить..."
+
+# smartling.placeholder_format=C
+#. Explains that before storing the report, DuckDuckGo will anonymize the conversation by removing PII like names, email addresses, and identifying metadata.
+msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
+msgid ""
+"Before storing this report, DuckDuckGo will anonymize your conversation by "
+"removing PII like names, email addresses, and identifying metadata."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -2778,7 +2825,8 @@ msgstr "Блокировка почтовых трекеров и скрытие
 # smartling.placeholder_format=C
 #. A disclaimer about AI-generated images in search results
 msgid "Block list is not exhaustive and may contain inaccuracies."
-msgstr "Список блокировки не является исчерпывающим и может содержать неточности."
+msgstr ""
+"Список блокировки не является исчерпывающим и может содержать неточности."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -2969,6 +3017,12 @@ msgstr "Бразилия"
 msgctxt "Sports module"
 msgid "Break Points Won"
 msgstr "Выигранные брейк-пойнты"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Break this down into clear, numbered steps."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -3428,6 +3482,12 @@ msgid "Cast"
 msgstr "Актеры"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Cast & Crew"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
 msgctxt "Tone option label for Casual"
 msgid "Casual"
@@ -3664,11 +3724,11 @@ msgid ""
 "DuckDuckGo Search. However, you can still access Chat when this setting is "
 "off by visiting %shttps://duck.ai%s directly."
 msgstr ""
-"Чат (на сервисе Duck.ai) позволяет анонимно общаться со сторонними "
-"чат-моделями на базе ИИ от OpenAI, Anthropic и других компаний. При "
-"отключении этой настройки из интерфейса DuckDuckGo Search исчезнут кнопка "
-"«Чат» и ссылки на чат-сервис. Вы по-прежнему можете воспользоваться чатом, "
-"посетив его страницу напрямую: %1$shttps://duck.ai%2$s."
+"Чат (на сервисе Duck.ai) позволяет анонимно общаться со сторонними чат-"
+"моделями на базе ИИ от OpenAI, Anthropic и других компаний. При отключении "
+"этой настройки из интерфейса DuckDuckGo Search исчезнут кнопка «Чат» и "
+"ссылки на чат-сервис. Вы по-прежнему можете воспользоваться чатом, посетив "
+"его страницу напрямую: %1$shttps://duck.ai%2$s."
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -3890,7 +3950,8 @@ msgstr "Проверьте орфографию"
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
 msgctxt "noresults"
 msgid "Check the DuckDuckGo subreddit for updates on this outage."
-msgstr "Последнюю информацию по этому сбою можно отследить в сабреддите DuckDuckGo."
+msgstr ""
+"Последнюю информацию по этому сбою можно отследить в сабреддите DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
@@ -4306,7 +4367,8 @@ msgstr "Нажмите %1$sНастройки%2$s в выпадающем мен
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
-msgstr "Выберите %1$sИспользовать текущие страницы%2$s, затем %3$sНажмите OK%4$s."
+msgstr ""
+"Выберите %1$sИспользовать текущие страницы%2$s, затем %3$sНажмите OK%4$s."
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -5025,7 +5087,8 @@ msgstr "Копировать"
 # smartling.placeholder_format=C
 #. Instructions on how to change the default search engine
 msgid "Copy &amp; paste %sabout:preferences#search%s into the address bar"
-msgstr "Скопируйте и вставьте %1$sabout:preferences#search%2$s в адресную строку"
+msgstr ""
+"Скопируйте и вставьте %1$sabout:preferences#search%2$s в адресную строку"
 
 # smartling.placeholder_format=C
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
@@ -5141,6 +5204,12 @@ msgstr "Создать изображение"
 msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr "Создать изображение"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Create a shopping list with quantities from this recipe."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed in the input field when starting a new image generation session.
@@ -5775,12 +5844,18 @@ msgstr "Диктовка в Duck.ai"
 # smartling.placeholder_format=C
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
-msgstr "Диктовка анонимизируется и никогда не используется для обучения моделей ИИ."
+msgstr ""
+"Диктовка анонимизируется и никогда не используется для обучения моделей ИИ."
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
 msgid "Dictation limit reached"
 msgstr "Достигнут лимит диктовки"
+
+# smartling.placeholder_format=C
+#. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
+msgid "Dictation temporarily unavailable"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
@@ -6083,6 +6158,22 @@ msgid "Done"
 msgstr "Готово"
 
 # smartling.placeholder_format=C
+#. Message shown in a modal after DuckDuckGo browser users disable AI features in Settings. The first two placeholders bold noai.duckduckgo.com. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
+"filtered out. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
+"and AI images filtered out. %sLearn more%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Double Faults"
@@ -6197,12 +6288,25 @@ msgstr ""
 "запросом сметы на ремонт холодильника."
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Draft a cover letter"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Draft a cover letter for this job."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
 msgctxt "Full sentence for drafting a social media post"
 msgid ""
 "Draft a few options for a social media post inviting people to my upcoming "
 "party."
-msgstr "Предложи несколько вариантов поста для соцсетей с приглашением на вечеринку."
+msgstr ""
+"Предложи несколько вариантов поста для соцсетей с приглашением на вечеринку."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a few options for a blog post title about strategies to increase team collaboration.
@@ -6224,7 +6328,8 @@ msgstr "Подготовь пост для соцсетей"
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Drag %sThis Button%s on top of the home icon:"
-msgstr "Переместите %1$sЭту кнопку%2$s на верхнюю часть значка домашней страницы:"
+msgstr ""
+"Переместите %1$sЭту кнопку%2$s на верхнюю часть значка домашней страницы:"
 
 # smartling.placeholder_format=C
 #. Indicates this is the number of draws for this team in e.g. soccer
@@ -6374,6 +6479,15 @@ msgstr ""
 "конфиденциальности!"
 
 # smartling.placeholder_format=C
+#. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
+msgctxt "About section description on the Duck.ai settings page"
+msgid ""
+"Duck.ai is created by DuckDuckGo. We're an independent online protection "
+"company for anyone who wants to take back control of their personal "
+"information."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
 msgctxt "duckai_migration"
 msgid "Duck.ai is moving domains"
@@ -6419,6 +6533,13 @@ msgstr ""
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
 msgstr "Сервис Duck.ai временно недоступен. Повторите попытку позже."
+
+# smartling.placeholder_format=C
+msgctxt "settings"
+msgid ""
+"Duck.ai lets you chat privately with popular AI models. Disabling it hides "
+"Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6495,8 +6616,8 @@ msgid ""
 "models, privacy focused AI, no account AI chat"
 msgstr ""
 "Duck.ai, DuckDuckGo AI, приватный чат-бот, бесплатный чат с ИИ, анонимный "
-"чат с ИИ, ИИ-чат без регистрации, OpenAI, Anthropic, Llama, Mistral, "
-"ИИ-модели с открытым кодом, конфиденциальный ИИ, чат с ИИ без учетной записи"
+"чат с ИИ, ИИ-чат без регистрации, OpenAI, Anthropic, Llama, Mistral, ИИ-"
+"модели с открытым кодом, конфиденциальный ИИ, чат с ИИ без учетной записи"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -6672,7 +6793,8 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr "Сервис DuckDuckGo AI Chat временно недоступен. Повторите попытку позже."
+msgstr ""
+"Сервис DuckDuckGo AI Chat временно недоступен. Повторите попытку позже."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -6949,8 +7071,8 @@ msgid ""
 msgstr ""
 "Каждый раз, когда вы просите нас порекомендовать парольную фразу, мы "
 "запрашиваем с серверов DuckDuckGo длинный список случайных слов. Затем в "
-"браузере мы наугад выбираем из списка 4–5 составных слов длиной минимум "
-"18–20 символов."
+"браузере мы наугад выбираем из списка 4–5 составных слов длиной минимум 18–"
+"20 символов."
 
 # smartling.placeholder_format=C
 msgctxt "Sports module"
@@ -7431,6 +7553,18 @@ msgid "Eritrea"
 msgstr "Эритрея"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Estimate the nutrition"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Estimate the nutritional information for this recipe."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Estonia"
 msgstr "Эстония"
 
@@ -7487,11 +7621,59 @@ msgid "Expires in 1 day"
 msgstr "Остался 1 день"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain the accepted answer in simple terms."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
 msgstr "Объясни основные принципы теории черных дыр на уровне старших классов."
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain the top answer"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this in simple, plain language."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this paper"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this repo"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this research paper in plain language."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this simply"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain what this repository does and how to use it."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label to show if song lyrics contain explicit content
@@ -7778,6 +7960,12 @@ msgstr ""
 "%1$sПодробнее...%2$s"
 
 # smartling.placeholder_format=C
+msgctxt "settings"
+msgid ""
+"Filters out known AI spam sites from image search results. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the final score of a sporting event.
 msgid "Final"
 msgstr "Итог"
@@ -7831,6 +8019,12 @@ msgstr "Подбери более удачное слово"
 msgctxt "Subtitle for the Web Search tool entry in the Tools dropdown menu"
 msgid "Find current information"
 msgstr "Найдите актуальную информацию"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Find me alternatives"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button that searches for results closer to the user's current location.
@@ -8310,6 +8504,12 @@ msgid "Generate More"
 msgstr "Создавай больше"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Generate a shopping list"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
 msgid "Generate a short answer from the web"
 msgstr "Генерация краткого ответа на основе ресурсов из интернета"
@@ -8599,6 +8799,12 @@ msgstr "Попробовать"
 msgctxt "Onboarding welcome screen button text"
 msgid "Give it a Try"
 msgstr "Попробовать"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Give me a quick background on this person."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9049,6 +9255,18 @@ msgid "Help Spread Privacy"
 msgstr "Помогите в распространении конфиденциальности"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Help me prep for the interview"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Help me tailor my resume for this job."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title of a SERP popup that invites users to take a survey (desktop only)
 msgctxt "User survey popup"
 msgid "Help us improve DuckDuckGo"
@@ -9128,7 +9346,8 @@ msgstr "Ответ пригодился"
 #. The title of a menu that shows other applications DuckDuckGo has made.
 msgctxt "showcase_aria_dropdown"
 msgid "Here are some things that we made that you might like."
-msgstr "Мы сделали несколько приложений, которые могут вас заинтересовать. Вот они!"
+msgstr ""
+"Мы сделали несколько приложений, которые могут вас заинтересовать. Вот они!"
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -9566,6 +9785,14 @@ msgid "I Agree"
 msgstr "Принимаю условия"
 
 # smartling.placeholder_format=C
+#. Text for the button that takes the user to the external DuckDuckGo login subscription page.
+msgctxt ""
+"Text for the I already have a subscription button in the Duck.ai settings "
+"page"
+msgid "I Already Have a Subscription"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for the button that takes the user to the login subscription page.
 msgctxt "Text for the I have a subscription button"
 msgid "I Have a Subscription"
@@ -9833,7 +10060,8 @@ msgstr "Изображения по запросу «%1$s»"
 # smartling.placeholder_format=C
 #. A label that indicates a specific search result for images has been blocked by the safe search filter. The placeholder value is the name of the search result that was blocked.
 msgid "Images for %s blocked by safe search"
-msgstr "Изображения по запросу «%1$s» заблокированы в рамках безопасного поиска."
+msgstr ""
+"Изображения по запросу «%1$s» заблокированы в рамках безопасного поиска."
 
 # smartling.placeholder_format=C
 #. Title for the section that showcases the image results for a certain query, ex. Images for <b>beach</b>
@@ -10143,6 +10371,12 @@ msgid "Install Mac Browser"
 msgstr "Установить браузер для Mac"
 
 # smartling.placeholder_format=C
+#. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
+msgctxt "settings"
+msgid "Install Now"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of a button to install the DuckDuckGo app
 msgctxt "Serp footer content"
 msgid "Install Our App"
@@ -10240,10 +10474,42 @@ msgid "Is deleted data really deleted?"
 msgstr "Удалены ли данные на самом деле?"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is it worth taking?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this place any good?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"Is this place any good? Summarize its reputation based on reviews and "
+"ratings."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "Is this video helpful?"
 msgstr "Видео пригодилось?"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this worth watching?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Is this worth watching? Give me a spoiler-free take."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -10668,7 +10934,8 @@ msgstr "Подробнее об активной защите конфиденц
 # smartling.placeholder_format=C
 msgctxt "showcase_newsletter"
 msgid "Learn about online privacy right in your inbox."
-msgstr "Получайте рекомендации о защите персональных данных на электронную почту."
+msgstr ""
+"Получайте рекомендации о защите персональных данных на электронную почту."
 
 # smartling.placeholder_format=C
 #. Link to a page with more information about how DuckDuckGo settings are managed.
@@ -10722,7 +10989,8 @@ msgstr "Подробнее о работе этой функции"
 # smartling.placeholder_format=C
 msgctxt "SERP footer content"
 msgid "Learn why reducing online tracking is important."
-msgstr "Узнайте, почему важно ограничивать отслеживание ваших действий в интернете."
+msgstr ""
+"Узнайте, почему важно ограничивать отслеживание ваших действий в интернете."
 
 # smartling.placeholder_format=C
 #. A link that takes users to a page where they can learn more about the dangers of online tracking.
@@ -10858,6 +11126,12 @@ msgstr "Шрифт ссылки:"
 #. https://duckduckgo.com/params under "Color Settings"
 msgid "Links:"
 msgstr "Ссылки:"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "List the tools, materials, or prerequisites I need for this."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -11266,6 +11540,12 @@ msgstr "Управляй своей подпиской"
 msgctxt "Exclusion message manage sites button"
 msgid "Manage blocked sites"
 msgstr "Настроить блокировку"
+
+# smartling.placeholder_format=C
+#. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
+msgctxt "setting"
+msgid "Manage in Browser Settings"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to the site exclusion settings page
@@ -13023,7 +13303,8 @@ msgstr "Оман"
 #. http://i.imgur.com/zQWKLIm.png
 msgctxt "settings"
 msgid "Omits objectionable (mostly adult) material"
-msgstr "Исключает из выдачи нежелательные материалы (в основном — \"для взрослых\")"
+msgstr ""
+"Исключает из выдачи нежелательные материалы (в основном — \"для взрослых\")"
 
 # smartling.placeholder_format=C
 msgid "On"
@@ -13182,7 +13463,8 @@ msgstr "Открыть сайт %1$s"
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open %sLocation%s, and ensure location is %senabled%s"
-msgstr "Убедитесь, что %1$sгеолокация%2$s (в одноименном разделе) %3$sвключена%4$s."
+msgstr ""
+"Убедитесь, что %1$sгеолокация%2$s (в одноименном разделе) %3$sвключена%4$s."
 
 #  Chrome/Firefox on Android/iOS
 # smartling.placeholder_format=C
@@ -13345,7 +13627,8 @@ msgstr "Открыть панель «Как работает Duck.ai»"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open the Safari menu and select %sSettings for DuckDuckGo...%s"
-msgstr "Откройте меню Safari и выберите пункт «%1$sНастройки для DuckDuckGo...%2$s»"
+msgstr ""
+"Откройте меню Safari и выберите пункт «%1$sНастройки для DuckDuckGo...%2$s»"
 
 # smartling.placeholder_format=C
 #. Label for the time a business opens. For example: 'Opens at 10am'
@@ -14099,6 +14382,12 @@ msgstr ""
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
+msgid "Please describe why the chat response is harmful or illegal. (optional)"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
+msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
 msgstr ""
 "Опишите, почему ответ чата является незаконным или вредоносным. "
@@ -14125,6 +14414,14 @@ msgid ""
 msgstr ""
 "Внимание! При запуске нового чата (независимо от модели) текущий сеанс будет "
 "удален."
+
+# smartling.placeholder_format=C
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
+msgctxt "Feedback prompt"
+msgid ""
+"Please paste your prompt and the problematic output (with any personal "
+"information removed) and describe why the content is harmful or illegal."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -14594,6 +14891,12 @@ msgid "Privacy"
 msgstr "Настройки конфиденциальности"
 
 # smartling.placeholder_format=C
+#. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
+msgctxt "Section heading on the Duck.ai settings page"
+msgid "Privacy & Terms"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Privacy Blog"
 msgstr "Блог о конфиденциальности"
 
@@ -14662,6 +14965,12 @@ msgstr "Политика конфиденциальности и условия 
 msgctxt "Copy used to compose link in sentences"
 msgid "Privacy Policy and Terms of Service"
 msgstr "Политика конфиденциальности и условия обслуживания"
+
+# smartling.placeholder_format=C
+#. Text for a button that links to the terms of use and privacy policy page.
+msgctxt "Secondary button text in active privacy modal"
+msgid "Privacy Policy and Terms of Service"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title displayed on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
@@ -14763,7 +15072,8 @@ msgstr "Приватные чаты без сохранения"
 #. The device location shared is is not logged by us
 msgctxt "precise_user_location"
 msgid "Private to us and secured on your device"
-msgstr "Ваши данные остаются конфиденциальными и надежно хранятся на вашем устройстве"
+msgstr ""
+"Ваши данные остаются конфиденциальными и надежно хранятся на вашем устройстве"
 
 # smartling.placeholder_format=C
 #. Heading above the group of Pro-tier locked models in the model picker dropdown, when the user is on the Plus tier.
@@ -15163,6 +15473,30 @@ msgstr "Рецепты по запросу «%1$s%2$s%3$s»"
 msgctxt "Brief for recommending a book"
 msgid "Recommend a book"
 msgstr "Порекомендовать книгу"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar books"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar books."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar movies or shows."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar titles"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
@@ -15566,6 +15900,15 @@ msgid "Republic of Moldova"
 msgstr "Молдова"
 
 # smartling.placeholder_format=C
+#. Note indicating that sharing the conversation is mandatory when reporting harmful or illegal content. Rendered alongside the standard share label (DUCKCHAT_RESPONSE_FEEDBACK_SHARE_PROMPT_RESPONSE_LABEL), not replacing it.
+msgctxt ""
+"Note shown under the share-content switch label on the Duck.ai response "
+"feedback form when the user has selected Harmful or Illegal as the feedback "
+"reason"
+msgid "Required for harmful or illegal reports"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
 msgctxt "Description for extended reasoning mode in Duck.ai"
 msgid "Researches before responding"
@@ -15803,6 +16146,12 @@ msgstr "Отзывы"
 msgctxt "maps_places"
 msgid "Reviews"
 msgstr "Отзывы"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Rewrite this recipe scaled for a different number of servings."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Romania"
@@ -16636,7 +16985,8 @@ msgstr ""
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
 msgctxt "Sync feature benefit description"
 msgid "Securely stored on DuckDuckGo's server with end-to-end encryption."
-msgstr "Надежно хранится на сервере DuckDuckGo с применением сквозного шифрования."
+msgstr ""
+"Надежно хранится на сервере DuckDuckGo с применением сквозного шифрования."
 
 # smartling.placeholder_format=C
 #. List item explaining that synced chats are stored with end-to-end encryption on DuckDuckGo's server and only the user can access them.
@@ -16814,7 +17164,8 @@ msgstr "Выберите %1$sDuckDuckGo%2$s и нажмите %3$sУстанов
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Select %sDuckDuckGo%s in the Default Search Engine drop down"
-msgstr "Выберите %1$sDuckDuckGo%2$s поисковой системой по умолчанию в выпадающем меню"
+msgstr ""
+"Выберите %1$sDuckDuckGo%2$s поисковой системой по умолчанию в выпадающем меню"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
@@ -16834,7 +17185,8 @@ msgstr "Выберите %1$sDuckDuckGo%2$s в списке поисковых �
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s under the%sDefault Search Engine%s section"
-msgstr "Выберите %1$sDuckDuckGo%2$s в разделе%3$sПоисковая система по умолчанию%4$s"
+msgstr ""
+"Выберите %1$sDuckDuckGo%2$s в разделе%3$sПоисковая система по умолчанию%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user were in the settings menu they can change their default search engine.
@@ -16919,7 +17271,8 @@ msgstr "Выберите %1$sНастройки%2$s, затем %3$sДополн
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sDefault search engine%s"
-msgstr "Выберите %1$sНастройки%2$s, а затем %3$sПоисковая система по умолчанию%4$s"
+msgstr ""
+"Выберите %1$sНастройки%2$s, а затем %3$sПоисковая система по умолчанию%4$s"
 
 #  Chrome/Firefox on Android
 # smartling.placeholder_format=C
@@ -17015,7 +17368,8 @@ msgstr "Выбранный текст со страницы %1$s"
 #. Displayed when the user's text selection exceeds the maximum message size for AI tools (summary, translation, etc.).
 msgctxt "Error message for selection input limit"
 msgid "Selected text is too long. Try again with a shorter selection."
-msgstr "Выделенный текст слишком длинный. Попробуйте выбрать фрагмент покороче."
+msgstr ""
+"Выделенный текст слишком длинный. Попробуйте выбрать фрагмент покороче."
 
 # smartling.placeholder_format=C
 #. Label for the semi-finals knockout stage in e.g. the soccer World Cup
@@ -17136,6 +17490,12 @@ msgid "Set Up Now"
 msgstr "Настрой сейчас"
 
 # smartling.placeholder_format=C
+#. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
+msgctxt "Encrypted storage setup button shown in native browsers"
+msgid "Set Up Sync & Backup"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
 msgctxt "Title for the Sync & Backup intro screen"
 msgid "Set Up Sync & Backup"
@@ -17227,7 +17587,8 @@ msgstr "Поделиться"
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "Share DuckDuckGo and help friends take their privacy back!"
-msgstr "Поделитесь DuckDuckGo и помогите друзьям вернуть свою конфиденциальность!"
+msgstr ""
+"Поделитесь DuckDuckGo и помогите друзьям вернуть свою конфиденциальность!"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button that opens a feedback modal when clicked.
@@ -17315,6 +17676,13 @@ msgstr "Поделиться адресом страницы"
 msgctxt "feedback form"
 msgid "Share positive feedback"
 msgstr "Отправить положительный отзыв"
+
+# smartling.placeholder_format=C
+#. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
+msgctxt ""
+"Label beside the share-content switch on the Duck.ai response feedback form"
+msgid "Share this conversation with DuckDuckGo"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -17755,7 +18123,8 @@ msgstr "Показывает поисковые подсказки при вво
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows the privacy benefits of using DuckDuckGo on the homepage"
-msgstr "Показывает преимущества приватного поиска с DuckDuckGo на стартовой странице"
+msgstr ""
+"Показывает преимущества приватного поиска с DuckDuckGo на стартовой странице"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -17849,7 +18218,8 @@ msgstr "Поиск по сайту временно недоступен. Мы �
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Sites you block will be hidden from all your search results"
-msgstr "Сайты, которые ты заблокируешь, будут скрыты из всех твоих результатов поиска"
+msgstr ""
+"Сайты, которые ты заблокируешь, будут скрыты из всех твоих результатов поиска"
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes full name (tooltip)
@@ -17988,7 +18358,8 @@ msgstr "Что-то пошло не так"
 #. Error message indicating that the user's settings weren't able to be saved.
 msgctxt "cloudsave"
 msgid "Something went wrong saving to the server, please try again."
-msgstr "Что-то пошло не так при сохранении на сервер, пожалуйста, попробуйте снова."
+msgstr ""
+"Что-то пошло не так при сохранении на сервер, пожалуйста, попробуйте снова."
 
 # smartling.placeholder_format=C
 #. Body copy displayed under the Set Up Now button when the sync setup call fails.
@@ -18084,7 +18455,8 @@ msgctxt "noresults"
 msgid ""
 "Sorry, we ran into an error displaying these results. %sClick here%s to try "
 "again."
-msgstr "При отображении результатов произошла ошибка. %1$sПовторить попытку%2$s"
+msgstr ""
+"При отображении результатов произошла ошибка. %1$sПовторить попытку%2$s"
 
 # smartling.placeholder_format=C
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
@@ -18570,6 +18942,24 @@ msgid "Suggest a title for a blog post"
 msgstr "Предложи заголовок для статьи в блоге"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest related articles or topics worth exploring next."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Suggest related articles to explore"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest some alternatives to this product."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
 msgctxt "directions"
 msgid "Suggestions:"
@@ -18581,10 +18971,100 @@ msgid "Suggestions:"
 msgstr "Рекомендации:"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Sum up the reviews"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A short title for the a message asking the AI to summarize a text.
 msgctxt "Title for the summarize message"
 msgid "Summarize"
 msgstr "Краткий пересказ"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize the Q&As"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the background and notable work of this person."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the key details of this event."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the questions and answers on this page."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize their background"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this book"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this book."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this discussion"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this discussion thread."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this page"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this page."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this video"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this video."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize what the reviews say."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -18914,6 +19394,12 @@ msgid "Syria"
 msgstr "Сирия"
 
 # smartling.placeholder_format=C
+#. Text for a button that enables the theme to follow the operating system's color scheme preference.
+msgctxt "System theme button for theme selector"
+msgid "System"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Abbreviation indicating this is the total score for a game
 msgctxt "Sports module"
 msgid "T"
@@ -18940,6 +19426,12 @@ msgstr "ТВ"
 msgctxt "language_name"
 msgid "Tahitian"
 msgstr "Таитянский"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Tailor my resume"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Taiwan"
@@ -18969,6 +19461,13 @@ msgstr "Ваши личные данные теперь под контроле�
 msgctxt "homepage ATB modal"
 msgid "Take control of your personal data!"
 msgstr "Ваши личные данные — под вашим контролем!"
+
+# smartling.placeholder_format=C
+#. Description for the Feedback section of the Duck.ai settings page, asking the user to take an anonymous survey to let us know how we can make Duck.ai better.
+msgctxt "Feedback section description on the Duck.ai settings page"
+msgid ""
+"Take this anonymous survey to let us know how we can make Duck.ai better."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -19250,7 +19749,8 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider does not save this chat or any associated data on their "
 "servers."
-msgstr "Поставщик не хранит этот чат и связанные с ним данные на своих серверах."
+msgstr ""
+"Поставщик не хранит этот чат и связанные с ним данные на своих серверах."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19273,6 +19773,12 @@ msgstr "Сервер столкнулся с ошибкой и не смог в�
 #. https://duck.co/media/files/theme.png
 msgid "Theme"
 msgstr "Тема"
+
+# smartling.placeholder_format=C
+#. Text for the theme selector label that allows users to switch between Light and dark theme.
+msgctxt "Label for the theme selector feature"
+msgid "Theme"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/LpFhb1e.png
@@ -19379,7 +19885,8 @@ msgctxt "AI Chat: Error message for when a model is removed"
 msgid ""
 "This AI model is no longer available. Try starting a new chat with a "
 "different model."
-msgstr "Эта ИИ-модель больше недоступна. Попробуйте запустить чат с другой моделью."
+msgstr ""
+"Эта ИИ-модель больше недоступна. Попробуйте запустить чат с другой моделью."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is no longer supported because it has been upgraded to a newest version.
@@ -19532,7 +20039,8 @@ msgstr ""
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF."
-msgstr "Формат не поддерживается. Прикрепите изображение в JPG, PNG, WebP или GIF."
+msgstr ""
+"Формат не поддерживается. Прикрепите изображение в JPG, PNG, WebP или GIF."
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
@@ -19585,7 +20093,8 @@ msgstr "Для нормальной работы данной странице �
 #. Information tooltip text explaining that the current page's content will be included with the chat message.
 msgctxt "Tooltip explaining that page content will be sent to Duck.ai"
 msgid "This page's content will be sent with your message to Duck.ai"
-msgstr "Содержимое страницы будет отправлено в Duck.ai вместе с вашим сообщением."
+msgstr ""
+"Содержимое страницы будет отправлено в Duck.ai вместе с вашим сообщением."
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -19661,7 +20170,8 @@ msgstr "Здесь это видео пока недоступно. Его мо�
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr "Эта страница не использует безопасное зашифрованное соединение (HTTPS)."
+msgstr ""
+"Эта страница не использует безопасное зашифрованное соединение (HTTPS)."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -19808,7 +20318,8 @@ msgstr ""
 msgctxt ""
 "Copy stating agreement to Duck.ai Privacy Policy and Terms of Service."
 msgid "To continue, you must agree to Duck.ai’s %s and %s"
-msgstr "Чтобы продолжить, примите положения разделов «%1$s» и «%2$s» сервиса Duck.ai."
+msgstr ""
+"Чтобы продолжить, примите положения разделов «%1$s» и «%2$s» сервиса Duck.ai."
 
 # smartling.placeholder_format=C
 #. Text stating agreement to AI Chat Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'To continue, you must agree to DuckDuckGo AI Chat’s Privacy Policy and Terms of Service'
@@ -20112,6 +20623,18 @@ msgstr ""
 "кинотеатра?»"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Translate this page"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
+msgctxt "Page suggestion prompt"
+msgid "Translate this page into %s."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text for a region that will display translated text.
 msgctxt "translations_module"
 msgid "Translation"
@@ -20211,11 +20734,13 @@ msgstr "Чтобы не получать подобные сообщения, п
 #. Text for a promotional card that encourages users to try the encrypted AI model whose inference runs in a confidential environment so the model provider cannot access user data. %s is replaced with the model's full display name (e.g. 'GPT-OSS 120B').
 msgctxt "Promotional text for encrypted AI model"
 msgid "Try %s, our first model with zero provider visibility."
-msgstr "Попробуйте %1$s — нашу первую ИИ-модель с нулевой видимостью для поставщика."
+msgstr ""
+"Попробуйте %1$s — нашу первую ИИ-модель с нулевой видимостью для поставщика."
 
 # smartling.placeholder_format=C
 msgid "Try %sDuck.ai%s, our private AI chat service:"
-msgstr "Попробуйте %1$sDuck.ai%2$s — приватный чат с искусственным интеллектом:"
+msgstr ""
+"Попробуйте %1$sDuck.ai%2$s — приватный чат с искусственным интеллектом:"
 
 # smartling.placeholder_format=C
 #. Button text to retry loading an explore more question that failed
@@ -20251,6 +20776,12 @@ msgstr "Повторите попытку"
 msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
 msgstr "Попробовать бесплатно"
+
+# smartling.placeholder_format=C
+#. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
+msgctxt "settings"
+msgid "Try It Now"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -20316,14 +20847,16 @@ msgstr ""
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
 msgctxt "precise_user_location"
 msgid "Try enabling anonymous location for more accurate results."
-msgstr "Для более точных результатов попробуйте использовать анонимную геопозицию."
+msgstr ""
+"Для более точных результатов попробуйте использовать анонимную геопозицию."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the screen of the onboarding where the user picks a chat model.
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr "Попробуйте поэкспериментировать с каждой моделью: они дадут разные ответы."
+msgstr ""
+"Попробуйте поэкспериментировать с каждой моделью: они дадут разные ответы."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
@@ -20463,7 +20996,8 @@ msgstr "Новинки платформы: ИИ-модели с открытым
 #. Message displayed to suggest the user to try the provided prompts or enter their own.
 msgctxt "Prompt suggestion message"
 msgid "Try these prompts to get started or enter your own prompt below"
-msgstr "Попробуйте начать с готовых запросов или введите собственный вариант ниже."
+msgstr ""
+"Попробуйте начать с готовых запросов или введите собственный вариант ниже."
 
 # smartling.placeholder_format=C
 #. Description for the empty state displayed when searching recent chats in Duck.ai returns no results, suggesting the user rephrase their search query.
@@ -20489,6 +21023,22 @@ msgstr "Попробуйте: %1$s"
 msgctxt "new user poll"
 msgid "Trying DuckDuckGo again"
 msgstr "Снова пробую DuckDuckGo"
+
+# smartling.placeholder_format=C
+#. Message shown in a modal after supported third-party browser users disable AI features in Settings. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -20603,7 +21153,8 @@ msgstr "Duck Player — просмотр YouTube без целевой рекл�
 #. Tells users which setting to change to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on “Precise Location” for more accurate results."
-msgstr "Для получения более точных результатов выберите вариант «Точная геопозиция»."
+msgstr ""
+"Для получения более точных результатов выберите вариант «Точная геопозиция»."
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -20810,14 +21361,15 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sOpen with%s select %sA specific page or pages%s"
-msgstr "Под %1$sОткрыть с%2$s выберите %3$sОпределенная страница или страницы%4$s"
+msgstr ""
+"Под %1$sОткрыть с%2$s выберите %3$sОпределенная страница или страницы%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
 msgstr ""
-"В меню %1$sПри запуске > Домашняя страница%2$s введите: "
-"https://duckduckgo.com"
+"В меню %1$sПри запуске > Домашняя страница%2$s введите: https://duckduckgo."
+"com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -20827,15 +21379,16 @@ msgstr "В меню %1$sНастройки поиска%2$s выберите %3$
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch in the address bar with%s select %sAdd New%s"
-msgstr "В разделе %1$sпоиска в адресной строке%2$s выберите %3$sДобавить новый%4$s"
+msgstr ""
+"В разделе %1$sпоиска в адресной строке%2$s выберите %3$sДобавить новый%4$s"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
 msgstr ""
-"Под разделом %1$sПоиск%2$s нажмите на %3$sУправление поисковыми "
-"системами...%4$s"
+"Под разделом %1$sПоиск%2$s нажмите на %3$sУправление поисковыми системами..."
+"%4$s"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -20849,7 +21402,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine
 msgid "Under Search click the drop down and select %sDuckDuckGo%s"
-msgstr "В разделе поиска нажмите на выпадающий список и выберите %1$sDuckDuckGo%2$s"
+msgstr ""
+"В разделе поиска нажмите на выпадающий список и выберите %1$sDuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings" header
@@ -21066,8 +21620,8 @@ msgid ""
 "Update the DuckDuckGo browser to activate your subscription in Duck.ai and "
 "access advanced models"
 msgstr ""
-"Чтобы активировать подписку в Duck.ai и пользоваться продвинутыми "
-"ИИ-моделями, обновите браузер DuckDuckGo."
+"Чтобы активировать подписку в Duck.ai и пользоваться продвинутыми ИИ-"
+"моделями, обновите браузер DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. The placeholder indicates a formatted date (e.g., 'Updated 2 days ago')
@@ -21248,6 +21802,12 @@ msgid "Uruguay"
 msgstr "Уругвай"
 
 # smartling.placeholder_format=C
+#. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
+msgctxt "Navigation label on the Duck.ai settings page"
+msgid "Usage"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A feedback suggestion
 msgctxt "Feedback prompt"
 msgid "Usage limit"
@@ -21303,7 +21863,8 @@ msgstr "Используйте DuckDuckGo Private Search"
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Use DuckDuckGo private search on your iPad, iPhone, or Android!"
-msgstr "Пользуйтесь DuckDuckGo Private Search на вашем iPad, iPhone, или Android!"
+msgstr ""
+"Пользуйтесь DuckDuckGo Private Search на вашем iPad, iPhone, или Android!"
 
 # smartling.placeholder_format=C
 #. User clicks this button to share their device's location
@@ -21415,7 +21976,8 @@ msgstr "Видеоролики заблокированы в рамках без
 # smartling.placeholder_format=C
 #. A label that indicates a specific search result for videos has been blocked by the safe search filter. The placeholder value is the name of the search result that was blocked.
 msgid "Videos for %s blocked by safe search"
-msgstr "Видеоролики по запросу «%1$s» заблокированы в рамках безопасного поиска."
+msgstr ""
+"Видеоролики по запросу «%1$s» заблокированы в рамках безопасного поиска."
 
 # smartling.placeholder_format=C
 #. Title for the section that showcases the video results for a certain query, ex. Videos for <b>japan</b>
@@ -21701,6 +22263,12 @@ msgid "Wales"
 msgstr "Уэльс"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Walk me through the steps"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for walking directions on a map.
 msgctxt "directions"
 msgid "Walking"
@@ -21819,6 +22387,17 @@ msgstr ""
 "местоположение%2$s."
 
 # smartling.placeholder_format=C
+#. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
+msgctxt ""
+"Inline warning shown below the share-content toggle when the user selects "
+"Harmful or Illegal but has not enabled sharing"
+msgid ""
+"We can only fix what we can see. To report a harmful or illegal response, "
+"please share this conversation with DuckDuckGo so we can investigate and "
+"address the issue."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
 msgctxt ""
 "Inline warning shown below the share-content toggle when the user selects "
@@ -21914,7 +22493,8 @@ msgstr "Мы не отслеживаем вас. Никогда."
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with a Continue button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don't track you. That's our Privacy Policy in a nutshell."
-msgstr "Никакой слежки за вами. Вот краткий обзор нашей Политики конфиденциальности."
+msgstr ""
+"Никакой слежки за вами. Вот краткий обзор нашей Политики конфиденциальности."
 
 # smartling.placeholder_format=C
 #. Description for the audio identification highlight in the dictation consent modal.
@@ -21955,7 +22535,8 @@ msgstr "Мы не следим за вами, ни в режиме приват�
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with an Agree button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don’t track you. That’s our Privacy Policy in a nutshell…"
-msgstr "Мы не шпионим за вами. Вот краткий обзор нашей политики конфиденциальности…"
+msgstr ""
+"Мы не шпионим за вами. Вот краткий обзор нашей политики конфиденциальности…"
 
 # smartling.placeholder_format=C
 #. Displayed when the user's voice chat session is ended because of being inactive for too long.
@@ -22041,7 +22622,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
-msgstr "Пока вы гуляете по Интернету, мы не даем трекерам собирать ваши данные."
+msgstr ""
+"Пока вы гуляете по Интернету, мы не даем трекерам собирать ваши данные."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -22362,6 +22944,103 @@ msgstr ""
 "технологий."
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the counterarguments?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the hours & location?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key contributions of this paper?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key contributions?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key details?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key points covered in this video?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key points?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key takeaways from this article?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key takeaways?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key things I will learn from this course?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main counterarguments or criticisms of this?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main questions this page answers?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the must-try dishes here?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"What are the opening hours, location, and contact details for this place?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the pros and cons of this product?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the pros and cons?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
 msgctxt "feedback form"
 msgid "What bothered you most?"
@@ -22462,6 +23141,12 @@ msgid "What does atria mean in the context of a medical article?"
 msgstr "Что значит «атриум» в контексте медицинской статьи?"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What does this answer?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
@@ -22472,6 +23157,12 @@ msgstr "Какую функцию нам следует добавить? (не�
 msgctxt "cloudsave"
 msgid "What information gets saved?"
 msgstr "Какая информация сохраняется?"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What interview questions might come up for this role?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -22488,6 +23179,12 @@ msgstr ""
 msgctxt "Full sentence for looking up basic facts"
 msgid "What is the capital city of Albania?"
 msgstr "Как называется столица Албании?"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What is the overall verdict and rating for this?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to a page with additional information.
@@ -22512,6 +23209,12 @@ msgid "What people say:"
 msgstr "Мнения других:"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What should I order?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
 msgctxt "feedback form"
 msgid "What stood out?"
@@ -22522,6 +23225,18 @@ msgstr "На что вы обратили внимание?"
 msgctxt "feedback form"
 msgid "What was wrong with the response? (optional)"
 msgstr "Какая проблема возникла с ответом? (Необязательно)"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I learn?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I need?"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -22543,6 +23258,12 @@ msgid "What's New"
 msgstr "Что нового"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What's the verdict?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to a page featuring the most recent updates from DuckDuckGo.
 msgid "What’s New"
 msgstr "Что нового"
@@ -22558,7 +23279,8 @@ msgstr "На какие бренды обратить внимание нови�
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "When enabled, Duck.ai will show instant answers in the chat."
-msgstr "При активации этой настройки Duck.ai будет показывать быстрые ответы в чате."
+msgstr ""
+"При активации этой настройки Duck.ai будет показывать быстрые ответы в чате."
 
 # smartling.placeholder_format=C
 #. Text of a button that performs a search for the available streaming services that show a particular movie or tv show
@@ -22591,6 +23313,12 @@ msgid "Which features are missing? (Optional)"
 msgstr "Каких функций не хватает? (по желанию)"
 
 # smartling.placeholder_format=C
+#. An invitation for users to leave feedback
+msgctxt "Feedback prompt"
+msgid "Which features are missing? (optional)"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
 msgid "White"
 msgstr "Белый"
@@ -22605,6 +23333,18 @@ msgstr "Белый"
 #. Link to an about us page.
 msgid "Who We Are"
 msgstr "Кто мы"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Who are the main cast and crew, and what else are they known for?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Who is this person?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Header above a collection of privacy-related links.
@@ -23037,7 +23777,8 @@ msgstr ""
 
 # smartling.placeholder_format=C
 msgid "You can also use %sDuck.ai%s to answer questions or summarize text."
-msgstr "Сервис %1$sDuck.ai%2$s также умеет отвечать на вопросы и резюмировать текст."
+msgstr ""
+"Сервис %1$sDuck.ai%2$s также умеет отвечать на вопросы и резюмировать текст."
 
 # smartling.placeholder_format=C
 msgid ""
@@ -23066,7 +23807,8 @@ msgstr ""
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
 msgctxt "Third party map app picker feedback dialog"
 msgid "You can change this any time in %sSearch Settings%s"
-msgstr "Вы в любой момент можете изменить свой выбор в %1$sнастройках поиска%2$s"
+msgstr ""
+"Вы в любой момент можете изменить свой выбор в %1$sнастройках поиска%2$s"
 
 # smartling.placeholder_format=C
 #. Text explaning how to change a passphrase.
@@ -23099,7 +23841,8 @@ msgstr "Это напоминание можно скрыть в %1$sнастр�
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
-msgstr "Теперь на этом устройстве можно хранить до 100 чатов. Общайтесь больше!"
+msgstr ""
+"Теперь на этом устройстве можно хранить до 100 чатов. Общайтесь больше!"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -23117,25 +23860,29 @@ msgstr "Число файлов, прикрепляемых к одной бес
 #. Error message displayed when the user has select more images than are allowed to be uploaded. Placeholder is the number of images that are allowed. E.g. You can only attach 3 images per chat
 msgctxt "Error message when input exceeds image upload limit"
 msgid "You can only attach %s images at a time"
-msgstr "Число изображений, прикрепляемых за один раз, ограничено: максимум %1$s."
+msgstr ""
+"Число изображений, прикрепляемых за один раз, ограничено: максимум %1$s."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has select more images than are allowed to be uploaded. Placeholder is the number of images that are allowed. E.g. You can only attach 3 images per chat
 msgctxt "Error message when input exceeds image upload limit"
 msgid "You can only attach %s images at a time."
-msgstr "Число изображений, прикрепляемых за один раз, ограничено: максимум %1$s."
+msgstr ""
+"Число изображений, прикрепляемых за один раз, ограничено: максимум %1$s."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more images across the conversation than allowed. Placeholder is the maximum number of images. E.g. You can only attach 5 images per conversation
 msgctxt "Error message when total image count exceeds conversation limit"
 msgid "You can only attach %s images per conversation"
-msgstr "Число изображений, прикрепляемых к одной беседе, ограничено: максимум %1$s."
+msgstr ""
+"Число изображений, прикрепляемых к одной беседе, ограничено: максимум %1$s."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more images across the conversation than allowed. Placeholder is the maximum number of images. E.g. You can only attach 5 images per conversation
 msgctxt "Error message when total image count exceeds conversation limit"
 msgid "You can only attach %s images per conversation."
-msgstr "Число изображений, прикрепляемых к одной беседе, ограничено: максимум %1$s."
+msgstr ""
+"Число изображений, прикрепляемых к одной беседе, ограничено: максимум %1$s."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
@@ -23362,7 +24109,8 @@ msgstr "Вы исчерпали голосовой лимит на сегодн�
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
 msgid "You've reached your dictation usage limit. Try again later."
-msgstr "Вы достигли лимита использования функции диктовки. Повторите попытку позже."
+msgstr ""
+"Вы достигли лимита использования функции диктовки. Повторите попытку позже."
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -23523,7 +24271,8 @@ msgstr ""
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never used to train AI models"
-msgstr "Ваши чаты сохраняются в секрете и не используются для обучения моделей ИИ"
+msgstr ""
+"Ваши чаты сохраняются в секрете и не используются для обучения моделей ИИ"
 
 # smartling.placeholder_format=C
 #. Text for a description of the active privacy protection for DuckDuckGo's AI Chat feature.
@@ -23545,8 +24294,8 @@ msgctxt "Menu item description"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
 msgstr ""
-"Ваши чаты конфиденциальны. Мы не храним их и не используем для обучения "
-"ИИ-моделей."
+"Ваши чаты конфиденциальны. Мы не храним их и не используем для обучения ИИ-"
+"моделей."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the active privacy protection.
@@ -23580,8 +24329,8 @@ msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
 msgstr ""
-"Ваши чаты импортированы. Продолжай с того места, где ты остановился, в "
-"Duck.ai."
+"Ваши чаты импортированы. Продолжай с того места, где ты остановился, в Duck."
+"ai."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.

--- a/locales/sc_IT/LC_MESSAGES/duckduckgo.po
+++ b/locales/sc_IT/LC_MESSAGES/duckduckgo.po
@@ -1165,6 +1165,11 @@ msgctxt "feedback form"
 msgid "Address is incorrect"
 msgstr "S'indiritzu no est curretu"
 
+#. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Adjust the servings"
+msgstr ""
+
 #. as in multiple advertisements
 msgid "Ads"
 msgstr "Publitzidade"
@@ -1339,6 +1344,13 @@ msgstr ""
 #. Heading shown on the empty chat screen. The text between the two %s markers is displayed inside a clickable privacy button. First %s renders a shield icon, second %s is an invisible end marker. Keep the word 'private' between both %s markers.
 msgctxt "Empty state heading in Duck.ai chat mode"
 msgid "All chats are %sprivate%s"
+msgstr ""
+
+#. Paragraph in the Privacy & Terms section of the About & Legal page in Duck.ai settings, summarizing how chats are anonymized and are not stored or used to train chat models.
+msgctxt "Privacy & Terms section description on the Duck.ai settings page"
+msgid ""
+"All chats are anonymized by DuckDuckGo, and your conversations are not used "
+"to train chat models by DuckDuckGo or the model providers"
 msgstr ""
 
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1554,6 +1566,12 @@ msgstr ""
 msgctxt "precise_user_location"
 msgid "Anonymous location enabled"
 msgstr "Positzione anònima ativada"
+
+msgctxt "settings"
+msgid ""
+"Anonymously generates answers for search queries based on web content. "
+"Choose how often you want it to appear, or disable it completely."
+msgstr ""
 
 #. Instant Answer tab name
 msgid "Answer"
@@ -1778,6 +1796,11 @@ msgstr ""
 
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse
 msgid "Ask a follow-up with Duck.ai"
+msgstr ""
+
+#. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
+msgctxt "Page suggestion chip label"
+msgid "Ask about this page"
 msgstr ""
 
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2102,6 +2125,11 @@ msgstr ""
 msgid "Barcode"
 msgstr "Còdighe de barras"
 
+#. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Based on this page, is this course worth taking?"
+msgstr ""
+
 msgctxt "settings"
 msgid "Basic"
 msgstr "Bàsicu"
@@ -2133,6 +2161,13 @@ msgstr ""
 #. Placeholder text displayed while the assistant waits for the user to choose an action.
 msgctxt "Assistant response placeholder"
 msgid "Before continuing..."
+msgstr ""
+
+#. Explains that before storing the report, DuckDuckGo will anonymize the conversation by removing PII like names, email addresses, and identifying metadata.
+msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
+msgid ""
+"Before storing this report, DuckDuckGo will anonymize your conversation by "
+"removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
 #. Label that's displayed next to a past start date below a web search result.
@@ -2391,6 +2426,11 @@ msgstr "Brasile"
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Break Points Won"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Break this down into clear, numbered steps."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -2765,6 +2805,11 @@ msgstr "Traballa cun nois"
 #. Text of a button that performs a search for the cast of a particular movie or tv show
 msgctxt "Movie/TV Show Title instant answer"
 msgid "Cast"
+msgstr ""
+
+#. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Cast & Crew"
 msgstr ""
 
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -4163,6 +4208,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Create a shopping list with quantities from this recipe."
+msgstr ""
+
 #. Placeholder text displayed in the input field when starting a new image generation session.
 msgctxt "Placeholder text for the image generation input field"
 msgid "Create an image of a cute duck..."
@@ -4689,6 +4739,10 @@ msgstr ""
 msgid "Dictation limit reached"
 msgstr ""
 
+#. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
+msgid "Dictation temporarily unavailable"
+msgstr ""
+
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
@@ -4935,6 +4989,20 @@ msgctxt "precise_user_location"
 msgid "Done"
 msgstr "Fatu"
 
+#. Message shown in a modal after DuckDuckGo browser users disable AI features in Settings. The first two placeholders bold noai.duckduckgo.com. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
+"filtered out. %sLearn More%s"
+msgstr ""
+
+#. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
+"and AI images filtered out. %sLearn more%s"
+msgstr ""
+
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Double Faults"
@@ -5025,6 +5093,16 @@ msgctxt "Full sentence for writing an email"
 msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
+msgstr ""
+
+#. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Draft a cover letter"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Draft a cover letter for this job."
 msgstr ""
 
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -5165,6 +5243,14 @@ msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
 msgstr ""
 
+#. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
+msgctxt "About section description on the Duck.ai settings page"
+msgid ""
+"Duck.ai is created by DuckDuckGo. We're an independent online protection "
+"company for anyone who wants to take back control of their personal "
+"information."
+msgstr ""
+
 #. Title shown when an update is required before proceeding.
 msgctxt "duckai_migration"
 msgid "Duck.ai is moving domains"
@@ -5198,6 +5284,12 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Duck.ai lets you chat privately with popular AI models. Disabling it hides "
+"Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
 
 msgctxt "settings"
@@ -5986,6 +6078,16 @@ msgstr ""
 msgid "Eritrea"
 msgstr ""
 
+#. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Estimate the nutrition"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Estimate the nutritional information for this recipe."
+msgstr ""
+
 msgid "Estonia"
 msgstr "Estònia"
 
@@ -6030,10 +6132,50 @@ msgctxt "merchant promotion product ad extension"
 msgid "Expires in 1 day"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain the accepted answer in simple terms."
+msgstr ""
+
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
+msgstr ""
+
+#. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain the top answer"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this in simple, plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this paper"
+msgstr ""
+
+#. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this repo"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this research paper in plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this simply"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain what this repository does and how to use it."
 msgstr ""
 
 #. Label to show if song lyrics contain explicit content
@@ -6266,6 +6408,11 @@ msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
 msgstr ""
 
+msgctxt "settings"
+msgid ""
+"Filters out known AI spam sites from image search results. %sLearn More%s"
+msgstr ""
+
 #. Label for the final score of a sporting event.
 msgid "Final"
 msgstr "Finale"
@@ -6308,6 +6455,11 @@ msgstr ""
 #. Short description shown below the 'Web Search' label in the Tools dropdown.
 msgctxt "Subtitle for the Web Search tool entry in the Tools dropdown menu"
 msgid "Find current information"
+msgstr ""
+
+#. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Find me alternatives"
 msgstr ""
 
 #. Button that searches for results closer to the user's current location.
@@ -6698,6 +6850,11 @@ msgstr ""
 msgid "Generate More"
 msgstr ""
 
+#. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Generate a shopping list"
+msgstr ""
+
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
 msgid "Generate a short answer from the web"
 msgstr ""
@@ -6933,6 +7090,11 @@ msgstr ""
 #. Text for a button inviting users to give it a try for the Duck.ai product. On click, they're taken to the Duck.ai page.
 msgctxt "Onboarding welcome screen button text"
 msgid "Give it a Try"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Give me a quick background on this person."
 msgstr ""
 
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -7298,6 +7460,16 @@ msgstr "Agiuda a difùndere DuckDuckGo!"
 #. Link to a page with information about sharing DuckDuckGo with friends.
 msgid "Help Spread Privacy"
 msgstr "Agiuda a difùndere sa riservadesa"
+
+#. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Help me prep for the interview"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Help me tailor my resume for this job."
+msgstr ""
 
 #. Title of a SERP popup that invites users to take a survey (desktop only)
 msgctxt "User survey popup"
@@ -7727,6 +7899,13 @@ msgstr ""
 #. Text displayed on the button on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
 msgctxt "Onboarding terms screen button text"
 msgid "I Agree"
+msgstr ""
+
+#. Text for the button that takes the user to the external DuckDuckGo login subscription page.
+msgctxt ""
+"Text for the I already have a subscription button in the Duck.ai settings "
+"page"
+msgid "I Already Have a Subscription"
 msgstr ""
 
 #. Text for the button that takes the user to the login subscription page.
@@ -8203,6 +8382,11 @@ msgctxt "Sidemenu browser promo"
 msgid "Install Mac Browser"
 msgstr ""
 
+#. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
+msgctxt "settings"
+msgid "Install Now"
+msgstr ""
+
 #. Text of a button to install the DuckDuckGo app
 msgctxt "Serp footer content"
 msgid "Install Our App"
@@ -8282,10 +8466,37 @@ msgctxt "cloudsave"
 msgid "Is deleted data really deleted?"
 msgstr "Is datos meos, sunt cantzellados a beru?"
 
+#. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is it worth taking?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this place any good?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"Is this place any good? Summarize its reputation based on reviews and "
+"ratings."
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "Is this video helpful?"
 msgstr "Est de agiudu, custu vìdeu?"
+
+#. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this worth watching?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Is this worth watching? Give me a spoiler-free take."
+msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
 msgctxt "Weather IA"
@@ -8789,6 +9000,11 @@ msgstr "Orìgine de su ligàmene:"
 msgid "Links:"
 msgstr "Ligàmenes:"
 
+#. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "List the tools, materials, or prerequisites I need for this."
+msgstr ""
+
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
 msgid "Listen"
 msgstr "Ascurta"
@@ -9126,6 +9342,11 @@ msgstr ""
 #. Label for linke navigating to site exclusion feature on Settings page
 msgctxt "Exclusion message manage sites button"
 msgid "Manage blocked sites"
+msgstr ""
+
+#. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
+msgctxt "setting"
+msgid "Manage in Browser Settings"
 msgstr ""
 
 #. Link to the site exclusion settings page
@@ -11446,6 +11667,11 @@ msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
+msgid "Please describe why the chat response is harmful or illegal. (optional)"
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
+msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
 msgstr ""
 
@@ -11464,6 +11690,13 @@ msgctxt "Modal disclaimer text"
 msgid ""
 "Please note: starting a new chat with any model will delete your current "
 "chat session."
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
+msgctxt "Feedback prompt"
+msgid ""
+"Please paste your prompt and the problematic output (with any personal "
+"information removed) and describe why the content is harmful or illegal."
 msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -11850,6 +12083,11 @@ msgctxt "settings"
 msgid "Privacy"
 msgstr "Riservadesa"
 
+#. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
+msgctxt "Section heading on the Duck.ai settings page"
+msgid "Privacy & Terms"
+msgstr ""
+
 msgid "Privacy Blog"
 msgstr "Diàriu de riservadesa"
 
@@ -11903,6 +12141,11 @@ msgstr ""
 
 #. Text used in other strings to link to the Privacy Policy and Terms of Service content.
 msgctxt "Copy used to compose link in sentences"
+msgid "Privacy Policy and Terms of Service"
+msgstr ""
+
+#. Text for a button that links to the terms of use and privacy policy page.
+msgctxt "Secondary button text in active privacy modal"
 msgid "Privacy Policy and Terms of Service"
 msgstr ""
 
@@ -12313,6 +12556,26 @@ msgctxt "Brief for recommending a book"
 msgid "Recommend a book"
 msgstr ""
 
+#. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar books"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar books."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar movies or shows."
+msgstr ""
+
+#. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar titles"
+msgstr ""
+
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
 msgid "Recording failed. Please try again."
 msgstr ""
@@ -12637,6 +12900,14 @@ msgstr ""
 msgid "Republic of Moldova"
 msgstr ""
 
+#. Note indicating that sharing the conversation is mandatory when reporting harmful or illegal content. Rendered alongside the standard share label (DUCKCHAT_RESPONSE_FEEDBACK_SHARE_PROMPT_RESPONSE_LABEL), not replacing it.
+msgctxt ""
+"Note shown under the share-content switch label on the Duck.ai response "
+"feedback form when the user has selected Harmful or Illegal as the feedback "
+"reason"
+msgid "Required for harmful or illegal reports"
+msgstr ""
+
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
 msgctxt "Description for extended reasoning mode in Duck.ai"
 msgid "Researches before responding"
@@ -12823,6 +13094,11 @@ msgstr "Opiniones"
 msgctxt "maps_places"
 msgid "Reviews"
 msgstr "Opiniones"
+
+#. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Rewrite this recipe scaled for a different number of servings."
+msgstr ""
 
 msgid "Romania"
 msgstr "Romania"
@@ -13905,6 +14181,11 @@ msgctxt "Setup button for native sync flow"
 msgid "Set Up Now"
 msgstr ""
 
+#. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
+msgctxt "Encrypted storage setup button shown in native browsers"
+msgid "Set Up Sync & Backup"
+msgstr ""
+
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
 msgctxt "Title for the Sync & Backup intro screen"
 msgid "Set Up Sync & Backup"
@@ -14051,6 +14332,12 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
+msgctxt ""
+"Label beside the share-content switch on the Duck.ai response feedback form"
+msgid "Share this conversation with DuckDuckGo"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -15079,6 +15366,21 @@ msgctxt "Brief for suggesting a blog post title"
 msgid "Suggest a title for a blog post"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest related articles or topics worth exploring next."
+msgstr ""
+
+#. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Suggest related articles to explore"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest some alternatives to this product."
+msgstr ""
+
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
 msgctxt "directions"
 msgid "Suggestions:"
@@ -15088,9 +15390,84 @@ msgctxt "noresults"
 msgid "Suggestions:"
 msgstr "Cussìgios:"
 
+#. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Sum up the reviews"
+msgstr ""
+
 #. A short title for the a message asking the AI to summarize a text.
 msgctxt "Title for the summarize message"
 msgid "Summarize"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize the Q&As"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the background and notable work of this person."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the key details of this event."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the questions and answers on this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize their background"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this book"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this book."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this discussion"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this discussion thread."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this video"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this video."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize what the reviews say."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -15345,6 +15722,11 @@ msgstr ""
 msgid "Syria"
 msgstr ""
 
+#. Text for a button that enables the theme to follow the operating system's color scheme preference.
+msgctxt "System theme button for theme selector"
+msgid "System"
+msgstr ""
+
 #. Abbreviation indicating this is the total score for a game
 msgctxt "Sports module"
 msgid "T"
@@ -15368,6 +15750,11 @@ msgctxt "language_name"
 msgid "Tahitian"
 msgstr "Tahitianu"
 
+#. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Tailor my resume"
+msgstr ""
+
 msgid "Taiwan"
 msgstr "Taiwan"
 
@@ -15390,6 +15777,12 @@ msgstr "Controlla is datos personales tuos"
 msgctxt "homepage ATB modal"
 msgid "Take control of your personal data!"
 msgstr "Controlla is datos personales tuos!"
+
+#. Description for the Feedback section of the Duck.ai settings page, asking the user to take an anonymous survey to let us know how we can make Duck.ai better.
+msgctxt "Feedback section description on the Duck.ai settings page"
+msgid ""
+"Take this anonymous survey to let us know how we can make Duck.ai better."
+msgstr ""
 
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
 msgctxt "Description for reasoning mode in Duck.ai"
@@ -15639,6 +16032,11 @@ msgstr ""
 #. https://duck.co/media/files/theme.png
 msgid "Theme"
 msgstr "Tema"
+
+#. Text for the theme selector label that allows users to switch between Light and dark theme.
+msgctxt "Label for the theme selector feature"
+msgid "Theme"
+msgstr ""
 
 #. http://i.imgur.com/LpFhb1e.png
 msgctxt "settings"
@@ -16299,6 +16697,16 @@ msgid ""
 "movie theatre?”"
 msgstr ""
 
+#. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Translate this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
+msgctxt "Page suggestion prompt"
+msgid "Translate this page into %s."
+msgstr ""
+
 #. Placeholder text for a region that will display translated text.
 msgctxt "translations_module"
 msgid "Translation"
@@ -16413,6 +16821,11 @@ msgstr ""
 #. Call-to-action button for the subscription promo in the SERP sidemenu.
 msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
+msgstr ""
+
+#. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
+msgctxt "settings"
+msgid "Try It Now"
 msgstr ""
 
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -16609,6 +17022,20 @@ msgstr "Proa %s"
 msgctxt "new user poll"
 msgid "Trying DuckDuckGo again"
 msgstr "Torra a proare DuckDuckGo"
+
+#. Message shown in a modal after supported third-party browser users disable AI features in Settings. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+#. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
 
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
 msgctxt "Assistant response placeholder"
@@ -17223,6 +17650,11 @@ msgstr "Urdu"
 msgid "Uruguay"
 msgstr "Uruguay"
 
+#. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
+msgctxt "Navigation label on the Duck.ai settings page"
+msgid "Usage"
+msgstr ""
+
 #. A feedback suggestion
 msgctxt "Feedback prompt"
 msgid "Usage limit"
@@ -17574,6 +18006,11 @@ msgstr "Abetende sa positzione..."
 msgid "Wales"
 msgstr "Galles"
 
+#. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Walk me through the steps"
+msgstr ""
+
 #. Label for walking directions on a map.
 msgctxt "directions"
 msgid "Walking"
@@ -17664,6 +18101,16 @@ msgstr ""
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
+msgstr ""
+
+#. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
+msgctxt ""
+"Inline warning shown below the share-content toggle when the user selects "
+"Harmful or Illegal but has not enabled sharing"
+msgid ""
+"We can only fix what we can see. To report a harmful or illegal response, "
+"please share this conversation with DuckDuckGo so we can investigate and "
+"address the issue."
 msgstr ""
 
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -18101,6 +18548,87 @@ msgid ""
 "experience."
 msgstr ""
 
+#. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the counterarguments?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the hours & location?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key contributions of this paper?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key contributions?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key details?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key points covered in this video?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key points?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key takeaways from this article?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key takeaways?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key things I will learn from this course?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main counterarguments or criticisms of this?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main questions this page answers?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the must-try dishes here?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"What are the opening hours, location, and contact details for this place?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the pros and cons of this product?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the pros and cons?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
 msgctxt "feedback form"
 msgid "What bothered you most?"
@@ -18184,6 +18712,11 @@ msgctxt "Full sentence for defining a term"
 msgid "What does atria mean in the context of a medical article?"
 msgstr ""
 
+#. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What does this answer?"
+msgstr ""
+
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
@@ -18193,6 +18726,11 @@ msgstr ""
 msgctxt "cloudsave"
 msgid "What information gets saved?"
 msgstr "Cales datos sunt sarvados?"
+
+#. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What interview questions might come up for this role?"
+msgstr ""
 
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
@@ -18206,6 +18744,11 @@ msgstr ""
 #. Text for a prompt suggestion for looking up the capital city of Albania.
 msgctxt "Full sentence for looking up basic facts"
 msgid "What is the capital city of Albania?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What is the overall verdict and rating for this?"
 msgstr ""
 
 #. Link to a page with additional information.
@@ -18226,6 +18769,11 @@ msgctxt "maps_places"
 msgid "What people say:"
 msgstr "Su chi narat sa gente:"
 
+#. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What should I order?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
 msgctxt "feedback form"
 msgid "What stood out?"
@@ -18234,6 +18782,16 @@ msgstr ""
 #. Question on a feedback form for a negative feedback response.
 msgctxt "feedback form"
 msgid "What was wrong with the response? (optional)"
+msgstr ""
+
+#. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I learn?"
+msgstr ""
+
+#. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I need?"
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -18248,6 +18806,11 @@ msgstr ""
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
 msgctxt "SERP footer content"
 msgid "What's New"
+msgstr ""
+
+#. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What's the verdict?"
 msgstr ""
 
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -18290,6 +18853,11 @@ msgctxt "Feedback prompt"
 msgid "Which features are missing? (Optional)"
 msgstr ""
 
+#. An invitation for users to leave feedback
+msgctxt "Feedback prompt"
+msgid "Which features are missing? (optional)"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
 msgid "White"
 msgstr "Biancu"
@@ -18302,6 +18870,16 @@ msgstr "Biancu"
 #. Link to an about us page.
 msgid "Who We Are"
 msgstr "Chie semus"
+
+#. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Who are the main cast and crew, and what else are they known for?"
+msgstr ""
+
+#. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Who is this person?"
+msgstr ""
 
 #. Header above a collection of privacy-related links.
 msgid "Why Privacy"

--- a/locales/si_LK/LC_MESSAGES/duckduckgo.po
+++ b/locales/si_LK/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: si_LK\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -177,8 +177,8 @@ msgid ""
 "browser again to continue the chat, or switch to a Plus or free model."
 msgstr ""
 "%1$s ලබා ගත හැක්කේ Pro සමඟ පමණි. කතාබහ දිගටම කරගෙන යාමට මෙම බ්‍රවුසරයේ ඔබේ "
-"DuckDuckGo ග්‍රාහකත්වය නැවත උත්ශ්‍රේණිගත කරන්න, නැතහොත් Plus හෝ නොමිලේ "
-"ප්‍රකාරයකට මාරු වන්න."
+"DuckDuckGo ග්‍රාහකත්වය නැවත උත්ශ්‍රේණිගත කරන්න, නැතහොත් Plus හෝ නොමිලේ ප්‍රකාරයකට මාරු "
+"වන්න."
 
 # smartling.placeholder_format=C
 #. Text for the disclaimer message that appears when a Plus subscriber tries to use a Pro-only model. %s is replaced with the model name. Example: Claude Opus 4.6 is only available with Pro. Upgrade your DuckDuckGo subscription in this browser again to continue the chat, or switch to a Plus or free model.
@@ -189,8 +189,8 @@ msgid ""
 "browser again to continue the chat, or switch to a Plus or free model."
 msgstr ""
 "%1$s ලබා ගත හැක්කේ Pro සමඟ පමණි. කතාබහ දිගටම කරගෙන යාමට මෙම බ්‍රවුසරයේ ඔබේ "
-"DuckDuckGo ග්‍රාහකත්වය නැවත උත්ශ්‍රේණිගත කරන්න, නැතහොත් Plus හෝ නොමිලේ "
-"ප්‍රකාරයකට මාරු වන්න."
+"DuckDuckGo ග්‍රාහකත්වය නැවත උත්ශ්‍රේණිගත කරන්න, නැතහොත් Plus හෝ නොමිලේ ප්‍රකාරයකට මාරු "
+"වන්න."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI (Artificial Intelligence) chat model is temporarily unavailable. Example: 'GPT 4o is only available with a DuckDuckGo subscription.'
@@ -207,8 +207,7 @@ msgid ""
 "model."
 msgstr ""
 "%1$s ලබා ගත හැක්කේ DuckDuckGo දායකත්වයක් සමඟ පමණි. චැට් දිගටම කරගෙන යාමට මෙම "
-"බ්‍රව්සරයේ ඔබේ දායකත්වය නැවත සක්‍රිය කරන්න, නැත්නම් නොමිලේ ආකෘතියකට මාරු "
-"වන්න."
+"බ්‍රව්සරයේ ඔබේ දායකත්වය නැවත සක්‍රිය කරන්න, නැත්නම් නොමිලේ ආකෘතියකට මාරු වන්න."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is temporarily unavailable. Example: 'GPT 3.5 Turbo is temporarily unavailable. Please switch to a different model or try again later.'
@@ -217,8 +216,8 @@ msgid ""
 "%s is temporarily unavailable. Please switch to a different model or try "
 "again later."
 msgstr ""
-"%1$s තාවකාලිකව ලබා ගත නොහැක. කරුණාකර වෙනත් ආකෘතියකට මාරු වන්න නැතිනම් පසුව "
-"නැවත උත්සාහ කරන්න."
+"%1$s තාවකාලිකව ලබා ගත නොහැක. කරුණාකර වෙනත් ආකෘතියකට මාරු වන්න නැතිනම් පසුව නැවත උත්සාහ "
+"කරන්න."
 
 # smartling.placeholder_format=C
 #. Reddit's "fake internet points". https://support.reddithelp.com/hc/en-us/articles/204511829-What-is-karma
@@ -309,9 +308,9 @@ msgid ""
 "provider can see your prompts or the model’s responses, or save this chat on "
 "their servers."
 msgstr ""
-"%1$s ක් රියාත්මක වන්නේ විශ්වාසදායක ක් රියාත්මක කිරීමේ පරිසරයක ය. මෙයින් "
-"අදහස් කරන්නේ ආකෘති සපයන්නාට පවා ඔබේ විමසීම් හෝ ආකෘතියේ ප්‍රතිචාර දැකීමට හෝ "
-"මෙම කතාබහ ඔවුන්ගේ සර්වරවල සුරැකීමට නොහැකි බවයි."
+"%1$s ක් රියාත්මක වන්නේ විශ්වාසදායක ක් රියාත්මක කිරීමේ පරිසරයක ය. මෙයින් අදහස් කරන්නේ ආකෘති "
+"සපයන්නාට පවා ඔබේ විමසීම් හෝ ආකෘතියේ ප්‍රතිචාර දැකීමට හෝ මෙම කතාබහ ඔවුන්ගේ සර්වරවල සුරැකීමට "
+"නොහැකි බවයි."
 
 # smartling.placeholder_format=C
 #. Label shown in the batch selection toolbar when exactly one chat is selected. %s is replaced with 1. Use singular agreement where the language requires it.
@@ -391,8 +390,8 @@ msgid ""
 "%s will be leaving Duck.ai in %s days (%s). After that, you can switch "
 "models to continue this chat."
 msgstr ""
-"%1$s දින %2$sකින් (%3$s) Duck.ai හැර යනු ඇත. ඊට පසු, ඔබට මෙම කතාබහ දිගටම "
-"කරගෙන යාමට ආකෘති මාරු කළ හැකි ය."
+"%1$s දින %2$sකින් (%3$s) Duck.ai හැර යනු ඇත. ඊට පසු, ඔබට මෙම කතාබහ දිගටම කරගෙන "
+"යාමට ආකෘති මාරු කළ හැකි ය."
 
 # smartling.placeholder_format=C
 #. Displayed in a saved chat when its AI model is about to be retired tomorrow. First placeholder is the friendly model name, second placeholder is the removal date formatted in the user's browser locale (e.g., 'June 15, 2026' in en-US). Singular-day form.
@@ -403,8 +402,8 @@ msgid ""
 "%s will be leaving Duck.ai in 1 day (%s). After that, you can switch models "
 "to continue this chat."
 msgstr ""
-"%1$s දින 1කින් Duck.ai හැර යනු ඇත (%2$s). ඊට පසු, ඔබට මෙම කතාබහ දිගටම කරගෙන "
-"යාමට ආකෘති මාරු කළ හැකි ය."
+"%1$s දින 1කින් Duck.ai හැර යනු ඇත (%2$s). ඊට පසු, ඔබට මෙම කතාබහ දිගටම කරගෙන යාමට "
+"ආකෘති මාරු කළ හැකි ය."
 
 # smartling.placeholder_format=C
 #. Shown in a text selection chip when the selection contains multiple words. %s is replaced with the number of words, e.g. '142 words'.
@@ -417,8 +416,8 @@ msgstr "%1$s වචන"
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
 msgstr ""
-"%1$sක්ලික් කරන්න %2$sඑක් කරන්න%3$sපරීක්ෂා කරන්න %4$sඉඩ දෙන්න%5$s, අනතුරුව "
-"%6$sහරි%7$sක්ලික් කරන්න"
+"%1$sක්ලික් කරන්න %2$sඑක් කරන්න%3$sපරීක්ෂා කරන්න %4$sඉඩ දෙන්න%5$s, අනතුරුව %6$sහරි%7$sක්ලික් "
+"කරන්න"
 
 # Firefox, obsolete
 # smartling.placeholder_format=C
@@ -426,8 +425,8 @@ msgstr ""
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAllow%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
 msgstr ""
-"%1$sAllow%2$s %3$sක්ලික් කරන්න %4$sAdd%5$s ක්ලික් කරන්න %6$sAllow%7$s මත හරි "
-"ලකුණ දමන්න, ඉන්පසුව %8$sOkay%9$s ක්ලික් කරන්න"
+"%1$sAllow%2$s %3$sක්ලික් කරන්න %4$sAdd%5$s ක්ලික් කරන්න %6$sAllow%7$s මත හරි ලකුණ "
+"දමන්න, ඉන්පසුව %8$sOkay%9$s ක්ලික් කරන්න"
 
 # Firefox
 # smartling.placeholder_format=C
@@ -447,8 +446,7 @@ msgid ""
 "%sClick here%s to try again, if you think there should be results for this "
 "search."
 msgstr ""
-"මෙයට ප්‍රතිඵලයක් තිබෙන්නටම අවශ්‍යයැයි සිතෙනවානම්, නැවත් උත්සාහ කිරීමට "
-"%1$sමෙතන ක්ලික් කරන්න%2$s."
+"මෙයට ප්‍රතිඵලයක් තිබෙන්නටම අවශ්‍යයැයි සිතෙනවානම්, නැවත් උත්සාහ කිරීමට %1$sමෙතන ක්ලික් කරන්න%2$s."
 
 # smartling.placeholder_format=C
 #. Header for a page with information about sharing DuckDuckGo.
@@ -474,8 +472,7 @@ msgctxt "Footer text for About Sync modal"
 msgid ""
 "%sLearn more%s about how chats are stored privately on DuckDuckGo's server."
 msgstr ""
-"%1$sDuckDuckGo සර්වරයේ කතාබස් පෞද්ගලිකව ගබඩා වන ආකාරය පිළිබඳ%2$s වැඩිදුර "
-"ඉගෙන ගන්න."
+"%1$sDuckDuckGo සර්වරයේ කතාබස් පෞද්ගලිකව ගබඩා වන ආකාරය පිළිබඳ%2$s වැඩිදුර ඉගෙන ගන්න."
 
 # smartling.placeholder_format=C
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
@@ -494,8 +491,8 @@ msgstr "මුල් තිරයේ ඇති DuckDuckGo යෙදුම් න
 msgctxt "Error or no results message"
 msgid "%sOops!%s%sSomething went wrong. Please %srefresh%s and try again."
 msgstr ""
-"%1$sඅපොයි!%2$s%3$sකුමක් හෝ වැරැද්දක් සිදු විය. කරුණාකර %4$sනැවුම් කරන්න%5$s "
-"සහ නැවත උත්සාහ කරන්න."
+"%1$sඅපොයි!%2$s%3$sකුමක් හෝ වැරැද්දක් සිදු විය. කරුණාකර %4$sනැවුම් කරන්න%5$s සහ නැවත "
+"උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. Tagline in a popover encouraging the user to download the DuckDuckGo browser
@@ -813,8 +810,7 @@ msgstr "පැය 6ක පරිශීලන සීමාවට ළඟා වී
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "6-hour usage limit reached. You can continue this chat after %s."
 msgstr ""
-"පැය 6ක පරිශීලන සීමාවට ළඟා වී තිබේ. ඔබට %1$sට පසුව මෙම කතාබහ දිගටම කරගෙන යා "
-"හැක."
+"පැය 6ක පරිශීලන සීමාවට ළඟා වී තිබේ. ඔබට %1$sට පසුව මෙම කතාබහ දිගටම කරගෙන යා හැක."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable 6-hour Duck.ai usage limit and can opt in to continue using the daily limit.
@@ -822,8 +818,8 @@ msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "6-hour usage limit reached. You can keep chatting by using your daily limit."
 msgstr ""
-"පැය 6ක පරිශීලන සීමාවට ළඟා වී තිබේ. ඔබේ දෛනික සීමාව භාවිතා කිරීමෙන් ඔබට දිගට "
-"ම කතාබස් කළ හැකි ය."
+"පැය 6ක පරිශීලන සීමාවට ළඟා වී තිබේ. ඔබේ දෛනික සීමාව භාවිතා කිරීමෙන් ඔබට දිගට ම කතාබස් කළ "
+"හැකි ය."
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes abbreviation
@@ -877,8 +873,8 @@ msgid ""
 "A network issue is preventing Search Assist from generating an answer. "
 "Please check your connection and try again."
 msgstr ""
-"ජාල ගැටලුවක් හේතුවෙන් Search Assist මගින් පිළිතුරක් ජනනය කිරීම වැළකී ඇත. "
-"කරුණාකර ඔබේ සම්බන්ධතාව පරීක්ෂා කර නැවත උත්සාහ කරන්න."
+"ජාල ගැටලුවක් හේතුවෙන් Search Assist මගින් පිළිතුරක් ජනනය කිරීම වැළකී ඇත. කරුණාකර ඔබේ "
+"සම්බන්ධතාව පරීක්ෂා කර නැවත උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of AI Chat is available and they need to refresh the page.
@@ -886,8 +882,8 @@ msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of AI Chat is available! Please refresh this page to continue."
 msgstr ""
-"AI Chat හි නව අනුවාදයක් ලබා ගත හැකි ය! දිගටම කරගෙන යාමට කරුණාකර මෙම පිටුව "
-"නැවත නැවුම් කරන්න."
+"AI Chat හි නව අනුවාදයක් ලබා ගත හැකි ය! දිගටම කරගෙන යාමට කරුණාකර මෙම පිටුව නැවත නැවුම් "
+"කරන්න."
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of Duck.ai is available and they need to refresh the page.
@@ -895,8 +891,8 @@ msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of Duck.ai is available! Please refresh this page to continue."
 msgstr ""
-"Duck.ai හි නව අනුවාදයක් ලබා ගත හැකි ය! දිගටම කරගෙන යාමට කරුණාකර මෙම පිටුව "
-"නැවත නැවුම් කරන්න."
+"Duck.ai හි නව අනුවාදයක් ලබා ගත හැකි ය! දිගටම කරගෙන යාමට කරුණාකර මෙම පිටුව නැවත නැවුම් "
+"කරන්න."
 
 # smartling.placeholder_format=C
 #. Shown when the Duck.ai desktop app has been open a long time and a newer version exists.
@@ -934,10 +930,9 @@ msgid ""
 "still access AI Chat when this setting is off by visiting %sduckduckgo.com/"
 "aichat%s."
 msgstr ""
-"AI Chat ඔබට 3පාර්ශවයේ AI Chat ආකෘති සමඟ නිර්නාමික සංවාද පැවැත්වීමට ඉඩ සලසයි. "
-"මෙය ක්‍රියා විරහිත කිරීමෙන් DuckDuckGo Search AI Chat විශේෂාංගය සඟවනු ඇත. "
-"මෙම සැකසුම ක්‍රියා විරහිත වූ විට ඔබට තවමත් %1$sduckduckgo.com/aichat%2$s AI "
-"Chat වෙත ප්‍රවේශ විය හැකිය."
+"AI Chat ඔබට 3පාර්ශවයේ AI Chat ආකෘති සමඟ නිර්නාමික සංවාද පැවැත්වීමට ඉඩ සලසයි. මෙය "
+"ක්‍රියා විරහිත කිරීමෙන් DuckDuckGo Search AI Chat විශේෂාංගය සඟවනු ඇත. මෙම සැකසුම ක්‍රියා "
+"විරහිත වූ විට ඔබට තවමත් %1$sduckduckgo.com/aichat%2$s AI Chat වෙත ප්‍රවේශ විය හැකිය."
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -998,10 +993,10 @@ msgid ""
 "questions, which is our private AI-powered chat service that supports chat "
 "models from OpenAI, and Anthropic, and more."
 msgstr ""
-"AI සහය සහිත පිළිතුරු දැනට සෘජුවම පසු විපරම් ප්‍රශ්නවලට සහය නොදක්වයි. කෙසේ "
-"වෙතත්, අපි පසු විපරම් ප්‍රශ්න සඳහා %1$sDuck.ai%2$s පිරිනමමු, තවද බොහෝ විට එය "
-"වෙත සබැඳෙමු, එය OpenAI සහ Anthropic, සහ තවත් දෑ වෙතින් චැට් ආකෘති සඳහා සහය "
-"දක්වන අපගේ පෞද්ගලික AI බලයෙන් ක්‍රියාත්මක වන චැට් සේවාවක් වේ."
+"AI සහය සහිත පිළිතුරු දැනට සෘජුවම පසු විපරම් ප්‍රශ්නවලට සහය නොදක්වයි. කෙසේ වෙතත්, අපි පසු විපරම් "
+"ප්‍රශ්න සඳහා %1$sDuck.ai%2$s පිරිනමමු, තවද බොහෝ විට එය වෙත සබැඳෙමු, එය OpenAI සහ "
+"Anthropic, සහ තවත් දෑ වෙතින් චැට් ආකෘති සඳහා සහය දක්වන අපගේ පෞද්ගලික AI බලයෙන් "
+"ක්‍රියාත්මක වන චැට් සේවාවක් වේ."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has turned off AI features and will no longer see AI-assisted answers.
@@ -1186,8 +1181,8 @@ msgid ""
 "Activate your %s in this browser again to continue the chat, or switch to a "
 "free model."
 msgstr ""
-"චැට් දිගටම කරගෙන යාමට මෙම බ්රව්සරයේ ඔබේ %1$s නැවත සක්රිය කරන්න, නැත්නම් "
-"නොමිලේ ආකෘතියකට මාරු වන්න."
+"චැට් දිගටම කරගෙන යාමට මෙම බ්රව්සරයේ ඔබේ %1$s නැවත සක්රිය කරන්න, නැත්නම් නොමිලේ ආකෘතියකට "
+"මාරු වන්න."
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an active DuckDuckGo subscription.
@@ -1223,8 +1218,8 @@ msgstr "දැන්වීම"
 msgid ""
 "Ad clicks are managed by %s’s ad network and are not used to profile you."
 msgstr ""
-"වෙළඳ දැන්වීම් ක්ලික් කිරීම් කළමනාකරණය කරනු ලබන්නේ %1$sහි වෙළඳ දැන්වීම් ජාලය "
-"මගින් වන අතර ඒවා ඔබේ හැසිරීම මත පදනම්ව තීරණ ගැනීමට භාවිත කරනු නොලැබේ."
+"වෙළඳ දැන්වීම් ක්ලික් කිරීම් කළමනාකරණය කරනු ලබන්නේ %1$sහි වෙළඳ දැන්වීම් ජාලය මගින් වන අතර ඒවා "
+"ඔබේ හැසිරීම මත පදනම්ව තීරණ ගැනීමට භාවිත කරනු නොලැබේ."
 
 # smartling.placeholder_format=C
 #. Information that ad clicks are managed by Microsoft.
@@ -1232,8 +1227,8 @@ msgid ""
 "Ad clicks are managed by Microsoft’s ad network and are not used to profile "
 "you."
 msgstr ""
-"දැන්වීම් ක්ලික් කිරීම් කළමනාකරණය කරනු ලබන්නේ Microsoft හි දැන්වීම් ජාලය "
-"විසිනි, ඒවා ඔබව පැතිකඩ කිරීමට භාවිතා නොකෙරේ."
+"දැන්වීම් ක්ලික් කිරීම් කළමනාකරණය කරනු ලබන්නේ Microsoft හි දැන්වීම් ජාලය විසිනි, ඒවා ඔබව පැතිකඩ "
+"කිරීමට භාවිතා නොකෙරේ."
 
 # smartling.placeholder_format=C
 #. An item in the ads tooltip that explains that ad clicks aren’t used to profile you.
@@ -1284,8 +1279,7 @@ msgstr "DuckDuckGo දිගුව එක් කරන්න"
 msgid ""
 "Add DuckDuckGo Privacy Essentials to your browser for free with one download:"
 msgstr ""
-"එක් බාගැනීමකින් DuckDuckGo Privacy Essentials ඔබේ බ්‍රවුසරය වෙත නොමිලේ එක් "
-"කරන්න:"
+"එක් බාගැනීමකින් DuckDuckGo Privacy Essentials ඔබේ බ්‍රවුසරය වෙත නොමිලේ එක් කරන්න:"
 
 #  IE default search engine instruction
 # smartling.placeholder_format=C
@@ -1438,6 +1432,12 @@ msgstr "ලිපින තිරුව:"
 msgctxt "feedback form"
 msgid "Address is incorrect"
 msgstr "ලිපිනය වැරදියි"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Adjust the servings"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. as in multiple advertisements
@@ -1651,6 +1651,14 @@ msgid "All chats are %sprivate%s"
 msgstr "සියලුම කතාබස් %1$sපුද්ගලික%2$s වේ"
 
 # smartling.placeholder_format=C
+#. Paragraph in the Privacy & Terms section of the About & Legal page in Duck.ai settings, summarizing how chats are anonymized and are not stored or used to train chat models.
+msgctxt "Privacy & Terms section description on the Duck.ai settings page"
+msgid ""
+"All chats are anonymized by DuckDuckGo, and your conversations are not used "
+"to train chat models by DuckDuckGo or the model providers"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
 msgctxt "Privacy modal header in Duck.ai chat"
 msgid "All chats are private"
@@ -1695,8 +1703,8 @@ msgid ""
 "All personal metadata (for example, your IP address) is removed before "
 "sending a chat to the AI provider."
 msgstr ""
-"AI සැපයුම්කරුට කතාබහක් යැවීමට පෙර සියලුම පුද්ගලික පාර-දත්ත (උදාහරණයක් ලෙස, "
-"ඔබගේ IP ලිපිනය) ඉවත් කරනු ලැබේ."
+"AI සැපයුම්කරුට කතාබහක් යැවීමට පෙර සියලුම පුද්ගලික පාර-දත්ත (උදාහරණයක් ලෙස, ඔබගේ IP ලිපිනය) "
+"ඉවත් කරනු ලැබේ."
 
 # smartling.placeholder_format=C
 #. A filter that shows search results from all countries.
@@ -1722,8 +1730,7 @@ msgctxt "voice chat"
 msgid ""
 "Allow DuckDuckGo microphone access in System Settings to use voice chat."
 msgstr ""
-"හඬ කතාබස් භාවිතා කිරීමට පද්ධති සැකසීම් තුළ DuckDuckGo මයික්‍රෆෝනයට ප්‍රවේශය "
-"ලබා දෙන්න."
+"හඬ කතාබස් භාවිතා කිරීමට පද්ධති සැකසීම් තුළ DuckDuckGo මයික්‍රෆෝනයට ප්‍රවේශය ලබා දෙන්න."
 
 # smartling.placeholder_format=C
 #. Tells users which icon to press in their browser. Part of a list of instructions on how to enable location service.
@@ -1749,10 +1756,9 @@ msgid ""
 "sends AI-generated queries to a search engine with limited data retention. "
 "Prompts and responses with %s still have %szero provider visibility%s."
 msgstr ""
-"අදාළ විමසීම්වලට ප්‍රතිචාර වැඩි දියුණු කිරීම සඳහා වෙබයේ සෙවීමට %1$s හට ඉඩ "
-"දෙයි. සීමිත දත්ත රඳවා ගැනීමක් සහිත සෙවුම් යන්ත්‍රයකට AI-ජනනය කරන ලද විමසුම් "
-"පමණක් යවයි. %2$s සහිත විමසීම් සහ ප්‍රතිචාර වලට තවමත් %3$sසැපයුම්කරුගේ "
-"දෘශ්‍යතාව ශුන්‍ය වේ%4$s."
+"අදාළ විමසීම්වලට ප්‍රතිචාර වැඩි දියුණු කිරීම සඳහා වෙබයේ සෙවීමට %1$s හට ඉඩ දෙයි. සීමිත දත්ත "
+"රඳවා ගැනීමක් සහිත සෙවුම් යන්ත්‍රයකට AI-ජනනය කරන ලද විමසුම් පමණක් යවයි. %2$s සහිත විමසීම් සහ "
+"ප්‍රතිචාර වලට තවමත් %3$sසැපයුම්කරුගේ දෘශ්‍යතාව ශුන්‍ය වේ%4$s."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -1760,8 +1766,7 @@ msgid ""
 "Allows Cloud Save key to be stored locally on device (required to use Cloud "
 "Save)"
 msgstr ""
-"Cloud Save යතුර උපාංගයේ දේශීයව ගබඩා කිරීමට ඉඩ දෙයි (Cloud Save භාවිතා කිරීමට "
-"අවශ්‍ය වේ)"
+"Cloud Save යතුර උපාංගයේ දේශීයව ගබඩා කිරීමට ඉඩ දෙයි (Cloud Save භාවිතා කිරීමට අවශ්‍ය වේ)"
 
 # smartling.placeholder_format=C
 #. Pending title indicating near completion.
@@ -1899,8 +1904,7 @@ msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
 msgstr ""
-"%1$s, %2$s සහ විවෘත මූලාශ්ර %3$s සහ %4$sඇතුළු ජනප්රිය AI ආකෘති සඳහා "
-"නිර්නාමික ප්රවේශය."
+"%1$s, %2$s සහ විවෘත මූලාශ්ර %3$s සහ %4$sඇතුළු ජනප්රිය AI ආකෘති සඳහා නිර්නාමික ප්රවේශය."
 
 # smartling.placeholder_format=C
 #. Text with information about Duck.ai and supported AI models, the placeholders list AI models. Example: 'Anonymous access to popular AI models, including GPT, Claude, and open-source Llama and Mistral.'
@@ -1909,14 +1913,20 @@ msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
 msgstr ""
-"%1$s, %2$s සහ විවෘත මූලාශ්ර %3$s සහ %4$sඇතුළු ජනප්රිය AI ආකෘති සඳහා "
-"නිර්නාමික ප්රවේශය."
+"%1$s, %2$s සහ විවෘත මූලාශ්ර %3$s සහ %4$sඇතුළු ජනප්රිය AI ආකෘති සඳහා නිර්නාමික ප්රවේශය."
 
 # smartling.placeholder_format=C
 #. Confirmation message after location service is enabled.
 msgctxt "precise_user_location"
 msgid "Anonymous location enabled"
 msgstr "නිර්නාමික ස්ථානය සබල කර ඇත"
+
+# smartling.placeholder_format=C
+msgctxt "settings"
+msgid ""
+"Anonymously generates answers for search queries based on web content. "
+"Choose how often you want it to appear, or disable it completely."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -1963,8 +1973,8 @@ msgid ""
 "Any additional instructions you want Duck.ai to follow. e.g. Always tell me "
 "facts about ducks"
 msgstr ""
-"Duck.ai අනුගමනය කිරීමට ඔයාට අවශ්‍ය ඕනෑම අමතර උපදෙසක්. උදා. තාරාවන් ගැන හැම "
-"විටම කරුණු මට කියන්න"
+"Duck.ai අනුගමනය කිරීමට ඔයාට අවශ්‍ය ඕනෑම අමතර උපදෙසක්. උදා. තාරාවන් ගැන හැම විටම කරුණු "
+"මට කියන්න"
 
 # smartling.placeholder_format=C
 #. Shown in video filtering. https://duckduckgo.com/?q=videos+of+cats&iax=videos&ia=videos
@@ -2084,8 +2094,7 @@ msgid ""
 "Are you sure you want to disable history? This will delete all chats, "
 "including pinned chats."
 msgstr ""
-"ඔබට ඉතිහාසය අක්‍රිය කිරීමට අවශ්‍ය බව විශ්වාසද? මෙය පින් කළ කතා ඇතුළුව, "
-"සියලුම කතා මකා දමනු ඇත."
+"ඔබට ඉතිහාසය අක්‍රිය කිරීමට අවශ්‍ය බව විශ්වාසද? මෙය පින් කළ කතා ඇතුළුව, සියලුම කතා මකා දමනු ඇත."
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to disable recent chats, with a warning that it will also delete currently saved chats.
@@ -2094,8 +2103,8 @@ msgid ""
 "Are you sure you want to disable recent chats? This will also delete any "
 "recent chats that are currently saved."
 msgstr ""
-"ඔබට මෑත කාලීන කතාබස් අක්‍රිය කළ යුතු බවට ඔබට විශ්වාස ද? මෙය දැනට සුරකින ලද "
-"ඕනෑම මෑත කාලීන කතාබස් ද මකා දමනු ඇත."
+"ඔබට මෑත කාලීන කතාබස් අක්‍රිය කළ යුතු බවට ඔබට විශ්වාස ද? මෙය දැනට සුරකින ලද ඕනෑම මෑත "
+"කාලීන කතාබස් ද මකා දමනු ඇත."
 
 # smartling.placeholder_format=C
 #. Question asking user if they want to share the URL of the page they were on when giving feedback
@@ -2133,9 +2142,8 @@ msgid ""
 "As per our privacy policy, we do not collect or share any personal "
 "information ourselves. All of this privacy protection happens on your device."
 msgstr ""
-"අපගේ රහස්‍යතා ප්‍රතිපත්තියට අනුව, අපි කිසිදු පෞද්ගලික තොරතුරක් අප විසින්ම "
-"රැස්කර හෝ හුවමාරුකර නොගන්නෙමු. මෙම සියලු රහස්‍යතා ආරක්ෂාව ඔබගේ උපාංගයේ සිදු "
-"වේ."
+"අපගේ රහස්‍යතා ප්‍රතිපත්තියට අනුව, අපි කිසිදු පෞද්ගලික තොරතුරක් අප විසින්ම රැස්කර හෝ හුවමාරුකර "
+"නොගන්නෙමු. මෙම සියලු රහස්‍යතා ආරක්ෂාව ඔබගේ උපාංගයේ සිදු වේ."
 
 # smartling.placeholder_format=C
 #. A button to ask Duck.ai a question
@@ -2196,6 +2204,12 @@ msgstr "පසු විපරම් ප්‍රශ්නයක් අසන්
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse
 msgid "Ask a follow-up with Duck.ai"
 msgstr "Duck.ai සමඟ පසු විපරමක් විමසන්න"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
+msgctxt "Page suggestion chip label"
+msgid "Ask about this page"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2259,14 +2273,12 @@ msgid ""
 "(shows more frequently on a wider range of searches). For now, AI-assisted "
 "answers are only available in the U.S. (English) region."
 msgstr ""
-"Assist යනු අදාළ වෙබ් අන්තර්ගතය සාරාංශ කිරීම මත පදනම්ව සමහර සෙවුම් සඳහා "
-"AI-සහය සහිත පිළිතුරු නිර්නාමිකව ජනනය කළ හැකි සේවාවකි. ඔබට කොපමණ වාරයක් "
-"Assist පෙනී සිටීමට අවශ්‍ය දැ යි ඔබට තෝරා ගත හැකිය: කිසි විටෙකත් (සෙවුම් "
-"ප්‍රතිඵලවලින් Assist UI සම්පූර්ණයෙන්ම ඉවත් කරයි), ඉල්ලුම මත (ඔබ Assist "
-"බොත්තම ක්ලික් කළහොත් AI-සහාය සහිත පිළිතුරු පමණක් පෙන්වයි), සමහර විට (ඉහළ "
-"අදාළ වන විට AI-සහය සහිත පිළිතුරු පමණක් පෙන්වයි), හෝ බොහෝ විට (පුළුල් පරාසයක "
-"සෙවුම් මත නිතර පෙන්වයි). දැනට, AI සහය සහිත පිළිතුරු ලබා ගත හැක්කේ එක්සත් "
-"ජනපද (ඉංග්‍රීසි) කලාපයේ පමණි."
+"Assist යනු අදාළ වෙබ් අන්තර්ගතය සාරාංශ කිරීම මත පදනම්ව සමහර සෙවුම් සඳහා AI-සහය සහිත "
+"පිළිතුරු නිර්නාමිකව ජනනය කළ හැකි සේවාවකි. ඔබට කොපමණ වාරයක් Assist පෙනී සිටීමට අවශ්‍ය දැ යි "
+"ඔබට තෝරා ගත හැකිය: කිසි විටෙකත් (සෙවුම් ප්‍රතිඵලවලින් Assist UI සම්පූර්ණයෙන්ම ඉවත් කරයි), ඉල්ලුම "
+"මත (ඔබ Assist බොත්තම ක්ලික් කළහොත් AI-සහාය සහිත පිළිතුරු පමණක් පෙන්වයි), සමහර විට (ඉහළ "
+"අදාළ වන විට AI-සහය සහිත පිළිතුරු පමණක් පෙන්වයි), හෝ බොහෝ විට (පුළුල් පරාසයක සෙවුම් මත නිතර "
+"පෙන්වයි). දැනට, AI සහය සහිත පිළිතුරු ලබා ගත හැක්කේ එක්සත් ජනපද (ඉංග්‍රීසි) කලාපයේ පමණි."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2278,12 +2290,11 @@ msgid ""
 "to remember that responses are auto-generated from cited sources and based "
 "on %scrawling the web%s."
 msgstr ""
-"Assist යනු අපගේ සෙවුම් ප්‍රතිඵලවල ඇති විකල්ප විශේෂාංගයක් වන අතර එයට "
-"නිර්නාමික ව සෙවුම් විමසුම් සඳහා AI සහය සහිත පිළිතුරු ජනනය කළ හැකිය. මෙය සිදු "
-"කිරීම සඳහා, එය අදාළ අන්තර්ගතයන් සඳහා වෙබ් ස්කෑන් කරන අතර පසුව සොයාගත් අදාළ "
-"තොරතුරු මත පදනම්ව කෙටි පිළිතුරක් ජනනය කිරීම සඳහා AI-බලැති ස්වාභාවික භාෂා "
-"තාක්ෂණය භාවිත කරයි. ප්රතිචාර උපුටා දක්වන ලද මූලාශ්රවලින් ස්වයංක්රීයව ජනනය වන "
-"අතර %1$sවෙබ් කැටි ගැසීම%2$s මත පදනම් වන බව මතක තබා ගැනීම වැදගත්ය."
+"Assist යනු අපගේ සෙවුම් ප්‍රතිඵලවල ඇති විකල්ප විශේෂාංගයක් වන අතර එයට නිර්නාමික ව සෙවුම් විමසුම් "
+"සඳහා AI සහය සහිත පිළිතුරු ජනනය කළ හැකිය. මෙය සිදු කිරීම සඳහා, එය අදාළ අන්තර්ගතයන් සඳහා "
+"වෙබ් ස්කෑන් කරන අතර පසුව සොයාගත් අදාළ තොරතුරු මත පදනම්ව කෙටි පිළිතුරක් ජනනය කිරීම සඳහා AI-"
+"බලැති ස්වාභාවික භාෂා තාක්ෂණය භාවිත කරයි. ප්රතිචාර උපුටා දක්වන ලද මූලාශ්රවලින් ස්වයංක්රීයව "
+"ජනනය වන අතර %1$sවෙබ් කැටි ගැසීම%2$s මත පදනම් වන බව මතක තබා ගැනීම වැදගත්ය."
 
 # smartling.placeholder_format=C
 #. Title for the dropdown menu where users select the assistant's role. Example: 'Assistant role: Travel guide'
@@ -2421,9 +2432,7 @@ msgstr "ලැයිස්තුගත මූලාශ්‍ර මත පදන
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid ""
 "Auto-generated based on listed sources. Responses may contain inaccuracies."
-msgstr ""
-"ලැයිස්තුගත මූලාශ්‍ර මත පදනම්ව ස්වයංක්‍රීයව ජනනය වේ. ප්‍රතිචාරවල සාවද්‍ය තැන් "
-"තිබිය හැක."
+msgstr "ලැයිස්තුගත මූලාශ්‍ර මත පදනම්ව ස්වයංක්‍රීයව ජනනය වේ. ප්‍රතිචාරවල සාවද්‍ය තැන් තිබිය හැක."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI) on mobile
@@ -2448,9 +2457,9 @@ msgid ""
 "look up and summarize information in response to some searches. For now, "
 "Assist is only available in English regions."
 msgstr ""
-"අදාළ සෙවීම් සඳහා ස්වයංක්‍රීයව Assist පෙන්වයි. Assist හට නිර්නාමිකව සමහර "
-"සෙවීම් වලට ප්‍රතිචාර වශයෙන් තොරතුරු සොයා බලා සාරාංශගත කළ හැක. දැනට, Assist "
-"ලබා ගත හැක්කේ ඉංග්‍රීසි කලාපවල පමණි."
+"අදාළ සෙවීම් සඳහා ස්වයංක්‍රීයව Assist පෙන්වයි. Assist හට නිර්නාමිකව සමහර සෙවීම් වලට ප්‍රතිචාර "
+"වශයෙන් තොරතුරු සොයා බලා සාරාංශගත කළ හැක. දැනට, Assist ලබා ගත හැක්කේ ඉංග්‍රීසි කලාපවල "
+"පමණි."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2459,17 +2468,15 @@ msgid ""
 "anonymously look up and summarize information in response to some searches. "
 "For now, DuckAssist is only available in English regions."
 msgstr ""
-"අදාළ සෙවීම් සඳහා ස්වයංක්‍රීයව DuckAssist පෙන්වයි. DuckAssist හට නිර්නාමිකව "
-"සමහර සෙවීම් වලට ප්‍රතිචාර වශයෙන් තොරතුරු සොයා බලා සාරාංශගත කළ හැක. දැනට, "
-"DuckAssist ලබා ගත හැක්කේ ඉංග්‍රීසි කලාපවල පමණි."
+"අදාළ සෙවීම් සඳහා ස්වයංක්‍රීයව DuckAssist පෙන්වයි. DuckAssist හට නිර්නාමිකව සමහර සෙවීම් "
+"වලට ප්‍රතිචාර වශයෙන් තොරතුරු සොයා බලා සාරාංශගත කළ හැක. දැනට, DuckAssist ලබා ගත "
+"හැක්කේ ඉංග්‍රීසි කලාපවල පමණි."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Autoplay short, silent video previews when you hover over video results."
-msgstr ""
-"ඔබ වීඩියෝ ප්‍රතිඵල මත සැරිසරන විට කෙටි, නිහඬ වීඩියෝ පෙරදසුන් ස්වයංක්‍රීයව "
-"ධාවනය කරන්න."
+msgstr "ඔබ වීඩියෝ ප්‍රතිඵල මත සැරිසරන විට කෙටි, නිහඬ වීඩියෝ පෙරදසුන් ස්වයංක්‍රීයව ධාවනය කරන්න."
 
 # smartling.placeholder_format=C
 #. Screen-reader label for the radiogroup of tool options inside the Tools dropdown. Announced when assistive technology enters the group of menuitemradio items.
@@ -2611,6 +2618,12 @@ msgid "Barcode"
 msgstr "තීරු කේතය"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Based on this page, is this course worth taking?"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Basic"
 msgstr "මූලික"
@@ -2649,6 +2662,14 @@ msgstr "පිතිකරු"
 msgctxt "Assistant response placeholder"
 msgid "Before continuing..."
 msgstr "ඉදිරියට යාමට පෙර..."
+
+# smartling.placeholder_format=C
+#. Explains that before storing the report, DuckDuckGo will anonymize the conversation by removing PII like names, email addresses, and identifying metadata.
+msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
+msgid ""
+"Before storing this report, DuckDuckGo will anonymize your conversation by "
+"removing PII like names, email addresses, and identifying metadata."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -2967,6 +2988,12 @@ msgid "Break Points Won"
 msgstr "විවේක ලකුණු ජයග්‍රහණය කළා"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Break this down into clear, numbered steps."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
 msgctxt "Weather IA"
 msgid "Breezy"
@@ -3023,18 +3050,16 @@ msgid ""
 "Browse as usual while we add privacy protection. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
 msgstr ""
-"අපි රහස්‍යතා ආරක්ෂාව එක් කරන තුරු සාමාන්‍ය පරිදි බ්‍රවුස් කරන්න. අපි අපේ "
-"සෙවුම් යාන්ත්‍රණය, නිරික්සු අවහිරය හා ගුප්ත කේතන බලාත්කුරුව එක් %1$s%2$s "
-"දිගුවක්%3$s වෙත ගොනු කර ඇත්තෙමු."
+"අපි රහස්‍යතා ආරක්ෂාව එක් කරන තුරු සාමාන්‍ය පරිදි බ්‍රවුස් කරන්න. අපි අපේ සෙවුම් යාන්ත්‍රණය, නිරික්සු "
+"අවහිරය හා ගුප්ත කේතන බලාත්කුරුව එක් %1$s%2$s දිගුවක්%3$s වෙත ගොනු කර ඇත්තෙමු."
 
 # smartling.placeholder_format=C
 msgid ""
 "Browse as usual, and we'll take care of the rest. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
 msgstr ""
-"සාමාන්‍ය පරිදි බ්‍රවුස්කරන්න, අපි අනික්වා ගැන බලා ගන්නෙමු. අපි අපේ සෙවුම් "
-"යාන්ත්‍රණය, නිරික්සු අවහිරකාරකය හා ගුප්ත කේතන බලාත්කාරකය එක් %1$s%2$s "
-"දිගුවක%3$sට සම්පිණ්ඩනය කළෙමු."
+"සාමාන්‍ය පරිදි බ්‍රවුස්කරන්න, අපි අනික්වා ගැන බලා ගන්නෙමු. අපි අපේ සෙවුම් යාන්ත්‍රණය, නිරික්සු "
+"අවහිරකාරකය හා ගුප්ත කේතන බලාත්කාරකය එක් %1$s%2$s දිගුවක%3$sට සම්පිණ්ඩනය කළෙමු."
 
 # smartling.placeholder_format=C
 msgid ""
@@ -3042,9 +3067,8 @@ msgid ""
 "search, tracker blocking, and site encryption, all in one download, for "
 "%smajor browsers%s."
 msgstr ""
-"සාමාන්‍ය පරිදි බ්‍රවුස්කරන්න, අපි අනික්වා ගැන බලා ගන්නෙමු. %1$sප්‍රධාන "
-"බ්‍රවුසර්%2$s සඳහා පුද්ගලික සෙවුම, නිරික්සුව අවහිර කිරීම හා අඩවි ගුප්ත කේතනය "
-"යන සියල්ල එකම බාගැනීමකින් ලබාගන්න."
+"සාමාන්‍ය පරිදි බ්‍රවුස්කරන්න, අපි අනික්වා ගැන බලා ගන්නෙමු. %1$sප්‍රධාන බ්‍රවුසර්%2$s සඳහා පුද්ගලික "
+"සෙවුම, නිරික්සුව අවහිර කිරීම හා අඩවි ගුප්ත කේතනය යන සියල්ල එකම බාගැනීමකින් ලබාගන්න."
 
 # smartling.placeholder_format=C
 #. Header for a call to action to browse with the DuckDuckGo browser
@@ -3151,11 +3175,10 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"පෙරනිමියෙන් සැකසීම් පුද්ගලික නොවන බ්‍රව්සර් කුකීස් තුළ ගබඩා කර ඇත (ඔබගේ "
-"බ්‍රව්සරයේ). ඔබේ සැකසීම් වඩාත් ස්ථිර ආකාරයකින් ගබඩා කිරීමට ඔබට නිර්ණාමික "
-"Cloud Save භාවිතා කළ හැකිය (ක්ලවුඩයේ ඇති දුරස්ථ සර්වරයක). පුද්ගලිකව හඳුනාගත "
-"හැකි තොරතුරු ක්ලවුඩය තුළ ගබඩා නොවන අතර ඔබගේ මුර පදය කිසි විටෙකත් ඔබගේ "
-"බ්‍රව්සරයෙන් ඉවත් නොවේ."
+"පෙරනිමියෙන් සැකසීම් පුද්ගලික නොවන බ්‍රව්සර් කුකීස් තුළ ගබඩා කර ඇත (ඔබගේ බ්‍රව්සරයේ). ඔබේ සැකසීම් "
+"වඩාත් ස්ථිර ආකාරයකින් ගබඩා කිරීමට ඔබට නිර්ණාමික Cloud Save භාවිතා කළ හැකිය (ක්ලවුඩයේ ඇති "
+"දුරස්ථ සර්වරයක). පුද්ගලිකව හඳුනාගත හැකි තොරතුරු ක්ලවුඩය තුළ ගබඩා නොවන අතර ඔබගේ මුර පදය කිසි "
+"විටෙකත් ඔබගේ බ්‍රව්සරයෙන් ඉවත් නොවේ."
 
 # smartling.placeholder_format=C
 #. Description for the consent highlight in the dictation consent modal. %s is replaced with a link to the help page.
@@ -3163,8 +3186,8 @@ msgid ""
 "By enabling dictation, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
 msgstr ""
-"කියවන විට ලිවීම සක්‍රීය කිරීමෙන්, මෙම විශේෂාංගය භාවිතා කිරීම සඳහා ඔබගේ හඬ "
-"දත්ත OpenAI වෙත යැවීමට ඔබ එකඟ වෙයි. ආරම්භ කිරීමට පෙර අපේ %1$s බලන්න."
+"කියවන විට ලිවීම සක්‍රීය කිරීමෙන්, මෙම විශේෂාංගය භාවිතා කිරීම සඳහා ඔබගේ හඬ දත්ත OpenAI වෙත "
+"යැවීමට ඔබ එකඟ වෙයි. ආරම්භ කිරීමට පෙර අපේ %1$s බලන්න."
 
 # smartling.placeholder_format=C
 #. Description for the 'enable voice chat' section of the voice chat consent modal. Placeholder for the voice chat help page link and text. Example: 'By enabling voice chat, you consent to your voice data being sent to OpenAI for the use of this feature. See our voice chat help page before getting started.'
@@ -3173,8 +3196,8 @@ msgid ""
 "By enabling voice chat, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
 msgstr ""
-"හඬ කතාබස් සක්‍රීය කිරීමෙන්, මෙම විශේෂාංගය භාවිතා කිරීම සඳහා ඔයාගේ හඬ දත්ත "
-"OpenAI වෙත යැවීමට ඔයා එකඟ වෙනවා. ආරම්භ කිරීමට පෙර අපේ %1$s බලන්න."
+"හඬ කතාබස් සක්‍රීය කිරීමෙන්, මෙම විශේෂාංගය භාවිතා කිරීම සඳහා ඔයාගේ හඬ දත්ත OpenAI වෙත "
+"යැවීමට ඔයා එකඟ වෙනවා. ආරම්භ කිරීමට පෙර අපේ %1$s බලන්න."
 
 # smartling.placeholder_format=C
 #. Golf leaderboard: player missed the cut
@@ -3209,9 +3232,7 @@ msgstr "කැමරූන්"
 #. Text for a prompt suggestion for creating a few simple recipes using chicken, broccoli, and rice.
 msgctxt "Full sentence for crafting a recipe"
 msgid "Can you create a few simple recipes using chicken, broccoli, and rice?"
-msgstr ""
-"කුකුළු මස්, බ්‍රොකොලි සහ සහල් භාවිත කරමින් සරල වට්ටෝරු කිහිපයක් නිර්මාණය කළ "
-"හැකිද?"
+msgstr "කුකුළු මස්, බ්‍රොකොලි සහ සහල් භාවිත කරමින් සරල වට්ටෝරු කිහිපයක් නිර්මාණය කළ හැකිද?"
 
 # smartling.placeholder_format=C
 msgid "Canada"
@@ -3420,6 +3441,12 @@ msgstr "වෘත්තීන්"
 msgctxt "Movie/TV Show Title instant answer"
 msgid "Cast"
 msgstr "නළු වරණය"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Cast & Crew"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -3654,11 +3681,11 @@ msgid ""
 "DuckDuckGo Search. However, you can still access Chat when this setting is "
 "off by visiting %shttps://duck.ai%s directly."
 msgstr ""
-"චැට් (අපගේ Duck.ai සේවාව හරහා) ඔබට 3 වන පාර්ශවයේ AI චැට් ආකෘති සමඟ නිර්නාමික "
-"සංවාද කිරීමට ඉඩ සලසයි, එය OpenAI, Anthropic සහ තවත් ආකෘති සඳහා සහය දක්වයි. "
-"මෙම සැකසුම අක්‍රිය කිරීමෙන් DuckDuckGo Search හි චැට් බොත්තම් සහ සබැඳි සඟවනු "
-"ඇත. කෙසේ වෙතත්, මෙම සැකසුම ක්‍රියා විරහිත වූ විට ඔබට තවමත් "
-"%1$shttps://duck.ai%2$s වෙත පිවිසීමෙන් සෘජුව චැට් වෙත ප්‍රවේශ විය හැකිය."
+"චැට් (අපගේ Duck.ai සේවාව හරහා) ඔබට 3 වන පාර්ශවයේ AI චැට් ආකෘති සමඟ නිර්නාමික සංවාද "
+"කිරීමට ඉඩ සලසයි, එය OpenAI, Anthropic සහ තවත් ආකෘති සඳහා සහය දක්වයි. මෙම සැකසුම අක්‍රිය "
+"කිරීමෙන් DuckDuckGo Search හි චැට් බොත්තම් සහ සබැඳි සඟවනු ඇත. කෙසේ වෙතත්, මෙම සැකසුම "
+"ක්‍රියා විරහිත වූ විට ඔබට තවමත් %1$shttps://duck.ai%2$s වෙත පිවිසීමෙන් සෘජුව චැට් වෙත "
+"ප්‍රවේශ විය හැකිය."
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -3714,8 +3741,7 @@ msgstr "පෞද්ගලිකව චැට් කරන්න"
 msgctxt "Promotional text (mobile)"
 msgid "Chat privately on any website with Duck.ai built into our free browser."
 msgstr ""
-"අපගේ ගාස්තු රහිත බ්රවුසරයේ ඇති Duck.ai සමඟ ඕනෑම වෙබ් අඩවියක පෞද්ගලිකව කතාබහේ "
-"යෙදෙන්න."
+"අපගේ ගාස්තු රහිත බ්රවුසරයේ ඇති Duck.ai සමඟ ඕනෑම වෙබ් අඩවියක පෞද්ගලිකව කතාබහේ යෙදෙන්න."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card encouraging third-party browser users to download the DuckDuckGo browser. Not shown in the DuckDuckGo browser or on Linux.
@@ -3723,8 +3749,8 @@ msgctxt "Promotional text"
 msgid ""
 "Chat privately on any website with the Duck.ai sidebar in our free browser."
 msgstr ""
-"අපගේ ගාස්තු රහිත බ්‍රවුසරයේ ඇති Duck.ai පැති තීරුව සමඟ ඕනෑම වෙබ් අඩවියක "
-"පුද්ගලිකව කතාබහේ යෙදෙන්න."
+"අපගේ ගාස්තු රහිත බ්‍රවුසරයේ ඇති Duck.ai පැති තීරුව සමඟ ඕනෑම වෙබ් අඩවියක පුද්ගලිකව කතාබහේ "
+"යෙදෙන්න."
 
 # smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
@@ -3787,8 +3813,8 @@ msgid ""
 "Chats are stored locally on your device instead of on DuckDuckGo servers or "
 "remote servers. Disabling chat history will delete pinned chats."
 msgstr ""
-"ඔබේ උපාංගයේ DuckDuckGo සර්වර හෝ වෙනත් දුරස්ථ සර්වර මත වෙනුවට දේශීයව චැට් "
-"ගබඩා කර ඇත. කතාබස් ඉතිහාසය අක්‍රිය කිරීමෙන් පින් කළ කතාබස් මකා දැමෙනු ඇත."
+"ඔබේ උපාංගයේ DuckDuckGo සර්වර හෝ වෙනත් දුරස්ථ සර්වර මත වෙනුවට දේශීයව චැට් ගබඩා කර ඇත. "
+"කතාබස් ඉතිහාසය අක්‍රිය කිරීමෙන් පින් කළ කතාබස් මකා දැමෙනු ඇත."
 
 # smartling.placeholder_format=C
 #. Text explaining how the Chat History feature stores the user's chats locally to their device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection. Also explains that disabling chat history will delete pinned chats.
@@ -3800,11 +3826,10 @@ msgid ""
 "history will delete pinned chats, and disable the temporary storage of new "
 "prompts and responses."
 msgstr ""
-"කතාබස් ඔබගේ උපාංගයේ දේශීයව ගබඩා කර ඇත. ඔබගේ අන්තර්ජාල සම්බන්ධතාවය නැති "
-"වුවහොත් කතාබහක් නැවත ලබා ගැනීමට උපකාර කිරීම සඳහා, නව විමසීම් සහ ප්‍රතිචාර "
-"සංකේතනය කර යැවීමෙන් පසු තාවකාලිකව DuckDuckGo සේවාදායකයක ගබඩා කරනු ලැබේ. "
-"කතාබස් ඉතිහාසය අක්‍රිය කිරීමෙන් පින් කළ කතාබස් මැකෙනු ඇති අතර නව විමසීම් සහ "
-"ප්‍රතිචාර තාවකාලිකව ගබඩා කිරීම අක්‍රිය කරනු ඇත."
+"කතාබස් ඔබගේ උපාංගයේ දේශීයව ගබඩා කර ඇත. ඔබගේ අන්තර්ජාල සම්බන්ධතාවය නැති වුවහොත් කතාබහක් "
+"නැවත ලබා ගැනීමට උපකාර කිරීම සඳහා, නව විමසීම් සහ ප්‍රතිචාර සංකේතනය කර යැවීමෙන් පසු "
+"තාවකාලිකව DuckDuckGo සේවාදායකයක ගබඩා කරනු ලැබේ. කතාබස් ඉතිහාසය අක්‍රිය කිරීමෙන් පින් කළ "
+"කතාබස් මැකෙනු ඇති අතර නව විමසීම් සහ ප්‍රතිචාර තාවකාලිකව ගබඩා කිරීම අක්‍රිය කරනු ඇත."
 
 # smartling.placeholder_format=C
 #. Title shown above the body copy in the Duck.ai recent chats IndexedDB unavailable notice.
@@ -3826,8 +3851,8 @@ msgctxt "Sync file storage inline disclaimer body"
 msgid ""
 "Chats with attachments have stopped syncing. Free up storage to resume Sync."
 msgstr ""
-"ඇමුණුම් සහිත කතාබස් සමමුහුර්ත වීම නැවතී ඇත. සමමුහුර්ත වීම නැවත ආරම්භ කිරීමට "
-"ගබඩාවේ ඉඩ නිදහස් කරගන්න."
+"ඇමුණුම් සහිත කතාබස් සමමුහුර්ත වීම නැවතී ඇත. සමමුහුර්ත වීම නැවත ආරම්භ කිරීමට ගබඩාවේ ඉඩ නිදහස් "
+"කරගන්න."
 
 # smartling.placeholder_format=C
 #. Message shown when we have no data from upstream to display
@@ -3979,9 +4004,7 @@ msgstr "සේවාවක් තෝරන්න"
 msgctxt "settings"
 msgid ""
 "Choose which app to use when you need directions for a location search result"
-msgstr ""
-"ඔබට ස්ථාන සෙවුම් ප්‍රතිඵලයක් සඳහා උපදෙස් අවශ්‍ය විට භාවිත කළ යුතු යෙදුම "
-"තෝරන්න"
+msgstr "ඔබට ස්ථාන සෙවුම් ප්‍රතිඵලයක් සඳහා උපදෙස් අවශ්‍ය විට භාවිත කළ යුතු යෙදුම තෝරන්න"
 
 # smartling.placeholder_format=C
 #. Accessible label for the citations popover dialog in Duck.ai chat responses.
@@ -4162,9 +4185,9 @@ msgid ""
 "Clearing browser data deletes chats. Some browsers may keep recent chats "
 "indefinitely or auto-delete them after 7+ days of no AI Chat use."
 msgstr ""
-"බ්‍රවුසර දත්ත මකා දැමීමෙන් කතාබස් මකා දමනු ලැබේ. සමහර බ්‍රවුසර මෑත කාලීන "
-"කතාබස් කාලය නොසලකා තබා ගන්නා හෝ AI Chat භාවිත නොකිරීමෙන් දින 7කට පසු ඒවා "
-"ස්වයංක්‍රීයව මකා දැමිය හැකි ය."
+"බ්‍රවුසර දත්ත මකා දැමීමෙන් කතාබස් මකා දමනු ලැබේ. සමහර බ්‍රවුසර මෑත කාලීන කතාබස් කාලය "
+"නොසලකා තබා ගන්නා හෝ AI Chat භාවිත නොකිරීමෙන් දින 7කට පසු ඒවා ස්වයංක්‍රීයව මකා දැමිය හැකි "
+"ය."
 
 # smartling.placeholder_format=C
 #. Text explaining what happens to recent chats when browser data is cleared.
@@ -4174,9 +4197,8 @@ msgid ""
 "indefinitely or auto-deleted after 7 days without using Duck.ai, depending "
 "on your browser."
 msgstr ""
-"බ්‍රවුසර දත්ත මකා දැමීම මෑත කතාබස් මකා දමයි. Duck.ai භාවිත නොකර දින 7කට පසු, "
-"ඔබේ බ්‍රව්සරය මත පදනම්ව මෑත කතාබස් දින නියමයක් නොමැතිව සුරැකීමට හෝ "
-"ස්වයංක්‍රීයව මකා දැමිය හැකිය."
+"බ්‍රවුසර දත්ත මකා දැමීම මෑත කතාබස් මකා දමයි. Duck.ai භාවිත නොකර දින 7කට පසු, ඔබේ "
+"බ්‍රව්සරය මත පදනම්ව මෑත කතාබස් දින නියමයක් නොමැතිව සුරැකීමට හෝ ස්වයංක්‍රීයව මකා දැමිය හැකිය."
 
 # smartling.placeholder_format=C
 #. Warning message shown on the Block domain success modal. Blocked sites are stored in localStorage which is cleared alongside cookies when users clear browser data. Followed by a linked 'our free browser' text.
@@ -4185,8 +4207,8 @@ msgid ""
 "Clearing browser data will reset your blocked sites. Save your block list "
 "permanently in"
 msgstr ""
-"බ්රව්සර් දත්ත ඉවත් කිරීමෙන් ඔබගේ අවහිර කරන ලද වෙබ් අඩවි යළි සැකසේ. ඔබගේ "
-"අවහිර ලැයිස්තුව අපගේ ගාස්තු රහිත බ්‍රවුසරයේ"
+"බ්රව්සර් දත්ත ඉවත් කිරීමෙන් ඔබගේ අවහිර කරන ලද වෙබ් අඩවි යළි සැකසේ. ඔබගේ අවහිර ලැයිස්තුව අපගේ "
+"ගාස්තු රහිත බ්‍රවුසරයේ"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -4195,9 +4217,9 @@ msgid ""
 "%sDuck.ai%s, our private AI chat service that supports chat models from "
 "OpenAI, Anthropic, and more."
 msgstr ""
-"මාතෘකාවක් පිළිබඳව වැඩිදුරටත් විමසා බලන්න \"තවත්\" මත ක්ලික් කරන්න, සහ "
-"%1$sDuck.ai%2$s හරහා පසු විපරම් ප්‍රශ්න අසන්න OpenAI, Anthropic සහ තවත් බොහෝ "
-"ආයතනවලින් චැට් ආකෘතිවලට සහය දක්වන අපගේ පෞද්ගලික AI චැට් සේවය."
+"මාතෘකාවක් පිළිබඳව වැඩිදුරටත් විමසා බලන්න \"තවත්\" මත ක්ලික් කරන්න, සහ %1$sDuck.ai%2$s "
+"හරහා පසු විපරම් ප්‍රශ්න අසන්න OpenAI, Anthropic සහ තවත් බොහෝ ආයතනවලින් චැට් ආකෘතිවලට සහය "
+"දක්වන අපගේ පෞද්ගලික AI චැට් සේවය."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4271,8 +4293,8 @@ msgid ""
 "Click %sSafari%s in the top menu (On Windows, click the %sgears icon%s in "
 "the top right)"
 msgstr ""
-"ඉහළ මෙනුවෙන් %1$sSafari%2$s මත ක්ලික් කරන්න (වින්ඩෝව්ස් වලදී, ඉහළ මෙනුවේ "
-"දකුණු පස %3$sgears icon%4$s මත ක්ලික් කරන්න)"
+"ඉහළ මෙනුවෙන් %1$sSafari%2$s මත ක්ලික් කරන්න (වින්ඩෝව්ස් වලදී, ඉහළ මෙනුවේ දකුණු පස "
+"%3$sgears icon%4$s මත ක්ලික් කරන්න)"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4302,8 +4324,7 @@ msgstr "%1$sYes%2$s කලික් කරන්න"
 #. Tells the user where to click to open their browser's settings menu.
 msgid "Click %ssettings/hamburger icon %s on the Chrome toolbar (top right)."
 msgstr ""
-"Chrom උපකරණ කොටුවේ (ඉහළ දකුණ) %1$ssettings/hamburger icon %2$s මත ක්ලික් "
-"කරන්න."
+"Chrom උපකරණ කොටුවේ (ඉහළ දකුණ) %1$ssettings/hamburger icon %2$s මත ක්ලික් කරන්න."
 
 #  Maxthon default search engine instruction
 # smartling.placeholder_format=C
@@ -4365,9 +4386,8 @@ msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Search Settings%s."
 msgstr ""
-"%1$sමගේ දත්ත මකන්න%2$s ක්ලික් කරන්න හෝ තට්ටු කරන්න. මෙය ක්ලවුඩවලින් දත්ත "
-"ඉවත් කරන නමුදු, ඔබ විසින් %3$sසියලුම සැකසුම් යළි පිහිටුවන්න%4$s ක්ලික්/තට්ටු "
-"කරන තෙක් ඔබේ බ්‍රවුසරයේ පවතී."
+"%1$sමගේ දත්ත මකන්න%2$s ක්ලික් කරන්න හෝ තට්ටු කරන්න. මෙය ක්ලවුඩවලින් දත්ත ඉවත් කරන නමුදු, ඔබ "
+"විසින් %3$sසියලුම සැකසුම් යළි පිහිටුවන්න%4$s ක්ලික්/තට්ටු කරන තෙක් ඔබේ බ්‍රවුසරයේ පවතී."
 
 # smartling.placeholder_format=C
 #. Tells users where to click in order to disable the cloud save feature and delete any data backed-up to the cloud.
@@ -4378,9 +4398,8 @@ msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Settings%s."
 msgstr ""
-"%1$sමගේ දත්ත මකන්න%2$s ක්ලික් කරන්න හෝ තට්ටු කරන්න. මෙය ක්ලවුඩවලින් දත්ත "
-"ඉවත් කරන නමුදු, ඔබ විසින් %3$sසියලුම සැකසුම් යළි පිහිටුවන්න%4$s ක්ලික්/තට්ටු "
-"කරන තෙක් ඔබේ බ්‍රවුසරයේ පවතී."
+"%1$sමගේ දත්ත මකන්න%2$s ක්ලික් කරන්න හෝ තට්ටු කරන්න. මෙය ක්ලවුඩවලින් දත්ත ඉවත් කරන නමුදු, ඔබ "
+"විසින් %3$sසියලුම සැකසුම් යළි පිහිටුවන්න%4$s ක්ලික්/තට්ටු කරන තෙක් ඔබේ බ්‍රවුසරයේ පවතී."
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -4449,8 +4468,8 @@ msgid ""
 "Click the dropdown menu beside %sSearch engine used in the address bar%s and "
 "select %sDuckDuckGo%s."
 msgstr ""
-"ලිපින තීරුව %1$sහි භාවිතා කර ඇති සෙවුම් යන්ත්‍රය%2$s අසල ඇති ඩ්‍රොප් ඩවුන් "
-"මෙනුව ක්ලික් කර %3$sDuckDuckGo%4$s තෝරන්න."
+"ලිපින තීරුව %1$sහි භාවිතා කර ඇති සෙවුම් යන්ත්‍රය%2$s අසල ඇති ඩ්‍රොප් ඩවුන් මෙනුව ක්ලික් කර "
+"%3$sDuckDuckGo%4$s තෝරන්න."
 
 # smartling.placeholder_format=C
 #. First step in a list of steps to take to disable the user's ad blocker
@@ -4458,8 +4477,8 @@ msgid ""
 "Click the icon of the ad blocker extension. It's usually in the upper right "
 "hand corner of your browser."
 msgstr ""
-"Ad blocker කිරීමේ දිගුවේ අයිකනය ක්ලික් කරන්න. එය සාමාන්යයෙන් ඔබේ බ්‍රව්සරයේ "
-"ඉහළ දකුණු කෙළවරේ තියෙනවා."
+"Ad blocker කිරීමේ දිගුවේ අයිකනය ක්ලික් කරන්න. එය සාමාන්යයෙන් ඔබේ බ්‍රව්සරයේ ඉහළ දකුණු කෙළවරේ "
+"තියෙනවා."
 
 #  Safari default search engine instruction
 # smartling.placeholder_format=C
@@ -4648,8 +4667,8 @@ msgid ""
 "Cloud Save lets you save your settings more permanently by entering a "
 "passphrase. It is entirely optional."
 msgstr ""
-"මුරවදනක් ඇතුලත් කිරීම මඟින් ඔබගේ සැකසුම් ක්ලව්ඩයේ සුරෑකීම වඩාත් තහවුරු "
-"කිරීමට හැකියාව Cloud Save. එය සම්පූර්ණයෙන්ම ඔබගේ තේරීමකි."
+"මුරවදනක් ඇතුලත් කිරීම මඟින් ඔබගේ සැකසුම් ක්ලව්ඩයේ සුරෑකීම වඩාත් තහවුරු කිරීමට හැකියාව Cloud "
+"Save. එය සම්පූර්ණයෙන්ම ඔබගේ තේරීමකි."
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -5079,8 +5098,7 @@ msgstr "කොස්ටාරිකාව"
 msgctxt "Error message when the recovery code fails to generate"
 msgid "Couldn't load your recovery code. Please close this and try again."
 msgstr ""
-"ඔබේ ප් රතිසාධන කේතය පූරණය කළ නොහැකි විය. කරුණාකර මෙය වසා දාලා නැවත උත්සාහ "
-"කරන්න."
+"ඔබේ ප් රතිසාධන කේතය පූරණය කළ නොහැකි විය. කරුණාකර මෙය වසා දාලා නැවත උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. Pairs with a Retry button. Shown after two consecutive failed attempts to load the device list.
@@ -5124,6 +5142,12 @@ msgstr "රූපය සාදන්න"
 msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr "රූපය සාදන්න"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Create a shopping list with quantities from this recipe."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed in the input field when starting a new image generation session.
@@ -5388,8 +5412,7 @@ msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "Daily usage limit reached. You can keep chatting by using your weekly limit."
 msgstr ""
-"දෛනික පරිශීලන සීමාවට ළඟා විය. ඔබට ඔබේ සතිපතා සීමාව භාවිතා කරමින් කතාබස් "
-"කරගෙන යා හැකිය."
+"දෛනික පරිශීලන සීමාවට ළඟා විය. ඔබට ඔබේ සතිපතා සීමාව භාවිතා කරමින් කතාබස් කරගෙන යා හැකිය."
 
 # smartling.placeholder_format=C
 #. The name of the Danish language
@@ -5757,8 +5780,8 @@ msgstr "Duck.ai අසා ලිවීම"
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
 msgstr ""
-"කියවන විට ලිවීම අප විසින් නිර්නාමික කර ඇති අතර, එය AI ආකෘති පුහුණු කිරීමට "
-"කිසිවිටෙකත් භාවිතා කරනු නොලැබේ."
+"කියවන විට ලිවීම අප විසින් නිර්නාමික කර ඇති අතර, එය AI ආකෘති පුහුණු කිරීමට කිසිවිටෙකත් භාවිතා කරනු "
+"නොලැබේ."
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
@@ -5766,13 +5789,18 @@ msgid "Dictation limit reached"
 msgstr "අසා ලිවීම් සීමාවට ළඟා විය"
 
 # smartling.placeholder_format=C
+#. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
+msgid "Dictation temporarily unavailable"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
 "chat in Duck.ai without having to type."
 msgstr ""
-"කථනය පාඨ බවට පරිවර්තනය කිරීම සඳහා “කියවන විට ලිවීම“ OpenAI ආකෘතියක් භාවිතා "
-"කරන බැවින්, ටයිප් නොකර Duck.ai මත කතාබස් කිරීමට ඔබට පුළුවන."
+"කථනය පාඨ බවට පරිවර්තනය කිරීම සඳහා “කියවන විට ලිවීම“ OpenAI ආකෘතියක් භාවිතා කරන බැවින්, "
+"ටයිප් නොකර Duck.ai මත කතාබස් කිරීමට ඔබට පුළුවන."
 
 # smartling.placeholder_format=C
 #. In 0-click box -- link to definition.
@@ -6066,6 +6094,22 @@ msgid "Done"
 msgstr "සිදුවිය"
 
 # smartling.placeholder_format=C
+#. Message shown in a modal after DuckDuckGo browser users disable AI features in Settings. The first two placeholders bold noai.duckduckgo.com. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
+"filtered out. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
+"and AI images filtered out. %sLearn more%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Double Faults"
@@ -6166,8 +6210,8 @@ msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for "
 "ceiling fan repair services."
 msgstr ""
-"සිවිලිම් විදුලි පංකා අළුත්වැඩියා සේවා සඳහා උපුටා දැක්වීමක් ඉල්ලා සිටින "
-"විකුණුම්කරුවෙකුට සංක්ෂිප්ත හා සවිස්තරාත්මක විද්‍යුත් තැපෑලක් කෙටුම්පත් කරන්න."
+"සිවිලිම් විදුලි පංකා අළුත්වැඩියා සේවා සඳහා උපුටා දැක්වීමක් ඉල්ලා සිටින විකුණුම්කරුවෙකුට සංක්ෂිප්ත හා "
+"සවිස්තරාත්මක විද්‍යුත් තැපෑලක් කෙටුම්පත් කරන්න."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion asking for an email draft to a vendor requesting a quote for home refrigerator repair services.
@@ -6176,8 +6220,20 @@ msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
 msgstr ""
-"ගෘහ ශීතකරණ අළුත්වැඩියා සේවා සඳහා මිල කැඳවීමක් ඉල්ලා සිටින විකුණුම්කරුවෙකුට "
-"සංක්ෂිප්ත හා සවිස්තරාත්මක විද්‍යුත් තැපෑලක් කෙටුම්පත් කරන්න."
+"ගෘහ ශීතකරණ අළුත්වැඩියා සේවා සඳහා මිල කැඳවීමක් ඉල්ලා සිටින විකුණුම්කරුවෙකුට සංක්ෂිප්ත හා "
+"සවිස්තරාත්මක විද්‍යුත් තැපෑලක් කෙටුම්පත් කරන්න."
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Draft a cover letter"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Draft a cover letter for this job."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -6186,8 +6242,8 @@ msgid ""
 "Draft a few options for a social media post inviting people to my upcoming "
 "party."
 msgstr ""
-"මගේ ඉදිරි සාදයට පුද්ගලයන්ට ආරාධනා කරන සමාජ මාධ්‍ය පළ කිරීමක් සඳහා විකල්ප "
-"කිහිපයක් කෙටුම්පත් කරන්න."
+"මගේ ඉදිරි සාදයට පුද්ගලයන්ට ආරාධනා කරන සමාජ මාධ්‍ය පළ කිරීමක් සඳහා විකල්ප කිහිපයක් කෙටුම්පත් "
+"කරන්න."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a few options for a blog post title about strategies to increase team collaboration.
@@ -6196,8 +6252,8 @@ msgid ""
 "Draft a few options for a title of a post I’m writing about strategies to "
 "increase team collaboration."
 msgstr ""
-"කණ්ඩායම් සහයෝගීතාව වැඩි කිරීම සඳහා උපාය මාර්ග ගැන මම ලියන තනතුරක මාතෘකාවක් "
-"සඳහා විකල්ප කිහිපයක් කෙටුම්පත් කරන්න."
+"කණ්ඩායම් සහයෝගීතාව වැඩි කිරීම සඳහා උපාය මාර්ග ගැන මම ලියන තනතුරක මාතෘකාවක් සඳහා විකල්ප "
+"කිහිපයක් කෙටුම්පත් කරන්න."
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for drafting a social media post.
@@ -6323,9 +6379,8 @@ msgid ""
 "content is only included when you attach it, unless you choose to attach "
 "pages automatically in Settings."
 msgstr ""
-"ඔබ නරඹන පිටුව පිළිබඳ ප්‍රශ්නවලට පිළිතුරු දීමට Duck.ai හට දැන් උදව් කළ හැක. "
-"සැකසුම් තුළ පිටු ස්වයංක්‍රීයව ඇමිණීමට ඔබ තෝරා නොගන්නේ නම්, පිටු අන්තර්ගතය "
-"ඇතුළත් වන්නේ ඔබ එය අමුණන විට පමණි."
+"ඔබ නරඹන පිටුව පිළිබඳ ප්‍රශ්නවලට පිළිතුරු දීමට Duck.ai හට දැන් උදව් කළ හැක. සැකසුම් තුළ පිටු "
+"ස්වයංක්‍රීයව ඇමිණීමට ඔබ තෝරා නොගන්නේ නම්, පිටු අන්තර්ගතය ඇතුළත් වන්නේ ඔබ එය අමුණන විට පමණි."
 
 # smartling.placeholder_format=C
 #. Shown in the Duck.ai recent chats list on standalone when the browser API needed to store chats locally is missing or unavailable.
@@ -6335,9 +6390,8 @@ msgid ""
 "Duck.ai can’t access local storage to save your chats. Please check your "
 "browser settings or disable any extensions and try again."
 msgstr ""
-"ඔබගේ කතාබස් සුරැකීම සඳහා Duck.ai දේශීය ගබඩාවට පිවිසිය නොහැක. කරුණාකර ඔබගේ "
-"බ්‍රවුසර සැකසුම් පරීක්ෂා කරන්න, නැතහොත් කිනම් හෝ දිගුවක් වේ නම්, එය අක්‍රිය "
-"කර නැවත උත්සාහ කරන්න."
+"ඔබගේ කතාබස් සුරැකීම සඳහා Duck.ai දේශීය ගබඩාවට පිවිසිය නොහැක. කරුණාකර ඔබගේ බ්‍රවුසර "
+"සැකසුම් පරීක්ෂා කරන්න, නැතහොත් කිනම් හෝ දිගුවක් වේ නම්, එය අක්‍රිය කර නැවත උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. Displayed when the chat service has reached the maximum number of messages for one day.
@@ -6346,14 +6400,23 @@ msgid ""
 "Duck.ai has reached the maximum number of messages for one day. Please "
 "continue this chat tomorrow."
 msgstr ""
-"Duck.ai එක් දිනක් සඳහා උපරිම පණිවිඩ සංඛ්‍යාවට ළඟා වී ඇත. කරුණාකර හෙට මෙම "
-"කතාබස් දිගටම කරගෙන යන්න."
+"Duck.ai එක් දිනක් සඳහා උපරිම පණිවිඩ සංඛ්‍යාවට ළඟා වී ඇත. කරුණාකර හෙට මෙම කතාබස් දිගටම "
+"කරගෙන යන්න."
 
 # smartling.placeholder_format=C
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
 msgstr "අපේ පුද්ගලික සහ නොමිලේ DuckDuckGo බ්‍රවුසරයේ හොඳම අංගය Duck.ai වේ!"
+
+# smartling.placeholder_format=C
+#. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
+msgctxt "About section description on the Duck.ai settings page"
+msgid ""
+"Duck.ai is created by DuckDuckGo. We're an independent online protection "
+"company for anyone who wants to take back control of their personal "
+"information."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
@@ -6368,8 +6431,8 @@ msgid ""
 "Duck.ai is still a DuckDuckGo product, but will now have an easier to "
 "remember home on the web: https://duck.ai"
 msgstr ""
-"Duck.ai තවමත් DuckDuckGo නිෂ්පාදනයක්, නමුත් දැන් මතක තබා ගැනීමට පහසු මුල් "
-"පිටුවක් සමගින් අන්තර්ජාලයේ: https://duck.ai"
+"Duck.ai තවමත් DuckDuckGo නිෂ්පාදනයක්, නමුත් දැන් මතක තබා ගැනීමට පහසු මුල් පිටුවක් සමගින් "
+"අන්තර්ජාලයේ: https://duck.ai"
 
 # smartling.placeholder_format=C
 #. Headline for domain change notice.
@@ -6384,8 +6447,8 @@ msgid ""
 "Duck.ai is temporarily unavailable. If this persists, please email this "
 "anonymous code %s to %s"
 msgstr ""
-"Duck.ai තාවකාලිකව ලබා ගත නොහැක. මෙය දිගටම පවතින්නේ නම්, කරුණාකර මෙම %1$s "
-"නිර්නාමික කේතය %2$s වෙත ඊමේල් කරන්න"
+"Duck.ai තාවකාලිකව ලබා ගත නොහැක. මෙය දිගටම පවතින්නේ නම්, කරුණාකර මෙම %1$s නිර්නාමික "
+"කේතය %2$s වෙත ඊමේල් කරන්න"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -6403,17 +6466,23 @@ msgstr "Duck.ai තාවකාලිකව ලබා ගත නොහැක. �
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
+"Duck.ai lets you chat privately with popular AI models. Disabling it hides "
+"Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
+msgstr ""
+
+# smartling.placeholder_format=C
+msgctxt "settings"
+msgid ""
 "Duck.ai lets you have anonymous conversations with 3rd-party AI chat models, "
 "including models from OpenAI, Anthropic, and others. Turning this setting "
 "off will hide Duck.ai buttons and links on DuckDuckGo Search. However, you "
 "can still access Duck.ai when this setting is off by visiting %shttps://duck."
 "ai%s directly."
 msgstr ""
-"Duck.ai මඟින් OpenAI, Anthropic සහ වෙනත් අයගේ ආකෘති ඇතුළුව 3වන පාර්ශවීය AI "
-"චැට් ආකෘති සමඟ නිර්නාමික සංවාද කිරීමට ඔබට ඉඩ සලසයි. මෙම සැකසුම අක්‍රිය "
-"කිරීමෙන් DuckDuckGo Search හි Duck.ai බොත්තම් සහ සබැඳි සඟවනු ඇත. කෙසේ වෙතත්, "
-"මෙම සැකසුම ක්‍රියා විරහිත වූ විටත් ඔබට %1$shttps://duck.ai%2$s වෙත "
-"පිවිසීමෙන් Duck.ai වෙත ප්‍රවේශ විය හැක හැකිය."
+"Duck.ai මඟින් OpenAI, Anthropic සහ වෙනත් අයගේ ආකෘති ඇතුළුව 3වන පාර්ශවීය AI චැට් ආකෘති "
+"සමඟ නිර්නාමික සංවාද කිරීමට ඔබට ඉඩ සලසයි. මෙම සැකසුම අක්‍රිය කිරීමෙන් DuckDuckGo Search හි "
+"Duck.ai බොත්තම් සහ සබැඳි සඟවනු ඇත. කෙසේ වෙතත්, මෙම සැකසුම ක්‍රියා විරහිත වූ විටත් ඔබට "
+"%1$shttps://duck.ai%2$s වෙත පිවිසීමෙන් Duck.ai වෙත ප්‍රවේශ විය හැක හැකිය."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
@@ -6428,8 +6497,8 @@ msgid ""
 "Duck.ai might have lost your recent chats. You can still use Duck.ai as "
 "usual."
 msgstr ""
-"Duck.ai තුළ ඔබේ මෑත කතාබස් නොතිබීමට ඉඩ ඇත. ඔයාට තවමත් සාමාන්‍ය පරිදි Duck.ai "
-"භාවිතා කරන්න පුළුවන්."
+"Duck.ai තුළ ඔබේ මෑත කතාබස් නොතිබීමට ඉඩ ඇත. ඔයාට තවමත් සාමාන්‍ය පරිදි Duck.ai භාවිතා "
+"කරන්න පුළුවන්."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
@@ -6443,8 +6512,7 @@ msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
 msgstr ""
-"Duck.ai ප්‍රතිචාර විශේෂිත මූලාශ්‍ර මත පදනම් නොවී ඇත හෝ නිරවද්‍යතාව සඳහා "
-"පරීක්ෂා කර නැත."
+"Duck.ai ප්‍රතිචාර විශේෂිත මූලාශ්‍ර මත පදනම් නොවී ඇත හෝ නිරවද්‍යතාව සඳහා පරීක්ෂා කර නැත."
 
 # smartling.placeholder_format=C
 #. Title shown when native app needs to reload for service update.
@@ -6472,10 +6540,9 @@ msgid ""
 "AI chat no sign up, OpenAI, Anthropic, Llama, Mistral, open source AI "
 "models, privacy focused AI, no account AI chat"
 msgstr ""
-"Duck.ai, DuckDuckGo AI, පුද්ගලික AI චැට්බොට්, නොමිලේ AI කතාබස්, නිර්නාමික AI "
-"කතාබහ, ලියාපදිංචි වීමක් නොමැති AI කතාබස්, OpenAI, Anthropic, Llama, Mistral, "
-"විවෘත මූලාශ්‍ර AI ආකෘති, පෞද්ගලිකත්වය කේන්ද්‍ර කරගත් AI, ගිණුමක් නොමැති AI "
-"කතාබස්"
+"Duck.ai, DuckDuckGo AI, පුද්ගලික AI චැට්බොට්, නොමිලේ AI කතාබස්, නිර්නාමික AI කතාබහ, "
+"ලියාපදිංචි වීමක් නොමැති AI කතාබස්, OpenAI, Anthropic, Llama, Mistral, විවෘත මූලාශ්‍ර AI "
+"ආකෘති, පෞද්ගලිකත්වය කේන්ද්‍ර කරගත් AI, ගිණුමක් නොමැති AI කතාබස්"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -6503,13 +6570,12 @@ msgid ""
 "relevant), or Often (shows more frequently on a wider range of searches). "
 "For now, DuckAssist is only available in the U.S. (English) region."
 msgstr ""
-"DuckAssist හට නිර්නාමිකව සමහර සෙවීම් වලට ප්‍රතිචාර වශයෙන් තොරතුරු සොයා බලා "
-"සාරාංශගත කළ හැක. කොපමණ වාරයක් DuckAssist පෙනී සිටීමට අවශ්‍ය දැ යි ඔබට තෝරා "
-"ගත හැකිය: කිසි විටෙකත් (සෙවුම් ප්‍රතිඵලවලින් DuckAssist UI සම්පූර්ණයෙන්ම "
-"ඉවත් කරයි), On-demand (ඔබ සහාය බොත්තම ක්ලික් කළහොත් පමණක් පෙන්වයි), සමහර විට "
-"(ඉතා අදාළ වන විට පමණක් පෙන්වයි), හෝ බොහෝ විට (පුළුල් පරාසයක සෙවුම් මත නිතර "
-"නිතර පෙන්වයි). දැනට, DuckAssist ලබා ගත හැක්කේ එක්සත් ජනපද (ඉංග්‍රීසි) කලාපයේ "
-"පමණි."
+"DuckAssist හට නිර්නාමිකව සමහර සෙවීම් වලට ප්‍රතිචාර වශයෙන් තොරතුරු සොයා බලා සාරාංශගත කළ "
+"හැක. කොපමණ වාරයක් DuckAssist පෙනී සිටීමට අවශ්‍ය දැ යි ඔබට තෝරා ගත හැකිය: කිසි විටෙකත් "
+"(සෙවුම් ප්‍රතිඵලවලින් DuckAssist UI සම්පූර්ණයෙන්ම ඉවත් කරයි), On-demand (ඔබ සහාය බොත්තම "
+"ක්ලික් කළහොත් පමණක් පෙන්වයි), සමහර විට (ඉතා අදාළ වන විට පමණක් පෙන්වයි), හෝ බොහෝ විට (පුළුල් "
+"පරාසයක සෙවුම් මත නිතර නිතර පෙන්වයි). දැනට, DuckAssist ලබා ගත හැක්කේ එක්සත් ජනපද "
+"(ඉංග්‍රීසි) කලාපයේ පමණි."
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6518,10 +6584,9 @@ msgid ""
 "%sDuckDuckGo AI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI, and Anthropic, and more."
 msgstr ""
-"DuckAssist ට පසුවිපරම් ප්‍රශ්නවලට පිළිතුරු දිය නොහැක, කෙසේ වෙතත්, අපි "
-"%1$sDuckDuckGo AI Chat%2$s සේවය ද ලබා දෙන්නෙමු, එය OpenAI සහ Anthropic "
-"වෙතින් වන චැට් ආකෘති සඳහා සහය දක්වන පෞද්ගලික AI බලයෙන් ක්‍රියාත්මක වන චැට් "
-"සේවාවක් වේ."
+"DuckAssist ට පසුවිපරම් ප්‍රශ්නවලට පිළිතුරු දිය නොහැක, කෙසේ වෙතත්, අපි %1$sDuckDuckGo AI "
+"Chat%2$s සේවය ද ලබා දෙන්නෙමු, එය OpenAI සහ Anthropic වෙතින් වන චැට් ආකෘති සඳහා සහය "
+"දක්වන පෞද්ගලික AI බලයෙන් ක්‍රියාත්මක වන චැට් සේවාවක් වේ."
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6530,10 +6595,9 @@ msgid ""
 "DuckDuckGo %sAI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI and Anthropic."
 msgstr ""
-"DuckAssist ට පසුවිපරම් ප්‍රශ්නවලට පිළිතුරු දිය නොහැක, කෙසේ වෙතත්, අපි "
-"DuckDuckGo %1$sAI Chat%2$s සේවය ද ලබා දෙන්නෙමු, එය OpenAI සහ Anthropic "
-"වෙතින් වන චැට් ආකෘති සඳහා සහය දක්වන පෞද්ගලික AI බලයෙන් ක්‍රියාත්මක වන චැට් "
-"සේවාවක් වේ."
+"DuckAssist ට පසුවිපරම් ප්‍රශ්නවලට පිළිතුරු දිය නොහැක, කෙසේ වෙතත්, අපි DuckDuckGo %1$sAI "
+"Chat%2$s සේවය ද ලබා දෙන්නෙමු, එය OpenAI සහ Anthropic වෙතින් වන චැට් ආකෘති සඳහා සහය "
+"දක්වන පෞද්ගලික AI බලයෙන් ක්‍රියාත්මක වන චැට් සේවාවක් වේ."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6545,12 +6609,11 @@ msgid ""
 "responses are currently based on Wikipedia and related content and are not "
 "checked for accuracy."
 msgstr ""
-"DuckAssist යනු අපගේ සෙවුම් ප්‍රතිඵලවල ඇති නව විශේෂාංගයක් වන අතර එයට "
-"නිර්නාමික ව සෙවුම් විමසුම් සඳහා පිළිතුරු ජනනය කළ හැකිය. මෙය සිදු කිරීම සඳහා, "
-"එය අදාළ අන්තර්ගතයන් සඳහා විකිපීඩියාව සහ ඒ ආශ්‍රිත අඩවි පිරික්සන අතර පසුව එම "
-"තොරතුරු වල සාරාංශයක් ජනනය කිරීම සඳහා AI බලයෙන් ක්‍රියාත්මක වන ස්වාභාවික භාෂා "
-"තාක්ෂණය භාවිතා කරයි. එහි ප්‍රතිචාර දැනට විකිපීඩියාව සහ අදාළ අන්තර්ගතයන් මත "
-"පදනම් වී ඇති අතර නිරවද්‍යතාව සඳහා පරීක්ෂා කර නොමැති බව කරුණාවෙන් සලකන්න."
+"DuckAssist යනු අපගේ සෙවුම් ප්‍රතිඵලවල ඇති නව විශේෂාංගයක් වන අතර එයට නිර්නාමික ව සෙවුම් "
+"විමසුම් සඳහා පිළිතුරු ජනනය කළ හැකිය. මෙය සිදු කිරීම සඳහා, එය අදාළ අන්තර්ගතයන් සඳහා විකිපීඩියාව "
+"සහ ඒ ආශ්‍රිත අඩවි පිරික්සන අතර පසුව එම තොරතුරු වල සාරාංශයක් ජනනය කිරීම සඳහා AI බලයෙන් "
+"ක්‍රියාත්මක වන ස්වාභාවික භාෂා තාක්ෂණය භාවිතා කරයි. එහි ප්‍රතිචාර දැනට විකිපීඩියාව සහ අදාළ "
+"අන්තර්ගතයන් මත පදනම් වී ඇති අතර නිරවද්‍යතාව සඳහා පරීක්ෂා කර නොමැති බව කරුණාවෙන් සලකන්න."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6564,15 +6627,13 @@ msgid ""
 "It’s important to remember that responses are auto-generated from cited "
 "sources and based on %scrawling the web%s."
 msgstr ""
-"DuckAssist යනු අපගේ සෙවුම් ප්‍රතිඵලවල ඇති නව විශේෂාංගයක් වන අතර එයට "
-"නිර්නාමික ව සෙවුම් විමසුම් සඳහා පිළිතුරු ජනනය කළ හැකිය. මෙය සිදු කිරීම සඳහා, "
-"එය අදාළ අන්තර්ගතයන් සඳහා වෙබ් ස්කෑන් කරන අතර පසුව සොයාගත් අදාළ තොරතුරු මත "
-"පදනම්ව කෙටි පිළිතුරක් ජනනය කිරීම සඳහා AI-බලැති ස්වාභාවික භාෂා තාක්ෂණය භාවිත "
-"කරයි. DuckAssist ප්‍රතිචාර සෑම විටම මූලාශ්‍ර එකකට හෝ දෙකකට සෘජුවම සම්බන්ධ වන "
-"අතර, පිළිතුර පැමිණි ස්ථානය උපුටා දක්වයි, එබැවින් ඔබට පහසුවෙන් ගොස් වඩාත් "
-"සවිස්තරාත්මක තොරතුරු ලබා ගත හැකිය. ප්රතිචාර උපුටා දක්වන ලද මූලාශ්රවලින් "
-"ස්වයංක්රීයව ජනනය වන අතර %1$sවෙබ් කැටි ගැසීම%2$s මත පදනම් වන බව මතක තබා ගැනීම "
-"වැදගත්ය."
+"DuckAssist යනු අපගේ සෙවුම් ප්‍රතිඵලවල ඇති නව විශේෂාංගයක් වන අතර එයට නිර්නාමික ව සෙවුම් "
+"විමසුම් සඳහා පිළිතුරු ජනනය කළ හැකිය. මෙය සිදු කිරීම සඳහා, එය අදාළ අන්තර්ගතයන් සඳහා වෙබ් ස්කෑන් "
+"කරන අතර පසුව සොයාගත් අදාළ තොරතුරු මත පදනම්ව කෙටි පිළිතුරක් ජනනය කිරීම සඳහා AI-බලැති "
+"ස්වාභාවික භාෂා තාක්ෂණය භාවිත කරයි. DuckAssist ප්‍රතිචාර සෑම විටම මූලාශ්‍ර එකකට හෝ දෙකකට "
+"සෘජුවම සම්බන්ධ වන අතර, පිළිතුර පැමිණි ස්ථානය උපුටා දක්වයි, එබැවින් ඔබට පහසුවෙන් ගොස් වඩාත් "
+"සවිස්තරාත්මක තොරතුරු ලබා ගත හැකිය. ප්රතිචාර උපුටා දක්වන ලද මූලාශ්රවලින් ස්වයංක්රීයව ජනනය වන "
+"අතර %1$sවෙබ් කැටි ගැසීම%2$s මත පදනම් වන බව මතක තබා ගැනීම වැදගත්ය."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
@@ -6580,8 +6641,8 @@ msgid ""
 "DuckAssist responses are auto-generated based on listed sources and not "
 "checked for accuracy."
 msgstr ""
-"DuckAssist ප්‍රතිචාර ලැයිස්තුගත මූලාශ්‍ර මත පදනම්ව ස්වයංක්‍රීයව ජනනය වන අතර "
-"නිරවද්‍යතාව සඳහා පරීක්‍ෂා කර නොමැත."
+"DuckAssist ප්‍රතිචාර ලැයිස්තුගත මූලාශ්‍ර මත පදනම්ව ස්වයංක්‍රීයව ජනනය වන අතර නිරවද්‍යතාව සඳහා "
+"පරීක්‍ෂා කර නොමැත."
 
 # smartling.placeholder_format=C
 #. Displayed when the chat service has reached the maximum number of messages for one day.
@@ -6590,8 +6651,8 @@ msgid ""
 "DuckDuckGo AI Chat has reached the maximum number of messages for one day. "
 "Please continue this chat tomorrow."
 msgstr ""
-"DuckDuckGo AI Chat එක දවසකට උපරිම පණිවිඩ සංඛ්‍යාවට ළඟා වෙලා ඇත. කරුණාකර හෙට "
-"මෙම කතාබස් දිගටම කරගෙන යන්න."
+"DuckDuckGo AI Chat එක දවසකට උපරිම පණිවිඩ සංඛ්‍යාවට ළඟා වෙලා ඇත. කරුණාකර හෙට මෙම "
+"කතාබස් දිගටම කරගෙන යන්න."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the AI chat service and supported AI models. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -6600,8 +6661,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"DuckDuckGo AI Chat පුද්ගලික AI බලැති චැට් සේවාවක් වන අතර එය දැනට %1$s %2$s "
-"සහ %3$s %4$s චැට් මාදිලි සඳහා සහාය දක්වයි."
+"DuckDuckGo AI Chat පුද්ගලික AI බලැති චැට් සේවාවක් වන අතර එය දැනට %1$s %2$s සහ %3$s "
+"%4$s චැට් මාදිලි සඳහා සහාය දක්වයි."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the welcome screen of the onboarding. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -6610,8 +6671,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"DuckDuckGo AI Chat පුද්ගලික AI බලැති චැට් සේවාවක් වන අතර එය දැනට %1$s %2$s "
-"සහ %3$s %4$s චැට් මාදිලි සඳහා සහාය දක්වයි."
+"DuckDuckGo AI Chat පුද්ගලික AI බලැති චැට් සේවාවක් වන අතර එය දැනට %1$s %2$s සහ %3$s "
+"%4$s චැට් මාදිලි සඳහා සහාය දක්වයි."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding DuckDuckGo AI Chat.
@@ -6637,9 +6698,7 @@ msgctxt "Error message for VQD error"
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. Please refresh the page and "
 "try again."
-msgstr ""
-"DuckDuckGo AI Chat තාවකාලිකව නොමැත. කරුණාකර පිටුව නැවුම් කර නැවත උත්සාහ "
-"කරන්න."
+msgstr "DuckDuckGo AI Chat තාවකාලිකව නොමැත. කරුණාකර පිටුව නැවුම් කර නැවත උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -6764,8 +6823,8 @@ msgid ""
 "DuckDuckGo anonymizes these reports by automatically removing PII like "
 "names, email addresses, phone numbers, and identifying metadata."
 msgstr ""
-"DuckDuckGo නම, විද්‍යුත් තැපැල් ලිපින, දුරකථන අංක සහ හඳුනාගත හැකි පාර-දත්ත "
-"වැනි PII ස්වයංක්‍රීයව ඉවත් කිරීමෙන් මෙම වාර්තා නිර්නාමික කරයි."
+"DuckDuckGo නම, විද්‍යුත් තැපැල් ලිපින, දුරකථන අංක සහ හඳුනාගත හැකි පාර-දත්ත වැනි PII "
+"ස්වයංක්‍රීයව ඉවත් කිරීමෙන් මෙම වාර්තා නිර්නාමික කරයි."
 
 # smartling.placeholder_format=C
 #. The first %s is the agree button label ('Agree'). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. The leading sentence mirrors the drawer-style inline disclaimer (DUCKCHAT_TOS_INLINE_DISCLAIMER).
@@ -6773,8 +6832,8 @@ msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid ""
 "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to Duck.ai's %s."
 msgstr ""
-"DuckDuckGo ඔබගේ කතාබස් නිර්නාමික කරයි. '%1$s' ක්ලික් කිරීමෙන් ඔබ Duck.ai "
-"%2$s වෙත එකඟ වෙයි."
+"DuckDuckGo ඔබගේ කතාබස් නිර්නාමික කරයි. '%1$s' ක්ලික් කිරීමෙන් ඔබ Duck.ai %2$s වෙත එකඟ "
+"වෙයි."
 
 # smartling.placeholder_format=C
 #. Shown below the input on the empty state when the user has not yet accepted the terms of service. The first %s is the action button label ('Ask' for chat, 'Create' for image generation). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. Clicking the action button both accepts the terms and submits the prompt.
@@ -6783,8 +6842,7 @@ msgctxt ""
 "users"
 msgid "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to our %s."
 msgstr ""
-"DuckDuckGo ඔබගේ කතාබස් නිර්නාමික කරයි. '%1$s' ක්ලික් කිරීමෙන් ඔබ අපගේ %2$s "
-"වෙත එකඟ වෙයි."
+"DuckDuckGo ඔබගේ කතාබස් නිර්නාමික කරයි. '%1$s' ක්ලික් කිරීමෙන් ඔබ අපගේ %2$s වෙත එකඟ වෙයි."
 
 # smartling.placeholder_format=C
 #. An information popup explaining that we block trackers
@@ -6793,9 +6851,8 @@ msgid ""
 "companies like Google and Facebook, who often try to track you on other "
 "websites."
 msgstr ""
-"ගූගල් සහ ෆේස්බුක් වැනි සමාගම්වල ට්‍රැකර් ඇතුළු ඔබ පිවිසෙන වෙබ් අඩවි වල "
-"DuckDuckGo ට්‍රැකර් අවහිර කරයි, බොහෝ විට වෙනත් වෙබ් අඩවි වල ඔබව නිරීක්ෂණය "
-"කිරීමට උත්සාහ කරයි."
+"ගූගල් සහ ෆේස්බුක් වැනි සමාගම්වල ට්‍රැකර් ඇතුළු ඔබ පිවිසෙන වෙබ් අඩවි වල DuckDuckGo ට්‍රැකර් අවහිර "
+"කරයි, බොහෝ විට වෙනත් වෙබ් අඩවි වල ඔබව නිරීක්ෂණය කිරීමට උත්සාහ කරයි."
 
 # smartling.placeholder_format=C
 #. Description of how DuckDuckGo keeps a user's location anonymous while the user searches on a map of their area.
@@ -6807,11 +6864,11 @@ msgid ""
 "away, such that you remain anonymous. %sLearn more about how we designed "
 "this technology to protect your privacy%s."
 msgstr ""
-"DuckDuckGo සැලසුම අනුව පුද්ගලිකයි. ඔබ ස්ථානය සක්‍රීය කරන විට, එය ඔබේ දේශීය "
-"උපාංගයේ පමණක් ගබඩා වේ. ඔබ සොයන විට, ඔබේ උපාංගය එය අප වෙත යවයි, එම සෙවුමේ "
-"ප්‍රතිඵල වැඩි දියුණු කිරීම සඳහා අපි එය භාවිතා කරමු, පසුව ඔබ නිර්නාමික වන "
-"පරිදි අපි එය වහාම ඉවත දමමු. %1$sඔබේ පුද්ගලිකත්වය ආරක්ෂා කිරීමට අප මෙම "
-"තාක්ෂණය කෙසේ නිර්මාණය කර ඇතිදැයි යන්න තවදුරටත් ඉගෙන ගන්න%2$s."
+"DuckDuckGo සැලසුම අනුව පුද්ගලිකයි. ඔබ ස්ථානය සක්‍රීය කරන විට, එය ඔබේ දේශීය උපාංගයේ පමණක් "
+"ගබඩා වේ. ඔබ සොයන විට, ඔබේ උපාංගය එය අප වෙත යවයි, එම සෙවුමේ ප්‍රතිඵල වැඩි දියුණු කිරීම "
+"සඳහා අපි එය භාවිතා කරමු, පසුව ඔබ නිර්නාමික වන පරිදි අපි එය වහාම ඉවත දමමු. %1$sඔබේ "
+"පුද්ගලිකත්වය ආරක්ෂා කිරීමට අප මෙම තාක්ෂණය කෙසේ නිර්මාණය කර ඇතිදැයි යන්න තවදුරටත් ඉගෙන "
+"ගන්න%2$s."
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
@@ -6831,8 +6888,8 @@ msgid ""
 "DuckDuckGo only uses your approximate location. That's all we need to "
 "deliver better results, closer to you. %sLearn more%s."
 msgstr ""
-"DuckDuckGo භාවිතා කරන්නේ ඔබගේ ආසන්න ස්ථානය පමණි. ඔබට වඩා සමීප හොඳ ප්‍රතිඵල "
-"ලබා දීමට අපට අවශ්‍ය වන්නේ එපමණයි. %1$sතවත් ඉගෙන ගන්න%2$s."
+"DuckDuckGo භාවිතා කරන්නේ ඔබගේ ආසන්න ස්ථානය පමණි. ඔබට වඩා සමීප හොඳ ප්‍රතිඵල ලබා දීමට "
+"අපට අවශ්‍ය වන්නේ එපමණයි. %1$sතවත් ඉගෙන ගන්න%2$s."
 
 # smartling.placeholder_format=C
 msgid "DuckDuckGo search"
@@ -6918,9 +6975,9 @@ msgid ""
 "random words from that list, ensuring that the passphrase is at least 18-20 "
 "characters long."
 msgstr ""
-"ඔබ මුරපද යෝජනාවක් ඉල්ලා සිටින සෑම අවස්ථාවකම, DuckDuckGo සර්වර වලින් අපට දිගු "
-"අහඹු වචන ලැයිස්තුවක් ලැබේ. බ්‍රව්සරයේ දී, අපි එම ලැයිස්තුවෙන් අහඹු වචන 4-5 "
-"ක් තෝරා ගනිමු, මුරපදය අවම වශයෙන් අක්ෂර 18-20 ක් වත් ඇති බව සහතික කරමු."
+"ඔබ මුරපද යෝජනාවක් ඉල්ලා සිටින සෑම අවස්ථාවකම, DuckDuckGo සර්වර වලින් අපට දිගු අහඹු වචන "
+"ලැයිස්තුවක් ලැබේ. බ්‍රව්සරයේ දී, අපි එම ලැයිස්තුවෙන් අහඹු වචන 4-5 ක් තෝරා ගනිමු, මුරපදය අවම "
+"වශයෙන් අක්ෂර 18-20 ක් වත් ඇති බව සහතික කරමු."
 
 # smartling.placeholder_format=C
 msgctxt "Sports module"
@@ -6984,9 +7041,7 @@ msgstr "රූපය සංස්කරණය කෙරේ..."
 msgctxt "Info text for the editing message feature"
 msgid ""
 "Editing your message will remove the response below and generate a new one."
-msgstr ""
-"ඔබේ පණිවිඩය සංස්කරණය කිරීමෙන් පහත ප්‍රතිචාරය ඉවත් කර නව ප්‍රතිචාරයක් ජනනය "
-"කරයි."
+msgstr "ඔබේ පණිවිඩය සංස්කරණය කිරීමෙන් පහත ප්‍රතිචාරය ඉවත් කර නව ප්‍රතිචාරයක් ජනනය කරයි."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of an editor in its responses.
@@ -7118,8 +7173,8 @@ msgid ""
 "Enable anonymous location for more accurate results. You can always change "
 "your mind later."
 msgstr ""
-"වඩාත් නිවැරදි ප්‍රතිඵල සඳහා නිර්නාමික ස්ථානය සක්‍රීය කරන්න. ඔබට පසුව සෑම "
-"විටම ඔබේ අදහස වෙනස් කළ හැකිය."
+"වඩාත් නිවැරදි ප්‍රතිඵල සඳහා නිර්නාමික ස්ථානය සක්‍රීය කරන්න. ඔබට පසුව සෑම විටම ඔබේ අදහස වෙනස් "
+"කළ හැකිය."
 
 # smartling.placeholder_format=C
 #. Title of the dictation privacy consent modal shown on first use.
@@ -7130,9 +7185,7 @@ msgstr "Duck.ai මත අසා ලිවීම සක් රීය කරන�
 #. Prompt to enable location service so that search results can be displayed near the user's current location.
 msgctxt "precise_user_location"
 msgid "Enable location settings on your device to use anonymous location"
-msgstr ""
-"නිර්නාමික පිහිටීම භාවිතා කිරීම සඳහා ඔබේ උපාංගය මත පිහිටීම් සැකසුම් සක්‍රිය "
-"කරන්න"
+msgstr "නිර්නාමික පිහිටීම භාවිතා කිරීම සඳහා ඔබේ උපාංගය මත පිහිටීම් සැකසුම් සක්‍රිය කරන්න"
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -7164,8 +7217,8 @@ msgid ""
 "Enabling anonymous location gives more accurate results but still keeps your "
 "searches and exact location private to DuckDuckGo."
 msgstr ""
-"නිර්නාමික ස්ථානය සක්‍රිය කිරීම වඩාත් නිවැරදි ප්‍රතිඵල ලබා දෙන නමුත් ඉන් "
-"තවමත් ඔබේ සෙවුම් සහ නිශ්චිත ස්ථානය DuckDuckGo වෙත පෞද්ගලිකව තබා ගනී."
+"නිර්නාමික ස්ථානය සක්‍රිය කිරීම වඩාත් නිවැරදි ප්‍රතිඵල ලබා දෙන නමුත් ඉන් තවමත් ඔබේ සෙවුම් සහ නිශ්චිත "
+"ස්ථානය DuckDuckGo වෙත පෞද්ගලිකව තබා ගනී."
 
 # smartling.placeholder_format=C
 msgid "Encrypt Connections"
@@ -7327,8 +7380,8 @@ msgid ""
 "Enter a new passphrase and click/tap %sSave Settings%s. This will save your "
 "data under your new passphrase."
 msgstr ""
-"නව මුරපදයක් ඇතුලත් කර %1$sසැකසුම් සුරකින්න%2$s ක්ලික්/තට්ටු කරන්න. මෙය ඔබගේ "
-"නව මුරදය යටතේ ඔබගේ දත්ත සුරකිනු ඇත."
+"නව මුරපදයක් ඇතුලත් කර %1$sසැකසුම් සුරකින්න%2$s ක්ලික්/තට්ටු කරන්න. මෙය ඔබගේ නව මුරදය යටතේ "
+"ඔබගේ දත්ත සුරකිනු ඇත."
 
 # smartling.placeholder_format=C
 #. Label for the field where a user enters their passphrase.
@@ -7396,6 +7449,18 @@ msgid "Eritrea"
 msgstr "එරිත්‍රියාව"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Estimate the nutrition"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Estimate the nutritional information for this recipe."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Estonia"
 msgstr "එස්ටෝනියාව"
 
@@ -7429,9 +7494,7 @@ msgstr "සිතියම පුළුල් කරන්න"
 #. Subtitle for the Collaborations promotional card at the bottom of search results. Describes the branded merchandise line. 'Give a duck' is a wordplay on the DuckDuckGo brand name.
 msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
-msgstr ""
-"පෞද්ගලිකත්වය ගැන සැලකිල්ලක් දක්වන අය සඳහා විශේෂඥ ලෙස නිර්මාණය කරන ලද "
-"නිෂ්පාදන."
+msgstr "පෞද්ගලිකත්වය ගැන සැලකිල්ලක් දක්වන අය සඳහා විශේෂඥ ලෙස නිර්මාණය කරන ලද නිෂ්පාදන."
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
@@ -7452,11 +7515,59 @@ msgid "Expires in 1 day"
 msgstr "දින 1 කින් කල් ඉකුත් වේ"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain the accepted answer in simple terms."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
 msgstr "කළු කුහර පිළිබඳ මූලික සංකල්ප උසස් පාසැල් මට්ටමින් මට පැහැදිලි කරන්න."
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain the top answer"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this in simple, plain language."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this paper"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this repo"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this research paper in plain language."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this simply"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain what this repository does and how to use it."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label to show if song lyrics contain explicit content
@@ -7633,9 +7744,7 @@ msgstr "ප්‍රතිපෝෂණය සාර්ථකව යවන ලද
 msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and improvements."
-msgstr ""
-"ඔබේ වැනි ප්‍රතිචාර සෘජුවම අපගේ නිෂ්පාදන යාවත්කාලීන කිරීම් සහ වැඩිදියුණු "
-"කිරීම් බලපායි."
+msgstr "ඔබේ වැනි ප්‍රතිචාර සෘජුවම අපගේ නිෂ්පාදන යාවත්කාලීන කිරීම් සහ වැඩිදියුණු කිරීම් බලපායි."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -7644,18 +7753,15 @@ msgid ""
 "Feedback like yours directly influences our product updates and "
 "improvements. Hopefully we can address the issue you shared too."
 msgstr ""
-"ඔබේ වැනි ප්‍රතිචාර අපගේ නිෂ්පාදන යාවත්කාලීන කිරීම් සහ වැඩිදියුණු කිරීම් "
-"සෘජුවම බලපායි. ඔබ බෙදාගත් ගැටලුවටත් අපට විසඳුමක් සොයාගත හැකි යැයි මම "
-"බලාපොරොත්තු වෙමි."
+"ඔබේ වැනි ප්‍රතිචාර අපගේ නිෂ්පාදන යාවත්කාලීන කිරීම් සහ වැඩිදියුණු කිරීම් සෘජුවම බලපායි. ඔබ බෙදාගත් "
+"ගැටලුවටත් අපට විසඳුමක් සොයාගත හැකි යැයි මම බලාපොරොත්තු වෙමි."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box
 msgid ""
 "Feel free to adjust the settings below. Then, just copy and paste the code "
 "into your website."
-msgstr ""
-"පහත සැකසුම් සකස් කිරීමට නිදහස් වන්න. ඉන්පසු කේතය ඔබේ වෙබ් අඩවියට පිටපත් "
-"කරන්න."
+msgstr "පහත සැකසුම් සකස් කිරීමට නිදහස් වන්න. ඉන්පසු කේතය ඔබේ වෙබ් අඩවියට පිටපත් කරන්න."
 
 # smartling.placeholder_format=C
 msgid "Fiji"
@@ -7741,6 +7847,12 @@ msgid ""
 msgstr "රූප සෙවුම් ප්‍රතිඵලවලින් AI-ජනනය කරන ලද රූප පෙරහන් කරයි. %1$sතව දැනගන්න%2$s"
 
 # smartling.placeholder_format=C
+msgctxt "settings"
+msgid ""
+"Filters out known AI spam sites from image search results. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the final score of a sporting event.
 msgid "Final"
 msgstr "ඉවරයි"
@@ -7794,6 +7906,12 @@ msgid "Find current information"
 msgstr "වත්මන් තොරතුරු සොයන්න"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Find me alternatives"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Button that searches for results closer to the user's current location.
 msgctxt "precise_user_location"
 msgid "Find results closer to you"
@@ -7810,9 +7928,7 @@ msgstr "ඔබට සමීප ප්‍රතිඵල සොයා ගන්�
 msgctxt "Precise user location overlay"
 msgid ""
 "Find results near you. %sYour location stays private, secure, and anonymous."
-msgstr ""
-"ඔබට අසල ප්‍රතිඵල සොයා ගන්න. %1$sඔබේ ස්ථානය පුද්ගලිකව, ආරක්ෂිතව සහ නිර්නාමිකව "
-"පවතී."
+msgstr "ඔබට අසල ප්‍රතිඵල සොයා ගන්න. %1$sඔබේ ස්ථානය පුද්ගලිකව, ආරක්ෂිතව සහ නිර්නාමිකව පවතී."
 
 # smartling.placeholder_format=C
 #. Loading message shown while generating explore more follow-up questions
@@ -7876,8 +7992,8 @@ msgid ""
 "Follow the instructions for turning off the ad blocker for DuckDuckGo. You "
 "may have to select a menu option or click a button."
 msgstr ""
-"DuckDuckGo සඳහා දැන්වීම් අවහිරකරණය අක්‍රීය කිරීමට උපදෙස් අනුගමනය කරන්න. ඔයාට "
-"මෙනු විකල්පයක් තෝරන්න හෝ බොත්තමක් ක්ලික් කරන්න වෙන්න පුළුවන්."
+"DuckDuckGo සඳහා දැන්වීම් අවහිරකරණය අක්‍රීය කිරීමට උපදෙස් අනුගමනය කරන්න. ඔයාට මෙනු විකල්පයක් "
+"තෝරන්න හෝ බොත්තමක් ක්ලික් කරන්න වෙන්න පුළුවන්."
 
 # smartling.placeholder_format=C
 #. Privacy reassurance and instructions intro.
@@ -8100,8 +8216,8 @@ msgid ""
 "strong>."
 msgstr ""
 "Mac හි යෙදුම් මෙනු තීරුවෙන්, <strong>DuckDuckGo</strong> තෝරන්න &gt; "
-"<strong>යාවත්කාලීන සඳහා පරීක්ෂා කරන්න...</strong>, ඉන්පසු <strong>යාවත්කාලීන "
-"ස්ථාපනය කරන්න</strong> තෝරන්න."
+"<strong>යාවත්කාලීන සඳහා පරීක්ෂා කරන්න...</strong>, ඉන්පසු <strong>යාවත්කාලීන ස්ථාපනය "
+"කරන්න</strong> තෝරන්න."
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -8267,6 +8383,12 @@ msgstr "රූපය ජනනය කරන්න"
 #. Text for the button that generates more of an answer from duckassist when the answer has come from a collapsed state
 msgid "Generate More"
 msgstr "තවත් ජනනය කරන්න"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Generate a shopping list"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
@@ -8446,8 +8568,8 @@ msgid ""
 "Get access to advanced AI models in Duck.ai by subscribing to DuckDuckGo, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"අපගේ VPN සහ අනෙකුත් ප්‍රිමියම් පෞද්ගලිකත්ව ආරක්ෂණ ඇතුළත් වන DuckDuckGo වෙත "
-"දායක වීමෙන් Duck.ai හි උසස් AI ආකෘති වෙත ප්‍රවේශය ලබා ගන්න."
+"අපගේ VPN සහ අනෙකුත් ප්‍රිමියම් පෞද්ගලිකත්ව ආරක්ෂණ ඇතුළත් වන DuckDuckGo වෙත දායක වීමෙන් Duck."
+"ai හි උසස් AI ආකෘති වෙත ප්‍රවේශය ලබා ගන්න."
 
 # smartling.placeholder_format=C
 #. Description for the subscription setting where users can subscribe to DuckDuckGo.
@@ -8458,8 +8580,8 @@ msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"අපගේ VPN සහ අනෙකුත් ප්‍රිමියම් පෞද්ගලිකත්ව ආරක්ෂණ ද ඇතුළත් වන DuckDuckGo "
-"දායකත්වයක් සමඟ Duck.ai හි උසස් AI ආකෘති වෙත ප්‍රවේශය ලබා ගන්න."
+"අපගේ VPN සහ අනෙකුත් ප්‍රිමියම් පෞද්ගලිකත්ව ආරක්ෂණ ද ඇතුළත් වන DuckDuckGo දායකත්වයක් සමඟ "
+"Duck.ai හි උසස් AI ආකෘති වෙත ප්‍රවේශය ලබා ගන්න."
 
 # smartling.placeholder_format=C
 #. A button for users to generate an AI generated answer from their query on the duckassist module
@@ -8558,6 +8680,12 @@ msgid "Give it a Try"
 msgstr "උත්සාහ කර බලන්න"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Give me a quick background on this person."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
@@ -8570,8 +8698,8 @@ msgid ""
 "Go to %sSettings > Privacy & Security > Location Services%s, and make sure "
 "“Location Services” is turned on."
 msgstr ""
-"%1$sසැකසුම්> පෞද්ගලිකත්වය සහ ආරක්ෂාව > ස්ථාන සේවා%2$s වෙත ගොස් \"ස්ථාන "
-"සේවා\" සක්‍රිය කර ඇති බවට වග බලා ගන්න."
+"%1$sසැකසුම්> පෞද්ගලිකත්වය සහ ආරක්ෂාව > ස්ථාන සේවා%2$s වෙත ගොස් \"ස්ථාන සේවා\" සක්‍රිය කර "
+"ඇති බවට වග බලා ගන්න."
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -8580,8 +8708,8 @@ msgid ""
 "Go to %sSettings > Privacy > Permission manager > Location%s and scroll down "
 "to %sDuckDuckGo%s."
 msgstr ""
-"%1$sසැකසුම් > පෞද්ගලිකත්වය > අවසර කළමනාකරු > ස්ථාන%2$s වෙත ගොස් "
-"%3$sDuckDuckGo%4$s වෙත පහළට අනුචලනය කරන්න."
+"%1$sසැකසුම් > පෞද්ගලිකත්වය > අවසර කළමනාකරු > ස්ථාන%2$s වෙත ගොස් %3$sDuckDuckGo%4$s "
+"වෙත පහළට අනුචලනය කරන්න."
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9004,6 +9132,18 @@ msgid "Help Spread Privacy"
 msgstr "පෞද්ගලිකත්වය ව්‍යාප්ත කිරීමට උදවු කරන්න"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Help me prep for the interview"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Help me tailor my resume for this job."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title of a SERP popup that invites users to take a survey (desktop only)
 msgctxt "User survey popup"
 msgid "Help us improve DuckDuckGo"
@@ -9240,8 +9380,8 @@ msgid ""
 "Highlights key facts in Search Assist answers to help you find important "
 "information faster."
 msgstr ""
-"වැදගත් තොරතුරු වේගයෙන් සොයා ගැනීමට ඔබට උපකාර කිරීම සඳහා Search Assist "
-"පිළිතුරුවල ප්‍රධාන කරුණු ඉස්මතු කරයි."
+"වැදගත් තොරතුරු වේගයෙන් සොයා ගැනීමට ඔබට උපකාර කිරීම සඳහා Search Assist පිළිතුරුවල ප්‍රධාන "
+"කරුණු ඉස්මතු කරයි."
 
 # smartling.placeholder_format=C
 #. The name of the Hindi language
@@ -9268,8 +9408,8 @@ msgid ""
 "Hit %sReturn%s on your keyboard to %ssave DuckDuckGo to the list. %sThen "
 "click %sMake Default%s"
 msgstr ""
-"ඔබගේ යතුරුපුවරුවේ %1$sReturn%2$s බොත්තම ඔබා %3$sDuckDuckGo ලැයිස්තුවේ "
-"සුරකින්න.%4$sඉන්පසුව %5$sMake Default%6$s මත ක්ලික් කරන්න"
+"ඔබගේ යතුරුපුවරුවේ %1$sReturn%2$s බොත්තම ඔබා %3$sDuckDuckGo ලැයිස්තුවේ සුරකින්න."
+"%4$sඉන්පසුව %5$sMake Default%6$s මත ක්ලික් කරන්න"
 
 # smartling.placeholder_format=C
 #. The name of the Hmong Daw language
@@ -9283,8 +9423,8 @@ msgid ""
 "Hold on! Changing it back will disable the DuckDuckGo extension and you'll "
 "lose our privacy protection."
 msgstr ""
-"නවත්වන්න! එය නැවත වෙනස් කිරීමෙන් DuckDuckGo දිගුව අක්‍රීය වන අතර ඔබට අපගේ "
-"රහස්‍යතා ආරක්ෂාව අහිමි වේ."
+"නවත්වන්න! එය නැවත වෙනස් කිරීමෙන් DuckDuckGo දිගුව අක්‍රීය වන අතර ඔබට අපගේ රහස්‍යතා ආරක්ෂාව "
+"අහිමි වේ."
 
 # smartling.placeholder_format=C
 #. Heading shown above warning messages in the AI chat, for non-critical issues like unsupported file formats or file size limits. Analogous to 'Oops...' for error messages.
@@ -9334,8 +9474,8 @@ msgid ""
 "Hotel ad clicks are managed by Tripadvisor’s ad network and are not used to "
 "profile you."
 msgstr ""
-"හෝටල් දැන්වීම් ක්ලික් කිරීම් Tripadvisor හි දැන්වීම් ජාලය මගින් කළමනාකරණය "
-"කරනු ලබන අතර ඔබව පැතිකඩ කිරීමට භාවිත නොකෙරේ."
+"හෝටල් දැන්වීම් ක්ලික් කිරීම් Tripadvisor හි දැන්වීම් ජාලය මගින් කළමනාකරණය කරනු ලබන අතර ඔබව "
+"පැතිකඩ කිරීමට භාවිත නොකෙරේ."
 
 # smartling.placeholder_format=C
 #. Refers to hours of operation for a business.
@@ -9477,8 +9617,8 @@ msgid ""
 "How should I tactfully approach a colleague about their constant pencil "
 "tapping and what should I say?"
 msgstr ""
-"ඔවුන්ගේ නිරන්තර පැන්සල් තට්ටු කිරීම ගැන සගයෙකුට උපායශීලීව ප්‍රවේශ විය යුත්තේ "
-"කෙසේද සහ මා කුමක් කිව යුතුද?"
+"ඔවුන්ගේ නිරන්තර පැන්සල් තට්ටු කිරීම ගැන සගයෙකුට උපායශීලීව ප්‍රවේශ විය යුත්තේ කෙසේද සහ මා කුමක් "
+"කිව යුතුද?"
 
 # smartling.placeholder_format=C
 #. The title for a feedback prompt that includes thumbs up and thumbs down buttons
@@ -9517,6 +9657,14 @@ msgstr "සුළි කුණාටුව"
 msgctxt "Onboarding terms screen button text"
 msgid "I Agree"
 msgstr "මම එකඟයි"
+
+# smartling.placeholder_format=C
+#. Text for the button that takes the user to the external DuckDuckGo login subscription page.
+msgctxt ""
+"Text for the I already have a subscription button in the Duck.ai settings "
+"page"
+msgid "I Already Have a Subscription"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the button that takes the user to the login subscription page.
@@ -9592,8 +9740,8 @@ msgid ""
 "I like the book Name of the Wind. What are some other good books/series most "
 "like it and why?"
 msgstr ""
-"සුළඟේ නම කියන පොතට මම කැමතියි. තවත් හොඳ පොත්/කතා මාලා කිහිපයක් එයට වඩාත්ම "
-"කැමති මොනවාද සහ ඇයි?"
+"සුළඟේ නම කියන පොතට මම කැමතියි. තවත් හොඳ පොත්/කතා මාලා කිහිපයක් එයට වඩාත්ම කැමති මොනවාද "
+"සහ ඇයි?"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the user needs more help or information on how to use the chat.
@@ -9628,8 +9776,8 @@ msgid ""
 "If the browser location remains unavailable, then go to %sSettings > General "
 "> Reset > 'Reset Location & Privacy'%s."
 msgstr ""
-"බ්‍රවුසර් පිහිටීම දිගටම ලද නොහැකි නම්, %1$sසැකසුම් > සාමාන්‍ය > යළි සකසන්න > "
-"'පිහිටීම හා රහස්‍යතාව යළි සකසන්න'%2$s වෙත යන්න."
+"බ්‍රවුසර් පිහිටීම දිගටම ලද නොහැකි නම්, %1$sසැකසුම් > සාමාන්‍ය > යළි සකසන්න > 'පිහිටීම හා "
+"රහස්‍යතාව යළි සකසන්න'%2$s වෙත යන්න."
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -9639,9 +9787,8 @@ msgid ""
 "> Menu > Settings > Site settings > Location%s, and ensure DuckDuckGo is "
 "allowed location access."
 msgstr ""
-"බ්‍රවුසර් පිහිටීම දිගටම ලද නොහැකි නම්, ඔබේ බ්‍රවුසරයෙන් %1$s⋮ > මෙනුව > "
-"සැකසුම් > අඩවි සැකසුම් > පිහිටීම%2$s වෙත ගොස්, DuckDuckGo වෙත ප්‍රවේශය සඳහා "
-"අවසර දී ඇති ද යන්න දැනගන්න."
+"බ්‍රවුසර් පිහිටීම දිගටම ලද නොහැකි නම්, ඔබේ බ්‍රවුසරයෙන් %1$s⋮ > මෙනුව > සැකසුම් > අඩවි සැකසුම් > "
+"පිහිටීම%2$s වෙත ගොස්, DuckDuckGo වෙත ප්‍රවේශය සඳහා අවසර දී ඇති ද යන්න දැනගන්න."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -9656,8 +9803,8 @@ msgid ""
 "If you don't see %sDuckDuckGo,%s you will need to add it to the list of "
 "%sOther Search Engines%s"
 msgstr ""
-"ඔබට %1$sDuckDuckGo%2$s දැක ගැනීමට නොහැකිනම්, ඔබට සිදුවෙනවා එය %3$sOther "
-"Search Engines%4$s ලැයිස්තුවට එකතු කරන්න"
+"ඔබට %1$sDuckDuckGo%2$s දැක ගැනීමට නොහැකිනම්, ඔබට සිදුවෙනවා එය %3$sOther Search "
+"Engines%4$s ලැයිස්තුවට එකතු කරන්න"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding the AI model providers and links to their support pages. Example: 'If you have concerns about our chat providers or any particular chat response, you can also reach out directly to OpenAI and Anthropic support pages.'
@@ -9666,8 +9813,8 @@ msgid ""
 "If you have concerns about our chat providers or any particular chat "
 "response, you can also reach out directly to %s and %s support pages."
 msgstr ""
-"අපගේ චැට් සපයන්නන් හෝ කිසියම් විශේෂිත චැට් ප්‍රතිචාරයක් ගැන ඔබට කනස්සල්ලක් "
-"ඇත්නම්, ඔබට කෙලින්ම %1$s සහ %2$s සහාය පිටු වෙත ළඟා විය හැකිය."
+"අපගේ චැට් සපයන්නන් හෝ කිසියම් විශේෂිත චැට් ප්‍රතිචාරයක් ගැන ඔබට කනස්සල්ලක් ඇත්නම්, ඔබට කෙලින්ම "
+"%1$s සහ %2$s සහාය පිටු වෙත ළඟා විය හැකිය."
 
 # smartling.placeholder_format=C
 #. Body copy explaining what the recovery code is for and how it can be saved.
@@ -9676,17 +9823,14 @@ msgid ""
 "If you lose access to your devices, you will need this code to recover your "
 "saved chats. You can save this code to your device as a text file."
 msgstr ""
-"ඔබට ඔබගේ උපාංගවලට ප්‍රවේශය අහිමි වුවහොත්, ඔබගේ සුරකින ලද කතාබස් නැවත ලබා "
-"ගැනීමට මෙම කේතය අවශ්‍ය වනු ඇත. ඔබට මෙම කේතය ඔබගේ උපාංගයට පෙළ ගොනුවක් ලෙස "
-"සුරැකිය හැකි ය."
+"ඔබට ඔබගේ උපාංගවලට ප්‍රවේශය අහිමි වුවහොත්, ඔබගේ සුරකින ලද කතාබස් නැවත ලබා ගැනීමට මෙම "
+"කේතය අවශ්‍ය වනු ඇත. ඔබට මෙම කේතය ඔබගේ උපාංගයට පෙළ ගොනුවක් ලෙස සුරැකිය හැකි ය."
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
-msgstr ""
-"ඔබට තවමත් අවශ්‍යයනම් අපිට උදවු කරන්න, %1$sDuckDuckGo ව්‍යාප්ත කරන්න උදවු "
-"කරන්න%2$s"
+msgstr "ඔබට තවමත් අවශ්‍යයනම් අපිට උදවු කරන්න, %1$sDuckDuckGo ව්‍යාප්ත කරන්න උදවු කරන්න%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -9696,17 +9840,15 @@ msgid ""
 "If you want to use DuckDuckGo without JavaScript, please use our %s or %s "
 "versions."
 msgstr ""
-"ඔබට DuckDuckGo ජාවාස්ක්‍රිප්ට් නැතුව භාවිතා කිරීමට අවශ්‍යයනම්, කරුණාකර අපගේ "
-"%1$s හෝ %2$s යන පිටපත් භාවිතා කරන්න."
+"ඔබට DuckDuckGo ජාවාස්ක්‍රිප්ට් නැතුව භාවිතා කිරීමට අවශ්‍යයනම්, කරුණාකර අපගේ %1$s හෝ %2$s "
+"යන පිටපත් භාවිතා කරන්න."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "If you want, select Home Page next to New windows and New tabs (open with)."
-msgstr ""
-"ඔබට අවශ්‍යයනම්, අලුත් කවුළු හා ටැබ් සඳහා මුල් පිටුවක් තෝරා ගන්න (සමග විවෘත "
-"කරන්න)."
+msgstr "ඔබට අවශ්‍යයනම්, අලුත් කවුළු හා ටැබ් සඳහා මුල් පිටුවක් තෝරා ගන්න (සමග විවෘත කරන්න)."
 
 # smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that adds an image to the AI chat message being composed.
@@ -9835,8 +9977,7 @@ msgctxt "settings"
 msgid ""
 "Improves result legibility with updated URL format, placement, and color"
 msgstr ""
-"යාවත්කාලීන කළ URL ආකෘතිය, ස්ථානගත කිරීම සහ වර්ණය සමඟ ප්‍රතිඵල වලංගු භාවය "
-"වැඩි දියුණු කරයි"
+"යාවත්කාලීන කළ URL ආකෘතිය, ස්ථානගත කිරීම සහ වර්ණය සමඟ ප්‍රතිඵල වලංගු භාවය වැඩි දියුණු කරයි"
 
 # smartling.placeholder_format=C
 #. A label that appears in front of the name of a company that DuckDuckGo has partnered with. For example, 'In partnership with Wikipedia'
@@ -9849,8 +9990,8 @@ msgid ""
 "In some older browsers, it's necessary to redirect your clicks through our "
 "server to prevent search leakage. %sLearn more%s."
 msgstr ""
-"සමහර පැරණි බ්‍රව්සර් වලදී, සෙවුම් කාන්දු වීම වැළැක්වීම සඳහා ඔබේ ක්ලික් "
-"කිරීම් අපගේ සර්වරය හරහා හරවා යැවීම අවශ්‍ය වේ. %1$sතවත් ඉගෙන ගන්න%2$s."
+"සමහර පැරණි බ්‍රව්සර් වලදී, සෙවුම් කාන්දු වීම වැළැක්වීම සඳහා ඔබේ ක්ලික් කිරීම් අපගේ සර්වරය හරහා "
+"හරවා යැවීම අවශ්‍ය වේ. %1$sතවත් ඉගෙන ගන්න%2$s."
 
 # smartling.placeholder_format=C
 #. Instructions accompanying DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE; tells the user where to use the code on a DuckDuckGo browser.
@@ -9861,8 +10002,8 @@ msgid ""
 "In the DuckDuckGo browser, go to Settings › Sync & Backup, and then “Sync "
 "with another device”."
 msgstr ""
-"DuckDuckGo බ්‍රවුසරයේ, සැකසුම් › Sync & Backup වෙත ගොස්, පසුව “වෙනත් "
-"උපාංගයක් සමග සමමුහුර්ත කරන්න” වෙත යන්න."
+"DuckDuckGo බ්‍රවුසරයේ, සැකසුම් › Sync & Backup වෙත ගොස්, පසුව “වෙනත් උපාංගයක් සමග "
+"සමමුහුර්ත කරන්න” වෙත යන්න."
 
 #  SeaMonkey default search engine instruction
 # smartling.placeholder_format=C
@@ -9877,8 +10018,8 @@ msgid ""
 "In the interest of transparency, this data is not encrypted: You can see "
 "exactly what information we store."
 msgstr ""
-"විනිවිදභාවය පිළිබඳ උනන්දුව නිසා, මෙම දත්ත කේතනය වී නැත: ඔබට නිසැකයෙන්ම දැන "
-"ගැනීමට හැකියි අප ගබඩා කරන්නේ කුමන දත්තද කියා."
+"විනිවිදභාවය පිළිබඳ උනන්දුව නිසා, මෙම දත්ත කේතනය වී නැත: ඔබට නිසැකයෙන්ම දැන ගැනීමට හැකියි අප "
+"ගබඩා කරන්නේ කුමන දත්තද කියා."
 
 # smartling.placeholder_format=C
 msgid "In the menu at the top select %sTools%s > %sSettings%s"
@@ -9889,8 +10030,8 @@ msgstr "ඉහළ ඇති මෙනුවෙන් %1$sTools%2$s > %3$sSetting
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "In the popup, check %sMake this my default search provider%s"
 msgstr ""
-"උද්දීපනය වන කොටුවෙන්, %1$sMake this my default search provider%2$s මත හරි "
-"සලකුණ යොදන්න"
+"උද්දීපනය වන කොටුවෙන්, %1$sMake this my default search provider%2$s මත හරි සලකුණ "
+"යොදන්න"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -10096,6 +10237,12 @@ msgid "Install Mac Browser"
 msgstr "Mac බ්‍රවුසරය ස්ථාපනය කරන්න"
 
 # smartling.placeholder_format=C
+#. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
+msgctxt "settings"
+msgid "Install Now"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of a button to install the DuckDuckGo app
 msgctxt "Serp footer content"
 msgid "Install Our App"
@@ -10193,10 +10340,42 @@ msgid "Is deleted data really deleted?"
 msgstr "මැකූ දත්ත ඇත්තටම මැකුණාද?"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is it worth taking?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this place any good?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"Is this place any good? Summarize its reputation based on reviews and "
+"ratings."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "Is this video helpful?"
 msgstr "මෙම වීඩියෝව ප්‍රයෝජනවත් වීද?"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this worth watching?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Is this worth watching? Give me a spoiler-free take."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -10247,10 +10426,9 @@ msgid ""
 "through Microsoft's Ad Network. Clicks lead directly to merchant landing "
 "pages and unlike ads, DuckDuckGo is not compensated for these results."
 msgstr ""
-"ඔබගේ සෙවුම් පද වලට අදාලත්වය මත අයිතම ශ්‍රේණිගත කර ඇති අතර Microsoft හි "
-"දැන්වීම් ජාලය හරහා බෙදා හරිනු ලැබේ. ක්ලික් කිරීම් සෘජුවම වෙළෙන්දා පිවිසීමේ "
-"පිටු වෙත යොමු කරන අතර දැන්වීම් මෙන් නොව, DuckDuckGo මෙම ප්‍රතිඵල සඳහා හිලවු "
-"නොකෙරේ."
+"ඔබගේ සෙවුම් පද වලට අදාලත්වය මත අයිතම ශ්‍රේණිගත කර ඇති අතර Microsoft හි දැන්වීම් ජාලය "
+"හරහා බෙදා හරිනු ලැබේ. ක්ලික් කිරීම් සෘජුවම වෙළෙන්දා පිවිසීමේ පිටු වෙත යොමු කරන අතර දැන්වීම් මෙන් "
+"නොව, DuckDuckGo මෙම ප්‍රතිඵල සඳහා හිලවු නොකෙරේ."
 
 # smartling.placeholder_format=C
 #. Text explaining why passphrases use a series of words instead of random numbers and letters.
@@ -10259,8 +10437,7 @@ msgid ""
 "It’s easier to remember 4-5 words than 10 random letters and numbers, and "
 "far more secure."
 msgstr ""
-"අහඹු අකුරු සහ අංක 10 ට වඩා වචන 4-5 මතක තබා ගැනීම පහසු වන අතර, වඩාත් ආරක්ෂිත "
-"වේ."
+"අහඹු අකුරු සහ අංක 10 ට වඩා වචන 4-5 මතක තබා ගැනීම පහසු වන අතර, වඩාත් ආරක්ෂිත වේ."
 
 # smartling.placeholder_format=C
 msgid "Ivory Coast"
@@ -10807,6 +10984,12 @@ msgid "Links:"
 msgstr "සබැදි:"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "List the tools, materials, or prerequisites I need for this."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
 msgid "Listen"
 msgstr "සවන්දෙන්න"
@@ -10915,9 +11098,7 @@ msgstr "අනුචලනය කරන විට තවත් පින්ත�
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Loads more results in Images, Videos, and Shopping when scrolling"
-msgstr ""
-"අනුචලනය කරන විට පින්තූර, වීඩියෝ හා සාප්පු සවාරි තුළ වැඩිපුර ප්‍රතිඵල පූරණය "
-"කරයි"
+msgstr "අනුචලනය කරන විට පින්තූර, වීඩියෝ හා සාප්පු සවාරි තුළ වැඩිපුර ප්‍රතිඵල පූරණය කරයි"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/WTkvs9I.png
@@ -11097,7 +11278,8 @@ msgstr "සියළුම වචන වල අක්ෂර වින්‍ය�
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Make sure to check %s\"Make this my default search provider\"%s"
-msgstr "%1$s\"Make this my default search provider\"%2$s මත හරි ලකුණ දැමුවාදැයි බලන්න"
+msgstr ""
+"%1$s\"Make this my default search provider\"%2$s මත හරි ලකුණ දැමුවාදැයි බලන්න"
 
 # smartling.placeholder_format=C
 #. Message prompting users to check the spelling of their search term.
@@ -11213,6 +11395,12 @@ msgstr "ඔබේ දායකත්වය කළමනාකරණය කරන
 msgctxt "Exclusion message manage sites button"
 msgid "Manage blocked sites"
 msgstr "අවහිර කරන ලද අඩවි කළමනාකරණය කරන්න"
+
+# smartling.placeholder_format=C
+#. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
+msgctxt "setting"
+msgid "Manage in Browser Settings"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to the site exclusion settings page
@@ -11437,9 +11625,7 @@ msgstr "මයික්රොනීසියාව"
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
 msgid ""
 "Microphone access was denied. Please allow microphone access and try again."
-msgstr ""
-"මයික්‍රෆෝන ප්‍රවේශය ප්‍රතික්ෂේප විය. කරුණාකර මයික්‍රෆෝන ප්‍රවේශය ඉඩ දී නැවත "
-"උත්සාහ කරන්න."
+msgstr "මයික්‍රෆෝන ප්‍රවේශය ප්‍රතික්ෂේප විය. කරුණාකර මයික්‍රෆෝන ප්‍රවේශය ඉඩ දී නැවත උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. The Microsoft brand name.
@@ -11664,9 +11850,7 @@ msgstr "මාසික සීමාවට ළඟා විය"
 #. Displayed when the user has reached a fixed monthly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Monthly usage limit reached. You can continue this chat after %s."
-msgstr ""
-"මාසික පරිශීලන සීමාවට ළඟා වී තිබේ. ඔබට %1$sට පසුව මෙම කතාබහ දිගටම කරගෙන යා "
-"හැක."
+msgstr "මාසික පරිශීලන සීමාවට ළඟා වී තිබේ. ඔබට %1$sට පසුව මෙම කතාබහ දිගටම කරගෙන යා හැක."
 
 # smartling.placeholder_format=C
 #. Used to point to additional social networking profiles (in results).
@@ -12189,10 +12373,10 @@ msgid ""
 "internet connection. Disabling chat history will delete pinned chats, and "
 "disable the temporary storage of new prompts and responses."
 msgstr ""
-"ඔබගේ අන්තර්ජාල සම්බන්ධතාවය නැති වුවහොත් කතාබහක් නැවත ලබා ගැනීමට උපකාර කිරීම "
-"සඳහා, නව විමසීම් සහ ප්‍රතිචාර සංකේතනය කර යැවීමෙන් පසු තාවකාලිකව DuckDuckGo "
-"සේවාදායකයක ගබඩා කරනු ලැබේ. කතාබස් ඉතිහාසය අක්‍රිය කිරීමෙන් පින් කළ කතාබස් "
-"මැකෙනු ඇති අතර නව විමසීම් සහ ප්‍රතිචාර තාවකාලිකව ගබඩා කිරීම අක්‍රිය කරනු ඇත."
+"ඔබගේ අන්තර්ජාල සම්බන්ධතාවය නැති වුවහොත් කතාබහක් නැවත ලබා ගැනීමට උපකාර කිරීම සඳහා, නව "
+"විමසීම් සහ ප්‍රතිචාර සංකේතනය කර යැවීමෙන් පසු තාවකාලිකව DuckDuckGo සේවාදායකයක ගබඩා කරනු "
+"ලැබේ. කතාබස් ඉතිහාසය අක්‍රිය කිරීමෙන් පින් කළ කතාබස් මැකෙනු ඇති අතර නව විමසීම් සහ ප්‍රතිචාර "
+"තාවකාලිකව ගබඩා කිරීම අක්‍රිය කරනු ඇත."
 
 # smartling.placeholder_format=C
 #. Question in a feedback form.
@@ -13008,8 +13192,8 @@ msgid ""
 "On Mac, %sClick Maxthon > Preferences%s, On Windows, %sClick the %s icon > "
 "Settings%s"
 msgstr ""
-"මැක් වල, %1$sClick Maxthon > Preferences%2$s, වින්ඩෝව්ස් වල, %3$sClick the "
-"%4$s icon > Settings%5$s"
+"මැක් වල, %1$sClick Maxthon > Preferences%2$s, වින්ඩෝව්ස් වල, %3$sClick the %4$s "
+"icon > Settings%5$s"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
@@ -13031,8 +13215,8 @@ msgid ""
 "One of the files attached has more pages than we support. Please upload "
 "files with %s pages or fewer."
 msgstr ""
-"අමුණා ඇති ගොනුවලින් එකක අපට ක්‍රියාත්මක කළ හැකි ප්‍රමාණයට වඩා පිටු තිබේ. "
-"පිටු %1$s ක් හෝ ඊට අඩු පිටු ඇති ගොනු උඩුගත කරන්න."
+"අමුණා ඇති ගොනුවලින් එකක අපට ක්‍රියාත්මක කළ හැකි ප්‍රමාණයට වඩා පිටු තිබේ. පිටු %1$s ක් හෝ ඊට අඩු "
+"පිටු ඇති ගොනු උඩුගත කරන්න."
 
 # smartling.placeholder_format=C
 #. Response a user can select in a feedback form, indicating that they heard about DuckDuckGo in an online article.
@@ -13058,9 +13242,7 @@ msgctxt "cloudsave"
 msgid ""
 "Only the settings that you have changed. They are detailed on the %sURL "
 "Parameters%s page."
-msgstr ""
-"ඔබ වෙනස් කර ඇති සැකසුම් පමණයි. ඒවා %1$sURL පරාමිතීන්%2$s පිටුවේ සවිස්තරව "
-"දක්වා ඇත."
+msgstr "ඔබ වෙනස් කර ඇති සැකසුම් පමණයි. ඒවා %1$sURL පරාමිතීන්%2$s පිටුවේ සවිස්තරව දක්වා ඇත."
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers only when the user clicks the Assist button.
@@ -13075,8 +13257,7 @@ msgid ""
 "Oops! An unexpected error occurred while translating this text. Please try "
 "again later."
 msgstr ""
-"අපොයි! මෙම පෙළ පරිවර්තනය කිරීමේදී අනපේක්ෂිත දෝෂයක් ඇතිවිය. කරුණාකර පසුව නැවත "
-"උත්සාහ කරන්න."
+"අපොයි! මෙම පෙළ පරිවර්තනය කිරීමේදී අනපේක්ෂිත දෝෂයක් ඇතිවිය. කරුණාකර පසුව නැවත උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. Title shown in a fatal error modal when Duck.ai fails to load.
@@ -13393,8 +13574,8 @@ msgid ""
 "Other search engines track your searches even when you’re in private "
 "browsing mode. We don’t track you &mdash; period."
 msgstr ""
-"ඔබ පුද්ගලික ගවේෂණ මාදිලියේ සිටියදී පවා වෙනත් සෙවුම් යන්ත්‍ර ඔබගේ සෙවීම් "
-"නිරීක්ෂණය කරයි. අපි ඔබව කාල පරිච්ඡේද — ක් නිරීක්ෂණය නොකරමු."
+"ඔබ පුද්ගලික ගවේෂණ මාදිලියේ සිටියදී පවා වෙනත් සෙවුම් යන්ත්‍ර ඔබගේ සෙවීම් නිරීක්ෂණය කරයි. අපි ඔබව "
+"කාල පරිච්ඡේද — ක් නිරීක්ෂණය නොකරමු."
 
 # smartling.placeholder_format=C
 msgctxt "SERP footer content"
@@ -13407,8 +13588,8 @@ msgid ""
 "Our privacy policy is simple: we don’t collect or share any of your personal "
 "information."
 msgstr ""
-"අපගේ පෞද්ගලිකත්වය සමිබන්ද ප්‍රතිපත්තිය සරලයි: අපි ඔබගේ පෞද්ගලික තොරතුරු එකතු "
-"කරන්නේ හෝ බෙදා හරින්නේ නැත."
+"අපගේ පෞද්ගලිකත්වය සමිබන්ද ප්‍රතිපත්තිය සරලයි: අපි ඔබගේ පෞද්ගලික තොරතුරු එකතු කරන්නේ හෝ බෙදා "
+"හරින්නේ නැත."
 
 # smartling.placeholder_format=C
 msgid ""
@@ -13416,9 +13597,8 @@ msgid ""
 "tracker blocker, encryption enforcer, and more. Available on %siOS & "
 "Android%s."
 msgstr ""
-"ජංගම දුරකථන සඳහා වන අපගේ පුද්ගලික බ්‍රවුසරය අපගේ සෙවුම් යාන්ත්‍රණය, නිරික්සු "
-"අවහිරකාරකය, ගුප්තකේතන බලාත්කාරකය හා තවත් දැයින් සන්නද්ධව තිබේ. %1$siOS & "
-"Android%2$sහි ලද හැක."
+"ජංගම දුරකථන සඳහා වන අපගේ පුද්ගලික බ්‍රවුසරය අපගේ සෙවුම් යාන්ත්‍රණය, නිරික්සු අවහිරකාරකය, "
+"ගුප්තකේතන බලාත්කාරකය හා තවත් දැයින් සන්නද්ධව තිබේ. %1$siOS & Android%2$sහි ලද හැක."
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the information was out of date.
@@ -13671,8 +13851,8 @@ msgid ""
 "Passphrases cannot be recovered as we don't associate your IP address, "
 "browser fingerprint, or any other information with the file."
 msgstr ""
-"අපි ඔබගේ IP ලිපිනය, බ්‍රව්සර් ඇඟිලි සලකුණු හෝ වෙනත් තොරතුරු ගොනුව සමඟ "
-"සම්බන්ධ නොකරන බැවින් මුරපද යථාවත් කර ගත නොහැක."
+"අපි ඔබගේ IP ලිපිනය, බ්‍රව්සර් ඇඟිලි සලකුණු හෝ වෙනත් තොරතුරු ගොනුව සමඟ සම්බන්ධ නොකරන බැවින් මුරපද "
+"යථාවත් කර ගත නොහැක."
 
 # smartling.placeholder_format=C
 #. Label for the section of recent chats that were edited in the past 7 days.
@@ -13866,10 +14046,9 @@ msgid ""
 "answers. To turn them off and hide the Assist button visit %sSearch "
 "Settings%s."
 msgstr ""
-"ඔබේ සෙවුම ප්‍රශ්නයක් ලෙසත් සම්පූර්ණ වාක්‍යයකින් ලියා ඇති විට AI-සහය සහිත "
-"පිළිතුරු ස්වයංක්‍රීයව දිස්වීමේ ඉඩකඩ වැඩි වන අතර බොහෝ විට හොඳ පිළිතුරු ලැබේ. "
-"ඒවා ක්‍රියා විරහිත කිරීමට සහ Assist බොත්තම සැඟවීමට %1$sසෙවුම් සැකසුම්%2$s "
-"වෙත පිවිසෙන්න."
+"ඔබේ සෙවුම ප්‍රශ්නයක් ලෙසත් සම්පූර්ණ වාක්‍යයකින් ලියා ඇති විට AI-සහය සහිත පිළිතුරු ස්වයංක්‍රීයව දිස්වීමේ "
+"ඉඩකඩ වැඩි වන අතර බොහෝ විට හොඳ පිළිතුරු ලැබේ. ඒවා ක්‍රියා විරහිත කිරීමට සහ Assist බොත්තම "
+"සැඟවීමට %1$sසෙවුම් සැකසුම්%2$s වෙත පිවිසෙන්න."
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -13878,10 +14057,9 @@ msgid ""
 "DuckAssist more likely to appear and often yields better answers. To adjust "
 "how this feature works, or to turn it off, visit %sDuckAssist Settings%s."
 msgstr ""
-"ඔබේ සෙවුම ප්‍රශ්නයක් ලෙස සහ සම්පූර්ණ වාක්‍යයක් තුළ වාක්‍ය කණ්ඩ කිරීමෙන් "
-"DuckAssist දිස්වීමට වැඩි ඉඩක් ඇති අතර බොහෝ විට වඩා හොඳ පිළිතුරු ලබා දෙයි. "
-"මෙම විශේෂාංගය ක්‍රියා කරන ආකාරය සකස් කිරීමට හෝ එය ක්‍රියා විරහිත "
-"කිරීමට,%1$sDuckAssist%2$s සැකසුම් වෙත පිවිසෙන්න."
+"ඔබේ සෙවුම ප්‍රශ්නයක් ලෙස සහ සම්පූර්ණ වාක්‍යයක් තුළ වාක්‍ය කණ්ඩ කිරීමෙන් DuckAssist දිස්වීමට වැඩි "
+"ඉඩක් ඇති අතර බොහෝ විට වඩා හොඳ පිළිතුරු ලබා දෙයි. මෙම විශේෂාංගය ක්‍රියා කරන ආකාරය සකස් "
+"කිරීමට හෝ එය ක්‍රියා විරහිත කිරීමට,%1$sDuckAssist%2$s සැකසුම් වෙත පිවිසෙන්න."
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -13891,10 +14069,9 @@ msgid ""
 "answers. To turn it off and hide the Assist button visit %sDuckAssist "
 "Settings%s."
 msgstr ""
-"ඔබේ සෙවුම ප්‍රශ්නයක් ලෙස සහ සම්පූර්ණ වාක්‍යයක් තුළ වාක්‍ය කණ්ඩ කිරීමෙන් "
-"DuckAssist දිස්වීමට වැඩි ඉඩක් ඇති අතර බොහෝ විට වඩා හොඳ පිළිතුරු ලබා දෙයි. එය "
-"නිවා දැමීමට සහ Assist බොත්තම සැඟවීමට %1$sDuckAssist සැකසුම්%2$s වෙත "
-"පිවිසෙන්න."
+"ඔබේ සෙවුම ප්‍රශ්නයක් ලෙස සහ සම්පූර්ණ වාක්‍යයක් තුළ වාක්‍ය කණ්ඩ කිරීමෙන් DuckAssist දිස්වීමට වැඩි "
+"ඉඩක් ඇති අතර බොහෝ විට වඩා හොඳ පිළිතුරු ලබා දෙයි. එය නිවා දැමීමට සහ Assist බොත්තම සැඟවීමට "
+"%1$sDuckAssist සැකසුම්%2$s වෙත පිවිසෙන්න."
 
 # smartling.placeholder_format=C
 #. Button that allows users to manually select a location on a map.
@@ -13927,8 +14104,7 @@ msgid ""
 "Pick a popular AI to chat with, like GPT-5 mini, Claude Haiku 4.5, Mistral, "
 "etc."
 msgstr ""
-"GPT-5 mini, Claude Haiku 4.5, Mistral වැනි ජනප්‍රිය AI එකක් සමඟ කතාබස් "
-"කිරීමට තෝරන්න."
+"GPT-5 mini, Claude Haiku 4.5, Mistral වැනි ජනප්‍රිය AI එකක් සමඟ කතාබස් කිරීමට තෝරන්න."
 
 # smartling.placeholder_format=C
 #. Describes the ability to choose from popular AI models. Pairs with a chat-bubble pictogram.
@@ -13937,8 +14113,7 @@ msgid ""
 "Pick a popular AI to chat with, like GPT-5 mini, Claude Haiku 4.5, "
 "Mistral, etc."
 msgstr ""
-"කතාබස් කිරීම සඳහා GPT-5 mini, Claude Haiku 4.5, Mistral වැනි ජනප්‍රිය AI "
-"එකක් තෝරන්න."
+"කතාබස් කිරීම සඳහා GPT-5 mini, Claude Haiku 4.5, Mistral වැනි ජනප්‍රිය AI එකක් තෝරන්න."
 
 # smartling.placeholder_format=C
 #. The description of the third party map app picker, shown on iOS when a user is given an option of which app to navigate to a destination with
@@ -13959,8 +14134,8 @@ msgstr "විශේෂ වූ ප්‍රශ්නයක් තෝරා ග�
 msgid ""
 "Pick your ad blocker and follow the instructions to allow ads on DuckDuckGo."
 msgstr ""
-"ඔබේ දැන්වීම් අවහිරකාරකය තෝරාගෙන DuckDuckGo හි දැන්වීම්වලට ඉඩ දීම සඳහා උපදෙස් "
-"අනුගමනය කරන්න."
+"ඔබේ දැන්වීම් අවහිරකාරකය තෝරාගෙන DuckDuckGo හි දැන්වීම්වලට ඉඩ දීම සඳහා උපදෙස් අනුගමනය "
+"කරන්න."
 
 # smartling.placeholder_format=C
 #. Text for a button that pins a chat, as in it will it will add the chat to the pinned chats list.
@@ -14030,9 +14205,7 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this prompt was made by a "
 "human."
-msgstr ""
-"මෙම සෙවුම මිනිසෙකු විසින් කරන ලද බව තහවුරු කිරීමට කරුණාකර පහත අභියෝගය "
-"සම්පූර්ණ කරන්න."
+msgstr "මෙම සෙවුම මිනිසෙකු විසින් කරන ලද බව තහවුරු කිරීමට කරුණාකර පහත අභියෝගය සම්පූර්ණ කරන්න."
 
 # smartling.placeholder_format=C
 #. Bot challenge explanation
@@ -14040,17 +14213,19 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this search was made by a "
 "human."
+msgstr "මෙම සෙවුම මිනිසෙකු විසින් කරන ලද බව තහවුරු කිරීමට කරුණාකර පහත අභියෝගය සම්පූර්ණ කරන්න."
+
+# smartling.placeholder_format=C
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
+msgctxt "Feedback prompt"
+msgid "Please describe why the chat response is harmful or illegal. (optional)"
 msgstr ""
-"මෙම සෙවුම මිනිසෙකු විසින් කරන ලද බව තහවුරු කිරීමට කරුණාකර පහත අභියෝගය "
-"සම්පූර්ණ කරන්න."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
-msgstr ""
-"කතාබස් ප්‍රතිචාරය නීතිවිරෝධී හෝ හානිකර වන්නේ මන්ද යන්න පැහැදිලි කරන්න. "
-"(විකල්ප)"
+msgstr "කතාබස් ප්‍රතිචාරය නීතිවිරෝධී හෝ හානිකර වන්නේ මන්ද යන්න පැහැදිලි කරන්න. (විකල්ප)"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to enter their passphrase.
@@ -14071,8 +14246,15 @@ msgid ""
 "Please note: starting a new chat with any model will delete your current "
 "chat session."
 msgstr ""
-"කරුණාකර සලකන්න: ඕනෑම ආකෘතියක් සමඟ නව චැට් ආරම්භ කිරීම ඔබේ වර්තමාන චැට් සැසිය "
-"මකා දමනු ඇත."
+"කරුණාකර සලකන්න: ඕනෑම ආකෘතියක් සමඟ නව චැට් ආරම්භ කිරීම ඔබේ වර්තමාන චැට් සැසිය මකා දමනු ඇත."
+
+# smartling.placeholder_format=C
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
+msgctxt "Feedback prompt"
+msgid ""
+"Please paste your prompt and the problematic output (with any personal "
+"information removed) and describe why the content is harmful or illegal."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -14081,8 +14263,8 @@ msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is illegal or harmful."
 msgstr ""
-"කරුණාකර ඔබේ පණිවිඩය සහ ගැටලුකාරී ප්‍රතිදානය (ඕනෑම පුද්ගලික තොරතුරක් ඉවත් කර) "
-"අලවා අන්තර්ගතය නීති විරෝධී හෝ හානිකර වන්නේ මන්දැ යි යන්න විස්තර කරන්න."
+"කරුණාකර ඔබේ පණිවිඩය සහ ගැටලුකාරී ප්‍රතිදානය (ඕනෑම පුද්ගලික තොරතුරක් ඉවත් කර) අලවා අන්තර්ගතය "
+"නීති විරෝධී හෝ හානිකර වන්නේ මන්දැ යි යන්න විස්තර කරන්න."
 
 # smartling.placeholder_format=C
 #. Title on a feedback form.
@@ -14540,6 +14722,12 @@ msgid "Privacy"
 msgstr "පෞද්ගලිකත්වය"
 
 # smartling.placeholder_format=C
+#. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
+msgctxt "Section heading on the Duck.ai settings page"
+msgid "Privacy & Terms"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Privacy Blog"
 msgstr "පෞද්ගලිකත්වය සම්බන්ධ බ්ලොගය"
 
@@ -14608,6 +14796,12 @@ msgstr "රහස්‍යතා ප්‍රතිපත්තිය සහ භ
 msgctxt "Copy used to compose link in sentences"
 msgid "Privacy Policy and Terms of Service"
 msgstr "රහස්‍යතා ප්‍රතිපත්තිය සහ සේවා නියම"
+
+# smartling.placeholder_format=C
+#. Text for a button that links to the terms of use and privacy policy page.
+msgctxt "Secondary button text in active privacy modal"
+msgid "Privacy Policy and Terms of Service"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title displayed on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
@@ -14824,8 +15018,8 @@ msgid ""
 "Provide a few suggestions to make the following text more concise. [Insert "
 "your own text here.]"
 msgstr ""
-"පහත දැක්වෙන පාඨය වඩාත් සංක්ෂිප්ත කිරීම සඳහා යෝජනා කිහිපයක් ලබා දෙන්න. [ඔබේම "
-"පෙළ මෙහි ඇතුලත් කරන්න.]"
+"පහත දැක්වෙන පාඨය වඩාත් සංක්ෂිප්ත කිරීම සඳහා යෝජනා කිහිපයක් ලබා දෙන්න. [ඔබේම පෙළ මෙහි "
+"ඇතුලත් කරන්න.]"
 
 # smartling.placeholder_format=C
 #. In the context of a standings table for NHL (hockey), column title that abbreviates 'Total Points' (the total points of this team)
@@ -15062,8 +15256,8 @@ msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
 msgstr ""
-"මෑත කාලීන කතාබස් DuckDuckGo සේවාදායකයන් හෝ වෙනත් දුරස්ථ සේවාදායකයන් මත "
-"වෙනුවට ඔබේ උපාංගයේ දේශීයව ගබඩා කර ඇත."
+"මෑත කාලීන කතාබස් DuckDuckGo සේවාදායකයන් හෝ වෙනත් දුරස්ථ සේවාදායකයන් මත වෙනුවට ඔබේ "
+"උපාංගයේ දේශීයව ගබඩා කර ඇත."
 
 # smartling.placeholder_format=C
 #. Text explaining that recent chats are stored locally on the user's device.
@@ -15072,8 +15266,8 @@ msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
 msgstr ""
-"මෑත කාලීන කතාබස් DuckDuckGo සේවාදායකයන් හෝ වෙනත් දුරස්ථ සේවාදායකයන් මත "
-"වෙනුවට ඔබේ උපාංගයේ දේශීයව ගබඩා කර ඇත."
+"මෑත කාලීන කතාබස් DuckDuckGo සේවාදායකයන් හෝ වෙනත් දුරස්ථ සේවාදායකයන් මත වෙනුවට ඔබේ "
+"උපාංගයේ දේශීයව ගබඩා කර ඇත."
 
 # smartling.placeholder_format=C
 #. Text explaining how recent chats are stored locally on the user's device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection.
@@ -15083,9 +15277,9 @@ msgid ""
 "are encrypted and temporarily stored on a DuckDuckGo server after being "
 "sent, to help recover a chat if you lose your internet connection."
 msgstr ""
-"මෑත කතාබස් ඔබගේ උපාංගයේ දේශීයව ගබඩා කර ඇත. ඔබගේ අන්තර්ජාල සම්බන්ධතාවය නැති "
-"වුවහොත් කතාබහක් නැවත ලබා ගැනීමට උපකාර කිරීම සඳහා, නව විමසීම් සහ ප්‍රතිචාර "
-"සංකේතනය කර යැවීමෙන් පසු තාවකාලිකව DuckDuckGo සේවාදායකයක ගබඩා කරනු ලැබේ."
+"මෑත කතාබස් ඔබගේ උපාංගයේ දේශීයව ගබඩා කර ඇත. ඔබගේ අන්තර්ජාල සම්බන්ධතාවය නැති වුවහොත් "
+"කතාබහක් නැවත ලබා ගැනීමට උපකාර කිරීම සඳහා, නව විමසීම් සහ ප්‍රතිචාර සංකේතනය කර යැවීමෙන් පසු "
+"තාවකාලිකව DuckDuckGo සේවාදායකයක ගබඩා කරනු ලැබේ."
 
 # smartling.placeholder_format=C
 msgctxt "region filter"
@@ -15107,6 +15301,30 @@ msgstr "%1$s%2$s%3$s සඳහා වට්ටෝරු"
 msgctxt "Brief for recommending a book"
 msgid "Recommend a book"
 msgstr "පොතක් නිර්දේශ කරන්න"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar books"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar books."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar movies or shows."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar titles"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
@@ -15178,9 +15396,7 @@ msgctxt "settings"
 msgid ""
 "Reduces extra space in and around results and reduces size of result title "
 "text"
-msgstr ""
-"ප්‍රතිඵල තුළ සහ අවට අමතර ඉඩ අඩු කරමින් ප්‍රතිඵල මාතෘකාවේ පෙළ ප්‍රමාණය අඩු "
-"කරයි"
+msgstr "ප්‍රතිඵල තුළ සහ අවට අමතර ඉඩ අඩු කරමින් ප්‍රතිඵල මාතෘකාවේ පෙළ ප්‍රමාණය අඩු කරයි"
 
 # smartling.placeholder_format=C
 #. Label for the input field where users specify how they want to be referred to. Example: 'Refer to me as John'
@@ -15321,8 +15537,8 @@ msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
 msgstr ""
-"උපදෙස් අනුගමනය කරමින් හෝ ඔබේ බ්‍රවුසරයේ &quot;Refresh&quot; හෝ "
-"&quot;Reload&quot; බොත්තම ක්ලික් කරමින් DuckDuckGo නැවත පූරණය කරන්න."
+"උපදෙස් අනුගමනය කරමින් හෝ ඔබේ බ්‍රවුසරයේ &quot;Refresh&quot; හෝ &quot;Reload&quot; "
+"බොත්තම ක්ලික් කරමින් DuckDuckGo නැවත පූරණය කරන්න."
 
 # smartling.placeholder_format=C
 #. checkbox label that allows the user to save the setting
@@ -15412,8 +15628,8 @@ msgid ""
 "Removes the \"Ask\" button so answers appear automatically in response to "
 "relevant searches. Cached answers always display automatically."
 msgstr ""
-"අදාළ සෙවීම් වලට ප්‍රතිචාර වශයෙන් පිළිතුරු ස්වයංක්‍රීයව දිස්වන පරිදි \"Ask\" "
-"බොත්තම ඉවත් කරයි. හැඹිලි සහිත පිළිතුරු සෑම විටම ස්වයංක්‍රීයව දර්ශනය වේ."
+"අදාළ සෙවීම් වලට ප්‍රතිචාර වශයෙන් පිළිතුරු ස්වයංක්‍රීයව දිස්වන පරිදි \"Ask\" බොත්තම ඉවත් කරයි. "
+"හැඹිලි සහිත පිළිතුරු සෑම විටම ස්වයංක්‍රීයව දර්ශනය වේ."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -15421,9 +15637,8 @@ msgid ""
 "Removes the \"Generate\" button so answers appear automatically in response "
 "to relevant searches. Cached answers always display automatically."
 msgstr ""
-"අදාළ සෙවීම් වලට ප්‍රතිචාර වශයෙන් පිළිතුරු ස්වයංක්‍රීයව දිස්වන පරිදි "
-"\"Generate\" බොත්තම ඉවත් කරයි. හැඹිලි සහිත පිළිතුරු සෑම විටම ස්වයංක්‍රීයව "
-"දර්ශනය වේ."
+"අදාළ සෙවීම් වලට ප්‍රතිචාර වශයෙන් පිළිතුරු ස්වයංක්‍රීයව දිස්වන පරිදි \"Generate\" බොත්තම ඉවත් "
+"කරයි. හැඹිලි සහිත පිළිතුරු සෑම විටම ස්වයංක්‍රීයව දර්ශනය වේ."
 
 # smartling.placeholder_format=C
 #. Text for a button to rename a chat, as in it will allow the user to change the title of the chat.
@@ -15481,9 +15696,9 @@ msgid ""
 "service. Your anonymous feedback is also shared with %s to help improve "
 "their services."
 msgstr ""
-"වාර්තා නිර්නාමික වන අතර අපගේ සෙවුම් සේවාව වැඩිදියුණු කිරීමට උදවු කිරීමට "
-"DuckDuckGo වෙත යවනු ලැබේ. ඔබේ නිර්නාමික ප්‍රතිපෝෂණය ඔවුන්ගේ සේවා වැඩිදියුණු "
-"කිරීමට උදවු කිරීමට %1$s සමඟ ද බෙදා ගනු ලැබේ."
+"වාර්තා නිර්නාමික වන අතර අපගේ සෙවුම් සේවාව වැඩිදියුණු කිරීමට උදවු කිරීමට DuckDuckGo වෙත යවනු "
+"ලැබේ. ඔබේ නිර්නාමික ප්‍රතිපෝෂණය ඔවුන්ගේ සේවා වැඩිදියුණු කිරීමට උදවු කිරීමට %1$s සමඟ ද බෙදා ගනු "
+"ලැබේ."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -15491,8 +15706,8 @@ msgid ""
 "Reports sent to DuckDuckGo are anonymous. Please do not include any personal "
 "or identifying information in your feedback."
 msgstr ""
-"DuckDuckGo වෙත යවන වාර්තා නිර්නාමික වේ. කරුණාකර ඔබේ ප්‍රතිචාරයේ කිසිදු "
-"පුද්ගලික හෝ හඳුනාගත හැකි තොරතුරු ඇතුළත් නොකරන්න."
+"DuckDuckGo වෙත යවන වාර්තා නිර්නාමික වේ. කරුණාකර ඔබේ ප්‍රතිචාරයේ කිසිදු පුද්ගලික හෝ හඳුනාගත "
+"හැකි තොරතුරු ඇතුළත් නොකරන්න."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -15501,13 +15716,22 @@ msgid ""
 "translate during this page load, and are anonymous. Please do not include "
 "any personal or identifying information in your feedback."
 msgstr ""
-"DuckDuckGo වෙත යවන වාර්තා වලට මෙම පිටු පැටවීමේදී ඔබ අපෙන් පරිවර්තනය කිරීමට "
-"ඉල්ලා ඇති සියලු පෙළ ඇතුළත් වන අතර, ඒවා නිර්නාමික වේ. කරුණාකර ඔබේ ප්‍රතිචාරයේ "
-"කිසිදු පුද්ගලික හෝ හඳුනාගත හැකි තොරතුරු ඇතුළත් නොකරන්න."
+"DuckDuckGo වෙත යවන වාර්තා වලට මෙම පිටු පැටවීමේදී ඔබ අපෙන් පරිවර්තනය කිරීමට ඉල්ලා ඇති සියලු "
+"පෙළ ඇතුළත් වන අතර, ඒවා නිර්නාමික වේ. කරුණාකර ඔබේ ප්‍රතිචාරයේ කිසිදු පුද්ගලික හෝ හඳුනාගත හැකි "
+"තොරතුරු ඇතුළත් නොකරන්න."
 
 # smartling.placeholder_format=C
 msgid "Republic of Moldova"
 msgstr "මෝල්ඩෝවා ජනරජය"
+
+# smartling.placeholder_format=C
+#. Note indicating that sharing the conversation is mandatory when reporting harmful or illegal content. Rendered alongside the standard share label (DUCKCHAT_RESPONSE_FEEDBACK_SHARE_PROMPT_RESPONSE_LABEL), not replacing it.
+msgctxt ""
+"Note shown under the share-content switch label on the Duck.ai response "
+"feedback form when the user has selected Harmful or Illegal as the feedback "
+"reason"
+msgid "Required for harmful or illegal reports"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
@@ -15574,9 +15798,8 @@ msgid ""
 "legal, financial, investment, or other professional advice. AI-assisted "
 "answers are subject to our %sTerms of Service%s."
 msgstr ""
-"ප්‍රතිචාර අධ්‍යාපනික අරමුණු සඳහා පමණක් වන අතර වෛද්‍ය, නීතිමය, මූල්‍ය, ආයෝජන "
-"හෝ වෙනත් වෘත්තීය උපදෙස් ලෙස අදහස් නොකෙරේ. AI-සහය සහිත පිළිතුරු අපගේ %1$sසේවා "
-"කොන්දේසි%2$s යටතේ පවතී."
+"ප්‍රතිචාර අධ්‍යාපනික අරමුණු සඳහා පමණක් වන අතර වෛද්‍ය, නීතිමය, මූල්‍ය, ආයෝජන හෝ වෙනත් වෘත්තීය "
+"උපදෙස් ලෙස අදහස් නොකෙරේ. AI-සහය සහිත පිළිතුරු අපගේ %1$sසේවා කොන්දේසි%2$s යටතේ පවතී."
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -15585,9 +15808,8 @@ msgid ""
 "legal, financial, investment, or other professional advice. DuckAssist is "
 "subject to our %sTerms of Service%s."
 msgstr ""
-"ප්‍රතිචාර අධ්‍යාපනික අරමුණු සඳහා පමණක් වන අතර වෛද්‍ය, නීතිමය, මූල්‍ය, ආයෝජන "
-"හෝ වෙනත් වෘත්තීය උපදෙස් ලෙස අදහස් නොකෙරේ. DuckAssist අපගේ %1$sසේවා "
-"කොන්දේසි%2$s යටතේ පවතී."
+"ප්‍රතිචාර අධ්‍යාපනික අරමුණු සඳහා පමණක් වන අතර වෛද්‍ය, නීතිමය, මූල්‍ය, ආයෝජන හෝ වෙනත් වෘත්තීය "
+"උපදෙස් ලෙස අදහස් නොකෙරේ. DuckAssist අපගේ %1$sසේවා කොන්දේසි%2$s යටතේ පවතී."
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -15597,10 +15819,9 @@ msgid ""
 "generated based on web content and may contain inaccuracies. Search Assist "
 "is subject to our %sTerms of Service%s."
 msgstr ""
-"ප්‍රතිචාර අධ්‍යාපනික අරමුණු සඳහා පමණක් වන අතර වෛද්‍ය, නීතිමය, මූල්‍ය, ආයෝජන "
-"හෝ වෙනත් වෘත්තීය උපදෙස් ලෙස අදහස් නොකෙරේ. ඒවා වෙබ් අන්තර්ගතය මත පදනම්ව ජනනය "
-"කර ඇති අතර සාවද්‍යතා අඩංගු විය හැක. Search Assist අපගේ %1$sසේවා කොන්දේසි%2$s "
-"යටතේ පවතී."
+"ප්‍රතිචාර අධ්‍යාපනික අරමුණු සඳහා පමණක් වන අතර වෛද්‍ය, නීතිමය, මූල්‍ය, ආයෝජන හෝ වෙනත් වෘත්තීය "
+"උපදෙස් ලෙස අදහස් නොකෙරේ. ඒවා වෙබ් අන්තර්ගතය මත පදනම්ව ජනනය කර ඇති අතර සාවද්‍යතා අඩංගු "
+"විය හැක. Search Assist අපගේ %1$sසේවා කොන්දේසි%2$s යටතේ පවතී."
 
 # smartling.placeholder_format=C
 #. Label on the button for restoring all previous website data.
@@ -15742,6 +15963,12 @@ msgstr "විචාර"
 msgctxt "maps_places"
 msgid "Reviews"
 msgstr "විචාර"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Rewrite this recipe scaled for a different number of servings."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Romania"
@@ -16013,8 +16240,8 @@ msgid ""
 "Save up to 30 of your most recent chats locally on your device, with the "
 "option for more with Encrypted Storage."
 msgstr ""
-"ගුප්ත කේතිත ආචයනය සමඟ තවත් බොහෝ දේ සඳහා විකල්පය සමඟින්, ඔබගේ උපාංගයේ ඔබගේ "
-"මෑත කාලීන කතාබස් 30ක් දක්වා ස්ථානීයව සුරකින්න."
+"ගුප්ත කේතිත ආචයනය සමඟ තවත් බොහෝ දේ සඳහා විකල්පය සමඟින්, ඔබගේ උපාංගයේ ඔබගේ මෑත කාලීන "
+"කතාබස් 30ක් දක්වා ස්ථානීයව සුරකින්න."
 
 # smartling.placeholder_format=C
 #. Short text for native DDG browser users explaining how Chat History stores up to 30 of their most recent chats locally on their device.
@@ -16157,8 +16384,8 @@ msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)"
 msgstr ""
-"පහලට අනුචලනය කර %1$sSearch in the address bar%2$s සොයන්න. ඉන්පසු "
-"%3$sChange%4$s ක්ලික් කරන්න (හෝ %5$sAdd new%6$s)"
+"පහලට අනුචලනය කර %1$sSearch in the address bar%2$s සොයන්න. ඉන්පසු %3$sChange%4$s "
+"ක්ලික් කරන්න (හෝ %5$sAdd new%6$s)"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
@@ -16167,8 +16394,8 @@ msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)."
 msgstr ""
-"පහලට අනුචලනය කර %1$sලිපින තීරුව සොයන්න%2$s සොයා ගන්න. %3$sවෙනස් කරන්න%4$s මත "
-"ක්ලික් කරන්න (හෝ %5$sඅළුතින්%6$s එකතු කරන්න)."
+"පහලට අනුචලනය කර %1$sලිපින තීරුව සොයන්න%2$s සොයා ගන්න. %3$sවෙනස් කරන්න%4$s මත ක්ලික් කරන්න "
+"(හෝ %5$sඅළුතින්%6$s එකතු කරන්න)."
 
 # smartling.placeholder_format=C
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -16240,13 +16467,12 @@ msgid ""
 "(on a wide range of searches). For now, Search Assist is only available in a "
 "subset of English speaking regions."
 msgstr ""
-"Search Assist යනු සෙවුම් විමසුම් සඳහා නිර්නාමිකව පිළිතුරු ජනනය කරන "
-"විශේෂාංගයකි. මෙය සිදු කිරීම සඳහා, එය අදාළ අන්තර්ගතයන් සඳහා වෙබ් ස්කෑන් කරන "
-"අතර පසුව කෙටි පිළිතුරක් ජනනය කිරීම සඳහා AI භාවිත කරයි. ඔබට එය කොපමණ වාර "
-"ගණනක් පෙනී සිටීමට අවශ්‍යද යන්න තෝරා ගත හැක: කිසි විටෙකත්, ඉල්ලූ-විට (Assist "
-"ක්ලික් කළ විට පමණක්), සමහර විට (දැඩිව අදාළ වන විට), හෝ බොහෝ විට (පුළුල් "
-"පරාසයක සෙවුම් මත). දැනට, Search Assist ලබා ගත හැක්කේ ඉංග්‍රීසි කතා කරන "
-"කලාපවල උප කණ්ඩායමක පමණි."
+"Search Assist යනු සෙවුම් විමසුම් සඳහා නිර්නාමිකව පිළිතුරු ජනනය කරන විශේෂාංගයකි. මෙය සිදු කිරීම "
+"සඳහා, එය අදාළ අන්තර්ගතයන් සඳහා වෙබ් ස්කෑන් කරන අතර පසුව කෙටි පිළිතුරක් ජනනය කිරීම සඳහා AI "
+"භාවිත කරයි. ඔබට එය කොපමණ වාර ගණනක් පෙනී සිටීමට අවශ්‍යද යන්න තෝරා ගත හැක: කිසි විටෙකත්, "
+"ඉල්ලූ-විට (Assist ක්ලික් කළ විට පමණක්), සමහර විට (දැඩිව අදාළ වන විට), හෝ බොහෝ විට (පුළුල් "
+"පරාසයක සෙවුම් මත). දැනට, Search Assist ලබා ගත හැක්කේ ඉංග්‍රීසි කතා කරන කලාපවල උප "
+"කණ්ඩායමක පමණි."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI) when the answer is not found and the answer is unsourced or with no sources
@@ -16254,8 +16480,8 @@ msgid ""
 "Search Assist couldn't find enough reliable information to generate an "
 "answer for this question. Try another search."
 msgstr ""
-"මෙම ප්‍රශ්නය සඳහා පිළිතුරක් උත්පාදනය කිරීම සඳහා ප්‍රමාණවත් විශ්වාසදායක "
-"තොරතුරු සොයාගැනීමට Search Assist හට නොහැකි විය. තවත් සෙවීමක් කරන්න."
+"මෙම ප්‍රශ්නය සඳහා පිළිතුරක් උත්පාදනය කිරීම සඳහා ප්‍රමාණවත් විශ්වාසදායක තොරතුරු සොයාගැනීමට "
+"Search Assist හට නොහැකි විය. තවත් සෙවීමක් කරන්න."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -16264,10 +16490,9 @@ msgid ""
 "search queries. To do this, it %sscans the web%s for relevant content and "
 "then uses AI to generate a brief answer based on information found."
 msgstr ""
-"Search Assist යනු නිර්නාමිකව සෙවුම් විමසුම් සඳහා පිළිතුරු ජනනය කරන විකල්ප "
-"විශේෂාංගයකි. %1$sමෙය%2$s සිදු කිරීම සඳහා, එය අදාළ අන්තර්ගතය සඳහා වෙබ් ස්කෑන් "
-"කර පසුව සොයාගත් තොරතුරු මත පදනම්ව කෙටි පිළිතුරක් ජනනය කිරීම සඳහා AI භාවිත "
-"කරයි."
+"Search Assist යනු නිර්නාමිකව සෙවුම් විමසුම් සඳහා පිළිතුරු ජනනය කරන විකල්ප විශේෂාංගයකි. "
+"%1$sමෙය%2$s සිදු කිරීම සඳහා, එය අදාළ අන්තර්ගතය සඳහා වෙබ් ස්කෑන් කර පසුව සොයාගත් තොරතුරු "
+"මත පදනම්ව කෙටි පිළිතුරක් ජනනය කිරීම සඳහා AI භාවිත කරයි."
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/search_box. top header
@@ -16388,8 +16613,8 @@ msgid ""
 "Search other sites with %s shortcuts: a search for ”!w ducks” will search "
 "for “ducks” directly on Wikipedia."
 msgstr ""
-"%1$s කෙටිමං භාවිතයෙන් වෙනත් අඩවි සොයන්න: ”!w ducks” සෙවීමකින් විකිපීඩියාවේ "
-"“ducks” සෘජුවම සොයාගත හැක."
+"%1$s කෙටිමං භාවිතයෙන් වෙනත් අඩවි සොයන්න: ”!w ducks” සෙවීමකින් විකිපීඩියාවේ “ducks” සෘජුවම "
+"සොයාගත හැක."
 
 # smartling.placeholder_format=C
 #. Placeholder text for the search form when no text has been entered
@@ -16408,8 +16633,8 @@ msgid ""
 "Search privately with our app or extension, add private web search to your "
 "favorite browser, or search directly at %sduckduckgo.com%s."
 msgstr ""
-"අපගේ යෙදුම හෝ දිගුව භාවිතයෙන් සොයන්න, ඔබේ ප්‍රියතම බ්‍රවුසරයට පුද්ගලික වෙබ් "
-"සෙවුම එක් කරන්න, නැතහොත් %1$sduckduckgo.com%2$s වෙතින් ඍජුවම සෙවීම් කරන්න."
+"අපගේ යෙදුම හෝ දිගුව භාවිතයෙන් සොයන්න, ඔබේ ප්‍රියතම බ්‍රවුසරයට පුද්ගලික වෙබ් සෙවුම එක් කරන්න, "
+"නැතහොත් %1$sduckduckgo.com%2$s වෙතින් ඍජුවම සෙවීම් කරන්න."
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/6LZAoqH.png
@@ -16417,8 +16642,7 @@ msgctxt "settings"
 msgid ""
 "Search queries are included in URL (if off, searches will use POST requests)"
 msgstr ""
-"සෙවුම් විමසුම් URL එකෙහි අන්තර්ගතයි (සංවෘත කර ඇත්නම්, සෙවුම් POST ඉල්ලීම් "
-"භාවිතා කරනු ඇත)"
+"සෙවුම් විමසුම් URL එකෙහි අන්තර්ගතයි (සංවෘත කර ඇත්නම්, සෙවුම් POST ඉල්ලීම් භාවිතා කරනු ඇත)"
 
 # smartling.placeholder_format=C
 #. Describes how cookies are used to store user settings privately and securely.
@@ -16430,11 +16654,10 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"සෙවුම් සැකසුම් ඔබේ බ්‍රව්සරයේ පුද්ගලික නොවන බ්‍රව්සර් කුකීස් සහ අභ්‍යන්තර "
-"ගබඩා තුළ ගබඩා කර ඇත, නමුත් ඔබට ඔබගේ සැකසුම් නිර්නාමිකව ක්ලවුඩයේ ඇති දුරස්ථ "
-"සර්වරයක ගබඩා කිරීමට Cloud Save භාවිත කළ හැක. පුද්ගලිකව හඳුනාගත හැකි තොරතුරු "
-"ක්ලවුඩය තුළ ගබඩා නොවන අතර, ඔබේ මුරපදය කිසි විටෙකත් ඔබේ බ්‍රව්සරයෙන් ඉවත් "
-"නොවේ."
+"සෙවුම් සැකසුම් ඔබේ බ්‍රව්සරයේ පුද්ගලික නොවන බ්‍රව්සර් කුකීස් සහ අභ්‍යන්තර ගබඩා තුළ ගබඩා කර ඇත, "
+"නමුත් ඔබට ඔබගේ සැකසුම් නිර්නාමිකව ක්ලවුඩයේ ඇති දුරස්ථ සර්වරයක ගබඩා කිරීමට Cloud Save භාවිත "
+"කළ හැක. පුද්ගලිකව හඳුනාගත හැකි තොරතුරු ක්ලවුඩය තුළ ගබඩා නොවන අතර, ඔබේ මුරපදය කිසි විටෙකත් "
+"ඔබේ බ්‍රව්සරයෙන් ඉවත් නොවේ."
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -16531,8 +16754,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
 msgstr ""
-"මුල සිට අග දක්වා ම සංකේතනය භාවිතා කර අපගේ සේවාදායකයේ සීමාවක් නැති කතාබස් "
-"ආරක්ෂිතව ගබඩා කර, ඔබේ සියලුම උපාංගවලින් ඒවාට ප්‍රවේශ වෙන්න."
+"මුල සිට අග දක්වා ම සංකේතනය භාවිතා කර අපගේ සේවාදායකයේ සීමාවක් නැති කතාබස් ආරක්ෂිතව ගබඩා "
+"කර, ඔබේ සියලුම උපාංගවලින් ඒවාට ප්‍රවේශ වෙන්න."
 
 # smartling.placeholder_format=C
 #. Text explaining that the Encrypted Storage feature stores the user's chats encrypted on their device.
@@ -16541,8 +16764,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
 msgstr ""
-"මුල සිට අග දක්වා ම සංකේතනය භාවිතා කර අපගේ සේවාදායකයේ සීමාවක් නැති කතාබස් "
-"ආරක්ෂිතව ගබඩා කර, ඔබේ සියලුම උපාංගවලින් ඒවාට ප්‍රවේශ වෙන්න."
+"මුල සිට අග දක්වා ම සංකේතනය භාවිතා කර අපගේ සේවාදායකයේ සීමාවක් නැති කතාබස් ආරක්ෂිතව ගබඩා "
+"කර, ඔබේ සියලුම උපාංගවලින් ඒවාට ප්‍රවේශ වෙන්න."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -16551,8 +16774,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your synced devices."
 msgstr ""
-"මුල සිට අග දක්වා ම සංකේතනය භාවිත කර අපගේ සේවාදායකයේ සීමාවක් නැති කතාබස් "
-"ආරක්ෂිතව ගබඩා කර, ඔබ සමකාලීන කරන ලද සියලුම උපාංගවලින් ඒවාට ප්‍රවේශ වන්න."
+"මුල සිට අග දක්වා ම සංකේතනය භාවිත කර අපගේ සේවාදායකයේ සීමාවක් නැති කතාබස් ආරක්ෂිතව ගබඩා "
+"කර, ඔබ සමකාලීන කරන ලද සියලුම උපාංගවලින් ඒවාට ප්‍රවේශ වන්න."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -16561,8 +16784,8 @@ msgid ""
 "Securely store your chats on our server using end-to-end encryption, and "
 "access them from all your devices."
 msgstr ""
-"මුල සිට අග දක්වා ම සංකේතනය භාවිත කර ඔබේ කතාබස් ආරක්ෂිතව අපගේ සේවාදායකයේ ගබඩා "
-"කර, ඔබේ සියලුම උපාංගවලින් ඒවාට ප්‍රවේශ වන්න."
+"මුල සිට අග දක්වා ම සංකේතනය භාවිත කර ඔබේ කතාබස් ආරක්ෂිතව අපගේ සේවාදායකයේ ගබඩා කර, "
+"ඔබේ සියලුම උපාංගවලින් ඒවාට ප්‍රවේශ වන්න."
 
 # smartling.placeholder_format=C
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
@@ -16577,8 +16800,8 @@ msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
 msgstr ""
-"DuckDuckGo සර්වරයේ මුල සිට අග දක්වා ගුප්ත කේතනය සමඟ ආරක්ෂිතව ගබඩා කර ඇත. ඔබට "
-"හැර වෙන කිසිවෙකුට ඔබගේ දත්ත දැකිය නොහැක, අපටවත් නොවේ."
+"DuckDuckGo සර්වරයේ මුල සිට අග දක්වා ගුප්ත කේතනය සමඟ ආරක්ෂිතව ගබඩා කර ඇත. ඔබට හැර වෙන "
+"කිසිවෙකුට ඔබගේ දත්ත දැකිය නොහැක, අපටවත් නොවේ."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -16796,8 +17019,8 @@ msgstr ""
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sOpera > Options%s (on Windows)"
 msgstr ""
-"%1$sOpera > Preferences%2$s (මැක් වල) හෝ %3$sOpera > Options%4$s (වින්ඩෝව්ස් "
-"වල) තෝරන්න"
+"%1$sOpera > Preferences%2$s (මැක් වල) හෝ %3$sOpera > Options%4$s (වින්ඩෝව්ස් වල) "
+"තෝරන්න"
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -16862,8 +17085,8 @@ msgid ""
 "Select %sUse this webpage as your only home page%s (or one of the other "
 "options if you prefer)"
 msgstr ""
-"%1$sUse this webpage as your only home page%2$s තෝරන්න (හෝ ඔබ කැමතිනම් "
-"අනෙකුත් විකල්ප වලින් එකක් තෝරන්න)"
+"%1$sUse this webpage as your only home page%2$s තෝරන්න (හෝ ඔබ කැමතිනම් අනෙකුත් "
+"විකල්ප වලින් එකක් තෝරන්න)"
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
@@ -16985,8 +17208,8 @@ msgid ""
 "respond. These instructions will apply to all of your conversations going "
 "forward."
 msgstr ""
-"ඔබේ පණිවිඩ සහ ප්‍රතිචාර දැක්විය යුතු ආකාරය පිළිබඳ උපදෙස් සමඟ AI ආකෘති වෙත "
-"විමසුමක් යවයි. මෙම උපදෙස් ඔබේ සියලුම සංවාද සඳහා ඉදිරියට අදාළ වනු ඇත."
+"ඔබේ පණිවිඩ සහ ප්‍රතිචාර දැක්විය යුතු ආකාරය පිළිබඳ උපදෙස් සමඟ AI ආකෘති වෙත විමසුමක් යවයි. මෙම "
+"උපදෙස් ඔබේ සියලුම සංවාද සඳහා ඉදිරියට අදාළ වනු ඇත."
 
 # smartling.placeholder_format=C
 msgid "Senegal"
@@ -17062,6 +17285,12 @@ msgid "Set Up Now"
 msgstr "දැන් සකසන්න"
 
 # smartling.placeholder_format=C
+#. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
+msgctxt "Encrypted storage setup button shown in native browsers"
+msgid "Set Up Sync & Backup"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
 msgctxt "Title for the Sync & Backup intro screen"
 msgid "Set Up Sync & Backup"
@@ -17090,8 +17319,8 @@ msgid ""
 "Set up Sync & Backup after turning on Chat History to keep your chats synced "
 "across devices."
 msgstr ""
-"ඔබේ කතාබස් උපාංග අතර සමමුහුර්තව තබා ගැනීමට කතාබස් ඉතිහාසය ක්‍රියාත්මක "
-"කිරීමෙන් පසු Sync & Backup පිහිටුුවන්න."
+"ඔබේ කතාබස් උපාංග අතර සමමුහුර්තව තබා ගැනීමට කතාබස් ඉතිහාසය ක්‍රියාත්මක කිරීමෙන් පසු Sync & "
+"Backup පිහිටුුවන්න."
 
 # smartling.placeholder_format=C
 #. Prompt for the user to indicate their location on a map, to enable more relevant search results.
@@ -17178,8 +17407,8 @@ msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
 msgstr ""
-"අදාළත්වය වැඩි දියුණු කිරීම සඳහා AI ආකෘති සමඟ නගර මට්ටමේ ස්ථානයක් බෙදා ගන්න. "
-"Duck.ai කිසි විටෙකත් ඔබේ නිශ්චිත ස්ථානය අපට හෝ AI ආකෘතිවලට හෙළි නොකරයි."
+"අදාළත්වය වැඩි දියුණු කිරීම සඳහා AI ආකෘති සමඟ නගර මට්ටමේ ස්ථානයක් බෙදා ගන්න. Duck.ai කිසි "
+"විටෙකත් ඔබේ නිශ්චිත ස්ථානය අපට හෝ AI ආකෘතිවලට හෙළි නොකරයි."
 
 # smartling.placeholder_format=C
 #. Menu option to share feedback about a result
@@ -17240,6 +17469,13 @@ msgid "Share positive feedback"
 msgstr "ධනාත්මක ප්‍රතිපෝෂණ බෙදා ගන්න"
 
 # smartling.placeholder_format=C
+#. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
+msgctxt ""
+"Label beside the share-content switch on the Duck.ai response feedback form"
+msgid "Share this conversation with DuckDuckGo"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
 msgctxt ""
 "Label beside the share-content switch on the Duck.ai response feedback form"
@@ -17255,8 +17491,8 @@ msgid ""
 "Share your prompt and chat response with DuckDuckGo (required for illegal "
 "and harmful report)"
 msgstr ""
-"ඔබේ කඩිනම් සහ කතාබස් ප්‍රතිචාරය DuckDuckGo සමග බෙදා ගන්න (නීති විරෝධී සහ "
-"හානිකර වාර්තා සඳහා අවශ්‍ය වේ)"
+"ඔබේ කඩිනම් සහ කතාබස් ප්‍රතිචාරය DuckDuckGo සමග බෙදා ගන්න (නීති විරෝධී සහ හානිකර වාර්තා "
+"සඳහා අවශ්‍ය වේ)"
 
 # smartling.placeholder_format=C
 #. An invitation for users to leave feedback
@@ -17377,8 +17613,7 @@ msgstr "DuckAssist <sup>BETA</sup> පෙන්වන්න"
 msgctxt "duckassist_optin"
 msgid "Show DuckAssist more often. (You can also completely %sturn it off%s.)"
 msgstr ""
-"DuckAssist නිතර නිතර පෙන්වන්න. (ඔබට සම්පූර්ණයෙන්ම %1$sඑය ක්‍රියා විරහිත "
-"කිරීමටද%2$s හැකිය.)"
+"DuckAssist නිතර නිතර පෙන්වන්න. (ඔබට සම්පූර්ණයෙන්ම %1$sඑය ක්‍රියා විරහිත කිරීමටද%2$s හැකිය.)"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
@@ -17604,8 +17839,8 @@ msgid ""
 "Shows a reminder that searches on DuckDuckGo are always private. Turning "
 "this off hides the reminder and never affects search privacy."
 msgstr ""
-"DuckDuckGo හි සෙවීම් සැමවිටම පුද්ගලික බව මතක් කිරීමක් පෙන්වයි. මෙය අක්‍රිය "
-"කිරීම මතක් කිරීම සඟවයි සහ සෙවුම් පෞද්ගලිකත්වයට කිසි විටෙකත් බලපාන්නේ නැත."
+"DuckDuckGo හි සෙවීම් සැමවිටම පුද්ගලික බව මතක් කිරීමක් පෙන්වයි. මෙය අක්‍රිය කිරීම මතක් කිරීම සඟවයි "
+"සහ සෙවුම් පෞද්ගලිකත්වයට කිසි විටෙකත් බලපාන්නේ නැත."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -17613,8 +17848,8 @@ msgid ""
 "Shows a reminder that searches on DuckDuckGo are always protected. Turning "
 "this off hides the reminder and never affects search protection."
 msgstr ""
-"DuckDuckGo හි සෙවීම් සැමවිටම ආරක්ෂිත බව මතක් කිරීමක් පෙන්වයි. මෙය අක්‍රිය "
-"කිරීම මතක් කිරීම සඟවන අතර සෙවුම් ආරක්ෂාවට කිසි විටෙකත් බලපාන්නේ නැත."
+"DuckDuckGo හි සෙවීම් සැමවිටම ආරක්ෂිත බව මතක් කිරීමක් පෙන්වයි. මෙය අක්‍රිය කිරීම මතක් කිරීම සඟවන "
+"අතර සෙවුම් ආරක්ෂාවට කිසි විටෙකත් බලපාන්නේ නැත."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -17652,8 +17887,7 @@ msgctxt "settings"
 msgid ""
 "Shows occasional reminders to sign up for the DuckDuckGo privacy newsletters"
 msgstr ""
-"DuckDuckGo පෞදගලිකත්වය සම්බන්ධ පුවත් ලිපි සඳහා ලියපදිංචිය ඉඳහිට මතක් කරන "
-"පණිවුඩ පෙන්වන්න"
+"DuckDuckGo පෞදගලිකත්වය සම්බන්ධ පුවත් ලිපි සඳහා ලියපදිංචිය ඉඳහිට මතක් කරන පණිවුඩ පෙන්වන්න"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -17974,8 +18208,7 @@ msgid ""
 "Sorry, the uploaded image couldn't be processed. Please try a different "
 "image or format."
 msgstr ""
-"කනගාටුයි, උඩුගත කළ රූපය සැකසිය නොහැකි විය. කරුණාකර වෙනස් රූපයක් හෝ ආකෘතියක් "
-"උත්සාහ කරන්න."
+"කනගාටුයි, උඩුගත කළ රූපය සැකසිය නොහැකි විය. කරුණාකර වෙනස් රූපයක් හෝ ආකෘතියක් උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. Body copy shown when a scanned or pasted pairing payload fails schema validation.
@@ -17984,16 +18217,16 @@ msgid ""
 "Sorry, this code is invalid. Please make sure the correct code was entered "
 "or scanned."
 msgstr ""
-"කනගාටුයි, මෙම කේතය අවලංගු වේ. කරුණාකර නිවැරදි කේතය ඇතුළත් කර හෝ ස්කෑන් කර "
-"ඇති බවට වග බලා ගන්න."
+"කනගාටුයි, මෙම කේතය අවලංගු වේ. කරුණාකර නිවැරදි කේතය ඇතුළත් කර හෝ ස්කෑන් කර ඇති බවට වග "
+"බලා ගන්න."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
 msgid ""
 "Sorry, we couldn't generate a richer answer. You can try asking Duck.ai."
 msgstr ""
-"කණගාටුයි, අපට වඩාත් පොහොසත් පිළිතුරක් නිර්මාණය කරන්නට නොහැකි විය. ඔබට "
-"Duck.ai එකෙන් අහන්න උත්සාහ කළ හැක."
+"කණගාටුයි, අපට වඩාත් පොහොසත් පිළිතුරක් නිර්මාණය කරන්නට නොහැකි විය. ඔබට Duck.ai එකෙන් අහන්න "
+"උත්සාහ කළ හැක."
 
 # smartling.placeholder_format=C
 #. Inform the users that "something" went wrong and that they could try to refresh the page to resolve the error. Placeholders are for markup, please ignore.
@@ -18002,16 +18235,15 @@ msgid ""
 "Sorry, we ran into an error displaying these results. %sClick here%s to try "
 "again."
 msgstr ""
-"කණගාටුයි, මෙම ප්‍රතිඵල පෙන්වීමේදී අපට දෝෂයක් ඇති විය. නැවත උත්සාහ "
-"කිරීමට%1$sමෙහි ක්ලික් කරන්න%2$s ."
+"කණගාටුයි, මෙම ප්‍රතිඵල පෙන්වීමේදී අපට දෝෂයක් ඇති විය. නැවත උත්සාහ කිරීමට%1$sමෙහි ක්ලික් "
+"කරන්න%2$s ."
 
 # smartling.placeholder_format=C
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
 msgstr ""
-"සමාවන්න, අපට ඔබේ ප්‍රතිපෝෂණ ඉදිරිපත් කිරීමට නොහැකි විය. කරුණාකර පසුව නැවත "
-"උත්සාහ කරන්න."
+"සමාවන්න, අපට ඔබේ ප්‍රතිපෝෂණ ඉදිරිපත් කිරීමට නොහැකි විය. කරුණාකර පසුව නැවත උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -18409,8 +18641,8 @@ msgid ""
 "Subscribe to DuckDuckGo to unlock higher limits in Duck.ai, or come back "
 "later to create more images."
 msgstr ""
-"Duck.ai තුළ ඇති ඉහළ සීමාවන් අගුළු හැර ගැනීමට DuckDuckGo වෙත ග්‍රාහකත්වය "
-"ලබාගන්න, නැතහොත් තවත් රූප නිර්මාණය කිරීමට පසුව නැවත එන්න."
+"Duck.ai තුළ ඇති ඉහළ සීමාවන් අගුළු හැර ගැනීමට DuckDuckGo වෙත ග්‍රාහකත්වය ලබාගන්න, නැතහොත් "
+"තවත් රූප නිර්මාණය කිරීමට පසුව නැවත එන්න."
 
 # smartling.placeholder_format=C
 #. Description shown to free users who have reached their image generation limit, encouraging them to subscribe.
@@ -18478,15 +18710,31 @@ msgctxt "Full sentence for composing a card"
 msgid ""
 "Suggest a phrase to write on a get-well card for someone recovering from a "
 "surgery?"
-msgstr ""
-"සැත්කමකින් සුවය ලැබූ කෙනෙකුට get-well කාඩ්පතක ලිවීමට වාක්ය ඛණ්ඩයක් යෝජනා "
-"කරනවාද?"
+msgstr "සැත්කමකින් සුවය ලැබූ කෙනෙකුට get-well කාඩ්පතක ලිවීමට වාක්ය ඛණ්ඩයක් යෝජනා කරනවාද?"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for asking for a suggestion of a blog post title.
 msgctxt "Brief for suggesting a blog post title"
 msgid "Suggest a title for a blog post"
 msgstr "බ්ලොග් සටහනක් සඳහා මාතෘකාවක් යෝජනා කරන්න"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest related articles or topics worth exploring next."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Suggest related articles to explore"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest some alternatives to this product."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
@@ -18500,10 +18748,100 @@ msgid "Suggestions:"
 msgstr "යෝජනා:"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Sum up the reviews"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A short title for the a message asking the AI to summarize a text.
 msgctxt "Title for the summarize message"
 msgid "Summarize"
 msgstr "සාරාංශ කරන්න"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize the Q&As"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the background and notable work of this person."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the key details of this event."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the questions and answers on this page."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize their background"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this book"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this book."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this discussion"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this discussion thread."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this page"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this page."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this video"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this video."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize what the reviews say."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -18664,9 +19002,7 @@ msgstr "ඔබ ගැන අනවසරයෙන් පරික්ෂා න�
 msgctxt "AI Chat warning when switching from an encrypted model"
 msgid ""
 "Switching will send your chat to a model without zero provider visibility"
-msgstr ""
-"ආකෘතිය මාරු කිරීමෙන්, ඔබේ කතාබහ සපයන්නාගේ දෘශ්‍යතාව ශුන්‍ය නොවන ආකෘතියකට "
-"යවනු ඇත"
+msgstr "ආකෘතිය මාරු කිරීමෙන්, ඔබේ කතාබහ සපයන්නාගේ දෘශ්‍යතාව ශුන්‍ය නොවන ආකෘතියකට යවනු ඇත"
 
 # smartling.placeholder_format=C
 msgid "Switzerland"
@@ -18721,8 +19057,7 @@ msgstr "Sync & Backup සක්‍රිය කරන ලදී!"
 msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
-"Sync & Backup දත්ත මාස 18ක කාලයක් තිස්සේ අකර්මණ්‍යව තිබූ පසු ඒවා ප්‍රතිසාධනය "
-"කළ නොහැක."
+"Sync & Backup දත්ත මාස 18ක කාලයක් තිස්සේ අකර්මණ්‍යව තිබූ පසු ඒවා ප්‍රතිසාධනය කළ නොහැක."
 
 # smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
@@ -18771,9 +19106,9 @@ msgid ""
 msgstr ""
 "ප්‍රතිසාධන කේතය සමමුහුර්ත කරන්න\n"
 "\n"
-"ප්‍රතිසාධන කේතය මඟින් ඔබේ මුරපද, ස්වයංක්‍රීය පිරවීම් දත්ත සහ Duck.ai කතාබස් "
-"උපාංග කිහිපයක් අතර සමමුහුර්ත කිරීමට ඉඩ සලසන අතර, උපාංගයකට ප්‍රවේශය අහිමි "
-"වුවහොත් ඔබේ සමමුහුර්ත දත්ත ප්‍රතිසාධනය කර ගනී.\n"
+"ප්‍රතිසාධන කේතය මඟින් ඔබේ මුරපද, ස්වයංක්‍රීය පිරවීම් දත්ත සහ Duck.ai කතාබස් උපාංග කිහිපයක් අතර "
+"සමමුහුර්ත කිරීමට ඉඩ සලසන අතර, උපාංගයකට ප්‍රවේශය අහිමි වුවහොත් ඔබේ සමමුහුර්ත දත්ත ප්‍රතිසාධනය "
+"කර ගනී.\n"
 "\n"
 "මෙම තොරතුරු ආරක්ෂිතව තබා ගන්න.\n"
 "මෙම කේතයට ප්‍රවේශය ඇති ඕනෑම අයෙකුට ඔබේ සමමුහුර්ත දත්ත වෙත ප්‍රවේශ විය හැක.\n"
@@ -18782,14 +19117,12 @@ msgstr ""
 "\n"
 "මෙම කේතය ක්‍රියා කරන්නේ කෙසේ ද?\n"
 "1. ඔබේ බ්‍රවුසරයෙන් Duck.ai වෙත ගොස් Duck.ai සැකසුම් විවෘත කරන්න.\n"
-"2. \"Sync & Backup සක්‍රීය කරන්න, තෝරා, ඉන්පසු \"සමමුහුර්ත දත්ත ප්‍රතිසාධනය "
-"කරන්න\" තෝරන්න\n"
-"3. ඉහත ප්‍රතිසාධන කේතය පිටපත් කර \"මෙහි ඔබේ කේතය අලවන්න\" යනුවෙන් දැක්වෙන "
-"ස්ථානයේ අලවන්න\n"
+"2. \"Sync & Backup සක්‍රීය කරන්න, තෝරා, ඉන්පසු \"සමමුහුර්ත දත්ත ප්‍රතිසාධනය කරන්න\" තෝරන්න\n"
+"3. ඉහත ප්‍රතිසාධන කේතය පිටපත් කර \"මෙහි ඔබේ කේතය අලවන්න\" යනුවෙන් දැක්වෙන ස්ථානයේ "
+"අලවන්න\n"
 "\n"
-"ඔබ DuckDuckGo බ්‍රවුසරය Sync & Backup සක්‍රීය කර නොමැතිව මාස 18 කට වැඩි "
-"කාලයක් භාවිතා නොකරන්නේ නම්, ඔබගේ දත්ත සර්වරයෙන් මනා දමනු ලබන අතර ප්‍රතිසාධනය "
-"කළ නොහැක."
+"ඔබ DuckDuckGo බ්‍රවුසරය Sync & Backup සක්‍රීය කර නොමැතිව මාස 18 කට වැඩි කාලයක් භාවිතා "
+"නොකරන්නේ නම්, ඔබගේ දත්ත සර්වරයෙන් මනා දමනු ලබන අතර ප්‍රතිසාධනය කළ නොහැක."
 
 # smartling.placeholder_format=C
 #. Secondary button label on the Sync & Backup intro screen that takes the user to the camera scan screen to pair with another device.
@@ -18832,6 +19165,12 @@ msgid "Syria"
 msgstr "සිරියාව"
 
 # smartling.placeholder_format=C
+#. Text for a button that enables the theme to follow the operating system's color scheme preference.
+msgctxt "System theme button for theme selector"
+msgid "System"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Abbreviation indicating this is the total score for a game
 msgctxt "Sports module"
 msgid "T"
@@ -18858,6 +19197,12 @@ msgstr "රූපවාහිනිය"
 msgctxt "language_name"
 msgid "Tahitian"
 msgstr "ටහීටියානු"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Tailor my resume"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Taiwan"
@@ -18887,6 +19232,13 @@ msgstr "ඔබේ පුද්ගලික දත්ත පාලනය කර �
 msgctxt "homepage ATB modal"
 msgid "Take control of your personal data!"
 msgstr "ඔබේ පුද්ගලික දත්ත පාලනය කර ගන්න!"
+
+# smartling.placeholder_format=C
+#. Description for the Feedback section of the Duck.ai settings page, asking the user to take an anonymous survey to let us know how we can make Duck.ai better.
+msgctxt "Feedback section description on the Duck.ai settings page"
+msgid ""
+"Take this anonymous survey to let us know how we can make Duck.ai better."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -19101,9 +19453,9 @@ msgid ""
 "link is at increased risk of being intercepted by a third party. In rare "
 "cases this includes passwords, or payment details."
 msgstr ""
-"එයින් අදහස් වන්නේ ඔබගේ උපාංගය සහ මෙම සබැඳිය පිටුපස ඇති වෙබ් පිටුව අතර යවන ලද "
-"තොරතුරු තෙවන පාර්ශවයක් විසින් වළක්වාලීමේ අවදානම වැඩි බවයි. දුර්ලභ "
-"අවස්ථාවන්හි මුරපද හෝ ගෙවීම් විස්තර මෙයට ඇතුළත් වේ."
+"එයින් අදහස් වන්නේ ඔබගේ උපාංගය සහ මෙම සබැඳිය පිටුපස ඇති වෙබ් පිටුව අතර යවන ලද තොරතුරු තෙවන "
+"පාර්ශවයක් විසින් වළක්වාලීමේ අවදානම වැඩි බවයි. දුර්ලභ අවස්ථාවන්හි මුරපද හෝ ගෙවීම් විස්තර මෙයට "
+"ඇතුළත් වේ."
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -19112,8 +19464,8 @@ msgid ""
 "The Cloud Save bookmarklet allows any changes you make to your settings to "
 "automatically save in the cloud."
 msgstr ""
-"වලාකුළු තුළ ස්වයංක්‍රීයව සුරැකීමට ඔබගේ සැකසුම් වල සිදුකරන ඕනෑම වෙනස්කමක් "
-"Cloud Save කුඩා පිටු සලකුණු මඟින් ඉඩ දෙයි."
+"වලාකුළු තුළ ස්වයංක්‍රීයව සුරැකීමට ඔබගේ සැකසුම් වල සිදුකරන ඕනෑම වෙනස්කමක් Cloud Save කුඩා පිටු "
+"සලකුණු මඟින් ඉඩ දෙයි."
 
 # smartling.placeholder_format=C
 msgid "The Gambia"
@@ -19143,8 +19495,8 @@ msgid ""
 "The encryption key is only saved in your browser's local storage, and only "
 "you can access it."
 msgstr ""
-"සංකේතාංකන යතුර ඔබගේ බ්‍රවුසරයේ දේශීය ගබඩාවේ පමණක් සුරකින අතර, ඊට ප්‍රවේශ විය "
-"හැක්කේ ඔබට පමණි."
+"සංකේතාංකන යතුර ඔබගේ බ්‍රවුසරයේ දේශීය ගබඩාවේ පමණක් සුරකින අතර, ඊට ප්‍රවේශ විය හැක්කේ ඔබට "
+"පමණි."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider deletes all chat data within 30 days.
@@ -19165,9 +19517,7 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider does not save this chat or any associated data on their "
 "servers."
-msgstr ""
-"ආකෘති සපයන්නා මෙම කතාබස් හෝ ඒ ආශ්‍රිත කිසිදු දත්තයක් ඔවුන්ගේ සර්වරවල "
-"සුරකින්නේ නැත."
+msgstr "ආකෘති සපයන්නා මෙම කතාබස් හෝ ඒ ආශ්‍රිත කිසිදු දත්තයක් ඔවුන්ගේ සර්වරවල සුරකින්නේ නැත."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19190,6 +19540,12 @@ msgstr "සේවාදායකයෙහි දෝෂයක් ඇතිවූ 
 #. https://duck.co/media/files/theme.png
 msgid "Theme"
 msgstr "තේමාව"
+
+# smartling.placeholder_format=C
+#. Text for the theme selector label that allows users to switch between Light and dark theme.
+msgctxt "Label for the theme selector feature"
+msgid "Theme"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/LpFhb1e.png
@@ -19220,8 +19576,8 @@ msgid ""
 "There was an error saving this chat locally. Please check your browser "
 "settings to make sure local data storage is enabled."
 msgstr ""
-"මෙම කතාබහ අභ්‍යන්තරව සුරැකීමේදී දෝෂයක් සිදු විය. අභ්‍යන්තර දත්ත ගබඩා සක්‍රිය "
-"කර ඇති බවට වග බලා ගැනීම සඳහා කරුණාකර ඔබේ බ්‍රව්සර් සැකසුම් පරීක්ෂා කරන්න."
+"මෙම කතාබහ අභ්‍යන්තරව සුරැකීමේදී දෝෂයක් සිදු විය. අභ්‍යන්තර දත්ත ගබඩා සක්‍රිය කර ඇති බවට වග බලා "
+"ගැනීම සඳහා කරුණාකර ඔබේ බ්‍රව්සර් සැකසුම් පරීක්ෂා කරන්න."
 
 # smartling.placeholder_format=C
 #. Error modal body line 1.
@@ -19236,8 +19592,8 @@ msgid ""
 "There was still an error displaying the search results. Please wait a few "
 "minutes before you try again."
 msgstr ""
-"සෙවුම් ප්‍රතිඵල පෙන්වීමේ දෝෂයක් තවමත් පැවතිණි. ඔබ නැවත උත්සාහ කිරීමට පෙර "
-"කරුණාකර මිනිත්තු කිහිපයක් රැඳී සිටින්න."
+"සෙවුම් ප්‍රතිඵල පෙන්වීමේ දෝෂයක් තවමත් පැවතිණි. ඔබ නැවත උත්සාහ කිරීමට පෙර කරුණාකර මිනිත්තු කිහිපයක් "
+"රැඳී සිටින්න."
 
 # smartling.placeholder_format=C
 #. Error message for explore more questions when a retryable error occurs (timeout, network)
@@ -19256,9 +19612,9 @@ msgid ""
 "visit by blocking hidden trackers, encrypting connections where possible, "
 "and by making DuckDuckGo your default search engine."
 msgstr ""
-"සැඟවුණු ට්‍රැකර් අවහිර කිරීමෙන්, හැකි සෑම තැනකම සම්බන්ධතා සංකේතනය කිරීමෙන් "
-"සහ DuckDuckGo ඔබේ සුපුරුදු සෙවුම් යන්ත්‍රය බවට පත් කිරීමෙන් ඔබ පිවිසෙන වෙබ් "
-"අඩවි වලට පෞද්ගලිකත්වය එක් කිරීමට මෙම බ්‍රව්සර් අවසර භාවිතා කරයි."
+"සැඟවුණු ට්‍රැකර් අවහිර කිරීමෙන්, හැකි සෑම තැනකම සම්බන්ධතා සංකේතනය කිරීමෙන් සහ DuckDuckGo "
+"ඔබේ සුපුරුදු සෙවුම් යන්ත්‍රය බවට පත් කිරීමෙන් ඔබ පිවිසෙන වෙබ් අඩවි වලට පෞද්ගලිකත්වය එක් කිරීමට මෙම "
+"බ්‍රව්සර් අවසර භාවිතා කරයි."
 
 # smartling.placeholder_format=C
 #. Secondary line under DUCKCHAT_SYNC_PAIRING_ALREADY_SYNCED_TITLE.
@@ -19296,8 +19652,8 @@ msgid ""
 "This AI model is no longer available. Try starting a new chat with a "
 "different model."
 msgstr ""
-"මෙම AI ආකෘතිය තවදුරටත් ලබා ගත නොහැක. වෙනස් ආකෘතියක් සමඟ නව කතාබස් ආරම්භ "
-"කිරීමට උත්සාහ කරන්න."
+"මෙම AI ආකෘතිය තවදුරටත් ලබා ගත නොහැක. වෙනස් ආකෘතියක් සමඟ නව කතාබස් ආරම්භ කිරීමට උත්සාහ "
+"කරන්න."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is no longer supported because it has been upgraded to a newest version.
@@ -19306,8 +19662,8 @@ msgid ""
 "This AI model version is no longer supported. Try starting a new chat with "
 "the latest version of this model."
 msgstr ""
-"මෙම AI ආකෘති අනුවාදය තවදුරටත් සහය නොදක්වයි. මෙම ආකෘතියේ නවතම අනුවාදය සමඟ නව "
-"කතාබහක් ආරම්භ කරන්න."
+"මෙම AI ආකෘති අනුවාදය තවදුරටත් සහය නොදක්වයි. මෙම ආකෘතියේ නවතම අනුවාදය සමඟ නව කතාබහක් "
+"ආරම්භ කරන්න."
 
 # smartling.placeholder_format=C
 #. Appears below a type of search results called 'Instant Answers'
@@ -19334,9 +19690,8 @@ msgid ""
 "This conversation was generated with Duck.ai (%s) using %s's %s Model. AI "
 "chats may display inaccurate or offensive information (see %s for more info)."
 msgstr ""
-"මෙම සංවාදය Duck.ai (%1$s) සමඟ ජනනය කරන ලද්දේ %2$sගේ %3$s ආකෘතිය භාවිත "
-"කරමිනි. AI කතාබස් සාවද්‍ය හෝ අපහාසාත්මක තොරතුරු ප්‍රදර්ශනය කළ හැකිය (වැඩි "
-"විස්තර සඳහා %4$s බලන්න)."
+"මෙම සංවාදය Duck.ai (%1$s) සමඟ ජනනය කරන ලද්දේ %2$sගේ %3$s ආකෘතිය භාවිත කරමිනි. AI "
+"කතාබස් සාවද්‍ය හෝ අපහාසාත්මක තොරතුරු ප්‍රදර්ශනය කළ හැකිය (වැඩි විස්තර සඳහා %4$s බලන්න)."
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with multiple AI models in the same chat, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using multiple chat models. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -19346,8 +19701,8 @@ msgid ""
 "models. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
 msgstr ""
-"බහු කතාබස් ආකෘති භාවිත කරමින් Duck.ai (%1$s) සමඟ මෙම සංවාදය ජනනය කරන ලදී. AI "
-"කතාබස් සාවද්‍ය හෝ අහිතකර තොරතුරු පෙන්විය හැකිය (වැඩි විස්තර සඳහා %2$s බලන්න)."
+"බහු කතාබස් ආකෘති භාවිත කරමින් Duck.ai (%1$s) සමඟ මෙම සංවාදය ජනනය කරන ලදී. AI කතාබස් "
+"සාවද්‍ය හෝ අහිතකර තොරතුරු පෙන්විය හැකිය (වැඩි විස්තර සඳහා %2$s බලන්න)."
 
 # smartling.placeholder_format=C
 #. When a user exports a transcript of a voice chat they had with the AI. This text goes at the very top of the downloaded file as a header. Placeholders are for links. Example: 'This conversation was generated with Duck.ai voice chat (https://duck.ai). AI may provide inaccurate or offensive information. (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -19356,8 +19711,8 @@ msgid ""
 "This conversation was generated with Duck.ai voice chat (%s). AI may provide "
 "inaccurate or offensive information. (see %s for more info)."
 msgstr ""
-"මෙම සංවාදය Duck.ai හඬ කතාබස් (%1$s) සමඟින් ජනනය කරන ලදී. AI මඟින් සාවද්‍ය හෝ "
-"අහිතකර තොරතුරු සැපයිය හැකිය. (වැඩිදුර තොරතුරු සඳහා %2$s බලන්න)."
+"මෙම සංවාදය Duck.ai හඬ කතාබස් (%1$s) සමඟින් ජනනය කරන ලදී. AI මඟින් සාවද්‍ය හෝ අහිතකර "
+"තොරතුරු සැපයිය හැකිය. (වැඩිදුර තොරතුරු සඳහා %2$s බලන්න)."
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with DuckDuckGo AI Chat (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/aichat/privacy-terms for more info).'
@@ -19368,8 +19723,8 @@ msgid ""
 "more info)."
 msgstr ""
 "මෙම සංවාදය DuckDuckGo AI Chat (%1$s) සමඟ ජනනය කරන ලද්දේ %2$sහි %3$s ආකෘතිය "
-"භාවිතා කරමිනි. AI කතාබස් සාවද්‍ය හෝ වැරදිසහගත තොරතුරු ප්‍රදර්ශනය කළ හැකිය "
-"(වැඩි විස්තර සඳහා %4$s බලන්න)."
+"භාවිතා කරමිනි. AI කතාබස් සාවද්‍ය හෝ වැරදිසහගත තොරතුරු ප්‍රදර්ශනය කළ හැකිය (වැඩි විස්තර සඳහා "
+"%4$s බලන්න)."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
@@ -19473,8 +19828,8 @@ msgid ""
 "This model provider deletes data associated with this chat within 30 days. "
 "Other model providers follow a zero data retention model."
 msgstr ""
-"මෙම ආකෘති සැපයුම්කරු දින 30ක් ඇතුළත මෙම කතාබහ හා සම්බන්ධ දත්ත මකා දමයි. "
-"අනෙකුත් ආකෘති සපයන්නන් ශුන්‍ය දත්ත රඳවා ගැනීමේ ආකෘතියක් අනුගමනය කරයි."
+"මෙම ආකෘති සැපයුම්කරු දින 30ක් ඇතුළත මෙම කතාබහ හා සම්බන්ධ දත්ත මකා දමයි. අනෙකුත් ආකෘති "
+"සපයන්නන් ශුන්‍ය දත්ත රඳවා ගැනීමේ ආකෘතියක් අනුගමනය කරයි."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers, and that other providers may retain chat data for a limited time instead.
@@ -19483,8 +19838,8 @@ msgid ""
 "This model provider does not store any data associated with this chat. Other "
 "model providers follow a limited data retention model."
 msgstr ""
-"මෙම ආකෘති සැපයුම්කරු මෙම කතාබහ හා සම්බන්ධ කිසිදු දත්තයක් ගබඩා නොකරයි. "
-"අනෙකුත් ආකෘති සපයන්නන් සීමිත දත්ත රඳවා ගැනීමේ ආකෘතියක් අනුගමනය කරයි."
+"මෙම ආකෘති සැපයුම්කරු මෙම කතාබහ හා සම්බන්ධ කිසිදු දත්තයක් ගබඩා නොකරයි. අනෙකුත් ආකෘති සපයන්නන් "
+"සීමිත දත්ත රඳවා ගැනීමේ ආකෘතියක් අනුගමනය කරයි."
 
 # smartling.placeholder_format=C
 #. Info that page may refresh during update.
@@ -19521,8 +19876,8 @@ msgid ""
 "This saves your chats with end-to-end encryption on DuckDuckGo's secure "
 "server, which later can be accessed from any browser."
 msgstr ""
-"මෙය DuckDuckGo ආරක්ෂිත සේවාදායකයේ ඔබේ කතාබස් මුල සිට අග දක්වා ගුප්ත කේතනය "
-"සමඟ සුරකින අතර පසුව ඕනෑම බ්රවුසරයකින් ඒවාට ප්රවේශ විය හැකිය."
+"මෙය DuckDuckGo ආරක්ෂිත සේවාදායකයේ ඔබේ කතාබස් මුල සිට අග දක්වා ගුප්ත කේතනය සමඟ සුරකින "
+"අතර පසුව ඕනෑම බ්රවුසරයකින් ඒවාට ප්රවේශ විය හැකිය."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -19531,8 +19886,8 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again."
 msgstr ""
-"මෙම සැකසුම ඔබේ බ්‍රව්සරයේ ගබඩා වේ, එයින් අදහස් වන්නේ ඔබ duckduckgo.com "
-"බ්‍රව්සර දත්ත මකා දැමුවහොත්, ඔබට නැවත AI සහාය සහිත පිළිතුරු දැකිය හැක."
+"මෙම සැකසුම ඔබේ බ්‍රව්සරයේ ගබඩා වේ, එයින් අදහස් වන්නේ ඔබ duckduckgo.com බ්‍රව්සර දත්ත මකා "
+"දැමුවහොත්, ඔබට නැවත AI සහාය සහිත පිළිතුරු දැකිය හැක."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -19542,9 +19897,9 @@ msgid ""
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
 msgstr ""
-"මෙම සැකසුම ඔබේ බ්‍රව්සරයේ ගබඩා වේ, එයින් අදහස් වන්නේ ඔබ duckduckgo.com "
-"බ්‍රව්සර දත්ත මකා දැමුවහොත්, ඔබට නැවත AI සහාය සහිත පිළිතුරු දැකිය හැක. කෙසේ "
-"වෙතත්, අපට %1$s හි AI-සහය සහිත පිළිතුරු කිසිවිටෙකත් පෙන්වන ආරම්භක පිටුවක් ඇත."
+"මෙම සැකසුම ඔබේ බ්‍රව්සරයේ ගබඩා වේ, එයින් අදහස් වන්නේ ඔබ duckduckgo.com බ්‍රව්සර දත්ත මකා "
+"දැමුවහොත්, ඔබට නැවත AI සහාය සහිත පිළිතුරු දැකිය හැක. කෙසේ වෙතත්, අපට %1$s හි AI-සහය "
+"සහිත පිළිතුරු කිසිවිටෙකත් පෙන්වන ආරම්භක පිටුවක් ඇත."
 
 # smartling.placeholder_format=C
 #. User feedback indicating that a translation is helpful
@@ -19583,9 +19938,9 @@ msgid ""
 "Sync & Backup. You'll still be able to access your chats in other browsers "
 "connected to Sync & Backup."
 msgstr ""
-"මින් ඔබගේ සියලුම Duck.ai කතාබස් මෙම බ්‍රව්සරයෙන් මකා දමා Sync & Backup "
-"විසන්ධි කරයි. Sync & Backup ට සම්බන්ධ කර ඇති අනෙකුත් බ්‍රව්සර්වලින් ඔයාට "
-"තවමත් ඔයාගේ කතාබස් වෙත ප්‍රවේශ වීමට හැකි වනු ඇත."
+"මින් ඔබගේ සියලුම Duck.ai කතාබස් මෙම බ්‍රව්සරයෙන් මකා දමා Sync & Backup විසන්ධි කරයි. Sync "
+"& Backup ට සම්බන්ධ කර ඇති අනෙකුත් බ්‍රව්සර්වලින් ඔයාට තවමත් ඔයාගේ කතාබස් වෙත ප්‍රවේශ වීමට "
+"හැකි වනු ඇත."
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to clear all recentchats, with a warning that this action cannot be undone.
@@ -19594,8 +19949,7 @@ msgid ""
 "This will delete all your recent chats, unless they're pinned. This cannot "
 "be undone."
 msgstr ""
-"මෙය ඔයාගේ මෑත කාලීන කතාබස් සියල්ල මකා දමයි, ඒවා අමුණලා නැත්නම්. මෙය ආපසු "
-"හැරවිය නොහැක."
+"මෙය ඔයාගේ මෑත කාලීන කතාබස් සියල්ල මකා දමයි, ඒවා අමුණලා නැත්නම්. මෙය ආපසු හැරවිය නොහැක."
 
 # smartling.placeholder_format=C
 #. Message explaining what will happen when the user deletes an image.
@@ -19733,8 +20087,8 @@ msgid ""
 "To print directions:%sGo back to the map.%sSelect the route you want to "
 "print.%sClick the print icon.%s"
 msgstr ""
-"දිශාවන් මුද්‍රණය කිරීම සඳහා:%1$sසිතියම වෙත ආපසු යන්න.%2$sඔබට මුද්‍රණය කිරීමට "
-"අවශ්‍ය මාර්ගය තෝරන්න.%3$sමුද්‍රණ නිරූපකය ක්ලික් කරන්න.%4$s"
+"දිශාවන් මුද්‍රණය කිරීම සඳහා:%1$sසිතියම වෙත ආපසු යන්න.%2$sඔබට මුද්‍රණය කිරීමට අවශ්‍ය මාර්ගය "
+"තෝරන්න.%3$sමුද්‍රණ නිරූපකය ක්ලික් කරන්න.%4$s"
 
 # smartling.placeholder_format=C
 #. Explains where the user can find their recovery code. Figma frame 3703-44420.
@@ -19744,9 +20098,9 @@ msgid ""
 "you first set up Sync. This code may have been saved as a PDF on the device "
 "you originally used to set up Sync."
 msgstr ""
-"ඔබේ සමමුහුර්ත කළ දත්ත ප්‍රතිසාධනය කිරීම සඳහා ඔබ විසින් පළමු වරට සමමුහුර්ත "
-"කිරීම සැකසීමේ දී සුරකින ලද ප්‍රතිසාධන කේතය අවශ්‍ය වනු ඇත. මෙම කේතය ඔබ මුල් "
-"වරට සමමුහු සැකසීමට භාවිතා කළ උපාංගයේ PDF ගොනුවක් ලෙස සුරැකී තිබිය හැකිය."
+"ඔබේ සමමුහුර්ත කළ දත්ත ප්‍රතිසාධනය කිරීම සඳහා ඔබ විසින් පළමු වරට සමමුහුර්ත කිරීම සැකසීමේ දී සුරකින "
+"ලද ප්‍රතිසාධන කේතය අවශ්‍ය වනු ඇත. මෙම කේතය ඔබ මුල් වරට සමමුහු සැකසීමට භාවිතා කළ උපාංගයේ "
+"PDF ගොනුවක් ලෙස සුරැකී තිබිය හැකිය."
 
 # smartling.placeholder_format=C
 #. Body text explaining that the user needs to update their DDG browser before migration can proceed.
@@ -19755,8 +20109,8 @@ msgid ""
 "To transfer your chat history to Duck.ai, please update your DuckDuckGo "
 "browser to the latest version and try again."
 msgstr ""
-"ඔබේ කතාබස් ඉතිහාසය Duck.ai වෙත මාරු කිරීමට, කරුණාකර ඔබේ DuckDuckGo බ්‍රවුසරය "
-"නවතම අනුවාදයට යාවත්කාලීන කර නැවත උත්සාහ කරන්න."
+"ඔබේ කතාබස් ඉතිහාසය Duck.ai වෙත මාරු කිරීමට, කරුණාකර ඔබේ DuckDuckGo බ්‍රවුසරය නවතම "
+"අනුවාදයට යාවත්කාලීන කර නැවත උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
@@ -19764,8 +20118,8 @@ msgid ""
 "To use dictation, allow your browser to access the microphone in your system "
 "settings."
 msgstr ""
-"අසා ලිවීම භාවිත කිරීමට, ඔබේ පද්ධති සැකසුම් තුළින් මයික්‍රොෆෝනය වෙත ප්‍රවේශ "
-"වීමට ඔබේ බ්‍රවුසරයට ඉඩ දෙන්න."
+"අසා ලිවීම භාවිත කිරීමට, ඔබේ පද්ධති සැකසුම් තුළින් මයික්‍රොෆෝනය වෙත ප්‍රවේශ වීමට ඔබේ බ්‍රවුසරයට ඉඩ "
+"දෙන්න."
 
 # smartling.placeholder_format=C
 msgid "Today"
@@ -19955,8 +20309,8 @@ msgid ""
 "Tracking attempts blocked by DuckDuckGo appear here. Keep browsing to see "
 "how many we block."
 msgstr ""
-"DuckDuckGo විසින් අවහිර කළ නිරීක්ෂණය කිරීමේ ප්‍රයත්න මෙහි දිස් වේ.අපි කොපමණ "
-"ප්‍රමාණයක් අවහිර කරනවාදැයි බැලීමට බ්‍රවුස් කරන්න."
+"DuckDuckGo විසින් අවහිර කළ නිරීක්ෂණය කිරීමේ ප්‍රයත්න මෙහි දිස් වේ.අපි කොපමණ ප්‍රමාණයක් අවහිර "
+"කරනවාදැයි බැලීමට බ්‍රවුස් කරන්න."
 
 # smartling.placeholder_format=C
 #. Placeholder for when we cannot report any blocked trackers yet
@@ -20004,8 +20358,8 @@ msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
 msgstr ""
-"මෙම ඉංග්‍රීසි වාක්‍යය ප්‍රංශ භාෂාවට පරිවර්තනය කරන්න: \"මම ළඟම ඇති චිත්‍රපට "
-"ශාලාවට යන්නේ කෙසේද?\""
+"මෙම ඉංග්‍රීසි වාක්‍යය ප්‍රංශ භාෂාවට පරිවර්තනය කරන්න: \"මම ළඟම ඇති චිත්‍රපට ශාලාවට යන්නේ "
+"කෙසේද?\""
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for translating a sentence into another language. Translate the whole sentence and please use target language instead of 'English' and modify the sentence to translate into 'English' instead of 'French'. Example: 'Translate this {target language} sentence into English: “How do I get to the nearest movie theatre?”'
@@ -20014,8 +20368,20 @@ msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
 msgstr ""
-"මෙම ඉංග්‍රීසි වාක්‍යය ප්‍රංශ භාෂාවට පරිවර්තනය කරන්න: \"මම ළඟම ඇති චිත්‍රපට "
-"ශාලාවට යන්නේ කෙසේද?\""
+"මෙම ඉංග්‍රීසි වාක්‍යය ප්‍රංශ භාෂාවට පරිවර්තනය කරන්න: \"මම ළඟම ඇති චිත්‍රපට ශාලාවට යන්නේ "
+"කෙසේද?\""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Translate this page"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
+msgctxt "Page suggestion prompt"
+msgid "Translate this page into %s."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder text for a region that will display translated text.
@@ -20159,6 +20525,12 @@ msgid "Try Free"
 msgstr "නොමිලේ අත්හදා බලන්න"
 
 # smartling.placeholder_format=C
+#. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
+msgctxt "settings"
+msgid "Try It Now"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
 msgctxt "Promotional CTA for new AI models"
 msgid "Try Now"
@@ -20214,9 +20586,7 @@ msgstr "වෙනත් වචන සමග උත්සාහ කරන්න."
 # smartling.placeholder_format=C
 #. Prompt encouraging the user to turn off their ad blocker to see more results for their query.
 msgid "Try disabling your ad blocker on DuckDuckGo to see more results."
-msgstr ""
-"තවත් ප්‍රතිඵල දැකීමට DuckDuckGo හි ඔබේ දැන්වීම් අවහිරකරණය අබල කිරීමට උත්සාහ "
-"කරන්න."
+msgstr "තවත් ප්‍රතිඵල දැකීමට DuckDuckGo හි ඔබේ දැන්වීම් අවහිරකරණය අබල කිරීමට උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
@@ -20229,9 +20599,7 @@ msgstr "වඩාත් නිවැරදි ප්‍රතිඵල සඳහ
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr ""
-"එක් එක් ආකෘතිය සමඟ අත්හදා බැලීමට උත්සාහ කරන්න - ඔවුන් විවිධ ප්‍රතිචාර ලබා "
-"දෙනු ඇත."
+msgstr "එක් එක් ආකෘතිය සමඟ අත්හදා බැලීමට උත්සාහ කරන්න - ඔවුන් විවිධ ප්‍රතිචාර ලබා දෙනු ඇත."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
@@ -20393,6 +20761,22 @@ msgstr "උත්සාහ කරන්න : %1$s"
 msgctxt "new user poll"
 msgid "Trying DuckDuckGo again"
 msgstr "නැවතත් DuckDuckGo උත්සාහ කරනවා"
+
+# smartling.placeholder_format=C
+#. Message shown in a modal after supported third-party browser users disable AI features in Settings. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -20563,8 +20947,8 @@ msgid ""
 "Types out DuckAssist answers as they're generated. Turning this off may "
 "result in a short delay between a search and the answer being displayed."
 msgstr ""
-"DuckAssist පිළිතුරු උත්පාදනය වන විට ඒවා ටයිප් කරයි. මෙය ක්‍රියාවිරහිත "
-"කිරීමෙන් සෙවීමක් සහ ප්‍රදර්ශනය වන පිළිතුර අතර කෙටි ප්‍රමාදයක් ඇති විය හැක."
+"DuckAssist පිළිතුරු උත්පාදනය වන විට ඒවා ටයිප් කරයි. මෙය ක්‍රියාවිරහිත කිරීමෙන් සෙවීමක් සහ "
+"ප්‍රදර්ශනය වන පිළිතුර අතර කෙටි ප්‍රමාදයක් ඇති විය හැක."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -20694,8 +21078,8 @@ msgid ""
 "Under %sOn startup%s, click %sOpen a specific page%s then click %sSet "
 "Pages%s."
 msgstr ""
-"%1$sOn startup%2$s වලට පහළින්, %3$sOpen a specific page%4$s ක්ලික් කර "
-"%5$sSet Pages%6$s මත ක්ලික් කරන්න."
+"%1$sOn startup%2$s වලට පහළින්, %3$sOpen a specific page%4$s ක්ලික් කර %5$sSet "
+"Pages%6$s මත ක්ලික් කරන්න."
 
 #  Maxthon homepage instruction
 # smartling.placeholder_format=C
@@ -20703,8 +21087,8 @@ msgstr ""
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
 msgstr ""
-"%1$sOn startup%2$s වලට පහළීන් ඇති, %3$sHomepage%4$s තෝරාගෙන ඇතුළු කරන්න: "
-"https://duckduckgo.com"
+"%1$sOn startup%2$s වලට පහළීන් ඇති, %3$sHomepage%4$s තෝරාගෙන ඇතුළු කරන්න: https://"
+"duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -20820,8 +21204,8 @@ msgid ""
 "Unlock %s, higher AI reasoning, and 2x higher usage limits than the Plus "
 "plan by upgrading to Pro."
 msgstr ""
-"Pro වෙත උත්ශ්‍රේණිගත කිරීමෙන් %1$s, වඩා ඉහළ AI තර්කනයක් සහ Plus සැලැස්මට වඩා "
-"2 ගුණයක් ඉහළ AI පරිශීලන සීමා අගුළු හැර ගන්න."
+"Pro වෙත උත්ශ්‍රේණිගත කිරීමෙන් %1$s, වඩා ඉහළ AI තර්කනයක් සහ Plus සැලැස්මට වඩා 2 ගුණයක් "
+"ඉහළ AI පරිශීලන සීමා අගුළු හැර ගන්න."
 
 # smartling.placeholder_format=C
 #. Title for the subscription promo shown in the SERP sidemenu.
@@ -20955,8 +21339,8 @@ msgid ""
 "Update the DuckDuckGo browser to activate your subscription in Duck.ai and "
 "access advanced models"
 msgstr ""
-"Duck.ai හි ඔබේ දායකත්වය සක්රිය කිරීමට සහ උසස් ආකෘති වෙත ප්‍රවේශ වීමට "
-"DuckDuckGo බ්‍රවුසරය යාවත්කාලීන කරන්න"
+"Duck.ai හි ඔබේ දායකත්වය සක්රිය කිරීමට සහ උසස් ආකෘති වෙත ප්‍රවේශ වීමට DuckDuckGo බ්‍රවුසරය "
+"යාවත්කාලීන කරන්න"
 
 # smartling.placeholder_format=C
 #. The placeholder indicates a formatted date (e.g., 'Updated 2 days ago')
@@ -21081,16 +21465,15 @@ msgid ""
 "Upgrade to Pro to unlock 2x higher limits than Plus, or come back later to "
 "create more images."
 msgstr ""
-"Plus ප්‍රකාරයට වඩා දෙගුණයකින් ඉහළ සීමාවන් අගුළු ඇරීමට Pro වෙත උත්ශ්‍රේණිගත "
-"කරන්න, නැත්නම් තවත් රූප නිර්මාණය කිරීමට පසුව නැවත එන්න."
+"Plus ප්‍රකාරයට වඩා දෙගුණයකින් ඉහළ සීමාවන් අගුළු ඇරීමට Pro වෙත උත්ශ්‍රේණිගත කරන්න, නැත්නම් තවත් "
+"රූප නිර්මාණය කිරීමට පසුව නැවත එන්න."
 
 # smartling.placeholder_format=C
 #. Upsell message shown in the voice chat limit and duration limit modals for Plus subscribers, encouraging them to upgrade to Pro.
 msgctxt "voice chat limit modal"
 msgid "Upgrade to Pro to unlock 2x higher usage limits than Plus"
 msgstr ""
-"Plus ප්‍රකාරයට වඩා දෙගුණයකින් පුළුල් පරිශීලන සීමා අගුළු හැර ගැනීමට Pro වෙත "
-"උත්ශ්‍රේණිගත කරන්න"
+"Plus ප්‍රකාරයට වඩා දෙගුණයකින් පුළුල් පරිශීලන සීමා අගුළු හැර ගැනීමට Pro වෙත උත්ශ්‍රේණිගත කරන්න"
 
 # smartling.placeholder_format=C
 #. Heading in a promotion for a desktop web browser
@@ -21139,6 +21522,12 @@ msgid "Uruguay"
 msgstr "උරුගුවේ"
 
 # smartling.placeholder_format=C
+#. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
+msgctxt "Navigation label on the Duck.ai settings page"
+msgid "Usage"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A feedback suggestion
 msgctxt "Feedback prompt"
 msgid "Usage limit"
@@ -21180,9 +21569,9 @@ msgid ""
 "Use ChatGPT, Claude, and other AIs, privately. Protect chats from hackers, "
 "scammers, and companies. Keep info confidential. Free. No account required."
 msgstr ""
-"ChatGPT, Claude, සහ අනෙකුත් AI පද්ධති පුද්ගලිකව භාවිත කරන්න. හැකර්වරුන්, "
-"වංචාකරුවන් සහ සමාගම් වලින් ඔබේ කතාබස් ආරක්ෂා කරගන්න. තොරතුරු රහසිගතව තබා "
-"ගන්න. ගාස්තු රහිතයි. ගිණුමක් අවශ්‍ය නොවේ."
+"ChatGPT, Claude, සහ අනෙකුත් AI පද්ධති පුද්ගලිකව භාවිත කරන්න. හැකර්වරුන්, වංචාකරුවන් සහ "
+"සමාගම් වලින් ඔබේ කතාබස් ආරක්ෂා කරගන්න. තොරතුරු රහසිගතව තබා ගන්න. ගාස්තු රහිතයි. ගිණුමක් අවශ්‍ය "
+"නොවේ."
 
 # smartling.placeholder_format=C
 #. Header above instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -21224,8 +21613,8 @@ msgctxt "Description for the recovery section inside Manage"
 msgid ""
 "Use this code to restore your saved chats if you lose access to your devices."
 msgstr ""
-"ඔබේ උපාංගවලට ප්‍රවේශය අහිමි වුණොත් ඔබේ සුරකින ලද කතාබස් ප්‍රතිසාධනය කිරීමට "
-"මේ කේතය භාවිතා කරන්න."
+"ඔබේ උපාංගවලට ප්‍රවේශය අහිමි වුණොත් ඔබේ සුරකින ලද කතාබස් ප්‍රතිසාධනය කිරීමට මේ කේතය භාවිතා "
+"කරන්න."
 
 # smartling.placeholder_format=C
 #. Prompt to ask the user if they want to use their approximate location for more accurate results
@@ -21375,8 +21764,8 @@ msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Microsoft's ad network"
 msgstr ""
-"දැන්වීම් බැලීම DuckDuckGo මගින් පුද්ගලිකත්වය ආරක්ෂා කරයි. දැන්වීම් ක්ලික් "
-"කිරීම් කළමනාකරණය කරනු ලබන්නේ Microsoftහි දැන්වීම් ජාලය විසිනි"
+"දැන්වීම් බැලීම DuckDuckGo මගින් පුද්ගලිකත්වය ආරක්ෂා කරයි. දැන්වීම් ක්ලික් කිරීම් කළමනාකරණය කරනු "
+"ලබන්නේ Microsoftහි දැන්වීම් ජාලය විසිනි"
 
 # smartling.placeholder_format=C
 #. Information about TripAdvisor ads for DuckDuckGo's users. This appears in a tooltip.
@@ -21385,8 +21774,8 @@ msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "TripAdvisor's ad network."
 msgstr ""
-"දැන්වීම් බැලීම DuckDuckGo මගින් පුද්ගලිකත්වය ආරක්ෂා කරයි. දැන්වීම් ක්ලික් "
-"කිරීම් TripAdvisor හි දැන්වීම් ජාලය විසින් කළමනාකරණය කරනු ලැබේ."
+"දැන්වීම් බැලීම DuckDuckGo මගින් පුද්ගලිකත්වය ආරක්ෂා කරයි. දැන්වීම් ක්ලික් කිරීම් TripAdvisor හි "
+"දැන්වීම් ජාලය විසින් කළමනාකරණය කරනු ලැබේ."
 
 # smartling.placeholder_format=C
 msgid "Virgin Islands"
@@ -21398,8 +21787,8 @@ msgctxt "duckassist"
 msgid ""
 "Visit %sAssist Settings%s to adjust how this feature works or turn it off."
 msgstr ""
-"මෙම විශේෂාංගය ක්‍රියා කරන ආකාරය සකස් කිරීමට හෝ එය අක්‍රිය කිරීමට %1$sAssist "
-"සැකසුම්%2$s වෙත පිවිසෙන්න."
+"මෙම විශේෂාංගය ක්‍රියා කරන ආකාරය සකස් කිරීමට හෝ එය අක්‍රිය කිරීමට %1$sAssist සැකසුම්%2$s "
+"වෙත පිවිසෙන්න."
 
 # smartling.placeholder_format=C
 #. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
@@ -21408,8 +21797,8 @@ msgid ""
 "Visit %sDuckAssist Settings%s to adjust how this feature works or turn it "
 "off."
 msgstr ""
-"මෙම විශේෂාංගය ක්‍රියා කරන ආකාරය සකස් කිරීමට හෝ එය අක්‍රිය කිරීමට "
-"%1$sDuckAssist සැකසුම්%2$s වෙත පිවිසෙන්න."
+"මෙම විශේෂාංගය ක්‍රියා කරන ආකාරය සකස් කිරීමට හෝ එය අක්‍රිය කිරීමට %1$sDuckAssist "
+"සැකසුම්%2$s වෙත පිවිසෙන්න."
 
 # smartling.placeholder_format=C
 #. Prompt to visit DuckDuckGo on another device.
@@ -21418,8 +21807,8 @@ msgid ""
 "Visit %sDuckDuckGo.com%s on your tablet or phone and follow the provided "
 "instructions."
 msgstr ""
-"%1$sDuckDuckGo.com%2$s වෙතට ඔබගේ දුරකථනයෙන් හෝ ටැබ්ලට් එකෙන් පැමිණ සපයා ඇති "
-"උපදෙස් පිළිපදින්න."
+"%1$sDuckDuckGo.com%2$s වෙතට ඔබගේ දුරකථනයෙන් හෝ ටැබ්ලට් එකෙන් පැමිණ සපයා ඇති උපදෙස් "
+"පිළිපදින්න."
 
 # smartling.placeholder_format=C
 #. Primary button to visit Duck.ai.
@@ -21434,9 +21823,9 @@ msgid ""
 "Visit Duck.ai in your other browser and go to %sDuck.ai Settings%s > %sSync "
 "& Backup%s > %sManage%s then select %sSync With Another Device%s."
 msgstr ""
-"ඔබගේ අනෙක් බ්‍රව්සරයෙන් Duck.ai වෙත පිවිස %1$sDuck.ai සැකසීම්%2$s > %3$sSync "
-"& Backup%4$s > %5$sකළමනාකරණය කරන්න%6$s වෙත ගොස් %7$sවෙනත් උපාංගයක් සමඟ "
-"සමමුහුර්ත කරන්න%8$s තෝරන්න."
+"ඔබගේ අනෙක් බ්‍රව්සරයෙන් Duck.ai වෙත පිවිස %1$sDuck.ai සැකසීම්%2$s > %3$sSync & "
+"Backup%4$s > %5$sකළමනාකරණය කරන්න%6$s වෙත ගොස් %7$sවෙනත් උපාංගයක් සමඟ සමමුහුර්ත "
+"කරන්න%8$s තෝරන්න."
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -21446,9 +21835,9 @@ msgid ""
 "On” under Sync & Backup and select “Sync With Another Device”. Or scan the "
 "QR on your Recovery PDF."
 msgstr ""
-"ඔබගේ අනෙක් බ්‍රවුසරයෙන් Duck.ai වෙත පිවිස Duck.ai සැකසුම් විවෘත කරන්න. “Turn "
-"On” තෝරන්න Sync & Backup යටතේ, “තවත් උපාංගයක් සමඟ සමමුහුර්ත කරන්න” තෝරන්න. "
-"නැතහොත් ඔබගේ ප්‍රතිසාධන PDF එකේ QR ස්කෑන් කරන්න."
+"ඔබගේ අනෙක් බ්‍රවුසරයෙන් Duck.ai වෙත පිවිස Duck.ai සැකසුම් විවෘත කරන්න. “Turn On” තෝරන්න "
+"Sync & Backup යටතේ, “තවත් උපාංගයක් සමඟ සමමුහුර්ත කරන්න” තෝරන්න. නැතහොත් ඔබගේ ප්‍රතිසාධන "
+"PDF එකේ QR ස්කෑන් කරන්න."
 
 # smartling.placeholder_format=C
 #. Shared body copy for every screen in the Sync Another Device flow (QR display, camera scan, camera-unavailable fallback, manual entry). Bold tags wrap navigation breadcrumbs. Render with <Translate /> so the HTML is interpreted; plain `translate()` will trip the html-string warning.
@@ -21470,10 +21859,9 @@ msgid ""
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
 msgstr ""
-"ඔබගේ අනෙක් බ්‍රවුසරයෙන් හෝ DuckDuckGo යෙදුමෙන් Duck.ai වෙත පිවිස Duck.ai "
-"සැකසුම් විවෘත කරන්න. “ක්‍රියාත්මක කරන්න” තෝරා Sync & Backup යටතේ, “තවත් "
-"උපාංගයක් සමග සමමුහුර්ත කරන්න” තෝරන්න. නැතහොත් ඔබගේ ප්‍රතිසාධන PDF ගොනුවේ QR "
-"කේතය ස්කෑන් කරන්න."
+"ඔබගේ අනෙක් බ්‍රවුසරයෙන් හෝ DuckDuckGo යෙදුමෙන් Duck.ai වෙත පිවිස Duck.ai සැකසුම් විවෘත "
+"කරන්න. “ක්‍රියාත්මක කරන්න” තෝරා Sync & Backup යටතේ, “තවත් උපාංගයක් සමග සමමුහුර්ත කරන්න” "
+"තෝරන්න. නැතහොත් ඔබගේ ප්‍රතිසාධන PDF ගොනුවේ QR කේතය ස්කෑන් කරන්න."
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -21526,8 +21914,7 @@ msgstr "හඬ කතාබහ අවසන්"
 msgctxt "voice chat"
 msgid "Voice chat is anonymized by us, and never used to train AI models."
 msgstr ""
-"හඬ කතාබස් අපි නිර්නාමික කරලා තියෙනවා, AI ආකෘති පුහුණු කිරීමට කිසි විටෙකත් "
-"භාවිතා කරන්නේ නැහැ."
+"හඬ කතාබස් අපි නිර්නාමික කරලා තියෙනවා, AI ආකෘති පුහුණු කිරීමට කිසි විටෙකත් භාවිතා කරන්නේ නැහැ."
 
 # smartling.placeholder_format=C
 #. Title of the modal shown when the user has reached their daily voice chat limit.
@@ -21586,6 +21973,12 @@ msgstr "ස්ථානය බලාපොරොත්තුවෙන්..."
 # smartling.placeholder_format=C
 msgid "Wales"
 msgstr "වේල්ස්"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Walk me through the steps"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for walking directions on a map.
@@ -21665,8 +22058,8 @@ msgid ""
 "Watch in Duck Player to block personalized ads on YouTube and prevent your "
 "viewing activity from influencing YouTube recommendations."
 msgstr ""
-"YouTube හි පුද්ගලාරෝපිත දැන්වීම් අවහිර කිරීමට සහ යූ ටියුබ් නිර්දේශයන්ට "
-"බලපෑම් කිරීමෙන් ඔබේ නැරඹීමේ ක්රියාකාරකම් වළක්වා ගැනීමට Duck Player හි නරඹන්න."
+"YouTube හි පුද්ගලාරෝපිත දැන්වීම් අවහිර කිරීමට සහ යූ ටියුබ් නිර්දේශයන්ට බලපෑම් කිරීමෙන් ඔබේ නැරඹීමේ "
+"ක්රියාකාරකම් වළක්වා ගැනීමට Duck Player හි නරඹන්න."
 
 # smartling.placeholder_format=C
 #. A button that takes a user to another site in order to watch a video. The placeholder is the name of the video site. For example: 'Watch on Vimeo'
@@ -21686,10 +22079,9 @@ msgid ""
 "independent company and has no relationship with YouTube, where most videos "
 "are hosted."
 msgstr ""
-"මෙහි වීඩියෝවක් නැරඹීම යන්නෙන් අදහස් කරන්නේ එහි සත්කාරකත්වය දරන වෙබ් අඩවියට "
-"ඔබව නිරීක්ෂණය කළ හැකි බව වන අතර, ඊට හේතුව අප එහි සිට අන්තර්ගතය විකාශය කළ "
-"යුතු වීමයි. DuckDuckGo යනු ස්වාධීන සමාගමක් වන අතර බොහෝ වීඩියෝ දර්ශන "
-"සත්කාරකත්වය සපයන YouTube සමඟ කිසිදු සම්බන්ධයක් නොමැත."
+"මෙහි වීඩියෝවක් නැරඹීම යන්නෙන් අදහස් කරන්නේ එහි සත්කාරකත්වය දරන වෙබ් අඩවියට ඔබව නිරීක්ෂණය කළ "
+"හැකි බව වන අතර, ඊට හේතුව අප එහි සිට අන්තර්ගතය විකාශය කළ යුතු වීමයි. DuckDuckGo යනු ස්වාධීන "
+"සමාගමක් වන අතර බොහෝ වීඩියෝ දර්ශන සත්කාරකත්වය සපයන YouTube සමඟ කිසිදු සම්බන්ධයක් නොමැත."
 
 # smartling.placeholder_format=C
 #. Heading for the highlight card explaining anonymized prompt delivery.
@@ -21701,9 +22093,18 @@ msgstr "අපි නිර්නාමික කරමු"
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
+msgstr "ඔබට වඩාත් නිවැරදි ප්‍රතිඵල පෙන්වීමට අපට%1$s ඔබේ ස්ථානය%2$s නිර්නාමික කළ හැකිය."
+
+# smartling.placeholder_format=C
+#. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
+msgctxt ""
+"Inline warning shown below the share-content toggle when the user selects "
+"Harmful or Illegal but has not enabled sharing"
+msgid ""
+"We can only fix what we can see. To report a harmful or illegal response, "
+"please share this conversation with DuckDuckGo so we can investigate and "
+"address the issue."
 msgstr ""
-"ඔබට වඩාත් නිවැරදි ප්‍රතිඵල පෙන්වීමට අපට%1$s ඔබේ ස්ථානය%2$s නිර්නාමික කළ "
-"හැකිය."
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -21715,17 +22116,15 @@ msgid ""
 "please share your prompt and response so we can investigate and address the "
 "issue."
 msgstr ""
-"අපට පෙනෙන දේ පමණක් නිවැරදි කළ හැකි ය. හානිකර හෝ නීති විරෝධී ප්‍රතිචාරයක් "
-"වාර්තා කිරීමට, කරුණාකර ඔයාගේ ක්ෂණික පණිවිඩය සහ ප්‍රතිචාරය බෙදා ගන්න එවිට අපට "
-"ගැටලුව විමර්ශනය කර විසඳා ගත හැකිය."
+"අපට පෙනෙන දේ පමණක් නිවැරදි කළ හැකි ය. හානිකර හෝ නීති විරෝධී ප්‍රතිචාරයක් වාර්තා කිරීමට, "
+"කරුණාකර ඔයාගේ ක්ෂණික පණිවිඩය සහ ප්‍රතිචාරය බෙදා ගන්න එවිට අපට ගැටලුව විමර්ශනය කර විසඳා ගත "
+"හැකිය."
 
 # smartling.placeholder_format=C
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can use your anonymous%s location%s to show you nearby results."
-msgstr ""
-"ඔබට ආසන්න ප්‍රතිඵල පෙන්වීම සඳහා අපට ඔබේ නිර්නාමික%1$s පිහිටීම%2$s භාවිතා කළ "
-"හැකිය."
+msgstr "ඔබට ආසන්න ප්‍රතිඵල පෙන්වීම සඳහා අපට ඔබේ නිර්නාමික%1$s පිහිටීම%2$s භාවිතා කළ හැකිය."
 
 # smartling.placeholder_format=C
 #. Error message displayed when one or more attached files are encrypted and cannot be read.
@@ -21733,8 +22132,7 @@ msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
 msgstr ""
-"අමුණා ඇති ගොනුවලින් යටත් පිරිසෙයින් එකක් හෝ සංකේතනය කර ඇති නිසා, අපට ඒවා "
-"කියවිය නොහැක."
+"අමුණා ඇති ගොනුවලින් යටත් පිරිසෙයින් එකක් හෝ සංකේතනය කර ඇති නිසා, අපට ඒවා කියවිය නොහැක."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -21750,9 +22148,7 @@ msgstr "අපි පරිශීලක නාම හෝ පුද්ගලි�
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don't store your personal info or track you. Ever."
-msgstr ""
-"කවදාවත් අප ඔබගේ පෞද්ගලික දත්ත ගබඩා කරන්නේ හෝ ඔබව අනවසරයෙන් පරීක්ෂා කරන්නේද "
-"නැත."
+msgstr "කවදාවත් අප ඔබගේ පෞද්ගලික දත්ත ගබඩා කරන්නේ හෝ ඔබව අනවසරයෙන් පරීක්ෂා කරන්නේද නැත."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -21764,8 +22160,8 @@ msgid ""
 "We don't store your personal info. We don't follow you around with ads. We "
 "don't track you. Ever."
 msgstr ""
-"අපි ඔබේ පුද්ගලික තතු ගබඩා කර නොගන්නෙමු. අපි වෙළෙඳ දැන්වීම්වලින් ඔබව කරදරයට "
-"පත් නොකරන්නෙමු. අපි ඔබව නිරික්සන්නේ නැත. කවදත්."
+"අපි ඔබේ පුද්ගලික තතු ගබඩා කර නොගන්නෙමු. අපි වෙළෙඳ දැන්වීම්වලින් ඔබව කරදරයට පත් නොකරන්නෙමු. "
+"අපි ඔබව නිරික්සන්නේ නැත. කවදත්."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -21779,8 +22175,8 @@ msgid ""
 "We don't track you, so we could use your help telling us what brought you "
 "back today:"
 msgstr ""
-"අපි ඔබව අනවසරයෙන් පරීක්ෂා කරන්නේ නැත, ඉතින් අද ඔබව මෙහි ගෙන ආවේ කුමක්ද යැයි "
-"පැවසුවහොත් එය අපට උපකාරී වීමට හැක:"
+"අපි ඔබව අනවසරයෙන් පරීක්ෂා කරන්නේ නැත, ඉතින් අද ඔබව මෙහි ගෙන ආවේ කුමක්ද යැයි පැවසුවහොත් එය "
+"අපට උපකාරී වීමට හැක:"
 
 # smartling.placeholder_format=C
 #. Message prompting users to fill out a feedback form.
@@ -21789,8 +22185,8 @@ msgid ""
 "We don't track you, so we could use your help telling us what convinced you "
 "to try us out today:"
 msgstr ""
-"අපි ඔබව ලුහුබැඳ නොයන්නෙමු, එබැවින් අද අපව අත්හදා බැලීමට ඔබට ඒත්තු ගැන්වූ දේ "
-"අපට පැවසීමට ඔබගේ උදව් භාවිතා කළ හැකිය:"
+"අපි ඔබව ලුහුබැඳ නොයන්නෙමු, එබැවින් අද අපව අත්හදා බැලීමට ඔබට ඒත්තු ගැන්වූ දේ අපට පැවසීමට "
+"ඔබගේ උදව් භාවිතා කළ හැකිය:"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -21830,8 +22226,8 @@ msgid ""
 "We don’t store your search history. We therefore have nothing to sell to "
 "advertisers that track you across the Internet."
 msgstr ""
-"අප ඔබගේ සෙවුම් ඉතිහාසය ගබඩා කරන්නේ නැත. එම නිසා අපට අන්තර්ජාලය හරහා දැන්වීම "
-"වලට විකිණීමට කිසිවක් නැත."
+"අප ඔබගේ සෙවුම් ඉතිහාසය ගබඩා කරන්නේ නැත. එම නිසා අපට අන්තර්ජාලය හරහා දැන්වීම වලට විකිණීමට "
+"කිසිවක් නැත."
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -21857,8 +22253,8 @@ msgid ""
 "We have agreements with all AI providers to ensure your chats aren't used to "
 "train AIs."
 msgstr ""
-"ඔබගේ කතාබස් AI පුහුණු කිරීම සඳහා භාවිතා නොකිරීමට අපි සියලුම AI සපයන්නන් සමඟ "
-"ගිවිසුම් ඇති කරගෙන ඇත්තෙමු."
+"ඔබගේ කතාබස් AI පුහුණු කිරීම සඳහා භාවිතා නොකිරීමට අපි සියලුම AI සපයන්නන් සමඟ ගිවිසුම් ඇති කරගෙන "
+"ඇත්තෙමු."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -21883,8 +22279,8 @@ msgid ""
 "We make money from %sprivacy-respecting search ads%s, not by exploiting your "
 "data."
 msgstr ""
-"අපි %1$sපෞද්ගලිකත්වයට ගරු කරන සෙවුම් දැන්වීම්%2$s මගින් මුදල් උපයන්නෙමු, ඔබේ "
-"දත්ත සූරාකෑමෙන් නොවේ."
+"අපි %1$sපෞද්ගලිකත්වයට ගරු කරන සෙවුම් දැන්වීම්%2$s මගින් මුදල් උපයන්නෙමු, ඔබේ දත්ත සූරාකෑමෙන් "
+"නොවේ."
 
 # smartling.placeholder_format=C
 #. Message describing how DuckDuckGo users location access anonymously to provide better search results.
@@ -21893,16 +22289,15 @@ msgid ""
 "We only use your anonymous location to deliver better results, closer to "
 "you. You can always change your mind later."
 msgstr ""
-"අපි ඔබට වඩා ආසන්නයෙන් ඇති, වඩා හොඳ ප්‍රතිඵල ලබා දීම සඳහා පමණක් ඔබේ නිර්නාමික "
-"පිහිටීම භාවිතා කරන්නෙමු. ඔබට ඕනෑම මොහොතක පසුව ඔබේ අදහස වෙනස් කරගත හැක."
+"අපි ඔබට වඩා ආසන්නයෙන් ඇති, වඩා හොඳ ප්‍රතිඵල ලබා දීම සඳහා පමණක් ඔබේ නිර්නාමික පිහිටීම භාවිතා "
+"කරන්නෙමු. ඔබට ඕනෑම මොහොතක පසුව ඔබේ අදහස වෙනස් කරගත හැක."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
 msgstr ""
-"අපි DuckDuckGo සෑම කෙනෙකුටම වඩා හොඳ කිරීම සඳහා ඔබේ නිර්නාමික ප්‍රතිචාර මත "
-"රඳා සිටිමු."
+"අපි DuckDuckGo සෑම කෙනෙකුටම වඩා හොඳ කිරීම සඳහා ඔබේ නිර්නාමික ප්‍රතිචාර මත රඳා සිටිමු."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -21923,15 +22318,13 @@ msgid ""
 "incorporated at the discretion of %s. Corrections may not show up in results "
 "right away."
 msgstr ""
-"DuckDuckGo වැඩි දියුණු කිරීම සඳහා අපි මෙවැනි ප්‍රතිපෝෂණ භාවිතා කරමු. %1$s හි "
-"අභිමතය පරිදි යෝජනා ඇතුළත් කෙරේ. නිවැරදි කිරීම් වහාම ප්‍රතිඵලවල නොපෙන්වයි."
+"DuckDuckGo වැඩි දියුණු කිරීම සඳහා අපි මෙවැනි ප්‍රතිපෝෂණ භාවිතා කරමු. %1$s හි අභිමතය පරිදි "
+"යෝජනා ඇතුළත් කෙරේ. නිවැරදි කිරීම් වහාම ප්‍රතිඵලවල නොපෙන්වයි."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
-msgstr ""
-"ඔබ බ්‍රවුස් කරන විට ඔබගේ දත්ත රැස් කිරීමට උත්සාහ කරන ට්‍රැකර් අපි අවහිර "
-"කරන්නෙමු."
+msgstr "ඔබ බ්‍රවුස් කරන විට ඔබගේ දත්ත රැස් කිරීමට උත්සාහ කරන ට්‍රැකර් අපි අවහිර කරන්නෙමු."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -21940,8 +22333,8 @@ msgid ""
 "We're aware of this issue and are currently working to resolve it. If you "
 "continue to see this error, please reach out to %s."
 msgstr ""
-"අපි මෙම ගැටලුව පිළිබඳව දන්නා අතර දැනට එය විසඳීමට කටයුතු කරමින් සිටිමු. ඔබට "
-"මෙම දෝෂය දිගටම පෙනේ නම්, කරුණාකර %1$s වෙත සම්බන්ධ වන්න."
+"අපි මෙම ගැටලුව පිළිබඳව දන්නා අතර දැනට එය විසඳීමට කටයුතු කරමින් සිටිමු. ඔබට මෙම දෝෂය දිගටම "
+"පෙනේ නම්, කරුණාකර %1$s වෙත සම්බන්ධ වන්න."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -21950,8 +22343,8 @@ msgid ""
 "We're aware of this issue and are currently working to resolve it. Sometimes "
 "clearing your browser's cache can help."
 msgstr ""
-"අපි මෙම ගැටලුව පිළිබඳව දන්නා අතර දැනට එය විසඳීමට කටයුතු කරමින් සිටිමු. සමහර "
-"විට ඔබගේ බ්‍රවුසරයේ හැඹිලිය හිස් කිරීම උපකාරී විය හැක."
+"අපි මෙම ගැටලුව පිළිබඳව දන්නා අතර දැනට එය විසඳීමට කටයුතු කරමින් සිටිමු. සමහර විට ඔබගේ "
+"බ්‍රවුසරයේ හැඹිලිය හිස් කිරීම උපකාරී විය හැක."
 
 # smartling.placeholder_format=C
 #. Header for a feedback form for new users.
@@ -21966,8 +22359,7 @@ msgid ""
 "We're sorry for this inconvenience. We’re working hard to make your "
 "experience better."
 msgstr ""
-"අප මේ අපහසුතාව ගැන කනගාටුව ප්‍රකාශ කරමු. ඔබේ අත්දැකීම වඩා හොඳ කිරීමට අපි "
-"මහන්සි වෙමින් සිටිමු."
+"අප මේ අපහසුතාව ගැන කනගාටුව ප්‍රකාශ කරමු. ඔබේ අත්දැකීම වඩා හොඳ කිරීමට අපි මහන්සි වෙමින් සිටිමු."
 
 # smartling.placeholder_format=C
 #. Body text explaining the service update requires a page reload.
@@ -21976,8 +22368,7 @@ msgid ""
 "We've updated the Duck.ai service. For the change to take effect, we need to "
 "reload the page."
 msgstr ""
-"අපි Duck.ai සේවාව යාවත්කාලීන කළෙමු. වෙනස ක්‍රියාත්මක වීමට, අප පිටුව නැවත "
-"පූරණය කළ යුතුය."
+"අපි Duck.ai සේවාව යාවත්කාලීන කළෙමු. වෙනස ක්‍රියාත්මක වීමට, අප පිටුව නැවත පූරණය කළ යුතුය."
 
 # smartling.placeholder_format=C
 #. Instant Answer Tab Name
@@ -22080,8 +22471,8 @@ msgid ""
 "Weekly usage limit reached. You can keep chatting by using your monthly "
 "limit."
 msgstr ""
-"සතිපතා පරිශීලන සීමාවට ළඟා වී ඇත. ඔබේ මාසික සීමාව භාවිතා කිරීමෙන් ඔබට දිගටම "
-"කතාබහේ යෙදිය හැකි ය."
+"සතිපතා පරිශීලන සීමාවට ළඟා වී ඇත. ඔබේ මාසික සීමාව භාවිතා කිරීමෙන් ඔබට දිගටම කතාබහේ යෙදිය "
+"හැකි ය."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -22095,8 +22486,8 @@ msgid ""
 "Welcome to Duck.ai! All of your chats here are private, anonymized by us and "
 "not used to train AI models."
 msgstr ""
-"Duck.ai වෙත සාදරයෙන් පිළිගනිමු! මෙහි ඇති ඔබගේ සියලු කතාබස් පුද්ගලිකයි, අප "
-"විසින් නිර්නාමිකෘත කර ඇති අතර AI ආකෘති පුහුණු කිරීමට භාවිත නොකෙරේ."
+"Duck.ai වෙත සාදරයෙන් පිළිගනිමු! මෙහි ඇති ඔබගේ සියලු කතාබස් පුද්ගලිකයි, අප විසින් නිර්නාමිකෘත කර "
+"ඇති අතර AI ආකෘති පුහුණු කිරීමට භාවිත නොකෙරේ."
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened.
@@ -22105,9 +22496,8 @@ msgid ""
 "Welcome to DuckDuckGo AI Chat! All of your chats here are private, "
 "anonymized by us and not used to train AI models."
 msgstr ""
-"DuckDuckGo AI Chat වෙත සාදරයෙන් පිළිගනිමු! මෙහි ඇති ඔබගේ සියලු කතාබස් "
-"පුද්ගලිකයි, අප විසින් නිර්නාමිකෘත කර ඇති අතර AI ආකෘති පුහුණු කිරීමට භාවිත "
-"නොකෙරේ."
+"DuckDuckGo AI Chat වෙත සාදරයෙන් පිළිගනිමු! මෙහි ඇති ඔබගේ සියලු කතාබස් පුද්ගලිකයි, අප විසින් "
+"නිර්නාමිකෘත කර ඇති අතර AI ආකෘති පුහුණු කිරීමට භාවිත නොකෙරේ."
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened. Example: 'Welcome to DuckDuckGo AI Chat! This chat session is powered by OpenAI’s GPT-3. All of your chats here are private, and are never stored by DuckDuckGo or used to train AI models.'
@@ -22117,17 +22507,15 @@ msgid ""
 "of your chats here are private, and are never stored by DuckDuckGo or used "
 "to train AI models."
 msgstr ""
-"DuckDuckGo AI Chat වෙත සාදරයෙන් පිළිගනිමු! මෙම කතාබස් සැසිය බලගන්වන්නේ "
-"%1$sගේ %2$s විසිනි. මෙහි ඔබගේ සියලු කතාබස් පෞද්ගලික වන අතර, කිසි විටෙකත් "
-"DuckDuckGo විසින් ගබඩා කර හෝ AI ආකෘති පුහුණු කිරීම සඳහා භාවිත නොකෙරේ."
+"DuckDuckGo AI Chat වෙත සාදරයෙන් පිළිගනිමු! මෙම කතාබස් සැසිය බලගන්වන්නේ %1$sගේ %2$s "
+"විසිනි. මෙහි ඔබගේ සියලු කතාබස් පෞද්ගලික වන අතර, කිසි විටෙකත් DuckDuckGo විසින් ගබඩා කර හෝ AI "
+"ආකෘති පුහුණු කිරීම සඳහා භාවිත නොකෙරේ."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai! You can now import your downloaded chats."
-msgstr ""
-"නව Duck.ai වෙත සාදරයෙන් පිළිගනිමු! දැන් ඔයාට බාගත කරගත් කතාබස් ආයාත කරන්න "
-"පුළුවන්."
+msgstr "නව Duck.ai වෙත සාදරයෙන් පිළිගනිමු! දැන් ඔයාට බාගත කරගත් කතාබස් ආයාත කරන්න පුළුවන්."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -22195,8 +22583,8 @@ msgid ""
 "We’re really sorry, but it seems there was a problem loading Duck.ai. Try "
 "reloading the page."
 msgstr ""
-"අපිට ඇත්තටම කණගාටුයි, නමුත් Duck.ai පූරණය කිරීමේදී ගැටලුවක් ඇතිවූ බව පෙනේ. "
-"පිටුව නැවත ප්‍රවේශනය කර උත්සාහ කරන්න."
+"අපිට ඇත්තටම කණගාටුයි, නමුත් Duck.ai පූරණය කිරීමේදී ගැටලුවක් ඇතිවූ බව පෙනේ. පිටුව නැවත "
+"ප්‍රවේශනය කර උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to suggest an AI (Artificial Intelligence) model to be added to the product, and this field is optional.
@@ -22211,8 +22599,7 @@ msgid ""
 "What are some arguments, counter-arguments, and rebuttals to the concept of "
 "a plant-based diet?"
 msgstr ""
-"ශාක පදනම් කරගත් ආහාරයක් පිළිබඳ සංකල්පයට සමහර තර්ක, ප්‍රති-තර්ක සහ "
-"ප්‍රතිවිරෝධතා මොනවාද?"
+"ශාක පදනම් කරගත් ආහාරයක් පිළිබඳ සංකල්පයට සමහර තර්ක, ප්‍රති-තර්ක සහ ප්‍රතිවිරෝධතා මොනවාද?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for considering factors when purchasing a computer monitor.
@@ -22233,8 +22620,8 @@ msgid ""
 "What are some options for the word ‘better’ in the context of “We really "
 "need to do better.”"
 msgstr ""
-"“අපි ඇත්තටම වඩා හොඳ කරන්න ඕන” යන සන්දර්භය තුළ 'වඩා හොඳ' යන වචනය සඳහා සමහර "
-"විකල්ප මොනවාද."
+"“අපි ඇත්තටම වඩා හොඳ කරන්න ඕන” යන සන්දර්භය තුළ 'වඩා හොඳ' යන වචනය සඳහා සමහර විකල්ප "
+"මොනවාද."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
@@ -22253,11 +22640,107 @@ msgid ""
 "easy to understand for people with or without much AI, or technical, "
 "experience."
 msgstr ""
-"Duck.ai භාවිතා කිරීමට උනන්දුවක් දක්වන කෙනෙකුට DuckDuckGo බ්‍රව්සරය බාගැනීමේ "
-"ප්‍රතිලාභ මොනවා ද? නිල DuckDuckGo මූලාශ්‍ර පමණක් යොමු කරන්න. Duck.ai ඒකාබද්ධ "
-"කිරීම් සහ රහස්‍යතා ආරක්ෂණ කෙරෙහි අවධානය යොමු කරමින්, ප්‍රතිචාරය මාතෘකා සහිත "
-"පැහැදිලි කොටස්වලට බෙදන්න. AI හෝ තාක්ෂණික අත්දැකීම් ඇති හෝ නැති අයට එය තරමක් "
-"කෙටි, සරල සහ තේරුම් ගැනීමට පහසු වන පරිදි සකසන්න."
+"Duck.ai භාවිතා කිරීමට උනන්දුවක් දක්වන කෙනෙකුට DuckDuckGo බ්‍රව්සරය බාගැනීමේ ප්‍රතිලාභ මොනවා "
+"ද? නිල DuckDuckGo මූලාශ්‍ර පමණක් යොමු කරන්න. Duck.ai ඒකාබද්ධ කිරීම් සහ රහස්‍යතා ආරක්ෂණ "
+"කෙරෙහි අවධානය යොමු කරමින්, ප්‍රතිචාරය මාතෘකා සහිත පැහැදිලි කොටස්වලට බෙදන්න. AI හෝ තාක්ෂණික "
+"අත්දැකීම් ඇති හෝ නැති අයට එය තරමක් කෙටි, සරල සහ තේරුම් ගැනීමට පහසු වන පරිදි සකසන්න."
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the counterarguments?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the hours & location?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key contributions of this paper?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key contributions?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key details?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key points covered in this video?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key points?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key takeaways from this article?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key takeaways?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key things I will learn from this course?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main counterarguments or criticisms of this?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main questions this page answers?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the must-try dishes here?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"What are the opening hours, location, and contact details for this place?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the pros and cons of this product?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the pros and cons?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
@@ -22360,6 +22843,12 @@ msgid "What does atria mean in the context of a medical article?"
 msgstr "වෛද්‍ය ලිපියක සන්දර්භය තුළ ඇට්රියා අදහස් කරන්නේ කුමක්ද?"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What does this answer?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
@@ -22372,20 +22861,31 @@ msgid "What information gets saved?"
 msgstr "සුරකින තොරතුරු මොනවාද?"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What interview questions might come up for this role?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
 msgid ""
 "What is the Cloud Save bookmarklet and how does it differ from the URL "
 "parameter bookmarklet?"
 msgstr ""
-"Cloud Save පොත් සලකුණු යනු කුමක්ද සහ එය URL පරාමිති පොත් සලකුණු වලින් වෙනස් "
-"වන්නේ කෙසේද?"
+"Cloud Save පොත් සලකුණු යනු කුමක්ද සහ එය URL පරාමිති පොත් සලකුණු වලින් වෙනස් වන්නේ කෙසේද?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for looking up the capital city of Albania.
 msgctxt "Full sentence for looking up basic facts"
 msgid "What is the capital city of Albania?"
 msgstr "ඇල්බේනියාවේ අගනුවර කුමක්ද?"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What is the overall verdict and rating for this?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to a page with additional information.
@@ -22410,6 +22910,12 @@ msgid "What people say:"
 msgstr "මිනිසුන් පවසන දේ:"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What should I order?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
 msgctxt "feedback form"
 msgid "What stood out?"
@@ -22420,6 +22926,18 @@ msgstr "කැපී පෙනුණේ කුමක් ද?"
 msgctxt "feedback form"
 msgid "What was wrong with the response? (optional)"
 msgstr "ප්‍රතිචාරයේ තිබූ ගැටලුව කුමක් ද? (විකල්ප)"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I learn?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I need?"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -22439,6 +22957,12 @@ msgid "What's New"
 msgstr "අලුත් දෑ"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What's the verdict?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to a page featuring the most recent updates from DuckDuckGo.
 msgid "What’s New"
 msgstr "අලුත් දෑ"
@@ -22450,8 +22974,8 @@ msgid ""
 "When buying an electric guitar for a beginner, what are the top product "
 "brands I should consider?"
 msgstr ""
-"ආරම්භකයෙකු සඳහා විදුලි ගිටාරයක් මිලදී ගැනීමේදී, මා සලකා බැලිය යුතු ඉහළම "
-"නිෂ්පාදන වෙළඳ නාම මොනවාද?"
+"ආරම්භකයෙකු සඳහා විදුලි ගිටාරයක් මිලදී ගැනීමේදී, මා සලකා බැලිය යුතු ඉහළම නිෂ්පාදන වෙළඳ නාම "
+"මොනවාද?"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -22489,6 +23013,12 @@ msgid "Which features are missing? (Optional)"
 msgstr "අතුරුදහන් වී ඇති විශේෂාංග මොනවාද? (විකල්ප)"
 
 # smartling.placeholder_format=C
+#. An invitation for users to leave feedback
+msgctxt "Feedback prompt"
+msgid "Which features are missing? (optional)"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
 msgid "White"
 msgstr "සුදු"
@@ -22503,6 +23033,18 @@ msgstr "සුදු"
 #. Link to an about us page.
 msgid "Who We Are"
 msgstr "අපි කවුද"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Who are the main cast and crew, and what else are they known for?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Who is this person?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Header above a collection of privacy-related links.
@@ -22892,9 +23434,7 @@ msgctxt "Disclaimer bellow chat input - desktop"
 msgid ""
 "You are chatting with %s. AI chats may display inaccurate or offensive "
 "information."
-msgstr ""
-"ඔබට එය %1$sහි නැරඹිය හැකිය. AI කතාබස් සාවද්ය හෝ අමනාපකාරී තොරතුරු පෙන්විය "
-"හැකිය."
+msgstr "ඔබට එය %1$sහි නැරඹිය හැකිය. AI කතාබස් සාවද්ය හෝ අමනාපකාරී තොරතුරු පෙන්විය හැකිය."
 
 # smartling.placeholder_format=C
 #. Provide users with the ability to retry their search on a different search engine. First placeholder will be a link with the text "try your search again" OR "try your search later". Second is a URL to the !bangs page: https://duckduckgo.com/bangs.
@@ -22903,8 +23443,8 @@ msgid ""
 "You can %s or search directly on other search engines from DuckDuckGo using "
 "%s search shortcuts."
 msgstr ""
-"ඔබට %2$s සෙවුම් කෙටිමං භාවිත කරමින් DuckDuckGo වෙතින් වෙනත් සෙවුම් යන්ත්‍ර "
-"මත කඍජුව %1$s හෝ සෙවිය හැකිය."
+"ඔබට %2$s සෙවුම් කෙටිමං භාවිත කරමින් DuckDuckGo වෙතින් වෙනත් සෙවුම් යන්ත්‍ර මත කඍජුව %1$s හෝ "
+"සෙවිය හැකිය."
 
 # smartling.placeholder_format=C
 #. Text informing the user that they can access DuckDuckGo AI Chat directly at a specific URL. The placeholder %s will be replaced with the link. Example: 'You can access DuckDuckGo AI Chat directly at duck.ai.'
@@ -22918,8 +23458,8 @@ msgctxt "duckassist"
 msgid ""
 "You can adjust how %s works or turn it off anytime in %sSearch Settings%s."
 msgstr ""
-"ඔබට %1$s ක්‍රියා කරන ආකාරය සකස් කිරීමට හෝ ඕනෑම වේලාවක %2$sසෙවුම් සැකසුම්%3$s "
-"තුළ එය අක්‍රිය කළ හැකිය."
+"ඔබට %1$s ක්‍රියා කරන ආකාරය සකස් කිරීමට හෝ ඕනෑම වේලාවක %2$sසෙවුම් සැකසුම්%3$s තුළ එය "
+"අක්‍රිය කළ හැකිය."
 
 # smartling.placeholder_format=C
 #. Assist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate Assist.
@@ -22928,22 +23468,21 @@ msgid ""
 "You can adjust how Assist works or turn it off anytime in %sSearch "
 "Settings%s."
 msgstr ""
-"ඔබට %1$sසෙවුම් සැකසීම්%2$s තුළ ඕනෑම වේලාවක Assist ක්‍රියා කරන ආකාරය සකස් "
-"කිරීමට හෝ එය අක්‍රිය කිරීමට හැකිය."
+"ඔබට %1$sසෙවුම් සැකසීම්%2$s තුළ ඕනෑම වේලාවක Assist ක්‍රියා කරන ආකාරය සකස් කිරීමට හෝ එය "
+"අක්‍රිය කිරීමට හැකිය."
 
 # smartling.placeholder_format=C
 msgid "You can also use %sDuck.ai%s to answer questions or summarize text."
 msgstr ""
-"ප්‍රශ්නවලට පිළිතුරු දීමට හෝ පෙළ සාරාංශ කිරීමට ඔබට %1$sDuck.ai%2$s ද භාවිත කළ "
-"හැකිය."
+"ප්‍රශ්නවලට පිළිතුරු දීමට හෝ පෙළ සාරාංශ කිරීමට ඔබට %1$sDuck.ai%2$s ද භාවිත කළ හැකිය."
 
 # smartling.placeholder_format=C
 msgid ""
 "You can also use %sDuckDuckGo AI Chat%s to answer questions or summarize "
 "text."
 msgstr ""
-"ඔබට ප්‍රශ්නවලට පිළිතුරු දීමට හෝ පෙළ සාරාංශ කිරීමට %1$sDuckDuckGo AI Chat%2$s "
-"ද භාාවිත කළ හැකිය."
+"ඔබට ප්‍රශ්නවලට පිළිතුරු දීමට හෝ පෙළ සාරාංශ කිරීමට %1$sDuckDuckGo AI Chat%2$s ද භාාවිත "
+"කළ හැකිය."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach more text selections than are allowed. Placeholder is the maximum number of text selections. E.g. You can attach up to 5 text selections.
@@ -22957,8 +23496,8 @@ msgid ""
 "You can change how frequently you see Search Assist, or turn it off "
 "entirely, in %sSearch Settings%s."
 msgstr ""
-"ඔබට %1$sසෙවුම් සැකසුම්%2$s තුළ Search Assist දකින වාර ගණන වෙනස් කළ හැකි අතර, "
-"එය සම්පූර්ණයෙන්ම අක්‍රිය කළ හැකිය."
+"ඔබට %1$sසෙවුම් සැකසුම්%2$s තුළ Search Assist දකින වාර ගණන වෙනස් කළ හැකි අතර, එය "
+"සම්පූර්ණයෙන්ම අක්‍රිය කළ හැකිය."
 
 # smartling.placeholder_format=C
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
@@ -22973,8 +23512,8 @@ msgid ""
 "You can do this by saving your settings under a different passphrase, "
 "optionally deleting the first set."
 msgstr ""
-"වෙනස් මුර පදයක් යටතේ ඔබගේ සැකසුම් සුරැකීමෙන් ඔබට මෙය කළ හැකිය, විකල්පයක් ලෙස "
-"පළමු සමූහය මකනවා."
+"වෙනස් මුර පදයක් යටතේ ඔබගේ සැකසුම් සුරැකීමෙන් ඔබට මෙය කළ හැකිය, විකල්පයක් ලෙස පළමු සමූහය "
+"මකනවා."
 
 # smartling.placeholder_format=C
 #. Prefix for filename location sentence.
@@ -23054,8 +23593,8 @@ msgid ""
 "You can only block up to %s sites. To block %s, you'll need to unblock "
 "another site first."
 msgstr ""
-"ඔබට අවහිර කළ හැක්කේ අඩවි %1$s දක්වා පමණි. %2$s අවහිර කිරීමට, ඔබ මුලින්ම "
-"වෙනත් වෙබ් අඩවියක් අහිතකර කිරීමට අවශ්ය වේ."
+"ඔබට අවහිර කළ හැක්කේ අඩවි %1$s දක්වා පමණි. %2$s අවහිර කිරීමට, ඔබ මුලින්ම වෙනත් වෙබ් අඩවියක් "
+"අහිතකර කිරීමට අවශ්ය වේ."
 
 # smartling.placeholder_format=C
 #. Text explaining the benefits of the cloud save feature.
@@ -23112,8 +23651,8 @@ msgid ""
 "You now have access to %s, higher AI reasoning, and 2x higher usage limits "
 "than Plus."
 msgstr ""
-"ඔබට දැන් %1$s වෙත ප් රවේශය, ඉහළ AI තර්කනය සහ Plus ප්‍රකාරයට වඩා දෙගුණයක් "
-"පුළුල් පරිශීලන සීමාවන් ඇත."
+"ඔබට දැන් %1$s වෙත ප් රවේශය, ඉහළ AI තර්කනය සහ Plus ප්‍රකාරයට වඩා දෙගුණයක් පුළුල් පරිශීලන "
+"සීමාවන් ඇත."
 
 # smartling.placeholder_format=C
 #. Description text for the welcome modal displayed after the user subscribes to DuckDuckGo.
@@ -23122,8 +23661,8 @@ msgid ""
 "You now have access to advanced AI models. You can access the VPN and other "
 "DuckDuckGo subscription protections in the DuckDuckGo browser."
 msgstr ""
-"ඔබට දැන් උසස් AI ආකෘති වෙත ප්‍රවේශය ඇත. ඔබට DuckDuckGo බ්‍රවුසරයේ VPN සහ "
-"අනෙකුත් DuckDuckGo දායකත්ව ආරක්ෂණ වෙත ප්‍රවේශ විය හැක."
+"ඔබට දැන් උසස් AI ආකෘති වෙත ප්‍රවේශය ඇත. ඔබට DuckDuckGo බ්‍රවුසරයේ VPN සහ අනෙකුත් "
+"DuckDuckGo දායකත්ව ආරක්ෂණ වෙත ප්‍රවේශ විය හැක."
 
 # smartling.placeholder_format=C
 #. Welcome message that appears after the DuckDuckGo extension is installed.
@@ -23145,9 +23684,9 @@ msgid ""
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
 msgstr ""
-"මෙම බ්‍රව්සරයෙන් ඔබගේ සුරකින ලද කතාබස් වෙත ප්‍රවේශ වීමට ඔබට තවදුරටත් නොහැකි "
-"වනු ඇත. අවසාන කතාබස් 30 තවමත් දේශීය ගබඩාවේ පවතිනු ඇත. මින් ඔබේ කතාබස් "
-"සංකේතනය කළ සර්වරයෙන් මකා දමනු නොලැබේ."
+"මෙම බ්‍රව්සරයෙන් ඔබගේ සුරකින ලද කතාබස් වෙත ප්‍රවේශ වීමට ඔබට තවදුරටත් නොහැකි වනු ඇත. අවසාන "
+"කතාබස් 30 තවමත් දේශීය ගබඩාවේ පවතිනු ඇත. මින් ඔබේ කතාබස් සංකේතනය කළ සර්වරයෙන් මකා දමනු "
+"නොලැබේ."
 
 # smartling.placeholder_format=C
 #. Explains that turning off disconnects this browser only; the last 30 chats stay in local storage and the encrypted server backup is not deleted.
@@ -23157,9 +23696,9 @@ msgid ""
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
 msgstr ""
-"මෙම බ්‍රව්සරයෙන් ඔබගේ සුරකින ලද කතාබස් වෙත ප්‍රවේශ වීමට ඔබට තවදුරටත් නොහැකි "
-"වනු ඇත. අවසාන කතාබස් 30 තවමත් ස්ථානීය ගබඩාවේ පවතිනු ඇත. මින් ඔබේ කතාබස් "
-"සංකේතනය කළ සර්වරයෙන් මකා දමනු නොලැබේ."
+"මෙම බ්‍රව්සරයෙන් ඔබගේ සුරකින ලද කතාබස් වෙත ප්‍රවේශ වීමට ඔබට තවදුරටත් නොහැකි වනු ඇත. අවසාන "
+"කතාබස් 30 තවමත් ස්ථානීය ගබඩාවේ පවතිනු ඇත. මින් ඔබේ කතාබස් සංකේතනය කළ සර්වරයෙන් මකා දමනු "
+"නොලැබේ."
 
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
@@ -23172,9 +23711,7 @@ msgctxt "Update browser banner"
 msgid ""
 "You'll receive automatic DuckDuckGo app updates once you have the latest "
 "version."
-msgstr ""
-"ඔබට නවතම අනුවාදය ලැබුණු පසු ඔබට ස්වයංක්‍රීය DuckDuckGo යෙදුම් යාවත්කාලීන "
-"ලැබෙනු ඇත."
+msgstr "ඔබට නවතම අනුවාදය ලැබුණු පසු ඔබට ස්වයංක්‍රීය DuckDuckGo යෙදුම් යාවත්කාලීන ලැබෙනු ඇත."
 
 # smartling.placeholder_format=C
 #. shown when DDG is selected after eu preference menu on android
@@ -23183,8 +23720,8 @@ msgid ""
 "You're now searching privately in Chrome. Use our app instead of Chrome to "
 "browse privately too. It’s already installed and can:"
 msgstr ""
-"දැන් ඔබ Chromeහි පුද්ගලිකව සොයමින් සිටී. පුද්ගලිකව පිරික්සීමටත් Chrome "
-"වෙනුවට අපගේ යෙදුම භාවිතා කරන්න. එය දැනටමත් ස්ථාපනය කර ඇති අතර හැකියාව ඇත්තේ:"
+"දැන් ඔබ Chromeහි පුද්ගලිකව සොයමින් සිටී. පුද්ගලිකව පිරික්සීමටත් Chrome වෙනුවට අපගේ යෙදුම භාවිතා "
+"කරන්න. එය දැනටමත් ස්ථාපනය කර ඇති අතර හැකියාව ඇත්තේ:"
 
 # smartling.placeholder_format=C
 #. Confirmation message that appears after the DuckDuckGo browser extension is installed.
@@ -23197,8 +23734,8 @@ msgid ""
 "You're now searching with privacy. %sGet tips to reduce your footprint even "
 "more."
 msgstr ""
-"ඔබ දැන් පෞද්ගලිකත්වයෙන් යුතුව සොයයි. %1$sඔබගේ පා සටහන් තව දුරටත් අවම කර "
-"ගැනීමට ඉඟි ලබා ගන්න."
+"ඔබ දැන් පෞද්ගලිකත්වයෙන් යුතුව සොයයි. %1$sඔබගේ පා සටහන් තව දුරටත් අවම කර ගැනීමට ඉඟි ලබා "
+"ගන්න."
 
 # smartling.placeholder_format=C
 #. Title of a notice thanking the user for turning off their adblocker
@@ -23268,9 +23805,8 @@ msgid ""
 "You've run out of Sync & Backup storage for Duck.ai chats with attachments. "
 "Delete the %s oldest chats to resume Sync. Pinned chats will not be deleted."
 msgstr ""
-"ඔබට ඇමුණුම් සහිත Duck.ai කතාබස් සඳහා Sync & Backup ඉඩ අවසන් වී ඇත. සමමුහුර්ත "
-"කිරීම නැවත ආරම්භ කිරීමට පැරණිතම කතාබස් %1$s මකන්න. ඇමුණූ කතාබස් මකා දමනු "
-"නොලැබේ."
+"ඔබට ඇමුණුම් සහිත Duck.ai කතාබස් සඳහා Sync & Backup ඉඩ අවසන් වී ඇත. සමමුහුර්ත කිරීම නැවත "
+"ආරම්භ කිරීමට පැරණිතම කතාබස් %1$s මකන්න. ඇමුණූ කතාබස් මකා දමනු නොලැබේ."
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -23280,9 +23816,8 @@ msgid ""
 "oldest chats with attachments to resume Sync. Pinned chats will not be "
 "deleted."
 msgstr ""
-"ඔබට Duck.ai කතාබස් සඳහා Sync & Backup ඉඩ අවසන් වී ඇත. සමමුහුර්ත කිරීම නැවත "
-"ආරම්භ කිරීමට ඇමුතුම් සමඟ පැරණිතම කතාබස් %1$s මකන්න. ඇමුණූ කතාබස් මකා දමනු "
-"නොලැබේ."
+"ඔබට Duck.ai කතාබස් සඳහා Sync & Backup ඉඩ අවසන් වී ඇත. සමමුහුර්ත කිරීම නැවත ආරම්භ කිරීමට "
+"ඇමුතුම් සමඟ පැරණිතම කතාබස් %1$s මකන්න. ඇමුණූ කතාබස් මකා දමනු නොලැබේ."
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the sync storage limit.
@@ -23296,9 +23831,8 @@ msgid ""
 "YouTube (owned by Google) does not let you watch videos anonymously. As "
 "such, watching YouTube videos here will be tracked by YouTube/Google."
 msgstr ""
-"Youtube (Google සතු) ඔබට නිර්නාමිකව වීඩියෝ දර්ශන නැරඹීමට ඉඩ ලබා දෙන්නේ නැහැ. "
-"ඒ වගේම, Youtube වීඩියෝ නැරඹීමේදී Google/Youtube මගින් අනවසරයෙන් පරීක්ෂා "
-"කිරීමකට ලක් වෙන්න පුළුවන්."
+"Youtube (Google සතු) ඔබට නිර්නාමිකව වීඩියෝ දර්ශන නැරඹීමට ඉඩ ලබා දෙන්නේ නැහැ. ඒ වගේම, "
+"Youtube වීඩියෝ නැරඹීමේදී Google/Youtube මගින් අනවසරයෙන් පරීක්ෂා කිරීමකට ලක් වෙන්න පුළුවන්."
 
 # smartling.placeholder_format=C
 #. Label for a privacy disclaimer related to YouTube videos
@@ -23342,9 +23876,8 @@ msgid ""
 "disconnected from sync. Your %s most recent chats will be available in local "
 "storage on these browsers:"
 msgstr ""
-"ඔබේ උපස්ථය DuckDuckGo සර්වරයෙන් මකා දැමෙනු ඇත. සියලුම උපාංග සමමුහුර්තකරණයෙන් "
-"විසන්ධි වනු ඇත. ඔබගේ මෑත කාලීන කතාබස් %1$s මෙම බ්‍රව්සර්වල දේශීය ගබඩාවේ ලබා "
-"ගත හැකිය:"
+"ඔබේ උපස්ථය DuckDuckGo සර්වරයෙන් මකා දැමෙනු ඇත. සියලුම උපාංග සමමුහුර්තකරණයෙන් විසන්ධි වනු "
+"ඇත. ඔබගේ මෑත කාලීන කතාබස් %1$s මෙම බ්‍රව්සර්වල දේශීය ගබඩාවේ ලබා ගත හැකිය:"
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list.
@@ -23354,9 +23887,8 @@ msgid ""
 "disconnected from sync. Your 100 most recent chats will be available in "
 "local storage on these browsers:"
 msgstr ""
-"ඔබේ උපස්ථය DuckDuckGo සර්වරයෙන් මකා දැමෙනු ඇත. සියලුම උපාංග සමමුහුර්තකරණයෙන් "
-"විසන්ධි වනු ඇත. ඔබේ මෑත කාලීන කතාබස් 100 මෙම බ්‍රව්සර්වල දේශීය ගබඩාවේ ලබා ගත "
-"හැකිය:"
+"ඔබේ උපස්ථය DuckDuckGo සර්වරයෙන් මකා දැමෙනු ඇත. සියලුම උපාංග සමමුහුර්තකරණයෙන් විසන්ධි වනු "
+"ඇත. ඔබේ මෑත කාලීන කතාබස් 100 මෙම බ්‍රව්සර්වල දේශීය ගබඩාවේ ලබා ගත හැකිය:"
 
 # smartling.placeholder_format=C
 #. List item indicating that a site exclusion filter is currently active for the search
@@ -23381,8 +23913,8 @@ msgid ""
 "Your browser provides a list of your most-visited sites. DuckDuckGo never "
 "has access to this data."
 msgstr ""
-"ඔබගේ බ්‍රවුසරය ඔබ වැඩිපුරම නරඹන අඩවි ලැයිස්තුවක් සපයයි. DuckDuckGo වෙත "
-"කිසිවිටෙක මෙම දත්ත වෙත ප්‍රවේශය නොමැත."
+"ඔබගේ බ්‍රවුසරය ඔබ වැඩිපුරම නරඹන අඩවි ලැයිස්තුවක් සපයයි. DuckDuckGo වෙත කිසිවිටෙක මෙම දත්ත "
+"වෙත ප්‍රවේශය නොමැත."
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
@@ -23390,8 +23922,8 @@ msgid ""
 "Your browser provides the list of most-visited sites. DuckDuckGo never has "
 "access to this data."
 msgstr ""
-"ඔබගේ බ්‍රව්සරය නිතරම නරඹන අඩවි ලැයිස්තුවක් සපයනවා. නමුත් DuckDuckGo වලට "
-"කවදාවත් අවසරයක් නැහැ ඒ දත්ත වලට."
+"ඔබගේ බ්‍රව්සරය නිතරම නරඹන අඩවි ලැයිස්තුවක් සපයනවා. නමුත් DuckDuckGo වලට කවදාවත් අවසරයක් "
+"නැහැ ඒ දත්ත වලට."
 
 # smartling.placeholder_format=C
 #. Disclaimer text shown bellow chat input. Example: 'You are chatting with GPT-3. AI chats may display inaccurate or offensive information.'
@@ -23399,9 +23931,7 @@ msgctxt "Disclaimer bellow chat input - desktop"
 msgid ""
 "Your chat with %s is private. AI chats may display inaccurate or offensive "
 "information."
-msgstr ""
-"%1$s සමඟ ඔයාගේ චැට් පුද්ගලිකයි. AI චැට් සාවද්‍ය හෝ අමනාපකාරී තොරතුරු පෙන්විය "
-"හැකිය."
+msgstr "%1$s සමඟ ඔයාගේ චැට් පුද්ගලිකයි. AI චැට් සාවද්‍ය හෝ අමනාපකාරී තොරතුරු පෙන්විය හැකිය."
 
 # smartling.placeholder_format=C
 #. Body copy shown after Sync & Backup is enabled, confirming chats are now syncing.
@@ -23414,8 +23944,7 @@ msgstr "ඔබගේ කතාබස් දැන් සුරැකෙමින
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never saved or used to train AI models"
 msgstr ""
-"ඔබේ කතාබස් පුද්ගලික වන අතර AI ආකෘති පුහුණු කිරීම සඳහා කිසිවිටෙකත් සුරකිනු හෝ "
-"භාවිත නොකෙරේ"
+"ඔබේ කතාබස් පුද්ගලික වන අතර AI ආකෘති පුහුණු කිරීම සඳහා කිසිවිටෙකත් සුරකිනු හෝ භාවිත නොකෙරේ"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
@@ -23429,8 +23958,7 @@ msgctxt "Active Privacy protection description"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
 msgstr ""
-"ඔබගේ කතාබස් පුද්ගලිකයි, අප විසින් නිර්නාමිකෘත කර ඇති අතර AI ආකෘති පුහුණු "
-"කිරීමට භාවිත නොකෙරේ."
+"ඔබගේ කතාබස් පුද්ගලිකයි, අප විසින් නිර්නාමිකෘත කර ඇති අතර AI ආකෘති පුහුණු කිරීමට භාවිත නොකෙරේ."
 
 # smartling.placeholder_format=C
 #. Text explaining that user chats are private and not used for AI (Artificial Intelligence) training.
@@ -23438,8 +23966,7 @@ msgctxt "Body text for privacy protection modal"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
 msgstr ""
-"ඔබගේ කතාබස් පුද්ගලිකයි, අප විසින් නිර්නාමිකෘත කර ඇති අතර AI ආකෘති පුහුණු "
-"කිරීමට භාවිත නොකෙරේ."
+"ඔබගේ කතාබස් පුද්ගලිකයි, අප විසින් නිර්නාමිකෘත කර ඇති අතර AI ආකෘති පුහුණු කිරීමට භාවිත නොකෙරේ."
 
 # smartling.placeholder_format=C
 #. Text for a menu item that describes the privacy protection feature.
@@ -23447,8 +23974,8 @@ msgctxt "Menu item description"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
 msgstr ""
-"ඔබේ කතාබස් පුද්ගලික වන අතර, අප විසින් කිසි විටෙකත් සුරකින අතර AI ආකෘති "
-"පුහුණු කිරීමට භාවිත නොකෙරේ."
+"ඔබේ කතාබස් පුද්ගලික වන අතර, අප විසින් කිසි විටෙකත් සුරකින අතර AI ආකෘති පුහුණු කිරීමට භාවිත "
+"නොකෙරේ."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the active privacy protection.
@@ -23456,8 +23983,8 @@ msgctxt "Modal body for privacy"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
 msgstr ""
-"ඔබේ කතාබස් පුද්ගලික වන අතර, අප විසින් කිසි විටෙකත් සුරකින අතර AI ආකෘති "
-"පුහුණු කිරීමට භාවිත නොකෙරේ."
+"ඔබේ කතාබස් පුද්ගලික වන අතර, අප විසින් කිසි විටෙකත් සුරකින අතර AI ආකෘති පුහුණු කිරීමට භාවිත "
+"නොකෙරේ."
 
 # smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that chats are stored locally on the user's device.
@@ -23472,9 +23999,8 @@ msgid ""
 "Your chats are still private, anonymized by us, and not used to train AI "
 "models. Follow these steps to keep your chat history."
 msgstr ""
-"ඔබගේ කතාබස් පුද්ගලික වන අතර ඒ්වා අප විසින් නිර්නාමික කර තිබේ. තව ද ඒ්වා "
-"කෘත්‍රිම බුද්ධි ආකෘති පුහුණු කිරීමට යොදා ගනු නොලැබේ. ඔබේ කතාබස් ඉතිහාසය තබා "
-"ගැනීමට මේ පියවර අනුගමනය කරන්න."
+"ඔබගේ කතාබස් පුද්ගලික වන අතර ඒ්වා අප විසින් නිර්නාමික කර තිබේ. තව ද ඒ්වා කෘත්‍රිම බුද්ධි ආකෘති "
+"පුහුණු කිරීමට යොදා ගනු නොලැබේ. ඔබේ කතාබස් ඉතිහාසය තබා ගැනීමට මේ පියවර අනුගමනය කරන්න."
 
 # smartling.placeholder_format=C
 #. Body shown after import completes.
@@ -23514,8 +24040,8 @@ msgid ""
 "Your email address will not be shared, %sor associated with anonymous "
 "searches. [%sExample message%s]"
 msgstr ""
-"ඔබගේ විද්‍යුත් තැපැල් ලිපිනය බෙදාහැරීමක්, %1$sහෝ නිර්නාමික සෙවුම් සමඟ "
-"සම්බන්ධ කිරීමක් සිදු නොවේ. [%2$sඋදාහරණ පණිවිඩය%3$s]"
+"ඔබගේ විද්‍යුත් තැපැල් ලිපිනය බෙදාහැරීමක්, %1$sහෝ නිර්නාමික සෙවුම් සමඟ සම්බන්ධ කිරීමක් සිදු නොවේ. "
+"[%2$sඋදාහරණ පණිවිඩය%3$s]"
 
 # smartling.placeholder_format=C
 #. A prompt for the user to provide feedback on the third party map app directions experience
@@ -23558,10 +24084,9 @@ msgid ""
 "browser. We save the settings file using the key as the name. DuckDuckGo "
 "never knows your passphrase."
 msgstr ""
-"%1$sSHA-2%2$s ලෙස හැඳින්වෙන ආරක්ෂිත හැෂ් ඇල්ගොරිතම භාවිතා කිරීමෙන් ඔබගේ "
-"මුරපදය 512-bit යතුරක් ජනනය කරයි.. ඔබගේ බ්‍රව්සරයෙන් පිටවන්නේ යතුර සහ ආශ්‍රිත "
-"සැකසුම් ගොනුව පමණි. යතුර නම ලෙස භාවිතා කර අපි සැකසුම් ගොනුව සුරකිමු. "
-"DuckDuckGo කිසි විටෙකත් ඔබේ මුරපදය දන්නේ නැත."
+"%1$sSHA-2%2$s ලෙස හැඳින්වෙන ආරක්ෂිත හැෂ් ඇල්ගොරිතම භාවිතා කිරීමෙන් ඔබගේ මුරපදය 512-bit "
+"යතුරක් ජනනය කරයි.. ඔබගේ බ්‍රව්සරයෙන් පිටවන්නේ යතුර සහ ආශ්‍රිත සැකසුම් ගොනුව පමණි. යතුර නම ලෙස "
+"භාවිතා කර අපි සැකසුම් ගොනුව සුරකිමු. DuckDuckGo කිසි විටෙකත් ඔබේ මුරපදය දන්නේ නැත."
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -23576,9 +24101,8 @@ msgid ""
 "personally identifiable metadata, so model providers can't tie your "
 "conversations back to you."
 msgstr ""
-"ඔබගේ විමසීම් DuckDuckGo සර්වර හරහා යවනු ලබන අතර ඒවායෙන් පුද්ගලිකව හඳුනාගත "
-"හැකි පාර-දත්ත ඉවත් කරනු ලැබේ, එබැවින් ආකෘති සපයන්නන්ට ඔබගේ සංවාද ඔබ හා නැවත "
-"සම්බන්ධ කළ නොහැක."
+"ඔබගේ විමසීම් DuckDuckGo සර්වර හරහා යවනු ලබන අතර ඒවායෙන් පුද්ගලිකව හඳුනාගත හැකි පාර-දත්ත "
+"ඉවත් කරනු ලැබේ, එබැවින් ආකෘති සපයන්නන්ට ඔබගේ සංවාද ඔබ හා නැවත සම්බන්ධ කළ නොහැක."
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -23592,8 +24116,8 @@ msgid ""
 "Your recent chats live here! You can refer to your chats or clear them "
 "anytime."
 msgstr ""
-"ඔබගේ මෑත කාලීන කතාබස් මෙහි ඇත! ඔබට ඔබේ කතාබස් වෙත යොමු විය හැකි ය හෝ ඕනෑම "
-"වේලාවක ඒවා ඉවත් කළ හැකි ය."
+"ඔබගේ මෑත කාලීන කතාබස් මෙහි ඇත! ඔබට ඔබේ කතාබස් වෙත යොමු විය හැකි ය හෝ ඕනෑම වේලාවක "
+"ඒවා ඉවත් කළ හැකි ය."
 
 # smartling.placeholder_format=C
 #. Message on a feedback form.
@@ -23636,8 +24160,8 @@ msgid ""
 "You’re now searching privately in Chrome. Use our browser instead of Chrome "
 "for more protection. It’s already installed and can:"
 msgstr ""
-"දැන් ඔබ Chrome හි පුද්ගලිකව සොයමින් සිටී. වැඩි ආරක්ෂාව සඳහා Chrome වෙනුවට "
-"අපේ බ්‍රවුසරය භාවිත කරන්න. එය දැනටමත් ස්ථාපනය කර ඇති අතර හැකියාව ඇත්තේ:"
+"දැන් ඔබ Chrome හි පුද්ගලිකව සොයමින් සිටී. වැඩි ආරක්ෂාව සඳහා Chrome වෙනුවට අපේ බ්‍රවුසරය "
+"භාවිත කරන්න. එය දැනටමත් ස්ථාපනය කර ඇති අතර හැකියාව ඇත්තේ:"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has exceeded the maximum message size.
@@ -23646,8 +24170,7 @@ msgid ""
 "You’ve exceeded the maximum message size. Please shorten your message and "
 "try again."
 msgstr ""
-"ඔබ උපරිම පණිවිඩ ප්‍රමාණය ඉක්මවා ඇත. කරුණාකර ඔබගේ පණිවිඩය කෙටි කර නැවත උත්සාහ "
-"කරන්න."
+"ඔබ උපරිම පණිවිඩ ප්‍රමාණය ඉක්මවා ඇත. කරුණාකර ඔබගේ පණිවිඩය කෙටි කර නැවත උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -23656,8 +24179,8 @@ msgid ""
 "You’ve reached the maximum chat length in this conversation. Clear this "
 "conversation with the Fire Button to continue."
 msgstr ""
-"ඔබ මෙම සංවාදයේ උපරිම කතාබස් දිගට පැමිණ ඇත. දිගටම කරගෙන යාම සඳහා Fire Button "
-"සමඟ මෙම සංවාදය ඉවත් කරන්න."
+"ඔබ මෙම සංවාදයේ උපරිම කතාබස් දිගට පැමිණ ඇත. දිගටම කරගෙන යාම සඳහා Fire Button සමඟ "
+"මෙම සංවාදය ඉවත් කරන්න."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -23665,9 +24188,7 @@ msgctxt "Error message for conversation limit"
 msgid ""
 "You’ve reached the maximum chat length in this conversation. Start a new "
 "chat to continue."
-msgstr ""
-"ඔබ මෙම සංවාදයේ උපරිම කතාබස් දිගට පැමිණ ඇත. ඉදිරියට යාමට නව කතාබහක් ආරම්භ "
-"ගන්න."
+msgstr "ඔබ මෙම සංවාදයේ උපරිම කතාබස් දිගට පැමිණ ඇත. ඉදිරියට යාමට නව කතාබහක් ආරම්භ ගන්න."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -23682,8 +24203,8 @@ msgid ""
 "You’ve reached the maximum number of messages for one day. Please continue "
 "this chat tomorrow."
 msgstr ""
-"ඔබ එක් දිනක් සඳහා උපරිම පණිවිඩ සංඛ්‍යාවට ළඟා වී ඇත. කරුණාකර හෙට මෙම කතාබස් "
-"දිගටම කරගෙන යන්න."
+"ඔබ එක් දිනක් සඳහා උපරිම පණිවිඩ සංඛ්‍යාවට ළඟා වී ඇත. කරුණාකර හෙට මෙම කතාබස් දිගටම කරගෙන "
+"යන්න."
 
 # smartling.placeholder_format=C
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.

--- a/locales/si_LK/LC_MESSAGES/duckduckgo.po
+++ b/locales/si_LK/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: si_LK\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -177,8 +177,8 @@ msgid ""
 "browser again to continue the chat, or switch to a Plus or free model."
 msgstr ""
 "%1$s ලබා ගත හැක්කේ Pro සමඟ පමණි. කතාබහ දිගටම කරගෙන යාමට මෙම බ්‍රවුසරයේ ඔබේ "
-"DuckDuckGo ග්‍රාහකත්වය නැවත උත්ශ්‍රේණිගත කරන්න, නැතහොත් Plus හෝ නොමිලේ ප්‍රකාරයකට මාරු "
-"වන්න."
+"DuckDuckGo ග්‍රාහකත්වය නැවත උත්ශ්‍රේණිගත කරන්න, නැතහොත් Plus හෝ නොමිලේ "
+"ප්‍රකාරයකට මාරු වන්න."
 
 # smartling.placeholder_format=C
 #. Text for the disclaimer message that appears when a Plus subscriber tries to use a Pro-only model. %s is replaced with the model name. Example: Claude Opus 4.6 is only available with Pro. Upgrade your DuckDuckGo subscription in this browser again to continue the chat, or switch to a Plus or free model.
@@ -189,8 +189,8 @@ msgid ""
 "browser again to continue the chat, or switch to a Plus or free model."
 msgstr ""
 "%1$s ලබා ගත හැක්කේ Pro සමඟ පමණි. කතාබහ දිගටම කරගෙන යාමට මෙම බ්‍රවුසරයේ ඔබේ "
-"DuckDuckGo ග්‍රාහකත්වය නැවත උත්ශ්‍රේණිගත කරන්න, නැතහොත් Plus හෝ නොමිලේ ප්‍රකාරයකට මාරු "
-"වන්න."
+"DuckDuckGo ග්‍රාහකත්වය නැවත උත්ශ්‍රේණිගත කරන්න, නැතහොත් Plus හෝ නොමිලේ "
+"ප්‍රකාරයකට මාරු වන්න."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI (Artificial Intelligence) chat model is temporarily unavailable. Example: 'GPT 4o is only available with a DuckDuckGo subscription.'
@@ -207,7 +207,8 @@ msgid ""
 "model."
 msgstr ""
 "%1$s ලබා ගත හැක්කේ DuckDuckGo දායකත්වයක් සමඟ පමණි. චැට් දිගටම කරගෙන යාමට මෙම "
-"බ්‍රව්සරයේ ඔබේ දායකත්වය නැවත සක්‍රිය කරන්න, නැත්නම් නොමිලේ ආකෘතියකට මාරු වන්න."
+"බ්‍රව්සරයේ ඔබේ දායකත්වය නැවත සක්‍රිය කරන්න, නැත්නම් නොමිලේ ආකෘතියකට මාරු "
+"වන්න."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is temporarily unavailable. Example: 'GPT 3.5 Turbo is temporarily unavailable. Please switch to a different model or try again later.'
@@ -216,8 +217,8 @@ msgid ""
 "%s is temporarily unavailable. Please switch to a different model or try "
 "again later."
 msgstr ""
-"%1$s තාවකාලිකව ලබා ගත නොහැක. කරුණාකර වෙනත් ආකෘතියකට මාරු වන්න නැතිනම් පසුව නැවත උත්සාහ "
-"කරන්න."
+"%1$s තාවකාලිකව ලබා ගත නොහැක. කරුණාකර වෙනත් ආකෘතියකට මාරු වන්න නැතිනම් පසුව "
+"නැවත උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. Reddit's "fake internet points". https://support.reddithelp.com/hc/en-us/articles/204511829-What-is-karma
@@ -308,9 +309,9 @@ msgid ""
 "provider can see your prompts or the model’s responses, or save this chat on "
 "their servers."
 msgstr ""
-"%1$s ක් රියාත්මක වන්නේ විශ්වාසදායක ක් රියාත්මක කිරීමේ පරිසරයක ය. මෙයින් අදහස් කරන්නේ ආකෘති "
-"සපයන්නාට පවා ඔබේ විමසීම් හෝ ආකෘතියේ ප්‍රතිචාර දැකීමට හෝ මෙම කතාබහ ඔවුන්ගේ සර්වරවල සුරැකීමට "
-"නොහැකි බවයි."
+"%1$s ක් රියාත්මක වන්නේ විශ්වාසදායක ක් රියාත්මක කිරීමේ පරිසරයක ය. මෙයින් "
+"අදහස් කරන්නේ ආකෘති සපයන්නාට පවා ඔබේ විමසීම් හෝ ආකෘතියේ ප්‍රතිචාර දැකීමට හෝ "
+"මෙම කතාබහ ඔවුන්ගේ සර්වරවල සුරැකීමට නොහැකි බවයි."
 
 # smartling.placeholder_format=C
 #. Label shown in the batch selection toolbar when exactly one chat is selected. %s is replaced with 1. Use singular agreement where the language requires it.
@@ -390,8 +391,8 @@ msgid ""
 "%s will be leaving Duck.ai in %s days (%s). After that, you can switch "
 "models to continue this chat."
 msgstr ""
-"%1$s දින %2$sකින් (%3$s) Duck.ai හැර යනු ඇත. ඊට පසු, ඔබට මෙම කතාබහ දිගටම කරගෙන "
-"යාමට ආකෘති මාරු කළ හැකි ය."
+"%1$s දින %2$sකින් (%3$s) Duck.ai හැර යනු ඇත. ඊට පසු, ඔබට මෙම කතාබහ දිගටම "
+"කරගෙන යාමට ආකෘති මාරු කළ හැකි ය."
 
 # smartling.placeholder_format=C
 #. Displayed in a saved chat when its AI model is about to be retired tomorrow. First placeholder is the friendly model name, second placeholder is the removal date formatted in the user's browser locale (e.g., 'June 15, 2026' in en-US). Singular-day form.
@@ -402,8 +403,8 @@ msgid ""
 "%s will be leaving Duck.ai in 1 day (%s). After that, you can switch models "
 "to continue this chat."
 msgstr ""
-"%1$s දින 1කින් Duck.ai හැර යනු ඇත (%2$s). ඊට පසු, ඔබට මෙම කතාබහ දිගටම කරගෙන යාමට "
-"ආකෘති මාරු කළ හැකි ය."
+"%1$s දින 1කින් Duck.ai හැර යනු ඇත (%2$s). ඊට පසු, ඔබට මෙම කතාබහ දිගටම කරගෙන "
+"යාමට ආකෘති මාරු කළ හැකි ය."
 
 # smartling.placeholder_format=C
 #. Shown in a text selection chip when the selection contains multiple words. %s is replaced with the number of words, e.g. '142 words'.
@@ -416,8 +417,8 @@ msgstr "%1$s වචන"
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
 msgstr ""
-"%1$sක්ලික් කරන්න %2$sඑක් කරන්න%3$sපරීක්ෂා කරන්න %4$sඉඩ දෙන්න%5$s, අනතුරුව %6$sහරි%7$sක්ලික් "
-"කරන්න"
+"%1$sක්ලික් කරන්න %2$sඑක් කරන්න%3$sපරීක්ෂා කරන්න %4$sඉඩ දෙන්න%5$s, අනතුරුව "
+"%6$sහරි%7$sක්ලික් කරන්න"
 
 # Firefox, obsolete
 # smartling.placeholder_format=C
@@ -425,8 +426,8 @@ msgstr ""
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAllow%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
 msgstr ""
-"%1$sAllow%2$s %3$sක්ලික් කරන්න %4$sAdd%5$s ක්ලික් කරන්න %6$sAllow%7$s මත හරි ලකුණ "
-"දමන්න, ඉන්පසුව %8$sOkay%9$s ක්ලික් කරන්න"
+"%1$sAllow%2$s %3$sක්ලික් කරන්න %4$sAdd%5$s ක්ලික් කරන්න %6$sAllow%7$s මත හරි "
+"ලකුණ දමන්න, ඉන්පසුව %8$sOkay%9$s ක්ලික් කරන්න"
 
 # Firefox
 # smartling.placeholder_format=C
@@ -446,7 +447,8 @@ msgid ""
 "%sClick here%s to try again, if you think there should be results for this "
 "search."
 msgstr ""
-"මෙයට ප්‍රතිඵලයක් තිබෙන්නටම අවශ්‍යයැයි සිතෙනවානම්, නැවත් උත්සාහ කිරීමට %1$sමෙතන ක්ලික් කරන්න%2$s."
+"මෙයට ප්‍රතිඵලයක් තිබෙන්නටම අවශ්‍යයැයි සිතෙනවානම්, නැවත් උත්සාහ කිරීමට "
+"%1$sමෙතන ක්ලික් කරන්න%2$s."
 
 # smartling.placeholder_format=C
 #. Header for a page with information about sharing DuckDuckGo.
@@ -472,7 +474,8 @@ msgctxt "Footer text for About Sync modal"
 msgid ""
 "%sLearn more%s about how chats are stored privately on DuckDuckGo's server."
 msgstr ""
-"%1$sDuckDuckGo සර්වරයේ කතාබස් පෞද්ගලිකව ගබඩා වන ආකාරය පිළිබඳ%2$s වැඩිදුර ඉගෙන ගන්න."
+"%1$sDuckDuckGo සර්වරයේ කතාබස් පෞද්ගලිකව ගබඩා වන ආකාරය පිළිබඳ%2$s වැඩිදුර "
+"ඉගෙන ගන්න."
 
 # smartling.placeholder_format=C
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
@@ -491,8 +494,8 @@ msgstr "මුල් තිරයේ ඇති DuckDuckGo යෙදුම් න
 msgctxt "Error or no results message"
 msgid "%sOops!%s%sSomething went wrong. Please %srefresh%s and try again."
 msgstr ""
-"%1$sඅපොයි!%2$s%3$sකුමක් හෝ වැරැද්දක් සිදු විය. කරුණාකර %4$sනැවුම් කරන්න%5$s සහ නැවත "
-"උත්සාහ කරන්න."
+"%1$sඅපොයි!%2$s%3$sකුමක් හෝ වැරැද්දක් සිදු විය. කරුණාකර %4$sනැවුම් කරන්න%5$s "
+"සහ නැවත උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. Tagline in a popover encouraging the user to download the DuckDuckGo browser
@@ -810,7 +813,8 @@ msgstr "පැය 6ක පරිශීලන සීමාවට ළඟා වී
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "6-hour usage limit reached. You can continue this chat after %s."
 msgstr ""
-"පැය 6ක පරිශීලන සීමාවට ළඟා වී තිබේ. ඔබට %1$sට පසුව මෙම කතාබහ දිගටම කරගෙන යා හැක."
+"පැය 6ක පරිශීලන සීමාවට ළඟා වී තිබේ. ඔබට %1$sට පසුව මෙම කතාබහ දිගටම කරගෙන යා "
+"හැක."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable 6-hour Duck.ai usage limit and can opt in to continue using the daily limit.
@@ -818,8 +822,8 @@ msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "6-hour usage limit reached. You can keep chatting by using your daily limit."
 msgstr ""
-"පැය 6ක පරිශීලන සීමාවට ළඟා වී තිබේ. ඔබේ දෛනික සීමාව භාවිතා කිරීමෙන් ඔබට දිගට ම කතාබස් කළ "
-"හැකි ය."
+"පැය 6ක පරිශීලන සීමාවට ළඟා වී තිබේ. ඔබේ දෛනික සීමාව භාවිතා කිරීමෙන් ඔබට දිගට "
+"ම කතාබස් කළ හැකි ය."
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes abbreviation
@@ -873,8 +877,8 @@ msgid ""
 "A network issue is preventing Search Assist from generating an answer. "
 "Please check your connection and try again."
 msgstr ""
-"ජාල ගැටලුවක් හේතුවෙන් Search Assist මගින් පිළිතුරක් ජනනය කිරීම වැළකී ඇත. කරුණාකර ඔබේ "
-"සම්බන්ධතාව පරීක්ෂා කර නැවත උත්සාහ කරන්න."
+"ජාල ගැටලුවක් හේතුවෙන් Search Assist මගින් පිළිතුරක් ජනනය කිරීම වැළකී ඇත. "
+"කරුණාකර ඔබේ සම්බන්ධතාව පරීක්ෂා කර නැවත උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of AI Chat is available and they need to refresh the page.
@@ -882,8 +886,8 @@ msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of AI Chat is available! Please refresh this page to continue."
 msgstr ""
-"AI Chat හි නව අනුවාදයක් ලබා ගත හැකි ය! දිගටම කරගෙන යාමට කරුණාකර මෙම පිටුව නැවත නැවුම් "
-"කරන්න."
+"AI Chat හි නව අනුවාදයක් ලබා ගත හැකි ය! දිගටම කරගෙන යාමට කරුණාකර මෙම පිටුව "
+"නැවත නැවුම් කරන්න."
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of Duck.ai is available and they need to refresh the page.
@@ -891,8 +895,8 @@ msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of Duck.ai is available! Please refresh this page to continue."
 msgstr ""
-"Duck.ai හි නව අනුවාදයක් ලබා ගත හැකි ය! දිගටම කරගෙන යාමට කරුණාකර මෙම පිටුව නැවත නැවුම් "
-"කරන්න."
+"Duck.ai හි නව අනුවාදයක් ලබා ගත හැකි ය! දිගටම කරගෙන යාමට කරුණාකර මෙම පිටුව "
+"නැවත නැවුම් කරන්න."
 
 # smartling.placeholder_format=C
 #. Shown when the Duck.ai desktop app has been open a long time and a newer version exists.
@@ -930,9 +934,10 @@ msgid ""
 "still access AI Chat when this setting is off by visiting %sduckduckgo.com/"
 "aichat%s."
 msgstr ""
-"AI Chat ඔබට 3පාර්ශවයේ AI Chat ආකෘති සමඟ නිර්නාමික සංවාද පැවැත්වීමට ඉඩ සලසයි. මෙය "
-"ක්‍රියා විරහිත කිරීමෙන් DuckDuckGo Search AI Chat විශේෂාංගය සඟවනු ඇත. මෙම සැකසුම ක්‍රියා "
-"විරහිත වූ විට ඔබට තවමත් %1$sduckduckgo.com/aichat%2$s AI Chat වෙත ප්‍රවේශ විය හැකිය."
+"AI Chat ඔබට 3පාර්ශවයේ AI Chat ආකෘති සමඟ නිර්නාමික සංවාද පැවැත්වීමට ඉඩ සලසයි. "
+"මෙය ක්‍රියා විරහිත කිරීමෙන් DuckDuckGo Search AI Chat විශේෂාංගය සඟවනු ඇත. "
+"මෙම සැකසුම ක්‍රියා විරහිත වූ විට ඔබට තවමත් %1$sduckduckgo.com/aichat%2$s AI "
+"Chat වෙත ප්‍රවේශ විය හැකිය."
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -993,10 +998,10 @@ msgid ""
 "questions, which is our private AI-powered chat service that supports chat "
 "models from OpenAI, and Anthropic, and more."
 msgstr ""
-"AI සහය සහිත පිළිතුරු දැනට සෘජුවම පසු විපරම් ප්‍රශ්නවලට සහය නොදක්වයි. කෙසේ වෙතත්, අපි පසු විපරම් "
-"ප්‍රශ්න සඳහා %1$sDuck.ai%2$s පිරිනමමු, තවද බොහෝ විට එය වෙත සබැඳෙමු, එය OpenAI සහ "
-"Anthropic, සහ තවත් දෑ වෙතින් චැට් ආකෘති සඳහා සහය දක්වන අපගේ පෞද්ගලික AI බලයෙන් "
-"ක්‍රියාත්මක වන චැට් සේවාවක් වේ."
+"AI සහය සහිත පිළිතුරු දැනට සෘජුවම පසු විපරම් ප්‍රශ්නවලට සහය නොදක්වයි. කෙසේ "
+"වෙතත්, අපි පසු විපරම් ප්‍රශ්න සඳහා %1$sDuck.ai%2$s පිරිනමමු, තවද බොහෝ විට එය "
+"වෙත සබැඳෙමු, එය OpenAI සහ Anthropic, සහ තවත් දෑ වෙතින් චැට් ආකෘති සඳහා සහය "
+"දක්වන අපගේ පෞද්ගලික AI බලයෙන් ක්‍රියාත්මක වන චැට් සේවාවක් වේ."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has turned off AI features and will no longer see AI-assisted answers.
@@ -1181,8 +1186,8 @@ msgid ""
 "Activate your %s in this browser again to continue the chat, or switch to a "
 "free model."
 msgstr ""
-"චැට් දිගටම කරගෙන යාමට මෙම බ්රව්සරයේ ඔබේ %1$s නැවත සක්රිය කරන්න, නැත්නම් නොමිලේ ආකෘතියකට "
-"මාරු වන්න."
+"චැට් දිගටම කරගෙන යාමට මෙම බ්රව්සරයේ ඔබේ %1$s නැවත සක්රිය කරන්න, නැත්නම් "
+"නොමිලේ ආකෘතියකට මාරු වන්න."
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an active DuckDuckGo subscription.
@@ -1218,8 +1223,8 @@ msgstr "දැන්වීම"
 msgid ""
 "Ad clicks are managed by %s’s ad network and are not used to profile you."
 msgstr ""
-"වෙළඳ දැන්වීම් ක්ලික් කිරීම් කළමනාකරණය කරනු ලබන්නේ %1$sහි වෙළඳ දැන්වීම් ජාලය මගින් වන අතර ඒවා "
-"ඔබේ හැසිරීම මත පදනම්ව තීරණ ගැනීමට භාවිත කරනු නොලැබේ."
+"වෙළඳ දැන්වීම් ක්ලික් කිරීම් කළමනාකරණය කරනු ලබන්නේ %1$sහි වෙළඳ දැන්වීම් ජාලය "
+"මගින් වන අතර ඒවා ඔබේ හැසිරීම මත පදනම්ව තීරණ ගැනීමට භාවිත කරනු නොලැබේ."
 
 # smartling.placeholder_format=C
 #. Information that ad clicks are managed by Microsoft.
@@ -1227,8 +1232,8 @@ msgid ""
 "Ad clicks are managed by Microsoft’s ad network and are not used to profile "
 "you."
 msgstr ""
-"දැන්වීම් ක්ලික් කිරීම් කළමනාකරණය කරනු ලබන්නේ Microsoft හි දැන්වීම් ජාලය විසිනි, ඒවා ඔබව පැතිකඩ "
-"කිරීමට භාවිතා නොකෙරේ."
+"දැන්වීම් ක්ලික් කිරීම් කළමනාකරණය කරනු ලබන්නේ Microsoft හි දැන්වීම් ජාලය "
+"විසිනි, ඒවා ඔබව පැතිකඩ කිරීමට භාවිතා නොකෙරේ."
 
 # smartling.placeholder_format=C
 #. An item in the ads tooltip that explains that ad clicks aren’t used to profile you.
@@ -1279,7 +1284,8 @@ msgstr "DuckDuckGo දිගුව එක් කරන්න"
 msgid ""
 "Add DuckDuckGo Privacy Essentials to your browser for free with one download:"
 msgstr ""
-"එක් බාගැනීමකින් DuckDuckGo Privacy Essentials ඔබේ බ්‍රවුසරය වෙත නොමිලේ එක් කරන්න:"
+"එක් බාගැනීමකින් DuckDuckGo Privacy Essentials ඔබේ බ්‍රවුසරය වෙත නොමිලේ එක් "
+"කරන්න:"
 
 #  IE default search engine instruction
 # smartling.placeholder_format=C
@@ -1437,7 +1443,7 @@ msgstr "ලිපිනය වැරදියි"
 #. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Adjust the servings"
-msgstr ""
+msgstr "පරිමාණ සකස් කරන්න"
 
 # smartling.placeholder_format=C
 #. as in multiple advertisements
@@ -1657,6 +1663,8 @@ msgid ""
 "All chats are anonymized by DuckDuckGo, and your conversations are not used "
 "to train chat models by DuckDuckGo or the model providers"
 msgstr ""
+"සියලුම කතාබස් DuckDuckGo විසින් නිර්නාමික කර ඇති අතර, ඔබේ සංවාද DuckDuckGo "
+"හෝ ආකෘති සැපයුම්කරුවන් විසින් චැට් ආකෘති පුහුණු කිරීමට භාවිත කරනු නොලැබේ"
 
 # smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1703,8 +1711,8 @@ msgid ""
 "All personal metadata (for example, your IP address) is removed before "
 "sending a chat to the AI provider."
 msgstr ""
-"AI සැපයුම්කරුට කතාබහක් යැවීමට පෙර සියලුම පුද්ගලික පාර-දත්ත (උදාහරණයක් ලෙස, ඔබගේ IP ලිපිනය) "
-"ඉවත් කරනු ලැබේ."
+"AI සැපයුම්කරුට කතාබහක් යැවීමට පෙර සියලුම පුද්ගලික පාර-දත්ත (උදාහරණයක් ලෙස, "
+"ඔබගේ IP ලිපිනය) ඉවත් කරනු ලැබේ."
 
 # smartling.placeholder_format=C
 #. A filter that shows search results from all countries.
@@ -1730,7 +1738,8 @@ msgctxt "voice chat"
 msgid ""
 "Allow DuckDuckGo microphone access in System Settings to use voice chat."
 msgstr ""
-"හඬ කතාබස් භාවිතා කිරීමට පද්ධති සැකසීම් තුළ DuckDuckGo මයික්‍රෆෝනයට ප්‍රවේශය ලබා දෙන්න."
+"හඬ කතාබස් භාවිතා කිරීමට පද්ධති සැකසීම් තුළ DuckDuckGo මයික්‍රෆෝනයට ප්‍රවේශය "
+"ලබා දෙන්න."
 
 # smartling.placeholder_format=C
 #. Tells users which icon to press in their browser. Part of a list of instructions on how to enable location service.
@@ -1756,9 +1765,10 @@ msgid ""
 "sends AI-generated queries to a search engine with limited data retention. "
 "Prompts and responses with %s still have %szero provider visibility%s."
 msgstr ""
-"අදාළ විමසීම්වලට ප්‍රතිචාර වැඩි දියුණු කිරීම සඳහා වෙබයේ සෙවීමට %1$s හට ඉඩ දෙයි. සීමිත දත්ත "
-"රඳවා ගැනීමක් සහිත සෙවුම් යන්ත්‍රයකට AI-ජනනය කරන ලද විමසුම් පමණක් යවයි. %2$s සහිත විමසීම් සහ "
-"ප්‍රතිචාර වලට තවමත් %3$sසැපයුම්කරුගේ දෘශ්‍යතාව ශුන්‍ය වේ%4$s."
+"අදාළ විමසීම්වලට ප්‍රතිචාර වැඩි දියුණු කිරීම සඳහා වෙබයේ සෙවීමට %1$s හට ඉඩ "
+"දෙයි. සීමිත දත්ත රඳවා ගැනීමක් සහිත සෙවුම් යන්ත්‍රයකට AI-ජනනය කරන ලද විමසුම් "
+"පමණක් යවයි. %2$s සහිත විමසීම් සහ ප්‍රතිචාර වලට තවමත් %3$sසැපයුම්කරුගේ "
+"දෘශ්‍යතාව ශුන්‍ය වේ%4$s."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -1766,7 +1776,8 @@ msgid ""
 "Allows Cloud Save key to be stored locally on device (required to use Cloud "
 "Save)"
 msgstr ""
-"Cloud Save යතුර උපාංගයේ දේශීයව ගබඩා කිරීමට ඉඩ දෙයි (Cloud Save භාවිතා කිරීමට අවශ්‍ය වේ)"
+"Cloud Save යතුර උපාංගයේ දේශීයව ගබඩා කිරීමට ඉඩ දෙයි (Cloud Save භාවිතා කිරීමට "
+"අවශ්‍ය වේ)"
 
 # smartling.placeholder_format=C
 #. Pending title indicating near completion.
@@ -1904,7 +1915,8 @@ msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
 msgstr ""
-"%1$s, %2$s සහ විවෘත මූලාශ්ර %3$s සහ %4$sඇතුළු ජනප්රිය AI ආකෘති සඳහා නිර්නාමික ප්රවේශය."
+"%1$s, %2$s සහ විවෘත මූලාශ්ර %3$s සහ %4$sඇතුළු ජනප්රිය AI ආකෘති සඳහා "
+"නිර්නාමික ප්රවේශය."
 
 # smartling.placeholder_format=C
 #. Text with information about Duck.ai and supported AI models, the placeholders list AI models. Example: 'Anonymous access to popular AI models, including GPT, Claude, and open-source Llama and Mistral.'
@@ -1913,7 +1925,8 @@ msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
 msgstr ""
-"%1$s, %2$s සහ විවෘත මූලාශ්ර %3$s සහ %4$sඇතුළු ජනප්රිය AI ආකෘති සඳහා නිර්නාමික ප්රවේශය."
+"%1$s, %2$s සහ විවෘත මූලාශ්ර %3$s සහ %4$sඇතුළු ජනප්රිය AI ආකෘති සඳහා "
+"නිර්නාමික ප්රවේශය."
 
 # smartling.placeholder_format=C
 #. Confirmation message after location service is enabled.
@@ -1927,6 +1940,9 @@ msgid ""
 "Anonymously generates answers for search queries based on web content. "
 "Choose how often you want it to appear, or disable it completely."
 msgstr ""
+"වෙබ් අන්තර්ගතය මත පදනම්ව සෙවුම් විමසුම් සඳහා නිර්නාමිකව පිළිතුරු ජනනය කරයි. "
+"එය කොපමණ වාර ගණනක් පෙනී සිටීමට අවශ්‍යද යන්න තෝරන්න, නැතහොත් එය සම්පූර්ණයෙන්ම "
+"අක්‍රිය කරන්න."
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -1973,8 +1989,8 @@ msgid ""
 "Any additional instructions you want Duck.ai to follow. e.g. Always tell me "
 "facts about ducks"
 msgstr ""
-"Duck.ai අනුගමනය කිරීමට ඔයාට අවශ්‍ය ඕනෑම අමතර උපදෙසක්. උදා. තාරාවන් ගැන හැම විටම කරුණු "
-"මට කියන්න"
+"Duck.ai අනුගමනය කිරීමට ඔයාට අවශ්‍ය ඕනෑම අමතර උපදෙසක්. උදා. තාරාවන් ගැන හැම "
+"විටම කරුණු මට කියන්න"
 
 # smartling.placeholder_format=C
 #. Shown in video filtering. https://duckduckgo.com/?q=videos+of+cats&iax=videos&ia=videos
@@ -2094,7 +2110,8 @@ msgid ""
 "Are you sure you want to disable history? This will delete all chats, "
 "including pinned chats."
 msgstr ""
-"ඔබට ඉතිහාසය අක්‍රිය කිරීමට අවශ්‍ය බව විශ්වාසද? මෙය පින් කළ කතා ඇතුළුව, සියලුම කතා මකා දමනු ඇත."
+"ඔබට ඉතිහාසය අක්‍රිය කිරීමට අවශ්‍ය බව විශ්වාසද? මෙය පින් කළ කතා ඇතුළුව, "
+"සියලුම කතා මකා දමනු ඇත."
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to disable recent chats, with a warning that it will also delete currently saved chats.
@@ -2103,8 +2120,8 @@ msgid ""
 "Are you sure you want to disable recent chats? This will also delete any "
 "recent chats that are currently saved."
 msgstr ""
-"ඔබට මෑත කාලීන කතාබස් අක්‍රිය කළ යුතු බවට ඔබට විශ්වාස ද? මෙය දැනට සුරකින ලද ඕනෑම මෑත "
-"කාලීන කතාබස් ද මකා දමනු ඇත."
+"ඔබට මෑත කාලීන කතාබස් අක්‍රිය කළ යුතු බවට ඔබට විශ්වාස ද? මෙය දැනට සුරකින ලද "
+"ඕනෑම මෑත කාලීන කතාබස් ද මකා දමනු ඇත."
 
 # smartling.placeholder_format=C
 #. Question asking user if they want to share the URL of the page they were on when giving feedback
@@ -2142,8 +2159,9 @@ msgid ""
 "As per our privacy policy, we do not collect or share any personal "
 "information ourselves. All of this privacy protection happens on your device."
 msgstr ""
-"අපගේ රහස්‍යතා ප්‍රතිපත්තියට අනුව, අපි කිසිදු පෞද්ගලික තොරතුරක් අප විසින්ම රැස්කර හෝ හුවමාරුකර "
-"නොගන්නෙමු. මෙම සියලු රහස්‍යතා ආරක්ෂාව ඔබගේ උපාංගයේ සිදු වේ."
+"අපගේ රහස්‍යතා ප්‍රතිපත්තියට අනුව, අපි කිසිදු පෞද්ගලික තොරතුරක් අප විසින්ම "
+"රැස්කර හෝ හුවමාරුකර නොගන්නෙමු. මෙම සියලු රහස්‍යතා ආරක්ෂාව ඔබගේ උපාංගයේ සිදු "
+"වේ."
 
 # smartling.placeholder_format=C
 #. A button to ask Duck.ai a question
@@ -2209,7 +2227,7 @@ msgstr "Duck.ai සමඟ පසු විපරමක් විමසන්න"
 #. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
 msgctxt "Page suggestion chip label"
 msgid "Ask about this page"
-msgstr ""
+msgstr "මෙම පිටුව ගැන විමසන්න"
 
 # smartling.placeholder_format=C
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2273,12 +2291,14 @@ msgid ""
 "(shows more frequently on a wider range of searches). For now, AI-assisted "
 "answers are only available in the U.S. (English) region."
 msgstr ""
-"Assist යනු අදාළ වෙබ් අන්තර්ගතය සාරාංශ කිරීම මත පදනම්ව සමහර සෙවුම් සඳහා AI-සහය සහිත "
-"පිළිතුරු නිර්නාමිකව ජනනය කළ හැකි සේවාවකි. ඔබට කොපමණ වාරයක් Assist පෙනී සිටීමට අවශ්‍ය දැ යි "
-"ඔබට තෝරා ගත හැකිය: කිසි විටෙකත් (සෙවුම් ප්‍රතිඵලවලින් Assist UI සම්පූර්ණයෙන්ම ඉවත් කරයි), ඉල්ලුම "
-"මත (ඔබ Assist බොත්තම ක්ලික් කළහොත් AI-සහාය සහිත පිළිතුරු පමණක් පෙන්වයි), සමහර විට (ඉහළ "
-"අදාළ වන විට AI-සහය සහිත පිළිතුරු පමණක් පෙන්වයි), හෝ බොහෝ විට (පුළුල් පරාසයක සෙවුම් මත නිතර "
-"පෙන්වයි). දැනට, AI සහය සහිත පිළිතුරු ලබා ගත හැක්කේ එක්සත් ජනපද (ඉංග්‍රීසි) කලාපයේ පමණි."
+"Assist යනු අදාළ වෙබ් අන්තර්ගතය සාරාංශ කිරීම මත පදනම්ව සමහර සෙවුම් සඳහා "
+"AI-සහය සහිත පිළිතුරු නිර්නාමිකව ජනනය කළ හැකි සේවාවකි. ඔබට කොපමණ වාරයක් "
+"Assist පෙනී සිටීමට අවශ්‍ය දැ යි ඔබට තෝරා ගත හැකිය: කිසි විටෙකත් (සෙවුම් "
+"ප්‍රතිඵලවලින් Assist UI සම්පූර්ණයෙන්ම ඉවත් කරයි), ඉල්ලුම මත (ඔබ Assist "
+"බොත්තම ක්ලික් කළහොත් AI-සහාය සහිත පිළිතුරු පමණක් පෙන්වයි), සමහර විට (ඉහළ "
+"අදාළ වන විට AI-සහය සහිත පිළිතුරු පමණක් පෙන්වයි), හෝ බොහෝ විට (පුළුල් පරාසයක "
+"සෙවුම් මත නිතර පෙන්වයි). දැනට, AI සහය සහිත පිළිතුරු ලබා ගත හැක්කේ එක්සත් "
+"ජනපද (ඉංග්‍රීසි) කලාපයේ පමණි."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2290,11 +2310,12 @@ msgid ""
 "to remember that responses are auto-generated from cited sources and based "
 "on %scrawling the web%s."
 msgstr ""
-"Assist යනු අපගේ සෙවුම් ප්‍රතිඵලවල ඇති විකල්ප විශේෂාංගයක් වන අතර එයට නිර්නාමික ව සෙවුම් විමසුම් "
-"සඳහා AI සහය සහිත පිළිතුරු ජනනය කළ හැකිය. මෙය සිදු කිරීම සඳහා, එය අදාළ අන්තර්ගතයන් සඳහා "
-"වෙබ් ස්කෑන් කරන අතර පසුව සොයාගත් අදාළ තොරතුරු මත පදනම්ව කෙටි පිළිතුරක් ජනනය කිරීම සඳහා AI-"
-"බලැති ස්වාභාවික භාෂා තාක්ෂණය භාවිත කරයි. ප්රතිචාර උපුටා දක්වන ලද මූලාශ්රවලින් ස්වයංක්රීයව "
-"ජනනය වන අතර %1$sවෙබ් කැටි ගැසීම%2$s මත පදනම් වන බව මතක තබා ගැනීම වැදගත්ය."
+"Assist යනු අපගේ සෙවුම් ප්‍රතිඵලවල ඇති විකල්ප විශේෂාංගයක් වන අතර එයට "
+"නිර්නාමික ව සෙවුම් විමසුම් සඳහා AI සහය සහිත පිළිතුරු ජනනය කළ හැකිය. මෙය සිදු "
+"කිරීම සඳහා, එය අදාළ අන්තර්ගතයන් සඳහා වෙබ් ස්කෑන් කරන අතර පසුව සොයාගත් අදාළ "
+"තොරතුරු මත පදනම්ව කෙටි පිළිතුරක් ජනනය කිරීම සඳහා AI-බලැති ස්වාභාවික භාෂා "
+"තාක්ෂණය භාවිත කරයි. ප්රතිචාර උපුටා දක්වන ලද මූලාශ්රවලින් ස්වයංක්රීයව ජනනය වන "
+"අතර %1$sවෙබ් කැටි ගැසීම%2$s මත පදනම් වන බව මතක තබා ගැනීම වැදගත්ය."
 
 # smartling.placeholder_format=C
 #. Title for the dropdown menu where users select the assistant's role. Example: 'Assistant role: Travel guide'
@@ -2432,7 +2453,9 @@ msgstr "ලැයිස්තුගත මූලාශ්‍ර මත පදන
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid ""
 "Auto-generated based on listed sources. Responses may contain inaccuracies."
-msgstr "ලැයිස්තුගත මූලාශ්‍ර මත පදනම්ව ස්වයංක්‍රීයව ජනනය වේ. ප්‍රතිචාරවල සාවද්‍ය තැන් තිබිය හැක."
+msgstr ""
+"ලැයිස්තුගත මූලාශ්‍ර මත පදනම්ව ස්වයංක්‍රීයව ජනනය වේ. ප්‍රතිචාරවල සාවද්‍ය තැන් "
+"තිබිය හැක."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI) on mobile
@@ -2457,9 +2480,9 @@ msgid ""
 "look up and summarize information in response to some searches. For now, "
 "Assist is only available in English regions."
 msgstr ""
-"අදාළ සෙවීම් සඳහා ස්වයංක්‍රීයව Assist පෙන්වයි. Assist හට නිර්නාමිකව සමහර සෙවීම් වලට ප්‍රතිචාර "
-"වශයෙන් තොරතුරු සොයා බලා සාරාංශගත කළ හැක. දැනට, Assist ලබා ගත හැක්කේ ඉංග්‍රීසි කලාපවල "
-"පමණි."
+"අදාළ සෙවීම් සඳහා ස්වයංක්‍රීයව Assist පෙන්වයි. Assist හට නිර්නාමිකව සමහර "
+"සෙවීම් වලට ප්‍රතිචාර වශයෙන් තොරතුරු සොයා බලා සාරාංශගත කළ හැක. දැනට, Assist "
+"ලබා ගත හැක්කේ ඉංග්‍රීසි කලාපවල පමණි."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2468,15 +2491,17 @@ msgid ""
 "anonymously look up and summarize information in response to some searches. "
 "For now, DuckAssist is only available in English regions."
 msgstr ""
-"අදාළ සෙවීම් සඳහා ස්වයංක්‍රීයව DuckAssist පෙන්වයි. DuckAssist හට නිර්නාමිකව සමහර සෙවීම් "
-"වලට ප්‍රතිචාර වශයෙන් තොරතුරු සොයා බලා සාරාංශගත කළ හැක. දැනට, DuckAssist ලබා ගත "
-"හැක්කේ ඉංග්‍රීසි කලාපවල පමණි."
+"අදාළ සෙවීම් සඳහා ස්වයංක්‍රීයව DuckAssist පෙන්වයි. DuckAssist හට නිර්නාමිකව "
+"සමහර සෙවීම් වලට ප්‍රතිචාර වශයෙන් තොරතුරු සොයා බලා සාරාංශගත කළ හැක. දැනට, "
+"DuckAssist ලබා ගත හැක්කේ ඉංග්‍රීසි කලාපවල පමණි."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Autoplay short, silent video previews when you hover over video results."
-msgstr "ඔබ වීඩියෝ ප්‍රතිඵල මත සැරිසරන විට කෙටි, නිහඬ වීඩියෝ පෙරදසුන් ස්වයංක්‍රීයව ධාවනය කරන්න."
+msgstr ""
+"ඔබ වීඩියෝ ප්‍රතිඵල මත සැරිසරන විට කෙටි, නිහඬ වීඩියෝ පෙරදසුන් ස්වයංක්‍රීයව "
+"ධාවනය කරන්න."
 
 # smartling.placeholder_format=C
 #. Screen-reader label for the radiogroup of tool options inside the Tools dropdown. Announced when assistive technology enters the group of menuitemradio items.
@@ -2621,7 +2646,7 @@ msgstr "තීරු කේතය"
 #. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Based on this page, is this course worth taking?"
-msgstr ""
+msgstr "මෙම පිටුව මත පදනම්ව, මෙම පාඨමාලාව හැදෑරීම වටිනවා ද?"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2670,6 +2695,8 @@ msgid ""
 "Before storing this report, DuckDuckGo will anonymize your conversation by "
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
+"මෙම වාර්තාව ගබඩා කිරීමට පෙර, DuckDuckGo විසින් නම්, ඊමේල් ලිපින සහ හඳුනාගත "
+"හැකි පාරදත්ත වැනි PII ඉවත් කිරීම මගින් ඔබගේ සංවාදය නිර්නාමික කරනු ඇත."
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -2991,7 +3018,7 @@ msgstr "විවේක ලකුණු ජයග්‍රහණය කළා"
 #. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Break this down into clear, numbered steps."
-msgstr ""
+msgstr "මෙය පැහැදිලි, අංක යොදා ඇති පියවරවලට බෙදන්න."
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -3050,16 +3077,18 @@ msgid ""
 "Browse as usual while we add privacy protection. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
 msgstr ""
-"අපි රහස්‍යතා ආරක්ෂාව එක් කරන තුරු සාමාන්‍ය පරිදි බ්‍රවුස් කරන්න. අපි අපේ සෙවුම් යාන්ත්‍රණය, නිරික්සු "
-"අවහිරය හා ගුප්ත කේතන බලාත්කුරුව එක් %1$s%2$s දිගුවක්%3$s වෙත ගොනු කර ඇත්තෙමු."
+"අපි රහස්‍යතා ආරක්ෂාව එක් කරන තුරු සාමාන්‍ය පරිදි බ්‍රවුස් කරන්න. අපි අපේ "
+"සෙවුම් යාන්ත්‍රණය, නිරික්සු අවහිරය හා ගුප්ත කේතන බලාත්කුරුව එක් %1$s%2$s "
+"දිගුවක්%3$s වෙත ගොනු කර ඇත්තෙමු."
 
 # smartling.placeholder_format=C
 msgid ""
 "Browse as usual, and we'll take care of the rest. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
 msgstr ""
-"සාමාන්‍ය පරිදි බ්‍රවුස්කරන්න, අපි අනික්වා ගැන බලා ගන්නෙමු. අපි අපේ සෙවුම් යාන්ත්‍රණය, නිරික්සු "
-"අවහිරකාරකය හා ගුප්ත කේතන බලාත්කාරකය එක් %1$s%2$s දිගුවක%3$sට සම්පිණ්ඩනය කළෙමු."
+"සාමාන්‍ය පරිදි බ්‍රවුස්කරන්න, අපි අනික්වා ගැන බලා ගන්නෙමු. අපි අපේ සෙවුම් "
+"යාන්ත්‍රණය, නිරික්සු අවහිරකාරකය හා ගුප්ත කේතන බලාත්කාරකය එක් %1$s%2$s "
+"දිගුවක%3$sට සම්පිණ්ඩනය කළෙමු."
 
 # smartling.placeholder_format=C
 msgid ""
@@ -3067,8 +3096,9 @@ msgid ""
 "search, tracker blocking, and site encryption, all in one download, for "
 "%smajor browsers%s."
 msgstr ""
-"සාමාන්‍ය පරිදි බ්‍රවුස්කරන්න, අපි අනික්වා ගැන බලා ගන්නෙමු. %1$sප්‍රධාන බ්‍රවුසර්%2$s සඳහා පුද්ගලික "
-"සෙවුම, නිරික්සුව අවහිර කිරීම හා අඩවි ගුප්ත කේතනය යන සියල්ල එකම බාගැනීමකින් ලබාගන්න."
+"සාමාන්‍ය පරිදි බ්‍රවුස්කරන්න, අපි අනික්වා ගැන බලා ගන්නෙමු. %1$sප්‍රධාන "
+"බ්‍රවුසර්%2$s සඳහා පුද්ගලික සෙවුම, නිරික්සුව අවහිර කිරීම හා අඩවි ගුප්ත කේතනය "
+"යන සියල්ල එකම බාගැනීමකින් ලබාගන්න."
 
 # smartling.placeholder_format=C
 #. Header for a call to action to browse with the DuckDuckGo browser
@@ -3175,10 +3205,11 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"පෙරනිමියෙන් සැකසීම් පුද්ගලික නොවන බ්‍රව්සර් කුකීස් තුළ ගබඩා කර ඇත (ඔබගේ බ්‍රව්සරයේ). ඔබේ සැකසීම් "
-"වඩාත් ස්ථිර ආකාරයකින් ගබඩා කිරීමට ඔබට නිර්ණාමික Cloud Save භාවිතා කළ හැකිය (ක්ලවුඩයේ ඇති "
-"දුරස්ථ සර්වරයක). පුද්ගලිකව හඳුනාගත හැකි තොරතුරු ක්ලවුඩය තුළ ගබඩා නොවන අතර ඔබගේ මුර පදය කිසි "
-"විටෙකත් ඔබගේ බ්‍රව්සරයෙන් ඉවත් නොවේ."
+"පෙරනිමියෙන් සැකසීම් පුද්ගලික නොවන බ්‍රව්සර් කුකීස් තුළ ගබඩා කර ඇත (ඔබගේ "
+"බ්‍රව්සරයේ). ඔබේ සැකසීම් වඩාත් ස්ථිර ආකාරයකින් ගබඩා කිරීමට ඔබට නිර්ණාමික "
+"Cloud Save භාවිතා කළ හැකිය (ක්ලවුඩයේ ඇති දුරස්ථ සර්වරයක). පුද්ගලිකව හඳුනාගත "
+"හැකි තොරතුරු ක්ලවුඩය තුළ ගබඩා නොවන අතර ඔබගේ මුර පදය කිසි විටෙකත් ඔබගේ "
+"බ්‍රව්සරයෙන් ඉවත් නොවේ."
 
 # smartling.placeholder_format=C
 #. Description for the consent highlight in the dictation consent modal. %s is replaced with a link to the help page.
@@ -3186,8 +3217,8 @@ msgid ""
 "By enabling dictation, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
 msgstr ""
-"කියවන විට ලිවීම සක්‍රීය කිරීමෙන්, මෙම විශේෂාංගය භාවිතා කිරීම සඳහා ඔබගේ හඬ දත්ත OpenAI වෙත "
-"යැවීමට ඔබ එකඟ වෙයි. ආරම්භ කිරීමට පෙර අපේ %1$s බලන්න."
+"කියවන විට ලිවීම සක්‍රීය කිරීමෙන්, මෙම විශේෂාංගය භාවිතා කිරීම සඳහා ඔබගේ හඬ "
+"දත්ත OpenAI වෙත යැවීමට ඔබ එකඟ වෙයි. ආරම්භ කිරීමට පෙර අපේ %1$s බලන්න."
 
 # smartling.placeholder_format=C
 #. Description for the 'enable voice chat' section of the voice chat consent modal. Placeholder for the voice chat help page link and text. Example: 'By enabling voice chat, you consent to your voice data being sent to OpenAI for the use of this feature. See our voice chat help page before getting started.'
@@ -3196,8 +3227,8 @@ msgid ""
 "By enabling voice chat, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
 msgstr ""
-"හඬ කතාබස් සක්‍රීය කිරීමෙන්, මෙම විශේෂාංගය භාවිතා කිරීම සඳහා ඔයාගේ හඬ දත්ත OpenAI වෙත "
-"යැවීමට ඔයා එකඟ වෙනවා. ආරම්භ කිරීමට පෙර අපේ %1$s බලන්න."
+"හඬ කතාබස් සක්‍රීය කිරීමෙන්, මෙම විශේෂාංගය භාවිතා කිරීම සඳහා ඔයාගේ හඬ දත්ත "
+"OpenAI වෙත යැවීමට ඔයා එකඟ වෙනවා. ආරම්භ කිරීමට පෙර අපේ %1$s බලන්න."
 
 # smartling.placeholder_format=C
 #. Golf leaderboard: player missed the cut
@@ -3232,7 +3263,9 @@ msgstr "කැමරූන්"
 #. Text for a prompt suggestion for creating a few simple recipes using chicken, broccoli, and rice.
 msgctxt "Full sentence for crafting a recipe"
 msgid "Can you create a few simple recipes using chicken, broccoli, and rice?"
-msgstr "කුකුළු මස්, බ්‍රොකොලි සහ සහල් භාවිත කරමින් සරල වට්ටෝරු කිහිපයක් නිර්මාණය කළ හැකිද?"
+msgstr ""
+"කුකුළු මස්, බ්‍රොකොලි සහ සහල් භාවිත කරමින් සරල වට්ටෝරු කිහිපයක් නිර්මාණය කළ "
+"හැකිද?"
 
 # smartling.placeholder_format=C
 msgid "Canada"
@@ -3446,7 +3479,7 @@ msgstr "නළු වරණය"
 #. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Cast & Crew"
-msgstr ""
+msgstr "නළු නිළි පිරිස"
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -3681,11 +3714,11 @@ msgid ""
 "DuckDuckGo Search. However, you can still access Chat when this setting is "
 "off by visiting %shttps://duck.ai%s directly."
 msgstr ""
-"චැට් (අපගේ Duck.ai සේවාව හරහා) ඔබට 3 වන පාර්ශවයේ AI චැට් ආකෘති සමඟ නිර්නාමික සංවාද "
-"කිරීමට ඉඩ සලසයි, එය OpenAI, Anthropic සහ තවත් ආකෘති සඳහා සහය දක්වයි. මෙම සැකසුම අක්‍රිය "
-"කිරීමෙන් DuckDuckGo Search හි චැට් බොත්තම් සහ සබැඳි සඟවනු ඇත. කෙසේ වෙතත්, මෙම සැකසුම "
-"ක්‍රියා විරහිත වූ විට ඔබට තවමත් %1$shttps://duck.ai%2$s වෙත පිවිසීමෙන් සෘජුව චැට් වෙත "
-"ප්‍රවේශ විය හැකිය."
+"චැට් (අපගේ Duck.ai සේවාව හරහා) ඔබට 3 වන පාර්ශවයේ AI චැට් ආකෘති සමඟ නිර්නාමික "
+"සංවාද කිරීමට ඉඩ සලසයි, එය OpenAI, Anthropic සහ තවත් ආකෘති සඳහා සහය දක්වයි. "
+"මෙම සැකසුම අක්‍රිය කිරීමෙන් DuckDuckGo Search හි චැට් බොත්තම් සහ සබැඳි සඟවනු "
+"ඇත. කෙසේ වෙතත්, මෙම සැකසුම ක්‍රියා විරහිත වූ විට ඔබට තවමත් "
+"%1$shttps://duck.ai%2$s වෙත පිවිසීමෙන් සෘජුව චැට් වෙත ප්‍රවේශ විය හැකිය."
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -3741,7 +3774,8 @@ msgstr "පෞද්ගලිකව චැට් කරන්න"
 msgctxt "Promotional text (mobile)"
 msgid "Chat privately on any website with Duck.ai built into our free browser."
 msgstr ""
-"අපගේ ගාස්තු රහිත බ්රවුසරයේ ඇති Duck.ai සමඟ ඕනෑම වෙබ් අඩවියක පෞද්ගලිකව කතාබහේ යෙදෙන්න."
+"අපගේ ගාස්තු රහිත බ්රවුසරයේ ඇති Duck.ai සමඟ ඕනෑම වෙබ් අඩවියක පෞද්ගලිකව කතාබහේ "
+"යෙදෙන්න."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card encouraging third-party browser users to download the DuckDuckGo browser. Not shown in the DuckDuckGo browser or on Linux.
@@ -3749,8 +3783,8 @@ msgctxt "Promotional text"
 msgid ""
 "Chat privately on any website with the Duck.ai sidebar in our free browser."
 msgstr ""
-"අපගේ ගාස්තු රහිත බ්‍රවුසරයේ ඇති Duck.ai පැති තීරුව සමඟ ඕනෑම වෙබ් අඩවියක පුද්ගලිකව කතාබහේ "
-"යෙදෙන්න."
+"අපගේ ගාස්තු රහිත බ්‍රවුසරයේ ඇති Duck.ai පැති තීරුව සමඟ ඕනෑම වෙබ් අඩවියක "
+"පුද්ගලිකව කතාබහේ යෙදෙන්න."
 
 # smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
@@ -3813,8 +3847,8 @@ msgid ""
 "Chats are stored locally on your device instead of on DuckDuckGo servers or "
 "remote servers. Disabling chat history will delete pinned chats."
 msgstr ""
-"ඔබේ උපාංගයේ DuckDuckGo සර්වර හෝ වෙනත් දුරස්ථ සර්වර මත වෙනුවට දේශීයව චැට් ගබඩා කර ඇත. "
-"කතාබස් ඉතිහාසය අක්‍රිය කිරීමෙන් පින් කළ කතාබස් මකා දැමෙනු ඇත."
+"ඔබේ උපාංගයේ DuckDuckGo සර්වර හෝ වෙනත් දුරස්ථ සර්වර මත වෙනුවට දේශීයව චැට් "
+"ගබඩා කර ඇත. කතාබස් ඉතිහාසය අක්‍රිය කිරීමෙන් පින් කළ කතාබස් මකා දැමෙනු ඇත."
 
 # smartling.placeholder_format=C
 #. Text explaining how the Chat History feature stores the user's chats locally to their device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection. Also explains that disabling chat history will delete pinned chats.
@@ -3826,10 +3860,11 @@ msgid ""
 "history will delete pinned chats, and disable the temporary storage of new "
 "prompts and responses."
 msgstr ""
-"කතාබස් ඔබගේ උපාංගයේ දේශීයව ගබඩා කර ඇත. ඔබගේ අන්තර්ජාල සම්බන්ධතාවය නැති වුවහොත් කතාබහක් "
-"නැවත ලබා ගැනීමට උපකාර කිරීම සඳහා, නව විමසීම් සහ ප්‍රතිචාර සංකේතනය කර යැවීමෙන් පසු "
-"තාවකාලිකව DuckDuckGo සේවාදායකයක ගබඩා කරනු ලැබේ. කතාබස් ඉතිහාසය අක්‍රිය කිරීමෙන් පින් කළ "
-"කතාබස් මැකෙනු ඇති අතර නව විමසීම් සහ ප්‍රතිචාර තාවකාලිකව ගබඩා කිරීම අක්‍රිය කරනු ඇත."
+"කතාබස් ඔබගේ උපාංගයේ දේශීයව ගබඩා කර ඇත. ඔබගේ අන්තර්ජාල සම්බන්ධතාවය නැති "
+"වුවහොත් කතාබහක් නැවත ලබා ගැනීමට උපකාර කිරීම සඳහා, නව විමසීම් සහ ප්‍රතිචාර "
+"සංකේතනය කර යැවීමෙන් පසු තාවකාලිකව DuckDuckGo සේවාදායකයක ගබඩා කරනු ලැබේ. "
+"කතාබස් ඉතිහාසය අක්‍රිය කිරීමෙන් පින් කළ කතාබස් මැකෙනු ඇති අතර නව විමසීම් සහ "
+"ප්‍රතිචාර තාවකාලිකව ගබඩා කිරීම අක්‍රිය කරනු ඇත."
 
 # smartling.placeholder_format=C
 #. Title shown above the body copy in the Duck.ai recent chats IndexedDB unavailable notice.
@@ -3851,8 +3886,8 @@ msgctxt "Sync file storage inline disclaimer body"
 msgid ""
 "Chats with attachments have stopped syncing. Free up storage to resume Sync."
 msgstr ""
-"ඇමුණුම් සහිත කතාබස් සමමුහුර්ත වීම නැවතී ඇත. සමමුහුර්ත වීම නැවත ආරම්භ කිරීමට ගබඩාවේ ඉඩ නිදහස් "
-"කරගන්න."
+"ඇමුණුම් සහිත කතාබස් සමමුහුර්ත වීම නැවතී ඇත. සමමුහුර්ත වීම නැවත ආරම්භ කිරීමට "
+"ගබඩාවේ ඉඩ නිදහස් කරගන්න."
 
 # smartling.placeholder_format=C
 #. Message shown when we have no data from upstream to display
@@ -4004,7 +4039,9 @@ msgstr "සේවාවක් තෝරන්න"
 msgctxt "settings"
 msgid ""
 "Choose which app to use when you need directions for a location search result"
-msgstr "ඔබට ස්ථාන සෙවුම් ප්‍රතිඵලයක් සඳහා උපදෙස් අවශ්‍ය විට භාවිත කළ යුතු යෙදුම තෝරන්න"
+msgstr ""
+"ඔබට ස්ථාන සෙවුම් ප්‍රතිඵලයක් සඳහා උපදෙස් අවශ්‍ය විට භාවිත කළ යුතු යෙදුම "
+"තෝරන්න"
 
 # smartling.placeholder_format=C
 #. Accessible label for the citations popover dialog in Duck.ai chat responses.
@@ -4185,9 +4222,9 @@ msgid ""
 "Clearing browser data deletes chats. Some browsers may keep recent chats "
 "indefinitely or auto-delete them after 7+ days of no AI Chat use."
 msgstr ""
-"බ්‍රවුසර දත්ත මකා දැමීමෙන් කතාබස් මකා දමනු ලැබේ. සමහර බ්‍රවුසර මෑත කාලීන කතාබස් කාලය "
-"නොසලකා තබා ගන්නා හෝ AI Chat භාවිත නොකිරීමෙන් දින 7කට පසු ඒවා ස්වයංක්‍රීයව මකා දැමිය හැකි "
-"ය."
+"බ්‍රවුසර දත්ත මකා දැමීමෙන් කතාබස් මකා දමනු ලැබේ. සමහර බ්‍රවුසර මෑත කාලීන "
+"කතාබස් කාලය නොසලකා තබා ගන්නා හෝ AI Chat භාවිත නොකිරීමෙන් දින 7කට පසු ඒවා "
+"ස්වයංක්‍රීයව මකා දැමිය හැකි ය."
 
 # smartling.placeholder_format=C
 #. Text explaining what happens to recent chats when browser data is cleared.
@@ -4197,8 +4234,9 @@ msgid ""
 "indefinitely or auto-deleted after 7 days without using Duck.ai, depending "
 "on your browser."
 msgstr ""
-"බ්‍රවුසර දත්ත මකා දැමීම මෑත කතාබස් මකා දමයි. Duck.ai භාවිත නොකර දින 7කට පසු, ඔබේ "
-"බ්‍රව්සරය මත පදනම්ව මෑත කතාබස් දින නියමයක් නොමැතිව සුරැකීමට හෝ ස්වයංක්‍රීයව මකා දැමිය හැකිය."
+"බ්‍රවුසර දත්ත මකා දැමීම මෑත කතාබස් මකා දමයි. Duck.ai භාවිත නොකර දින 7කට පසු, "
+"ඔබේ බ්‍රව්සරය මත පදනම්ව මෑත කතාබස් දින නියමයක් නොමැතිව සුරැකීමට හෝ "
+"ස්වයංක්‍රීයව මකා දැමිය හැකිය."
 
 # smartling.placeholder_format=C
 #. Warning message shown on the Block domain success modal. Blocked sites are stored in localStorage which is cleared alongside cookies when users clear browser data. Followed by a linked 'our free browser' text.
@@ -4207,8 +4245,8 @@ msgid ""
 "Clearing browser data will reset your blocked sites. Save your block list "
 "permanently in"
 msgstr ""
-"බ්රව්සර් දත්ත ඉවත් කිරීමෙන් ඔබගේ අවහිර කරන ලද වෙබ් අඩවි යළි සැකසේ. ඔබගේ අවහිර ලැයිස්තුව අපගේ "
-"ගාස්තු රහිත බ්‍රවුසරයේ"
+"බ්රව්සර් දත්ත ඉවත් කිරීමෙන් ඔබගේ අවහිර කරන ලද වෙබ් අඩවි යළි සැකසේ. ඔබගේ "
+"අවහිර ලැයිස්තුව අපගේ ගාස්තු රහිත බ්‍රවුසරයේ"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -4217,9 +4255,9 @@ msgid ""
 "%sDuck.ai%s, our private AI chat service that supports chat models from "
 "OpenAI, Anthropic, and more."
 msgstr ""
-"මාතෘකාවක් පිළිබඳව වැඩිදුරටත් විමසා බලන්න \"තවත්\" මත ක්ලික් කරන්න, සහ %1$sDuck.ai%2$s "
-"හරහා පසු විපරම් ප්‍රශ්න අසන්න OpenAI, Anthropic සහ තවත් බොහෝ ආයතනවලින් චැට් ආකෘතිවලට සහය "
-"දක්වන අපගේ පෞද්ගලික AI චැට් සේවය."
+"මාතෘකාවක් පිළිබඳව වැඩිදුරටත් විමසා බලන්න \"තවත්\" මත ක්ලික් කරන්න, සහ "
+"%1$sDuck.ai%2$s හරහා පසු විපරම් ප්‍රශ්න අසන්න OpenAI, Anthropic සහ තවත් බොහෝ "
+"ආයතනවලින් චැට් ආකෘතිවලට සහය දක්වන අපගේ පෞද්ගලික AI චැට් සේවය."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4293,8 +4331,8 @@ msgid ""
 "Click %sSafari%s in the top menu (On Windows, click the %sgears icon%s in "
 "the top right)"
 msgstr ""
-"ඉහළ මෙනුවෙන් %1$sSafari%2$s මත ක්ලික් කරන්න (වින්ඩෝව්ස් වලදී, ඉහළ මෙනුවේ දකුණු පස "
-"%3$sgears icon%4$s මත ක්ලික් කරන්න)"
+"ඉහළ මෙනුවෙන් %1$sSafari%2$s මත ක්ලික් කරන්න (වින්ඩෝව්ස් වලදී, ඉහළ මෙනුවේ "
+"දකුණු පස %3$sgears icon%4$s මත ක්ලික් කරන්න)"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4324,7 +4362,8 @@ msgstr "%1$sYes%2$s කලික් කරන්න"
 #. Tells the user where to click to open their browser's settings menu.
 msgid "Click %ssettings/hamburger icon %s on the Chrome toolbar (top right)."
 msgstr ""
-"Chrom උපකරණ කොටුවේ (ඉහළ දකුණ) %1$ssettings/hamburger icon %2$s මත ක්ලික් කරන්න."
+"Chrom උපකරණ කොටුවේ (ඉහළ දකුණ) %1$ssettings/hamburger icon %2$s මත ක්ලික් "
+"කරන්න."
 
 #  Maxthon default search engine instruction
 # smartling.placeholder_format=C
@@ -4386,8 +4425,9 @@ msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Search Settings%s."
 msgstr ""
-"%1$sමගේ දත්ත මකන්න%2$s ක්ලික් කරන්න හෝ තට්ටු කරන්න. මෙය ක්ලවුඩවලින් දත්ත ඉවත් කරන නමුදු, ඔබ "
-"විසින් %3$sසියලුම සැකසුම් යළි පිහිටුවන්න%4$s ක්ලික්/තට්ටු කරන තෙක් ඔබේ බ්‍රවුසරයේ පවතී."
+"%1$sමගේ දත්ත මකන්න%2$s ක්ලික් කරන්න හෝ තට්ටු කරන්න. මෙය ක්ලවුඩවලින් දත්ත "
+"ඉවත් කරන නමුදු, ඔබ විසින් %3$sසියලුම සැකසුම් යළි පිහිටුවන්න%4$s ක්ලික්/තට්ටු "
+"කරන තෙක් ඔබේ බ්‍රවුසරයේ පවතී."
 
 # smartling.placeholder_format=C
 #. Tells users where to click in order to disable the cloud save feature and delete any data backed-up to the cloud.
@@ -4398,8 +4438,9 @@ msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Settings%s."
 msgstr ""
-"%1$sමගේ දත්ත මකන්න%2$s ක්ලික් කරන්න හෝ තට්ටු කරන්න. මෙය ක්ලවුඩවලින් දත්ත ඉවත් කරන නමුදු, ඔබ "
-"විසින් %3$sසියලුම සැකසුම් යළි පිහිටුවන්න%4$s ක්ලික්/තට්ටු කරන තෙක් ඔබේ බ්‍රවුසරයේ පවතී."
+"%1$sමගේ දත්ත මකන්න%2$s ක්ලික් කරන්න හෝ තට්ටු කරන්න. මෙය ක්ලවුඩවලින් දත්ත "
+"ඉවත් කරන නමුදු, ඔබ විසින් %3$sසියලුම සැකසුම් යළි පිහිටුවන්න%4$s ක්ලික්/තට්ටු "
+"කරන තෙක් ඔබේ බ්‍රවුසරයේ පවතී."
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -4468,8 +4509,8 @@ msgid ""
 "Click the dropdown menu beside %sSearch engine used in the address bar%s and "
 "select %sDuckDuckGo%s."
 msgstr ""
-"ලිපින තීරුව %1$sහි භාවිතා කර ඇති සෙවුම් යන්ත්‍රය%2$s අසල ඇති ඩ්‍රොප් ඩවුන් මෙනුව ක්ලික් කර "
-"%3$sDuckDuckGo%4$s තෝරන්න."
+"ලිපින තීරුව %1$sහි භාවිතා කර ඇති සෙවුම් යන්ත්‍රය%2$s අසල ඇති ඩ්‍රොප් ඩවුන් "
+"මෙනුව ක්ලික් කර %3$sDuckDuckGo%4$s තෝරන්න."
 
 # smartling.placeholder_format=C
 #. First step in a list of steps to take to disable the user's ad blocker
@@ -4477,8 +4518,8 @@ msgid ""
 "Click the icon of the ad blocker extension. It's usually in the upper right "
 "hand corner of your browser."
 msgstr ""
-"Ad blocker කිරීමේ දිගුවේ අයිකනය ක්ලික් කරන්න. එය සාමාන්යයෙන් ඔබේ බ්‍රව්සරයේ ඉහළ දකුණු කෙළවරේ "
-"තියෙනවා."
+"Ad blocker කිරීමේ දිගුවේ අයිකනය ක්ලික් කරන්න. එය සාමාන්යයෙන් ඔබේ බ්‍රව්සරයේ "
+"ඉහළ දකුණු කෙළවරේ තියෙනවා."
 
 #  Safari default search engine instruction
 # smartling.placeholder_format=C
@@ -4667,8 +4708,8 @@ msgid ""
 "Cloud Save lets you save your settings more permanently by entering a "
 "passphrase. It is entirely optional."
 msgstr ""
-"මුරවදනක් ඇතුලත් කිරීම මඟින් ඔබගේ සැකසුම් ක්ලව්ඩයේ සුරෑකීම වඩාත් තහවුරු කිරීමට හැකියාව Cloud "
-"Save. එය සම්පූර්ණයෙන්ම ඔබගේ තේරීමකි."
+"මුරවදනක් ඇතුලත් කිරීම මඟින් ඔබගේ සැකසුම් ක්ලව්ඩයේ සුරෑකීම වඩාත් තහවුරු "
+"කිරීමට හැකියාව Cloud Save. එය සම්පූර්ණයෙන්ම ඔබගේ තේරීමකි."
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -5098,7 +5139,8 @@ msgstr "කොස්ටාරිකාව"
 msgctxt "Error message when the recovery code fails to generate"
 msgid "Couldn't load your recovery code. Please close this and try again."
 msgstr ""
-"ඔබේ ප් රතිසාධන කේතය පූරණය කළ නොහැකි විය. කරුණාකර මෙය වසා දාලා නැවත උත්සාහ කරන්න."
+"ඔබේ ප් රතිසාධන කේතය පූරණය කළ නොහැකි විය. කරුණාකර මෙය වසා දාලා නැවත උත්සාහ "
+"කරන්න."
 
 # smartling.placeholder_format=C
 #. Pairs with a Retry button. Shown after two consecutive failed attempts to load the device list.
@@ -5147,7 +5189,7 @@ msgstr "රූපය සාදන්න"
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
-msgstr ""
+msgstr "මෙම වට්ටෝරුවේ අඩංගු ප්‍රමාණයන්ට අනුව බඩු ලැයිස්තුවක් තනන්න."
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed in the input field when starting a new image generation session.
@@ -5412,7 +5454,8 @@ msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "Daily usage limit reached. You can keep chatting by using your weekly limit."
 msgstr ""
-"දෛනික පරිශීලන සීමාවට ළඟා විය. ඔබට ඔබේ සතිපතා සීමාව භාවිතා කරමින් කතාබස් කරගෙන යා හැකිය."
+"දෛනික පරිශීලන සීමාවට ළඟා විය. ඔබට ඔබේ සතිපතා සීමාව භාවිතා කරමින් කතාබස් "
+"කරගෙන යා හැකිය."
 
 # smartling.placeholder_format=C
 #. The name of the Danish language
@@ -5780,8 +5823,8 @@ msgstr "Duck.ai අසා ලිවීම"
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
 msgstr ""
-"කියවන විට ලිවීම අප විසින් නිර්නාමික කර ඇති අතර, එය AI ආකෘති පුහුණු කිරීමට කිසිවිටෙකත් භාවිතා කරනු "
-"නොලැබේ."
+"කියවන විට ලිවීම අප විසින් නිර්නාමික කර ඇති අතර, එය AI ආකෘති පුහුණු කිරීමට "
+"කිසිවිටෙකත් භාවිතා කරනු නොලැබේ."
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
@@ -5791,7 +5834,7 @@ msgstr "අසා ලිවීම් සීමාවට ළඟා විය"
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
 msgid "Dictation temporarily unavailable"
-msgstr ""
+msgstr "අසා ලිවීම තාවකාලිකව ලබාගත නොහැක"
 
 # smartling.placeholder_format=C
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
@@ -5799,8 +5842,8 @@ msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
 "chat in Duck.ai without having to type."
 msgstr ""
-"කථනය පාඨ බවට පරිවර්තනය කිරීම සඳහා “කියවන විට ලිවීම“ OpenAI ආකෘතියක් භාවිතා කරන බැවින්, "
-"ටයිප් නොකර Duck.ai මත කතාබස් කිරීමට ඔබට පුළුවන."
+"කථනය පාඨ බවට පරිවර්තනය කිරීම සඳහා “කියවන විට ලිවීම“ OpenAI ආකෘතියක් භාවිතා "
+"කරන බැවින්, ටයිප් නොකර Duck.ai මත කතාබස් කිරීමට ඔබට පුළුවන."
 
 # smartling.placeholder_format=C
 #. In 0-click box -- link to definition.
@@ -6100,6 +6143,8 @@ msgid ""
 "Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
 "filtered out. %sLearn More%s"
 msgstr ""
+"AI අවශ්‍ය නැද්ද? %1$snoai.duckduckgo.com%2$s කිසිදු AI විශේෂාංග ලබා නොදෙන "
+"අතර AI-ජනනය කරන ලද රූප පෙරහන් කරයි. %3$sවැඩිදුර දැනගන්න%4$s"
 
 # smartling.placeholder_format=C
 #. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
@@ -6108,6 +6153,8 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
+"AI අවශ්‍ය නැද්ද? %1$snoai.duckduckgo.com%2$s වෙත යන්න AI විශේෂාංග නොමැතිව සහ "
+"AI රූප පෙරහන් කර සෙවීම සඳහා. %3$sවැඩිදුර දැනගන්න%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6210,8 +6257,8 @@ msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for "
 "ceiling fan repair services."
 msgstr ""
-"සිවිලිම් විදුලි පංකා අළුත්වැඩියා සේවා සඳහා උපුටා දැක්වීමක් ඉල්ලා සිටින විකුණුම්කරුවෙකුට සංක්ෂිප්ත හා "
-"සවිස්තරාත්මක විද්‍යුත් තැපෑලක් කෙටුම්පත් කරන්න."
+"සිවිලිම් විදුලි පංකා අළුත්වැඩියා සේවා සඳහා උපුටා දැක්වීමක් ඉල්ලා සිටින "
+"විකුණුම්කරුවෙකුට සංක්ෂිප්ත හා සවිස්තරාත්මක විද්‍යුත් තැපෑලක් කෙටුම්පත් කරන්න."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion asking for an email draft to a vendor requesting a quote for home refrigerator repair services.
@@ -6220,20 +6267,20 @@ msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
 msgstr ""
-"ගෘහ ශීතකරණ අළුත්වැඩියා සේවා සඳහා මිල කැඳවීමක් ඉල්ලා සිටින විකුණුම්කරුවෙකුට සංක්ෂිප්ත හා "
-"සවිස්තරාත්මක විද්‍යුත් තැපෑලක් කෙටුම්පත් කරන්න."
+"ගෘහ ශීතකරණ අළුත්වැඩියා සේවා සඳහා මිල කැඳවීමක් ඉල්ලා සිටින විකුණුම්කරුවෙකුට "
+"සංක්ෂිප්ත හා සවිස්තරාත්මක විද්‍යුත් තැපෑලක් කෙටුම්පත් කරන්න."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Draft a cover letter"
-msgstr ""
+msgstr "ආවරණ ලිපියක් කෙටුම්පත් කරන්න"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Draft a cover letter for this job."
-msgstr ""
+msgstr "මෙම රැකියාව සඳහා ආවරණ ලිපියක් කෙටුම්පත් කරන්න."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -6242,8 +6289,8 @@ msgid ""
 "Draft a few options for a social media post inviting people to my upcoming "
 "party."
 msgstr ""
-"මගේ ඉදිරි සාදයට පුද්ගලයන්ට ආරාධනා කරන සමාජ මාධ්‍ය පළ කිරීමක් සඳහා විකල්ප කිහිපයක් කෙටුම්පත් "
-"කරන්න."
+"මගේ ඉදිරි සාදයට පුද්ගලයන්ට ආරාධනා කරන සමාජ මාධ්‍ය පළ කිරීමක් සඳහා විකල්ප "
+"කිහිපයක් කෙටුම්පත් කරන්න."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a few options for a blog post title about strategies to increase team collaboration.
@@ -6252,8 +6299,8 @@ msgid ""
 "Draft a few options for a title of a post I’m writing about strategies to "
 "increase team collaboration."
 msgstr ""
-"කණ්ඩායම් සහයෝගීතාව වැඩි කිරීම සඳහා උපාය මාර්ග ගැන මම ලියන තනතුරක මාතෘකාවක් සඳහා විකල්ප "
-"කිහිපයක් කෙටුම්පත් කරන්න."
+"කණ්ඩායම් සහයෝගීතාව වැඩි කිරීම සඳහා උපාය මාර්ග ගැන මම ලියන තනතුරක මාතෘකාවක් "
+"සඳහා විකල්ප කිහිපයක් කෙටුම්පත් කරන්න."
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for drafting a social media post.
@@ -6379,8 +6426,9 @@ msgid ""
 "content is only included when you attach it, unless you choose to attach "
 "pages automatically in Settings."
 msgstr ""
-"ඔබ නරඹන පිටුව පිළිබඳ ප්‍රශ්නවලට පිළිතුරු දීමට Duck.ai හට දැන් උදව් කළ හැක. සැකසුම් තුළ පිටු "
-"ස්වයංක්‍රීයව ඇමිණීමට ඔබ තෝරා නොගන්නේ නම්, පිටු අන්තර්ගතය ඇතුළත් වන්නේ ඔබ එය අමුණන විට පමණි."
+"ඔබ නරඹන පිටුව පිළිබඳ ප්‍රශ්නවලට පිළිතුරු දීමට Duck.ai හට දැන් උදව් කළ හැක. "
+"සැකසුම් තුළ පිටු ස්වයංක්‍රීයව ඇමිණීමට ඔබ තෝරා නොගන්නේ නම්, පිටු අන්තර්ගතය "
+"ඇතුළත් වන්නේ ඔබ එය අමුණන විට පමණි."
 
 # smartling.placeholder_format=C
 #. Shown in the Duck.ai recent chats list on standalone when the browser API needed to store chats locally is missing or unavailable.
@@ -6390,8 +6438,9 @@ msgid ""
 "Duck.ai can’t access local storage to save your chats. Please check your "
 "browser settings or disable any extensions and try again."
 msgstr ""
-"ඔබගේ කතාබස් සුරැකීම සඳහා Duck.ai දේශීය ගබඩාවට පිවිසිය නොහැක. කරුණාකර ඔබගේ බ්‍රවුසර "
-"සැකසුම් පරීක්ෂා කරන්න, නැතහොත් කිනම් හෝ දිගුවක් වේ නම්, එය අක්‍රිය කර නැවත උත්සාහ කරන්න."
+"ඔබගේ කතාබස් සුරැකීම සඳහා Duck.ai දේශීය ගබඩාවට පිවිසිය නොහැක. කරුණාකර ඔබගේ "
+"බ්‍රවුසර සැකසුම් පරීක්ෂා කරන්න, නැතහොත් කිනම් හෝ දිගුවක් වේ නම්, එය අක්‍රිය "
+"කර නැවත උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. Displayed when the chat service has reached the maximum number of messages for one day.
@@ -6400,8 +6449,8 @@ msgid ""
 "Duck.ai has reached the maximum number of messages for one day. Please "
 "continue this chat tomorrow."
 msgstr ""
-"Duck.ai එක් දිනක් සඳහා උපරිම පණිවිඩ සංඛ්‍යාවට ළඟා වී ඇත. කරුණාකර හෙට මෙම කතාබස් දිගටම "
-"කරගෙන යන්න."
+"Duck.ai එක් දිනක් සඳහා උපරිම පණිවිඩ සංඛ්‍යාවට ළඟා වී ඇත. කරුණාකර හෙට මෙම "
+"කතාබස් දිගටම කරගෙන යන්න."
 
 # smartling.placeholder_format=C
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
@@ -6417,6 +6466,9 @@ msgid ""
 "company for anyone who wants to take back control of their personal "
 "information."
 msgstr ""
+"Duck.ai නිර්මාණය කර ඇත්තේ DuckDuckGo විසිනි. තම පුද්ගලික තොරතූරුවල පාලනය "
+"නැවතත් සියතට ගැනීමට උවමනා ඔ්නෑම අයකු සඳහා සේවය කරන අන්තර්ජාල ආරක්ෂාව සලසන "
+"ස්වාධීන සමාගමක් ලෙස අපි කටයුතු කරමු."
 
 # smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
@@ -6431,8 +6483,8 @@ msgid ""
 "Duck.ai is still a DuckDuckGo product, but will now have an easier to "
 "remember home on the web: https://duck.ai"
 msgstr ""
-"Duck.ai තවමත් DuckDuckGo නිෂ්පාදනයක්, නමුත් දැන් මතක තබා ගැනීමට පහසු මුල් පිටුවක් සමගින් "
-"අන්තර්ජාලයේ: https://duck.ai"
+"Duck.ai තවමත් DuckDuckGo නිෂ්පාදනයක්, නමුත් දැන් මතක තබා ගැනීමට පහසු මුල් "
+"පිටුවක් සමගින් අන්තර්ජාලයේ: https://duck.ai"
 
 # smartling.placeholder_format=C
 #. Headline for domain change notice.
@@ -6447,8 +6499,8 @@ msgid ""
 "Duck.ai is temporarily unavailable. If this persists, please email this "
 "anonymous code %s to %s"
 msgstr ""
-"Duck.ai තාවකාලිකව ලබා ගත නොහැක. මෙය දිගටම පවතින්නේ නම්, කරුණාකර මෙම %1$s නිර්නාමික "
-"කේතය %2$s වෙත ඊමේල් කරන්න"
+"Duck.ai තාවකාලිකව ලබා ගත නොහැක. මෙය දිගටම පවතින්නේ නම්, කරුණාකර මෙම %1$s "
+"නිර්නාමික කේතය %2$s වෙත ඊමේල් කරන්න"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -6469,6 +6521,9 @@ msgid ""
 "Duck.ai lets you chat privately with popular AI models. Disabling it hides "
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
+"Duck.ai මගින් ඔබට ජනප්‍රිය AI ආකෘති සමඟ පෞද්ගලිකව කතාබස් කිරීමට ඉඩ ලබා දේ. "
+"එය අක්‍රිය කිරීමෙන් Duck.ai බොත්තම් සහ සබැඳි සැඟවෙනු ඇති නමුත් ඔබට තවමත්ඍජුව "
+"ම %1$sduck.ai%2$s වෙත පිවිසිය හැකි ය."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6479,10 +6534,11 @@ msgid ""
 "can still access Duck.ai when this setting is off by visiting %shttps://duck."
 "ai%s directly."
 msgstr ""
-"Duck.ai මඟින් OpenAI, Anthropic සහ වෙනත් අයගේ ආකෘති ඇතුළුව 3වන පාර්ශවීය AI චැට් ආකෘති "
-"සමඟ නිර්නාමික සංවාද කිරීමට ඔබට ඉඩ සලසයි. මෙම සැකසුම අක්‍රිය කිරීමෙන් DuckDuckGo Search හි "
-"Duck.ai බොත්තම් සහ සබැඳි සඟවනු ඇත. කෙසේ වෙතත්, මෙම සැකසුම ක්‍රියා විරහිත වූ විටත් ඔබට "
-"%1$shttps://duck.ai%2$s වෙත පිවිසීමෙන් Duck.ai වෙත ප්‍රවේශ විය හැක හැකිය."
+"Duck.ai මඟින් OpenAI, Anthropic සහ වෙනත් අයගේ ආකෘති ඇතුළුව 3වන පාර්ශවීය AI "
+"චැට් ආකෘති සමඟ නිර්නාමික සංවාද කිරීමට ඔබට ඉඩ සලසයි. මෙම සැකසුම අක්‍රිය "
+"කිරීමෙන් DuckDuckGo Search හි Duck.ai බොත්තම් සහ සබැඳි සඟවනු ඇත. කෙසේ වෙතත්, "
+"මෙම සැකසුම ක්‍රියා විරහිත වූ විටත් ඔබට %1$shttps://duck.ai%2$s වෙත "
+"පිවිසීමෙන් Duck.ai වෙත ප්‍රවේශ විය හැක හැකිය."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
@@ -6497,8 +6553,8 @@ msgid ""
 "Duck.ai might have lost your recent chats. You can still use Duck.ai as "
 "usual."
 msgstr ""
-"Duck.ai තුළ ඔබේ මෑත කතාබස් නොතිබීමට ඉඩ ඇත. ඔයාට තවමත් සාමාන්‍ය පරිදි Duck.ai භාවිතා "
-"කරන්න පුළුවන්."
+"Duck.ai තුළ ඔබේ මෑත කතාබස් නොතිබීමට ඉඩ ඇත. ඔයාට තවමත් සාමාන්‍ය පරිදි Duck.ai "
+"භාවිතා කරන්න පුළුවන්."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
@@ -6512,7 +6568,8 @@ msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
 msgstr ""
-"Duck.ai ප්‍රතිචාර විශේෂිත මූලාශ්‍ර මත පදනම් නොවී ඇත හෝ නිරවද්‍යතාව සඳහා පරීක්ෂා කර නැත."
+"Duck.ai ප්‍රතිචාර විශේෂිත මූලාශ්‍ර මත පදනම් නොවී ඇත හෝ නිරවද්‍යතාව සඳහා "
+"පරීක්ෂා කර නැත."
 
 # smartling.placeholder_format=C
 #. Title shown when native app needs to reload for service update.
@@ -6540,9 +6597,10 @@ msgid ""
 "AI chat no sign up, OpenAI, Anthropic, Llama, Mistral, open source AI "
 "models, privacy focused AI, no account AI chat"
 msgstr ""
-"Duck.ai, DuckDuckGo AI, පුද්ගලික AI චැට්බොට්, නොමිලේ AI කතාබස්, නිර්නාමික AI කතාබහ, "
-"ලියාපදිංචි වීමක් නොමැති AI කතාබස්, OpenAI, Anthropic, Llama, Mistral, විවෘත මූලාශ්‍ර AI "
-"ආකෘති, පෞද්ගලිකත්වය කේන්ද්‍ර කරගත් AI, ගිණුමක් නොමැති AI කතාබස්"
+"Duck.ai, DuckDuckGo AI, පුද්ගලික AI චැට්බොට්, නොමිලේ AI කතාබස්, නිර්නාමික AI "
+"කතාබහ, ලියාපදිංචි වීමක් නොමැති AI කතාබස්, OpenAI, Anthropic, Llama, Mistral, "
+"විවෘත මූලාශ්‍ර AI ආකෘති, පෞද්ගලිකත්වය කේන්ද්‍ර කරගත් AI, ගිණුමක් නොමැති AI "
+"කතාබස්"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -6570,12 +6628,13 @@ msgid ""
 "relevant), or Often (shows more frequently on a wider range of searches). "
 "For now, DuckAssist is only available in the U.S. (English) region."
 msgstr ""
-"DuckAssist හට නිර්නාමිකව සමහර සෙවීම් වලට ප්‍රතිචාර වශයෙන් තොරතුරු සොයා බලා සාරාංශගත කළ "
-"හැක. කොපමණ වාරයක් DuckAssist පෙනී සිටීමට අවශ්‍ය දැ යි ඔබට තෝරා ගත හැකිය: කිසි විටෙකත් "
-"(සෙවුම් ප්‍රතිඵලවලින් DuckAssist UI සම්පූර්ණයෙන්ම ඉවත් කරයි), On-demand (ඔබ සහාය බොත්තම "
-"ක්ලික් කළහොත් පමණක් පෙන්වයි), සමහර විට (ඉතා අදාළ වන විට පමණක් පෙන්වයි), හෝ බොහෝ විට (පුළුල් "
-"පරාසයක සෙවුම් මත නිතර නිතර පෙන්වයි). දැනට, DuckAssist ලබා ගත හැක්කේ එක්සත් ජනපද "
-"(ඉංග්‍රීසි) කලාපයේ පමණි."
+"DuckAssist හට නිර්නාමිකව සමහර සෙවීම් වලට ප්‍රතිචාර වශයෙන් තොරතුරු සොයා බලා "
+"සාරාංශගත කළ හැක. කොපමණ වාරයක් DuckAssist පෙනී සිටීමට අවශ්‍ය දැ යි ඔබට තෝරා "
+"ගත හැකිය: කිසි විටෙකත් (සෙවුම් ප්‍රතිඵලවලින් DuckAssist UI සම්පූර්ණයෙන්ම "
+"ඉවත් කරයි), On-demand (ඔබ සහාය බොත්තම ක්ලික් කළහොත් පමණක් පෙන්වයි), සමහර විට "
+"(ඉතා අදාළ වන විට පමණක් පෙන්වයි), හෝ බොහෝ විට (පුළුල් පරාසයක සෙවුම් මත නිතර "
+"නිතර පෙන්වයි). දැනට, DuckAssist ලබා ගත හැක්කේ එක්සත් ජනපද (ඉංග්‍රීසි) කලාපයේ "
+"පමණි."
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6584,9 +6643,10 @@ msgid ""
 "%sDuckDuckGo AI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI, and Anthropic, and more."
 msgstr ""
-"DuckAssist ට පසුවිපරම් ප්‍රශ්නවලට පිළිතුරු දිය නොහැක, කෙසේ වෙතත්, අපි %1$sDuckDuckGo AI "
-"Chat%2$s සේවය ද ලබා දෙන්නෙමු, එය OpenAI සහ Anthropic වෙතින් වන චැට් ආකෘති සඳහා සහය "
-"දක්වන පෞද්ගලික AI බලයෙන් ක්‍රියාත්මක වන චැට් සේවාවක් වේ."
+"DuckAssist ට පසුවිපරම් ප්‍රශ්නවලට පිළිතුරු දිය නොහැක, කෙසේ වෙතත්, අපි "
+"%1$sDuckDuckGo AI Chat%2$s සේවය ද ලබා දෙන්නෙමු, එය OpenAI සහ Anthropic "
+"වෙතින් වන චැට් ආකෘති සඳහා සහය දක්වන පෞද්ගලික AI බලයෙන් ක්‍රියාත්මක වන චැට් "
+"සේවාවක් වේ."
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6595,9 +6655,10 @@ msgid ""
 "DuckDuckGo %sAI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI and Anthropic."
 msgstr ""
-"DuckAssist ට පසුවිපරම් ප්‍රශ්නවලට පිළිතුරු දිය නොහැක, කෙසේ වෙතත්, අපි DuckDuckGo %1$sAI "
-"Chat%2$s සේවය ද ලබා දෙන්නෙමු, එය OpenAI සහ Anthropic වෙතින් වන චැට් ආකෘති සඳහා සහය "
-"දක්වන පෞද්ගලික AI බලයෙන් ක්‍රියාත්මක වන චැට් සේවාවක් වේ."
+"DuckAssist ට පසුවිපරම් ප්‍රශ්නවලට පිළිතුරු දිය නොහැක, කෙසේ වෙතත්, අපි "
+"DuckDuckGo %1$sAI Chat%2$s සේවය ද ලබා දෙන්නෙමු, එය OpenAI සහ Anthropic "
+"වෙතින් වන චැට් ආකෘති සඳහා සහය දක්වන පෞද්ගලික AI බලයෙන් ක්‍රියාත්මක වන චැට් "
+"සේවාවක් වේ."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6609,11 +6670,12 @@ msgid ""
 "responses are currently based on Wikipedia and related content and are not "
 "checked for accuracy."
 msgstr ""
-"DuckAssist යනු අපගේ සෙවුම් ප්‍රතිඵලවල ඇති නව විශේෂාංගයක් වන අතර එයට නිර්නාමික ව සෙවුම් "
-"විමසුම් සඳහා පිළිතුරු ජනනය කළ හැකිය. මෙය සිදු කිරීම සඳහා, එය අදාළ අන්තර්ගතයන් සඳහා විකිපීඩියාව "
-"සහ ඒ ආශ්‍රිත අඩවි පිරික්සන අතර පසුව එම තොරතුරු වල සාරාංශයක් ජනනය කිරීම සඳහා AI බලයෙන් "
-"ක්‍රියාත්මක වන ස්වාභාවික භාෂා තාක්ෂණය භාවිතා කරයි. එහි ප්‍රතිචාර දැනට විකිපීඩියාව සහ අදාළ "
-"අන්තර්ගතයන් මත පදනම් වී ඇති අතර නිරවද්‍යතාව සඳහා පරීක්ෂා කර නොමැති බව කරුණාවෙන් සලකන්න."
+"DuckAssist යනු අපගේ සෙවුම් ප්‍රතිඵලවල ඇති නව විශේෂාංගයක් වන අතර එයට "
+"නිර්නාමික ව සෙවුම් විමසුම් සඳහා පිළිතුරු ජනනය කළ හැකිය. මෙය සිදු කිරීම සඳහා, "
+"එය අදාළ අන්තර්ගතයන් සඳහා විකිපීඩියාව සහ ඒ ආශ්‍රිත අඩවි පිරික්සන අතර පසුව එම "
+"තොරතුරු වල සාරාංශයක් ජනනය කිරීම සඳහා AI බලයෙන් ක්‍රියාත්මක වන ස්වාභාවික භාෂා "
+"තාක්ෂණය භාවිතා කරයි. එහි ප්‍රතිචාර දැනට විකිපීඩියාව සහ අදාළ අන්තර්ගතයන් මත "
+"පදනම් වී ඇති අතර නිරවද්‍යතාව සඳහා පරීක්ෂා කර නොමැති බව කරුණාවෙන් සලකන්න."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6627,13 +6689,15 @@ msgid ""
 "It’s important to remember that responses are auto-generated from cited "
 "sources and based on %scrawling the web%s."
 msgstr ""
-"DuckAssist යනු අපගේ සෙවුම් ප්‍රතිඵලවල ඇති නව විශේෂාංගයක් වන අතර එයට නිර්නාමික ව සෙවුම් "
-"විමසුම් සඳහා පිළිතුරු ජනනය කළ හැකිය. මෙය සිදු කිරීම සඳහා, එය අදාළ අන්තර්ගතයන් සඳහා වෙබ් ස්කෑන් "
-"කරන අතර පසුව සොයාගත් අදාළ තොරතුරු මත පදනම්ව කෙටි පිළිතුරක් ජනනය කිරීම සඳහා AI-බලැති "
-"ස්වාභාවික භාෂා තාක්ෂණය භාවිත කරයි. DuckAssist ප්‍රතිචාර සෑම විටම මූලාශ්‍ර එකකට හෝ දෙකකට "
-"සෘජුවම සම්බන්ධ වන අතර, පිළිතුර පැමිණි ස්ථානය උපුටා දක්වයි, එබැවින් ඔබට පහසුවෙන් ගොස් වඩාත් "
-"සවිස්තරාත්මක තොරතුරු ලබා ගත හැකිය. ප්රතිචාර උපුටා දක්වන ලද මූලාශ්රවලින් ස්වයංක්රීයව ජනනය වන "
-"අතර %1$sවෙබ් කැටි ගැසීම%2$s මත පදනම් වන බව මතක තබා ගැනීම වැදගත්ය."
+"DuckAssist යනු අපගේ සෙවුම් ප්‍රතිඵලවල ඇති නව විශේෂාංගයක් වන අතර එයට "
+"නිර්නාමික ව සෙවුම් විමසුම් සඳහා පිළිතුරු ජනනය කළ හැකිය. මෙය සිදු කිරීම සඳහා, "
+"එය අදාළ අන්තර්ගතයන් සඳහා වෙබ් ස්කෑන් කරන අතර පසුව සොයාගත් අදාළ තොරතුරු මත "
+"පදනම්ව කෙටි පිළිතුරක් ජනනය කිරීම සඳහා AI-බලැති ස්වාභාවික භාෂා තාක්ෂණය භාවිත "
+"කරයි. DuckAssist ප්‍රතිචාර සෑම විටම මූලාශ්‍ර එකකට හෝ දෙකකට සෘජුවම සම්බන්ධ වන "
+"අතර, පිළිතුර පැමිණි ස්ථානය උපුටා දක්වයි, එබැවින් ඔබට පහසුවෙන් ගොස් වඩාත් "
+"සවිස්තරාත්මක තොරතුරු ලබා ගත හැකිය. ප්රතිචාර උපුටා දක්වන ලද මූලාශ්රවලින් "
+"ස්වයංක්රීයව ජනනය වන අතර %1$sවෙබ් කැටි ගැසීම%2$s මත පදනම් වන බව මතක තබා ගැනීම "
+"වැදගත්ය."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
@@ -6641,8 +6705,8 @@ msgid ""
 "DuckAssist responses are auto-generated based on listed sources and not "
 "checked for accuracy."
 msgstr ""
-"DuckAssist ප්‍රතිචාර ලැයිස්තුගත මූලාශ්‍ර මත පදනම්ව ස්වයංක්‍රීයව ජනනය වන අතර නිරවද්‍යතාව සඳහා "
-"පරීක්‍ෂා කර නොමැත."
+"DuckAssist ප්‍රතිචාර ලැයිස්තුගත මූලාශ්‍ර මත පදනම්ව ස්වයංක්‍රීයව ජනනය වන අතර "
+"නිරවද්‍යතාව සඳහා පරීක්‍ෂා කර නොමැත."
 
 # smartling.placeholder_format=C
 #. Displayed when the chat service has reached the maximum number of messages for one day.
@@ -6651,8 +6715,8 @@ msgid ""
 "DuckDuckGo AI Chat has reached the maximum number of messages for one day. "
 "Please continue this chat tomorrow."
 msgstr ""
-"DuckDuckGo AI Chat එක දවසකට උපරිම පණිවිඩ සංඛ්‍යාවට ළඟා වෙලා ඇත. කරුණාකර හෙට මෙම "
-"කතාබස් දිගටම කරගෙන යන්න."
+"DuckDuckGo AI Chat එක දවසකට උපරිම පණිවිඩ සංඛ්‍යාවට ළඟා වෙලා ඇත. කරුණාකර හෙට "
+"මෙම කතාබස් දිගටම කරගෙන යන්න."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the AI chat service and supported AI models. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -6661,8 +6725,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"DuckDuckGo AI Chat පුද්ගලික AI බලැති චැට් සේවාවක් වන අතර එය දැනට %1$s %2$s සහ %3$s "
-"%4$s චැට් මාදිලි සඳහා සහාය දක්වයි."
+"DuckDuckGo AI Chat පුද්ගලික AI බලැති චැට් සේවාවක් වන අතර එය දැනට %1$s %2$s "
+"සහ %3$s %4$s චැට් මාදිලි සඳහා සහාය දක්වයි."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the welcome screen of the onboarding. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -6671,8 +6735,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"DuckDuckGo AI Chat පුද්ගලික AI බලැති චැට් සේවාවක් වන අතර එය දැනට %1$s %2$s සහ %3$s "
-"%4$s චැට් මාදිලි සඳහා සහාය දක්වයි."
+"DuckDuckGo AI Chat පුද්ගලික AI බලැති චැට් සේවාවක් වන අතර එය දැනට %1$s %2$s "
+"සහ %3$s %4$s චැට් මාදිලි සඳහා සහාය දක්වයි."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding DuckDuckGo AI Chat.
@@ -6698,7 +6762,9 @@ msgctxt "Error message for VQD error"
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. Please refresh the page and "
 "try again."
-msgstr "DuckDuckGo AI Chat තාවකාලිකව නොමැත. කරුණාකර පිටුව නැවුම් කර නැවත උත්සාහ කරන්න."
+msgstr ""
+"DuckDuckGo AI Chat තාවකාලිකව නොමැත. කරුණාකර පිටුව නැවුම් කර නැවත උත්සාහ "
+"කරන්න."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -6823,8 +6889,8 @@ msgid ""
 "DuckDuckGo anonymizes these reports by automatically removing PII like "
 "names, email addresses, phone numbers, and identifying metadata."
 msgstr ""
-"DuckDuckGo නම, විද්‍යුත් තැපැල් ලිපින, දුරකථන අංක සහ හඳුනාගත හැකි පාර-දත්ත වැනි PII "
-"ස්වයංක්‍රීයව ඉවත් කිරීමෙන් මෙම වාර්තා නිර්නාමික කරයි."
+"DuckDuckGo නම, විද්‍යුත් තැපැල් ලිපින, දුරකථන අංක සහ හඳුනාගත හැකි පාර-දත්ත "
+"වැනි PII ස්වයංක්‍රීයව ඉවත් කිරීමෙන් මෙම වාර්තා නිර්නාමික කරයි."
 
 # smartling.placeholder_format=C
 #. The first %s is the agree button label ('Agree'). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. The leading sentence mirrors the drawer-style inline disclaimer (DUCKCHAT_TOS_INLINE_DISCLAIMER).
@@ -6832,8 +6898,8 @@ msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid ""
 "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to Duck.ai's %s."
 msgstr ""
-"DuckDuckGo ඔබගේ කතාබස් නිර්නාමික කරයි. '%1$s' ක්ලික් කිරීමෙන් ඔබ Duck.ai %2$s වෙත එකඟ "
-"වෙයි."
+"DuckDuckGo ඔබගේ කතාබස් නිර්නාමික කරයි. '%1$s' ක්ලික් කිරීමෙන් ඔබ Duck.ai "
+"%2$s වෙත එකඟ වෙයි."
 
 # smartling.placeholder_format=C
 #. Shown below the input on the empty state when the user has not yet accepted the terms of service. The first %s is the action button label ('Ask' for chat, 'Create' for image generation). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. Clicking the action button both accepts the terms and submits the prompt.
@@ -6842,7 +6908,8 @@ msgctxt ""
 "users"
 msgid "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to our %s."
 msgstr ""
-"DuckDuckGo ඔබගේ කතාබස් නිර්නාමික කරයි. '%1$s' ක්ලික් කිරීමෙන් ඔබ අපගේ %2$s වෙත එකඟ වෙයි."
+"DuckDuckGo ඔබගේ කතාබස් නිර්නාමික කරයි. '%1$s' ක්ලික් කිරීමෙන් ඔබ අපගේ %2$s "
+"වෙත එකඟ වෙයි."
 
 # smartling.placeholder_format=C
 #. An information popup explaining that we block trackers
@@ -6851,8 +6918,9 @@ msgid ""
 "companies like Google and Facebook, who often try to track you on other "
 "websites."
 msgstr ""
-"ගූගල් සහ ෆේස්බුක් වැනි සමාගම්වල ට්‍රැකර් ඇතුළු ඔබ පිවිසෙන වෙබ් අඩවි වල DuckDuckGo ට්‍රැකර් අවහිර "
-"කරයි, බොහෝ විට වෙනත් වෙබ් අඩවි වල ඔබව නිරීක්ෂණය කිරීමට උත්සාහ කරයි."
+"ගූගල් සහ ෆේස්බුක් වැනි සමාගම්වල ට්‍රැකර් ඇතුළු ඔබ පිවිසෙන වෙබ් අඩවි වල "
+"DuckDuckGo ට්‍රැකර් අවහිර කරයි, බොහෝ විට වෙනත් වෙබ් අඩවි වල ඔබව නිරීක්ෂණය "
+"කිරීමට උත්සාහ කරයි."
 
 # smartling.placeholder_format=C
 #. Description of how DuckDuckGo keeps a user's location anonymous while the user searches on a map of their area.
@@ -6864,11 +6932,11 @@ msgid ""
 "away, such that you remain anonymous. %sLearn more about how we designed "
 "this technology to protect your privacy%s."
 msgstr ""
-"DuckDuckGo සැලසුම අනුව පුද්ගලිකයි. ඔබ ස්ථානය සක්‍රීය කරන විට, එය ඔබේ දේශීය උපාංගයේ පමණක් "
-"ගබඩා වේ. ඔබ සොයන විට, ඔබේ උපාංගය එය අප වෙත යවයි, එම සෙවුමේ ප්‍රතිඵල වැඩි දියුණු කිරීම "
-"සඳහා අපි එය භාවිතා කරමු, පසුව ඔබ නිර්නාමික වන පරිදි අපි එය වහාම ඉවත දමමු. %1$sඔබේ "
-"පුද්ගලිකත්වය ආරක්ෂා කිරීමට අප මෙම තාක්ෂණය කෙසේ නිර්මාණය කර ඇතිදැයි යන්න තවදුරටත් ඉගෙන "
-"ගන්න%2$s."
+"DuckDuckGo සැලසුම අනුව පුද්ගලිකයි. ඔබ ස්ථානය සක්‍රීය කරන විට, එය ඔබේ දේශීය "
+"උපාංගයේ පමණක් ගබඩා වේ. ඔබ සොයන විට, ඔබේ උපාංගය එය අප වෙත යවයි, එම සෙවුමේ "
+"ප්‍රතිඵල වැඩි දියුණු කිරීම සඳහා අපි එය භාවිතා කරමු, පසුව ඔබ නිර්නාමික වන "
+"පරිදි අපි එය වහාම ඉවත දමමු. %1$sඔබේ පුද්ගලිකත්වය ආරක්ෂා කිරීමට අප මෙම "
+"තාක්ෂණය කෙසේ නිර්මාණය කර ඇතිදැයි යන්න තවදුරටත් ඉගෙන ගන්න%2$s."
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
@@ -6888,8 +6956,8 @@ msgid ""
 "DuckDuckGo only uses your approximate location. That's all we need to "
 "deliver better results, closer to you. %sLearn more%s."
 msgstr ""
-"DuckDuckGo භාවිතා කරන්නේ ඔබගේ ආසන්න ස්ථානය පමණි. ඔබට වඩා සමීප හොඳ ප්‍රතිඵල ලබා දීමට "
-"අපට අවශ්‍ය වන්නේ එපමණයි. %1$sතවත් ඉගෙන ගන්න%2$s."
+"DuckDuckGo භාවිතා කරන්නේ ඔබගේ ආසන්න ස්ථානය පමණි. ඔබට වඩා සමීප හොඳ ප්‍රතිඵල "
+"ලබා දීමට අපට අවශ්‍ය වන්නේ එපමණයි. %1$sතවත් ඉගෙන ගන්න%2$s."
 
 # smartling.placeholder_format=C
 msgid "DuckDuckGo search"
@@ -6975,9 +7043,9 @@ msgid ""
 "random words from that list, ensuring that the passphrase is at least 18-20 "
 "characters long."
 msgstr ""
-"ඔබ මුරපද යෝජනාවක් ඉල්ලා සිටින සෑම අවස්ථාවකම, DuckDuckGo සර්වර වලින් අපට දිගු අහඹු වචන "
-"ලැයිස්තුවක් ලැබේ. බ්‍රව්සරයේ දී, අපි එම ලැයිස්තුවෙන් අහඹු වචන 4-5 ක් තෝරා ගනිමු, මුරපදය අවම "
-"වශයෙන් අක්ෂර 18-20 ක් වත් ඇති බව සහතික කරමු."
+"ඔබ මුරපද යෝජනාවක් ඉල්ලා සිටින සෑම අවස්ථාවකම, DuckDuckGo සර්වර වලින් අපට දිගු "
+"අහඹු වචන ලැයිස්තුවක් ලැබේ. බ්‍රව්සරයේ දී, අපි එම ලැයිස්තුවෙන් අහඹු වචන 4-5 "
+"ක් තෝරා ගනිමු, මුරපදය අවම වශයෙන් අක්ෂර 18-20 ක් වත් ඇති බව සහතික කරමු."
 
 # smartling.placeholder_format=C
 msgctxt "Sports module"
@@ -7041,7 +7109,9 @@ msgstr "රූපය සංස්කරණය කෙරේ..."
 msgctxt "Info text for the editing message feature"
 msgid ""
 "Editing your message will remove the response below and generate a new one."
-msgstr "ඔබේ පණිවිඩය සංස්කරණය කිරීමෙන් පහත ප්‍රතිචාරය ඉවත් කර නව ප්‍රතිචාරයක් ජනනය කරයි."
+msgstr ""
+"ඔබේ පණිවිඩය සංස්කරණය කිරීමෙන් පහත ප්‍රතිචාරය ඉවත් කර නව ප්‍රතිචාරයක් ජනනය "
+"කරයි."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of an editor in its responses.
@@ -7173,8 +7243,8 @@ msgid ""
 "Enable anonymous location for more accurate results. You can always change "
 "your mind later."
 msgstr ""
-"වඩාත් නිවැරදි ප්‍රතිඵල සඳහා නිර්නාමික ස්ථානය සක්‍රීය කරන්න. ඔබට පසුව සෑම විටම ඔබේ අදහස වෙනස් "
-"කළ හැකිය."
+"වඩාත් නිවැරදි ප්‍රතිඵල සඳහා නිර්නාමික ස්ථානය සක්‍රීය කරන්න. ඔබට පසුව සෑම "
+"විටම ඔබේ අදහස වෙනස් කළ හැකිය."
 
 # smartling.placeholder_format=C
 #. Title of the dictation privacy consent modal shown on first use.
@@ -7185,7 +7255,9 @@ msgstr "Duck.ai මත අසා ලිවීම සක් රීය කරන�
 #. Prompt to enable location service so that search results can be displayed near the user's current location.
 msgctxt "precise_user_location"
 msgid "Enable location settings on your device to use anonymous location"
-msgstr "නිර්නාමික පිහිටීම භාවිතා කිරීම සඳහා ඔබේ උපාංගය මත පිහිටීම් සැකසුම් සක්‍රිය කරන්න"
+msgstr ""
+"නිර්නාමික පිහිටීම භාවිතා කිරීම සඳහා ඔබේ උපාංගය මත පිහිටීම් සැකසුම් සක්‍රිය "
+"කරන්න"
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -7217,8 +7289,8 @@ msgid ""
 "Enabling anonymous location gives more accurate results but still keeps your "
 "searches and exact location private to DuckDuckGo."
 msgstr ""
-"නිර්නාමික ස්ථානය සක්‍රිය කිරීම වඩාත් නිවැරදි ප්‍රතිඵල ලබා දෙන නමුත් ඉන් තවමත් ඔබේ සෙවුම් සහ නිශ්චිත "
-"ස්ථානය DuckDuckGo වෙත පෞද්ගලිකව තබා ගනී."
+"නිර්නාමික ස්ථානය සක්‍රිය කිරීම වඩාත් නිවැරදි ප්‍රතිඵල ලබා දෙන නමුත් ඉන් "
+"තවමත් ඔබේ සෙවුම් සහ නිශ්චිත ස්ථානය DuckDuckGo වෙත පෞද්ගලිකව තබා ගනී."
 
 # smartling.placeholder_format=C
 msgid "Encrypt Connections"
@@ -7380,8 +7452,8 @@ msgid ""
 "Enter a new passphrase and click/tap %sSave Settings%s. This will save your "
 "data under your new passphrase."
 msgstr ""
-"නව මුරපදයක් ඇතුලත් කර %1$sසැකසුම් සුරකින්න%2$s ක්ලික්/තට්ටු කරන්න. මෙය ඔබගේ නව මුරදය යටතේ "
-"ඔබගේ දත්ත සුරකිනු ඇත."
+"නව මුරපදයක් ඇතුලත් කර %1$sසැකසුම් සුරකින්න%2$s ක්ලික්/තට්ටු කරන්න. මෙය ඔබගේ "
+"නව මුරදය යටතේ ඔබගේ දත්ත සුරකිනු ඇත."
 
 # smartling.placeholder_format=C
 #. Label for the field where a user enters their passphrase.
@@ -7452,13 +7524,13 @@ msgstr "එරිත්‍රියාව"
 #. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Estimate the nutrition"
-msgstr ""
+msgstr "පෝෂණය අනුමාන කරන්න"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Estimate the nutritional information for this recipe."
-msgstr ""
+msgstr "මෙම වට්ටෝරුව සඳහා පෝෂණ තොරතුරු ඇස්තමේන්තු කරන්න."
 
 # smartling.placeholder_format=C
 msgid "Estonia"
@@ -7494,7 +7566,9 @@ msgstr "සිතියම පුළුල් කරන්න"
 #. Subtitle for the Collaborations promotional card at the bottom of search results. Describes the branded merchandise line. 'Give a duck' is a wordplay on the DuckDuckGo brand name.
 msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
-msgstr "පෞද්ගලිකත්වය ගැන සැලකිල්ලක් දක්වන අය සඳහා විශේෂඥ ලෙස නිර්මාණය කරන ලද නිෂ්පාදන."
+msgstr ""
+"පෞද්ගලිකත්වය ගැන සැලකිල්ලක් දක්වන අය සඳහා විශේෂඥ ලෙස නිර්මාණය කරන ලද "
+"නිෂ්පාදන."
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
@@ -7518,7 +7592,7 @@ msgstr "දින 1 කින් කල් ඉකුත් වේ"
 #. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain the accepted answer in simple terms."
-msgstr ""
+msgstr "පිළිගත් පිළිතුර සරල වචනවලින් පැහැදිලි කරන්න."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
@@ -7531,43 +7605,45 @@ msgstr "කළු කුහර පිළිබඳ මූලික සංකල�
 #. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain the top answer"
-msgstr ""
+msgstr "ඉහළ ම පිළිතුර පැහැදිලි කරන්න"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain this in simple, plain language."
-msgstr ""
+msgstr "මෙය සරල, පැහැදිලි භාෂාවෙන් විස්තර කරන්න."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain this paper"
-msgstr ""
+msgstr "මේ ලිපිය පැහැදිලි කරන්න"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain this repo"
-msgstr ""
+msgstr "මෙම සංචිතය (repo) පැහැදිලි කරන්න"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain this research paper in plain language."
-msgstr ""
+msgstr "මෙම පර්යේෂණ පත්‍රිකාව සරල භාෂාවෙන් පැහැදිලි කරන්න."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain this simply"
-msgstr ""
+msgstr "මෙය සරලව පැහැදිලි කරන්න"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain what this repository does and how to use it."
 msgstr ""
+"මෙම සංචිතය කරන්නේ කුමක් ද යන්න සහ එය භාවිතා කරන්නේ කෙසේ ද යන්න පැහැදිලි "
+"කරන්න."
 
 # smartling.placeholder_format=C
 #. Label to show if song lyrics contain explicit content
@@ -7744,7 +7820,9 @@ msgstr "ප්‍රතිපෝෂණය සාර්ථකව යවන ලද
 msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and improvements."
-msgstr "ඔබේ වැනි ප්‍රතිචාර සෘජුවම අපගේ නිෂ්පාදන යාවත්කාලීන කිරීම් සහ වැඩිදියුණු කිරීම් බලපායි."
+msgstr ""
+"ඔබේ වැනි ප්‍රතිචාර සෘජුවම අපගේ නිෂ්පාදන යාවත්කාලීන කිරීම් සහ වැඩිදියුණු "
+"කිරීම් බලපායි."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -7753,15 +7831,18 @@ msgid ""
 "Feedback like yours directly influences our product updates and "
 "improvements. Hopefully we can address the issue you shared too."
 msgstr ""
-"ඔබේ වැනි ප්‍රතිචාර අපගේ නිෂ්පාදන යාවත්කාලීන කිරීම් සහ වැඩිදියුණු කිරීම් සෘජුවම බලපායි. ඔබ බෙදාගත් "
-"ගැටලුවටත් අපට විසඳුමක් සොයාගත හැකි යැයි මම බලාපොරොත්තු වෙමි."
+"ඔබේ වැනි ප්‍රතිචාර අපගේ නිෂ්පාදන යාවත්කාලීන කිරීම් සහ වැඩිදියුණු කිරීම් "
+"සෘජුවම බලපායි. ඔබ බෙදාගත් ගැටලුවටත් අපට විසඳුමක් සොයාගත හැකි යැයි මම "
+"බලාපොරොත්තු වෙමි."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box
 msgid ""
 "Feel free to adjust the settings below. Then, just copy and paste the code "
 "into your website."
-msgstr "පහත සැකසුම් සකස් කිරීමට නිදහස් වන්න. ඉන්පසු කේතය ඔබේ වෙබ් අඩවියට පිටපත් කරන්න."
+msgstr ""
+"පහත සැකසුම් සකස් කිරීමට නිදහස් වන්න. ඉන්පසු කේතය ඔබේ වෙබ් අඩවියට පිටපත් "
+"කරන්න."
 
 # smartling.placeholder_format=C
 msgid "Fiji"
@@ -7851,6 +7932,8 @@ msgctxt "settings"
 msgid ""
 "Filters out known AI spam sites from image search results. %sLearn More%s"
 msgstr ""
+"රූප සෙවුම් ප්‍රතිඵලවලින් දන්නා AI අයාචිත අඩවි පෙරහන් කර ඉවත් කරයි. "
+"%1$sවැඩිදුර දැනගන්න%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the final score of a sporting event.
@@ -7909,7 +7992,7 @@ msgstr "වත්මන් තොරතුරු සොයන්න"
 #. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Find me alternatives"
-msgstr ""
+msgstr "මට විකල්ප සොයා දෙන්න"
 
 # smartling.placeholder_format=C
 #. Button that searches for results closer to the user's current location.
@@ -7928,7 +8011,9 @@ msgstr "ඔබට සමීප ප්‍රතිඵල සොයා ගන්�
 msgctxt "Precise user location overlay"
 msgid ""
 "Find results near you. %sYour location stays private, secure, and anonymous."
-msgstr "ඔබට අසල ප්‍රතිඵල සොයා ගන්න. %1$sඔබේ ස්ථානය පුද්ගලිකව, ආරක්ෂිතව සහ නිර්නාමිකව පවතී."
+msgstr ""
+"ඔබට අසල ප්‍රතිඵල සොයා ගන්න. %1$sඔබේ ස්ථානය පුද්ගලිකව, ආරක්ෂිතව සහ නිර්නාමිකව "
+"පවතී."
 
 # smartling.placeholder_format=C
 #. Loading message shown while generating explore more follow-up questions
@@ -7992,8 +8077,8 @@ msgid ""
 "Follow the instructions for turning off the ad blocker for DuckDuckGo. You "
 "may have to select a menu option or click a button."
 msgstr ""
-"DuckDuckGo සඳහා දැන්වීම් අවහිරකරණය අක්‍රීය කිරීමට උපදෙස් අනුගමනය කරන්න. ඔයාට මෙනු විකල්පයක් "
-"තෝරන්න හෝ බොත්තමක් ක්ලික් කරන්න වෙන්න පුළුවන්."
+"DuckDuckGo සඳහා දැන්වීම් අවහිරකරණය අක්‍රීය කිරීමට උපදෙස් අනුගමනය කරන්න. ඔයාට "
+"මෙනු විකල්පයක් තෝරන්න හෝ බොත්තමක් ක්ලික් කරන්න වෙන්න පුළුවන්."
 
 # smartling.placeholder_format=C
 #. Privacy reassurance and instructions intro.
@@ -8216,8 +8301,8 @@ msgid ""
 "strong>."
 msgstr ""
 "Mac හි යෙදුම් මෙනු තීරුවෙන්, <strong>DuckDuckGo</strong> තෝරන්න &gt; "
-"<strong>යාවත්කාලීන සඳහා පරීක්ෂා කරන්න...</strong>, ඉන්පසු <strong>යාවත්කාලීන ස්ථාපනය "
-"කරන්න</strong> තෝරන්න."
+"<strong>යාවත්කාලීන සඳහා පරීක්ෂා කරන්න...</strong>, ඉන්පසු <strong>යාවත්කාලීන "
+"ස්ථාපනය කරන්න</strong> තෝරන්න."
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -8388,7 +8473,7 @@ msgstr "තවත් ජනනය කරන්න"
 #. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Generate a shopping list"
-msgstr ""
+msgstr "සාප්පු සවාරි ලැයිස්තුවක් තනන්න"
 
 # smartling.placeholder_format=C
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
@@ -8568,8 +8653,8 @@ msgid ""
 "Get access to advanced AI models in Duck.ai by subscribing to DuckDuckGo, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"අපගේ VPN සහ අනෙකුත් ප්‍රිමියම් පෞද්ගලිකත්ව ආරක්ෂණ ඇතුළත් වන DuckDuckGo වෙත දායක වීමෙන් Duck."
-"ai හි උසස් AI ආකෘති වෙත ප්‍රවේශය ලබා ගන්න."
+"අපගේ VPN සහ අනෙකුත් ප්‍රිමියම් පෞද්ගලිකත්ව ආරක්ෂණ ඇතුළත් වන DuckDuckGo වෙත "
+"දායක වීමෙන් Duck.ai හි උසස් AI ආකෘති වෙත ප්‍රවේශය ලබා ගන්න."
 
 # smartling.placeholder_format=C
 #. Description for the subscription setting where users can subscribe to DuckDuckGo.
@@ -8580,8 +8665,8 @@ msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"අපගේ VPN සහ අනෙකුත් ප්‍රිමියම් පෞද්ගලිකත්ව ආරක්ෂණ ද ඇතුළත් වන DuckDuckGo දායකත්වයක් සමඟ "
-"Duck.ai හි උසස් AI ආකෘති වෙත ප්‍රවේශය ලබා ගන්න."
+"අපගේ VPN සහ අනෙකුත් ප්‍රිමියම් පෞද්ගලිකත්ව ආරක්ෂණ ද ඇතුළත් වන DuckDuckGo "
+"දායකත්වයක් සමඟ Duck.ai හි උසස් AI ආකෘති වෙත ප්‍රවේශය ලබා ගන්න."
 
 # smartling.placeholder_format=C
 #. A button for users to generate an AI generated answer from their query on the duckassist module
@@ -8683,7 +8768,7 @@ msgstr "උත්සාහ කර බලන්න"
 #. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Give me a quick background on this person."
-msgstr ""
+msgstr "මේ පුද්ගලයාගේ පසුබිම ගැන කෙටි විස්තරයක් ලබා දෙන්න."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -8698,8 +8783,8 @@ msgid ""
 "Go to %sSettings > Privacy & Security > Location Services%s, and make sure "
 "“Location Services” is turned on."
 msgstr ""
-"%1$sසැකසුම්> පෞද්ගලිකත්වය සහ ආරක්ෂාව > ස්ථාන සේවා%2$s වෙත ගොස් \"ස්ථාන සේවා\" සක්‍රිය කර "
-"ඇති බවට වග බලා ගන්න."
+"%1$sසැකසුම්> පෞද්ගලිකත්වය සහ ආරක්ෂාව > ස්ථාන සේවා%2$s වෙත ගොස් \"ස්ථාන "
+"සේවා\" සක්‍රිය කර ඇති බවට වග බලා ගන්න."
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -8708,8 +8793,8 @@ msgid ""
 "Go to %sSettings > Privacy > Permission manager > Location%s and scroll down "
 "to %sDuckDuckGo%s."
 msgstr ""
-"%1$sසැකසුම් > පෞද්ගලිකත්වය > අවසර කළමනාකරු > ස්ථාන%2$s වෙත ගොස් %3$sDuckDuckGo%4$s "
-"වෙත පහළට අනුචලනය කරන්න."
+"%1$sසැකසුම් > පෞද්ගලිකත්වය > අවසර කළමනාකරු > ස්ථාන%2$s වෙත ගොස් "
+"%3$sDuckDuckGo%4$s වෙත පහළට අනුචලනය කරන්න."
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9135,13 +9220,13 @@ msgstr "පෞද්ගලිකත්වය ව්‍යාප්ත කිර�
 #. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Help me prep for the interview"
-msgstr ""
+msgstr "සම්මුඛ පරීක්ෂණයට සූදානම් වීමට මට උදව් කරන්න"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Help me tailor my resume for this job."
-msgstr ""
+msgstr "මෙම රැකියාව සඳහා මගේ ජීව දත්ත පත්‍රය සකස් කර ගැනීමට මට උදව් කරන්න."
 
 # smartling.placeholder_format=C
 #. Title of a SERP popup that invites users to take a survey (desktop only)
@@ -9380,8 +9465,8 @@ msgid ""
 "Highlights key facts in Search Assist answers to help you find important "
 "information faster."
 msgstr ""
-"වැදගත් තොරතුරු වේගයෙන් සොයා ගැනීමට ඔබට උපකාර කිරීම සඳහා Search Assist පිළිතුරුවල ප්‍රධාන "
-"කරුණු ඉස්මතු කරයි."
+"වැදගත් තොරතුරු වේගයෙන් සොයා ගැනීමට ඔබට උපකාර කිරීම සඳහා Search Assist "
+"පිළිතුරුවල ප්‍රධාන කරුණු ඉස්මතු කරයි."
 
 # smartling.placeholder_format=C
 #. The name of the Hindi language
@@ -9408,8 +9493,8 @@ msgid ""
 "Hit %sReturn%s on your keyboard to %ssave DuckDuckGo to the list. %sThen "
 "click %sMake Default%s"
 msgstr ""
-"ඔබගේ යතුරුපුවරුවේ %1$sReturn%2$s බොත්තම ඔබා %3$sDuckDuckGo ලැයිස්තුවේ සුරකින්න."
-"%4$sඉන්පසුව %5$sMake Default%6$s මත ක්ලික් කරන්න"
+"ඔබගේ යතුරුපුවරුවේ %1$sReturn%2$s බොත්තම ඔබා %3$sDuckDuckGo ලැයිස්තුවේ "
+"සුරකින්න.%4$sඉන්පසුව %5$sMake Default%6$s මත ක්ලික් කරන්න"
 
 # smartling.placeholder_format=C
 #. The name of the Hmong Daw language
@@ -9423,8 +9508,8 @@ msgid ""
 "Hold on! Changing it back will disable the DuckDuckGo extension and you'll "
 "lose our privacy protection."
 msgstr ""
-"නවත්වන්න! එය නැවත වෙනස් කිරීමෙන් DuckDuckGo දිගුව අක්‍රීය වන අතර ඔබට අපගේ රහස්‍යතා ආරක්ෂාව "
-"අහිමි වේ."
+"නවත්වන්න! එය නැවත වෙනස් කිරීමෙන් DuckDuckGo දිගුව අක්‍රීය වන අතර ඔබට අපගේ "
+"රහස්‍යතා ආරක්ෂාව අහිමි වේ."
 
 # smartling.placeholder_format=C
 #. Heading shown above warning messages in the AI chat, for non-critical issues like unsupported file formats or file size limits. Analogous to 'Oops...' for error messages.
@@ -9474,8 +9559,8 @@ msgid ""
 "Hotel ad clicks are managed by Tripadvisor’s ad network and are not used to "
 "profile you."
 msgstr ""
-"හෝටල් දැන්වීම් ක්ලික් කිරීම් Tripadvisor හි දැන්වීම් ජාලය මගින් කළමනාකරණය කරනු ලබන අතර ඔබව "
-"පැතිකඩ කිරීමට භාවිත නොකෙරේ."
+"හෝටල් දැන්වීම් ක්ලික් කිරීම් Tripadvisor හි දැන්වීම් ජාලය මගින් කළමනාකරණය "
+"කරනු ලබන අතර ඔබව පැතිකඩ කිරීමට භාවිත නොකෙරේ."
 
 # smartling.placeholder_format=C
 #. Refers to hours of operation for a business.
@@ -9617,8 +9702,8 @@ msgid ""
 "How should I tactfully approach a colleague about their constant pencil "
 "tapping and what should I say?"
 msgstr ""
-"ඔවුන්ගේ නිරන්තර පැන්සල් තට්ටු කිරීම ගැන සගයෙකුට උපායශීලීව ප්‍රවේශ විය යුත්තේ කෙසේද සහ මා කුමක් "
-"කිව යුතුද?"
+"ඔවුන්ගේ නිරන්තර පැන්සල් තට්ටු කිරීම ගැන සගයෙකුට උපායශීලීව ප්‍රවේශ විය යුත්තේ "
+"කෙසේද සහ මා කුමක් කිව යුතුද?"
 
 # smartling.placeholder_format=C
 #. The title for a feedback prompt that includes thumbs up and thumbs down buttons
@@ -9664,7 +9749,7 @@ msgctxt ""
 "Text for the I already have a subscription button in the Duck.ai settings "
 "page"
 msgid "I Already Have a Subscription"
-msgstr ""
+msgstr "මට දැනටමත් ග්‍රාහකත්වයක් තිබේ"
 
 # smartling.placeholder_format=C
 #. Text for the button that takes the user to the login subscription page.
@@ -9740,8 +9825,8 @@ msgid ""
 "I like the book Name of the Wind. What are some other good books/series most "
 "like it and why?"
 msgstr ""
-"සුළඟේ නම කියන පොතට මම කැමතියි. තවත් හොඳ පොත්/කතා මාලා කිහිපයක් එයට වඩාත්ම කැමති මොනවාද "
-"සහ ඇයි?"
+"සුළඟේ නම කියන පොතට මම කැමතියි. තවත් හොඳ පොත්/කතා මාලා කිහිපයක් එයට වඩාත්ම "
+"කැමති මොනවාද සහ ඇයි?"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the user needs more help or information on how to use the chat.
@@ -9776,8 +9861,8 @@ msgid ""
 "If the browser location remains unavailable, then go to %sSettings > General "
 "> Reset > 'Reset Location & Privacy'%s."
 msgstr ""
-"බ්‍රවුසර් පිහිටීම දිගටම ලද නොහැකි නම්, %1$sසැකසුම් > සාමාන්‍ය > යළි සකසන්න > 'පිහිටීම හා "
-"රහස්‍යතාව යළි සකසන්න'%2$s වෙත යන්න."
+"බ්‍රවුසර් පිහිටීම දිගටම ලද නොහැකි නම්, %1$sසැකසුම් > සාමාන්‍ය > යළි සකසන්න > "
+"'පිහිටීම හා රහස්‍යතාව යළි සකසන්න'%2$s වෙත යන්න."
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -9787,8 +9872,9 @@ msgid ""
 "> Menu > Settings > Site settings > Location%s, and ensure DuckDuckGo is "
 "allowed location access."
 msgstr ""
-"බ්‍රවුසර් පිහිටීම දිගටම ලද නොහැකි නම්, ඔබේ බ්‍රවුසරයෙන් %1$s⋮ > මෙනුව > සැකසුම් > අඩවි සැකසුම් > "
-"පිහිටීම%2$s වෙත ගොස්, DuckDuckGo වෙත ප්‍රවේශය සඳහා අවසර දී ඇති ද යන්න දැනගන්න."
+"බ්‍රවුසර් පිහිටීම දිගටම ලද නොහැකි නම්, ඔබේ බ්‍රවුසරයෙන් %1$s⋮ > මෙනුව > "
+"සැකසුම් > අඩවි සැකසුම් > පිහිටීම%2$s වෙත ගොස්, DuckDuckGo වෙත ප්‍රවේශය සඳහා "
+"අවසර දී ඇති ද යන්න දැනගන්න."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -9803,8 +9889,8 @@ msgid ""
 "If you don't see %sDuckDuckGo,%s you will need to add it to the list of "
 "%sOther Search Engines%s"
 msgstr ""
-"ඔබට %1$sDuckDuckGo%2$s දැක ගැනීමට නොහැකිනම්, ඔබට සිදුවෙනවා එය %3$sOther Search "
-"Engines%4$s ලැයිස්තුවට එකතු කරන්න"
+"ඔබට %1$sDuckDuckGo%2$s දැක ගැනීමට නොහැකිනම්, ඔබට සිදුවෙනවා එය %3$sOther "
+"Search Engines%4$s ලැයිස්තුවට එකතු කරන්න"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding the AI model providers and links to their support pages. Example: 'If you have concerns about our chat providers or any particular chat response, you can also reach out directly to OpenAI and Anthropic support pages.'
@@ -9813,8 +9899,8 @@ msgid ""
 "If you have concerns about our chat providers or any particular chat "
 "response, you can also reach out directly to %s and %s support pages."
 msgstr ""
-"අපගේ චැට් සපයන්නන් හෝ කිසියම් විශේෂිත චැට් ප්‍රතිචාරයක් ගැන ඔබට කනස්සල්ලක් ඇත්නම්, ඔබට කෙලින්ම "
-"%1$s සහ %2$s සහාය පිටු වෙත ළඟා විය හැකිය."
+"අපගේ චැට් සපයන්නන් හෝ කිසියම් විශේෂිත චැට් ප්‍රතිචාරයක් ගැන ඔබට කනස්සල්ලක් "
+"ඇත්නම්, ඔබට කෙලින්ම %1$s සහ %2$s සහාය පිටු වෙත ළඟා විය හැකිය."
 
 # smartling.placeholder_format=C
 #. Body copy explaining what the recovery code is for and how it can be saved.
@@ -9823,14 +9909,17 @@ msgid ""
 "If you lose access to your devices, you will need this code to recover your "
 "saved chats. You can save this code to your device as a text file."
 msgstr ""
-"ඔබට ඔබගේ උපාංගවලට ප්‍රවේශය අහිමි වුවහොත්, ඔබගේ සුරකින ලද කතාබස් නැවත ලබා ගැනීමට මෙම "
-"කේතය අවශ්‍ය වනු ඇත. ඔබට මෙම කේතය ඔබගේ උපාංගයට පෙළ ගොනුවක් ලෙස සුරැකිය හැකි ය."
+"ඔබට ඔබගේ උපාංගවලට ප්‍රවේශය අහිමි වුවහොත්, ඔබගේ සුරකින ලද කතාබස් නැවත ලබා "
+"ගැනීමට මෙම කේතය අවශ්‍ය වනු ඇත. ඔබට මෙම කේතය ඔබගේ උපාංගයට පෙළ ගොනුවක් ලෙස "
+"සුරැකිය හැකි ය."
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
-msgstr "ඔබට තවමත් අවශ්‍යයනම් අපිට උදවු කරන්න, %1$sDuckDuckGo ව්‍යාප්ත කරන්න උදවු කරන්න%2$s"
+msgstr ""
+"ඔබට තවමත් අවශ්‍යයනම් අපිට උදවු කරන්න, %1$sDuckDuckGo ව්‍යාප්ත කරන්න උදවු "
+"කරන්න%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -9840,15 +9929,17 @@ msgid ""
 "If you want to use DuckDuckGo without JavaScript, please use our %s or %s "
 "versions."
 msgstr ""
-"ඔබට DuckDuckGo ජාවාස්ක්‍රිප්ට් නැතුව භාවිතා කිරීමට අවශ්‍යයනම්, කරුණාකර අපගේ %1$s හෝ %2$s "
-"යන පිටපත් භාවිතා කරන්න."
+"ඔබට DuckDuckGo ජාවාස්ක්‍රිප්ට් නැතුව භාවිතා කිරීමට අවශ්‍යයනම්, කරුණාකර අපගේ "
+"%1$s හෝ %2$s යන පිටපත් භාවිතා කරන්න."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "If you want, select Home Page next to New windows and New tabs (open with)."
-msgstr "ඔබට අවශ්‍යයනම්, අලුත් කවුළු හා ටැබ් සඳහා මුල් පිටුවක් තෝරා ගන්න (සමග විවෘත කරන්න)."
+msgstr ""
+"ඔබට අවශ්‍යයනම්, අලුත් කවුළු හා ටැබ් සඳහා මුල් පිටුවක් තෝරා ගන්න (සමග විවෘත "
+"කරන්න)."
 
 # smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that adds an image to the AI chat message being composed.
@@ -9977,7 +10068,8 @@ msgctxt "settings"
 msgid ""
 "Improves result legibility with updated URL format, placement, and color"
 msgstr ""
-"යාවත්කාලීන කළ URL ආකෘතිය, ස්ථානගත කිරීම සහ වර්ණය සමඟ ප්‍රතිඵල වලංගු භාවය වැඩි දියුණු කරයි"
+"යාවත්කාලීන කළ URL ආකෘතිය, ස්ථානගත කිරීම සහ වර්ණය සමඟ ප්‍රතිඵල වලංගු භාවය "
+"වැඩි දියුණු කරයි"
 
 # smartling.placeholder_format=C
 #. A label that appears in front of the name of a company that DuckDuckGo has partnered with. For example, 'In partnership with Wikipedia'
@@ -9990,8 +10082,8 @@ msgid ""
 "In some older browsers, it's necessary to redirect your clicks through our "
 "server to prevent search leakage. %sLearn more%s."
 msgstr ""
-"සමහර පැරණි බ්‍රව්සර් වලදී, සෙවුම් කාන්දු වීම වැළැක්වීම සඳහා ඔබේ ක්ලික් කිරීම් අපගේ සර්වරය හරහා "
-"හරවා යැවීම අවශ්‍ය වේ. %1$sතවත් ඉගෙන ගන්න%2$s."
+"සමහර පැරණි බ්‍රව්සර් වලදී, සෙවුම් කාන්දු වීම වැළැක්වීම සඳහා ඔබේ ක්ලික් "
+"කිරීම් අපගේ සර්වරය හරහා හරවා යැවීම අවශ්‍ය වේ. %1$sතවත් ඉගෙන ගන්න%2$s."
 
 # smartling.placeholder_format=C
 #. Instructions accompanying DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE; tells the user where to use the code on a DuckDuckGo browser.
@@ -10002,8 +10094,8 @@ msgid ""
 "In the DuckDuckGo browser, go to Settings › Sync & Backup, and then “Sync "
 "with another device”."
 msgstr ""
-"DuckDuckGo බ්‍රවුසරයේ, සැකසුම් › Sync & Backup වෙත ගොස්, පසුව “වෙනත් උපාංගයක් සමග "
-"සමමුහුර්ත කරන්න” වෙත යන්න."
+"DuckDuckGo බ්‍රවුසරයේ, සැකසුම් › Sync & Backup වෙත ගොස්, පසුව “වෙනත් "
+"උපාංගයක් සමග සමමුහුර්ත කරන්න” වෙත යන්න."
 
 #  SeaMonkey default search engine instruction
 # smartling.placeholder_format=C
@@ -10018,8 +10110,8 @@ msgid ""
 "In the interest of transparency, this data is not encrypted: You can see "
 "exactly what information we store."
 msgstr ""
-"විනිවිදභාවය පිළිබඳ උනන්දුව නිසා, මෙම දත්ත කේතනය වී නැත: ඔබට නිසැකයෙන්ම දැන ගැනීමට හැකියි අප "
-"ගබඩා කරන්නේ කුමන දත්තද කියා."
+"විනිවිදභාවය පිළිබඳ උනන්දුව නිසා, මෙම දත්ත කේතනය වී නැත: ඔබට නිසැකයෙන්ම දැන "
+"ගැනීමට හැකියි අප ගබඩා කරන්නේ කුමන දත්තද කියා."
 
 # smartling.placeholder_format=C
 msgid "In the menu at the top select %sTools%s > %sSettings%s"
@@ -10030,8 +10122,8 @@ msgstr "ඉහළ ඇති මෙනුවෙන් %1$sTools%2$s > %3$sSetting
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "In the popup, check %sMake this my default search provider%s"
 msgstr ""
-"උද්දීපනය වන කොටුවෙන්, %1$sMake this my default search provider%2$s මත හරි සලකුණ "
-"යොදන්න"
+"උද්දීපනය වන කොටුවෙන්, %1$sMake this my default search provider%2$s මත හරි "
+"සලකුණ යොදන්න"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -10240,7 +10332,7 @@ msgstr "Mac බ්‍රවුසරය ස්ථාපනය කරන්න"
 #. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
 msgctxt "settings"
 msgid "Install Now"
-msgstr ""
+msgstr "දැන් ස්ථාපනය කරන්න"
 
 # smartling.placeholder_format=C
 #. Text of a button to install the DuckDuckGo app
@@ -10343,13 +10435,13 @@ msgstr "මැකූ දත්ත ඇත්තටම මැකුණාද?"
 #. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Is it worth taking?"
-msgstr ""
+msgstr "මෙය ලබා ගැනීමට වටිනවා ද?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Is this place any good?"
-msgstr ""
+msgstr "මේ ස්ථානය හොඳ ද?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
@@ -10358,6 +10450,8 @@ msgid ""
 "Is this place any good? Summarize its reputation based on reviews and "
 "ratings."
 msgstr ""
+"මේ ස්ථානය හොඳ ද? සමාලෝචන සහ ශ්‍රේණිගත කිරීම් මත පදනම්ව එහි කීර්තිනාමය "
+"සාරාංශගත කරන්න."
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -10369,13 +10463,13 @@ msgstr "මෙම වීඩියෝව ප්‍රයෝජනවත් වී
 #. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Is this worth watching?"
-msgstr ""
+msgstr "මෙය නැරඹීමට තරම් වටිනවා ද?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Is this worth watching? Give me a spoiler-free take."
-msgstr ""
+msgstr "මෙය නැරඹීමට තරම් වටිනවා ද? කතා රසයට බාධා නොවන අයුරින් විස්තරයක් ලබා දෙන්න."
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -10426,9 +10520,10 @@ msgid ""
 "through Microsoft's Ad Network. Clicks lead directly to merchant landing "
 "pages and unlike ads, DuckDuckGo is not compensated for these results."
 msgstr ""
-"ඔබගේ සෙවුම් පද වලට අදාලත්වය මත අයිතම ශ්‍රේණිගත කර ඇති අතර Microsoft හි දැන්වීම් ජාලය "
-"හරහා බෙදා හරිනු ලැබේ. ක්ලික් කිරීම් සෘජුවම වෙළෙන්දා පිවිසීමේ පිටු වෙත යොමු කරන අතර දැන්වීම් මෙන් "
-"නොව, DuckDuckGo මෙම ප්‍රතිඵල සඳහා හිලවු නොකෙරේ."
+"ඔබගේ සෙවුම් පද වලට අදාලත්වය මත අයිතම ශ්‍රේණිගත කර ඇති අතර Microsoft හි "
+"දැන්වීම් ජාලය හරහා බෙදා හරිනු ලැබේ. ක්ලික් කිරීම් සෘජුවම වෙළෙන්දා පිවිසීමේ "
+"පිටු වෙත යොමු කරන අතර දැන්වීම් මෙන් නොව, DuckDuckGo මෙම ප්‍රතිඵල සඳහා හිලවු "
+"නොකෙරේ."
 
 # smartling.placeholder_format=C
 #. Text explaining why passphrases use a series of words instead of random numbers and letters.
@@ -10437,7 +10532,8 @@ msgid ""
 "It’s easier to remember 4-5 words than 10 random letters and numbers, and "
 "far more secure."
 msgstr ""
-"අහඹු අකුරු සහ අංක 10 ට වඩා වචන 4-5 මතක තබා ගැනීම පහසු වන අතර, වඩාත් ආරක්ෂිත වේ."
+"අහඹු අකුරු සහ අංක 10 ට වඩා වචන 4-5 මතක තබා ගැනීම පහසු වන අතර, වඩාත් ආරක්ෂිත "
+"වේ."
 
 # smartling.placeholder_format=C
 msgid "Ivory Coast"
@@ -10987,7 +11083,7 @@ msgstr "සබැදි:"
 #. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
-msgstr ""
+msgstr "මේ සඳහා මට අවශ්‍ය මෙවලම්, ද්‍රව්‍ය හෝ පූර්ව අවශ්‍යතා ලැයිස්තුගත කරන්න."
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -11098,7 +11194,9 @@ msgstr "අනුචලනය කරන විට තවත් පින්ත�
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Loads more results in Images, Videos, and Shopping when scrolling"
-msgstr "අනුචලනය කරන විට පින්තූර, වීඩියෝ හා සාප්පු සවාරි තුළ වැඩිපුර ප්‍රතිඵල පූරණය කරයි"
+msgstr ""
+"අනුචලනය කරන විට පින්තූර, වීඩියෝ හා සාප්පු සවාරි තුළ වැඩිපුර ප්‍රතිඵල පූරණය "
+"කරයි"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/WTkvs9I.png
@@ -11278,8 +11376,7 @@ msgstr "සියළුම වචන වල අක්ෂර වින්‍ය�
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Make sure to check %s\"Make this my default search provider\"%s"
-msgstr ""
-"%1$s\"Make this my default search provider\"%2$s මත හරි ලකුණ දැමුවාදැයි බලන්න"
+msgstr "%1$s\"Make this my default search provider\"%2$s මත හරි ලකුණ දැමුවාදැයි බලන්න"
 
 # smartling.placeholder_format=C
 #. Message prompting users to check the spelling of their search term.
@@ -11400,7 +11497,7 @@ msgstr "අවහිර කරන ලද අඩවි කළමනාකරණ�
 #. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
 msgctxt "setting"
 msgid "Manage in Browser Settings"
-msgstr ""
+msgstr "බ්‍රව්සර් සැකසුම් තුළ කළමනාකරණය කරන්න‍"
 
 # smartling.placeholder_format=C
 #. Link to the site exclusion settings page
@@ -11625,7 +11722,9 @@ msgstr "මයික්රොනීසියාව"
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
 msgid ""
 "Microphone access was denied. Please allow microphone access and try again."
-msgstr "මයික්‍රෆෝන ප්‍රවේශය ප්‍රතික්ෂේප විය. කරුණාකර මයික්‍රෆෝන ප්‍රවේශය ඉඩ දී නැවත උත්සාහ කරන්න."
+msgstr ""
+"මයික්‍රෆෝන ප්‍රවේශය ප්‍රතික්ෂේප විය. කරුණාකර මයික්‍රෆෝන ප්‍රවේශය ඉඩ දී නැවත "
+"උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. The Microsoft brand name.
@@ -11850,7 +11949,9 @@ msgstr "මාසික සීමාවට ළඟා විය"
 #. Displayed when the user has reached a fixed monthly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Monthly usage limit reached. You can continue this chat after %s."
-msgstr "මාසික පරිශීලන සීමාවට ළඟා වී තිබේ. ඔබට %1$sට පසුව මෙම කතාබහ දිගටම කරගෙන යා හැක."
+msgstr ""
+"මාසික පරිශීලන සීමාවට ළඟා වී තිබේ. ඔබට %1$sට පසුව මෙම කතාබහ දිගටම කරගෙන යා "
+"හැක."
 
 # smartling.placeholder_format=C
 #. Used to point to additional social networking profiles (in results).
@@ -12373,10 +12474,10 @@ msgid ""
 "internet connection. Disabling chat history will delete pinned chats, and "
 "disable the temporary storage of new prompts and responses."
 msgstr ""
-"ඔබගේ අන්තර්ජාල සම්බන්ධතාවය නැති වුවහොත් කතාබහක් නැවත ලබා ගැනීමට උපකාර කිරීම සඳහා, නව "
-"විමසීම් සහ ප්‍රතිචාර සංකේතනය කර යැවීමෙන් පසු තාවකාලිකව DuckDuckGo සේවාදායකයක ගබඩා කරනු "
-"ලැබේ. කතාබස් ඉතිහාසය අක්‍රිය කිරීමෙන් පින් කළ කතාබස් මැකෙනු ඇති අතර නව විමසීම් සහ ප්‍රතිචාර "
-"තාවකාලිකව ගබඩා කිරීම අක්‍රිය කරනු ඇත."
+"ඔබගේ අන්තර්ජාල සම්බන්ධතාවය නැති වුවහොත් කතාබහක් නැවත ලබා ගැනීමට උපකාර කිරීම "
+"සඳහා, නව විමසීම් සහ ප්‍රතිචාර සංකේතනය කර යැවීමෙන් පසු තාවකාලිකව DuckDuckGo "
+"සේවාදායකයක ගබඩා කරනු ලැබේ. කතාබස් ඉතිහාසය අක්‍රිය කිරීමෙන් පින් කළ කතාබස් "
+"මැකෙනු ඇති අතර නව විමසීම් සහ ප්‍රතිචාර තාවකාලිකව ගබඩා කිරීම අක්‍රිය කරනු ඇත."
 
 # smartling.placeholder_format=C
 #. Question in a feedback form.
@@ -13192,8 +13293,8 @@ msgid ""
 "On Mac, %sClick Maxthon > Preferences%s, On Windows, %sClick the %s icon > "
 "Settings%s"
 msgstr ""
-"මැක් වල, %1$sClick Maxthon > Preferences%2$s, වින්ඩෝව්ස් වල, %3$sClick the %4$s "
-"icon > Settings%5$s"
+"මැක් වල, %1$sClick Maxthon > Preferences%2$s, වින්ඩෝව්ස් වල, %3$sClick the "
+"%4$s icon > Settings%5$s"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
@@ -13215,8 +13316,8 @@ msgid ""
 "One of the files attached has more pages than we support. Please upload "
 "files with %s pages or fewer."
 msgstr ""
-"අමුණා ඇති ගොනුවලින් එකක අපට ක්‍රියාත්මක කළ හැකි ප්‍රමාණයට වඩා පිටු තිබේ. පිටු %1$s ක් හෝ ඊට අඩු "
-"පිටු ඇති ගොනු උඩුගත කරන්න."
+"අමුණා ඇති ගොනුවලින් එකක අපට ක්‍රියාත්මක කළ හැකි ප්‍රමාණයට වඩා පිටු තිබේ. "
+"පිටු %1$s ක් හෝ ඊට අඩු පිටු ඇති ගොනු උඩුගත කරන්න."
 
 # smartling.placeholder_format=C
 #. Response a user can select in a feedback form, indicating that they heard about DuckDuckGo in an online article.
@@ -13242,7 +13343,9 @@ msgctxt "cloudsave"
 msgid ""
 "Only the settings that you have changed. They are detailed on the %sURL "
 "Parameters%s page."
-msgstr "ඔබ වෙනස් කර ඇති සැකසුම් පමණයි. ඒවා %1$sURL පරාමිතීන්%2$s පිටුවේ සවිස්තරව දක්වා ඇත."
+msgstr ""
+"ඔබ වෙනස් කර ඇති සැකසුම් පමණයි. ඒවා %1$sURL පරාමිතීන්%2$s පිටුවේ සවිස්තරව "
+"දක්වා ඇත."
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers only when the user clicks the Assist button.
@@ -13257,7 +13360,8 @@ msgid ""
 "Oops! An unexpected error occurred while translating this text. Please try "
 "again later."
 msgstr ""
-"අපොයි! මෙම පෙළ පරිවර්තනය කිරීමේදී අනපේක්ෂිත දෝෂයක් ඇතිවිය. කරුණාකර පසුව නැවත උත්සාහ කරන්න."
+"අපොයි! මෙම පෙළ පරිවර්තනය කිරීමේදී අනපේක්ෂිත දෝෂයක් ඇතිවිය. කරුණාකර පසුව නැවත "
+"උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. Title shown in a fatal error modal when Duck.ai fails to load.
@@ -13574,8 +13678,8 @@ msgid ""
 "Other search engines track your searches even when you’re in private "
 "browsing mode. We don’t track you &mdash; period."
 msgstr ""
-"ඔබ පුද්ගලික ගවේෂණ මාදිලියේ සිටියදී පවා වෙනත් සෙවුම් යන්ත්‍ර ඔබගේ සෙවීම් නිරීක්ෂණය කරයි. අපි ඔබව "
-"කාල පරිච්ඡේද — ක් නිරීක්ෂණය නොකරමු."
+"ඔබ පුද්ගලික ගවේෂණ මාදිලියේ සිටියදී පවා වෙනත් සෙවුම් යන්ත්‍ර ඔබගේ සෙවීම් "
+"නිරීක්ෂණය කරයි. අපි ඔබව කාල පරිච්ඡේද — ක් නිරීක්ෂණය නොකරමු."
 
 # smartling.placeholder_format=C
 msgctxt "SERP footer content"
@@ -13588,8 +13692,8 @@ msgid ""
 "Our privacy policy is simple: we don’t collect or share any of your personal "
 "information."
 msgstr ""
-"අපගේ පෞද්ගලිකත්වය සමිබන්ද ප්‍රතිපත්තිය සරලයි: අපි ඔබගේ පෞද්ගලික තොරතුරු එකතු කරන්නේ හෝ බෙදා "
-"හරින්නේ නැත."
+"අපගේ පෞද්ගලිකත්වය සමිබන්ද ප්‍රතිපත්තිය සරලයි: අපි ඔබගේ පෞද්ගලික තොරතුරු එකතු "
+"කරන්නේ හෝ බෙදා හරින්නේ නැත."
 
 # smartling.placeholder_format=C
 msgid ""
@@ -13597,8 +13701,9 @@ msgid ""
 "tracker blocker, encryption enforcer, and more. Available on %siOS & "
 "Android%s."
 msgstr ""
-"ජංගම දුරකථන සඳහා වන අපගේ පුද්ගලික බ්‍රවුසරය අපගේ සෙවුම් යාන්ත්‍රණය, නිරික්සු අවහිරකාරකය, "
-"ගුප්තකේතන බලාත්කාරකය හා තවත් දැයින් සන්නද්ධව තිබේ. %1$siOS & Android%2$sහි ලද හැක."
+"ජංගම දුරකථන සඳහා වන අපගේ පුද්ගලික බ්‍රවුසරය අපගේ සෙවුම් යාන්ත්‍රණය, නිරික්සු "
+"අවහිරකාරකය, ගුප්තකේතන බලාත්කාරකය හා තවත් දැයින් සන්නද්ධව තිබේ. %1$siOS & "
+"Android%2$sහි ලද හැක."
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the information was out of date.
@@ -13851,8 +13956,8 @@ msgid ""
 "Passphrases cannot be recovered as we don't associate your IP address, "
 "browser fingerprint, or any other information with the file."
 msgstr ""
-"අපි ඔබගේ IP ලිපිනය, බ්‍රව්සර් ඇඟිලි සලකුණු හෝ වෙනත් තොරතුරු ගොනුව සමඟ සම්බන්ධ නොකරන බැවින් මුරපද "
-"යථාවත් කර ගත නොහැක."
+"අපි ඔබගේ IP ලිපිනය, බ්‍රව්සර් ඇඟිලි සලකුණු හෝ වෙනත් තොරතුරු ගොනුව සමඟ "
+"සම්බන්ධ නොකරන බැවින් මුරපද යථාවත් කර ගත නොහැක."
 
 # smartling.placeholder_format=C
 #. Label for the section of recent chats that were edited in the past 7 days.
@@ -14046,9 +14151,10 @@ msgid ""
 "answers. To turn them off and hide the Assist button visit %sSearch "
 "Settings%s."
 msgstr ""
-"ඔබේ සෙවුම ප්‍රශ්නයක් ලෙසත් සම්පූර්ණ වාක්‍යයකින් ලියා ඇති විට AI-සහය සහිත පිළිතුරු ස්වයංක්‍රීයව දිස්වීමේ "
-"ඉඩකඩ වැඩි වන අතර බොහෝ විට හොඳ පිළිතුරු ලැබේ. ඒවා ක්‍රියා විරහිත කිරීමට සහ Assist බොත්තම "
-"සැඟවීමට %1$sසෙවුම් සැකසුම්%2$s වෙත පිවිසෙන්න."
+"ඔබේ සෙවුම ප්‍රශ්නයක් ලෙසත් සම්පූර්ණ වාක්‍යයකින් ලියා ඇති විට AI-සහය සහිත "
+"පිළිතුරු ස්වයංක්‍රීයව දිස්වීමේ ඉඩකඩ වැඩි වන අතර බොහෝ විට හොඳ පිළිතුරු ලැබේ. "
+"ඒවා ක්‍රියා විරහිත කිරීමට සහ Assist බොත්තම සැඟවීමට %1$sසෙවුම් සැකසුම්%2$s "
+"වෙත පිවිසෙන්න."
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -14057,9 +14163,10 @@ msgid ""
 "DuckAssist more likely to appear and often yields better answers. To adjust "
 "how this feature works, or to turn it off, visit %sDuckAssist Settings%s."
 msgstr ""
-"ඔබේ සෙවුම ප්‍රශ්නයක් ලෙස සහ සම්පූර්ණ වාක්‍යයක් තුළ වාක්‍ය කණ්ඩ කිරීමෙන් DuckAssist දිස්වීමට වැඩි "
-"ඉඩක් ඇති අතර බොහෝ විට වඩා හොඳ පිළිතුරු ලබා දෙයි. මෙම විශේෂාංගය ක්‍රියා කරන ආකාරය සකස් "
-"කිරීමට හෝ එය ක්‍රියා විරහිත කිරීමට,%1$sDuckAssist%2$s සැකසුම් වෙත පිවිසෙන්න."
+"ඔබේ සෙවුම ප්‍රශ්නයක් ලෙස සහ සම්පූර්ණ වාක්‍යයක් තුළ වාක්‍ය කණ්ඩ කිරීමෙන් "
+"DuckAssist දිස්වීමට වැඩි ඉඩක් ඇති අතර බොහෝ විට වඩා හොඳ පිළිතුරු ලබා දෙයි. "
+"මෙම විශේෂාංගය ක්‍රියා කරන ආකාරය සකස් කිරීමට හෝ එය ක්‍රියා විරහිත "
+"කිරීමට,%1$sDuckAssist%2$s සැකසුම් වෙත පිවිසෙන්න."
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -14069,9 +14176,10 @@ msgid ""
 "answers. To turn it off and hide the Assist button visit %sDuckAssist "
 "Settings%s."
 msgstr ""
-"ඔබේ සෙවුම ප්‍රශ්නයක් ලෙස සහ සම්පූර්ණ වාක්‍යයක් තුළ වාක්‍ය කණ්ඩ කිරීමෙන් DuckAssist දිස්වීමට වැඩි "
-"ඉඩක් ඇති අතර බොහෝ විට වඩා හොඳ පිළිතුරු ලබා දෙයි. එය නිවා දැමීමට සහ Assist බොත්තම සැඟවීමට "
-"%1$sDuckAssist සැකසුම්%2$s වෙත පිවිසෙන්න."
+"ඔබේ සෙවුම ප්‍රශ්නයක් ලෙස සහ සම්පූර්ණ වාක්‍යයක් තුළ වාක්‍ය කණ්ඩ කිරීමෙන් "
+"DuckAssist දිස්වීමට වැඩි ඉඩක් ඇති අතර බොහෝ විට වඩා හොඳ පිළිතුරු ලබා දෙයි. එය "
+"නිවා දැමීමට සහ Assist බොත්තම සැඟවීමට %1$sDuckAssist සැකසුම්%2$s වෙත "
+"පිවිසෙන්න."
 
 # smartling.placeholder_format=C
 #. Button that allows users to manually select a location on a map.
@@ -14104,7 +14212,8 @@ msgid ""
 "Pick a popular AI to chat with, like GPT-5 mini, Claude Haiku 4.5, Mistral, "
 "etc."
 msgstr ""
-"GPT-5 mini, Claude Haiku 4.5, Mistral වැනි ජනප්‍රිය AI එකක් සමඟ කතාබස් කිරීමට තෝරන්න."
+"GPT-5 mini, Claude Haiku 4.5, Mistral වැනි ජනප්‍රිය AI එකක් සමඟ කතාබස් "
+"කිරීමට තෝරන්න."
 
 # smartling.placeholder_format=C
 #. Describes the ability to choose from popular AI models. Pairs with a chat-bubble pictogram.
@@ -14113,7 +14222,8 @@ msgid ""
 "Pick a popular AI to chat with, like GPT-5 mini, Claude Haiku 4.5, "
 "Mistral, etc."
 msgstr ""
-"කතාබස් කිරීම සඳහා GPT-5 mini, Claude Haiku 4.5, Mistral වැනි ජනප්‍රිය AI එකක් තෝරන්න."
+"කතාබස් කිරීම සඳහා GPT-5 mini, Claude Haiku 4.5, Mistral වැනි ජනප්‍රිය AI "
+"එකක් තෝරන්න."
 
 # smartling.placeholder_format=C
 #. The description of the third party map app picker, shown on iOS when a user is given an option of which app to navigate to a destination with
@@ -14134,8 +14244,8 @@ msgstr "විශේෂ වූ ප්‍රශ්නයක් තෝරා ග�
 msgid ""
 "Pick your ad blocker and follow the instructions to allow ads on DuckDuckGo."
 msgstr ""
-"ඔබේ දැන්වීම් අවහිරකාරකය තෝරාගෙන DuckDuckGo හි දැන්වීම්වලට ඉඩ දීම සඳහා උපදෙස් අනුගමනය "
-"කරන්න."
+"ඔබේ දැන්වීම් අවහිරකාරකය තෝරාගෙන DuckDuckGo හි දැන්වීම්වලට ඉඩ දීම සඳහා උපදෙස් "
+"අනුගමනය කරන්න."
 
 # smartling.placeholder_format=C
 #. Text for a button that pins a chat, as in it will it will add the chat to the pinned chats list.
@@ -14205,7 +14315,9 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this prompt was made by a "
 "human."
-msgstr "මෙම සෙවුම මිනිසෙකු විසින් කරන ලද බව තහවුරු කිරීමට කරුණාකර පහත අභියෝගය සම්පූර්ණ කරන්න."
+msgstr ""
+"මෙම සෙවුම මිනිසෙකු විසින් කරන ලද බව තහවුරු කිරීමට කරුණාකර පහත අභියෝගය "
+"සම්පූර්ණ කරන්න."
 
 # smartling.placeholder_format=C
 #. Bot challenge explanation
@@ -14213,19 +14325,25 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this search was made by a "
 "human."
-msgstr "මෙම සෙවුම මිනිසෙකු විසින් කරන ලද බව තහවුරු කිරීමට කරුණාකර පහත අභියෝගය සම්පූර්ණ කරන්න."
+msgstr ""
+"මෙම සෙවුම මිනිසෙකු විසින් කරන ලද බව තහවුරු කිරීමට කරුණාකර පහත අභියෝගය "
+"සම්පූර්ණ කරන්න."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is harmful or illegal. (optional)"
 msgstr ""
+"කතාබස් ප්‍රතිචාරය හානිකර හෝ නීතිවිරෝධී වන්නේ මන්ද යන්න පැහැදිලි කරන්න. "
+"(විකල්ප)"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
-msgstr "කතාබස් ප්‍රතිචාරය නීතිවිරෝධී හෝ හානිකර වන්නේ මන්ද යන්න පැහැදිලි කරන්න. (විකල්ප)"
+msgstr ""
+"කතාබස් ප්‍රතිචාරය නීතිවිරෝධී හෝ හානිකර වන්නේ මන්ද යන්න පැහැදිලි කරන්න. "
+"(විකල්ප)"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to enter their passphrase.
@@ -14246,7 +14364,8 @@ msgid ""
 "Please note: starting a new chat with any model will delete your current "
 "chat session."
 msgstr ""
-"කරුණාකර සලකන්න: ඕනෑම ආකෘතියක් සමඟ නව චැට් ආරම්භ කිරීම ඔබේ වර්තමාන චැට් සැසිය මකා දමනු ඇත."
+"කරුණාකර සලකන්න: ඕනෑම ආකෘතියක් සමඟ නව චැට් ආරම්භ කිරීම ඔබේ වර්තමාන චැට් සැසිය "
+"මකා දමනු ඇත."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -14255,6 +14374,8 @@ msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is harmful or illegal."
 msgstr ""
+"කරුණාකර ඔබේ පණිවිඩය සහ ගැටලුකාරී ප්‍රතිදානය (ඕනෑම පුද්ගලික තොරතුරක් ඉවත් කර) "
+"අලවා අන්තර්ගතය හානිකර හෝ නීති විරෝධී වන්නේ මන්දැ යි යන්න විස්තර කරන්න."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -14263,8 +14384,8 @@ msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is illegal or harmful."
 msgstr ""
-"කරුණාකර ඔබේ පණිවිඩය සහ ගැටලුකාරී ප්‍රතිදානය (ඕනෑම පුද්ගලික තොරතුරක් ඉවත් කර) අලවා අන්තර්ගතය "
-"නීති විරෝධී හෝ හානිකර වන්නේ මන්දැ යි යන්න විස්තර කරන්න."
+"කරුණාකර ඔබේ පණිවිඩය සහ ගැටලුකාරී ප්‍රතිදානය (ඕනෑම පුද්ගලික තොරතුරක් ඉවත් කර) "
+"අලවා අන්තර්ගතය නීති විරෝධී හෝ හානිකර වන්නේ මන්දැ යි යන්න විස්තර කරන්න."
 
 # smartling.placeholder_format=C
 #. Title on a feedback form.
@@ -14725,7 +14846,7 @@ msgstr "පෞද්ගලිකත්වය"
 #. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
 msgctxt "Section heading on the Duck.ai settings page"
 msgid "Privacy & Terms"
-msgstr ""
+msgstr "රහස්‍යතාව සහ නියම"
 
 # smartling.placeholder_format=C
 msgid "Privacy Blog"
@@ -14801,7 +14922,7 @@ msgstr "රහස්‍යතා ප්‍රතිපත්තිය සහ ස
 #. Text for a button that links to the terms of use and privacy policy page.
 msgctxt "Secondary button text in active privacy modal"
 msgid "Privacy Policy and Terms of Service"
-msgstr ""
+msgstr "රහස්‍යතා ප්‍රතිපත්තිය සහ සේවා නියම"
 
 # smartling.placeholder_format=C
 #. Title displayed on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
@@ -15018,8 +15139,8 @@ msgid ""
 "Provide a few suggestions to make the following text more concise. [Insert "
 "your own text here.]"
 msgstr ""
-"පහත දැක්වෙන පාඨය වඩාත් සංක්ෂිප්ත කිරීම සඳහා යෝජනා කිහිපයක් ලබා දෙන්න. [ඔබේම පෙළ මෙහි "
-"ඇතුලත් කරන්න.]"
+"පහත දැක්වෙන පාඨය වඩාත් සංක්ෂිප්ත කිරීම සඳහා යෝජනා කිහිපයක් ලබා දෙන්න. [ඔබේම "
+"පෙළ මෙහි ඇතුලත් කරන්න.]"
 
 # smartling.placeholder_format=C
 #. In the context of a standings table for NHL (hockey), column title that abbreviates 'Total Points' (the total points of this team)
@@ -15256,8 +15377,8 @@ msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
 msgstr ""
-"මෑත කාලීන කතාබස් DuckDuckGo සේවාදායකයන් හෝ වෙනත් දුරස්ථ සේවාදායකයන් මත වෙනුවට ඔබේ "
-"උපාංගයේ දේශීයව ගබඩා කර ඇත."
+"මෑත කාලීන කතාබස් DuckDuckGo සේවාදායකයන් හෝ වෙනත් දුරස්ථ සේවාදායකයන් මත "
+"වෙනුවට ඔබේ උපාංගයේ දේශීයව ගබඩා කර ඇත."
 
 # smartling.placeholder_format=C
 #. Text explaining that recent chats are stored locally on the user's device.
@@ -15266,8 +15387,8 @@ msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
 msgstr ""
-"මෑත කාලීන කතාබස් DuckDuckGo සේවාදායකයන් හෝ වෙනත් දුරස්ථ සේවාදායකයන් මත වෙනුවට ඔබේ "
-"උපාංගයේ දේශීයව ගබඩා කර ඇත."
+"මෑත කාලීන කතාබස් DuckDuckGo සේවාදායකයන් හෝ වෙනත් දුරස්ථ සේවාදායකයන් මත "
+"වෙනුවට ඔබේ උපාංගයේ දේශීයව ගබඩා කර ඇත."
 
 # smartling.placeholder_format=C
 #. Text explaining how recent chats are stored locally on the user's device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection.
@@ -15277,9 +15398,9 @@ msgid ""
 "are encrypted and temporarily stored on a DuckDuckGo server after being "
 "sent, to help recover a chat if you lose your internet connection."
 msgstr ""
-"මෑත කතාබස් ඔබගේ උපාංගයේ දේශීයව ගබඩා කර ඇත. ඔබගේ අන්තර්ජාල සම්බන්ධතාවය නැති වුවහොත් "
-"කතාබහක් නැවත ලබා ගැනීමට උපකාර කිරීම සඳහා, නව විමසීම් සහ ප්‍රතිචාර සංකේතනය කර යැවීමෙන් පසු "
-"තාවකාලිකව DuckDuckGo සේවාදායකයක ගබඩා කරනු ලැබේ."
+"මෑත කතාබස් ඔබගේ උපාංගයේ දේශීයව ගබඩා කර ඇත. ඔබගේ අන්තර්ජාල සම්බන්ධතාවය නැති "
+"වුවහොත් කතාබහක් නැවත ලබා ගැනීමට උපකාර කිරීම සඳහා, නව විමසීම් සහ ප්‍රතිචාර "
+"සංකේතනය කර යැවීමෙන් පසු තාවකාලිකව DuckDuckGo සේවාදායකයක ගබඩා කරනු ලැබේ."
 
 # smartling.placeholder_format=C
 msgctxt "region filter"
@@ -15306,25 +15427,25 @@ msgstr "පොතක් නිර්දේශ කරන්න"
 #. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Recommend similar books"
-msgstr ""
+msgstr "සමාන පොත් නිර්දේශ කරන්න"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Recommend similar books."
-msgstr ""
+msgstr "සමාන පොත් නිර්දේශ කරන්න."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Recommend similar movies or shows."
-msgstr ""
+msgstr "සමාන චිත්‍රපට හෝ වැඩසටහන් නිර්දේශ කරන්න."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Recommend similar titles"
-msgstr ""
+msgstr "සමාන මාතෘකා නිර්දේශ කරන්න"
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
@@ -15396,7 +15517,9 @@ msgctxt "settings"
 msgid ""
 "Reduces extra space in and around results and reduces size of result title "
 "text"
-msgstr "ප්‍රතිඵල තුළ සහ අවට අමතර ඉඩ අඩු කරමින් ප්‍රතිඵල මාතෘකාවේ පෙළ ප්‍රමාණය අඩු කරයි"
+msgstr ""
+"ප්‍රතිඵල තුළ සහ අවට අමතර ඉඩ අඩු කරමින් ප්‍රතිඵල මාතෘකාවේ පෙළ ප්‍රමාණය අඩු "
+"කරයි"
 
 # smartling.placeholder_format=C
 #. Label for the input field where users specify how they want to be referred to. Example: 'Refer to me as John'
@@ -15537,8 +15660,8 @@ msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
 msgstr ""
-"උපදෙස් අනුගමනය කරමින් හෝ ඔබේ බ්‍රවුසරයේ &quot;Refresh&quot; හෝ &quot;Reload&quot; "
-"බොත්තම ක්ලික් කරමින් DuckDuckGo නැවත පූරණය කරන්න."
+"උපදෙස් අනුගමනය කරමින් හෝ ඔබේ බ්‍රවුසරයේ &quot;Refresh&quot; හෝ "
+"&quot;Reload&quot; බොත්තම ක්ලික් කරමින් DuckDuckGo නැවත පූරණය කරන්න."
 
 # smartling.placeholder_format=C
 #. checkbox label that allows the user to save the setting
@@ -15628,8 +15751,8 @@ msgid ""
 "Removes the \"Ask\" button so answers appear automatically in response to "
 "relevant searches. Cached answers always display automatically."
 msgstr ""
-"අදාළ සෙවීම් වලට ප්‍රතිචාර වශයෙන් පිළිතුරු ස්වයංක්‍රීයව දිස්වන පරිදි \"Ask\" බොත්තම ඉවත් කරයි. "
-"හැඹිලි සහිත පිළිතුරු සෑම විටම ස්වයංක්‍රීයව දර්ශනය වේ."
+"අදාළ සෙවීම් වලට ප්‍රතිචාර වශයෙන් පිළිතුරු ස්වයංක්‍රීයව දිස්වන පරිදි \"Ask\" "
+"බොත්තම ඉවත් කරයි. හැඹිලි සහිත පිළිතුරු සෑම විටම ස්වයංක්‍රීයව දර්ශනය වේ."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -15637,8 +15760,9 @@ msgid ""
 "Removes the \"Generate\" button so answers appear automatically in response "
 "to relevant searches. Cached answers always display automatically."
 msgstr ""
-"අදාළ සෙවීම් වලට ප්‍රතිචාර වශයෙන් පිළිතුරු ස්වයංක්‍රීයව දිස්වන පරිදි \"Generate\" බොත්තම ඉවත් "
-"කරයි. හැඹිලි සහිත පිළිතුරු සෑම විටම ස්වයංක්‍රීයව දර්ශනය වේ."
+"අදාළ සෙවීම් වලට ප්‍රතිචාර වශයෙන් පිළිතුරු ස්වයංක්‍රීයව දිස්වන පරිදි "
+"\"Generate\" බොත්තම ඉවත් කරයි. හැඹිලි සහිත පිළිතුරු සෑම විටම ස්වයංක්‍රීයව "
+"දර්ශනය වේ."
 
 # smartling.placeholder_format=C
 #. Text for a button to rename a chat, as in it will allow the user to change the title of the chat.
@@ -15696,9 +15820,9 @@ msgid ""
 "service. Your anonymous feedback is also shared with %s to help improve "
 "their services."
 msgstr ""
-"වාර්තා නිර්නාමික වන අතර අපගේ සෙවුම් සේවාව වැඩිදියුණු කිරීමට උදවු කිරීමට DuckDuckGo වෙත යවනු "
-"ලැබේ. ඔබේ නිර්නාමික ප්‍රතිපෝෂණය ඔවුන්ගේ සේවා වැඩිදියුණු කිරීමට උදවු කිරීමට %1$s සමඟ ද බෙදා ගනු "
-"ලැබේ."
+"වාර්තා නිර්නාමික වන අතර අපගේ සෙවුම් සේවාව වැඩිදියුණු කිරීමට උදවු කිරීමට "
+"DuckDuckGo වෙත යවනු ලැබේ. ඔබේ නිර්නාමික ප්‍රතිපෝෂණය ඔවුන්ගේ සේවා වැඩිදියුණු "
+"කිරීමට උදවු කිරීමට %1$s සමඟ ද බෙදා ගනු ලැබේ."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -15706,8 +15830,8 @@ msgid ""
 "Reports sent to DuckDuckGo are anonymous. Please do not include any personal "
 "or identifying information in your feedback."
 msgstr ""
-"DuckDuckGo වෙත යවන වාර්තා නිර්නාමික වේ. කරුණාකර ඔබේ ප්‍රතිචාරයේ කිසිදු පුද්ගලික හෝ හඳුනාගත "
-"හැකි තොරතුරු ඇතුළත් නොකරන්න."
+"DuckDuckGo වෙත යවන වාර්තා නිර්නාමික වේ. කරුණාකර ඔබේ ප්‍රතිචාරයේ කිසිදු "
+"පුද්ගලික හෝ හඳුනාගත හැකි තොරතුරු ඇතුළත් නොකරන්න."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -15716,9 +15840,9 @@ msgid ""
 "translate during this page load, and are anonymous. Please do not include "
 "any personal or identifying information in your feedback."
 msgstr ""
-"DuckDuckGo වෙත යවන වාර්තා වලට මෙම පිටු පැටවීමේදී ඔබ අපෙන් පරිවර්තනය කිරීමට ඉල්ලා ඇති සියලු "
-"පෙළ ඇතුළත් වන අතර, ඒවා නිර්නාමික වේ. කරුණාකර ඔබේ ප්‍රතිචාරයේ කිසිදු පුද්ගලික හෝ හඳුනාගත හැකි "
-"තොරතුරු ඇතුළත් නොකරන්න."
+"DuckDuckGo වෙත යවන වාර්තා වලට මෙම පිටු පැටවීමේදී ඔබ අපෙන් පරිවර්තනය කිරීමට "
+"ඉල්ලා ඇති සියලු පෙළ ඇතුළත් වන අතර, ඒවා නිර්නාමික වේ. කරුණාකර ඔබේ ප්‍රතිචාරයේ "
+"කිසිදු පුද්ගලික හෝ හඳුනාගත හැකි තොරතුරු ඇතුළත් නොකරන්න."
 
 # smartling.placeholder_format=C
 msgid "Republic of Moldova"
@@ -15731,7 +15855,7 @@ msgctxt ""
 "feedback form when the user has selected Harmful or Illegal as the feedback "
 "reason"
 msgid "Required for harmful or illegal reports"
-msgstr ""
+msgstr "හානිකර හෝ නීති විරෝධී වාර්තා සඳහා අවශ්‍ය වේ"
 
 # smartling.placeholder_format=C
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
@@ -15798,8 +15922,9 @@ msgid ""
 "legal, financial, investment, or other professional advice. AI-assisted "
 "answers are subject to our %sTerms of Service%s."
 msgstr ""
-"ප්‍රතිචාර අධ්‍යාපනික අරමුණු සඳහා පමණක් වන අතර වෛද්‍ය, නීතිමය, මූල්‍ය, ආයෝජන හෝ වෙනත් වෘත්තීය "
-"උපදෙස් ලෙස අදහස් නොකෙරේ. AI-සහය සහිත පිළිතුරු අපගේ %1$sසේවා කොන්දේසි%2$s යටතේ පවතී."
+"ප්‍රතිචාර අධ්‍යාපනික අරමුණු සඳහා පමණක් වන අතර වෛද්‍ය, නීතිමය, මූල්‍ය, ආයෝජන "
+"හෝ වෙනත් වෘත්තීය උපදෙස් ලෙස අදහස් නොකෙරේ. AI-සහය සහිත පිළිතුරු අපගේ %1$sසේවා "
+"කොන්දේසි%2$s යටතේ පවතී."
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -15808,8 +15933,9 @@ msgid ""
 "legal, financial, investment, or other professional advice. DuckAssist is "
 "subject to our %sTerms of Service%s."
 msgstr ""
-"ප්‍රතිචාර අධ්‍යාපනික අරමුණු සඳහා පමණක් වන අතර වෛද්‍ය, නීතිමය, මූල්‍ය, ආයෝජන හෝ වෙනත් වෘත්තීය "
-"උපදෙස් ලෙස අදහස් නොකෙරේ. DuckAssist අපගේ %1$sසේවා කොන්දේසි%2$s යටතේ පවතී."
+"ප්‍රතිචාර අධ්‍යාපනික අරමුණු සඳහා පමණක් වන අතර වෛද්‍ය, නීතිමය, මූල්‍ය, ආයෝජන "
+"හෝ වෙනත් වෘත්තීය උපදෙස් ලෙස අදහස් නොකෙරේ. DuckAssist අපගේ %1$sසේවා "
+"කොන්දේසි%2$s යටතේ පවතී."
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -15819,9 +15945,10 @@ msgid ""
 "generated based on web content and may contain inaccuracies. Search Assist "
 "is subject to our %sTerms of Service%s."
 msgstr ""
-"ප්‍රතිචාර අධ්‍යාපනික අරමුණු සඳහා පමණක් වන අතර වෛද්‍ය, නීතිමය, මූල්‍ය, ආයෝජන හෝ වෙනත් වෘත්තීය "
-"උපදෙස් ලෙස අදහස් නොකෙරේ. ඒවා වෙබ් අන්තර්ගතය මත පදනම්ව ජනනය කර ඇති අතර සාවද්‍යතා අඩංගු "
-"විය හැක. Search Assist අපගේ %1$sසේවා කොන්දේසි%2$s යටතේ පවතී."
+"ප්‍රතිචාර අධ්‍යාපනික අරමුණු සඳහා පමණක් වන අතර වෛද්‍ය, නීතිමය, මූල්‍ය, ආයෝජන "
+"හෝ වෙනත් වෘත්තීය උපදෙස් ලෙස අදහස් නොකෙරේ. ඒවා වෙබ් අන්තර්ගතය මත පදනම්ව ජනනය "
+"කර ඇති අතර සාවද්‍යතා අඩංගු විය හැක. Search Assist අපගේ %1$sසේවා කොන්දේසි%2$s "
+"යටතේ පවතී."
 
 # smartling.placeholder_format=C
 #. Label on the button for restoring all previous website data.
@@ -15968,7 +16095,7 @@ msgstr "විචාර"
 #. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Rewrite this recipe scaled for a different number of servings."
-msgstr ""
+msgstr "වෙනස් සේවා ප්‍රමාණයකට ගැළපෙන පරිදි මෙම වට්ටෝරුව නැවත ලියන්න."
 
 # smartling.placeholder_format=C
 msgid "Romania"
@@ -16240,8 +16367,8 @@ msgid ""
 "Save up to 30 of your most recent chats locally on your device, with the "
 "option for more with Encrypted Storage."
 msgstr ""
-"ගුප්ත කේතිත ආචයනය සමඟ තවත් බොහෝ දේ සඳහා විකල්පය සමඟින්, ඔබගේ උපාංගයේ ඔබගේ මෑත කාලීන "
-"කතාබස් 30ක් දක්වා ස්ථානීයව සුරකින්න."
+"ගුප්ත කේතිත ආචයනය සමඟ තවත් බොහෝ දේ සඳහා විකල්පය සමඟින්, ඔබගේ උපාංගයේ ඔබගේ "
+"මෑත කාලීන කතාබස් 30ක් දක්වා ස්ථානීයව සුරකින්න."
 
 # smartling.placeholder_format=C
 #. Short text for native DDG browser users explaining how Chat History stores up to 30 of their most recent chats locally on their device.
@@ -16384,8 +16511,8 @@ msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)"
 msgstr ""
-"පහලට අනුචලනය කර %1$sSearch in the address bar%2$s සොයන්න. ඉන්පසු %3$sChange%4$s "
-"ක්ලික් කරන්න (හෝ %5$sAdd new%6$s)"
+"පහලට අනුචලනය කර %1$sSearch in the address bar%2$s සොයන්න. ඉන්පසු "
+"%3$sChange%4$s ක්ලික් කරන්න (හෝ %5$sAdd new%6$s)"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
@@ -16394,8 +16521,8 @@ msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)."
 msgstr ""
-"පහලට අනුචලනය කර %1$sලිපින තීරුව සොයන්න%2$s සොයා ගන්න. %3$sවෙනස් කරන්න%4$s මත ක්ලික් කරන්න "
-"(හෝ %5$sඅළුතින්%6$s එකතු කරන්න)."
+"පහලට අනුචලනය කර %1$sලිපින තීරුව සොයන්න%2$s සොයා ගන්න. %3$sවෙනස් කරන්න%4$s මත "
+"ක්ලික් කරන්න (හෝ %5$sඅළුතින්%6$s එකතු කරන්න)."
 
 # smartling.placeholder_format=C
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -16467,12 +16594,13 @@ msgid ""
 "(on a wide range of searches). For now, Search Assist is only available in a "
 "subset of English speaking regions."
 msgstr ""
-"Search Assist යනු සෙවුම් විමසුම් සඳහා නිර්නාමිකව පිළිතුරු ජනනය කරන විශේෂාංගයකි. මෙය සිදු කිරීම "
-"සඳහා, එය අදාළ අන්තර්ගතයන් සඳහා වෙබ් ස්කෑන් කරන අතර පසුව කෙටි පිළිතුරක් ජනනය කිරීම සඳහා AI "
-"භාවිත කරයි. ඔබට එය කොපමණ වාර ගණනක් පෙනී සිටීමට අවශ්‍යද යන්න තෝරා ගත හැක: කිසි විටෙකත්, "
-"ඉල්ලූ-විට (Assist ක්ලික් කළ විට පමණක්), සමහර විට (දැඩිව අදාළ වන විට), හෝ බොහෝ විට (පුළුල් "
-"පරාසයක සෙවුම් මත). දැනට, Search Assist ලබා ගත හැක්කේ ඉංග්‍රීසි කතා කරන කලාපවල උප "
-"කණ්ඩායමක පමණි."
+"Search Assist යනු සෙවුම් විමසුම් සඳහා නිර්නාමිකව පිළිතුරු ජනනය කරන "
+"විශේෂාංගයකි. මෙය සිදු කිරීම සඳහා, එය අදාළ අන්තර්ගතයන් සඳහා වෙබ් ස්කෑන් කරන "
+"අතර පසුව කෙටි පිළිතුරක් ජනනය කිරීම සඳහා AI භාවිත කරයි. ඔබට එය කොපමණ වාර "
+"ගණනක් පෙනී සිටීමට අවශ්‍යද යන්න තෝරා ගත හැක: කිසි විටෙකත්, ඉල්ලූ-විට (Assist "
+"ක්ලික් කළ විට පමණක්), සමහර විට (දැඩිව අදාළ වන විට), හෝ බොහෝ විට (පුළුල් "
+"පරාසයක සෙවුම් මත). දැනට, Search Assist ලබා ගත හැක්කේ ඉංග්‍රීසි කතා කරන "
+"කලාපවල උප කණ්ඩායමක පමණි."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI) when the answer is not found and the answer is unsourced or with no sources
@@ -16480,8 +16608,8 @@ msgid ""
 "Search Assist couldn't find enough reliable information to generate an "
 "answer for this question. Try another search."
 msgstr ""
-"මෙම ප්‍රශ්නය සඳහා පිළිතුරක් උත්පාදනය කිරීම සඳහා ප්‍රමාණවත් විශ්වාසදායක තොරතුරු සොයාගැනීමට "
-"Search Assist හට නොහැකි විය. තවත් සෙවීමක් කරන්න."
+"මෙම ප්‍රශ්නය සඳහා පිළිතුරක් උත්පාදනය කිරීම සඳහා ප්‍රමාණවත් විශ්වාසදායක "
+"තොරතුරු සොයාගැනීමට Search Assist හට නොහැකි විය. තවත් සෙවීමක් කරන්න."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -16490,9 +16618,10 @@ msgid ""
 "search queries. To do this, it %sscans the web%s for relevant content and "
 "then uses AI to generate a brief answer based on information found."
 msgstr ""
-"Search Assist යනු නිර්නාමිකව සෙවුම් විමසුම් සඳහා පිළිතුරු ජනනය කරන විකල්ප විශේෂාංගයකි. "
-"%1$sමෙය%2$s සිදු කිරීම සඳහා, එය අදාළ අන්තර්ගතය සඳහා වෙබ් ස්කෑන් කර පසුව සොයාගත් තොරතුරු "
-"මත පදනම්ව කෙටි පිළිතුරක් ජනනය කිරීම සඳහා AI භාවිත කරයි."
+"Search Assist යනු නිර්නාමිකව සෙවුම් විමසුම් සඳහා පිළිතුරු ජනනය කරන විකල්ප "
+"විශේෂාංගයකි. %1$sමෙය%2$s සිදු කිරීම සඳහා, එය අදාළ අන්තර්ගතය සඳහා වෙබ් ස්කෑන් "
+"කර පසුව සොයාගත් තොරතුරු මත පදනම්ව කෙටි පිළිතුරක් ජනනය කිරීම සඳහා AI භාවිත "
+"කරයි."
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/search_box. top header
@@ -16613,8 +16742,8 @@ msgid ""
 "Search other sites with %s shortcuts: a search for ”!w ducks” will search "
 "for “ducks” directly on Wikipedia."
 msgstr ""
-"%1$s කෙටිමං භාවිතයෙන් වෙනත් අඩවි සොයන්න: ”!w ducks” සෙවීමකින් විකිපීඩියාවේ “ducks” සෘජුවම "
-"සොයාගත හැක."
+"%1$s කෙටිමං භාවිතයෙන් වෙනත් අඩවි සොයන්න: ”!w ducks” සෙවීමකින් විකිපීඩියාවේ "
+"“ducks” සෘජුවම සොයාගත හැක."
 
 # smartling.placeholder_format=C
 #. Placeholder text for the search form when no text has been entered
@@ -16633,8 +16762,8 @@ msgid ""
 "Search privately with our app or extension, add private web search to your "
 "favorite browser, or search directly at %sduckduckgo.com%s."
 msgstr ""
-"අපගේ යෙදුම හෝ දිගුව භාවිතයෙන් සොයන්න, ඔබේ ප්‍රියතම බ්‍රවුසරයට පුද්ගලික වෙබ් සෙවුම එක් කරන්න, "
-"නැතහොත් %1$sduckduckgo.com%2$s වෙතින් ඍජුවම සෙවීම් කරන්න."
+"අපගේ යෙදුම හෝ දිගුව භාවිතයෙන් සොයන්න, ඔබේ ප්‍රියතම බ්‍රවුසරයට පුද්ගලික වෙබ් "
+"සෙවුම එක් කරන්න, නැතහොත් %1$sduckduckgo.com%2$s වෙතින් ඍජුවම සෙවීම් කරන්න."
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/6LZAoqH.png
@@ -16642,7 +16771,8 @@ msgctxt "settings"
 msgid ""
 "Search queries are included in URL (if off, searches will use POST requests)"
 msgstr ""
-"සෙවුම් විමසුම් URL එකෙහි අන්තර්ගතයි (සංවෘත කර ඇත්නම්, සෙවුම් POST ඉල්ලීම් භාවිතා කරනු ඇත)"
+"සෙවුම් විමසුම් URL එකෙහි අන්තර්ගතයි (සංවෘත කර ඇත්නම්, සෙවුම් POST ඉල්ලීම් "
+"භාවිතා කරනු ඇත)"
 
 # smartling.placeholder_format=C
 #. Describes how cookies are used to store user settings privately and securely.
@@ -16654,10 +16784,11 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"සෙවුම් සැකසුම් ඔබේ බ්‍රව්සරයේ පුද්ගලික නොවන බ්‍රව්සර් කුකීස් සහ අභ්‍යන්තර ගබඩා තුළ ගබඩා කර ඇත, "
-"නමුත් ඔබට ඔබගේ සැකසුම් නිර්නාමිකව ක්ලවුඩයේ ඇති දුරස්ථ සර්වරයක ගබඩා කිරීමට Cloud Save භාවිත "
-"කළ හැක. පුද්ගලිකව හඳුනාගත හැකි තොරතුරු ක්ලවුඩය තුළ ගබඩා නොවන අතර, ඔබේ මුරපදය කිසි විටෙකත් "
-"ඔබේ බ්‍රව්සරයෙන් ඉවත් නොවේ."
+"සෙවුම් සැකසුම් ඔබේ බ්‍රව්සරයේ පුද්ගලික නොවන බ්‍රව්සර් කුකීස් සහ අභ්‍යන්තර "
+"ගබඩා තුළ ගබඩා කර ඇත, නමුත් ඔබට ඔබගේ සැකසුම් නිර්නාමිකව ක්ලවුඩයේ ඇති දුරස්ථ "
+"සර්වරයක ගබඩා කිරීමට Cloud Save භාවිත කළ හැක. පුද්ගලිකව හඳුනාගත හැකි තොරතුරු "
+"ක්ලවුඩය තුළ ගබඩා නොවන අතර, ඔබේ මුරපදය කිසි විටෙකත් ඔබේ බ්‍රව්සරයෙන් ඉවත් "
+"නොවේ."
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -16754,8 +16885,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
 msgstr ""
-"මුල සිට අග දක්වා ම සංකේතනය භාවිතා කර අපගේ සේවාදායකයේ සීමාවක් නැති කතාබස් ආරක්ෂිතව ගබඩා "
-"කර, ඔබේ සියලුම උපාංගවලින් ඒවාට ප්‍රවේශ වෙන්න."
+"මුල සිට අග දක්වා ම සංකේතනය භාවිතා කර අපගේ සේවාදායකයේ සීමාවක් නැති කතාබස් "
+"ආරක්ෂිතව ගබඩා කර, ඔබේ සියලුම උපාංගවලින් ඒවාට ප්‍රවේශ වෙන්න."
 
 # smartling.placeholder_format=C
 #. Text explaining that the Encrypted Storage feature stores the user's chats encrypted on their device.
@@ -16764,8 +16895,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
 msgstr ""
-"මුල සිට අග දක්වා ම සංකේතනය භාවිතා කර අපගේ සේවාදායකයේ සීමාවක් නැති කතාබස් ආරක්ෂිතව ගබඩා "
-"කර, ඔබේ සියලුම උපාංගවලින් ඒවාට ප්‍රවේශ වෙන්න."
+"මුල සිට අග දක්වා ම සංකේතනය භාවිතා කර අපගේ සේවාදායකයේ සීමාවක් නැති කතාබස් "
+"ආරක්ෂිතව ගබඩා කර, ඔබේ සියලුම උපාංගවලින් ඒවාට ප්‍රවේශ වෙන්න."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -16774,8 +16905,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your synced devices."
 msgstr ""
-"මුල සිට අග දක්වා ම සංකේතනය භාවිත කර අපගේ සේවාදායකයේ සීමාවක් නැති කතාබස් ආරක්ෂිතව ගබඩා "
-"කර, ඔබ සමකාලීන කරන ලද සියලුම උපාංගවලින් ඒවාට ප්‍රවේශ වන්න."
+"මුල සිට අග දක්වා ම සංකේතනය භාවිත කර අපගේ සේවාදායකයේ සීමාවක් නැති කතාබස් "
+"ආරක්ෂිතව ගබඩා කර, ඔබ සමකාලීන කරන ලද සියලුම උපාංගවලින් ඒවාට ප්‍රවේශ වන්න."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -16784,8 +16915,8 @@ msgid ""
 "Securely store your chats on our server using end-to-end encryption, and "
 "access them from all your devices."
 msgstr ""
-"මුල සිට අග දක්වා ම සංකේතනය භාවිත කර ඔබේ කතාබස් ආරක්ෂිතව අපගේ සේවාදායකයේ ගබඩා කර, "
-"ඔබේ සියලුම උපාංගවලින් ඒවාට ප්‍රවේශ වන්න."
+"මුල සිට අග දක්වා ම සංකේතනය භාවිත කර ඔබේ කතාබස් ආරක්ෂිතව අපගේ සේවාදායකයේ ගබඩා "
+"කර, ඔබේ සියලුම උපාංගවලින් ඒවාට ප්‍රවේශ වන්න."
 
 # smartling.placeholder_format=C
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
@@ -16800,8 +16931,8 @@ msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
 msgstr ""
-"DuckDuckGo සර්වරයේ මුල සිට අග දක්වා ගුප්ත කේතනය සමඟ ආරක්ෂිතව ගබඩා කර ඇත. ඔබට හැර වෙන "
-"කිසිවෙකුට ඔබගේ දත්ත දැකිය නොහැක, අපටවත් නොවේ."
+"DuckDuckGo සර්වරයේ මුල සිට අග දක්වා ගුප්ත කේතනය සමඟ ආරක්ෂිතව ගබඩා කර ඇත. ඔබට "
+"හැර වෙන කිසිවෙකුට ඔබගේ දත්ත දැකිය නොහැක, අපටවත් නොවේ."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -17019,8 +17150,8 @@ msgstr ""
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sOpera > Options%s (on Windows)"
 msgstr ""
-"%1$sOpera > Preferences%2$s (මැක් වල) හෝ %3$sOpera > Options%4$s (වින්ඩෝව්ස් වල) "
-"තෝරන්න"
+"%1$sOpera > Preferences%2$s (මැක් වල) හෝ %3$sOpera > Options%4$s (වින්ඩෝව්ස් "
+"වල) තෝරන්න"
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -17085,8 +17216,8 @@ msgid ""
 "Select %sUse this webpage as your only home page%s (or one of the other "
 "options if you prefer)"
 msgstr ""
-"%1$sUse this webpage as your only home page%2$s තෝරන්න (හෝ ඔබ කැමතිනම් අනෙකුත් "
-"විකල්ප වලින් එකක් තෝරන්න)"
+"%1$sUse this webpage as your only home page%2$s තෝරන්න (හෝ ඔබ කැමතිනම් "
+"අනෙකුත් විකල්ප වලින් එකක් තෝරන්න)"
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
@@ -17208,8 +17339,8 @@ msgid ""
 "respond. These instructions will apply to all of your conversations going "
 "forward."
 msgstr ""
-"ඔබේ පණිවිඩ සහ ප්‍රතිචාර දැක්විය යුතු ආකාරය පිළිබඳ උපදෙස් සමඟ AI ආකෘති වෙත විමසුමක් යවයි. මෙම "
-"උපදෙස් ඔබේ සියලුම සංවාද සඳහා ඉදිරියට අදාළ වනු ඇත."
+"ඔබේ පණිවිඩ සහ ප්‍රතිචාර දැක්විය යුතු ආකාරය පිළිබඳ උපදෙස් සමඟ AI ආකෘති වෙත "
+"විමසුමක් යවයි. මෙම උපදෙස් ඔබේ සියලුම සංවාද සඳහා ඉදිරියට අදාළ වනු ඇත."
 
 # smartling.placeholder_format=C
 msgid "Senegal"
@@ -17288,7 +17419,7 @@ msgstr "දැන් සකසන්න"
 #. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
 msgctxt "Encrypted storage setup button shown in native browsers"
 msgid "Set Up Sync & Backup"
-msgstr ""
+msgstr "Sync & Backup සකසන්න"
 
 # smartling.placeholder_format=C
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
@@ -17319,8 +17450,8 @@ msgid ""
 "Set up Sync & Backup after turning on Chat History to keep your chats synced "
 "across devices."
 msgstr ""
-"ඔබේ කතාබස් උපාංග අතර සමමුහුර්තව තබා ගැනීමට කතාබස් ඉතිහාසය ක්‍රියාත්මක කිරීමෙන් පසු Sync & "
-"Backup පිහිටුුවන්න."
+"ඔබේ කතාබස් උපාංග අතර සමමුහුර්තව තබා ගැනීමට කතාබස් ඉතිහාසය ක්‍රියාත්මක "
+"කිරීමෙන් පසු Sync & Backup පිහිටුුවන්න."
 
 # smartling.placeholder_format=C
 #. Prompt for the user to indicate their location on a map, to enable more relevant search results.
@@ -17407,8 +17538,8 @@ msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
 msgstr ""
-"අදාළත්වය වැඩි දියුණු කිරීම සඳහා AI ආකෘති සමඟ නගර මට්ටමේ ස්ථානයක් බෙදා ගන්න. Duck.ai කිසි "
-"විටෙකත් ඔබේ නිශ්චිත ස්ථානය අපට හෝ AI ආකෘතිවලට හෙළි නොකරයි."
+"අදාළත්වය වැඩි දියුණු කිරීම සඳහා AI ආකෘති සමඟ නගර මට්ටමේ ස්ථානයක් බෙදා ගන්න. "
+"Duck.ai කිසි විටෙකත් ඔබේ නිශ්චිත ස්ථානය අපට හෝ AI ආකෘතිවලට හෙළි නොකරයි."
 
 # smartling.placeholder_format=C
 #. Menu option to share feedback about a result
@@ -17473,7 +17604,7 @@ msgstr "ධනාත්මක ප්‍රතිපෝෂණ බෙදා ගන
 msgctxt ""
 "Label beside the share-content switch on the Duck.ai response feedback form"
 msgid "Share this conversation with DuckDuckGo"
-msgstr ""
+msgstr "මෙම සංවාදය DuckDuckGo සමඟ බෙදා ගන්න"
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -17491,8 +17622,8 @@ msgid ""
 "Share your prompt and chat response with DuckDuckGo (required for illegal "
 "and harmful report)"
 msgstr ""
-"ඔබේ කඩිනම් සහ කතාබස් ප්‍රතිචාරය DuckDuckGo සමග බෙදා ගන්න (නීති විරෝධී සහ හානිකර වාර්තා "
-"සඳහා අවශ්‍ය වේ)"
+"ඔබේ කඩිනම් සහ කතාබස් ප්‍රතිචාරය DuckDuckGo සමග බෙදා ගන්න (නීති විරෝධී සහ "
+"හානිකර වාර්තා සඳහා අවශ්‍ය වේ)"
 
 # smartling.placeholder_format=C
 #. An invitation for users to leave feedback
@@ -17613,7 +17744,8 @@ msgstr "DuckAssist <sup>BETA</sup> පෙන්වන්න"
 msgctxt "duckassist_optin"
 msgid "Show DuckAssist more often. (You can also completely %sturn it off%s.)"
 msgstr ""
-"DuckAssist නිතර නිතර පෙන්වන්න. (ඔබට සම්පූර්ණයෙන්ම %1$sඑය ක්‍රියා විරහිත කිරීමටද%2$s හැකිය.)"
+"DuckAssist නිතර නිතර පෙන්වන්න. (ඔබට සම්පූර්ණයෙන්ම %1$sඑය ක්‍රියා විරහිත "
+"කිරීමටද%2$s හැකිය.)"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
@@ -17839,8 +17971,8 @@ msgid ""
 "Shows a reminder that searches on DuckDuckGo are always private. Turning "
 "this off hides the reminder and never affects search privacy."
 msgstr ""
-"DuckDuckGo හි සෙවීම් සැමවිටම පුද්ගලික බව මතක් කිරීමක් පෙන්වයි. මෙය අක්‍රිය කිරීම මතක් කිරීම සඟවයි "
-"සහ සෙවුම් පෞද්ගලිකත්වයට කිසි විටෙකත් බලපාන්නේ නැත."
+"DuckDuckGo හි සෙවීම් සැමවිටම පුද්ගලික බව මතක් කිරීමක් පෙන්වයි. මෙය අක්‍රිය "
+"කිරීම මතක් කිරීම සඟවයි සහ සෙවුම් පෞද්ගලිකත්වයට කිසි විටෙකත් බලපාන්නේ නැත."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -17848,8 +17980,8 @@ msgid ""
 "Shows a reminder that searches on DuckDuckGo are always protected. Turning "
 "this off hides the reminder and never affects search protection."
 msgstr ""
-"DuckDuckGo හි සෙවීම් සැමවිටම ආරක්ෂිත බව මතක් කිරීමක් පෙන්වයි. මෙය අක්‍රිය කිරීම මතක් කිරීම සඟවන "
-"අතර සෙවුම් ආරක්ෂාවට කිසි විටෙකත් බලපාන්නේ නැත."
+"DuckDuckGo හි සෙවීම් සැමවිටම ආරක්ෂිත බව මතක් කිරීමක් පෙන්වයි. මෙය අක්‍රිය "
+"කිරීම මතක් කිරීම සඟවන අතර සෙවුම් ආරක්ෂාවට කිසි විටෙකත් බලපාන්නේ නැත."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -17887,7 +18019,8 @@ msgctxt "settings"
 msgid ""
 "Shows occasional reminders to sign up for the DuckDuckGo privacy newsletters"
 msgstr ""
-"DuckDuckGo පෞදගලිකත්වය සම්බන්ධ පුවත් ලිපි සඳහා ලියපදිංචිය ඉඳහිට මතක් කරන පණිවුඩ පෙන්වන්න"
+"DuckDuckGo පෞදගලිකත්වය සම්බන්ධ පුවත් ලිපි සඳහා ලියපදිංචිය ඉඳහිට මතක් කරන "
+"පණිවුඩ පෙන්වන්න"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18208,7 +18341,8 @@ msgid ""
 "Sorry, the uploaded image couldn't be processed. Please try a different "
 "image or format."
 msgstr ""
-"කනගාටුයි, උඩුගත කළ රූපය සැකසිය නොහැකි විය. කරුණාකර වෙනස් රූපයක් හෝ ආකෘතියක් උත්සාහ කරන්න."
+"කනගාටුයි, උඩුගත කළ රූපය සැකසිය නොහැකි විය. කරුණාකර වෙනස් රූපයක් හෝ ආකෘතියක් "
+"උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. Body copy shown when a scanned or pasted pairing payload fails schema validation.
@@ -18217,16 +18351,16 @@ msgid ""
 "Sorry, this code is invalid. Please make sure the correct code was entered "
 "or scanned."
 msgstr ""
-"කනගාටුයි, මෙම කේතය අවලංගු වේ. කරුණාකර නිවැරදි කේතය ඇතුළත් කර හෝ ස්කෑන් කර ඇති බවට වග "
-"බලා ගන්න."
+"කනගාටුයි, මෙම කේතය අවලංගු වේ. කරුණාකර නිවැරදි කේතය ඇතුළත් කර හෝ ස්කෑන් කර "
+"ඇති බවට වග බලා ගන්න."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
 msgid ""
 "Sorry, we couldn't generate a richer answer. You can try asking Duck.ai."
 msgstr ""
-"කණගාටුයි, අපට වඩාත් පොහොසත් පිළිතුරක් නිර්මාණය කරන්නට නොහැකි විය. ඔබට Duck.ai එකෙන් අහන්න "
-"උත්සාහ කළ හැක."
+"කණගාටුයි, අපට වඩාත් පොහොසත් පිළිතුරක් නිර්මාණය කරන්නට නොහැකි විය. ඔබට "
+"Duck.ai එකෙන් අහන්න උත්සාහ කළ හැක."
 
 # smartling.placeholder_format=C
 #. Inform the users that "something" went wrong and that they could try to refresh the page to resolve the error. Placeholders are for markup, please ignore.
@@ -18235,15 +18369,16 @@ msgid ""
 "Sorry, we ran into an error displaying these results. %sClick here%s to try "
 "again."
 msgstr ""
-"කණගාටුයි, මෙම ප්‍රතිඵල පෙන්වීමේදී අපට දෝෂයක් ඇති විය. නැවත උත්සාහ කිරීමට%1$sමෙහි ක්ලික් "
-"කරන්න%2$s ."
+"කණගාටුයි, මෙම ප්‍රතිඵල පෙන්වීමේදී අපට දෝෂයක් ඇති විය. නැවත උත්සාහ "
+"කිරීමට%1$sමෙහි ක්ලික් කරන්න%2$s ."
 
 # smartling.placeholder_format=C
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
 msgstr ""
-"සමාවන්න, අපට ඔබේ ප්‍රතිපෝෂණ ඉදිරිපත් කිරීමට නොහැකි විය. කරුණාකර පසුව නැවත උත්සාහ කරන්න."
+"සමාවන්න, අපට ඔබේ ප්‍රතිපෝෂණ ඉදිරිපත් කිරීමට නොහැකි විය. කරුණාකර පසුව නැවත "
+"උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -18641,8 +18776,8 @@ msgid ""
 "Subscribe to DuckDuckGo to unlock higher limits in Duck.ai, or come back "
 "later to create more images."
 msgstr ""
-"Duck.ai තුළ ඇති ඉහළ සීමාවන් අගුළු හැර ගැනීමට DuckDuckGo වෙත ග්‍රාහකත්වය ලබාගන්න, නැතහොත් "
-"තවත් රූප නිර්මාණය කිරීමට පසුව නැවත එන්න."
+"Duck.ai තුළ ඇති ඉහළ සීමාවන් අගුළු හැර ගැනීමට DuckDuckGo වෙත ග්‍රාහකත්වය "
+"ලබාගන්න, නැතහොත් තවත් රූප නිර්මාණය කිරීමට පසුව නැවත එන්න."
 
 # smartling.placeholder_format=C
 #. Description shown to free users who have reached their image generation limit, encouraging them to subscribe.
@@ -18710,7 +18845,9 @@ msgctxt "Full sentence for composing a card"
 msgid ""
 "Suggest a phrase to write on a get-well card for someone recovering from a "
 "surgery?"
-msgstr "සැත්කමකින් සුවය ලැබූ කෙනෙකුට get-well කාඩ්පතක ලිවීමට වාක්ය ඛණ්ඩයක් යෝජනා කරනවාද?"
+msgstr ""
+"සැත්කමකින් සුවය ලැබූ කෙනෙකුට get-well කාඩ්පතක ලිවීමට වාක්ය ඛණ්ඩයක් යෝජනා "
+"කරනවාද?"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for asking for a suggestion of a blog post title.
@@ -18722,19 +18859,19 @@ msgstr "බ්ලොග් සටහනක් සඳහා මාතෘකාව
 #. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Suggest related articles or topics worth exploring next."
-msgstr ""
+msgstr "ඊළඟට ගවේෂණය කිරීමට සුදුසු ලිපි හෝ මාතෘකා යෝජනා කරන්න."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Suggest related articles to explore"
-msgstr ""
+msgstr "ගවේෂණය කිරීමට අදාළ ලිපි යෝජනා කරන්න"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Suggest some alternatives to this product."
-msgstr ""
+msgstr "මෙම නිෂ්පාදනය සඳහා විකල්ප කිහිපයක් යෝජනා කරන්න."
 
 # smartling.placeholder_format=C
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
@@ -18751,7 +18888,7 @@ msgstr "යෝජනා:"
 #. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Sum up the reviews"
-msgstr ""
+msgstr "සමාලෝචන සාරාංශගත කරන්න"
 
 # smartling.placeholder_format=C
 #. A short title for the a message asking the AI to summarize a text.
@@ -18763,85 +18900,85 @@ msgstr "සාරාංශ කරන්න"
 #. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize the Q&As"
-msgstr ""
+msgstr "ප්‍රශ්නෝත්තර සාරාංශගත කරන්න"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the background and notable work of this person."
-msgstr ""
+msgstr "මෙම පුද්ගලයාගේ පසුබිම සහ කැපී පෙනෙන වැඩ කටයුතු සාරාංශගත කරන්න."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the key details of this event."
-msgstr ""
+msgstr "මෙම සිදුවීමේ ප්‍රධාන විස්තර සාරාංශගත කරන්න."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the questions and answers on this page."
-msgstr ""
+msgstr "මෙම පිටුවේ ඇති ප්‍රශ්න සහ පිළිතුරු සාරාංශගත කරන්න."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize their background"
-msgstr ""
+msgstr "ඔවුන්ගේ පසුබිම සාරාංශගත කරන්න"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this book"
-msgstr ""
+msgstr "මෙම පොත සාරාංශගත කරන්න"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this book."
-msgstr ""
+msgstr "මෙම පොත සාරාංශගත කරන්න."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this discussion"
-msgstr ""
+msgstr "මෙම සකච්ඡාව සාරාංශගත කරන්න"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this discussion thread."
-msgstr ""
+msgstr "මෙම සාකච්ඡා හුය සාරාංශගත කරන්න."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this page"
-msgstr ""
+msgstr "මෙම පිටුව සාරාංශගත කරන්න"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this page."
-msgstr ""
+msgstr "මෙම පිටුව සාරාංශගත කරන්න."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this video"
-msgstr ""
+msgstr "මෙම වීඩියෝව සාරාංශගත කරන්න"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this video."
-msgstr ""
+msgstr "මෙම වීඩියෝව සාරාංශගත කරන්න."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize what the reviews say."
-msgstr ""
+msgstr "සමාලෝචනවලින් පවසන දේ සාරාංශගත කරන්න."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -19002,7 +19139,9 @@ msgstr "ඔබ ගැන අනවසරයෙන් පරික්ෂා න�
 msgctxt "AI Chat warning when switching from an encrypted model"
 msgid ""
 "Switching will send your chat to a model without zero provider visibility"
-msgstr "ආකෘතිය මාරු කිරීමෙන්, ඔබේ කතාබහ සපයන්නාගේ දෘශ්‍යතාව ශුන්‍ය නොවන ආකෘතියකට යවනු ඇත"
+msgstr ""
+"ආකෘතිය මාරු කිරීමෙන්, ඔබේ කතාබහ සපයන්නාගේ දෘශ්‍යතාව ශුන්‍ය නොවන ආකෘතියකට "
+"යවනු ඇත"
 
 # smartling.placeholder_format=C
 msgid "Switzerland"
@@ -19057,7 +19196,8 @@ msgstr "Sync & Backup සක්‍රිය කරන ලදී!"
 msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
-"Sync & Backup දත්ත මාස 18ක කාලයක් තිස්සේ අකර්මණ්‍යව තිබූ පසු ඒවා ප්‍රතිසාධනය කළ නොහැක."
+"Sync & Backup දත්ත මාස 18ක කාලයක් තිස්සේ අකර්මණ්‍යව තිබූ පසු ඒවා ප්‍රතිසාධනය "
+"කළ නොහැක."
 
 # smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
@@ -19106,9 +19246,9 @@ msgid ""
 msgstr ""
 "ප්‍රතිසාධන කේතය සමමුහුර්ත කරන්න\n"
 "\n"
-"ප්‍රතිසාධන කේතය මඟින් ඔබේ මුරපද, ස්වයංක්‍රීය පිරවීම් දත්ත සහ Duck.ai කතාබස් උපාංග කිහිපයක් අතර "
-"සමමුහුර්ත කිරීමට ඉඩ සලසන අතර, උපාංගයකට ප්‍රවේශය අහිමි වුවහොත් ඔබේ සමමුහුර්ත දත්ත ප්‍රතිසාධනය "
-"කර ගනී.\n"
+"ප්‍රතිසාධන කේතය මඟින් ඔබේ මුරපද, ස්වයංක්‍රීය පිරවීම් දත්ත සහ Duck.ai කතාබස් "
+"උපාංග කිහිපයක් අතර සමමුහුර්ත කිරීමට ඉඩ සලසන අතර, උපාංගයකට ප්‍රවේශය අහිමි "
+"වුවහොත් ඔබේ සමමුහුර්ත දත්ත ප්‍රතිසාධනය කර ගනී.\n"
 "\n"
 "මෙම තොරතුරු ආරක්ෂිතව තබා ගන්න.\n"
 "මෙම කේතයට ප්‍රවේශය ඇති ඕනෑම අයෙකුට ඔබේ සමමුහුර්ත දත්ත වෙත ප්‍රවේශ විය හැක.\n"
@@ -19117,12 +19257,14 @@ msgstr ""
 "\n"
 "මෙම කේතය ක්‍රියා කරන්නේ කෙසේ ද?\n"
 "1. ඔබේ බ්‍රවුසරයෙන් Duck.ai වෙත ගොස් Duck.ai සැකසුම් විවෘත කරන්න.\n"
-"2. \"Sync & Backup සක්‍රීය කරන්න, තෝරා, ඉන්පසු \"සමමුහුර්ත දත්ත ප්‍රතිසාධනය කරන්න\" තෝරන්න\n"
-"3. ඉහත ප්‍රතිසාධන කේතය පිටපත් කර \"මෙහි ඔබේ කේතය අලවන්න\" යනුවෙන් දැක්වෙන ස්ථානයේ "
-"අලවන්න\n"
+"2. \"Sync & Backup සක්‍රීය කරන්න, තෝරා, ඉන්පසු \"සමමුහුර්ත දත්ත ප්‍රතිසාධනය "
+"කරන්න\" තෝරන්න\n"
+"3. ඉහත ප්‍රතිසාධන කේතය පිටපත් කර \"මෙහි ඔබේ කේතය අලවන්න\" යනුවෙන් දැක්වෙන "
+"ස්ථානයේ අලවන්න\n"
 "\n"
-"ඔබ DuckDuckGo බ්‍රවුසරය Sync & Backup සක්‍රීය කර නොමැතිව මාස 18 කට වැඩි කාලයක් භාවිතා "
-"නොකරන්නේ නම්, ඔබගේ දත්ත සර්වරයෙන් මනා දමනු ලබන අතර ප්‍රතිසාධනය කළ නොහැක."
+"ඔබ DuckDuckGo බ්‍රවුසරය Sync & Backup සක්‍රීය කර නොමැතිව මාස 18 කට වැඩි "
+"කාලයක් භාවිතා නොකරන්නේ නම්, ඔබගේ දත්ත සර්වරයෙන් මනා දමනු ලබන අතර ප්‍රතිසාධනය "
+"කළ නොහැක."
 
 # smartling.placeholder_format=C
 #. Secondary button label on the Sync & Backup intro screen that takes the user to the camera scan screen to pair with another device.
@@ -19168,7 +19310,7 @@ msgstr "සිරියාව"
 #. Text for a button that enables the theme to follow the operating system's color scheme preference.
 msgctxt "System theme button for theme selector"
 msgid "System"
-msgstr ""
+msgstr "පද්ධතිය"
 
 # smartling.placeholder_format=C
 #. Abbreviation indicating this is the total score for a game
@@ -19202,7 +19344,7 @@ msgstr "ටහීටියානු"
 #. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Tailor my resume"
-msgstr ""
+msgstr "මගේ ජීව දත්ත පත්‍රය සකසන්න"
 
 # smartling.placeholder_format=C
 msgid "Taiwan"
@@ -19239,6 +19381,8 @@ msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
+"Duck.ai වඩා හොඳ කළ හැක්කේ කෙසේදැයි අපව දැනුවත් කිරීමට මෙම නිර්නාමික "
+"සමීක්ෂණයට සහභාගි වන්න."
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -19453,9 +19597,9 @@ msgid ""
 "link is at increased risk of being intercepted by a third party. In rare "
 "cases this includes passwords, or payment details."
 msgstr ""
-"එයින් අදහස් වන්නේ ඔබගේ උපාංගය සහ මෙම සබැඳිය පිටුපස ඇති වෙබ් පිටුව අතර යවන ලද තොරතුරු තෙවන "
-"පාර්ශවයක් විසින් වළක්වාලීමේ අවදානම වැඩි බවයි. දුර්ලභ අවස්ථාවන්හි මුරපද හෝ ගෙවීම් විස්තර මෙයට "
-"ඇතුළත් වේ."
+"එයින් අදහස් වන්නේ ඔබගේ උපාංගය සහ මෙම සබැඳිය පිටුපස ඇති වෙබ් පිටුව අතර යවන ලද "
+"තොරතුරු තෙවන පාර්ශවයක් විසින් වළක්වාලීමේ අවදානම වැඩි බවයි. දුර්ලභ "
+"අවස්ථාවන්හි මුරපද හෝ ගෙවීම් විස්තර මෙයට ඇතුළත් වේ."
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -19464,8 +19608,8 @@ msgid ""
 "The Cloud Save bookmarklet allows any changes you make to your settings to "
 "automatically save in the cloud."
 msgstr ""
-"වලාකුළු තුළ ස්වයංක්‍රීයව සුරැකීමට ඔබගේ සැකසුම් වල සිදුකරන ඕනෑම වෙනස්කමක් Cloud Save කුඩා පිටු "
-"සලකුණු මඟින් ඉඩ දෙයි."
+"වලාකුළු තුළ ස්වයංක්‍රීයව සුරැකීමට ඔබගේ සැකසුම් වල සිදුකරන ඕනෑම වෙනස්කමක් "
+"Cloud Save කුඩා පිටු සලකුණු මඟින් ඉඩ දෙයි."
 
 # smartling.placeholder_format=C
 msgid "The Gambia"
@@ -19495,8 +19639,8 @@ msgid ""
 "The encryption key is only saved in your browser's local storage, and only "
 "you can access it."
 msgstr ""
-"සංකේතාංකන යතුර ඔබගේ බ්‍රවුසරයේ දේශීය ගබඩාවේ පමණක් සුරකින අතර, ඊට ප්‍රවේශ විය හැක්කේ ඔබට "
-"පමණි."
+"සංකේතාංකන යතුර ඔබගේ බ්‍රවුසරයේ දේශීය ගබඩාවේ පමණක් සුරකින අතර, ඊට ප්‍රවේශ විය "
+"හැක්කේ ඔබට පමණි."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider deletes all chat data within 30 days.
@@ -19517,7 +19661,9 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider does not save this chat or any associated data on their "
 "servers."
-msgstr "ආකෘති සපයන්නා මෙම කතාබස් හෝ ඒ ආශ්‍රිත කිසිදු දත්තයක් ඔවුන්ගේ සර්වරවල සුරකින්නේ නැත."
+msgstr ""
+"ආකෘති සපයන්නා මෙම කතාබස් හෝ ඒ ආශ්‍රිත කිසිදු දත්තයක් ඔවුන්ගේ සර්වරවල "
+"සුරකින්නේ නැත."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19545,7 +19691,7 @@ msgstr "තේමාව"
 #. Text for the theme selector label that allows users to switch between Light and dark theme.
 msgctxt "Label for the theme selector feature"
 msgid "Theme"
-msgstr ""
+msgstr "තේමාව"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/LpFhb1e.png
@@ -19576,8 +19722,8 @@ msgid ""
 "There was an error saving this chat locally. Please check your browser "
 "settings to make sure local data storage is enabled."
 msgstr ""
-"මෙම කතාබහ අභ්‍යන්තරව සුරැකීමේදී දෝෂයක් සිදු විය. අභ්‍යන්තර දත්ත ගබඩා සක්‍රිය කර ඇති බවට වග බලා "
-"ගැනීම සඳහා කරුණාකර ඔබේ බ්‍රව්සර් සැකසුම් පරීක්ෂා කරන්න."
+"මෙම කතාබහ අභ්‍යන්තරව සුරැකීමේදී දෝෂයක් සිදු විය. අභ්‍යන්තර දත්ත ගබඩා සක්‍රිය "
+"කර ඇති බවට වග බලා ගැනීම සඳහා කරුණාකර ඔබේ බ්‍රව්සර් සැකසුම් පරීක්ෂා කරන්න."
 
 # smartling.placeholder_format=C
 #. Error modal body line 1.
@@ -19592,8 +19738,8 @@ msgid ""
 "There was still an error displaying the search results. Please wait a few "
 "minutes before you try again."
 msgstr ""
-"සෙවුම් ප්‍රතිඵල පෙන්වීමේ දෝෂයක් තවමත් පැවතිණි. ඔබ නැවත උත්සාහ කිරීමට පෙර කරුණාකර මිනිත්තු කිහිපයක් "
-"රැඳී සිටින්න."
+"සෙවුම් ප්‍රතිඵල පෙන්වීමේ දෝෂයක් තවමත් පැවතිණි. ඔබ නැවත උත්සාහ කිරීමට පෙර "
+"කරුණාකර මිනිත්තු කිහිපයක් රැඳී සිටින්න."
 
 # smartling.placeholder_format=C
 #. Error message for explore more questions when a retryable error occurs (timeout, network)
@@ -19612,9 +19758,9 @@ msgid ""
 "visit by blocking hidden trackers, encrypting connections where possible, "
 "and by making DuckDuckGo your default search engine."
 msgstr ""
-"සැඟවුණු ට්‍රැකර් අවහිර කිරීමෙන්, හැකි සෑම තැනකම සම්බන්ධතා සංකේතනය කිරීමෙන් සහ DuckDuckGo "
-"ඔබේ සුපුරුදු සෙවුම් යන්ත්‍රය බවට පත් කිරීමෙන් ඔබ පිවිසෙන වෙබ් අඩවි වලට පෞද්ගලිකත්වය එක් කිරීමට මෙම "
-"බ්‍රව්සර් අවසර භාවිතා කරයි."
+"සැඟවුණු ට්‍රැකර් අවහිර කිරීමෙන්, හැකි සෑම තැනකම සම්බන්ධතා සංකේතනය කිරීමෙන් "
+"සහ DuckDuckGo ඔබේ සුපුරුදු සෙවුම් යන්ත්‍රය බවට පත් කිරීමෙන් ඔබ පිවිසෙන වෙබ් "
+"අඩවි වලට පෞද්ගලිකත්වය එක් කිරීමට මෙම බ්‍රව්සර් අවසර භාවිතා කරයි."
 
 # smartling.placeholder_format=C
 #. Secondary line under DUCKCHAT_SYNC_PAIRING_ALREADY_SYNCED_TITLE.
@@ -19652,8 +19798,8 @@ msgid ""
 "This AI model is no longer available. Try starting a new chat with a "
 "different model."
 msgstr ""
-"මෙම AI ආකෘතිය තවදුරටත් ලබා ගත නොහැක. වෙනස් ආකෘතියක් සමඟ නව කතාබස් ආරම්භ කිරීමට උත්සාහ "
-"කරන්න."
+"මෙම AI ආකෘතිය තවදුරටත් ලබා ගත නොහැක. වෙනස් ආකෘතියක් සමඟ නව කතාබස් ආරම්භ "
+"කිරීමට උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is no longer supported because it has been upgraded to a newest version.
@@ -19662,8 +19808,8 @@ msgid ""
 "This AI model version is no longer supported. Try starting a new chat with "
 "the latest version of this model."
 msgstr ""
-"මෙම AI ආකෘති අනුවාදය තවදුරටත් සහය නොදක්වයි. මෙම ආකෘතියේ නවතම අනුවාදය සමඟ නව කතාබහක් "
-"ආරම්භ කරන්න."
+"මෙම AI ආකෘති අනුවාදය තවදුරටත් සහය නොදක්වයි. මෙම ආකෘතියේ නවතම අනුවාදය සමඟ නව "
+"කතාබහක් ආරම්භ කරන්න."
 
 # smartling.placeholder_format=C
 #. Appears below a type of search results called 'Instant Answers'
@@ -19690,8 +19836,9 @@ msgid ""
 "This conversation was generated with Duck.ai (%s) using %s's %s Model. AI "
 "chats may display inaccurate or offensive information (see %s for more info)."
 msgstr ""
-"මෙම සංවාදය Duck.ai (%1$s) සමඟ ජනනය කරන ලද්දේ %2$sගේ %3$s ආකෘතිය භාවිත කරමිනි. AI "
-"කතාබස් සාවද්‍ය හෝ අපහාසාත්මක තොරතුරු ප්‍රදර්ශනය කළ හැකිය (වැඩි විස්තර සඳහා %4$s බලන්න)."
+"මෙම සංවාදය Duck.ai (%1$s) සමඟ ජනනය කරන ලද්දේ %2$sගේ %3$s ආකෘතිය භාවිත "
+"කරමිනි. AI කතාබස් සාවද්‍ය හෝ අපහාසාත්මක තොරතුරු ප්‍රදර්ශනය කළ හැකිය (වැඩි "
+"විස්තර සඳහා %4$s බලන්න)."
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with multiple AI models in the same chat, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using multiple chat models. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -19701,8 +19848,8 @@ msgid ""
 "models. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
 msgstr ""
-"බහු කතාබස් ආකෘති භාවිත කරමින් Duck.ai (%1$s) සමඟ මෙම සංවාදය ජනනය කරන ලදී. AI කතාබස් "
-"සාවද්‍ය හෝ අහිතකර තොරතුරු පෙන්විය හැකිය (වැඩි විස්තර සඳහා %2$s බලන්න)."
+"බහු කතාබස් ආකෘති භාවිත කරමින් Duck.ai (%1$s) සමඟ මෙම සංවාදය ජනනය කරන ලදී. AI "
+"කතාබස් සාවද්‍ය හෝ අහිතකර තොරතුරු පෙන්විය හැකිය (වැඩි විස්තර සඳහා %2$s බලන්න)."
 
 # smartling.placeholder_format=C
 #. When a user exports a transcript of a voice chat they had with the AI. This text goes at the very top of the downloaded file as a header. Placeholders are for links. Example: 'This conversation was generated with Duck.ai voice chat (https://duck.ai). AI may provide inaccurate or offensive information. (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -19711,8 +19858,8 @@ msgid ""
 "This conversation was generated with Duck.ai voice chat (%s). AI may provide "
 "inaccurate or offensive information. (see %s for more info)."
 msgstr ""
-"මෙම සංවාදය Duck.ai හඬ කතාබස් (%1$s) සමඟින් ජනනය කරන ලදී. AI මඟින් සාවද්‍ය හෝ අහිතකර "
-"තොරතුරු සැපයිය හැකිය. (වැඩිදුර තොරතුරු සඳහා %2$s බලන්න)."
+"මෙම සංවාදය Duck.ai හඬ කතාබස් (%1$s) සමඟින් ජනනය කරන ලදී. AI මඟින් සාවද්‍ය හෝ "
+"අහිතකර තොරතුරු සැපයිය හැකිය. (වැඩිදුර තොරතුරු සඳහා %2$s බලන්න)."
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with DuckDuckGo AI Chat (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/aichat/privacy-terms for more info).'
@@ -19723,8 +19870,8 @@ msgid ""
 "more info)."
 msgstr ""
 "මෙම සංවාදය DuckDuckGo AI Chat (%1$s) සමඟ ජනනය කරන ලද්දේ %2$sහි %3$s ආකෘතිය "
-"භාවිතා කරමිනි. AI කතාබස් සාවද්‍ය හෝ වැරදිසහගත තොරතුරු ප්‍රදර්ශනය කළ හැකිය (වැඩි විස්තර සඳහා "
-"%4$s බලන්න)."
+"භාවිතා කරමිනි. AI කතාබස් සාවද්‍ය හෝ වැරදිසහගත තොරතුරු ප්‍රදර්ශනය කළ හැකිය "
+"(වැඩි විස්තර සඳහා %4$s බලන්න)."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
@@ -19828,8 +19975,8 @@ msgid ""
 "This model provider deletes data associated with this chat within 30 days. "
 "Other model providers follow a zero data retention model."
 msgstr ""
-"මෙම ආකෘති සැපයුම්කරු දින 30ක් ඇතුළත මෙම කතාබහ හා සම්බන්ධ දත්ත මකා දමයි. අනෙකුත් ආකෘති "
-"සපයන්නන් ශුන්‍ය දත්ත රඳවා ගැනීමේ ආකෘතියක් අනුගමනය කරයි."
+"මෙම ආකෘති සැපයුම්කරු දින 30ක් ඇතුළත මෙම කතාබහ හා සම්බන්ධ දත්ත මකා දමයි. "
+"අනෙකුත් ආකෘති සපයන්නන් ශුන්‍ය දත්ත රඳවා ගැනීමේ ආකෘතියක් අනුගමනය කරයි."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers, and that other providers may retain chat data for a limited time instead.
@@ -19838,8 +19985,8 @@ msgid ""
 "This model provider does not store any data associated with this chat. Other "
 "model providers follow a limited data retention model."
 msgstr ""
-"මෙම ආකෘති සැපයුම්කරු මෙම කතාබහ හා සම්බන්ධ කිසිදු දත්තයක් ගබඩා නොකරයි. අනෙකුත් ආකෘති සපයන්නන් "
-"සීමිත දත්ත රඳවා ගැනීමේ ආකෘතියක් අනුගමනය කරයි."
+"මෙම ආකෘති සැපයුම්කරු මෙම කතාබහ හා සම්බන්ධ කිසිදු දත්තයක් ගබඩා නොකරයි. "
+"අනෙකුත් ආකෘති සපයන්නන් සීමිත දත්ත රඳවා ගැනීමේ ආකෘතියක් අනුගමනය කරයි."
 
 # smartling.placeholder_format=C
 #. Info that page may refresh during update.
@@ -19876,8 +20023,8 @@ msgid ""
 "This saves your chats with end-to-end encryption on DuckDuckGo's secure "
 "server, which later can be accessed from any browser."
 msgstr ""
-"මෙය DuckDuckGo ආරක්ෂිත සේවාදායකයේ ඔබේ කතාබස් මුල සිට අග දක්වා ගුප්ත කේතනය සමඟ සුරකින "
-"අතර පසුව ඕනෑම බ්රවුසරයකින් ඒවාට ප්රවේශ විය හැකිය."
+"මෙය DuckDuckGo ආරක්ෂිත සේවාදායකයේ ඔබේ කතාබස් මුල සිට අග දක්වා ගුප්ත කේතනය "
+"සමඟ සුරකින අතර පසුව ඕනෑම බ්රවුසරයකින් ඒවාට ප්රවේශ විය හැකිය."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -19886,8 +20033,8 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again."
 msgstr ""
-"මෙම සැකසුම ඔබේ බ්‍රව්සරයේ ගබඩා වේ, එයින් අදහස් වන්නේ ඔබ duckduckgo.com බ්‍රව්සර දත්ත මකා "
-"දැමුවහොත්, ඔබට නැවත AI සහාය සහිත පිළිතුරු දැකිය හැක."
+"මෙම සැකසුම ඔබේ බ්‍රව්සරයේ ගබඩා වේ, එයින් අදහස් වන්නේ ඔබ duckduckgo.com "
+"බ්‍රව්සර දත්ත මකා දැමුවහොත්, ඔබට නැවත AI සහාය සහිත පිළිතුරු දැකිය හැක."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -19897,9 +20044,9 @@ msgid ""
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
 msgstr ""
-"මෙම සැකසුම ඔබේ බ්‍රව්සරයේ ගබඩා වේ, එයින් අදහස් වන්නේ ඔබ duckduckgo.com බ්‍රව්සර දත්ත මකා "
-"දැමුවහොත්, ඔබට නැවත AI සහාය සහිත පිළිතුරු දැකිය හැක. කෙසේ වෙතත්, අපට %1$s හි AI-සහය "
-"සහිත පිළිතුරු කිසිවිටෙකත් පෙන්වන ආරම්භක පිටුවක් ඇත."
+"මෙම සැකසුම ඔබේ බ්‍රව්සරයේ ගබඩා වේ, එයින් අදහස් වන්නේ ඔබ duckduckgo.com "
+"බ්‍රව්සර දත්ත මකා දැමුවහොත්, ඔබට නැවත AI සහාය සහිත පිළිතුරු දැකිය හැක. කෙසේ "
+"වෙතත්, අපට %1$s හි AI-සහය සහිත පිළිතුරු කිසිවිටෙකත් පෙන්වන ආරම්භක පිටුවක් ඇත."
 
 # smartling.placeholder_format=C
 #. User feedback indicating that a translation is helpful
@@ -19938,9 +20085,9 @@ msgid ""
 "Sync & Backup. You'll still be able to access your chats in other browsers "
 "connected to Sync & Backup."
 msgstr ""
-"මින් ඔබගේ සියලුම Duck.ai කතාබස් මෙම බ්‍රව්සරයෙන් මකා දමා Sync & Backup විසන්ධි කරයි. Sync "
-"& Backup ට සම්බන්ධ කර ඇති අනෙකුත් බ්‍රව්සර්වලින් ඔයාට තවමත් ඔයාගේ කතාබස් වෙත ප්‍රවේශ වීමට "
-"හැකි වනු ඇත."
+"මින් ඔබගේ සියලුම Duck.ai කතාබස් මෙම බ්‍රව්සරයෙන් මකා දමා Sync & Backup "
+"විසන්ධි කරයි. Sync & Backup ට සම්බන්ධ කර ඇති අනෙකුත් බ්‍රව්සර්වලින් ඔයාට "
+"තවමත් ඔයාගේ කතාබස් වෙත ප්‍රවේශ වීමට හැකි වනු ඇත."
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to clear all recentchats, with a warning that this action cannot be undone.
@@ -19949,7 +20096,8 @@ msgid ""
 "This will delete all your recent chats, unless they're pinned. This cannot "
 "be undone."
 msgstr ""
-"මෙය ඔයාගේ මෑත කාලීන කතාබස් සියල්ල මකා දමයි, ඒවා අමුණලා නැත්නම්. මෙය ආපසු හැරවිය නොහැක."
+"මෙය ඔයාගේ මෑත කාලීන කතාබස් සියල්ල මකා දමයි, ඒවා අමුණලා නැත්නම්. මෙය ආපසු "
+"හැරවිය නොහැක."
 
 # smartling.placeholder_format=C
 #. Message explaining what will happen when the user deletes an image.
@@ -20087,8 +20235,8 @@ msgid ""
 "To print directions:%sGo back to the map.%sSelect the route you want to "
 "print.%sClick the print icon.%s"
 msgstr ""
-"දිශාවන් මුද්‍රණය කිරීම සඳහා:%1$sසිතියම වෙත ආපසු යන්න.%2$sඔබට මුද්‍රණය කිරීමට අවශ්‍ය මාර්ගය "
-"තෝරන්න.%3$sමුද්‍රණ නිරූපකය ක්ලික් කරන්න.%4$s"
+"දිශාවන් මුද්‍රණය කිරීම සඳහා:%1$sසිතියම වෙත ආපසු යන්න.%2$sඔබට මුද්‍රණය කිරීමට "
+"අවශ්‍ය මාර්ගය තෝරන්න.%3$sමුද්‍රණ නිරූපකය ක්ලික් කරන්න.%4$s"
 
 # smartling.placeholder_format=C
 #. Explains where the user can find their recovery code. Figma frame 3703-44420.
@@ -20098,9 +20246,9 @@ msgid ""
 "you first set up Sync. This code may have been saved as a PDF on the device "
 "you originally used to set up Sync."
 msgstr ""
-"ඔබේ සමමුහුර්ත කළ දත්ත ප්‍රතිසාධනය කිරීම සඳහා ඔබ විසින් පළමු වරට සමමුහුර්ත කිරීම සැකසීමේ දී සුරකින "
-"ලද ප්‍රතිසාධන කේතය අවශ්‍ය වනු ඇත. මෙම කේතය ඔබ මුල් වරට සමමුහු සැකසීමට භාවිතා කළ උපාංගයේ "
-"PDF ගොනුවක් ලෙස සුරැකී තිබිය හැකිය."
+"ඔබේ සමමුහුර්ත කළ දත්ත ප්‍රතිසාධනය කිරීම සඳහා ඔබ විසින් පළමු වරට සමමුහුර්ත "
+"කිරීම සැකසීමේ දී සුරකින ලද ප්‍රතිසාධන කේතය අවශ්‍ය වනු ඇත. මෙම කේතය ඔබ මුල් "
+"වරට සමමුහු සැකසීමට භාවිතා කළ උපාංගයේ PDF ගොනුවක් ලෙස සුරැකී තිබිය හැකිය."
 
 # smartling.placeholder_format=C
 #. Body text explaining that the user needs to update their DDG browser before migration can proceed.
@@ -20109,8 +20257,8 @@ msgid ""
 "To transfer your chat history to Duck.ai, please update your DuckDuckGo "
 "browser to the latest version and try again."
 msgstr ""
-"ඔබේ කතාබස් ඉතිහාසය Duck.ai වෙත මාරු කිරීමට, කරුණාකර ඔබේ DuckDuckGo බ්‍රවුසරය නවතම "
-"අනුවාදයට යාවත්කාලීන කර නැවත උත්සාහ කරන්න."
+"ඔබේ කතාබස් ඉතිහාසය Duck.ai වෙත මාරු කිරීමට, කරුණාකර ඔබේ DuckDuckGo බ්‍රවුසරය "
+"නවතම අනුවාදයට යාවත්කාලීන කර නැවත උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
@@ -20118,8 +20266,8 @@ msgid ""
 "To use dictation, allow your browser to access the microphone in your system "
 "settings."
 msgstr ""
-"අසා ලිවීම භාවිත කිරීමට, ඔබේ පද්ධති සැකසුම් තුළින් මයික්‍රොෆෝනය වෙත ප්‍රවේශ වීමට ඔබේ බ්‍රවුසරයට ඉඩ "
-"දෙන්න."
+"අසා ලිවීම භාවිත කිරීමට, ඔබේ පද්ධති සැකසුම් තුළින් මයික්‍රොෆෝනය වෙත ප්‍රවේශ "
+"වීමට ඔබේ බ්‍රවුසරයට ඉඩ දෙන්න."
 
 # smartling.placeholder_format=C
 msgid "Today"
@@ -20309,8 +20457,8 @@ msgid ""
 "Tracking attempts blocked by DuckDuckGo appear here. Keep browsing to see "
 "how many we block."
 msgstr ""
-"DuckDuckGo විසින් අවහිර කළ නිරීක්ෂණය කිරීමේ ප්‍රයත්න මෙහි දිස් වේ.අපි කොපමණ ප්‍රමාණයක් අවහිර "
-"කරනවාදැයි බැලීමට බ්‍රවුස් කරන්න."
+"DuckDuckGo විසින් අවහිර කළ නිරීක්ෂණය කිරීමේ ප්‍රයත්න මෙහි දිස් වේ.අපි කොපමණ "
+"ප්‍රමාණයක් අවහිර කරනවාදැයි බැලීමට බ්‍රවුස් කරන්න."
 
 # smartling.placeholder_format=C
 #. Placeholder for when we cannot report any blocked trackers yet
@@ -20358,8 +20506,8 @@ msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
 msgstr ""
-"මෙම ඉංග්‍රීසි වාක්‍යය ප්‍රංශ භාෂාවට පරිවර්තනය කරන්න: \"මම ළඟම ඇති චිත්‍රපට ශාලාවට යන්නේ "
-"කෙසේද?\""
+"මෙම ඉංග්‍රීසි වාක්‍යය ප්‍රංශ භාෂාවට පරිවර්තනය කරන්න: \"මම ළඟම ඇති චිත්‍රපට "
+"ශාලාවට යන්නේ කෙසේද?\""
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for translating a sentence into another language. Translate the whole sentence and please use target language instead of 'English' and modify the sentence to translate into 'English' instead of 'French'. Example: 'Translate this {target language} sentence into English: “How do I get to the nearest movie theatre?”'
@@ -20368,20 +20516,20 @@ msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
 msgstr ""
-"මෙම ඉංග්‍රීසි වාක්‍යය ප්‍රංශ භාෂාවට පරිවර්තනය කරන්න: \"මම ළඟම ඇති චිත්‍රපට ශාලාවට යන්නේ "
-"කෙසේද?\""
+"මෙම ඉංග්‍රීසි වාක්‍යය ප්‍රංශ භාෂාවට පරිවර්තනය කරන්න: \"මම ළඟම ඇති චිත්‍රපට "
+"ශාලාවට යන්නේ කෙසේද?\""
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Translate this page"
-msgstr ""
+msgstr "මෙම පිටුව පරිවර්තනය කරන්න"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
 msgctxt "Page suggestion prompt"
 msgid "Translate this page into %s."
-msgstr ""
+msgstr "මෙම පිටුව %1$s භාෂාවට පරිවර්තනය කරන්න."
 
 # smartling.placeholder_format=C
 #. Placeholder text for a region that will display translated text.
@@ -20528,7 +20676,7 @@ msgstr "නොමිලේ අත්හදා බලන්න"
 #. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
 msgctxt "settings"
 msgid "Try It Now"
-msgstr ""
+msgstr "දැන් අත්හදා බලන්න"
 
 # smartling.placeholder_format=C
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -20586,7 +20734,9 @@ msgstr "වෙනත් වචන සමග උත්සාහ කරන්න."
 # smartling.placeholder_format=C
 #. Prompt encouraging the user to turn off their ad blocker to see more results for their query.
 msgid "Try disabling your ad blocker on DuckDuckGo to see more results."
-msgstr "තවත් ප්‍රතිඵල දැකීමට DuckDuckGo හි ඔබේ දැන්වීම් අවහිරකරණය අබල කිරීමට උත්සාහ කරන්න."
+msgstr ""
+"තවත් ප්‍රතිඵල දැකීමට DuckDuckGo හි ඔබේ දැන්වීම් අවහිරකරණය අබල කිරීමට උත්සාහ "
+"කරන්න."
 
 # smartling.placeholder_format=C
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
@@ -20599,7 +20749,9 @@ msgstr "වඩාත් නිවැරදි ප්‍රතිඵල සඳහ
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr "එක් එක් ආකෘතිය සමඟ අත්හදා බැලීමට උත්සාහ කරන්න - ඔවුන් විවිධ ප්‍රතිචාර ලබා දෙනු ඇත."
+msgstr ""
+"එක් එක් ආකෘතිය සමඟ අත්හදා බැලීමට උත්සාහ කරන්න - ඔවුන් විවිධ ප්‍රතිචාර ලබා "
+"දෙනු ඇත."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
@@ -20769,6 +20921,8 @@ msgid ""
 "Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
+"AI විශේෂාංග අක්‍රීය කිරීමට උත්සාහ කරනවා ද? ඔයාගේ සැකසුම් මතක තබා ගැනීමට "
+"%1$sDuckDuckGo No AI%2$s සෙවුම් දිගුව ස්ථාපනය කරන්න. %3$sවැඩිදුර දැනගන්න%4$s"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -20777,6 +20931,8 @@ msgid ""
 "Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
+"AI විශේෂාංග අක්‍රීය කිරීමට උත්සාහ කරනවා ද? ඔබේ සැකසුම් මතක තබා ගැනීමට "
+"%1$sDuckDuckGo No AI%2$s සෙවුම් දිගුව වෙත මාරු වෙන්න. %3$sවැඩිදුර දැනගන්න%4$s"
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -20947,8 +21103,8 @@ msgid ""
 "Types out DuckAssist answers as they're generated. Turning this off may "
 "result in a short delay between a search and the answer being displayed."
 msgstr ""
-"DuckAssist පිළිතුරු උත්පාදනය වන විට ඒවා ටයිප් කරයි. මෙය ක්‍රියාවිරහිත කිරීමෙන් සෙවීමක් සහ "
-"ප්‍රදර්ශනය වන පිළිතුර අතර කෙටි ප්‍රමාදයක් ඇති විය හැක."
+"DuckAssist පිළිතුරු උත්පාදනය වන විට ඒවා ටයිප් කරයි. මෙය ක්‍රියාවිරහිත "
+"කිරීමෙන් සෙවීමක් සහ ප්‍රදර්ශනය වන පිළිතුර අතර කෙටි ප්‍රමාදයක් ඇති විය හැක."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -21078,8 +21234,8 @@ msgid ""
 "Under %sOn startup%s, click %sOpen a specific page%s then click %sSet "
 "Pages%s."
 msgstr ""
-"%1$sOn startup%2$s වලට පහළින්, %3$sOpen a specific page%4$s ක්ලික් කර %5$sSet "
-"Pages%6$s මත ක්ලික් කරන්න."
+"%1$sOn startup%2$s වලට පහළින්, %3$sOpen a specific page%4$s ක්ලික් කර "
+"%5$sSet Pages%6$s මත ක්ලික් කරන්න."
 
 #  Maxthon homepage instruction
 # smartling.placeholder_format=C
@@ -21087,8 +21243,8 @@ msgstr ""
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
 msgstr ""
-"%1$sOn startup%2$s වලට පහළීන් ඇති, %3$sHomepage%4$s තෝරාගෙන ඇතුළු කරන්න: https://"
-"duckduckgo.com"
+"%1$sOn startup%2$s වලට පහළීන් ඇති, %3$sHomepage%4$s තෝරාගෙන ඇතුළු කරන්න: "
+"https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -21204,8 +21360,8 @@ msgid ""
 "Unlock %s, higher AI reasoning, and 2x higher usage limits than the Plus "
 "plan by upgrading to Pro."
 msgstr ""
-"Pro වෙත උත්ශ්‍රේණිගත කිරීමෙන් %1$s, වඩා ඉහළ AI තර්කනයක් සහ Plus සැලැස්මට වඩා 2 ගුණයක් "
-"ඉහළ AI පරිශීලන සීමා අගුළු හැර ගන්න."
+"Pro වෙත උත්ශ්‍රේණිගත කිරීමෙන් %1$s, වඩා ඉහළ AI තර්කනයක් සහ Plus සැලැස්මට වඩා "
+"2 ගුණයක් ඉහළ AI පරිශීලන සීමා අගුළු හැර ගන්න."
 
 # smartling.placeholder_format=C
 #. Title for the subscription promo shown in the SERP sidemenu.
@@ -21339,8 +21495,8 @@ msgid ""
 "Update the DuckDuckGo browser to activate your subscription in Duck.ai and "
 "access advanced models"
 msgstr ""
-"Duck.ai හි ඔබේ දායකත්වය සක්රිය කිරීමට සහ උසස් ආකෘති වෙත ප්‍රවේශ වීමට DuckDuckGo බ්‍රවුසරය "
-"යාවත්කාලීන කරන්න"
+"Duck.ai හි ඔබේ දායකත්වය සක්රිය කිරීමට සහ උසස් ආකෘති වෙත ප්‍රවේශ වීමට "
+"DuckDuckGo බ්‍රවුසරය යාවත්කාලීන කරන්න"
 
 # smartling.placeholder_format=C
 #. The placeholder indicates a formatted date (e.g., 'Updated 2 days ago')
@@ -21465,15 +21621,16 @@ msgid ""
 "Upgrade to Pro to unlock 2x higher limits than Plus, or come back later to "
 "create more images."
 msgstr ""
-"Plus ප්‍රකාරයට වඩා දෙගුණයකින් ඉහළ සීමාවන් අගුළු ඇරීමට Pro වෙත උත්ශ්‍රේණිගත කරන්න, නැත්නම් තවත් "
-"රූප නිර්මාණය කිරීමට පසුව නැවත එන්න."
+"Plus ප්‍රකාරයට වඩා දෙගුණයකින් ඉහළ සීමාවන් අගුළු ඇරීමට Pro වෙත උත්ශ්‍රේණිගත "
+"කරන්න, නැත්නම් තවත් රූප නිර්මාණය කිරීමට පසුව නැවත එන්න."
 
 # smartling.placeholder_format=C
 #. Upsell message shown in the voice chat limit and duration limit modals for Plus subscribers, encouraging them to upgrade to Pro.
 msgctxt "voice chat limit modal"
 msgid "Upgrade to Pro to unlock 2x higher usage limits than Plus"
 msgstr ""
-"Plus ප්‍රකාරයට වඩා දෙගුණයකින් පුළුල් පරිශීලන සීමා අගුළු හැර ගැනීමට Pro වෙත උත්ශ්‍රේණිගත කරන්න"
+"Plus ප්‍රකාරයට වඩා දෙගුණයකින් පුළුල් පරිශීලන සීමා අගුළු හැර ගැනීමට Pro වෙත "
+"උත්ශ්‍රේණිගත කරන්න"
 
 # smartling.placeholder_format=C
 #. Heading in a promotion for a desktop web browser
@@ -21525,7 +21682,7 @@ msgstr "උරුගුවේ"
 #. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
 msgctxt "Navigation label on the Duck.ai settings page"
 msgid "Usage"
-msgstr ""
+msgstr "භාවිතය"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -21569,9 +21726,9 @@ msgid ""
 "Use ChatGPT, Claude, and other AIs, privately. Protect chats from hackers, "
 "scammers, and companies. Keep info confidential. Free. No account required."
 msgstr ""
-"ChatGPT, Claude, සහ අනෙකුත් AI පද්ධති පුද්ගලිකව භාවිත කරන්න. හැකර්වරුන්, වංචාකරුවන් සහ "
-"සමාගම් වලින් ඔබේ කතාබස් ආරක්ෂා කරගන්න. තොරතුරු රහසිගතව තබා ගන්න. ගාස්තු රහිතයි. ගිණුමක් අවශ්‍ය "
-"නොවේ."
+"ChatGPT, Claude, සහ අනෙකුත් AI පද්ධති පුද්ගලිකව භාවිත කරන්න. හැකර්වරුන්, "
+"වංචාකරුවන් සහ සමාගම් වලින් ඔබේ කතාබස් ආරක්ෂා කරගන්න. තොරතුරු රහසිගතව තබා "
+"ගන්න. ගාස්තු රහිතයි. ගිණුමක් අවශ්‍ය නොවේ."
 
 # smartling.placeholder_format=C
 #. Header above instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -21613,8 +21770,8 @@ msgctxt "Description for the recovery section inside Manage"
 msgid ""
 "Use this code to restore your saved chats if you lose access to your devices."
 msgstr ""
-"ඔබේ උපාංගවලට ප්‍රවේශය අහිමි වුණොත් ඔබේ සුරකින ලද කතාබස් ප්‍රතිසාධනය කිරීමට මේ කේතය භාවිතා "
-"කරන්න."
+"ඔබේ උපාංගවලට ප්‍රවේශය අහිමි වුණොත් ඔබේ සුරකින ලද කතාබස් ප්‍රතිසාධනය කිරීමට "
+"මේ කේතය භාවිතා කරන්න."
 
 # smartling.placeholder_format=C
 #. Prompt to ask the user if they want to use their approximate location for more accurate results
@@ -21764,8 +21921,8 @@ msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Microsoft's ad network"
 msgstr ""
-"දැන්වීම් බැලීම DuckDuckGo මගින් පුද්ගලිකත්වය ආරක්ෂා කරයි. දැන්වීම් ක්ලික් කිරීම් කළමනාකරණය කරනු "
-"ලබන්නේ Microsoftහි දැන්වීම් ජාලය විසිනි"
+"දැන්වීම් බැලීම DuckDuckGo මගින් පුද්ගලිකත්වය ආරක්ෂා කරයි. දැන්වීම් ක්ලික් "
+"කිරීම් කළමනාකරණය කරනු ලබන්නේ Microsoftහි දැන්වීම් ජාලය විසිනි"
 
 # smartling.placeholder_format=C
 #. Information about TripAdvisor ads for DuckDuckGo's users. This appears in a tooltip.
@@ -21774,8 +21931,8 @@ msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "TripAdvisor's ad network."
 msgstr ""
-"දැන්වීම් බැලීම DuckDuckGo මගින් පුද්ගලිකත්වය ආරක්ෂා කරයි. දැන්වීම් ක්ලික් කිරීම් TripAdvisor හි "
-"දැන්වීම් ජාලය විසින් කළමනාකරණය කරනු ලැබේ."
+"දැන්වීම් බැලීම DuckDuckGo මගින් පුද්ගලිකත්වය ආරක්ෂා කරයි. දැන්වීම් ක්ලික් "
+"කිරීම් TripAdvisor හි දැන්වීම් ජාලය විසින් කළමනාකරණය කරනු ලැබේ."
 
 # smartling.placeholder_format=C
 msgid "Virgin Islands"
@@ -21787,8 +21944,8 @@ msgctxt "duckassist"
 msgid ""
 "Visit %sAssist Settings%s to adjust how this feature works or turn it off."
 msgstr ""
-"මෙම විශේෂාංගය ක්‍රියා කරන ආකාරය සකස් කිරීමට හෝ එය අක්‍රිය කිරීමට %1$sAssist සැකසුම්%2$s "
-"වෙත පිවිසෙන්න."
+"මෙම විශේෂාංගය ක්‍රියා කරන ආකාරය සකස් කිරීමට හෝ එය අක්‍රිය කිරීමට %1$sAssist "
+"සැකසුම්%2$s වෙත පිවිසෙන්න."
 
 # smartling.placeholder_format=C
 #. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
@@ -21797,8 +21954,8 @@ msgid ""
 "Visit %sDuckAssist Settings%s to adjust how this feature works or turn it "
 "off."
 msgstr ""
-"මෙම විශේෂාංගය ක්‍රියා කරන ආකාරය සකස් කිරීමට හෝ එය අක්‍රිය කිරීමට %1$sDuckAssist "
-"සැකසුම්%2$s වෙත පිවිසෙන්න."
+"මෙම විශේෂාංගය ක්‍රියා කරන ආකාරය සකස් කිරීමට හෝ එය අක්‍රිය කිරීමට "
+"%1$sDuckAssist සැකසුම්%2$s වෙත පිවිසෙන්න."
 
 # smartling.placeholder_format=C
 #. Prompt to visit DuckDuckGo on another device.
@@ -21807,8 +21964,8 @@ msgid ""
 "Visit %sDuckDuckGo.com%s on your tablet or phone and follow the provided "
 "instructions."
 msgstr ""
-"%1$sDuckDuckGo.com%2$s වෙතට ඔබගේ දුරකථනයෙන් හෝ ටැබ්ලට් එකෙන් පැමිණ සපයා ඇති උපදෙස් "
-"පිළිපදින්න."
+"%1$sDuckDuckGo.com%2$s වෙතට ඔබගේ දුරකථනයෙන් හෝ ටැබ්ලට් එකෙන් පැමිණ සපයා ඇති "
+"උපදෙස් පිළිපදින්න."
 
 # smartling.placeholder_format=C
 #. Primary button to visit Duck.ai.
@@ -21823,9 +21980,9 @@ msgid ""
 "Visit Duck.ai in your other browser and go to %sDuck.ai Settings%s > %sSync "
 "& Backup%s > %sManage%s then select %sSync With Another Device%s."
 msgstr ""
-"ඔබගේ අනෙක් බ්‍රව්සරයෙන් Duck.ai වෙත පිවිස %1$sDuck.ai සැකසීම්%2$s > %3$sSync & "
-"Backup%4$s > %5$sකළමනාකරණය කරන්න%6$s වෙත ගොස් %7$sවෙනත් උපාංගයක් සමඟ සමමුහුර්ත "
-"කරන්න%8$s තෝරන්න."
+"ඔබගේ අනෙක් බ්‍රව්සරයෙන් Duck.ai වෙත පිවිස %1$sDuck.ai සැකසීම්%2$s > %3$sSync "
+"& Backup%4$s > %5$sකළමනාකරණය කරන්න%6$s වෙත ගොස් %7$sවෙනත් උපාංගයක් සමඟ "
+"සමමුහුර්ත කරන්න%8$s තෝරන්න."
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -21835,9 +21992,9 @@ msgid ""
 "On” under Sync & Backup and select “Sync With Another Device”. Or scan the "
 "QR on your Recovery PDF."
 msgstr ""
-"ඔබගේ අනෙක් බ්‍රවුසරයෙන් Duck.ai වෙත පිවිස Duck.ai සැකසුම් විවෘත කරන්න. “Turn On” තෝරන්න "
-"Sync & Backup යටතේ, “තවත් උපාංගයක් සමඟ සමමුහුර්ත කරන්න” තෝරන්න. නැතහොත් ඔබගේ ප්‍රතිසාධන "
-"PDF එකේ QR ස්කෑන් කරන්න."
+"ඔබගේ අනෙක් බ්‍රවුසරයෙන් Duck.ai වෙත පිවිස Duck.ai සැකසුම් විවෘත කරන්න. “Turn "
+"On” තෝරන්න Sync & Backup යටතේ, “තවත් උපාංගයක් සමඟ සමමුහුර්ත කරන්න” තෝරන්න. "
+"නැතහොත් ඔබගේ ප්‍රතිසාධන PDF එකේ QR ස්කෑන් කරන්න."
 
 # smartling.placeholder_format=C
 #. Shared body copy for every screen in the Sync Another Device flow (QR display, camera scan, camera-unavailable fallback, manual entry). Bold tags wrap navigation breadcrumbs. Render with <Translate /> so the HTML is interpreted; plain `translate()` will trip the html-string warning.
@@ -21859,9 +22016,10 @@ msgid ""
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
 msgstr ""
-"ඔබගේ අනෙක් බ්‍රවුසරයෙන් හෝ DuckDuckGo යෙදුමෙන් Duck.ai වෙත පිවිස Duck.ai සැකසුම් විවෘත "
-"කරන්න. “ක්‍රියාත්මක කරන්න” තෝරා Sync & Backup යටතේ, “තවත් උපාංගයක් සමග සමමුහුර්ත කරන්න” "
-"තෝරන්න. නැතහොත් ඔබගේ ප්‍රතිසාධන PDF ගොනුවේ QR කේතය ස්කෑන් කරන්න."
+"ඔබගේ අනෙක් බ්‍රවුසරයෙන් හෝ DuckDuckGo යෙදුමෙන් Duck.ai වෙත පිවිස Duck.ai "
+"සැකසුම් විවෘත කරන්න. “ක්‍රියාත්මක කරන්න” තෝරා Sync & Backup යටතේ, “තවත් "
+"උපාංගයක් සමග සමමුහුර්ත කරන්න” තෝරන්න. නැතහොත් ඔබගේ ප්‍රතිසාධන PDF ගොනුවේ QR "
+"කේතය ස්කෑන් කරන්න."
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -21914,7 +22072,8 @@ msgstr "හඬ කතාබහ අවසන්"
 msgctxt "voice chat"
 msgid "Voice chat is anonymized by us, and never used to train AI models."
 msgstr ""
-"හඬ කතාබස් අපි නිර්නාමික කරලා තියෙනවා, AI ආකෘති පුහුණු කිරීමට කිසි විටෙකත් භාවිතා කරන්නේ නැහැ."
+"හඬ කතාබස් අපි නිර්නාමික කරලා තියෙනවා, AI ආකෘති පුහුණු කිරීමට කිසි විටෙකත් "
+"භාවිතා කරන්නේ නැහැ."
 
 # smartling.placeholder_format=C
 #. Title of the modal shown when the user has reached their daily voice chat limit.
@@ -21978,7 +22137,7 @@ msgstr "වේල්ස්"
 #. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Walk me through the steps"
-msgstr ""
+msgstr "පියවර හරහා මට මඟ පෙන්වන්න"
 
 # smartling.placeholder_format=C
 #. Label for walking directions on a map.
@@ -22058,8 +22217,8 @@ msgid ""
 "Watch in Duck Player to block personalized ads on YouTube and prevent your "
 "viewing activity from influencing YouTube recommendations."
 msgstr ""
-"YouTube හි පුද්ගලාරෝපිත දැන්වීම් අවහිර කිරීමට සහ යූ ටියුබ් නිර්දේශයන්ට බලපෑම් කිරීමෙන් ඔබේ නැරඹීමේ "
-"ක්රියාකාරකම් වළක්වා ගැනීමට Duck Player හි නරඹන්න."
+"YouTube හි පුද්ගලාරෝපිත දැන්වීම් අවහිර කිරීමට සහ යූ ටියුබ් නිර්දේශයන්ට "
+"බලපෑම් කිරීමෙන් ඔබේ නැරඹීමේ ක්රියාකාරකම් වළක්වා ගැනීමට Duck Player හි නරඹන්න."
 
 # smartling.placeholder_format=C
 #. A button that takes a user to another site in order to watch a video. The placeholder is the name of the video site. For example: 'Watch on Vimeo'
@@ -22079,9 +22238,10 @@ msgid ""
 "independent company and has no relationship with YouTube, where most videos "
 "are hosted."
 msgstr ""
-"මෙහි වීඩියෝවක් නැරඹීම යන්නෙන් අදහස් කරන්නේ එහි සත්කාරකත්වය දරන වෙබ් අඩවියට ඔබව නිරීක්ෂණය කළ "
-"හැකි බව වන අතර, ඊට හේතුව අප එහි සිට අන්තර්ගතය විකාශය කළ යුතු වීමයි. DuckDuckGo යනු ස්වාධීන "
-"සමාගමක් වන අතර බොහෝ වීඩියෝ දර්ශන සත්කාරකත්වය සපයන YouTube සමඟ කිසිදු සම්බන්ධයක් නොමැත."
+"මෙහි වීඩියෝවක් නැරඹීම යන්නෙන් අදහස් කරන්නේ එහි සත්කාරකත්වය දරන වෙබ් අඩවියට "
+"ඔබව නිරීක්ෂණය කළ හැකි බව වන අතර, ඊට හේතුව අප එහි සිට අන්තර්ගතය විකාශය කළ "
+"යුතු වීමයි. DuckDuckGo යනු ස්වාධීන සමාගමක් වන අතර බොහෝ වීඩියෝ දර්ශන "
+"සත්කාරකත්වය සපයන YouTube සමඟ කිසිදු සම්බන්ධයක් නොමැත."
 
 # smartling.placeholder_format=C
 #. Heading for the highlight card explaining anonymized prompt delivery.
@@ -22093,7 +22253,9 @@ msgstr "අපි නිර්නාමික කරමු"
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
-msgstr "ඔබට වඩාත් නිවැරදි ප්‍රතිඵල පෙන්වීමට අපට%1$s ඔබේ ස්ථානය%2$s නිර්නාමික කළ හැකිය."
+msgstr ""
+"ඔබට වඩාත් නිවැරදි ප්‍රතිඵල පෙන්වීමට අපට%1$s ඔබේ ස්ථානය%2$s නිර්නාමික කළ "
+"හැකිය."
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
@@ -22105,6 +22267,9 @@ msgid ""
 "please share this conversation with DuckDuckGo so we can investigate and "
 "address the issue."
 msgstr ""
+"අපට පෙනෙන දේ පමණක් නිවැරදි කළ හැකි ය. හානිකර හෝ නීති විරෝධී ප්‍රතිචාරයක් "
+"වාර්තා කිරීමට, කරුණාකර මෙම සංවාදය DuckDuckGo සමඟ බෙදා ගන්න, එවිට අපට ගැටලුව "
+"විමර්ශනය කර විසඳා ගත හැකිය."
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -22116,15 +22281,17 @@ msgid ""
 "please share your prompt and response so we can investigate and address the "
 "issue."
 msgstr ""
-"අපට පෙනෙන දේ පමණක් නිවැරදි කළ හැකි ය. හානිකර හෝ නීති විරෝධී ප්‍රතිචාරයක් වාර්තා කිරීමට, "
-"කරුණාකර ඔයාගේ ක්ෂණික පණිවිඩය සහ ප්‍රතිචාරය බෙදා ගන්න එවිට අපට ගැටලුව විමර්ශනය කර විසඳා ගත "
-"හැකිය."
+"අපට පෙනෙන දේ පමණක් නිවැරදි කළ හැකි ය. හානිකර හෝ නීති විරෝධී ප්‍රතිචාරයක් "
+"වාර්තා කිරීමට, කරුණාකර ඔයාගේ ක්ෂණික පණිවිඩය සහ ප්‍රතිචාරය බෙදා ගන්න එවිට අපට "
+"ගැටලුව විමර්ශනය කර විසඳා ගත හැකිය."
 
 # smartling.placeholder_format=C
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can use your anonymous%s location%s to show you nearby results."
-msgstr "ඔබට ආසන්න ප්‍රතිඵල පෙන්වීම සඳහා අපට ඔබේ නිර්නාමික%1$s පිහිටීම%2$s භාවිතා කළ හැකිය."
+msgstr ""
+"ඔබට ආසන්න ප්‍රතිඵල පෙන්වීම සඳහා අපට ඔබේ නිර්නාමික%1$s පිහිටීම%2$s භාවිතා කළ "
+"හැකිය."
 
 # smartling.placeholder_format=C
 #. Error message displayed when one or more attached files are encrypted and cannot be read.
@@ -22132,7 +22299,8 @@ msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
 msgstr ""
-"අමුණා ඇති ගොනුවලින් යටත් පිරිසෙයින් එකක් හෝ සංකේතනය කර ඇති නිසා, අපට ඒවා කියවිය නොහැක."
+"අමුණා ඇති ගොනුවලින් යටත් පිරිසෙයින් එකක් හෝ සංකේතනය කර ඇති නිසා, අපට ඒවා "
+"කියවිය නොහැක."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -22148,7 +22316,9 @@ msgstr "අපි පරිශීලක නාම හෝ පුද්ගලි�
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don't store your personal info or track you. Ever."
-msgstr "කවදාවත් අප ඔබගේ පෞද්ගලික දත්ත ගබඩා කරන්නේ හෝ ඔබව අනවසරයෙන් පරීක්ෂා කරන්නේද නැත."
+msgstr ""
+"කවදාවත් අප ඔබගේ පෞද්ගලික දත්ත ගබඩා කරන්නේ හෝ ඔබව අනවසරයෙන් පරීක්ෂා කරන්නේද "
+"නැත."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -22160,8 +22330,8 @@ msgid ""
 "We don't store your personal info. We don't follow you around with ads. We "
 "don't track you. Ever."
 msgstr ""
-"අපි ඔබේ පුද්ගලික තතු ගබඩා කර නොගන්නෙමු. අපි වෙළෙඳ දැන්වීම්වලින් ඔබව කරදරයට පත් නොකරන්නෙමු. "
-"අපි ඔබව නිරික්සන්නේ නැත. කවදත්."
+"අපි ඔබේ පුද්ගලික තතු ගබඩා කර නොගන්නෙමු. අපි වෙළෙඳ දැන්වීම්වලින් ඔබව කරදරයට "
+"පත් නොකරන්නෙමු. අපි ඔබව නිරික්සන්නේ නැත. කවදත්."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -22175,8 +22345,8 @@ msgid ""
 "We don't track you, so we could use your help telling us what brought you "
 "back today:"
 msgstr ""
-"අපි ඔබව අනවසරයෙන් පරීක්ෂා කරන්නේ නැත, ඉතින් අද ඔබව මෙහි ගෙන ආවේ කුමක්ද යැයි පැවසුවහොත් එය "
-"අපට උපකාරී වීමට හැක:"
+"අපි ඔබව අනවසරයෙන් පරීක්ෂා කරන්නේ නැත, ඉතින් අද ඔබව මෙහි ගෙන ආවේ කුමක්ද යැයි "
+"පැවසුවහොත් එය අපට උපකාරී වීමට හැක:"
 
 # smartling.placeholder_format=C
 #. Message prompting users to fill out a feedback form.
@@ -22185,8 +22355,8 @@ msgid ""
 "We don't track you, so we could use your help telling us what convinced you "
 "to try us out today:"
 msgstr ""
-"අපි ඔබව ලුහුබැඳ නොයන්නෙමු, එබැවින් අද අපව අත්හදා බැලීමට ඔබට ඒත්තු ගැන්වූ දේ අපට පැවසීමට "
-"ඔබගේ උදව් භාවිතා කළ හැකිය:"
+"අපි ඔබව ලුහුබැඳ නොයන්නෙමු, එබැවින් අද අපව අත්හදා බැලීමට ඔබට ඒත්තු ගැන්වූ දේ "
+"අපට පැවසීමට ඔබගේ උදව් භාවිතා කළ හැකිය:"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -22226,8 +22396,8 @@ msgid ""
 "We don’t store your search history. We therefore have nothing to sell to "
 "advertisers that track you across the Internet."
 msgstr ""
-"අප ඔබගේ සෙවුම් ඉතිහාසය ගබඩා කරන්නේ නැත. එම නිසා අපට අන්තර්ජාලය හරහා දැන්වීම වලට විකිණීමට "
-"කිසිවක් නැත."
+"අප ඔබගේ සෙවුම් ඉතිහාසය ගබඩා කරන්නේ නැත. එම නිසා අපට අන්තර්ජාලය හරහා දැන්වීම "
+"වලට විකිණීමට කිසිවක් නැත."
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -22253,8 +22423,8 @@ msgid ""
 "We have agreements with all AI providers to ensure your chats aren't used to "
 "train AIs."
 msgstr ""
-"ඔබගේ කතාබස් AI පුහුණු කිරීම සඳහා භාවිතා නොකිරීමට අපි සියලුම AI සපයන්නන් සමඟ ගිවිසුම් ඇති කරගෙන "
-"ඇත්තෙමු."
+"ඔබගේ කතාබස් AI පුහුණු කිරීම සඳහා භාවිතා නොකිරීමට අපි සියලුම AI සපයන්නන් සමඟ "
+"ගිවිසුම් ඇති කරගෙන ඇත්තෙමු."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -22279,8 +22449,8 @@ msgid ""
 "We make money from %sprivacy-respecting search ads%s, not by exploiting your "
 "data."
 msgstr ""
-"අපි %1$sපෞද්ගලිකත්වයට ගරු කරන සෙවුම් දැන්වීම්%2$s මගින් මුදල් උපයන්නෙමු, ඔබේ දත්ත සූරාකෑමෙන් "
-"නොවේ."
+"අපි %1$sපෞද්ගලිකත්වයට ගරු කරන සෙවුම් දැන්වීම්%2$s මගින් මුදල් උපයන්නෙමු, ඔබේ "
+"දත්ත සූරාකෑමෙන් නොවේ."
 
 # smartling.placeholder_format=C
 #. Message describing how DuckDuckGo users location access anonymously to provide better search results.
@@ -22289,15 +22459,16 @@ msgid ""
 "We only use your anonymous location to deliver better results, closer to "
 "you. You can always change your mind later."
 msgstr ""
-"අපි ඔබට වඩා ආසන්නයෙන් ඇති, වඩා හොඳ ප්‍රතිඵල ලබා දීම සඳහා පමණක් ඔබේ නිර්නාමික පිහිටීම භාවිතා "
-"කරන්නෙමු. ඔබට ඕනෑම මොහොතක පසුව ඔබේ අදහස වෙනස් කරගත හැක."
+"අපි ඔබට වඩා ආසන්නයෙන් ඇති, වඩා හොඳ ප්‍රතිඵල ලබා දීම සඳහා පමණක් ඔබේ නිර්නාමික "
+"පිහිටීම භාවිතා කරන්නෙමු. ඔබට ඕනෑම මොහොතක පසුව ඔබේ අදහස වෙනස් කරගත හැක."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
 msgstr ""
-"අපි DuckDuckGo සෑම කෙනෙකුටම වඩා හොඳ කිරීම සඳහා ඔබේ නිර්නාමික ප්‍රතිචාර මත රඳා සිටිමු."
+"අපි DuckDuckGo සෑම කෙනෙකුටම වඩා හොඳ කිරීම සඳහා ඔබේ නිර්නාමික ප්‍රතිචාර මත "
+"රඳා සිටිමු."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -22318,13 +22489,15 @@ msgid ""
 "incorporated at the discretion of %s. Corrections may not show up in results "
 "right away."
 msgstr ""
-"DuckDuckGo වැඩි දියුණු කිරීම සඳහා අපි මෙවැනි ප්‍රතිපෝෂණ භාවිතා කරමු. %1$s හි අභිමතය පරිදි "
-"යෝජනා ඇතුළත් කෙරේ. නිවැරදි කිරීම් වහාම ප්‍රතිඵලවල නොපෙන්වයි."
+"DuckDuckGo වැඩි දියුණු කිරීම සඳහා අපි මෙවැනි ප්‍රතිපෝෂණ භාවිතා කරමු. %1$s හි "
+"අභිමතය පරිදි යෝජනා ඇතුළත් කෙරේ. නිවැරදි කිරීම් වහාම ප්‍රතිඵලවල නොපෙන්වයි."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
-msgstr "ඔබ බ්‍රවුස් කරන විට ඔබගේ දත්ත රැස් කිරීමට උත්සාහ කරන ට්‍රැකර් අපි අවහිර කරන්නෙමු."
+msgstr ""
+"ඔබ බ්‍රවුස් කරන විට ඔබගේ දත්ත රැස් කිරීමට උත්සාහ කරන ට්‍රැකර් අපි අවහිර "
+"කරන්නෙමු."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -22333,8 +22506,8 @@ msgid ""
 "We're aware of this issue and are currently working to resolve it. If you "
 "continue to see this error, please reach out to %s."
 msgstr ""
-"අපි මෙම ගැටලුව පිළිබඳව දන්නා අතර දැනට එය විසඳීමට කටයුතු කරමින් සිටිමු. ඔබට මෙම දෝෂය දිගටම "
-"පෙනේ නම්, කරුණාකර %1$s වෙත සම්බන්ධ වන්න."
+"අපි මෙම ගැටලුව පිළිබඳව දන්නා අතර දැනට එය විසඳීමට කටයුතු කරමින් සිටිමු. ඔබට "
+"මෙම දෝෂය දිගටම පෙනේ නම්, කරුණාකර %1$s වෙත සම්බන්ධ වන්න."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -22343,8 +22516,8 @@ msgid ""
 "We're aware of this issue and are currently working to resolve it. Sometimes "
 "clearing your browser's cache can help."
 msgstr ""
-"අපි මෙම ගැටලුව පිළිබඳව දන්නා අතර දැනට එය විසඳීමට කටයුතු කරමින් සිටිමු. සමහර විට ඔබගේ "
-"බ්‍රවුසරයේ හැඹිලිය හිස් කිරීම උපකාරී විය හැක."
+"අපි මෙම ගැටලුව පිළිබඳව දන්නා අතර දැනට එය විසඳීමට කටයුතු කරමින් සිටිමු. සමහර "
+"විට ඔබගේ බ්‍රවුසරයේ හැඹිලිය හිස් කිරීම උපකාරී විය හැක."
 
 # smartling.placeholder_format=C
 #. Header for a feedback form for new users.
@@ -22359,7 +22532,8 @@ msgid ""
 "We're sorry for this inconvenience. We’re working hard to make your "
 "experience better."
 msgstr ""
-"අප මේ අපහසුතාව ගැන කනගාටුව ප්‍රකාශ කරමු. ඔබේ අත්දැකීම වඩා හොඳ කිරීමට අපි මහන්සි වෙමින් සිටිමු."
+"අප මේ අපහසුතාව ගැන කනගාටුව ප්‍රකාශ කරමු. ඔබේ අත්දැකීම වඩා හොඳ කිරීමට අපි "
+"මහන්සි වෙමින් සිටිමු."
 
 # smartling.placeholder_format=C
 #. Body text explaining the service update requires a page reload.
@@ -22368,7 +22542,8 @@ msgid ""
 "We've updated the Duck.ai service. For the change to take effect, we need to "
 "reload the page."
 msgstr ""
-"අපි Duck.ai සේවාව යාවත්කාලීන කළෙමු. වෙනස ක්‍රියාත්මක වීමට, අප පිටුව නැවත පූරණය කළ යුතුය."
+"අපි Duck.ai සේවාව යාවත්කාලීන කළෙමු. වෙනස ක්‍රියාත්මක වීමට, අප පිටුව නැවත "
+"පූරණය කළ යුතුය."
 
 # smartling.placeholder_format=C
 #. Instant Answer Tab Name
@@ -22471,8 +22646,8 @@ msgid ""
 "Weekly usage limit reached. You can keep chatting by using your monthly "
 "limit."
 msgstr ""
-"සතිපතා පරිශීලන සීමාවට ළඟා වී ඇත. ඔබේ මාසික සීමාව භාවිතා කිරීමෙන් ඔබට දිගටම කතාබහේ යෙදිය "
-"හැකි ය."
+"සතිපතා පරිශීලන සීමාවට ළඟා වී ඇත. ඔබේ මාසික සීමාව භාවිතා කිරීමෙන් ඔබට දිගටම "
+"කතාබහේ යෙදිය හැකි ය."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -22486,8 +22661,8 @@ msgid ""
 "Welcome to Duck.ai! All of your chats here are private, anonymized by us and "
 "not used to train AI models."
 msgstr ""
-"Duck.ai වෙත සාදරයෙන් පිළිගනිමු! මෙහි ඇති ඔබගේ සියලු කතාබස් පුද්ගලිකයි, අප විසින් නිර්නාමිකෘත කර "
-"ඇති අතර AI ආකෘති පුහුණු කිරීමට භාවිත නොකෙරේ."
+"Duck.ai වෙත සාදරයෙන් පිළිගනිමු! මෙහි ඇති ඔබගේ සියලු කතාබස් පුද්ගලිකයි, අප "
+"විසින් නිර්නාමිකෘත කර ඇති අතර AI ආකෘති පුහුණු කිරීමට භාවිත නොකෙරේ."
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened.
@@ -22496,8 +22671,9 @@ msgid ""
 "Welcome to DuckDuckGo AI Chat! All of your chats here are private, "
 "anonymized by us and not used to train AI models."
 msgstr ""
-"DuckDuckGo AI Chat වෙත සාදරයෙන් පිළිගනිමු! මෙහි ඇති ඔබගේ සියලු කතාබස් පුද්ගලිකයි, අප විසින් "
-"නිර්නාමිකෘත කර ඇති අතර AI ආකෘති පුහුණු කිරීමට භාවිත නොකෙරේ."
+"DuckDuckGo AI Chat වෙත සාදරයෙන් පිළිගනිමු! මෙහි ඇති ඔබගේ සියලු කතාබස් "
+"පුද්ගලිකයි, අප විසින් නිර්නාමිකෘත කර ඇති අතර AI ආකෘති පුහුණු කිරීමට භාවිත "
+"නොකෙරේ."
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened. Example: 'Welcome to DuckDuckGo AI Chat! This chat session is powered by OpenAI’s GPT-3. All of your chats here are private, and are never stored by DuckDuckGo or used to train AI models.'
@@ -22507,15 +22683,17 @@ msgid ""
 "of your chats here are private, and are never stored by DuckDuckGo or used "
 "to train AI models."
 msgstr ""
-"DuckDuckGo AI Chat වෙත සාදරයෙන් පිළිගනිමු! මෙම කතාබස් සැසිය බලගන්වන්නේ %1$sගේ %2$s "
-"විසිනි. මෙහි ඔබගේ සියලු කතාබස් පෞද්ගලික වන අතර, කිසි විටෙකත් DuckDuckGo විසින් ගබඩා කර හෝ AI "
-"ආකෘති පුහුණු කිරීම සඳහා භාවිත නොකෙරේ."
+"DuckDuckGo AI Chat වෙත සාදරයෙන් පිළිගනිමු! මෙම කතාබස් සැසිය බලගන්වන්නේ "
+"%1$sගේ %2$s විසිනි. මෙහි ඔබගේ සියලු කතාබස් පෞද්ගලික වන අතර, කිසි විටෙකත් "
+"DuckDuckGo විසින් ගබඩා කර හෝ AI ආකෘති පුහුණු කිරීම සඳහා භාවිත නොකෙරේ."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai! You can now import your downloaded chats."
-msgstr "නව Duck.ai වෙත සාදරයෙන් පිළිගනිමු! දැන් ඔයාට බාගත කරගත් කතාබස් ආයාත කරන්න පුළුවන්."
+msgstr ""
+"නව Duck.ai වෙත සාදරයෙන් පිළිගනිමු! දැන් ඔයාට බාගත කරගත් කතාබස් ආයාත කරන්න "
+"පුළුවන්."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -22583,8 +22761,8 @@ msgid ""
 "We’re really sorry, but it seems there was a problem loading Duck.ai. Try "
 "reloading the page."
 msgstr ""
-"අපිට ඇත්තටම කණගාටුයි, නමුත් Duck.ai පූරණය කිරීමේදී ගැටලුවක් ඇතිවූ බව පෙනේ. පිටුව නැවත "
-"ප්‍රවේශනය කර උත්සාහ කරන්න."
+"අපිට ඇත්තටම කණගාටුයි, නමුත් Duck.ai පූරණය කිරීමේදී ගැටලුවක් ඇතිවූ බව පෙනේ. "
+"පිටුව නැවත ප්‍රවේශනය කර උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to suggest an AI (Artificial Intelligence) model to be added to the product, and this field is optional.
@@ -22599,7 +22777,8 @@ msgid ""
 "What are some arguments, counter-arguments, and rebuttals to the concept of "
 "a plant-based diet?"
 msgstr ""
-"ශාක පදනම් කරගත් ආහාරයක් පිළිබඳ සංකල්පයට සමහර තර්ක, ප්‍රති-තර්ක සහ ප්‍රතිවිරෝධතා මොනවාද?"
+"ශාක පදනම් කරගත් ආහාරයක් පිළිබඳ සංකල්පයට සමහර තර්ක, ප්‍රති-තර්ක සහ "
+"ප්‍රතිවිරෝධතා මොනවාද?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for considering factors when purchasing a computer monitor.
@@ -22620,8 +22799,8 @@ msgid ""
 "What are some options for the word ‘better’ in the context of “We really "
 "need to do better.”"
 msgstr ""
-"“අපි ඇත්තටම වඩා හොඳ කරන්න ඕන” යන සන්දර්භය තුළ 'වඩා හොඳ' යන වචනය සඳහා සමහර විකල්ප "
-"මොනවාද."
+"“අපි ඇත්තටම වඩා හොඳ කරන්න ඕන” යන සන්දර්භය තුළ 'වඩා හොඳ' යන වචනය සඳහා සමහර "
+"විකල්ප මොනවාද."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
@@ -22640,107 +22819,108 @@ msgid ""
 "easy to understand for people with or without much AI, or technical, "
 "experience."
 msgstr ""
-"Duck.ai භාවිතා කිරීමට උනන්දුවක් දක්වන කෙනෙකුට DuckDuckGo බ්‍රව්සරය බාගැනීමේ ප්‍රතිලාභ මොනවා "
-"ද? නිල DuckDuckGo මූලාශ්‍ර පමණක් යොමු කරන්න. Duck.ai ඒකාබද්ධ කිරීම් සහ රහස්‍යතා ආරක්ෂණ "
-"කෙරෙහි අවධානය යොමු කරමින්, ප්‍රතිචාරය මාතෘකා සහිත පැහැදිලි කොටස්වලට බෙදන්න. AI හෝ තාක්ෂණික "
-"අත්දැකීම් ඇති හෝ නැති අයට එය තරමක් කෙටි, සරල සහ තේරුම් ගැනීමට පහසු වන පරිදි සකසන්න."
+"Duck.ai භාවිතා කිරීමට උනන්දුවක් දක්වන කෙනෙකුට DuckDuckGo බ්‍රව්සරය බාගැනීමේ "
+"ප්‍රතිලාභ මොනවා ද? නිල DuckDuckGo මූලාශ්‍ර පමණක් යොමු කරන්න. Duck.ai ඒකාබද්ධ "
+"කිරීම් සහ රහස්‍යතා ආරක්ෂණ කෙරෙහි අවධානය යොමු කරමින්, ප්‍රතිචාරය මාතෘකා සහිත "
+"පැහැදිලි කොටස්වලට බෙදන්න. AI හෝ තාක්ෂණික අත්දැකීම් ඇති හෝ නැති අයට එය තරමක් "
+"කෙටි, සරල සහ තේරුම් ගැනීමට පහසු වන පරිදි සකසන්න."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the counterarguments?"
-msgstr ""
+msgstr "ප්‍රතිවිරුද්ධ තර්ක මොනවා ද?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the hours & location?"
-msgstr ""
+msgstr "විවෘත වේලාවන් සහ ස්ථාන මොනවා ද?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key contributions of this paper?"
-msgstr ""
+msgstr "මෙම පත්‍රිකාවේ ප්‍රධාන දායකත්වයන් මොනවා ද?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key contributions?"
-msgstr ""
+msgstr "ප්‍රධාන දායකත්වයන් මොනවා ද?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key details?"
-msgstr ""
+msgstr "ප්‍රධාන විස්තර මොනවා ද?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key points covered in this video?"
-msgstr ""
+msgstr "මෙම වීඩියෝවේ ආවරණය වන ප්‍රධාන කරුණු මොනවා ද?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key points?"
-msgstr ""
+msgstr "ප්‍රධාන කරුණු මොනවා ද?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key takeaways from this article?"
-msgstr ""
+msgstr "මෙම ලිපියේ ඇති ප්‍රධාන කරුණු මොනවා ද?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key takeaways?"
-msgstr ""
+msgstr "ප්‍රධාන කරුණු මොනවා ද?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key things I will learn from this course?"
-msgstr ""
+msgstr "මෙම පාඨමාලාවෙන් මට ඉගෙන ගත හැකි ප්‍රධාන කරුණු මොනවා ද?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the main counterarguments or criticisms of this?"
-msgstr ""
+msgstr "මේ පිළිබඳ ප්‍රධාන ප්‍රතිවිරුද්ධ තර්ක හෝ විවේචන මොනවා ද?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the main questions this page answers?"
-msgstr ""
+msgstr "මෙම පිටුව පිළිතුරු දෙන ප්‍රධාන ප්‍රශ්න මොනවා ද?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the must-try dishes here?"
-msgstr ""
+msgstr "මෙම ස්ථානයේ අනිවාර්යයයෙන් ම අත්හදා බැලිය යුතු ආහාර වර්ග මොනවා ද?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid ""
 "What are the opening hours, location, and contact details for this place?"
-msgstr ""
+msgstr "මෙම ස්ථානයේ විවෘත වේලාවන්, පිහිටීම සහ සම්බන්ධ කර ගැනීමේ මොනවා ද?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the pros and cons of this product?"
-msgstr ""
+msgstr "මෙම නිෂ්පාදනයේ වාසි සහ අවාසි මොනවා ද?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the pros and cons?"
-msgstr ""
+msgstr "වාසි සහ අවාසි මොනවා ද?"
 
 # smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
@@ -22846,7 +23026,7 @@ msgstr "වෛද්‍ය ලිපියක සන්දර්භය තුළ
 #. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What does this answer?"
-msgstr ""
+msgstr "මෙයින් පිළිතුරු ලැබෙන්නේ කුමකට ද?"
 
 # smartling.placeholder_format=C
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
@@ -22864,7 +23044,7 @@ msgstr "සුරකින තොරතුරු මොනවාද?"
 #. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What interview questions might come up for this role?"
-msgstr ""
+msgstr "මේ කාර්යභාරය සඳහා සම්මුඛ පරීක්ෂණයේ දී මතු විය හැකි ප්‍රශ්න මොනවා ද?"
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -22873,7 +23053,8 @@ msgid ""
 "What is the Cloud Save bookmarklet and how does it differ from the URL "
 "parameter bookmarklet?"
 msgstr ""
-"Cloud Save පොත් සලකුණු යනු කුමක්ද සහ එය URL පරාමිති පොත් සලකුණු වලින් වෙනස් වන්නේ කෙසේද?"
+"Cloud Save පොත් සලකුණු යනු කුමක්ද සහ එය URL පරාමිති පොත් සලකුණු වලින් වෙනස් "
+"වන්නේ කෙසේද?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for looking up the capital city of Albania.
@@ -22885,7 +23066,7 @@ msgstr "ඇල්බේනියාවේ අගනුවර කුමක්ද?
 #. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What is the overall verdict and rating for this?"
-msgstr ""
+msgstr "මේ සඳහා සමස්ත තීන්දුව සහ ශ්‍රේණිගත කිරීම කුමක් ද?"
 
 # smartling.placeholder_format=C
 #. Link to a page with additional information.
@@ -22913,7 +23094,7 @@ msgstr "මිනිසුන් පවසන දේ:"
 #. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What should I order?"
-msgstr ""
+msgstr "මා ඇණවුම් කළ යුත්තේ මොනවා ද?"
 
 # smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
@@ -22931,13 +23112,13 @@ msgstr "ප්‍රතිචාරයේ තිබූ ගැටලුව කු
 #. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What will I learn?"
-msgstr ""
+msgstr "මට ඉගෙනගත හැක්කේ කුමක් ද?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What will I need?"
-msgstr ""
+msgstr "මට අවශ්‍ය වන්නේ මොනවා ද?්"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -22960,7 +23141,7 @@ msgstr "අලුත් දෑ"
 #. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What's the verdict?"
-msgstr ""
+msgstr "තීරණය කුමක්ද ?"
 
 # smartling.placeholder_format=C
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -22974,8 +23155,8 @@ msgid ""
 "When buying an electric guitar for a beginner, what are the top product "
 "brands I should consider?"
 msgstr ""
-"ආරම්භකයෙකු සඳහා විදුලි ගිටාරයක් මිලදී ගැනීමේදී, මා සලකා බැලිය යුතු ඉහළම නිෂ්පාදන වෙළඳ නාම "
-"මොනවාද?"
+"ආරම්භකයෙකු සඳහා විදුලි ගිටාරයක් මිලදී ගැනීමේදී, මා සලකා බැලිය යුතු ඉහළම "
+"නිෂ්පාදන වෙළඳ නාම මොනවාද?"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -23016,7 +23197,7 @@ msgstr "අතුරුදහන් වී ඇති විශේෂාංග �
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Which features are missing? (optional)"
-msgstr ""
+msgstr "අතුරුදහන් වී ඇති විශේෂාංග මොනවා ද? (විකල්ප)"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
@@ -23038,13 +23219,13 @@ msgstr "අපි කවුද"
 #. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Who are the main cast and crew, and what else are they known for?"
-msgstr ""
+msgstr "ප්‍රධාන නළු නිළි පිරිස කවු ද, ඔවුන් ප්‍රසිද්ධ මොනවා සඳහා ද?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Who is this person?"
-msgstr ""
+msgstr "මේ පුද්ගලයා කවු ද?"
 
 # smartling.placeholder_format=C
 #. Header above a collection of privacy-related links.
@@ -23434,7 +23615,9 @@ msgctxt "Disclaimer bellow chat input - desktop"
 msgid ""
 "You are chatting with %s. AI chats may display inaccurate or offensive "
 "information."
-msgstr "ඔබට එය %1$sහි නැරඹිය හැකිය. AI කතාබස් සාවද්ය හෝ අමනාපකාරී තොරතුරු පෙන්විය හැකිය."
+msgstr ""
+"ඔබට එය %1$sහි නැරඹිය හැකිය. AI කතාබස් සාවද්ය හෝ අමනාපකාරී තොරතුරු පෙන්විය "
+"හැකිය."
 
 # smartling.placeholder_format=C
 #. Provide users with the ability to retry their search on a different search engine. First placeholder will be a link with the text "try your search again" OR "try your search later". Second is a URL to the !bangs page: https://duckduckgo.com/bangs.
@@ -23443,8 +23626,8 @@ msgid ""
 "You can %s or search directly on other search engines from DuckDuckGo using "
 "%s search shortcuts."
 msgstr ""
-"ඔබට %2$s සෙවුම් කෙටිමං භාවිත කරමින් DuckDuckGo වෙතින් වෙනත් සෙවුම් යන්ත්‍ර මත කඍජුව %1$s හෝ "
-"සෙවිය හැකිය."
+"ඔබට %2$s සෙවුම් කෙටිමං භාවිත කරමින් DuckDuckGo වෙතින් වෙනත් සෙවුම් යන්ත්‍ර "
+"මත කඍජුව %1$s හෝ සෙවිය හැකිය."
 
 # smartling.placeholder_format=C
 #. Text informing the user that they can access DuckDuckGo AI Chat directly at a specific URL. The placeholder %s will be replaced with the link. Example: 'You can access DuckDuckGo AI Chat directly at duck.ai.'
@@ -23458,8 +23641,8 @@ msgctxt "duckassist"
 msgid ""
 "You can adjust how %s works or turn it off anytime in %sSearch Settings%s."
 msgstr ""
-"ඔබට %1$s ක්‍රියා කරන ආකාරය සකස් කිරීමට හෝ ඕනෑම වේලාවක %2$sසෙවුම් සැකසුම්%3$s තුළ එය "
-"අක්‍රිය කළ හැකිය."
+"ඔබට %1$s ක්‍රියා කරන ආකාරය සකස් කිරීමට හෝ ඕනෑම වේලාවක %2$sසෙවුම් සැකසුම්%3$s "
+"තුළ එය අක්‍රිය කළ හැකිය."
 
 # smartling.placeholder_format=C
 #. Assist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate Assist.
@@ -23468,21 +23651,22 @@ msgid ""
 "You can adjust how Assist works or turn it off anytime in %sSearch "
 "Settings%s."
 msgstr ""
-"ඔබට %1$sසෙවුම් සැකසීම්%2$s තුළ ඕනෑම වේලාවක Assist ක්‍රියා කරන ආකාරය සකස් කිරීමට හෝ එය "
-"අක්‍රිය කිරීමට හැකිය."
+"ඔබට %1$sසෙවුම් සැකසීම්%2$s තුළ ඕනෑම වේලාවක Assist ක්‍රියා කරන ආකාරය සකස් "
+"කිරීමට හෝ එය අක්‍රිය කිරීමට හැකිය."
 
 # smartling.placeholder_format=C
 msgid "You can also use %sDuck.ai%s to answer questions or summarize text."
 msgstr ""
-"ප්‍රශ්නවලට පිළිතුරු දීමට හෝ පෙළ සාරාංශ කිරීමට ඔබට %1$sDuck.ai%2$s ද භාවිත කළ හැකිය."
+"ප්‍රශ්නවලට පිළිතුරු දීමට හෝ පෙළ සාරාංශ කිරීමට ඔබට %1$sDuck.ai%2$s ද භාවිත කළ "
+"හැකිය."
 
 # smartling.placeholder_format=C
 msgid ""
 "You can also use %sDuckDuckGo AI Chat%s to answer questions or summarize "
 "text."
 msgstr ""
-"ඔබට ප්‍රශ්නවලට පිළිතුරු දීමට හෝ පෙළ සාරාංශ කිරීමට %1$sDuckDuckGo AI Chat%2$s ද භාාවිත "
-"කළ හැකිය."
+"ඔබට ප්‍රශ්නවලට පිළිතුරු දීමට හෝ පෙළ සාරාංශ කිරීමට %1$sDuckDuckGo AI Chat%2$s "
+"ද භාාවිත කළ හැකිය."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach more text selections than are allowed. Placeholder is the maximum number of text selections. E.g. You can attach up to 5 text selections.
@@ -23496,8 +23680,8 @@ msgid ""
 "You can change how frequently you see Search Assist, or turn it off "
 "entirely, in %sSearch Settings%s."
 msgstr ""
-"ඔබට %1$sසෙවුම් සැකසුම්%2$s තුළ Search Assist දකින වාර ගණන වෙනස් කළ හැකි අතර, එය "
-"සම්පූර්ණයෙන්ම අක්‍රිය කළ හැකිය."
+"ඔබට %1$sසෙවුම් සැකසුම්%2$s තුළ Search Assist දකින වාර ගණන වෙනස් කළ හැකි අතර, "
+"එය සම්පූර්ණයෙන්ම අක්‍රිය කළ හැකිය."
 
 # smartling.placeholder_format=C
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
@@ -23512,8 +23696,8 @@ msgid ""
 "You can do this by saving your settings under a different passphrase, "
 "optionally deleting the first set."
 msgstr ""
-"වෙනස් මුර පදයක් යටතේ ඔබගේ සැකසුම් සුරැකීමෙන් ඔබට මෙය කළ හැකිය, විකල්පයක් ලෙස පළමු සමූහය "
-"මකනවා."
+"වෙනස් මුර පදයක් යටතේ ඔබගේ සැකසුම් සුරැකීමෙන් ඔබට මෙය කළ හැකිය, විකල්පයක් ලෙස "
+"පළමු සමූහය මකනවා."
 
 # smartling.placeholder_format=C
 #. Prefix for filename location sentence.
@@ -23593,8 +23777,8 @@ msgid ""
 "You can only block up to %s sites. To block %s, you'll need to unblock "
 "another site first."
 msgstr ""
-"ඔබට අවහිර කළ හැක්කේ අඩවි %1$s දක්වා පමණි. %2$s අවහිර කිරීමට, ඔබ මුලින්ම වෙනත් වෙබ් අඩවියක් "
-"අහිතකර කිරීමට අවශ්ය වේ."
+"ඔබට අවහිර කළ හැක්කේ අඩවි %1$s දක්වා පමණි. %2$s අවහිර කිරීමට, ඔබ මුලින්ම "
+"වෙනත් වෙබ් අඩවියක් අහිතකර කිරීමට අවශ්ය වේ."
 
 # smartling.placeholder_format=C
 #. Text explaining the benefits of the cloud save feature.
@@ -23651,8 +23835,8 @@ msgid ""
 "You now have access to %s, higher AI reasoning, and 2x higher usage limits "
 "than Plus."
 msgstr ""
-"ඔබට දැන් %1$s වෙත ප් රවේශය, ඉහළ AI තර්කනය සහ Plus ප්‍රකාරයට වඩා දෙගුණයක් පුළුල් පරිශීලන "
-"සීමාවන් ඇත."
+"ඔබට දැන් %1$s වෙත ප් රවේශය, ඉහළ AI තර්කනය සහ Plus ප්‍රකාරයට වඩා දෙගුණයක් "
+"පුළුල් පරිශීලන සීමාවන් ඇත."
 
 # smartling.placeholder_format=C
 #. Description text for the welcome modal displayed after the user subscribes to DuckDuckGo.
@@ -23661,8 +23845,8 @@ msgid ""
 "You now have access to advanced AI models. You can access the VPN and other "
 "DuckDuckGo subscription protections in the DuckDuckGo browser."
 msgstr ""
-"ඔබට දැන් උසස් AI ආකෘති වෙත ප්‍රවේශය ඇත. ඔබට DuckDuckGo බ්‍රවුසරයේ VPN සහ අනෙකුත් "
-"DuckDuckGo දායකත්ව ආරක්ෂණ වෙත ප්‍රවේශ විය හැක."
+"ඔබට දැන් උසස් AI ආකෘති වෙත ප්‍රවේශය ඇත. ඔබට DuckDuckGo බ්‍රවුසරයේ VPN සහ "
+"අනෙකුත් DuckDuckGo දායකත්ව ආරක්ෂණ වෙත ප්‍රවේශ විය හැක."
 
 # smartling.placeholder_format=C
 #. Welcome message that appears after the DuckDuckGo extension is installed.
@@ -23684,9 +23868,9 @@ msgid ""
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
 msgstr ""
-"මෙම බ්‍රව්සරයෙන් ඔබගේ සුරකින ලද කතාබස් වෙත ප්‍රවේශ වීමට ඔබට තවදුරටත් නොහැකි වනු ඇත. අවසාන "
-"කතාබස් 30 තවමත් දේශීය ගබඩාවේ පවතිනු ඇත. මින් ඔබේ කතාබස් සංකේතනය කළ සර්වරයෙන් මකා දමනු "
-"නොලැබේ."
+"මෙම බ්‍රව්සරයෙන් ඔබගේ සුරකින ලද කතාබස් වෙත ප්‍රවේශ වීමට ඔබට තවදුරටත් නොහැකි "
+"වනු ඇත. අවසාන කතාබස් 30 තවමත් දේශීය ගබඩාවේ පවතිනු ඇත. මින් ඔබේ කතාබස් "
+"සංකේතනය කළ සර්වරයෙන් මකා දමනු නොලැබේ."
 
 # smartling.placeholder_format=C
 #. Explains that turning off disconnects this browser only; the last 30 chats stay in local storage and the encrypted server backup is not deleted.
@@ -23696,9 +23880,9 @@ msgid ""
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
 msgstr ""
-"මෙම බ්‍රව්සරයෙන් ඔබගේ සුරකින ලද කතාබස් වෙත ප්‍රවේශ වීමට ඔබට තවදුරටත් නොහැකි වනු ඇත. අවසාන "
-"කතාබස් 30 තවමත් ස්ථානීය ගබඩාවේ පවතිනු ඇත. මින් ඔබේ කතාබස් සංකේතනය කළ සර්වරයෙන් මකා දමනු "
-"නොලැබේ."
+"මෙම බ්‍රව්සරයෙන් ඔබගේ සුරකින ලද කතාබස් වෙත ප්‍රවේශ වීමට ඔබට තවදුරටත් නොහැකි "
+"වනු ඇත. අවසාන කතාබස් 30 තවමත් ස්ථානීය ගබඩාවේ පවතිනු ඇත. මින් ඔබේ කතාබස් "
+"සංකේතනය කළ සර්වරයෙන් මකා දමනු නොලැබේ."
 
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
@@ -23711,7 +23895,9 @@ msgctxt "Update browser banner"
 msgid ""
 "You'll receive automatic DuckDuckGo app updates once you have the latest "
 "version."
-msgstr "ඔබට නවතම අනුවාදය ලැබුණු පසු ඔබට ස්වයංක්‍රීය DuckDuckGo යෙදුම් යාවත්කාලීන ලැබෙනු ඇත."
+msgstr ""
+"ඔබට නවතම අනුවාදය ලැබුණු පසු ඔබට ස්වයංක්‍රීය DuckDuckGo යෙදුම් යාවත්කාලීන "
+"ලැබෙනු ඇත."
 
 # smartling.placeholder_format=C
 #. shown when DDG is selected after eu preference menu on android
@@ -23720,8 +23906,8 @@ msgid ""
 "You're now searching privately in Chrome. Use our app instead of Chrome to "
 "browse privately too. It’s already installed and can:"
 msgstr ""
-"දැන් ඔබ Chromeහි පුද්ගලිකව සොයමින් සිටී. පුද්ගලිකව පිරික්සීමටත් Chrome වෙනුවට අපගේ යෙදුම භාවිතා "
-"කරන්න. එය දැනටමත් ස්ථාපනය කර ඇති අතර හැකියාව ඇත්තේ:"
+"දැන් ඔබ Chromeහි පුද්ගලිකව සොයමින් සිටී. පුද්ගලිකව පිරික්සීමටත් Chrome "
+"වෙනුවට අපගේ යෙදුම භාවිතා කරන්න. එය දැනටමත් ස්ථාපනය කර ඇති අතර හැකියාව ඇත්තේ:"
 
 # smartling.placeholder_format=C
 #. Confirmation message that appears after the DuckDuckGo browser extension is installed.
@@ -23734,8 +23920,8 @@ msgid ""
 "You're now searching with privacy. %sGet tips to reduce your footprint even "
 "more."
 msgstr ""
-"ඔබ දැන් පෞද්ගලිකත්වයෙන් යුතුව සොයයි. %1$sඔබගේ පා සටහන් තව දුරටත් අවම කර ගැනීමට ඉඟි ලබා "
-"ගන්න."
+"ඔබ දැන් පෞද්ගලිකත්වයෙන් යුතුව සොයයි. %1$sඔබගේ පා සටහන් තව දුරටත් අවම කර "
+"ගැනීමට ඉඟි ලබා ගන්න."
 
 # smartling.placeholder_format=C
 #. Title of a notice thanking the user for turning off their adblocker
@@ -23805,8 +23991,9 @@ msgid ""
 "You've run out of Sync & Backup storage for Duck.ai chats with attachments. "
 "Delete the %s oldest chats to resume Sync. Pinned chats will not be deleted."
 msgstr ""
-"ඔබට ඇමුණුම් සහිත Duck.ai කතාබස් සඳහා Sync & Backup ඉඩ අවසන් වී ඇත. සමමුහුර්ත කිරීම නැවත "
-"ආරම්භ කිරීමට පැරණිතම කතාබස් %1$s මකන්න. ඇමුණූ කතාබස් මකා දමනු නොලැබේ."
+"ඔබට ඇමුණුම් සහිත Duck.ai කතාබස් සඳහා Sync & Backup ඉඩ අවසන් වී ඇත. සමමුහුර්ත "
+"කිරීම නැවත ආරම්භ කිරීමට පැරණිතම කතාබස් %1$s මකන්න. ඇමුණූ කතාබස් මකා දමනු "
+"නොලැබේ."
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -23816,8 +24003,9 @@ msgid ""
 "oldest chats with attachments to resume Sync. Pinned chats will not be "
 "deleted."
 msgstr ""
-"ඔබට Duck.ai කතාබස් සඳහා Sync & Backup ඉඩ අවසන් වී ඇත. සමමුහුර්ත කිරීම නැවත ආරම්භ කිරීමට "
-"ඇමුතුම් සමඟ පැරණිතම කතාබස් %1$s මකන්න. ඇමුණූ කතාබස් මකා දමනු නොලැබේ."
+"ඔබට Duck.ai කතාබස් සඳහා Sync & Backup ඉඩ අවසන් වී ඇත. සමමුහුර්ත කිරීම නැවත "
+"ආරම්භ කිරීමට ඇමුතුම් සමඟ පැරණිතම කතාබස් %1$s මකන්න. ඇමුණූ කතාබස් මකා දමනු "
+"නොලැබේ."
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the sync storage limit.
@@ -23831,8 +24019,9 @@ msgid ""
 "YouTube (owned by Google) does not let you watch videos anonymously. As "
 "such, watching YouTube videos here will be tracked by YouTube/Google."
 msgstr ""
-"Youtube (Google සතු) ඔබට නිර්නාමිකව වීඩියෝ දර්ශන නැරඹීමට ඉඩ ලබා දෙන්නේ නැහැ. ඒ වගේම, "
-"Youtube වීඩියෝ නැරඹීමේදී Google/Youtube මගින් අනවසරයෙන් පරීක්ෂා කිරීමකට ලක් වෙන්න පුළුවන්."
+"Youtube (Google සතු) ඔබට නිර්නාමිකව වීඩියෝ දර්ශන නැරඹීමට ඉඩ ලබා දෙන්නේ නැහැ. "
+"ඒ වගේම, Youtube වීඩියෝ නැරඹීමේදී Google/Youtube මගින් අනවසරයෙන් පරීක්ෂා "
+"කිරීමකට ලක් වෙන්න පුළුවන්."
 
 # smartling.placeholder_format=C
 #. Label for a privacy disclaimer related to YouTube videos
@@ -23876,8 +24065,9 @@ msgid ""
 "disconnected from sync. Your %s most recent chats will be available in local "
 "storage on these browsers:"
 msgstr ""
-"ඔබේ උපස්ථය DuckDuckGo සර්වරයෙන් මකා දැමෙනු ඇත. සියලුම උපාංග සමමුහුර්තකරණයෙන් විසන්ධි වනු "
-"ඇත. ඔබගේ මෑත කාලීන කතාබස් %1$s මෙම බ්‍රව්සර්වල දේශීය ගබඩාවේ ලබා ගත හැකිය:"
+"ඔබේ උපස්ථය DuckDuckGo සර්වරයෙන් මකා දැමෙනු ඇත. සියලුම උපාංග සමමුහුර්තකරණයෙන් "
+"විසන්ධි වනු ඇත. ඔබගේ මෑත කාලීන කතාබස් %1$s මෙම බ්‍රව්සර්වල දේශීය ගබඩාවේ ලබා "
+"ගත හැකිය:"
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list.
@@ -23887,8 +24077,9 @@ msgid ""
 "disconnected from sync. Your 100 most recent chats will be available in "
 "local storage on these browsers:"
 msgstr ""
-"ඔබේ උපස්ථය DuckDuckGo සර්වරයෙන් මකා දැමෙනු ඇත. සියලුම උපාංග සමමුහුර්තකරණයෙන් විසන්ධි වනු "
-"ඇත. ඔබේ මෑත කාලීන කතාබස් 100 මෙම බ්‍රව්සර්වල දේශීය ගබඩාවේ ලබා ගත හැකිය:"
+"ඔබේ උපස්ථය DuckDuckGo සර්වරයෙන් මකා දැමෙනු ඇත. සියලුම උපාංග සමමුහුර්තකරණයෙන් "
+"විසන්ධි වනු ඇත. ඔබේ මෑත කාලීන කතාබස් 100 මෙම බ්‍රව්සර්වල දේශීය ගබඩාවේ ලබා ගත "
+"හැකිය:"
 
 # smartling.placeholder_format=C
 #. List item indicating that a site exclusion filter is currently active for the search
@@ -23913,8 +24104,8 @@ msgid ""
 "Your browser provides a list of your most-visited sites. DuckDuckGo never "
 "has access to this data."
 msgstr ""
-"ඔබගේ බ්‍රවුසරය ඔබ වැඩිපුරම නරඹන අඩවි ලැයිස්තුවක් සපයයි. DuckDuckGo වෙත කිසිවිටෙක මෙම දත්ත "
-"වෙත ප්‍රවේශය නොමැත."
+"ඔබගේ බ්‍රවුසරය ඔබ වැඩිපුරම නරඹන අඩවි ලැයිස්තුවක් සපයයි. DuckDuckGo වෙත "
+"කිසිවිටෙක මෙම දත්ත වෙත ප්‍රවේශය නොමැත."
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
@@ -23922,8 +24113,8 @@ msgid ""
 "Your browser provides the list of most-visited sites. DuckDuckGo never has "
 "access to this data."
 msgstr ""
-"ඔබගේ බ්‍රව්සරය නිතරම නරඹන අඩවි ලැයිස්තුවක් සපයනවා. නමුත් DuckDuckGo වලට කවදාවත් අවසරයක් "
-"නැහැ ඒ දත්ත වලට."
+"ඔබගේ බ්‍රව්සරය නිතරම නරඹන අඩවි ලැයිස්තුවක් සපයනවා. නමුත් DuckDuckGo වලට "
+"කවදාවත් අවසරයක් නැහැ ඒ දත්ත වලට."
 
 # smartling.placeholder_format=C
 #. Disclaimer text shown bellow chat input. Example: 'You are chatting with GPT-3. AI chats may display inaccurate or offensive information.'
@@ -23931,7 +24122,9 @@ msgctxt "Disclaimer bellow chat input - desktop"
 msgid ""
 "Your chat with %s is private. AI chats may display inaccurate or offensive "
 "information."
-msgstr "%1$s සමඟ ඔයාගේ චැට් පුද්ගලිකයි. AI චැට් සාවද්‍ය හෝ අමනාපකාරී තොරතුරු පෙන්විය හැකිය."
+msgstr ""
+"%1$s සමඟ ඔයාගේ චැට් පුද්ගලිකයි. AI චැට් සාවද්‍ය හෝ අමනාපකාරී තොරතුරු පෙන්විය "
+"හැකිය."
 
 # smartling.placeholder_format=C
 #. Body copy shown after Sync & Backup is enabled, confirming chats are now syncing.
@@ -23944,7 +24137,8 @@ msgstr "ඔබගේ කතාබස් දැන් සුරැකෙමින
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never saved or used to train AI models"
 msgstr ""
-"ඔබේ කතාබස් පුද්ගලික වන අතර AI ආකෘති පුහුණු කිරීම සඳහා කිසිවිටෙකත් සුරකිනු හෝ භාවිත නොකෙරේ"
+"ඔබේ කතාබස් පුද්ගලික වන අතර AI ආකෘති පුහුණු කිරීම සඳහා කිසිවිටෙකත් සුරකිනු හෝ "
+"භාවිත නොකෙරේ"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
@@ -23958,7 +24152,8 @@ msgctxt "Active Privacy protection description"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
 msgstr ""
-"ඔබගේ කතාබස් පුද්ගලිකයි, අප විසින් නිර්නාමිකෘත කර ඇති අතර AI ආකෘති පුහුණු කිරීමට භාවිත නොකෙරේ."
+"ඔබගේ කතාබස් පුද්ගලිකයි, අප විසින් නිර්නාමිකෘත කර ඇති අතර AI ආකෘති පුහුණු "
+"කිරීමට භාවිත නොකෙරේ."
 
 # smartling.placeholder_format=C
 #. Text explaining that user chats are private and not used for AI (Artificial Intelligence) training.
@@ -23966,7 +24161,8 @@ msgctxt "Body text for privacy protection modal"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
 msgstr ""
-"ඔබගේ කතාබස් පුද්ගලිකයි, අප විසින් නිර්නාමිකෘත කර ඇති අතර AI ආකෘති පුහුණු කිරීමට භාවිත නොකෙරේ."
+"ඔබගේ කතාබස් පුද්ගලිකයි, අප විසින් නිර්නාමිකෘත කර ඇති අතර AI ආකෘති පුහුණු "
+"කිරීමට භාවිත නොකෙරේ."
 
 # smartling.placeholder_format=C
 #. Text for a menu item that describes the privacy protection feature.
@@ -23974,8 +24170,8 @@ msgctxt "Menu item description"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
 msgstr ""
-"ඔබේ කතාබස් පුද්ගලික වන අතර, අප විසින් කිසි විටෙකත් සුරකින අතර AI ආකෘති පුහුණු කිරීමට භාවිත "
-"නොකෙරේ."
+"ඔබේ කතාබස් පුද්ගලික වන අතර, අප විසින් කිසි විටෙකත් සුරකින අතර AI ආකෘති "
+"පුහුණු කිරීමට භාවිත නොකෙරේ."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the active privacy protection.
@@ -23983,8 +24179,8 @@ msgctxt "Modal body for privacy"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
 msgstr ""
-"ඔබේ කතාබස් පුද්ගලික වන අතර, අප විසින් කිසි විටෙකත් සුරකින අතර AI ආකෘති පුහුණු කිරීමට භාවිත "
-"නොකෙරේ."
+"ඔබේ කතාබස් පුද්ගලික වන අතර, අප විසින් කිසි විටෙකත් සුරකින අතර AI ආකෘති "
+"පුහුණු කිරීමට භාවිත නොකෙරේ."
 
 # smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that chats are stored locally on the user's device.
@@ -23999,8 +24195,9 @@ msgid ""
 "Your chats are still private, anonymized by us, and not used to train AI "
 "models. Follow these steps to keep your chat history."
 msgstr ""
-"ඔබගේ කතාබස් පුද්ගලික වන අතර ඒ්වා අප විසින් නිර්නාමික කර තිබේ. තව ද ඒ්වා කෘත්‍රිම බුද්ධි ආකෘති "
-"පුහුණු කිරීමට යොදා ගනු නොලැබේ. ඔබේ කතාබස් ඉතිහාසය තබා ගැනීමට මේ පියවර අනුගමනය කරන්න."
+"ඔබගේ කතාබස් පුද්ගලික වන අතර ඒ්වා අප විසින් නිර්නාමික කර තිබේ. තව ද ඒ්වා "
+"කෘත්‍රිම බුද්ධි ආකෘති පුහුණු කිරීමට යොදා ගනු නොලැබේ. ඔබේ කතාබස් ඉතිහාසය තබා "
+"ගැනීමට මේ පියවර අනුගමනය කරන්න."
 
 # smartling.placeholder_format=C
 #. Body shown after import completes.
@@ -24040,8 +24237,8 @@ msgid ""
 "Your email address will not be shared, %sor associated with anonymous "
 "searches. [%sExample message%s]"
 msgstr ""
-"ඔබගේ විද්‍යුත් තැපැල් ලිපිනය බෙදාහැරීමක්, %1$sහෝ නිර්නාමික සෙවුම් සමඟ සම්බන්ධ කිරීමක් සිදු නොවේ. "
-"[%2$sඋදාහරණ පණිවිඩය%3$s]"
+"ඔබගේ විද්‍යුත් තැපැල් ලිපිනය බෙදාහැරීමක්, %1$sහෝ නිර්නාමික සෙවුම් සමඟ "
+"සම්බන්ධ කිරීමක් සිදු නොවේ. [%2$sඋදාහරණ පණිවිඩය%3$s]"
 
 # smartling.placeholder_format=C
 #. A prompt for the user to provide feedback on the third party map app directions experience
@@ -24084,9 +24281,10 @@ msgid ""
 "browser. We save the settings file using the key as the name. DuckDuckGo "
 "never knows your passphrase."
 msgstr ""
-"%1$sSHA-2%2$s ලෙස හැඳින්වෙන ආරක්ෂිත හැෂ් ඇල්ගොරිතම භාවිතා කිරීමෙන් ඔබගේ මුරපදය 512-bit "
-"යතුරක් ජනනය කරයි.. ඔබගේ බ්‍රව්සරයෙන් පිටවන්නේ යතුර සහ ආශ්‍රිත සැකසුම් ගොනුව පමණි. යතුර නම ලෙස "
-"භාවිතා කර අපි සැකසුම් ගොනුව සුරකිමු. DuckDuckGo කිසි විටෙකත් ඔබේ මුරපදය දන්නේ නැත."
+"%1$sSHA-2%2$s ලෙස හැඳින්වෙන ආරක්ෂිත හැෂ් ඇල්ගොරිතම භාවිතා කිරීමෙන් ඔබගේ "
+"මුරපදය 512-bit යතුරක් ජනනය කරයි.. ඔබගේ බ්‍රව්සරයෙන් පිටවන්නේ යතුර සහ ආශ්‍රිත "
+"සැකසුම් ගොනුව පමණි. යතුර නම ලෙස භාවිතා කර අපි සැකසුම් ගොනුව සුරකිමු. "
+"DuckDuckGo කිසි විටෙකත් ඔබේ මුරපදය දන්නේ නැත."
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -24101,8 +24299,9 @@ msgid ""
 "personally identifiable metadata, so model providers can't tie your "
 "conversations back to you."
 msgstr ""
-"ඔබගේ විමසීම් DuckDuckGo සර්වර හරහා යවනු ලබන අතර ඒවායෙන් පුද්ගලිකව හඳුනාගත හැකි පාර-දත්ත "
-"ඉවත් කරනු ලැබේ, එබැවින් ආකෘති සපයන්නන්ට ඔබගේ සංවාද ඔබ හා නැවත සම්බන්ධ කළ නොහැක."
+"ඔබගේ විමසීම් DuckDuckGo සර්වර හරහා යවනු ලබන අතර ඒවායෙන් පුද්ගලිකව හඳුනාගත "
+"හැකි පාර-දත්ත ඉවත් කරනු ලැබේ, එබැවින් ආකෘති සපයන්නන්ට ඔබගේ සංවාද ඔබ හා නැවත "
+"සම්බන්ධ කළ නොහැක."
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -24116,8 +24315,8 @@ msgid ""
 "Your recent chats live here! You can refer to your chats or clear them "
 "anytime."
 msgstr ""
-"ඔබගේ මෑත කාලීන කතාබස් මෙහි ඇත! ඔබට ඔබේ කතාබස් වෙත යොමු විය හැකි ය හෝ ඕනෑම වේලාවක "
-"ඒවා ඉවත් කළ හැකි ය."
+"ඔබගේ මෑත කාලීන කතාබස් මෙහි ඇත! ඔබට ඔබේ කතාබස් වෙත යොමු විය හැකි ය හෝ ඕනෑම "
+"වේලාවක ඒවා ඉවත් කළ හැකි ය."
 
 # smartling.placeholder_format=C
 #. Message on a feedback form.
@@ -24160,8 +24359,8 @@ msgid ""
 "You’re now searching privately in Chrome. Use our browser instead of Chrome "
 "for more protection. It’s already installed and can:"
 msgstr ""
-"දැන් ඔබ Chrome හි පුද්ගලිකව සොයමින් සිටී. වැඩි ආරක්ෂාව සඳහා Chrome වෙනුවට අපේ බ්‍රවුසරය "
-"භාවිත කරන්න. එය දැනටමත් ස්ථාපනය කර ඇති අතර හැකියාව ඇත්තේ:"
+"දැන් ඔබ Chrome හි පුද්ගලිකව සොයමින් සිටී. වැඩි ආරක්ෂාව සඳහා Chrome වෙනුවට "
+"අපේ බ්‍රවුසරය භාවිත කරන්න. එය දැනටමත් ස්ථාපනය කර ඇති අතර හැකියාව ඇත්තේ:"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has exceeded the maximum message size.
@@ -24170,7 +24369,8 @@ msgid ""
 "You’ve exceeded the maximum message size. Please shorten your message and "
 "try again."
 msgstr ""
-"ඔබ උපරිම පණිවිඩ ප්‍රමාණය ඉක්මවා ඇත. කරුණාකර ඔබගේ පණිවිඩය කෙටි කර නැවත උත්සාහ කරන්න."
+"ඔබ උපරිම පණිවිඩ ප්‍රමාණය ඉක්මවා ඇත. කරුණාකර ඔබගේ පණිවිඩය කෙටි කර නැවත උත්සාහ "
+"කරන්න."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -24179,8 +24379,8 @@ msgid ""
 "You’ve reached the maximum chat length in this conversation. Clear this "
 "conversation with the Fire Button to continue."
 msgstr ""
-"ඔබ මෙම සංවාදයේ උපරිම කතාබස් දිගට පැමිණ ඇත. දිගටම කරගෙන යාම සඳහා Fire Button සමඟ "
-"මෙම සංවාදය ඉවත් කරන්න."
+"ඔබ මෙම සංවාදයේ උපරිම කතාබස් දිගට පැමිණ ඇත. දිගටම කරගෙන යාම සඳහා Fire Button "
+"සමඟ මෙම සංවාදය ඉවත් කරන්න."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -24188,7 +24388,9 @@ msgctxt "Error message for conversation limit"
 msgid ""
 "You’ve reached the maximum chat length in this conversation. Start a new "
 "chat to continue."
-msgstr "ඔබ මෙම සංවාදයේ උපරිම කතාබස් දිගට පැමිණ ඇත. ඉදිරියට යාමට නව කතාබහක් ආරම්භ ගන්න."
+msgstr ""
+"ඔබ මෙම සංවාදයේ උපරිම කතාබස් දිගට පැමිණ ඇත. ඉදිරියට යාමට නව කතාබහක් ආරම්භ "
+"ගන්න."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -24203,8 +24405,8 @@ msgid ""
 "You’ve reached the maximum number of messages for one day. Please continue "
 "this chat tomorrow."
 msgstr ""
-"ඔබ එක් දිනක් සඳහා උපරිම පණිවිඩ සංඛ්‍යාවට ළඟා වී ඇත. කරුණාකර හෙට මෙම කතාබස් දිගටම කරගෙන "
-"යන්න."
+"ඔබ එක් දිනක් සඳහා උපරිම පණිවිඩ සංඛ්‍යාවට ළඟා වී ඇත. කරුණාකර හෙට මෙම කතාබස් "
+"දිගටම කරගෙන යන්න."
 
 # smartling.placeholder_format=C
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.

--- a/locales/sk_SK/LC_MESSAGES/duckduckgo.po
+++ b/locales/sk_SK/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: sk_SK\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -87,8 +87,7 @@ msgstr "%1$s a %2$s Modely umelej inteligencie"
 #. Message that appears above the search results encouraging them to filter results by domain. The placeholder string would include a the name of a website. E.g. 'Reddit appears in some of the top results for this search.'
 msgctxt "Site filter message"
 msgid "%s appears in some of the top results for this search."
-msgstr ""
-"%1$s sa vyskytuje v niektorých z najlepších výsledkov pre toto vyhľadávanie."
+msgstr "%1$s sa vyskytuje v niektorých z najlepších výsledkov pre toto vyhľadávanie."
 
 # smartling.placeholder_format=C
 #. Number of tracking attempts blocked, when there is more than 1. Eg: '2 attempts' or '302 attempts'
@@ -99,8 +98,7 @@ msgstr "Pokusy: %1$s"
 # smartling.placeholder_format=C
 #. A summary description of how many tracking attempts where blocked, when there was more than 1. Eg: '1,028 attempts blocked by DuckDuckGo in the last 24 hours'
 msgid "%s attempts blocked by DuckDuckGo in the last 24 hours"
-msgstr ""
-"DuckDuckGo za posledných 24 hodín zablokoval nasledujúci počet pokusov: %1$s"
+msgstr "DuckDuckGo za posledných 24 hodín zablokoval nasledujúci počet pokusov: %1$s"
 
 # smartling.placeholder_format=C
 #. A label that indicates a specific search result has been blocked by the safe search filter. The placeholder value is the name of the search result that was blocked.
@@ -218,8 +216,7 @@ msgctxt "Error message for model unavailability"
 msgid ""
 "%s is temporarily unavailable. Please switch to a different model or try "
 "again later."
-msgstr ""
-"%1$s je dočasne nedostupný. Prejdite na iný model alebo to skúste neskôr."
+msgstr "%1$s je dočasne nedostupný. Prejdite na iný model alebo to skúste neskôr."
 
 # smartling.placeholder_format=C
 #. Reddit's "fake internet points". https://support.reddithelp.com/hc/en-us/articles/204511829-What-is-karma
@@ -447,8 +444,7 @@ msgctxt "noresults"
 msgid ""
 "%sClick here%s to try again, if you think there should be results for this "
 "search."
-msgstr ""
-"%1$sSkúste to znova%2$s, ak si myslíte, že sa mali nájsť nejaké výsledky."
+msgstr "%1$sSkúste to znova%2$s, ak si myslíte, že sa mali nájsť nejaké výsledky."
 
 # smartling.placeholder_format=C
 #. Header for a page with information about sharing DuckDuckGo.
@@ -473,15 +469,13 @@ msgstr "%1$sZistite, ako chránime informácie o vašej polohe%2$s."
 msgctxt "Footer text for About Sync modal"
 msgid ""
 "%sLearn more%s about how chats are stored privately on DuckDuckGo's server."
-msgstr ""
-"%1$sZisti viac%2$s o tom, ako sú čety súkromne uložené na serveri DuckDuckGo."
+msgstr "%1$sZisti viac%2$s o tom, ako sú čety súkromne uložené na serveri DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "%sLearn more%s about how chats are stored privately on your device."
-msgstr ""
-"%1$sZisti viac%2$s o tom, ako sú chaty súkromne uložené v tvojom zariadení."
+msgstr "%1$sZisti viac%2$s o tom, ako sú chaty súkromne uložené v tvojom zariadení."
 
 # smartling.placeholder_format=C
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
@@ -493,8 +487,7 @@ msgstr "%1$sDlho stlačte%2$s ikonu aplikácie DuckDuckGo na úvodnej obrazovke"
 #. A message displayed when there is an error loading content or no results on requery
 msgctxt "Error or no results message"
 msgid "%sOops!%s%sSomething went wrong. Please %srefresh%s and try again."
-msgstr ""
-"%1$sAch!%2$s%3$sNiečo sa pokazilo. Prosím, %4$sobnov%5$s a skús to znova."
+msgstr "%1$sAch!%2$s%3$sNiečo sa pokazilo. Prosím, %4$sobnov%5$s a skús to znova."
 
 # smartling.placeholder_format=C
 #. Tagline in a popover encouraging the user to download the DuckDuckGo browser
@@ -884,16 +877,14 @@ msgstr ""
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of AI Chat is available! Please refresh this page to continue."
-msgstr ""
-"K dispozícii je nová verzia AI Chat! Ak chceš pokračovať, obnov túto stránku."
+msgstr "K dispozícii je nová verzia AI Chat! Ak chceš pokračovať, obnov túto stránku."
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of Duck.ai is available and they need to refresh the page.
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of Duck.ai is available! Please refresh this page to continue."
-msgstr ""
-"Je k dispozícii nová verzia Duck.ai! Ak chceš pokračovať, obnov túto stránku."
+msgstr "Je k dispozícii nová verzia Duck.ai! Ak chceš pokračovať, obnov túto stránku."
 
 # smartling.placeholder_format=C
 #. Shown when the Duck.ai desktop app has been open a long time and a newer version exists.
@@ -1442,7 +1433,7 @@ msgstr "Adresa je nesprávna"
 #. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Adjust the servings"
-msgstr ""
+msgstr "Upraviť porcie"
 
 # smartling.placeholder_format=C
 #. as in multiple advertisements
@@ -1664,6 +1655,9 @@ msgid ""
 "All chats are anonymized by DuckDuckGo, and your conversations are not used "
 "to train chat models by DuckDuckGo or the model providers"
 msgstr ""
+"Všetky chaty sú anonymizované spoločnosťou DuckDuckGo a DuckDuckGo ani "
+"poskytovatelia modelov nepoužívajú tvoje konverzácie na trénovanie modelov "
+"chatu"
 
 # smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1808,8 +1802,7 @@ msgstr "Už je to synchronizované."
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Also search privately on your iPad, iPhone, or Android!"
-msgstr ""
-"Vyhľadávajte súkromne aj vo svojom zariadení iPad alebo iPhone či Androide!"
+msgstr "Vyhľadávajte súkromne aj vo svojom zariadení iPad alebo iPhone či Androide!"
 
 # smartling.placeholder_format=C
 #. Keyboard shortcut for Duck.ai
@@ -1942,6 +1935,8 @@ msgid ""
 "Anonymously generates answers for search queries based on web content. "
 "Choose how often you want it to appear, or disable it completely."
 msgstr ""
+"Anonymne generuje odpovede na vyhľadávacie dotazy na základe webového "
+"obsahu. Vyber, ako často sa má zobrazovať, alebo ju úplne vypni."
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -2226,7 +2221,7 @@ msgstr "Požiadaj Duck.ai o následnú komunikáciu"
 #. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
 msgctxt "Page suggestion chip label"
 msgid "Ask about this page"
-msgstr ""
+msgstr "Opýtaj sa na túto stránku"
 
 # smartling.placeholder_format=C
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2651,7 +2646,7 @@ msgstr "Čiarový kód"
 #. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Based on this page, is this course worth taking?"
-msgstr ""
+msgstr "Oplatí sa podľa tejto stránky absolvovať tento kurz?"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2700,6 +2695,9 @@ msgid ""
 "Before storing this report, DuckDuckGo will anonymize your conversation by "
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
+"Pred uložením tohto hlásenia DuckDuckGo anonymizuje tvoju konverzáciu "
+"odstránením osobných údajov, ako sú mená, e-mailové adresy a identifikačné "
+"metadáta."
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -2841,8 +2839,7 @@ msgstr "Zablokovať túto stránku vo všetkých výsledkoch"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Block trackers and take control of your personal data"
-msgstr ""
-"Blokujte sledovače a prevezmite späť kontrolu nad svojimi osobnými údajmi"
+msgstr "Blokujte sledovače a prevezmite späť kontrolu nad svojimi osobnými údajmi"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -3022,7 +3019,7 @@ msgstr "Získané body pri brejku"
 #. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Break this down into clear, numbered steps."
-msgstr ""
+msgstr "Rozdeľ to na jasné očíslované kroky."
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -3485,7 +3482,7 @@ msgstr "Obsadenie"
 #. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Cast & Crew"
-msgstr ""
+msgstr "Obsadenie a štáb"
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -5081,8 +5078,7 @@ msgstr "Kopírovať"
 # smartling.placeholder_format=C
 #. Instructions on how to change the default search engine
 msgid "Copy &amp; paste %sabout:preferences#search%s into the address bar"
-msgstr ""
-"Skopírujte a prilepte %1$sabout:preferences#search%2$s do panela s adresou."
+msgstr "Skopírujte a prilepte %1$sabout:preferences#search%2$s do panela s adresou."
 
 # smartling.placeholder_format=C
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
@@ -5201,7 +5197,7 @@ msgstr "Vytvoriť obrázok"
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
-msgstr ""
+msgstr "Vytvor nákupný zoznam s množstvami z tohto receptu."
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed in the input field when starting a new image generation session.
@@ -5848,7 +5844,7 @@ msgstr "Bol dosiahnutý limit pre diktovanie"
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
 msgid "Dictation temporarily unavailable"
-msgstr ""
+msgstr "Diktovanie je dočasne nedostupné"
 
 # smartling.placeholder_format=C
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
@@ -6131,8 +6127,7 @@ msgstr "Nevidíte súbor? %1$s%2$s%3$sKliknite sem a stiahnite si ho znova.%4$s
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Don't see the checkbox? %sFollow these steps%s."
-msgstr ""
-"Nevidíte začiarkavacie políčko? %1$sPostupujte podľa týchto krokov%2$s."
+msgstr "Nevidíte začiarkavacie políčko? %1$sPostupujte podľa týchto krokov%2$s."
 
 # smartling.placeholder_format=C
 #. Setting that hides a user's most visited sites when they open a new browser tab.
@@ -6158,6 +6153,8 @@ msgid ""
 "Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
 "filtered out. %sLearn More%s"
 msgstr ""
+"Nechceš AI? %1$snoai.duckduckgo.com%2$s neponúka žiadne funkcie AI a obrázky "
+"vytvorené AI sú odfiltrované. %3$sZisti viac%4$s"
 
 # smartling.placeholder_format=C
 #. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
@@ -6166,6 +6163,8 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
+"Nechceš AI? Navštív %1$snoai.duckduckgo.com%2$s pre vyhľadávanie bez funkcií "
+"AI a s odfiltrovanými obrázkami vytvorenými AI. %3$sZisti viac%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6285,13 +6284,13 @@ msgstr ""
 #. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Draft a cover letter"
-msgstr ""
+msgstr "Napíš sprievodný list"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Draft a cover letter for this job."
-msgstr ""
+msgstr "Napíš motivačný list na túto pracovnú pozíciu."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -6467,8 +6466,7 @@ msgstr ""
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
-msgstr ""
-"Duck.ai je najlepší v našom súkromnom a bezplatnom prehliadači DuckDuckGo!"
+msgstr "Duck.ai je najlepší v našom súkromnom a bezplatnom prehliadači DuckDuckGo!"
 
 # smartling.placeholder_format=C
 #. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
@@ -6478,6 +6476,9 @@ msgid ""
 "company for anyone who wants to take back control of their personal "
 "information."
 msgstr ""
+"Duck.ai vytvorila spoločnosť DuckDuckGo. Sme nezávislá spoločnosť na ochranu "
+"súkromia online pre každého, kto chce získať späť kontrolu nad svojimi "
+"osobnými údajmi."
 
 # smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
@@ -6530,6 +6531,9 @@ msgid ""
 "Duck.ai lets you chat privately with popular AI models. Disabling it hides "
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
+"Duck.ai ti umožňuje súkromne chatovať s populárnymi modelmi AI. Vypnutím sa "
+"skryjú tlačidlá a odkazy Duck.ai, ale stále môžeš navštíviť %1$sduck.ai%2$s "
+"priamo."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6763,8 +6767,8 @@ msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. If this persists, please "
 "email this anonymous code %s to %s"
 msgstr ""
-"DuckDuckGo AI Chat je dočasne nedostupný. Ak to bude pretrvávať, pošlite e-"
-"mailom tento anonymný kód %1$s na adresu %2$s"
+"DuckDuckGo AI Chat je dočasne nedostupný. Ak to bude pretrvávať, pošlite "
+"e-mailom tento anonymný kód %1$s na adresu %2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -6772,15 +6776,13 @@ msgctxt "Error message for VQD error"
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. Please refresh the page and "
 "try again."
-msgstr ""
-"DuckDuckGo AI Chat je dočasne nedostupný. Obnovte stránku a skúste to znova."
+msgstr "DuckDuckGo AI Chat je dočasne nedostupný. Obnovte stránku a skúste to znova."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr ""
-"DuckDuckGo AI Chat je dočasne nedostupný. Prosím, skúste to neskôr znova."
+msgstr "DuckDuckGo AI Chat je dočasne nedostupný. Prosím, skúste to neskôr znova."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -6918,8 +6920,7 @@ msgctxt ""
 "Inline terms-of-service disclaimer below chat or image-gen input for new "
 "users"
 msgid "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to our %s."
-msgstr ""
-"DuckDuckGo anonymizuje tvoje chaty. Kliknutím na „%1$s“ súhlasíš s %2$s."
+msgstr "DuckDuckGo anonymizuje tvoje chaty. Kliknutím na „%1$s“ súhlasíš s %2$s."
 
 # smartling.placeholder_format=C
 #. An information popup explaining that we block trackers
@@ -7120,8 +7121,7 @@ msgstr "Upravujem obrázok..."
 msgctxt "Info text for the editing message feature"
 msgid ""
 "Editing your message will remove the response below and generate a new one."
-msgstr ""
-"Úpravou tvojej správy sa odstráni nižšie uvedená odpoveď, a vytvorí sa nová."
+msgstr "Úpravou tvojej správy sa odstráni nižšie uvedená odpoveď, a vytvorí sa nová."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of an editor in its responses.
@@ -7536,13 +7536,13 @@ msgstr "Eritrea"
 #. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Estimate the nutrition"
-msgstr ""
+msgstr "Odhadni výživu"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Estimate the nutritional information for this recipe."
-msgstr ""
+msgstr "Odhadni nutričné údaje pre tento recept."
 
 # smartling.placeholder_format=C
 msgid "Estonia"
@@ -7602,7 +7602,7 @@ msgstr "Platnosť končí o 1 deň"
 #. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain the accepted answer in simple terms."
-msgstr ""
+msgstr "Vysvetli prijatú odpoveď jednoduchými slovami."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
@@ -7615,43 +7615,43 @@ msgstr "Vysvetliť základné pojmy čiernych dier na stredoškolskej úrovni."
 #. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain the top answer"
-msgstr ""
+msgstr "Vysvetli najlepšiu odpoveď"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain this in simple, plain language."
-msgstr ""
+msgstr "Vysvetli to jednoduchou a zrozumiteľnou rečou."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain this paper"
-msgstr ""
+msgstr "Vysvetli tento dokument"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain this repo"
-msgstr ""
+msgstr "Vysvetli tento repozitár"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain this research paper in plain language."
-msgstr ""
+msgstr "Vysvetli tento výskumný článok jednoduchým jazykom."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain this simply"
-msgstr ""
+msgstr "Vysvetli to jednoducho"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain what this repository does and how to use it."
-msgstr ""
+msgstr "Vysvetli, čo tento repozitár robí a ako ho používať."
 
 # smartling.placeholder_format=C
 #. Label to show if song lyrics contain explicit content
@@ -7944,6 +7944,8 @@ msgctxt "settings"
 msgid ""
 "Filters out known AI spam sites from image search results. %sLearn More%s"
 msgstr ""
+"Filtruje známe spamové stránky generované umelou inteligenciou vo výsledkoch "
+"vyhľadávania obrázkov. %1$sZistiť viac%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the final score of a sporting event.
@@ -7972,8 +7974,7 @@ msgstr "Finančný poradca"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Find %sDuckDuckGo%s and click%sMake default%s"
-msgstr ""
-"Nájdite %1$sDuckDuckGo%2$s a kliknite na%3$sNastaviť ako predvolené%4$s."
+msgstr "Nájdite %1$sDuckDuckGo%2$s a kliknite na%3$sNastaviť ako predvolené%4$s."
 
 # smartling.placeholder_format=C
 #. Sentence shown after export, includes a placeholder for one or more filenames with bold formatting for the filename(s).
@@ -7985,8 +7986,7 @@ msgstr "Nájdi <b>%1$s</b> v&nbsp;tvojom priečinku so&nbsp;stiahnutými súborm
 # smartling.placeholder_format=C
 #. Tells users how to change their default search engine to DuckDuckGo.
 msgid "Find DuckDuckGo in the displayed list and click %sMake Default%s"
-msgstr ""
-"Nájdite DuckDuckGo v zozname a vyberte %1$sNastaviť ako predvolený%2$s."
+msgstr "Nájdite DuckDuckGo v zozname a vyberte %1$sNastaviť ako predvolený%2$s."
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for finding a better word.
@@ -8004,7 +8004,7 @@ msgstr "Nájsť aktuálne informácie"
 #. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Find me alternatives"
-msgstr ""
+msgstr "Nájdi mi alternatívy"
 
 # smartling.placeholder_format=C
 #. Button that searches for results closer to the user's current location.
@@ -8455,8 +8455,7 @@ msgstr "Všeobecná umelá inteligencia s vysokou mierou moderovania"
 #. Text with short description for an AI (Artificial Intelligence) Model that has a low moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "General purpose AI with low built-in moderation"
-msgstr ""
-"Umelá inteligencia na všeobecné použitie s nízkou vstavanou moderovaním"
+msgstr "Umelá inteligencia na všeobecné použitie s nízkou vstavanou moderovaním"
 
 # smartling.placeholder_format=C
 #. Text with short description for an AI (Artificial Intelligence) Model that has a medium moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
@@ -8490,7 +8489,7 @@ msgstr "Generovať viac"
 #. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Generate a shopping list"
-msgstr ""
+msgstr "Vytvor nákupný zoznam"
 
 # smartling.placeholder_format=C
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
@@ -8787,14 +8786,13 @@ msgstr "Vyskúšaj to"
 #. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Give me a quick background on this person."
-msgstr ""
+msgstr "Poskytni mi stručné informácie o tejto osobe."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
-msgstr ""
-"Prejsť na %1$sOchrana osobných údajov a zabezpečenie > Lokalizačné služby%2$s"
+msgstr "Prejsť na %1$sOchrana osobných údajov a zabezpečenie > Lokalizačné služby%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9240,13 +9238,13 @@ msgstr "Pomôžte šíriť povedomie o ochrane súkromia"
 #. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Help me prep for the interview"
-msgstr ""
+msgstr "Pomôž mi pripraviť sa na pohovor"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Help me tailor my resume for this job."
-msgstr ""
+msgstr "Pomôž mi prispôsobiť môj životopis pre túto pracovnú pozíciu."
 
 # smartling.placeholder_format=C
 #. Title of a SERP popup that invites users to take a survey (desktop only)
@@ -9604,8 +9602,7 @@ msgstr "Otvárací čas chýba"
 #. This is the name of a user setting
 msgctxt "settings"
 msgid "Hover, Module, and Dropdown Background Color"
-msgstr ""
-"Farba pozadia pri ukázaní kurzorom, v moduloch a rozbaľovacích ponukách"
+msgstr "Farba pozadia pri ukázaní kurzorom, v moduloch a rozbaľovacích ponukách"
 
 # smartling.placeholder_format=C
 #. Label for a pill-shaped tab below the empty-state Duck.ai chat input. Clicking it opens a panel that explains how Duck.ai protects user privacy.
@@ -9770,7 +9767,7 @@ msgctxt ""
 "Text for the I already have a subscription button in the Duck.ai settings "
 "page"
 msgid "I Already Have a Subscription"
-msgstr ""
+msgstr "Už mám predplatné"
 
 # smartling.placeholder_format=C
 #. Text for the button that takes the user to the login subscription page.
@@ -10354,7 +10351,7 @@ msgstr "Inštalovať prehliadač pre Mac"
 #. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
 msgctxt "settings"
 msgid "Install Now"
-msgstr ""
+msgstr "Inštalovať teraz"
 
 # smartling.placeholder_format=C
 #. Text of a button to install the DuckDuckGo app
@@ -10457,13 +10454,13 @@ msgstr "Sú odstránené údaje naozaj natrvalo odstránené?"
 #. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Is it worth taking?"
-msgstr ""
+msgstr "Oplatí sa to?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Is this place any good?"
-msgstr ""
+msgstr "Je toto miesto dobré?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
@@ -10471,7 +10468,7 @@ msgctxt "Page suggestion prompt"
 msgid ""
 "Is this place any good? Summarize its reputation based on reviews and "
 "ratings."
-msgstr ""
+msgstr "Je toto miesto dobré? Zhrň jeho reputáciu na základe recenzií a hodnotení."
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -10483,13 +10480,13 @@ msgstr "Je toto video užitočné?"
 #. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Is this worth watching?"
-msgstr ""
+msgstr "Oplatí sa to pozrieť?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Is this worth watching? Give me a spoiler-free take."
-msgstr ""
+msgstr "Oplatí sa to pozrieť? Povedz mi o tom bez prezradenia výsledkov deja."
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -10521,8 +10518,7 @@ msgstr "Je to rýchly, bezplatný a poskytuje ti ešte väčšiu ochranu online.
 msgctxt "settings"
 msgid ""
 "It's okay to (very infrequently) ask me about my experience using DuckDuckGo"
-msgstr ""
-"Občas (naozaj len občas) sa ma môžete spýtať na môj názor na DuckDuckGo"
+msgstr "Občas (naozaj len občas) sa ma môžete spýtať na môj názor na DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. The name of the Italian language
@@ -10965,8 +10961,7 @@ msgstr "Viac informácií o tom, ako to funguje"
 # smartling.placeholder_format=C
 msgctxt "SERP footer content"
 msgid "Learn why reducing online tracking is important."
-msgstr ""
-"Ďalšie informácie o tom, prečo je dôležité obmedziť sledovanie na internete."
+msgstr "Ďalšie informácie o tom, prečo je dôležité obmedziť sledovanie na internete."
 
 # smartling.placeholder_format=C
 #. A link that takes users to a page where they can learn more about the dangers of online tracking.
@@ -11107,7 +11102,7 @@ msgstr "Odkazy:"
 #. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
-msgstr ""
+msgstr "Vymenuj nástroje, materiály alebo predpoklady, ktoré na to potrebujem."
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -11521,7 +11516,7 @@ msgstr "Spravovať blokované lokality"
 #. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
 msgctxt "setting"
 msgid "Manage in Browser Settings"
-msgstr ""
+msgstr "Spravovať v nastaveniach prehliadača"
 
 # smartling.placeholder_format=C
 #. Link to the site exclusion settings page
@@ -13383,8 +13378,7 @@ msgctxt "translations_module"
 msgid ""
 "Oops! An unexpected error occurred while translating this text. Please try "
 "again later."
-msgstr ""
-"Ajaj! Pri preklade tohto textu došlo k neočakávanej chybe. Skúste to neskôr."
+msgstr "Ajaj! Pri preklade tohto textu došlo k neočakávanej chybe. Skúste to neskôr."
 
 # smartling.placeholder_format=C
 #. Title shown in a fatal error modal when Duck.ai fails to load.
@@ -13463,8 +13457,7 @@ msgstr "Otvorte položku Poloha a uistite sa, že je poloha %1$szapnutá%2$s."
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open 'Privacy', then 'Location Services'."
-msgstr ""
-"Otvorte položku „Ochrana osobných údajov“ a potom „Služby určovania polohy“."
+msgstr "Otvorte položku „Ochrana osobných údajov“ a potom „Služby určovania polohy“."
 
 # smartling.placeholder_format=C
 #. Indicates a business is open 24 hours a day.
@@ -13601,8 +13594,7 @@ msgstr "Otvoriť panel Ako funguje Duck.ai"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open the Safari menu and select %sSettings for DuckDuckGo...%s"
-msgstr ""
-"Otvorte ponuku Safari a vyberte položku %1$sNastavenia pre DuckDuckGo...%2$s"
+msgstr "Otvorte ponuku Safari a vyberte položku %1$sNastavenia pre DuckDuckGo...%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the time a business opens. For example: 'Opens at 10am'
@@ -14360,14 +14352,13 @@ msgstr ""
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is harmful or illegal. (optional)"
-msgstr ""
+msgstr "Popíš, prečo je odpoveď v chate škodlivá alebo nezákonná. (nepovinné)"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
-msgstr ""
-"Popíšte, prečo je odpoveď v chate nelegálna alebo škodlivá. (Nepovinné)"
+msgstr "Popíšte, prečo je odpoveď v chate nelegálna alebo škodlivá. (Nepovinné)"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to enter their passphrase.
@@ -14398,6 +14389,8 @@ msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is harmful or illegal."
 msgstr ""
+"Vlož svoju výzvu a problematický výstup (bez akýchkoľvek osobných údajov) a "
+"popíš, prečo je obsah škodlivý alebo nezákonný."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -14870,7 +14863,7 @@ msgstr "Súkromie"
 #. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
 msgctxt "Section heading on the Duck.ai settings page"
 msgid "Privacy & Terms"
-msgstr ""
+msgstr "Zásady ochrany osobných údajov a podmienky používania"
 
 # smartling.placeholder_format=C
 msgid "Privacy Blog"
@@ -14946,7 +14939,7 @@ msgstr "Zásady ochrany osobných údajov a podmienky služby"
 #. Text for a button that links to the terms of use and privacy policy page.
 msgctxt "Secondary button text in active privacy modal"
 msgid "Privacy Policy and Terms of Service"
-msgstr ""
+msgstr "Zásady ochrany osobných údajov a podmienky služby"
 
 # smartling.placeholder_format=C
 #. Title displayed on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
@@ -15455,25 +15448,25 @@ msgstr "Odporučiť knihu"
 #. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Recommend similar books"
-msgstr ""
+msgstr "Odporuč podobné knihy"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Recommend similar books."
-msgstr ""
+msgstr "Odporuč podobné knihy."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Recommend similar movies or shows."
-msgstr ""
+msgstr "Odporuč podobné filmy alebo relácie."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Recommend similar titles"
-msgstr ""
+msgstr "Odporuč podobné názvy"
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
@@ -15884,7 +15877,7 @@ msgctxt ""
 "feedback form when the user has selected Harmful or Illegal as the feedback "
 "reason"
 msgid "Required for harmful or illegal reports"
-msgstr ""
+msgstr "Vyžaduje sa pre nahlásenie škodlivého alebo nelegálneho obsahu"
 
 # smartling.placeholder_format=C
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
@@ -16126,7 +16119,7 @@ msgstr "Recenzie"
 #. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Rewrite this recipe scaled for a different number of servings."
-msgstr ""
+msgstr "Prepíš tento recept na iný počet porcií."
 
 # smartling.placeholder_format=C
 msgid "Romania"
@@ -16412,8 +16405,7 @@ msgstr "Ulož si až 30 svojich najnovších chatov lokálne do svojho zariad
 msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
-msgstr ""
-"Ulož si svoje čety Duck.ai medzi zariadeniami pomocou end-to-end šifrovania."
+msgstr "Ulož si svoje čety Duck.ai medzi zariadeniami pomocou end-to-end šifrovania."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -16580,8 +16572,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down to the %sServices%s section and click %sAddress bar%s."
-msgstr ""
-"Prejdite nadol do časti %1$sSlužby%2$s a vyberte %3$sPanel s adresou%4$s."
+msgstr "Prejdite nadol do časti %1$sSlužby%2$s a vyberte %3$sPanel s adresou%4$s."
 
 # smartling.placeholder_format=C
 #. Rugby match stats
@@ -16731,8 +16722,7 @@ msgstr "Viditeľnosť vyhľadávania"
 # smartling.placeholder_format=C
 #. Message prompting users to download the DuckDuckGo app.
 msgid "Search and browse privately with the DuckDuckGo app."
-msgstr ""
-"Vyhľadávajte a prehľadávajte web súkromne pomocou aplikácie DuckDuckGo."
+msgstr "Vyhľadávajte a prehľadávajte web súkromne pomocou aplikácie DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Category a user can select on a feedback form.
@@ -16868,8 +16858,7 @@ msgstr "Vyhľadávajte cez DuckDuckGo"
 #. Text for a promotional card encouraging third-party browser users to download the DuckDuckGo browser. Not shown in the DuckDuckGo browser or on Linux.
 msgctxt "Promotional text"
 msgid "Search, browse, and chat privately in our free browser"
-msgstr ""
-"Vyhľadávaj, prehliadaj a chatuj súkromne v našom bezplatnom prehliadači"
+msgstr "Vyhľadávaj, prehliadaj a chatuj súkromne v našom bezplatnom prehliadači"
 
 # smartling.placeholder_format=C
 #. Message displayed sometimes at top of results (for bang syntax), e.g. <a href="https://duckduckgo.com/?q=twitter+test">https://duckduckgo.com/?q=twitter+test</a>
@@ -16913,8 +16902,7 @@ msgstr "Týždne sezóny"
 #. Description shown in the Sync & Backup settings section when sync is not yet enabled, explaining the feature.
 msgctxt "Description for sync and backup feature"
 msgid "Securely save and sync your chats across all your devices."
-msgstr ""
-"Bezpečne ukladaj a synchronizuj svoje chaty na všetkých svojich zariadeniach."
+msgstr "Bezpečne ukladaj a synchronizuj svoje chaty na všetkých svojich zariadeniach."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -16943,8 +16931,9 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your synced devices."
 msgstr ""
-"Bezpečne ukladaj takmer neobmedzený počet četov na našom serveri pomocou end-"
-"to-end šifrovania a pristupuj k nim zo všetkých synchronizovaných zariadení."
+"Bezpečne ukladaj takmer neobmedzený počet četov na našom serveri pomocou "
+"end-to-end šifrovania a pristupuj k nim zo všetkých synchronizovaných "
+"zariadení."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17142,15 +17131,13 @@ msgstr "Vyberte %1$sDuckDuckGo%2$s a potom %3$sPridať ako predvolené%4$s."
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Select %sDuckDuckGo%s in the Default Search Engine drop down"
-msgstr ""
-"V rozbaľovacej ponuke Predvolený vyhľadávač vyberte %1$sDuckDuckGo%2$s."
+msgstr "V rozbaľovacej ponuke Predvolený vyhľadávač vyberte %1$sDuckDuckGo%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %sDuckDuckGo%s in the list and %sallow%s location access"
-msgstr ""
-"V zozname vyberte %1$sDuckDuckGo%2$s a %3$spovoľte%4$s prístup k polohe"
+msgstr "V zozname vyberte %1$sDuckDuckGo%2$s a %3$spovoľte%4$s prístup k polohe"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -17467,7 +17454,7 @@ msgstr "Nastaviť teraz"
 #. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
 msgctxt "Encrypted storage setup button shown in native browsers"
 msgid "Set Up Sync & Backup"
-msgstr ""
+msgstr "Nastavenie Sync & Backup"
 
 # smartling.placeholder_format=C
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
@@ -17561,8 +17548,7 @@ msgstr "Zdieľať"
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "Share DuckDuckGo and help friends take their privacy back!"
-msgstr ""
-"Zdieľajte DuckDuckGo a pomôžte svojim priateľom získať späť ich súkromie!"
+msgstr "Zdieľajte DuckDuckGo a pomôžte svojim priateľom získať späť ich súkromie!"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button that opens a feedback modal when clicked.
@@ -17656,7 +17642,7 @@ msgstr "Zdieľajte kladnú spätnú väzbu"
 msgctxt ""
 "Label beside the share-content switch on the Duck.ai response feedback form"
 msgid "Share this conversation with DuckDuckGo"
-msgstr ""
+msgstr "Podeľ sa o túto konverzáciu s DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -17795,8 +17781,7 @@ msgstr "Zobraziť DuckAssist <sup>BETA</sup>"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show DuckAssist more often. (You can also completely %sturn it off%s.)"
-msgstr ""
-"Zobrazovať DuckAssist častejšie. (Môžete ho tiež úplne %1$svypnúť%2$s.)"
+msgstr "Zobrazovať DuckAssist častejšie. (Môžete ho tiež úplne %1$svypnúť%2$s.)"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
@@ -18044,8 +18029,7 @@ msgstr "Zobraziť vodorovné čiary medzi stránkami vo výsledkoch vyhľadávan
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows links to instructions for how to add DuckDuckGo to your browser"
-msgstr ""
-"Zobraziť odkazy na návod, ako pridať DuckDuckGo do webového prehliadača"
+msgstr "Zobraziť odkazy na návod, ako pridať DuckDuckGo do webového prehliadača"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers more frequently.
@@ -18061,14 +18045,12 @@ msgstr "Zobraziť najnavštevovanejšie odkazy na novej karte"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your browser"
-msgstr ""
-"Zobraziť občasné pripomenutia na pridanie DuckDuckGo do webového prehliadača"
+msgstr "Zobraziť občasné pripomenutia na pridanie DuckDuckGo do webového prehliadača"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr ""
-"Zobraziť občasné pripomenutia na pridanie služby DuckDuckGo do zariadení"
+msgstr "Zobraziť občasné pripomenutia na pridanie služby DuckDuckGo do zariadení"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18099,8 +18081,7 @@ msgstr "Zobrazovať návrhy pod vyhľadávacím poľom pri písaní"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows the privacy benefits of using DuckDuckGo on the homepage"
-msgstr ""
-"Zobraziť výhody DuckDuckGo v oblasti ochrany súkromia na domovskej stránke"
+msgstr "Zobraziť výhody DuckDuckGo v oblasti ochrany súkromia na domovskej stránke"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18110,8 +18091,7 @@ msgstr "Zobraziť pozadie tlačidla Hľadať"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message on top of the search results page"
-msgstr ""
-"Zobraziť uvítaciu správu v hornej časti stránky s výsledkami vyhľadávania"
+msgstr "Zobraziť uvítaciu správu v hornej časti stránky s výsledkami vyhľadávania"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18402,8 +18382,7 @@ msgctxt "Error message when an uploaded image cannot be decoded or processed"
 msgid ""
 "Sorry, the uploaded image couldn't be processed. Please try a different "
 "image or format."
-msgstr ""
-"Žiaľ, nahraný obrázok sa nepodarilo spracovať. Skús iný obrázok alebo formát."
+msgstr "Žiaľ, nahraný obrázok sa nepodarilo spracovať. Skús iný obrázok alebo formát."
 
 # smartling.placeholder_format=C
 #. Body copy shown when a scanned or pasted pairing payload fails schema validation.
@@ -18437,8 +18416,7 @@ msgstr ""
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr ""
-"Ľutujeme, ale nepodarilo sa nám odoslať vašu spätnú väzbu. Skúste to neskôr."
+msgstr "Ľutujeme, ale nepodarilo sa nám odoslať vašu spätnú väzbu. Skúste to neskôr."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -18492,8 +18470,7 @@ msgstr "Zdrojový text bol vymazaný"
 msgctxt "Error message for summary selection input limit"
 msgid ""
 "Source text is too long to summarize. Try again with a shorter selection."
-msgstr ""
-"Zdrojový text je príliš dlhý na zhrnutie. Skús to znova s kratším výberom."
+msgstr "Zdrojový text je príliš dlhý na zhrnutie. Skús to znova s kratším výberom."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under Interface Settings.in the end. It is a header
@@ -18753,8 +18730,7 @@ msgstr "Zablokujte skryté sledovače, ktoré na vás číhajú na iných weboch
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop most hidden trackers lurking on other websites."
-msgstr ""
-"Zablokujte väčšinu skrytých sledovačov, ktoré na vás číhajú na iných weboch."
+msgstr "Zablokujte väčšinu skrytých sledovačov, ktoré na vás číhajú na iných weboch."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18927,19 +18903,19 @@ msgstr "Návrh názvu pre príspevok na blogu"
 #. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Suggest related articles or topics worth exploring next."
-msgstr ""
+msgstr "Navrhni súvisiace články alebo témy, ktoré stoja za preskúmanie."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Suggest related articles to explore"
-msgstr ""
+msgstr "Navrhni súvisiace články na preskúmanie"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Suggest some alternatives to this product."
-msgstr ""
+msgstr "Navrhni nejaké alternatívy k tomuto produktu."
 
 # smartling.placeholder_format=C
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
@@ -18956,7 +18932,7 @@ msgstr "Návrhy:"
 #. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Sum up the reviews"
-msgstr ""
+msgstr "Zhrň recenzie"
 
 # smartling.placeholder_format=C
 #. A short title for the a message asking the AI to summarize a text.
@@ -18968,85 +18944,85 @@ msgstr "Zhrnúť"
 #. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize the Q&As"
-msgstr ""
+msgstr "Zhrň otázky a odpovede"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the background and notable work of this person."
-msgstr ""
+msgstr "Zhrň pozadie a významnú prácu tejto osoby."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the key details of this event."
-msgstr ""
+msgstr "Zhrň kľúčové podrobnosti tejto udalosti."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the questions and answers on this page."
-msgstr ""
+msgstr "Zhrň otázky a odpovede na tejto stránke."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize their background"
-msgstr ""
+msgstr "Zhrň ich pozadie"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this book"
-msgstr ""
+msgstr "Zhrň túto knihu"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this book."
-msgstr ""
+msgstr "Zhrň túto knihu."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this discussion"
-msgstr ""
+msgstr "Zhrň túto diskusiu"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this discussion thread."
-msgstr ""
+msgstr "Zhrň toto diskusné vlákno."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this page"
-msgstr ""
+msgstr "Zhrň túto stránku"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this page."
-msgstr ""
+msgstr "Zhrň túto stránku."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this video"
-msgstr ""
+msgstr "Zhrň toto video"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this video."
-msgstr ""
+msgstr "Zhrň toto video."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize what the reviews say."
-msgstr ""
+msgstr "Zhrň, čo hovoria recenzie."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -19207,8 +19183,7 @@ msgstr "Prejdite na vyhľadávač, ktorý vás nesleduje. Nikdy."
 msgctxt "AI Chat warning when switching from an encrypted model"
 msgid ""
 "Switching will send your chat to a model without zero provider visibility"
-msgstr ""
-"Prepnutím sa tvoj chat odošle modelu bez nulovej viditeľnosti poskytovateľa."
+msgstr "Prepnutím sa tvoj chat odošle modelu bez nulovej viditeľnosti poskytovateľa."
 
 # smartling.placeholder_format=C
 msgid "Switzerland"
@@ -19378,7 +19353,7 @@ msgstr "Sýria"
 #. Text for a button that enables the theme to follow the operating system's color scheme preference.
 msgctxt "System theme button for theme selector"
 msgid "System"
-msgstr ""
+msgstr "Systém"
 
 # smartling.placeholder_format=C
 #. Abbreviation indicating this is the total score for a game
@@ -19412,7 +19387,7 @@ msgstr "Tahitčina"
 #. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Tailor my resume"
-msgstr ""
+msgstr "Prispôsob môj životopis"
 
 # smartling.placeholder_format=C
 msgid "Taiwan"
@@ -19448,7 +19423,7 @@ msgstr "Získajte späť kontrolu nad svojimi osobnými údajmi!"
 msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
-msgstr ""
+msgstr "Vyplň tento anonymný prieskum a daj nám vedieť, ako môžeme Duck.ai vylepšiť."
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -19748,8 +19723,7 @@ msgstr "Uplynul časový limit žiadosti. Skús to znova."
 #. Inform the users that "something" went wrong and we are unable to show any results.
 msgctxt "noresults"
 msgid "The server encountered an error and could not complete your request."
-msgstr ""
-"Na serveri sa vyskytla chyba a server nemohol dokončiť tvoju požiadavku."
+msgstr "Na serveri sa vyskytla chyba a server nemohol dokončiť tvoju požiadavku."
 
 # smartling.placeholder_format=C
 #. Title for the theme menu:
@@ -19761,7 +19735,7 @@ msgstr "Motív"
 #. Text for the theme selector label that allows users to switch between Light and dark theme.
 msgctxt "Label for the theme selector feature"
 msgid "Theme"
-msgstr ""
+msgstr "Motív"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/LpFhb1e.png
@@ -19868,8 +19842,7 @@ msgctxt "AI Chat: Error message for when a model is removed"
 msgid ""
 "This AI model is no longer available. Try starting a new chat with a "
 "different model."
-msgstr ""
-"Tento model AI už nie je k dispozícii. Skúste začať nový chat iným modelom."
+msgstr "Tento model AI už nie je k dispozícii. Skúste začať nový chat iným modelom."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is no longer supported because it has been upgraded to a newest version.
@@ -20144,8 +20117,7 @@ msgstr "Tento preklad je nesprávny"
 # smartling.placeholder_format=C
 #. Label indicating that the video can't be played on the current page, and only on the website that owns the vide. The placeholder is the name of the website that owns the video.
 msgid "This video is not yet able to be watched here. You can watch it on %s."
-msgstr ""
-"Toto video tu ešte nie je možné sledovať. Môžete ho sledovať v službe %1$s."
+msgstr "Toto video tu ešte nie je možné sledovať. Môžete ho sledovať v službe %1$s."
 
 # smartling.placeholder_format=C
 #. Message indicating that a website is not using an encrypted connection and is not secure.
@@ -20268,8 +20240,8 @@ msgstr "Tipy"
 # smartling.placeholder_format=C
 msgid "Tired of being tracked online? %sWe can help.%s"
 msgstr ""
-"Už vás nebaví, že vás na internete niekto neustále sleduje? %1$sPomôžeme vám."
-"%2$s"
+"Už vás nebaví, že vás na internete niekto neustále sleduje? %1$sPomôžeme "
+"vám.%2$s"
 
 # smartling.placeholder_format=C
 #. This is the name of a user setting
@@ -20317,8 +20289,8 @@ msgid ""
 "To print directions:%sGo back to the map.%sSelect the route you want to "
 "print.%sClick the print icon.%s"
 msgstr ""
-"Tlač návodu:%1$sVráťte sa do mapy.%2$sVyberte trasu, ktorú chcete vytlačiť."
-"%3$sKliknite na ikonu tlače.%4$s"
+"Tlač návodu:%1$sVráťte sa do mapy.%2$sVyberte trasu, ktorú chcete "
+"vytlačiť.%3$sKliknite na ikonu tlače.%4$s"
 
 # smartling.placeholder_format=C
 #. Explains where the user can find their recovery code. Figma frame 3703-44420.
@@ -20608,13 +20580,13 @@ msgstr ""
 #. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Translate this page"
-msgstr ""
+msgstr "Prelož túto stránku"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
 msgctxt "Page suggestion prompt"
 msgid "Translate this page into %s."
-msgstr ""
+msgstr "Prelož túto stránku do jazyka %1$s."
 
 # smartling.placeholder_format=C
 #. Placeholder text for a region that will display translated text.
@@ -20761,7 +20733,7 @@ msgstr "Vyskúšať zadarmo"
 #. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
 msgctxt "settings"
 msgid "Try It Now"
-msgstr ""
+msgstr "Skús to teraz"
 
 # smartling.placeholder_format=C
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -20819,15 +20791,13 @@ msgstr "Skúste iné kľúčové slová."
 # smartling.placeholder_format=C
 #. Prompt encouraging the user to turn off their ad blocker to see more results for their query.
 msgid "Try disabling your ad blocker on DuckDuckGo to see more results."
-msgstr ""
-"Skús vypnúť blokovanie reklám na DuckDuckGo, aby si videl/-a viac výsledkov."
+msgstr "Skús vypnúť blokovanie reklám na DuckDuckGo, aby si videl/-a viac výsledkov."
 
 # smartling.placeholder_format=C
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
 msgctxt "precise_user_location"
 msgid "Try enabling anonymous location for more accurate results."
-msgstr ""
-"Presnejšie výsledky môžete získať povolením anonymného určovania polohy."
+msgstr "Presnejšie výsledky môžete získať povolením anonymného určovania polohy."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the screen of the onboarding where the user picks a chat model.
@@ -21006,6 +20976,9 @@ msgid ""
 "Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
+"Chceš vypnúť funkcie AI? Nainštaluj si vyhľadávacie rozšírenie "
+"%1$sDuckDuckGo No AI%2$s, aby sa tvoje nastavenia uložili. %3$sZistite "
+"viac%4$s"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -21014,6 +20987,8 @@ msgid ""
 "Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
+"Pokúšaš sa vypnúť funkcie AI? Prejdi na vyhľadávacie rozšírenie "
+"%1$sDuckDuckGo No AI%2$s, aby sa uložili tvoje nastavenia. %3$sZisti viac%4$s"
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -21115,8 +21090,7 @@ msgstr "Vypnúť:"
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on %sPrecise Location%s for more accurate results"
-msgstr ""
-"Ak chcete získať presnejšie výsledky, zapnite možnosť %1$sPresná poloha%2$s"
+msgstr "Ak chcete získať presnejšie výsledky, zapnite možnosť %1$sPresná poloha%2$s"
 
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
@@ -21133,8 +21107,7 @@ msgstr "Presnejšie výsledky môžete získať zapnutím nastavenia „Presná 
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on “Use precise location” for more accurate results."
-msgstr ""
-"Presnejšie výsledky môžete získať zapnutím nastavenia „Použiť presnú polohu“."
+msgstr "Presnejšie výsledky môžete získať zapnutím nastavenia „Použiť presnú polohu“."
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Create Image' label in the Tools dropdown.
@@ -21340,14 +21313,13 @@ msgstr ""
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
 msgstr ""
-"Pod možnosťou %1$sPri spustení > Domovská stránka%2$s napíšte: https://"
-"duckduckgo.com."
+"Pod možnosťou %1$sPri spustení > Domovská stránka%2$s napíšte: "
+"https://duckduckgo.com."
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch Settings%s select %sDuckDuckGo%s"
-msgstr ""
-"Pod možnosťou %1$sNastavenia vyhľadávania%2$s vyberte %3$sDuckDuckGo%4$s."
+msgstr "Pod možnosťou %1$sNastavenia vyhľadávania%2$s vyberte %3$sDuckDuckGo%4$s."
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -21360,8 +21332,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
-msgstr ""
-"Pod sekciou %1$sVyhľadávanie%2$s vyberte %3$sSpravovať vyhľadávače...%4$s."
+msgstr "Pod sekciou %1$sVyhľadávanie%2$s vyberte %3$sSpravovať vyhľadávače...%4$s."
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -21375,8 +21346,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine
 msgid "Under Search click the drop down and select %sDuckDuckGo%s"
-msgstr ""
-"V časti Vyhľadávanie vyberte rozbaľovaciu ponuku a potom %1$sDuckDuckGo%2$s."
+msgstr "V časti Vyhľadávanie vyberte rozbaľovaciu ponuku a potom %1$sDuckDuckGo%2$s."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings" header
@@ -21778,7 +21748,7 @@ msgstr "Uruguaj"
 #. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
 msgctxt "Navigation label on the Duck.ai settings page"
 msgid "Usage"
-msgstr ""
+msgstr "Používanie"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -22235,7 +22205,7 @@ msgstr "Wales"
 #. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Walk me through the steps"
-msgstr ""
+msgstr "Preveď ma krokmi"
 
 # smartling.placeholder_format=C
 #. Label for walking directions on a map.
@@ -22366,6 +22336,9 @@ msgid ""
 "please share this conversation with DuckDuckGo so we can investigate and "
 "address the issue."
 msgstr ""
+"Opraviť môžeme len to, čo vidíme. Ak chceš nahlásiť škodlivú alebo nezákonnú "
+"odpoveď, zdieľaj túto konverzáciu s DuckDuckGo, aby sme mohli problém "
+"preskúmať a riešiť."
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -22896,8 +22869,7 @@ msgctxt "Full sentence for finding a better word"
 msgid ""
 "What are some options for the word ‘better’ in the context of “We really "
 "need to do better.”"
-msgstr ""
-"Aké sú niektoré možnosti slova „lepší“ v kontexte „Naozaj musíme byť lepší“."
+msgstr "Aké sú niektoré možnosti slova „lepší“ v kontexte „Naozaj musíme byť lepší“."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
@@ -22927,98 +22899,98 @@ msgstr ""
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the counterarguments?"
-msgstr ""
+msgstr "Aké sú protiargumenty?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the hours & location?"
-msgstr ""
+msgstr "Aké sú otváracie hodiny a poloha?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key contributions of this paper?"
-msgstr ""
+msgstr "Aké sú hlavné prínosy tohto článku?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key contributions?"
-msgstr ""
+msgstr "Aké sú hlavné prínosy?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key details?"
-msgstr ""
+msgstr "Čo sú kľúčové informácie?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key points covered in this video?"
-msgstr ""
+msgstr "Aké sú hlavné body tohto videa?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key points?"
-msgstr ""
+msgstr "Aké sú hlavné body?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key takeaways from this article?"
-msgstr ""
+msgstr "Aké sú hlavné myšlienky tohto článku?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key takeaways?"
-msgstr ""
+msgstr "Aké sú hlavné body?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key things I will learn from this course?"
-msgstr ""
+msgstr "Aké sú hlavné veci, ktoré sa v tomto kurze naučím?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the main counterarguments or criticisms of this?"
-msgstr ""
+msgstr "Aké sú hlavné argumenty proti tomu alebo kritika?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the main questions this page answers?"
-msgstr ""
+msgstr "Aké sú hlavné otázky, na ktoré táto stránka odpovedá?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the must-try dishes here?"
-msgstr ""
+msgstr "Ktoré jedlá tu mám ochutnať?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid ""
 "What are the opening hours, location, and contact details for this place?"
-msgstr ""
+msgstr "Aké sú otváracie hodiny, poloha a kontaktné údaje tohto miesta?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the pros and cons of this product?"
-msgstr ""
+msgstr "Aké sú výhody a nevýhody tohto produktu?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the pros and cons?"
-msgstr ""
+msgstr "Aké sú výhody a nevýhody?"
 
 # smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
@@ -23124,7 +23096,7 @@ msgstr "Čo znamenajú predsiene v kontexte lekárskeho článku?"
 #. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What does this answer?"
-msgstr ""
+msgstr "Na čo táto odpoveď odpovedá?"
 
 # smartling.placeholder_format=C
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
@@ -23142,7 +23114,7 @@ msgstr "Aké údaje ukladáme?"
 #. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What interview questions might come up for this role?"
-msgstr ""
+msgstr "Aké otázky by mohli padnúť na pohovore na túto pozíciu?"
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -23164,7 +23136,7 @@ msgstr "Aké je hlavné mesto Albánska?"
 #. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What is the overall verdict and rating for this?"
-msgstr ""
+msgstr "Aký je pre toto celkový verdikt a hodnotenie?"
 
 # smartling.placeholder_format=C
 #. Link to a page with additional information.
@@ -23192,7 +23164,7 @@ msgstr "Čo hovoria iní:"
 #. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What should I order?"
-msgstr ""
+msgstr "Čo si mám objednať?"
 
 # smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
@@ -23210,13 +23182,13 @@ msgstr "Čo bolo na odpovedi nesprávne? (Nepovinné)"
 #. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What will I learn?"
-msgstr ""
+msgstr "Čo sa dozviem?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What will I need?"
-msgstr ""
+msgstr "Čo budem potrebovať?"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -23241,7 +23213,7 @@ msgstr "Novinky"
 #. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What's the verdict?"
-msgstr ""
+msgstr "Aký je verdikt?"
 
 # smartling.placeholder_format=C
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -23261,8 +23233,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "When enabled, Duck.ai will show instant answers in the chat."
-msgstr ""
-"Ak je toto povolené, Duck.ai bude v chate zobrazovať okamžité odpovede."
+msgstr "Ak je toto povolené, Duck.ai bude v chate zobrazovať okamžité odpovede."
 
 # smartling.placeholder_format=C
 #. Text of a button that performs a search for the available streaming services that show a particular movie or tv show
@@ -23280,8 +23251,7 @@ msgstr "Kde sledovať <strong>%1$s</strong>"
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Where it says Homepage click %sSet to Current Page%s."
-msgstr ""
-"Pri možnosti Domovská stránka vyberte %1$sNastaviť aktuálnu stránku%2$s."
+msgstr "Pri možnosti Domovská stránka vyberte %1$sNastaviť aktuálnu stránku%2$s."
 
 # smartling.placeholder_format=C
 #. Heading of a module showing what streaming services are showing a movie or series, e.g. Where to Watch The Matrix
@@ -23299,7 +23269,7 @@ msgstr "Ktoré funkcie chýbajú? (Nepovinné)"
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Which features are missing? (optional)"
-msgstr ""
+msgstr "Ktoré funkcie chýbajú? (nepovinné)"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
@@ -23321,13 +23291,13 @@ msgstr "Kto sme"
 #. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Who are the main cast and crew, and what else are they known for?"
-msgstr ""
+msgstr "Kto je hlavnom hereckom obsadení a štábe, a čím ďalším sú dané osoby známe?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Who is this person?"
-msgstr ""
+msgstr "Kto je táto osoba?"
 
 # smartling.placeholder_format=C
 #. Header above a collection of privacy-related links.
@@ -24201,8 +24171,7 @@ msgstr "Podľa vášho prehliadača ste tento odkaz už otvorili."
 # smartling.placeholder_format=C
 msgctxt "new tab page"
 msgid "Your browser provides a list of your most-visited sites."
-msgstr ""
-"Váš prehliadač poskytuje zoznam vašich najčastejšie navštevovaných lokalít."
+msgstr "Váš prehliadač poskytuje zoznam vašich najčastejšie navštevovaných lokalít."
 
 # smartling.placeholder_format=C
 #. Used as a description in a menu
@@ -24251,8 +24220,7 @@ msgstr ""
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never used to train AI models"
-msgstr ""
-"Tvoje rozhovory sú súkromné a nikdy sa nepoužívajú na trénovanie modelov AI"
+msgstr "Tvoje rozhovory sú súkromné a nikdy sa nepoužívajú na trénovanie modelov AI"
 
 # smartling.placeholder_format=C
 #. Text for a description of the active privacy protection for DuckDuckGo's AI Chat feature.
@@ -24313,8 +24281,7 @@ msgctxt "duckai_migration"
 msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
-msgstr ""
-"Tvoje čety boli importované. Pokračuj tam, kde si na Duck.ai skončil/-a."
+msgstr "Tvoje čety boli importované. Pokračuj tam, kde si na Duck.ai skončil/-a."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.
@@ -24480,8 +24447,7 @@ msgctxt "Error message for input limit"
 msgid ""
 "You’ve exceeded the maximum message size. Please shorten your message and "
 "try again."
-msgstr ""
-"Prekročili ste maximálnu veľkosť správy. Skráťte správu a skúste to znova."
+msgstr "Prekročili ste maximálnu veľkosť správy. Skráťte správu a skúste to znova."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -24819,8 +24785,7 @@ msgstr "oficiálnej webovej stránky"
 #. <em>%s</em> is for a hexadecimal color code as <em>#395323</em>, but it has to be safe encoded, and as <em>#</em> seems not safe, <em>%23</em> must be used in place of the sharp symbol, but they are the same for your browser.
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
-msgstr ""
-"alebo napíšte kód požadovanej farby, napr. %1$s (%2$s je kódovaný znak %3$s)."
+msgstr "alebo napíšte kód požadovanej farby, napr. %1$s (%2$s je kódovaný znak %3$s)."
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "

--- a/locales/sk_SK/LC_MESSAGES/duckduckgo.po
+++ b/locales/sk_SK/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: sk_SK\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -87,7 +87,8 @@ msgstr "%1$s a %2$s Modely umelej inteligencie"
 #. Message that appears above the search results encouraging them to filter results by domain. The placeholder string would include a the name of a website. E.g. 'Reddit appears in some of the top results for this search.'
 msgctxt "Site filter message"
 msgid "%s appears in some of the top results for this search."
-msgstr "%1$s sa vyskytuje v niektorých z najlepších výsledkov pre toto vyhľadávanie."
+msgstr ""
+"%1$s sa vyskytuje v niektorých z najlepších výsledkov pre toto vyhľadávanie."
 
 # smartling.placeholder_format=C
 #. Number of tracking attempts blocked, when there is more than 1. Eg: '2 attempts' or '302 attempts'
@@ -98,7 +99,8 @@ msgstr "Pokusy: %1$s"
 # smartling.placeholder_format=C
 #. A summary description of how many tracking attempts where blocked, when there was more than 1. Eg: '1,028 attempts blocked by DuckDuckGo in the last 24 hours'
 msgid "%s attempts blocked by DuckDuckGo in the last 24 hours"
-msgstr "DuckDuckGo za posledných 24 hodín zablokoval nasledujúci počet pokusov: %1$s"
+msgstr ""
+"DuckDuckGo za posledných 24 hodín zablokoval nasledujúci počet pokusov: %1$s"
 
 # smartling.placeholder_format=C
 #. A label that indicates a specific search result has been blocked by the safe search filter. The placeholder value is the name of the search result that was blocked.
@@ -216,7 +218,8 @@ msgctxt "Error message for model unavailability"
 msgid ""
 "%s is temporarily unavailable. Please switch to a different model or try "
 "again later."
-msgstr "%1$s je dočasne nedostupný. Prejdite na iný model alebo to skúste neskôr."
+msgstr ""
+"%1$s je dočasne nedostupný. Prejdite na iný model alebo to skúste neskôr."
 
 # smartling.placeholder_format=C
 #. Reddit's "fake internet points". https://support.reddithelp.com/hc/en-us/articles/204511829-What-is-karma
@@ -444,7 +447,8 @@ msgctxt "noresults"
 msgid ""
 "%sClick here%s to try again, if you think there should be results for this "
 "search."
-msgstr "%1$sSkúste to znova%2$s, ak si myslíte, že sa mali nájsť nejaké výsledky."
+msgstr ""
+"%1$sSkúste to znova%2$s, ak si myslíte, že sa mali nájsť nejaké výsledky."
 
 # smartling.placeholder_format=C
 #. Header for a page with information about sharing DuckDuckGo.
@@ -469,13 +473,15 @@ msgstr "%1$sZistite, ako chránime informácie o vašej polohe%2$s."
 msgctxt "Footer text for About Sync modal"
 msgid ""
 "%sLearn more%s about how chats are stored privately on DuckDuckGo's server."
-msgstr "%1$sZisti viac%2$s o tom, ako sú čety súkromne uložené na serveri DuckDuckGo."
+msgstr ""
+"%1$sZisti viac%2$s o tom, ako sú čety súkromne uložené na serveri DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "%sLearn more%s about how chats are stored privately on your device."
-msgstr "%1$sZisti viac%2$s o tom, ako sú chaty súkromne uložené v tvojom zariadení."
+msgstr ""
+"%1$sZisti viac%2$s o tom, ako sú chaty súkromne uložené v tvojom zariadení."
 
 # smartling.placeholder_format=C
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
@@ -487,7 +493,8 @@ msgstr "%1$sDlho stlačte%2$s ikonu aplikácie DuckDuckGo na úvodnej obrazovke"
 #. A message displayed when there is an error loading content or no results on requery
 msgctxt "Error or no results message"
 msgid "%sOops!%s%sSomething went wrong. Please %srefresh%s and try again."
-msgstr "%1$sAch!%2$s%3$sNiečo sa pokazilo. Prosím, %4$sobnov%5$s a skús to znova."
+msgstr ""
+"%1$sAch!%2$s%3$sNiečo sa pokazilo. Prosím, %4$sobnov%5$s a skús to znova."
 
 # smartling.placeholder_format=C
 #. Tagline in a popover encouraging the user to download the DuckDuckGo browser
@@ -877,14 +884,16 @@ msgstr ""
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of AI Chat is available! Please refresh this page to continue."
-msgstr "K dispozícii je nová verzia AI Chat! Ak chceš pokračovať, obnov túto stránku."
+msgstr ""
+"K dispozícii je nová verzia AI Chat! Ak chceš pokračovať, obnov túto stránku."
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of Duck.ai is available and they need to refresh the page.
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of Duck.ai is available! Please refresh this page to continue."
-msgstr "Je k dispozícii nová verzia Duck.ai! Ak chceš pokračovať, obnov túto stránku."
+msgstr ""
+"Je k dispozícii nová verzia Duck.ai! Ak chceš pokračovať, obnov túto stránku."
 
 # smartling.placeholder_format=C
 #. Shown when the Duck.ai desktop app has been open a long time and a newer version exists.
@@ -1430,6 +1439,12 @@ msgid "Address is incorrect"
 msgstr "Adresa je nesprávna"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Adjust the servings"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. as in multiple advertisements
 msgid "Ads"
 msgstr "Reklamy"
@@ -1643,6 +1658,14 @@ msgid "All chats are %sprivate%s"
 msgstr "Všetky chaty sú %1$ssúkromné%2$s"
 
 # smartling.placeholder_format=C
+#. Paragraph in the Privacy & Terms section of the About & Legal page in Duck.ai settings, summarizing how chats are anonymized and are not stored or used to train chat models.
+msgctxt "Privacy & Terms section description on the Duck.ai settings page"
+msgid ""
+"All chats are anonymized by DuckDuckGo, and your conversations are not used "
+"to train chat models by DuckDuckGo or the model providers"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
 msgctxt "Privacy modal header in Duck.ai chat"
 msgid "All chats are private"
@@ -1785,7 +1808,8 @@ msgstr "Už je to synchronizované."
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Also search privately on your iPad, iPhone, or Android!"
-msgstr "Vyhľadávajte súkromne aj vo svojom zariadení iPad alebo iPhone či Androide!"
+msgstr ""
+"Vyhľadávajte súkromne aj vo svojom zariadení iPad alebo iPhone či Androide!"
 
 # smartling.placeholder_format=C
 #. Keyboard shortcut for Duck.ai
@@ -1911,6 +1935,13 @@ msgstr ""
 msgctxt "precise_user_location"
 msgid "Anonymous location enabled"
 msgstr "Anonymná poloha je povolená"
+
+# smartling.placeholder_format=C
+msgctxt "settings"
+msgid ""
+"Anonymously generates answers for search queries based on web content. "
+"Choose how often you want it to appear, or disable it completely."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -2190,6 +2221,12 @@ msgstr "Opýtaj sa doplňujúcu otázku"
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse
 msgid "Ask a follow-up with Duck.ai"
 msgstr "Požiadaj Duck.ai o následnú komunikáciu"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
+msgctxt "Page suggestion chip label"
+msgid "Ask about this page"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2611,6 +2648,12 @@ msgid "Barcode"
 msgstr "Čiarový kód"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Based on this page, is this course worth taking?"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Basic"
 msgstr "Základné"
@@ -2649,6 +2692,14 @@ msgstr "Pálkar"
 msgctxt "Assistant response placeholder"
 msgid "Before continuing..."
 msgstr "Pred pokračovaním..."
+
+# smartling.placeholder_format=C
+#. Explains that before storing the report, DuckDuckGo will anonymize the conversation by removing PII like names, email addresses, and identifying metadata.
+msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
+msgid ""
+"Before storing this report, DuckDuckGo will anonymize your conversation by "
+"removing PII like names, email addresses, and identifying metadata."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -2790,7 +2841,8 @@ msgstr "Zablokovať túto stránku vo všetkých výsledkoch"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Block trackers and take control of your personal data"
-msgstr "Blokujte sledovače a prevezmite späť kontrolu nad svojimi osobnými údajmi"
+msgstr ""
+"Blokujte sledovače a prevezmite späť kontrolu nad svojimi osobnými údajmi"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -2965,6 +3017,12 @@ msgstr "Brazília"
 msgctxt "Sports module"
 msgid "Break Points Won"
 msgstr "Získané body pri brejku"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Break this down into clear, numbered steps."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -3422,6 +3480,12 @@ msgstr "Kariéra"
 msgctxt "Movie/TV Show Title instant answer"
 msgid "Cast"
 msgstr "Obsadenie"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Cast & Crew"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -5017,7 +5081,8 @@ msgstr "Kopírovať"
 # smartling.placeholder_format=C
 #. Instructions on how to change the default search engine
 msgid "Copy &amp; paste %sabout:preferences#search%s into the address bar"
-msgstr "Skopírujte a prilepte %1$sabout:preferences#search%2$s do panela s adresou."
+msgstr ""
+"Skopírujte a prilepte %1$sabout:preferences#search%2$s do panela s adresou."
 
 # smartling.placeholder_format=C
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
@@ -5131,6 +5196,12 @@ msgstr "Vytvoriť obrázok"
 msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr "Vytvoriť obrázok"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Create a shopping list with quantities from this recipe."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed in the input field when starting a new image generation session.
@@ -5775,6 +5846,11 @@ msgid "Dictation limit reached"
 msgstr "Bol dosiahnutý limit pre diktovanie"
 
 # smartling.placeholder_format=C
+#. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
+msgid "Dictation temporarily unavailable"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
@@ -6055,7 +6131,8 @@ msgstr "Nevidíte súbor? %1$s%2$s%3$sKliknite sem a stiahnite si ho znova.%4$s
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Don't see the checkbox? %sFollow these steps%s."
-msgstr "Nevidíte začiarkavacie políčko? %1$sPostupujte podľa týchto krokov%2$s."
+msgstr ""
+"Nevidíte začiarkavacie políčko? %1$sPostupujte podľa týchto krokov%2$s."
 
 # smartling.placeholder_format=C
 #. Setting that hides a user's most visited sites when they open a new browser tab.
@@ -6073,6 +6150,22 @@ msgstr "Hotovo"
 msgctxt "precise_user_location"
 msgid "Done"
 msgstr "Hotovo"
+
+# smartling.placeholder_format=C
+#. Message shown in a modal after DuckDuckGo browser users disable AI features in Settings. The first two placeholders bold noai.duckduckgo.com. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
+"filtered out. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
+"and AI images filtered out. %sLearn more%s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6187,6 +6280,18 @@ msgid ""
 msgstr ""
 "Vypracujte pre predajcu stručný podrobný e-mail so žiadosťou o cenovú ponuku "
 "na opravu domácej chladničky."
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Draft a cover letter"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Draft a cover letter for this job."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -6362,7 +6467,17 @@ msgstr ""
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
-msgstr "Duck.ai je najlepší v našom súkromnom a bezplatnom prehliadači DuckDuckGo!"
+msgstr ""
+"Duck.ai je najlepší v našom súkromnom a bezplatnom prehliadači DuckDuckGo!"
+
+# smartling.placeholder_format=C
+#. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
+msgctxt "About section description on the Duck.ai settings page"
+msgid ""
+"Duck.ai is created by DuckDuckGo. We're an independent online protection "
+"company for anyone who wants to take back control of their personal "
+"information."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
@@ -6408,6 +6523,13 @@ msgstr "Duck.ai je dočasne nedostupný. Obnov stránku a skúste to znova."
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
 msgstr "Duck.ai je dočasne nedostupný. Skús to neskôr znova, prosím."
+
+# smartling.placeholder_format=C
+msgctxt "settings"
+msgid ""
+"Duck.ai lets you chat privately with popular AI models. Disabling it hides "
+"Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6641,8 +6763,8 @@ msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. If this persists, please "
 "email this anonymous code %s to %s"
 msgstr ""
-"DuckDuckGo AI Chat je dočasne nedostupný. Ak to bude pretrvávať, pošlite "
-"e-mailom tento anonymný kód %1$s na adresu %2$s"
+"DuckDuckGo AI Chat je dočasne nedostupný. Ak to bude pretrvávať, pošlite e-"
+"mailom tento anonymný kód %1$s na adresu %2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -6650,13 +6772,15 @@ msgctxt "Error message for VQD error"
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. Please refresh the page and "
 "try again."
-msgstr "DuckDuckGo AI Chat je dočasne nedostupný. Obnovte stránku a skúste to znova."
+msgstr ""
+"DuckDuckGo AI Chat je dočasne nedostupný. Obnovte stránku a skúste to znova."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr "DuckDuckGo AI Chat je dočasne nedostupný. Prosím, skúste to neskôr znova."
+msgstr ""
+"DuckDuckGo AI Chat je dočasne nedostupný. Prosím, skúste to neskôr znova."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -6794,7 +6918,8 @@ msgctxt ""
 "Inline terms-of-service disclaimer below chat or image-gen input for new "
 "users"
 msgid "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to our %s."
-msgstr "DuckDuckGo anonymizuje tvoje chaty. Kliknutím na „%1$s“ súhlasíš s %2$s."
+msgstr ""
+"DuckDuckGo anonymizuje tvoje chaty. Kliknutím na „%1$s“ súhlasíš s %2$s."
 
 # smartling.placeholder_format=C
 #. An information popup explaining that we block trackers
@@ -6995,7 +7120,8 @@ msgstr "Upravujem obrázok..."
 msgctxt "Info text for the editing message feature"
 msgid ""
 "Editing your message will remove the response below and generate a new one."
-msgstr "Úpravou tvojej správy sa odstráni nižšie uvedená odpoveď, a vytvorí sa nová."
+msgstr ""
+"Úpravou tvojej správy sa odstráni nižšie uvedená odpoveď, a vytvorí sa nová."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of an editor in its responses.
@@ -7407,6 +7533,18 @@ msgid "Eritrea"
 msgstr "Eritrea"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Estimate the nutrition"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Estimate the nutritional information for this recipe."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Estonia"
 msgstr "Estónsko"
 
@@ -7461,11 +7599,59 @@ msgid "Expires in 1 day"
 msgstr "Platnosť končí o 1 deň"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain the accepted answer in simple terms."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
 msgstr "Vysvetliť základné pojmy čiernych dier na stredoškolskej úrovni."
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain the top answer"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this in simple, plain language."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this paper"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this repo"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this research paper in plain language."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this simply"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain what this repository does and how to use it."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label to show if song lyrics contain explicit content
@@ -7754,6 +7940,12 @@ msgstr ""
 "obrázkov. %1$sZistiť viac%2$s"
 
 # smartling.placeholder_format=C
+msgctxt "settings"
+msgid ""
+"Filters out known AI spam sites from image search results. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the final score of a sporting event.
 msgid "Final"
 msgstr "Konečné"
@@ -7780,7 +7972,8 @@ msgstr "Finančný poradca"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Find %sDuckDuckGo%s and click%sMake default%s"
-msgstr "Nájdite %1$sDuckDuckGo%2$s a kliknite na%3$sNastaviť ako predvolené%4$s."
+msgstr ""
+"Nájdite %1$sDuckDuckGo%2$s a kliknite na%3$sNastaviť ako predvolené%4$s."
 
 # smartling.placeholder_format=C
 #. Sentence shown after export, includes a placeholder for one or more filenames with bold formatting for the filename(s).
@@ -7792,7 +7985,8 @@ msgstr "Nájdi <b>%1$s</b> v&nbsp;tvojom priečinku so&nbsp;stiahnutými súborm
 # smartling.placeholder_format=C
 #. Tells users how to change their default search engine to DuckDuckGo.
 msgid "Find DuckDuckGo in the displayed list and click %sMake Default%s"
-msgstr "Nájdite DuckDuckGo v zozname a vyberte %1$sNastaviť ako predvolený%2$s."
+msgstr ""
+"Nájdite DuckDuckGo v zozname a vyberte %1$sNastaviť ako predvolený%2$s."
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for finding a better word.
@@ -7805,6 +7999,12 @@ msgstr "Nájdi lepšie slovo"
 msgctxt "Subtitle for the Web Search tool entry in the Tools dropdown menu"
 msgid "Find current information"
 msgstr "Nájsť aktuálne informácie"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Find me alternatives"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button that searches for results closer to the user's current location.
@@ -8255,7 +8455,8 @@ msgstr "Všeobecná umelá inteligencia s vysokou mierou moderovania"
 #. Text with short description for an AI (Artificial Intelligence) Model that has a low moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "General purpose AI with low built-in moderation"
-msgstr "Umelá inteligencia na všeobecné použitie s nízkou vstavanou moderovaním"
+msgstr ""
+"Umelá inteligencia na všeobecné použitie s nízkou vstavanou moderovaním"
 
 # smartling.placeholder_format=C
 #. Text with short description for an AI (Artificial Intelligence) Model that has a medium moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
@@ -8284,6 +8485,12 @@ msgstr "Generovať obrázok"
 #. Text for the button that generates more of an answer from duckassist when the answer has come from a collapsed state
 msgid "Generate More"
 msgstr "Generovať viac"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Generate a shopping list"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
@@ -8577,10 +8784,17 @@ msgid "Give it a Try"
 msgstr "Vyskúšaj to"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Give me a quick background on this person."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
-msgstr "Prejsť na %1$sOchrana osobných údajov a zabezpečenie > Lokalizačné služby%2$s"
+msgstr ""
+"Prejsť na %1$sOchrana osobných údajov a zabezpečenie > Lokalizačné služby%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9023,6 +9237,18 @@ msgid "Help Spread Privacy"
 msgstr "Pomôžte šíriť povedomie o ochrane súkromia"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Help me prep for the interview"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Help me tailor my resume for this job."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title of a SERP popup that invites users to take a survey (desktop only)
 msgctxt "User survey popup"
 msgid "Help us improve DuckDuckGo"
@@ -9378,7 +9604,8 @@ msgstr "Otvárací čas chýba"
 #. This is the name of a user setting
 msgctxt "settings"
 msgid "Hover, Module, and Dropdown Background Color"
-msgstr "Farba pozadia pri ukázaní kurzorom, v moduloch a rozbaľovacích ponukách"
+msgstr ""
+"Farba pozadia pri ukázaní kurzorom, v moduloch a rozbaľovacích ponukách"
 
 # smartling.placeholder_format=C
 #. Label for a pill-shaped tab below the empty-state Duck.ai chat input. Clicking it opens a panel that explains how Duck.ai protects user privacy.
@@ -9536,6 +9763,14 @@ msgstr "Hurikán"
 msgctxt "Onboarding terms screen button text"
 msgid "I Agree"
 msgstr "Súhlasím"
+
+# smartling.placeholder_format=C
+#. Text for the button that takes the user to the external DuckDuckGo login subscription page.
+msgctxt ""
+"Text for the I already have a subscription button in the Duck.ai settings "
+"page"
+msgid "I Already Have a Subscription"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the button that takes the user to the login subscription page.
@@ -10116,6 +10351,12 @@ msgid "Install Mac Browser"
 msgstr "Inštalovať prehliadač pre Mac"
 
 # smartling.placeholder_format=C
+#. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
+msgctxt "settings"
+msgid "Install Now"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of a button to install the DuckDuckGo app
 msgctxt "Serp footer content"
 msgid "Install Our App"
@@ -10213,10 +10454,42 @@ msgid "Is deleted data really deleted?"
 msgstr "Sú odstránené údaje naozaj natrvalo odstránené?"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is it worth taking?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this place any good?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"Is this place any good? Summarize its reputation based on reviews and "
+"ratings."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "Is this video helpful?"
 msgstr "Je toto video užitočné?"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this worth watching?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Is this worth watching? Give me a spoiler-free take."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -10248,7 +10521,8 @@ msgstr "Je to rýchly, bezplatný a poskytuje ti ešte väčšiu ochranu online.
 msgctxt "settings"
 msgid ""
 "It's okay to (very infrequently) ask me about my experience using DuckDuckGo"
-msgstr "Občas (naozaj len občas) sa ma môžete spýtať na môj názor na DuckDuckGo"
+msgstr ""
+"Občas (naozaj len občas) sa ma môžete spýtať na môj názor na DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. The name of the Italian language
@@ -10691,7 +10965,8 @@ msgstr "Viac informácií o tom, ako to funguje"
 # smartling.placeholder_format=C
 msgctxt "SERP footer content"
 msgid "Learn why reducing online tracking is important."
-msgstr "Ďalšie informácie o tom, prečo je dôležité obmedziť sledovanie na internete."
+msgstr ""
+"Ďalšie informácie o tom, prečo je dôležité obmedziť sledovanie na internete."
 
 # smartling.placeholder_format=C
 #. A link that takes users to a page where they can learn more about the dangers of online tracking.
@@ -10827,6 +11102,12 @@ msgstr "Písmo odkazov:"
 #. https://duckduckgo.com/params under "Color Settings"
 msgid "Links:"
 msgstr "Odkazy:"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "List the tools, materials, or prerequisites I need for this."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -11235,6 +11516,12 @@ msgstr "Správa tvojho predplatného"
 msgctxt "Exclusion message manage sites button"
 msgid "Manage blocked sites"
 msgstr "Spravovať blokované lokality"
+
+# smartling.placeholder_format=C
+#. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
+msgctxt "setting"
+msgid "Manage in Browser Settings"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to the site exclusion settings page
@@ -13096,7 +13383,8 @@ msgctxt "translations_module"
 msgid ""
 "Oops! An unexpected error occurred while translating this text. Please try "
 "again later."
-msgstr "Ajaj! Pri preklade tohto textu došlo k neočakávanej chybe. Skúste to neskôr."
+msgstr ""
+"Ajaj! Pri preklade tohto textu došlo k neočakávanej chybe. Skúste to neskôr."
 
 # smartling.placeholder_format=C
 #. Title shown in a fatal error modal when Duck.ai fails to load.
@@ -13175,7 +13463,8 @@ msgstr "Otvorte položku Poloha a uistite sa, že je poloha %1$szapnutá%2$s."
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open 'Privacy', then 'Location Services'."
-msgstr "Otvorte položku „Ochrana osobných údajov“ a potom „Služby určovania polohy“."
+msgstr ""
+"Otvorte položku „Ochrana osobných údajov“ a potom „Služby určovania polohy“."
 
 # smartling.placeholder_format=C
 #. Indicates a business is open 24 hours a day.
@@ -13312,7 +13601,8 @@ msgstr "Otvoriť panel Ako funguje Duck.ai"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open the Safari menu and select %sSettings for DuckDuckGo...%s"
-msgstr "Otvorte ponuku Safari a vyberte položku %1$sNastavenia pre DuckDuckGo...%2$s"
+msgstr ""
+"Otvorte ponuku Safari a vyberte položku %1$sNastavenia pre DuckDuckGo...%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the time a business opens. For example: 'Opens at 10am'
@@ -14069,8 +14359,15 @@ msgstr ""
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
+msgid "Please describe why the chat response is harmful or illegal. (optional)"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
+msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
-msgstr "Popíšte, prečo je odpoveď v chate nelegálna alebo škodlivá. (Nepovinné)"
+msgstr ""
+"Popíšte, prečo je odpoveď v chate nelegálna alebo škodlivá. (Nepovinné)"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to enter their passphrase.
@@ -14093,6 +14390,14 @@ msgid ""
 msgstr ""
 "Upozornenie: spustením nového chatu s ľubovoľným modelom sa vymaže vaša "
 "aktuálna relácia chatu."
+
+# smartling.placeholder_format=C
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
+msgctxt "Feedback prompt"
+msgid ""
+"Please paste your prompt and the problematic output (with any personal "
+"information removed) and describe why the content is harmful or illegal."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -14562,6 +14867,12 @@ msgid "Privacy"
 msgstr "Súkromie"
 
 # smartling.placeholder_format=C
+#. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
+msgctxt "Section heading on the Duck.ai settings page"
+msgid "Privacy & Terms"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Privacy Blog"
 msgstr "Blog o ochrane súkromia"
 
@@ -14630,6 +14941,12 @@ msgstr "Zásady ochrany osobných údajov a Podmienky používania"
 msgctxt "Copy used to compose link in sentences"
 msgid "Privacy Policy and Terms of Service"
 msgstr "Zásady ochrany osobných údajov a podmienky služby"
+
+# smartling.placeholder_format=C
+#. Text for a button that links to the terms of use and privacy policy page.
+msgctxt "Secondary button text in active privacy modal"
+msgid "Privacy Policy and Terms of Service"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title displayed on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
@@ -15135,6 +15452,30 @@ msgid "Recommend a book"
 msgstr "Odporučiť knihu"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar books"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar books."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar movies or shows."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar titles"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
 msgid "Recording failed. Please try again."
 msgstr "Nahrávanie sa nepodarilo. Skús to znova."
@@ -15537,6 +15878,15 @@ msgid "Republic of Moldova"
 msgstr "Moldavská republika"
 
 # smartling.placeholder_format=C
+#. Note indicating that sharing the conversation is mandatory when reporting harmful or illegal content. Rendered alongside the standard share label (DUCKCHAT_RESPONSE_FEEDBACK_SHARE_PROMPT_RESPONSE_LABEL), not replacing it.
+msgctxt ""
+"Note shown under the share-content switch label on the Duck.ai response "
+"feedback form when the user has selected Harmful or Illegal as the feedback "
+"reason"
+msgid "Required for harmful or illegal reports"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
 msgctxt "Description for extended reasoning mode in Duck.ai"
 msgid "Researches before responding"
@@ -15771,6 +16121,12 @@ msgstr "Recenzie"
 msgctxt "maps_places"
 msgid "Reviews"
 msgstr "Recenzie"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Rewrite this recipe scaled for a different number of servings."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Romania"
@@ -16056,7 +16412,8 @@ msgstr "Ulož si až 30 svojich najnovších chatov lokálne do svojho zariad
 msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
-msgstr "Ulož si svoje čety Duck.ai medzi zariadeniami pomocou end-to-end šifrovania."
+msgstr ""
+"Ulož si svoje čety Duck.ai medzi zariadeniami pomocou end-to-end šifrovania."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -16223,7 +16580,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down to the %sServices%s section and click %sAddress bar%s."
-msgstr "Prejdite nadol do časti %1$sSlužby%2$s a vyberte %3$sPanel s adresou%4$s."
+msgstr ""
+"Prejdite nadol do časti %1$sSlužby%2$s a vyberte %3$sPanel s adresou%4$s."
 
 # smartling.placeholder_format=C
 #. Rugby match stats
@@ -16373,7 +16731,8 @@ msgstr "Viditeľnosť vyhľadávania"
 # smartling.placeholder_format=C
 #. Message prompting users to download the DuckDuckGo app.
 msgid "Search and browse privately with the DuckDuckGo app."
-msgstr "Vyhľadávajte a prehľadávajte web súkromne pomocou aplikácie DuckDuckGo."
+msgstr ""
+"Vyhľadávajte a prehľadávajte web súkromne pomocou aplikácie DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Category a user can select on a feedback form.
@@ -16509,7 +16868,8 @@ msgstr "Vyhľadávajte cez DuckDuckGo"
 #. Text for a promotional card encouraging third-party browser users to download the DuckDuckGo browser. Not shown in the DuckDuckGo browser or on Linux.
 msgctxt "Promotional text"
 msgid "Search, browse, and chat privately in our free browser"
-msgstr "Vyhľadávaj, prehliadaj a chatuj súkromne v našom bezplatnom prehliadači"
+msgstr ""
+"Vyhľadávaj, prehliadaj a chatuj súkromne v našom bezplatnom prehliadači"
 
 # smartling.placeholder_format=C
 #. Message displayed sometimes at top of results (for bang syntax), e.g. <a href="https://duckduckgo.com/?q=twitter+test">https://duckduckgo.com/?q=twitter+test</a>
@@ -16553,7 +16913,8 @@ msgstr "Týždne sezóny"
 #. Description shown in the Sync & Backup settings section when sync is not yet enabled, explaining the feature.
 msgctxt "Description for sync and backup feature"
 msgid "Securely save and sync your chats across all your devices."
-msgstr "Bezpečne ukladaj a synchronizuj svoje chaty na všetkých svojich zariadeniach."
+msgstr ""
+"Bezpečne ukladaj a synchronizuj svoje chaty na všetkých svojich zariadeniach."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -16582,9 +16943,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your synced devices."
 msgstr ""
-"Bezpečne ukladaj takmer neobmedzený počet četov na našom serveri pomocou "
-"end-to-end šifrovania a pristupuj k nim zo všetkých synchronizovaných "
-"zariadení."
+"Bezpečne ukladaj takmer neobmedzený počet četov na našom serveri pomocou end-"
+"to-end šifrovania a pristupuj k nim zo všetkých synchronizovaných zariadení."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -16782,13 +17142,15 @@ msgstr "Vyberte %1$sDuckDuckGo%2$s a potom %3$sPridať ako predvolené%4$s."
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Select %sDuckDuckGo%s in the Default Search Engine drop down"
-msgstr "V rozbaľovacej ponuke Predvolený vyhľadávač vyberte %1$sDuckDuckGo%2$s."
+msgstr ""
+"V rozbaľovacej ponuke Predvolený vyhľadávač vyberte %1$sDuckDuckGo%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %sDuckDuckGo%s in the list and %sallow%s location access"
-msgstr "V zozname vyberte %1$sDuckDuckGo%2$s a %3$spovoľte%4$s prístup k polohe"
+msgstr ""
+"V zozname vyberte %1$sDuckDuckGo%2$s a %3$spovoľte%4$s prístup k polohe"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -17102,6 +17464,12 @@ msgid "Set Up Now"
 msgstr "Nastaviť teraz"
 
 # smartling.placeholder_format=C
+#. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
+msgctxt "Encrypted storage setup button shown in native browsers"
+msgid "Set Up Sync & Backup"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
 msgctxt "Title for the Sync & Backup intro screen"
 msgid "Set Up Sync & Backup"
@@ -17193,7 +17561,8 @@ msgstr "Zdieľať"
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "Share DuckDuckGo and help friends take their privacy back!"
-msgstr "Zdieľajte DuckDuckGo a pomôžte svojim priateľom získať späť ich súkromie!"
+msgstr ""
+"Zdieľajte DuckDuckGo a pomôžte svojim priateľom získať späť ich súkromie!"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button that opens a feedback modal when clicked.
@@ -17281,6 +17650,13 @@ msgstr "Zdieľaj adresu URL stránky"
 msgctxt "feedback form"
 msgid "Share positive feedback"
 msgstr "Zdieľajte kladnú spätnú väzbu"
+
+# smartling.placeholder_format=C
+#. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
+msgctxt ""
+"Label beside the share-content switch on the Duck.ai response feedback form"
+msgid "Share this conversation with DuckDuckGo"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -17419,7 +17795,8 @@ msgstr "Zobraziť DuckAssist <sup>BETA</sup>"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show DuckAssist more often. (You can also completely %sturn it off%s.)"
-msgstr "Zobrazovať DuckAssist častejšie. (Môžete ho tiež úplne %1$svypnúť%2$s.)"
+msgstr ""
+"Zobrazovať DuckAssist častejšie. (Môžete ho tiež úplne %1$svypnúť%2$s.)"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
@@ -17667,7 +18044,8 @@ msgstr "Zobraziť vodorovné čiary medzi stránkami vo výsledkoch vyhľadávan
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows links to instructions for how to add DuckDuckGo to your browser"
-msgstr "Zobraziť odkazy na návod, ako pridať DuckDuckGo do webového prehliadača"
+msgstr ""
+"Zobraziť odkazy na návod, ako pridať DuckDuckGo do webového prehliadača"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers more frequently.
@@ -17683,12 +18061,14 @@ msgstr "Zobraziť najnavštevovanejšie odkazy na novej karte"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your browser"
-msgstr "Zobraziť občasné pripomenutia na pridanie DuckDuckGo do webového prehliadača"
+msgstr ""
+"Zobraziť občasné pripomenutia na pridanie DuckDuckGo do webového prehliadača"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr "Zobraziť občasné pripomenutia na pridanie služby DuckDuckGo do zariadení"
+msgstr ""
+"Zobraziť občasné pripomenutia na pridanie služby DuckDuckGo do zariadení"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -17719,7 +18099,8 @@ msgstr "Zobrazovať návrhy pod vyhľadávacím poľom pri písaní"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows the privacy benefits of using DuckDuckGo on the homepage"
-msgstr "Zobraziť výhody DuckDuckGo v oblasti ochrany súkromia na domovskej stránke"
+msgstr ""
+"Zobraziť výhody DuckDuckGo v oblasti ochrany súkromia na domovskej stránke"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -17729,7 +18110,8 @@ msgstr "Zobraziť pozadie tlačidla Hľadať"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message on top of the search results page"
-msgstr "Zobraziť uvítaciu správu v hornej časti stránky s výsledkami vyhľadávania"
+msgstr ""
+"Zobraziť uvítaciu správu v hornej časti stránky s výsledkami vyhľadávania"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18020,7 +18402,8 @@ msgctxt "Error message when an uploaded image cannot be decoded or processed"
 msgid ""
 "Sorry, the uploaded image couldn't be processed. Please try a different "
 "image or format."
-msgstr "Žiaľ, nahraný obrázok sa nepodarilo spracovať. Skús iný obrázok alebo formát."
+msgstr ""
+"Žiaľ, nahraný obrázok sa nepodarilo spracovať. Skús iný obrázok alebo formát."
 
 # smartling.placeholder_format=C
 #. Body copy shown when a scanned or pasted pairing payload fails schema validation.
@@ -18054,7 +18437,8 @@ msgstr ""
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr "Ľutujeme, ale nepodarilo sa nám odoslať vašu spätnú väzbu. Skúste to neskôr."
+msgstr ""
+"Ľutujeme, ale nepodarilo sa nám odoslať vašu spätnú väzbu. Skúste to neskôr."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -18108,7 +18492,8 @@ msgstr "Zdrojový text bol vymazaný"
 msgctxt "Error message for summary selection input limit"
 msgid ""
 "Source text is too long to summarize. Try again with a shorter selection."
-msgstr "Zdrojový text je príliš dlhý na zhrnutie. Skús to znova s kratším výberom."
+msgstr ""
+"Zdrojový text je príliš dlhý na zhrnutie. Skús to znova s kratším výberom."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under Interface Settings.in the end. It is a header
@@ -18368,7 +18753,8 @@ msgstr "Zablokujte skryté sledovače, ktoré na vás číhajú na iných weboch
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop most hidden trackers lurking on other websites."
-msgstr "Zablokujte väčšinu skrytých sledovačov, ktoré na vás číhajú na iných weboch."
+msgstr ""
+"Zablokujte väčšinu skrytých sledovačov, ktoré na vás číhajú na iných weboch."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18538,6 +18924,24 @@ msgid "Suggest a title for a blog post"
 msgstr "Návrh názvu pre príspevok na blogu"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest related articles or topics worth exploring next."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Suggest related articles to explore"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest some alternatives to this product."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
 msgctxt "directions"
 msgid "Suggestions:"
@@ -18549,10 +18953,100 @@ msgid "Suggestions:"
 msgstr "Návrhy:"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Sum up the reviews"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A short title for the a message asking the AI to summarize a text.
 msgctxt "Title for the summarize message"
 msgid "Summarize"
 msgstr "Zhrnúť"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize the Q&As"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the background and notable work of this person."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the key details of this event."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the questions and answers on this page."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize their background"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this book"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this book."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this discussion"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this discussion thread."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this page"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this page."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this video"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this video."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize what the reviews say."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -18713,7 +19207,8 @@ msgstr "Prejdite na vyhľadávač, ktorý vás nesleduje. Nikdy."
 msgctxt "AI Chat warning when switching from an encrypted model"
 msgid ""
 "Switching will send your chat to a model without zero provider visibility"
-msgstr "Prepnutím sa tvoj chat odošle modelu bez nulovej viditeľnosti poskytovateľa."
+msgstr ""
+"Prepnutím sa tvoj chat odošle modelu bez nulovej viditeľnosti poskytovateľa."
 
 # smartling.placeholder_format=C
 msgid "Switzerland"
@@ -18880,6 +19375,12 @@ msgid "Syria"
 msgstr "Sýria"
 
 # smartling.placeholder_format=C
+#. Text for a button that enables the theme to follow the operating system's color scheme preference.
+msgctxt "System theme button for theme selector"
+msgid "System"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Abbreviation indicating this is the total score for a game
 msgctxt "Sports module"
 msgid "T"
@@ -18906,6 +19407,12 @@ msgstr "TV"
 msgctxt "language_name"
 msgid "Tahitian"
 msgstr "Tahitčina"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Tailor my resume"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Taiwan"
@@ -18935,6 +19442,13 @@ msgstr "Prevezmite kontrolu nad svojimi osobnými údajmi."
 msgctxt "homepage ATB modal"
 msgid "Take control of your personal data!"
 msgstr "Získajte späť kontrolu nad svojimi osobnými údajmi!"
+
+# smartling.placeholder_format=C
+#. Description for the Feedback section of the Duck.ai settings page, asking the user to take an anonymous survey to let us know how we can make Duck.ai better.
+msgctxt "Feedback section description on the Duck.ai settings page"
+msgid ""
+"Take this anonymous survey to let us know how we can make Duck.ai better."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -19234,13 +19748,20 @@ msgstr "Uplynul časový limit žiadosti. Skús to znova."
 #. Inform the users that "something" went wrong and we are unable to show any results.
 msgctxt "noresults"
 msgid "The server encountered an error and could not complete your request."
-msgstr "Na serveri sa vyskytla chyba a server nemohol dokončiť tvoju požiadavku."
+msgstr ""
+"Na serveri sa vyskytla chyba a server nemohol dokončiť tvoju požiadavku."
 
 # smartling.placeholder_format=C
 #. Title for the theme menu:
 #. https://duck.co/media/files/theme.png
 msgid "Theme"
 msgstr "Motív"
+
+# smartling.placeholder_format=C
+#. Text for the theme selector label that allows users to switch between Light and dark theme.
+msgctxt "Label for the theme selector feature"
+msgid "Theme"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/LpFhb1e.png
@@ -19347,7 +19868,8 @@ msgctxt "AI Chat: Error message for when a model is removed"
 msgid ""
 "This AI model is no longer available. Try starting a new chat with a "
 "different model."
-msgstr "Tento model AI už nie je k dispozícii. Skúste začať nový chat iným modelom."
+msgstr ""
+"Tento model AI už nie je k dispozícii. Skúste začať nový chat iným modelom."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is no longer supported because it has been upgraded to a newest version.
@@ -19622,7 +20144,8 @@ msgstr "Tento preklad je nesprávny"
 # smartling.placeholder_format=C
 #. Label indicating that the video can't be played on the current page, and only on the website that owns the vide. The placeholder is the name of the website that owns the video.
 msgid "This video is not yet able to be watched here. You can watch it on %s."
-msgstr "Toto video tu ešte nie je možné sledovať. Môžete ho sledovať v službe %1$s."
+msgstr ""
+"Toto video tu ešte nie je možné sledovať. Môžete ho sledovať v službe %1$s."
 
 # smartling.placeholder_format=C
 #. Message indicating that a website is not using an encrypted connection and is not secure.
@@ -19745,8 +20268,8 @@ msgstr "Tipy"
 # smartling.placeholder_format=C
 msgid "Tired of being tracked online? %sWe can help.%s"
 msgstr ""
-"Už vás nebaví, že vás na internete niekto neustále sleduje? %1$sPomôžeme "
-"vám.%2$s"
+"Už vás nebaví, že vás na internete niekto neustále sleduje? %1$sPomôžeme vám."
+"%2$s"
 
 # smartling.placeholder_format=C
 #. This is the name of a user setting
@@ -19794,8 +20317,8 @@ msgid ""
 "To print directions:%sGo back to the map.%sSelect the route you want to "
 "print.%sClick the print icon.%s"
 msgstr ""
-"Tlač návodu:%1$sVráťte sa do mapy.%2$sVyberte trasu, ktorú chcete "
-"vytlačiť.%3$sKliknite na ikonu tlače.%4$s"
+"Tlač návodu:%1$sVráťte sa do mapy.%2$sVyberte trasu, ktorú chcete vytlačiť."
+"%3$sKliknite na ikonu tlače.%4$s"
 
 # smartling.placeholder_format=C
 #. Explains where the user can find their recovery code. Figma frame 3703-44420.
@@ -20082,6 +20605,18 @@ msgstr ""
 "kina?“"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Translate this page"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
+msgctxt "Page suggestion prompt"
+msgid "Translate this page into %s."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text for a region that will display translated text.
 msgctxt "translations_module"
 msgid "Translation"
@@ -20223,6 +20758,12 @@ msgid "Try Free"
 msgstr "Vyskúšať zadarmo"
 
 # smartling.placeholder_format=C
+#. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
+msgctxt "settings"
+msgid "Try It Now"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
 msgctxt "Promotional CTA for new AI models"
 msgid "Try Now"
@@ -20278,13 +20819,15 @@ msgstr "Skúste iné kľúčové slová."
 # smartling.placeholder_format=C
 #. Prompt encouraging the user to turn off their ad blocker to see more results for their query.
 msgid "Try disabling your ad blocker on DuckDuckGo to see more results."
-msgstr "Skús vypnúť blokovanie reklám na DuckDuckGo, aby si videl/-a viac výsledkov."
+msgstr ""
+"Skús vypnúť blokovanie reklám na DuckDuckGo, aby si videl/-a viac výsledkov."
 
 # smartling.placeholder_format=C
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
 msgctxt "precise_user_location"
 msgid "Try enabling anonymous location for more accurate results."
-msgstr "Presnejšie výsledky môžete získať povolením anonymného určovania polohy."
+msgstr ""
+"Presnejšie výsledky môžete získať povolením anonymného určovania polohy."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the screen of the onboarding where the user picks a chat model.
@@ -20457,6 +21000,22 @@ msgid "Trying DuckDuckGo again"
 msgstr "Znova skúšam DuckDuckGo"
 
 # smartling.placeholder_format=C
+#. Message shown in a modal after supported third-party browser users disable AI features in Settings. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
 msgctxt "Assistant response placeholder"
 msgid "Trying with %s"
@@ -20556,7 +21115,8 @@ msgstr "Vypnúť:"
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on %sPrecise Location%s for more accurate results"
-msgstr "Ak chcete získať presnejšie výsledky, zapnite možnosť %1$sPresná poloha%2$s"
+msgstr ""
+"Ak chcete získať presnejšie výsledky, zapnite možnosť %1$sPresná poloha%2$s"
 
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
@@ -20573,7 +21133,8 @@ msgstr "Presnejšie výsledky môžete získať zapnutím nastavenia „Presná 
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on “Use precise location” for more accurate results."
-msgstr "Presnejšie výsledky môžete získať zapnutím nastavenia „Použiť presnú polohu“."
+msgstr ""
+"Presnejšie výsledky môžete získať zapnutím nastavenia „Použiť presnú polohu“."
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Create Image' label in the Tools dropdown.
@@ -20779,13 +21340,14 @@ msgstr ""
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
 msgstr ""
-"Pod možnosťou %1$sPri spustení > Domovská stránka%2$s napíšte: "
-"https://duckduckgo.com."
+"Pod možnosťou %1$sPri spustení > Domovská stránka%2$s napíšte: https://"
+"duckduckgo.com."
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch Settings%s select %sDuckDuckGo%s"
-msgstr "Pod možnosťou %1$sNastavenia vyhľadávania%2$s vyberte %3$sDuckDuckGo%4$s."
+msgstr ""
+"Pod možnosťou %1$sNastavenia vyhľadávania%2$s vyberte %3$sDuckDuckGo%4$s."
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -20798,7 +21360,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
-msgstr "Pod sekciou %1$sVyhľadávanie%2$s vyberte %3$sSpravovať vyhľadávače...%4$s."
+msgstr ""
+"Pod sekciou %1$sVyhľadávanie%2$s vyberte %3$sSpravovať vyhľadávače...%4$s."
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -20812,7 +21375,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine
 msgid "Under Search click the drop down and select %sDuckDuckGo%s"
-msgstr "V časti Vyhľadávanie vyberte rozbaľovaciu ponuku a potom %1$sDuckDuckGo%2$s."
+msgstr ""
+"V časti Vyhľadávanie vyberte rozbaľovaciu ponuku a potom %1$sDuckDuckGo%2$s."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings" header
@@ -21209,6 +21773,12 @@ msgstr "Urdčina"
 # smartling.placeholder_format=C
 msgid "Uruguay"
 msgstr "Uruguaj"
+
+# smartling.placeholder_format=C
+#. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
+msgctxt "Navigation label on the Duck.ai settings page"
+msgid "Usage"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -21662,6 +22232,12 @@ msgid "Wales"
 msgstr "Wales"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Walk me through the steps"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for walking directions on a map.
 msgctxt "directions"
 msgid "Walking"
@@ -21779,6 +22355,17 @@ msgid "We can anonymize%s your location%s to show you more accurate results."
 msgstr ""
 "Môžeme anonymizovať%1$s vašu polohu%2$s, aby sme vám ukázali presnejšie "
 "výsledky."
+
+# smartling.placeholder_format=C
+#. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
+msgctxt ""
+"Inline warning shown below the share-content toggle when the user selects "
+"Harmful or Illegal but has not enabled sharing"
+msgid ""
+"We can only fix what we can see. To report a harmful or illegal response, "
+"please share this conversation with DuckDuckGo so we can investigate and "
+"address the issue."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -22309,7 +22896,8 @@ msgctxt "Full sentence for finding a better word"
 msgid ""
 "What are some options for the word ‘better’ in the context of “We really "
 "need to do better.”"
-msgstr "Aké sú niektoré možnosti slova „lepší“ v kontexte „Naozaj musíme byť lepší“."
+msgstr ""
+"Aké sú niektoré možnosti slova „lepší“ v kontexte „Naozaj musíme byť lepší“."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
@@ -22334,6 +22922,103 @@ msgstr ""
 "ochranu súkromia. Urob to pomerne stručné, jednoduché a ľahko pochopiteľné "
 "pre ľudí ktorí majú skúsenosti s AI a technickými znalosťami a aj pre ľudí, "
 "ktorí ich nemajú."
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the counterarguments?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the hours & location?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key contributions of this paper?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key contributions?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key details?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key points covered in this video?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key points?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key takeaways from this article?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key takeaways?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key things I will learn from this course?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main counterarguments or criticisms of this?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main questions this page answers?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the must-try dishes here?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"What are the opening hours, location, and contact details for this place?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the pros and cons of this product?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the pros and cons?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
@@ -22436,6 +23121,12 @@ msgid "What does atria mean in the context of a medical article?"
 msgstr "Čo znamenajú predsiene v kontexte lekárskeho článku?"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What does this answer?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
@@ -22446,6 +23137,12 @@ msgstr "Akú funkciu by sme podľa teba mali pridať? (voliteľné)"
 msgctxt "cloudsave"
 msgid "What information gets saved?"
 msgstr "Aké údaje ukladáme?"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What interview questions might come up for this role?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -22462,6 +23159,12 @@ msgstr ""
 msgctxt "Full sentence for looking up basic facts"
 msgid "What is the capital city of Albania?"
 msgstr "Aké je hlavné mesto Albánska?"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What is the overall verdict and rating for this?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to a page with additional information.
@@ -22486,6 +23189,12 @@ msgid "What people say:"
 msgstr "Čo hovoria iní:"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What should I order?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
 msgctxt "feedback form"
 msgid "What stood out?"
@@ -22496,6 +23205,18 @@ msgstr "Čo vynikalo?"
 msgctxt "feedback form"
 msgid "What was wrong with the response? (optional)"
 msgstr "Čo bolo na odpovedi nesprávne? (Nepovinné)"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I learn?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I need?"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -22517,6 +23238,12 @@ msgid "What's New"
 msgstr "Novinky"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What's the verdict?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to a page featuring the most recent updates from DuckDuckGo.
 msgid "What’s New"
 msgstr "Novinky"
@@ -22534,7 +23261,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "When enabled, Duck.ai will show instant answers in the chat."
-msgstr "Ak je toto povolené, Duck.ai bude v chate zobrazovať okamžité odpovede."
+msgstr ""
+"Ak je toto povolené, Duck.ai bude v chate zobrazovať okamžité odpovede."
 
 # smartling.placeholder_format=C
 #. Text of a button that performs a search for the available streaming services that show a particular movie or tv show
@@ -22552,7 +23280,8 @@ msgstr "Kde sledovať <strong>%1$s</strong>"
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Where it says Homepage click %sSet to Current Page%s."
-msgstr "Pri možnosti Domovská stránka vyberte %1$sNastaviť aktuálnu stránku%2$s."
+msgstr ""
+"Pri možnosti Domovská stránka vyberte %1$sNastaviť aktuálnu stránku%2$s."
 
 # smartling.placeholder_format=C
 #. Heading of a module showing what streaming services are showing a movie or series, e.g. Where to Watch The Matrix
@@ -22565,6 +23294,12 @@ msgstr "Kde sledovať <strong>%1$s</strong>"
 msgctxt "Feedback prompt"
 msgid "Which features are missing? (Optional)"
 msgstr "Ktoré funkcie chýbajú? (Nepovinné)"
+
+# smartling.placeholder_format=C
+#. An invitation for users to leave feedback
+msgctxt "Feedback prompt"
+msgid "Which features are missing? (optional)"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
@@ -22581,6 +23316,18 @@ msgstr "Biela"
 #. Link to an about us page.
 msgid "Who We Are"
 msgstr "Kto sme"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Who are the main cast and crew, and what else are they known for?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Who is this person?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Header above a collection of privacy-related links.
@@ -23454,7 +24201,8 @@ msgstr "Podľa vášho prehliadača ste tento odkaz už otvorili."
 # smartling.placeholder_format=C
 msgctxt "new tab page"
 msgid "Your browser provides a list of your most-visited sites."
-msgstr "Váš prehliadač poskytuje zoznam vašich najčastejšie navštevovaných lokalít."
+msgstr ""
+"Váš prehliadač poskytuje zoznam vašich najčastejšie navštevovaných lokalít."
 
 # smartling.placeholder_format=C
 #. Used as a description in a menu
@@ -23503,7 +24251,8 @@ msgstr ""
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never used to train AI models"
-msgstr "Tvoje rozhovory sú súkromné a nikdy sa nepoužívajú na trénovanie modelov AI"
+msgstr ""
+"Tvoje rozhovory sú súkromné a nikdy sa nepoužívajú na trénovanie modelov AI"
 
 # smartling.placeholder_format=C
 #. Text for a description of the active privacy protection for DuckDuckGo's AI Chat feature.
@@ -23564,7 +24313,8 @@ msgctxt "duckai_migration"
 msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
-msgstr "Tvoje čety boli importované. Pokračuj tam, kde si na Duck.ai skončil/-a."
+msgstr ""
+"Tvoje čety boli importované. Pokračuj tam, kde si na Duck.ai skončil/-a."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.
@@ -23730,7 +24480,8 @@ msgctxt "Error message for input limit"
 msgid ""
 "You’ve exceeded the maximum message size. Please shorten your message and "
 "try again."
-msgstr "Prekročili ste maximálnu veľkosť správy. Skráťte správu a skúste to znova."
+msgstr ""
+"Prekročili ste maximálnu veľkosť správy. Skráťte správu a skúste to znova."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -24068,7 +24819,8 @@ msgstr "oficiálnej webovej stránky"
 #. <em>%s</em> is for a hexadecimal color code as <em>#395323</em>, but it has to be safe encoded, and as <em>#</em> seems not safe, <em>%23</em> must be used in place of the sharp symbol, but they are the same for your browser.
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
-msgstr "alebo napíšte kód požadovanej farby, napr. %1$s (%2$s je kódovaný znak %3$s)."
+msgstr ""
+"alebo napíšte kód požadovanej farby, napr. %1$s (%2$s je kódovaný znak %3$s)."
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "

--- a/locales/sl_SI/LC_MESSAGES/duckduckgo.po
+++ b/locales/sl_SI/LC_MESSAGES/duckduckgo.po
@@ -19002,7 +19002,7 @@ msgstr "Povzemi to stran"
 #. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this page."
-msgstr "Povzetek te strani."
+msgstr "Povzemi to stran."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.

--- a/locales/sl_SI/LC_MESSAGES/duckduckgo.po
+++ b/locales/sl_SI/LC_MESSAGES/duckduckgo.po
@@ -2,16 +2,15 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: sl_SI\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=4; plural=n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || "
-"n%100==4 ? 2 : 3;\n"
+"Plural-Forms: nplurals=4; plural=n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || n%100==4 ? 2 : 3;\n"
 
 # smartling.gettext_line_width = normalized : 79
 # smartling.placeholder_format=C
@@ -490,15 +489,13 @@ msgstr ""
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "%sLong-press%s the DuckDuckGo app icon on the home screen"
-msgstr ""
-"%1$sDolgo pritisnite%2$s ikono aplikacije DuckDuckGo na začetnem zaslonu."
+msgstr "%1$sDolgo pritisnite%2$s ikono aplikacije DuckDuckGo na začetnem zaslonu."
 
 # smartling.placeholder_format=C
 #. A message displayed when there is an error loading content or no results on requery
 msgctxt "Error or no results message"
 msgid "%sOops!%s%sSomething went wrong. Please %srefresh%s and try again."
-msgstr ""
-"%1$sUps!%2$s%3$sNekaj je šlo narobe. %4$sOsvežite%5$s in poskusite znova."
+msgstr "%1$sUps!%2$s%3$sNekaj je šlo narobe. %4$sOsvežite%5$s in poskusite znova."
 
 # smartling.placeholder_format=C
 #. Tagline in a popover encouraging the user to download the DuckDuckGo browser
@@ -815,8 +812,7 @@ msgstr "Dosežena je 6-urna omejitev uporabe."
 #. Displayed when the user has reached a fixed 6-hour Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "6-hour usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Dosežena je 6-urna omejitev uporabe. Ta klepet lahko nadaljujete po %1$s."
+msgstr "Dosežena je 6-urna omejitev uporabe. Ta klepet lahko nadaljujete po %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable 6-hour Duck.ai usage limit and can opt in to continue using the daily limit.
@@ -896,8 +892,7 @@ msgstr ""
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of Duck.ai is available! Please refresh this page to continue."
-msgstr ""
-"Na voljo je nova različica Duck.ai! Če želite nadaljevati, osvežite to stran."
+msgstr "Na voljo je nova različica Duck.ai! Če želite nadaljevati, osvežite to stran."
 
 # smartling.placeholder_format=C
 #. Shown when the Duck.ai desktop app has been open a long time and a newer version exists.
@@ -1445,7 +1440,7 @@ msgstr "Naslov ni pravilen"
 #. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Adjust the servings"
-msgstr ""
+msgstr "Prilagodi porcije"
 
 # smartling.placeholder_format=C
 #. as in multiple advertisements
@@ -1667,6 +1662,9 @@ msgid ""
 "All chats are anonymized by DuckDuckGo, and your conversations are not used "
 "to train chat models by DuckDuckGo or the model providers"
 msgstr ""
+"Vsi klepeti so anonimizirani s strani DuckDuckGo, vaši pogovori pa se ne "
+"uporabljajo za usposabljanje klepetalnih modelov niti pri DuckDuckGo niti "
+"pri ponudnikih modelov."
 
 # smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1944,6 +1942,8 @@ msgid ""
 "Anonymously generates answers for search queries based on web content. "
 "Choose how often you want it to appear, or disable it completely."
 msgstr ""
+"Anonimno ustvarja odgovore na iskalne poizvedbe na podlagi spletne vsebine. "
+"Izberite, kako pogosto želite, da se prikaže, ali ga popolnoma onemogočite."
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -2104,8 +2104,7 @@ msgstr "Ali ste prepričani, da želite izbrisati ta pogovor in začeti novega?"
 #. Text asking the user to confirm if they want to delete their current chat, explaining that this action cannot be undone.
 msgctxt "Body text for delete chat confirmation modal"
 msgid "Are you sure you want to delete this chat? This cannot be undone."
-msgstr ""
-"Ste prepričani, da želite izbrisati ta klepet? Tega ni mogoče razveljaviti."
+msgstr "Ste prepričani, da želite izbrisati ta klepet? Tega ni mogoče razveljaviti."
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to disable chat history, with a warning that it will also delete currently saved chats including pinned chats.
@@ -2230,7 +2229,7 @@ msgstr "Zastavite nadaljnje vprašanje za Duck.ai"
 #. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
 msgctxt "Page suggestion chip label"
 msgid "Ask about this page"
-msgstr ""
+msgstr "Vprašaj o tej strani"
 
 # smartling.placeholder_format=C
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2452,8 +2451,7 @@ msgstr "Samodejno odgovarjanje"
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid "Auto-generated based on listed sources. May contain inaccuracies."
-msgstr ""
-"Samodejno ustvarjeno na podlagi navedenih virov. Lahko vsebuje netočnosti."
+msgstr "Samodejno ustvarjeno na podlagi navedenih virov. Lahko vsebuje netočnosti."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
@@ -2652,7 +2650,7 @@ msgstr "Črtna koda"
 #. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Based on this page, is this course worth taking?"
-msgstr ""
+msgstr "Glede na to stran, se ta tečaj splača opraviti?"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2701,6 +2699,9 @@ msgid ""
 "Before storing this report, DuckDuckGo will anonymize your conversation by "
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
+"Preden shrani to poročilo, bo DuckDuckGo anonimiziral vaš pogovor z "
+"odstranitvijo osebnih podatkov, kot so imena, e-poštni naslovi in "
+"identifikacijski metapodatki."
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -2842,8 +2843,7 @@ msgstr "Blokiraj to spletno mesto v vseh rezultatih"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Block trackers and take control of your personal data"
-msgstr ""
-"Blokirajte sledilnike in prevzemite nadzor nad svojimi osebnimi podatki"
+msgstr "Blokirajte sledilnike in prevzemite nadzor nad svojimi osebnimi podatki"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -3023,7 +3023,7 @@ msgstr "Osvojene točke z odvzemom servisa"
 #. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Break this down into clear, numbered steps."
-msgstr ""
+msgstr "Razdeli to na jasne, oštevilčene korake."
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -3484,7 +3484,7 @@ msgstr "Predvajaj"
 #. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Cast & Crew"
-msgstr ""
+msgstr "Igralska zasedba in ekipa"
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -3725,8 +3725,8 @@ msgstr ""
 "klepeta z umetno inteligenco tretjih oseb, ki podpirajo modele OpenAI, "
 "Anthropic in druge. Če to nastavitev izklopiš, bodo gumbi in povezave za "
 "klepet v iskalniku DuckDuckGo skriti. Vendar pa lahko še vedno dostopaš do "
-"klepeta, ko je ta nastavitev izklopljena tako, da obiščeš %1$shttps://duck."
-"ai%2$s neposredno."
+"klepeta, ko je ta nastavitev izklopljena tako, da obiščeš "
+"%1$shttps://duck.ai%2$s neposredno."
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -4325,8 +4325,7 @@ msgstr "Kliknite %1$stukaj%2$s za prenos razširitve DuckDuckGo"
 # smartling.placeholder_format=C
 #. Link to download the DuckDuckGo browser extension.
 msgid "Click %sOpen%s to download and open the DuckDuckGo Safari extension"
-msgstr ""
-"Kliknite %1$sOdpri%2$s za prenos in odprite razširitev DuckDuckGo Safari"
+msgstr "Kliknite %1$sOdpri%2$s za prenos in odprite razširitev DuckDuckGo Safari"
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -4359,8 +4358,7 @@ msgstr "Kliknite %1$sNastavitve%2$s v spustnem meniju."
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
-msgstr ""
-"Kliknite %1$sUporabi trenutne strani%2$s, nato %3$skliknite V redu%4$s."
+msgstr "Kliknite %1$sUporabi trenutne strani%2$s, nato %3$skliknite V redu%4$s."
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -5079,8 +5077,7 @@ msgstr "Kopiraj"
 # smartling.placeholder_format=C
 #. Instructions on how to change the default search engine
 msgid "Copy &amp; paste %sabout:preferences#search%s into the address bar"
-msgstr ""
-"Kopirajte in prilepite %1$sabout:preferences#search%2$s v naslovno vrstico"
+msgstr "Kopirajte in prilepite %1$sabout:preferences#search%2$s v naslovno vrstico"
 
 # smartling.placeholder_format=C
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
@@ -5199,7 +5196,7 @@ msgstr "Ustvari sliko"
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
-msgstr ""
+msgstr "Ustvari nakupovalni seznam s količinami iz tega recepta."
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed in the input field when starting a new image generation session.
@@ -5456,8 +5453,7 @@ msgstr "Dosežena je dnevna omejitev"
 #. Displayed when the user has reached a fixed daily Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Daily usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Dosežena je dnevna omejitev uporabe. Ta klepet lahko nadaljujete po %1$s."
+msgstr "Dosežena je dnevna omejitev uporabe. Ta klepet lahko nadaljujete po %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable daily Duck.ai usage limit and can opt in to continue using the weekly limit.
@@ -5849,7 +5845,7 @@ msgstr "Dosežena je omejitev narekovanja"
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
 msgid "Dictation temporarily unavailable"
-msgstr ""
+msgstr "Narekovanje trenutno ni na voljo"
 
 # smartling.placeholder_format=C
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
@@ -6160,6 +6156,8 @@ msgid ""
 "Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
 "filtered out. %sLearn More%s"
 msgstr ""
+"Ne želite umetne inteligence? %1$snoai.duckduckgo.com%2$s ne ponuja funkcij "
+"UI in izloči slike, ustvarjene z UI. %3$sVeč o tem%4$s"
 
 # smartling.placeholder_format=C
 #. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
@@ -6168,6 +6166,9 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
+"Ne želite umetne inteligence? Obiščite %1$snoai.duckduckgo.com%2$s za "
+"iskanje brez funkcij umetne inteligence in z izločenimi slikami, "
+"ustvarjenimi z UI. %3$sVeč o tem%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6287,13 +6288,13 @@ msgstr ""
 #. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Draft a cover letter"
-msgstr ""
+msgstr "Pripravi spremno pismo"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Draft a cover letter for this job."
-msgstr ""
+msgstr "Pripravi spremno pismo za to delovno mesto."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -6383,8 +6384,7 @@ msgstr "Spustite svoje fotografije ali datoteke PDF"
 # smartling.placeholder_format=C
 #. A title explaining what Duck Player (DDG's feature to watch youtube videos more privately) does
 msgid "Duck Player lets you watch YouTube without targeted ads"
-msgstr ""
-"Predvajalnik Duck Player vam omogoča gledanje YouTuba brez ciljanih oglasov"
+msgstr "Predvajalnik Duck Player vam omogoča gledanje YouTuba brez ciljanih oglasov"
 
 # smartling.placeholder_format=C
 #. This is the DDG version of "Google it", meaning "search it".
@@ -6430,8 +6430,7 @@ msgstr "pogoji storitve Duck.ai"
 #. The HTML <title> for Duck.ai.
 msgctxt "duckai_seo"
 msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
-msgstr ""
-"Duck.ai by DuckDuckGo. Zasebni klepet z umetno inteligenco. Brezplačno."
+msgstr "Duck.ai by DuckDuckGo. Zasebni klepet z umetno inteligenco. Brezplačno."
 
 # smartling.placeholder_format=C
 #. Description explaining how the page context feature works in Duck.ai sidebar.
@@ -6471,8 +6470,7 @@ msgstr ""
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
-msgstr ""
-"Duck.ai najbolje deluje v našem zasebnem in brezplačnem brskalniku DuckDuckGo"
+msgstr "Duck.ai najbolje deluje v našem zasebnem in brezplačnem brskalniku DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
@@ -6482,6 +6480,8 @@ msgid ""
 "company for anyone who wants to take back control of their personal "
 "information."
 msgstr ""
+"Duck.ai je ustvaril DuckDuckGo. Smo neodvisno podjetje za spletno zaščito za "
+"vse, ki želijo znova prevzeti nadzor nad svojimi osebnimi podatki."
 
 # smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
@@ -6534,6 +6534,9 @@ msgid ""
 "Duck.ai lets you chat privately with popular AI models. Disabling it hides "
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
+"Duck.ai vam omogoča zasebno klepetanje s priljubljenimi modeli umetne "
+"inteligence. Če to izklopite, bodo gumbi in povezave za Duck.ai skriti, "
+"vendar lahko še vedno obiščete %1$sduck.ai%2$s neposredno."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6597,8 +6600,7 @@ msgstr "Duck.ai je nadgrajen!"
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
-msgstr ""
-"Duck.ai najbolje deluje v naši zasebni in brezplačni aplikaciji DuckDuckGo"
+msgstr "Duck.ai najbolje deluje v naši zasebni in brezplačni aplikaciji DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -6775,8 +6777,7 @@ msgctxt "Error message for VQD error"
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. Please refresh the page and "
 "try again."
-msgstr ""
-"DuckDuckGo AI Chat trenutno ni na voljo. Osvežite stran in poskusite znova."
+msgstr "DuckDuckGo AI Chat trenutno ni na voljo. Osvežite stran in poskusite znova."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -7124,8 +7125,7 @@ msgstr "Urejanje slike ..."
 msgctxt "Info text for the editing message feature"
 msgid ""
 "Editing your message will remove the response below and generate a new one."
-msgstr ""
-"Z urejanjem sporočila boste odstranili spodnji odgovor in ustvarili novega."
+msgstr "Z urejanjem sporočila boste odstranili spodnji odgovor in ustvarili novega."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of an editor in its responses.
@@ -7186,8 +7186,7 @@ msgstr "Omogoči funkcije UI"
 #. Text explaining how to enable the cloud save feature.
 msgctxt "cloudsave"
 msgid "Enable Cloud Save by entering your existing passphrase."
-msgstr ""
-"Omogočite storitev Cloud Save z vnosom svoje obstoječe varnostne fraze."
+msgstr "Omogočite storitev Cloud Save z vnosom svoje obstoječe varnostne fraze."
 
 # smartling.placeholder_format=C
 #. Primary button text in the dictation privacy consent modal to enable dictation.
@@ -7393,8 +7392,7 @@ msgstr "Prepričajte se, da so »Lokacijske storitve« %1$somogočene%2$s."
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location' is set to %sallow%s"
-msgstr ""
-"Prepričajte se, da je možnost »Lokacija« nastavljena na %1$sdovoli%2$s."
+msgstr "Prepričajte se, da je možnost »Lokacija« nastavljena na %1$sdovoli%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service.
@@ -7406,8 +7404,7 @@ msgstr "Preverite, ali je možnost »Lokacija« nastavljena na %1$sdovoli%2$s."
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure Location is set to %sAllow%s"
-msgstr ""
-"Prepričajte se, da je možnost »Lokacija« nastavljena na %1$sDovoli%2$s."
+msgstr "Prepričajte se, da je možnost »Lokacija« nastavljena na %1$sDovoli%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
@@ -7431,8 +7428,7 @@ msgstr "Prepričajte se, da ima brskalnik omogočen %1$sdostop do lokacije%2$s."
 #. Tells users how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed %slocation access%s."
-msgstr ""
-"Preverite, ali ima vaš brskalnik dovoljenje za %1$sdostop do lokacije%2$s."
+msgstr "Preverite, ali ima vaš brskalnik dovoljenje za %1$sdostop do lokacije%2$s."
 
 # smartling.placeholder_format=C
 #. Tells how to enable location service. Part of a list of instructions on how to enable location service.
@@ -7532,8 +7528,7 @@ msgstr "Ekvatorialna Gvineja"
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Erase your browsing data in a flash with our %sFire Button%s"
-msgstr ""
-"V trenutku izbrišite podatke o brskanju z našim gumbom %1$sFire Button%2$s"
+msgstr "V trenutku izbrišite podatke o brskanju z našim gumbom %1$sFire Button%2$s"
 
 # smartling.placeholder_format=C
 msgid "Eritrea"
@@ -7543,13 +7538,13 @@ msgstr "Eritreja"
 #. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Estimate the nutrition"
-msgstr ""
+msgstr "Oceni hranilne vrednosti"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Estimate the nutritional information for this recipe."
-msgstr ""
+msgstr "Oceni hranilne vrednosti za ta recept."
 
 # smartling.placeholder_format=C
 msgid "Estonia"
@@ -7609,7 +7604,7 @@ msgstr "Poteče čez 1 dan"
 #. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain the accepted answer in simple terms."
-msgstr ""
+msgstr "Razloži sprejeti odgovor s preprostimi besedami."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
@@ -7622,43 +7617,43 @@ msgstr "Pojasni mi temeljne koncepte črnih lukenj na srednješolski ravni."
 #. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain the top answer"
-msgstr ""
+msgstr "Razloži najboljši odgovor"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain this in simple, plain language."
-msgstr ""
+msgstr "Razloži to s preprostim, razumljivim jezikom."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain this paper"
-msgstr ""
+msgstr "Razloži mi ta članek"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain this repo"
-msgstr ""
+msgstr "Razloži mi ta repozitorij"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain this research paper in plain language."
-msgstr ""
+msgstr "Razloži ta raziskovalni članek v preprostem jeziku."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain this simply"
-msgstr ""
+msgstr "Razloži preprosto"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain what this repository does and how to use it."
-msgstr ""
+msgstr "Pojasni, kaj počne ta repozitorij in kako ga uporabljati."
 
 # smartling.placeholder_format=C
 #. Label to show if song lyrics contain explicit content
@@ -7950,6 +7945,8 @@ msgctxt "settings"
 msgid ""
 "Filters out known AI spam sites from image search results. %sLearn More%s"
 msgstr ""
+"Iz rezultatov iskanja slik izloči znana spletna mesta z neželeno vsebino, "
+"ustvarjena z umetno inteligenco. %1$sVeč o tem%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the final score of a sporting event.
@@ -8010,7 +8007,7 @@ msgstr "Poiščite trenutne informacije"
 #. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Find me alternatives"
-msgstr ""
+msgstr "Poišči druge možnosti"
 
 # smartling.placeholder_format=C
 #. Button that searches for results closer to the user's current location.
@@ -8209,8 +8206,7 @@ msgstr "Brezplačni in zasebni klepeti, ki jih anonimiziramo"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr ""
-"Brezplačni in zasebni klepeti, ki jih anonimiziramo. Račun ni potreben."
+msgstr "Brezplačni in zasebni klepeti, ki jih anonimiziramo. Račun ni potreben."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -8496,7 +8492,7 @@ msgstr "Ustvari več"
 #. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Generate a shopping list"
-msgstr ""
+msgstr "Ustvari nakupovalni seznam"
 
 # smartling.placeholder_format=C
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
@@ -8793,7 +8789,7 @@ msgstr "Preizkusi"
 #. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Give me a quick background on this person."
-msgstr ""
+msgstr "Na kratko mi opiši to osebo."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9245,13 +9241,13 @@ msgstr "Pomagajte razširiti zasebnost"
 #. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Help me prep for the interview"
-msgstr ""
+msgstr "Pomagaj mi pri pripravi na razgovor"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Help me tailor my resume for this job."
-msgstr ""
+msgstr "Pomagaj mi prilagoditi življenjepis za to delovno mesto."
 
 # smartling.placeholder_format=C
 #. Title of a SERP popup that invites users to take a survey (desktop only)
@@ -9706,8 +9702,7 @@ msgstr ""
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
 msgctxt "Duck.ai settings usage section"
 msgid "How much of your daily and weekly limits you've used so far."
-msgstr ""
-"Delež vaših dnevnih in tedenskih omejitev, ki ste jih doslej uporabili."
+msgstr "Delež vaših dnevnih in tedenskih omejitev, ki ste jih doslej uporabili."
 
 # smartling.placeholder_format=C
 #. A header for the feedback form in the assist negative feedback flow. The user is being asked to update how often they want AI-assisted answers to appear.
@@ -9781,7 +9776,7 @@ msgctxt ""
 "Text for the I already have a subscription button in the Duck.ai settings "
 "page"
 msgid "I Already Have a Subscription"
-msgstr ""
+msgstr "Naročnino že imam"
 
 # smartling.placeholder_format=C
 #. Text for the button that takes the user to the login subscription page.
@@ -10154,8 +10149,7 @@ msgstr "V zgornjem meniju izberite %1$sOrodja%2$s > %3$sNastavitve%4$s"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "In the popup, check %sMake this my default search provider%s"
-msgstr ""
-"V pojavnem oknu potrdite %1$sTo naj bo moj privzeti ponudnik iskanja%2$s"
+msgstr "V pojavnem oknu potrdite %1$sTo naj bo moj privzeti ponudnik iskanja%2$s"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -10364,7 +10358,7 @@ msgstr "Namestitev brskalnika za Mac"
 #. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
 msgctxt "settings"
 msgid "Install Now"
-msgstr ""
+msgstr "Namesti zdaj"
 
 # smartling.placeholder_format=C
 #. Text of a button to install the DuckDuckGo app
@@ -10467,13 +10461,13 @@ msgstr "So izbrisani podatki zares izbrisani?"
 #. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Is it worth taking?"
-msgstr ""
+msgstr "Je vredno vzeti?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Is this place any good?"
-msgstr ""
+msgstr "Je ta kraj v redu?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
@@ -10481,7 +10475,7 @@ msgctxt "Page suggestion prompt"
 msgid ""
 "Is this place any good? Summarize its reputation based on reviews and "
 "ratings."
-msgstr ""
+msgstr "Je ta kraj vreden obiska? Povzemi njegov ugled na podlagi ocen in mnenj."
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -10493,13 +10487,13 @@ msgstr "Je ta video v pomoč?"
 #. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Is this worth watching?"
-msgstr ""
+msgstr "Se splača gledati?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Is this worth watching? Give me a spoiler-free take."
-msgstr ""
+msgstr "Se splača gledati? Podaj mi mnenje brez razkritja vsebine."
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -10531,8 +10525,7 @@ msgstr "Je hiter, brezplačen in zagotavlja še večjo spletno zaščito."
 msgctxt "settings"
 msgid ""
 "It's okay to (very infrequently) ask me about my experience using DuckDuckGo"
-msgstr ""
-"Dovolim, da me (zelo redko) vprašate o mojih izkušnjah z uporabo DuckDuckGo"
+msgstr "Dovolim, da me (zelo redko) vprašate o mojih izkušnjah z uporabo DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. The name of the Italian language
@@ -11114,7 +11107,7 @@ msgstr "Povezave:"
 #. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
-msgstr ""
+msgstr "Naštej orodja, materiale ali predpogoje, ki jih potrebujem za to."
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -11530,7 +11523,7 @@ msgstr "Upravljanje blokiranih spletnih mest"
 #. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
 msgctxt "setting"
 msgid "Manage in Browser Settings"
-msgstr ""
+msgstr "Upravljaj v nastavitvah brskalnika"
 
 # smartling.placeholder_format=C
 #. Link to the site exclusion settings page
@@ -11982,8 +11975,7 @@ msgstr "Dosežena je mesečna omejitev"
 #. Displayed when the user has reached a fixed monthly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Monthly usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Dosežena je mesečna omejitev uporabe. Ta klepet lahko nadaljujete po %1$s."
+msgstr "Dosežena je mesečna omejitev uporabe. Ta klepet lahko nadaljujete po %1$s."
 
 # smartling.placeholder_format=C
 #. Used to point to additional social networking profiles (in results).
@@ -12145,8 +12137,7 @@ msgstr "Več statističnih podatkov o medaljah je na voljo na %1$s"
 msgctxt ""
 "Note on the Olympics module as to where they can find more information"
 msgid "More medal stats on %solympics.com%s"
-msgstr ""
-"Več statističnih podatkov o medaljah je na voljo na %1$solympics.com%2$s"
+msgstr "Več statističnih podatkov o medaljah je na voljo na %1$solympics.com%2$s"
 
 # smartling.placeholder_format=C
 #. A link to more information on a topic. The placeholder is the name of a website. For example 'More on Wikipedia'.
@@ -13447,8 +13438,7 @@ msgstr "Odpri spletno mesto %1$s"
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open %sLocation%s, and ensure location is %senabled%s"
-msgstr ""
-"Odprite %1$sLokacija%2$s in se prepričajte, da je lokacija %3$somogočena%4$s."
+msgstr "Odprite %1$sLokacija%2$s in se prepričajte, da je lokacija %3$somogočena%4$s."
 
 #  Chrome/Firefox on Android/iOS
 # smartling.placeholder_format=C
@@ -14353,8 +14343,7 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this prompt was made by a "
 "human."
-msgstr ""
-"Rešite naslednji izziv in s tem potrdite, da je ta poziv ustvaril človek."
+msgstr "Rešite naslednji izziv in s tem potrdite, da je ta poziv ustvaril človek."
 
 # smartling.placeholder_format=C
 #. Bot challenge explanation
@@ -14362,14 +14351,13 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this search was made by a "
 "human."
-msgstr ""
-"Rešite naslednji izziv in s tem potrdite, da je to iskanje opravil človek."
+msgstr "Rešite naslednji izziv in s tem potrdite, da je to iskanje opravil človek."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is harmful or illegal. (optional)"
-msgstr ""
+msgstr "Opišite, zakaj je odziv v klepetu škodljiv ali nezakonit. (Izbirno)"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
@@ -14406,6 +14394,8 @@ msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is harmful or illegal."
 msgstr ""
+"Prilepite poziv in problematičen odziv (brez morebitnih osebnih podatkov) "
+"ter opišite, zakaj je vsebina škodljiva ali nezakonita."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -14878,7 +14868,7 @@ msgstr "Zasebnost"
 #. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
 msgctxt "Section heading on the Duck.ai settings page"
 msgid "Privacy & Terms"
-msgstr ""
+msgstr "Zasebnost in pogoji"
 
 # smartling.placeholder_format=C
 msgid "Privacy Blog"
@@ -14954,7 +14944,7 @@ msgstr "Pravilnik o zasebnosti in pogoji storitve"
 #. Text for a button that links to the terms of use and privacy policy page.
 msgctxt "Secondary button text in active privacy modal"
 msgid "Privacy Policy and Terms of Service"
-msgstr ""
+msgstr "Pravilnik o zasebnosti in pogoji storitve"
 
 # smartling.placeholder_format=C
 #. Title displayed on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
@@ -15404,8 +15394,7 @@ msgstr "Nedavni zavihki"
 #. Text explaining that this feature can be adjusted in the settings. Placeholder is for adding a link to 'Settings'. Example: 'Recent chat storage can be adjusted in Settings.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "Recent chat storage can be adjusted in %s."
-msgstr ""
-"Nastavitve shranjevanja nedavnih klepetov je mogoče prilagoditi v %1$s."
+msgstr "Nastavitve shranjevanja nedavnih klepetov je mogoče prilagoditi v %1$s."
 
 # smartling.placeholder_format=C
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -15464,25 +15453,25 @@ msgstr "Priporoči knjigo"
 #. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Recommend similar books"
-msgstr ""
+msgstr "Priporoči podobne knjige"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Recommend similar books."
-msgstr ""
+msgstr "Priporoči podobne knjige."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Recommend similar movies or shows."
-msgstr ""
+msgstr "Priporoči podobne filme ali TV-oddaje."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Recommend similar titles"
-msgstr ""
+msgstr "Priporoči podobne naslove"
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
@@ -15708,8 +15697,7 @@ msgstr "Zapomni si mojo izbiro"
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings
 msgid "Remember my choice (this can be changed in %s%s%sSettings%s)"
-msgstr ""
-"Zapomni si mojo odločitev (to lahko spremenite v %1$s%2$s%3$sNastavitvah%4$s)"
+msgstr "Zapomni si mojo odločitev (to lahko spremenite v %1$s%2$s%3$sNastavitvah%4$s)"
 
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
@@ -15896,7 +15884,7 @@ msgctxt ""
 "feedback form when the user has selected Harmful or Illegal as the feedback "
 "reason"
 msgid "Required for harmful or illegal reports"
-msgstr ""
+msgstr "Obvezno za prijave škodljivih ali nezakonitih vsebin"
 
 # smartling.placeholder_format=C
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
@@ -16066,8 +16054,7 @@ msgstr "Rezultati ne vključujejo informacij z blokiranih spletnih mest."
 #. Message that appears when results exclude blocked sites
 msgctxt "Blocked sites filter disclaimer"
 msgid "Results exclude your blocked sites, which you can manage in your %s."
-msgstr ""
-"Rezultati ne vključujejo blokiranih strani, ki jih lahko upravljate v: %1$s."
+msgstr "Rezultati ne vključujejo blokiranih strani, ki jih lahko upravljate v: %1$s."
 
 # smartling.placeholder_format=C
 #. A label showing the source of the results, e.g. "Results from Reddit"
@@ -16138,7 +16125,7 @@ msgstr "Ocene"
 #. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Rewrite this recipe scaled for a different number of servings."
-msgstr ""
+msgstr "Prepiši ta recept, prilagojen za drugo število porcij."
 
 # smartling.placeholder_format=C
 msgid "Romania"
@@ -16424,8 +16411,7 @@ msgstr "Shrani do 30 vaših najnovejših klepetov lokalno v vaši napravi."
 msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
-msgstr ""
-"Shranite svoje klepete Duck.ai med napravami z uporabo celovitega šifriranja."
+msgstr "Shranite svoje klepete Duck.ai med napravami z uporabo celovitega šifriranja."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -16547,8 +16533,7 @@ msgstr "Pomaknite navzdol in kliknite %1$sPrikaži napredne nastavitve%2$s"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down and click %sView advanced settings%s."
-msgstr ""
-"Pomaknite stran navzdol in kliknite %1$sPrikaži napredne nastavitve%2$s."
+msgstr "Pomaknite stran navzdol in kliknite %1$sPrikaži napredne nastavitve%2$s."
 
 #  Edge Legacy default search engine instruction, obsolete?
 # smartling.placeholder_format=C
@@ -17127,8 +17112,8 @@ msgstr "V meniju Safari izberite %1$s»Nastavitev za to spletno mesto ...«%2$s.
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
 msgstr ""
-"Izberite %1$sPo meri%2$s in v vnosno polje vnesite %3$shttps://duckduckgo."
-"com%4$s"
+"Izberite %1$sPo meri%2$s in v vnosno polje vnesite "
+"%3$shttps://duckduckgo.com%4$s"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
@@ -17475,7 +17460,7 @@ msgstr "Nastavi zdaj"
 #. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
 msgctxt "Encrypted storage setup button shown in native browsers"
 msgid "Set Up Sync & Backup"
-msgstr ""
+msgstr "Nastavitev funkcije Sync & Backup"
 
 # smartling.placeholder_format=C
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
@@ -17663,7 +17648,7 @@ msgstr "Delite pozitivne povratne informacije"
 msgctxt ""
 "Label beside the share-content switch on the Duck.ai response feedback form"
 msgid "Share this conversation with DuckDuckGo"
-msgstr ""
+msgstr "Delite ta pogovor z DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -17802,8 +17787,7 @@ msgstr "Pokaži DuckAssist <sup>BETA</sup>"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show DuckAssist more often. (You can also completely %sturn it off%s.)"
-msgstr ""
-"Pogosteje prikažite DuckAssist. (Lahko ga tudi popolnoma %1$sizklopite%2$s.)"
+msgstr "Pogosteje prikažite DuckAssist. (Lahko ga tudi popolnoma %1$sizklopite%2$s.)"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
@@ -18076,8 +18060,7 @@ msgstr "Prikaže občasne opomnike, da dodate DuckDuckGo v svoje naprave"
 msgctxt "settings"
 msgid ""
 "Shows occasional reminders to sign up for the DuckDuckGo privacy newsletters"
-msgstr ""
-"Prikaže občasne opomnike, da se prijavite na glasila o zasebnosti DuckDuckGo"
+msgstr "Prikaže občasne opomnike, da se prijavite na glasila o zasebnosti DuckDuckGo"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18113,8 +18096,7 @@ msgstr "Prikaže pozdravno sporočilo na vrhu strani z rezultati iskanja"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message to EU Android preference menu users"
-msgstr ""
-"Prikaže pozdravno sporočilo uporabnikom v meniju z nastavitvami za EU Android"
+msgstr "Prikaže pozdravno sporočilo uporabnikom v meniju z nastavitvami za EU Android"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers sometimes.
@@ -18434,8 +18416,7 @@ msgstr ""
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr ""
-"Žal nismo mogli poslati vaših povratnih informacij. Poskusite znova pozneje."
+msgstr "Žal nismo mogli poslati vaših povratnih informacij. Poskusite znova pozneje."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -18740,8 +18721,7 @@ msgstr "Ustavi ustvarjanje"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop hidden trackers lurking on other websites."
-msgstr ""
-"Onemogočite skrite sledilnike, ki se skrivajo v drugih spletnih mestih."
+msgstr "Onemogočite skrite sledilnike, ki se skrivajo v drugih spletnih mestih."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -18921,19 +18901,19 @@ msgstr "Predlagaj naslov za objavo v spletnem dnevniku"
 #. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Suggest related articles or topics worth exploring next."
-msgstr ""
+msgstr "Predlagaj sorodne članke ali teme, ki jih je vredno raziskati."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Suggest related articles to explore"
-msgstr ""
+msgstr "Predlagaj sorodne članke za raziskovanje"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Suggest some alternatives to this product."
-msgstr ""
+msgstr "Predlagaj nekaj alternativ za ta izdelek."
 
 # smartling.placeholder_format=C
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
@@ -18950,7 +18930,7 @@ msgstr "Predlogi:"
 #. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Sum up the reviews"
-msgstr ""
+msgstr "Povzemi mnenja"
 
 # smartling.placeholder_format=C
 #. A short title for the a message asking the AI to summarize a text.
@@ -18962,85 +18942,85 @@ msgstr "Povzemi"
 #. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize the Q&As"
-msgstr ""
+msgstr "Povzemi vprašanja in odgovore"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the background and notable work of this person."
-msgstr ""
+msgstr "Povzemi ozadje in pomembnejše delo te osebe."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the key details of this event."
-msgstr ""
+msgstr "Povzemi ključne podrobnosti tega dogodka."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the questions and answers on this page."
-msgstr ""
+msgstr "Povzemi vprašanja in odgovore na tej strani."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize their background"
-msgstr ""
+msgstr "Povzemi ozadje"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this book"
-msgstr ""
+msgstr "Povzemi to knjigo"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this book."
-msgstr ""
+msgstr "Povzemi to knjigo."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this discussion"
-msgstr ""
+msgstr "Povzemi to razpravo"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this discussion thread."
-msgstr ""
+msgstr "Povzemi to nit razprave."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this page"
-msgstr ""
+msgstr "Povzemi to stran"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this page."
-msgstr ""
+msgstr "Povzetek te strani."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this video"
-msgstr ""
+msgstr "Povzemi ta videoposnetek"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this video."
-msgstr ""
+msgstr "Povzemi ta videoposnetek."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize what the reviews say."
-msgstr ""
+msgstr "Povzemi, kaj pravijo ocene."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -19201,8 +19181,7 @@ msgstr "Preklopite na iskalnik, ki vam ne sledi. Nikoli."
 msgctxt "AI Chat warning when switching from an encrypted model"
 msgid ""
 "Switching will send your chat to a model without zero provider visibility"
-msgstr ""
-"S preklopom bo vaš klepet poslan modelu, ki nima nobene vidnosti ponudnika."
+msgstr "S preklopom bo vaš klepet poslan modelu, ki nima nobene vidnosti ponudnika."
 
 # smartling.placeholder_format=C
 msgid "Switzerland"
@@ -19370,7 +19349,7 @@ msgstr "Sirija"
 #. Text for a button that enables the theme to follow the operating system's color scheme preference.
 msgctxt "System theme button for theme selector"
 msgid "System"
-msgstr ""
+msgstr "Sistem"
 
 # smartling.placeholder_format=C
 #. Abbreviation indicating this is the total score for a game
@@ -19404,7 +19383,7 @@ msgstr "Tahitijščina"
 #. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Tailor my resume"
-msgstr ""
+msgstr "Prilagodi moj življenjepis"
 
 # smartling.placeholder_format=C
 msgid "Taiwan"
@@ -19441,6 +19420,8 @@ msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
+"Sodelujte v tej anonimni anketi in nam sporočite, kako lahko izboljšamo "
+"Duck.ai."
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -19705,8 +19686,7 @@ msgstr ""
 msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider deletes any data associated with this chat within 30 days."
-msgstr ""
-"Ponudnik modela izbriše vse podatke, povezane s tem klepetom, v 30 dneh."
+msgstr "Ponudnik modela izbriše vse podatke, povezane s tem klepetom, v 30 dneh."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers.
@@ -19750,7 +19730,7 @@ msgstr "Tema"
 #. Text for the theme selector label that allows users to switch between Light and dark theme.
 msgctxt "Label for the theme selector feature"
 msgid "Theme"
-msgstr ""
+msgstr "Tema"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/LpFhb1e.png
@@ -20259,8 +20239,7 @@ msgstr "Nasveti"
 
 # smartling.placeholder_format=C
 msgid "Tired of being tracked online? %sWe can help.%s"
-msgstr ""
-"Utrujeni od tega, da vam sledijo na spletu? %1$sMi vam lahko pomagamo.%2$s"
+msgstr "Utrujeni od tega, da vam sledijo na spletu? %1$sMi vam lahko pomagamo.%2$s"
 
 # smartling.placeholder_format=C
 #. This is the name of a user setting
@@ -20583,8 +20562,7 @@ msgctxt "Full sentence for translating text"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr ""
-"Prevedi ta angleški stavek v francoščino: »Kako pridem do najbližjega kina?«"
+msgstr "Prevedi ta angleški stavek v francoščino: »Kako pridem do najbližjega kina?«"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for translating a sentence into another language. Translate the whole sentence and please use target language instead of 'English' and modify the sentence to translate into 'English' instead of 'French'. Example: 'Translate this {target language} sentence into English: “How do I get to the nearest movie theatre?”'
@@ -20592,20 +20570,19 @@ msgctxt "Full sentence for translating text prompt"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr ""
-"Prevedi ta slovenski stavek v angleščino: »Kako pridem do najbližjega kina?«"
+msgstr "Prevedi ta slovenski stavek v angleščino: »Kako pridem do najbližjega kina?«"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Translate this page"
-msgstr ""
+msgstr "Prevedi to stran"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
 msgctxt "Page suggestion prompt"
 msgid "Translate this page into %s."
-msgstr ""
+msgstr "Prevedi to stran v jezik %1$s."
 
 # smartling.placeholder_format=C
 #. Placeholder text for a region that will display translated text.
@@ -20754,7 +20731,7 @@ msgstr "Poskusite brezplačno"
 #. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
 msgctxt "settings"
 msgid "Try It Now"
-msgstr ""
+msgstr "Preizkusite zdaj"
 
 # smartling.placeholder_format=C
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -20795,8 +20772,7 @@ msgstr "Poskusi dodati mesto, državo ali poštno številko"
 #. Message to display during errors for users who have AI enabled to encourage them to use that feature while the site is having issues. Example: 'Try asking Duck.ai, our private AI chat service:'
 msgctxt "noresults"
 msgid "Try asking %s, our private AI chat service:"
-msgstr ""
-"Poskusite vprašati %1$s, našo zasebno storitev klepeta z umetno inteligenco:"
+msgstr "Poskusite vprašati %1$s, našo zasebno storitev klepeta z umetno inteligenco:"
 
 # smartling.placeholder_format=C
 #. A message suggesting that the user clears their filters and tries their search again when they get no results
@@ -20828,8 +20804,7 @@ msgstr "Preizkusite omogočiti anonimno lokacijo za natančnejše rezultate."
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr ""
-"Poskusite eksperimentirati z vsakim modelom – dobili boste različne odzive."
+msgstr "Poskusite eksperimentirati z vsakim modelom – dobili boste različne odzive."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
@@ -20967,8 +20942,7 @@ msgstr "Preizkusite nedavno dodana odprtokodna modela Llama 3.1 in Mixtral"
 #. Message displayed to suggest the user to try the provided prompts or enter their own.
 msgctxt "Prompt suggestion message"
 msgid "Try these prompts to get started or enter your own prompt below"
-msgstr ""
-"Če želite začeti, poskusite uporabiti te pozive ali spodaj vnesite svoj poziv"
+msgstr "Če želite začeti, poskusite uporabiti te pozive ali spodaj vnesite svoj poziv"
 
 # smartling.placeholder_format=C
 #. Description for the empty state displayed when searching recent chats in Duck.ai returns no results, suggesting the user rephrase their search query.
@@ -21002,6 +20976,8 @@ msgid ""
 "Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
+"Želite onemogočiti funkcije umetne inteligence? Namestite iskalno razširitev "
+"%1$sDuckDuckGo No AI%2$s, da si zapomni vaše nastavitve. %3$sVeč o tem%4$s"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -21010,6 +20986,8 @@ msgid ""
 "Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
+"Želite onemogočiti funkcije UI? Preklopite na iskalno razširitev "
+"%1$sDuckDuckGo No AI%2$s, da si zapomni vaše nastavitve. %3$sVeč o tem%4$s"
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -21116,8 +21094,7 @@ msgstr "Za natančnejše rezultate vklopite %1$sNatančno lokacijo%2$s."
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
-msgstr ""
-"Vklopite predvajalnik Duck Player za gledanje YouTuba brez ciljanih oglasov"
+msgstr "Vklopite predvajalnik Duck Player za gledanje YouTuba brez ciljanih oglasov"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service.
@@ -21280,8 +21257,7 @@ msgstr "Povratnih informacij ni mogoče poslati"
 #. Message shown to the user when the voice chat failed to establish a connection, and they should try again later.
 msgctxt "voice chat"
 msgid "Unable to connect to voice chat, please try again later."
-msgstr ""
-"Povezave z glasovnim klepetom ni mogoče vzpostaviti. Poskusi znova pozneje."
+msgstr "Povezave z glasovnim klepetom ni mogoče vzpostaviti. Poskusi znova pozneje."
 
 # smartling.placeholder_format=C
 #. Message shown to the user when there was an issue connecting to their microphone.
@@ -21328,14 +21304,12 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sOpen with%s select %sA specific page or pages%s"
-msgstr ""
-"Za nastavitev %1$sOdpri z%2$s izberite %3$sDoločena stran ali strani%4$s"
+msgstr "Za nastavitev %1$sOdpri z%2$s izberite %3$sDoločena stran ali strani%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
-msgstr ""
-"Za nastavitev %1$sZAGON > Domača stran%2$s vnesite: https://duckduckgo.com"
+msgstr "Za nastavitev %1$sZAGON > Domača stran%2$s vnesite: https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -21482,8 +21456,7 @@ msgstr "Odklenite napredne modele umetne inteligence z naročnino %1$s"
 #. Tooltip text shown when the user hovers over the free badge telling the user that they can unlock advanced AI (Artificial Intelligence) models with a DuckDuckGo subscription.
 msgctxt "Tooltip for the free badge"
 msgid "Unlock advanced AI models with a DuckDuckGo subscription"
-msgstr ""
-"Odklenite napredne modele umetne inteligence z naročnino na DuckDuckGo."
+msgstr "Odklenite napredne modele umetne inteligence z naročnino na DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. A link to a blog post explaining the new AI benefits to a subscription. Please keep translations to 50 characters or less.
@@ -21772,7 +21745,7 @@ msgstr "Urugvaj"
 #. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
 msgctxt "Navigation label on the Duck.ai settings page"
 msgid "Usage"
-msgstr ""
+msgstr "Uporaba"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -21830,8 +21803,7 @@ msgstr "Uporabite DuckDuckGo Private Search"
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Use DuckDuckGo private search on your iPad, iPhone, or Android!"
-msgstr ""
-"Uporabite zasebno iskanje DuckDuckGo na svojem iPadu, iPhonu ali Androidu!"
+msgstr "Uporabite zasebno iskanje DuckDuckGo na svojem iPadu, iPhonu ali Androidu!"
 
 # smartling.placeholder_format=C
 #. User clicks this button to share their device's location
@@ -22228,7 +22200,7 @@ msgstr "Wales"
 #. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Walk me through the steps"
-msgstr ""
+msgstr "Vodi me skozi korake"
 
 # smartling.placeholder_format=C
 #. Label for walking directions on a map.
@@ -22359,6 +22331,9 @@ msgid ""
 "please share this conversation with DuckDuckGo so we can investigate and "
 "address the issue."
 msgstr ""
+"Popravimo lahko le tisto, kar vidimo. Če želite prijaviti škodljiv ali "
+"nezakonit odgovor, delite ta pogovor z DuckDuckGo, da bomo lahko težavo "
+"preiskali in odpravili."
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -22387,8 +22362,7 @@ msgstr ""
 msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
-msgstr ""
-"Priloženih datotek ne moremo prebrati, ker je vsaj ena od njih šifrirana."
+msgstr "Priloženih datotek ne moremo prebrati, ker je vsaj ena od njih šifrirana."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -22568,8 +22542,7 @@ msgstr ""
 #. Message that appears after submitting a feedback form.
 msgctxt "feedback form"
 msgid "We use feedback like this to improve DuckDuckGo."
-msgstr ""
-"Uporabljamo takšne povratne informacije kot so te, za izboljšanje DuckDuckGo."
+msgstr "Uporabljamo takšne povratne informacije kot so te, za izboljšanje DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Placeholder can be Apple Maps, TripAdvisor, and/or Foursquare
@@ -22622,8 +22595,7 @@ msgctxt "duckai_migration"
 msgid ""
 "We're sorry for this inconvenience. We’re working hard to make your "
 "experience better."
-msgstr ""
-"Žal nam je za to nevšečnost. Prizadevamo si, da bi bila vaša izkušnja boljša."
+msgstr "Žal nam je za to nevšečnost. Prizadevamo si, da bi bila vaša izkušnja boljša."
 
 # smartling.placeholder_format=C
 #. Body text explaining the service update requires a page reload.
@@ -22727,8 +22699,7 @@ msgstr "Dosežena je tedenska omejitev"
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Weekly usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Dosežena je tedenska omejitev uporabe. Ta klepet lahko nadaljujete po %1$s."
+msgstr "Dosežena je tedenska omejitev uporabe. Ta klepet lahko nadaljujete po %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable weekly Duck.ai usage limit and can opt in to continue using the monthly limit.
@@ -22873,8 +22844,7 @@ msgstr ""
 #. Text for a prompt suggestion for considering factors when purchasing a computer monitor.
 msgctxt "Full sentence for preparing for a purchase"
 msgid "What are some factors to consider when purchasing a computer monitor?"
-msgstr ""
-"Katere dejavnike je treba upoštevati pri nakupu računalniškega zaslona?"
+msgstr "Katere dejavnike je treba upoštevati pri nakupu računalniškega zaslona?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for asking about must-see attractions in Paris for a first-time visitor.
@@ -22919,98 +22889,98 @@ msgstr ""
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the counterarguments?"
-msgstr ""
+msgstr "Kateri so protiargumenti?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the hours & location?"
-msgstr ""
+msgstr "Kakšen je delovni čas in kje je?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key contributions of this paper?"
-msgstr ""
+msgstr "Kateri so glavni prispevki tega članka?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key contributions?"
-msgstr ""
+msgstr "Kateri so ključni prispevki?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key details?"
-msgstr ""
+msgstr "Katere so ključne podrobnosti?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key points covered in this video?"
-msgstr ""
+msgstr "Katere so ključne točke, zajete v tem videoposnetku?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key points?"
-msgstr ""
+msgstr "Katere so ključne točke?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key takeaways from this article?"
-msgstr ""
+msgstr "Katere so ključne ugotovitve tega članka?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key takeaways?"
-msgstr ""
+msgstr "Kateri so glavni poudarki?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key things I will learn from this course?"
-msgstr ""
+msgstr "Katere so ključne stvari, ki se jih bom naučil/-a v tem tečaju?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the main counterarguments or criticisms of this?"
-msgstr ""
+msgstr "Kateri so glavni protiargumenti ali kritike tega?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the main questions this page answers?"
-msgstr ""
+msgstr "Na katera glavna vprašanja odgovarja ta stran?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the must-try dishes here?"
-msgstr ""
+msgstr "Katere jedi moraš tukaj poskusiti?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid ""
 "What are the opening hours, location, and contact details for this place?"
-msgstr ""
+msgstr "Kakšen je delovni čas, lokacija in kontaktni podatki za ta kraj?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the pros and cons of this product?"
-msgstr ""
+msgstr "Katere so prednosti in slabosti tega izdelka?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the pros and cons?"
-msgstr ""
+msgstr "Katere so prednosti in slabosti?"
 
 # smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
@@ -23116,7 +23086,7 @@ msgstr "Kaj pomeni atrija v kontekstu medicinskega članka?"
 #. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What does this answer?"
-msgstr ""
+msgstr "Kaj to odgovori?"
 
 # smartling.placeholder_format=C
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
@@ -23134,7 +23104,7 @@ msgstr "Katere informacije se shranijo?"
 #. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What interview questions might come up for this role?"
-msgstr ""
+msgstr "Katera vprašanja za razgovor se lahko pojavijo za to vlogo?"
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -23156,7 +23126,7 @@ msgstr "Katero je glavno mesto Albanije?"
 #. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What is the overall verdict and rating for this?"
-msgstr ""
+msgstr "Kakšna je skupna razsodba in ocena za to?"
 
 # smartling.placeholder_format=C
 #. Link to a page with additional information.
@@ -23184,7 +23154,7 @@ msgstr "Kaj pravijo ljudje:"
 #. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What should I order?"
-msgstr ""
+msgstr "Kaj naj naročim?"
 
 # smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
@@ -23202,13 +23172,13 @@ msgstr "Kaj je bilo narobe z odzivom? (izbirno)"
 #. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What will I learn?"
-msgstr ""
+msgstr "Kaj se bom naučil/-a?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What will I need?"
-msgstr ""
+msgstr "Kaj bom potreboval/-a?"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -23233,7 +23203,7 @@ msgstr "Kaj je novega"
 #. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What's the verdict?"
-msgstr ""
+msgstr "Kakšna je razsodba?"
 
 # smartling.placeholder_format=C
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -23271,8 +23241,7 @@ msgstr "Kje gledati: <strong>%1$s</strong>"
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Where it says Homepage click %sSet to Current Page%s."
-msgstr ""
-"Pri nastavitvi Domača Stran kliknite %1$sNastavi na trenutno stran%2$s."
+msgstr "Pri nastavitvi Domača Stran kliknite %1$sNastavi na trenutno stran%2$s."
 
 # smartling.placeholder_format=C
 #. Heading of a module showing what streaming services are showing a movie or series, e.g. Where to Watch The Matrix
@@ -23290,7 +23259,7 @@ msgstr "Katere funkcije manjkajo? (izbirno)"
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Which features are missing? (optional)"
-msgstr ""
+msgstr "Katere funkcije manjkajo? (Izbirno)"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
@@ -23312,13 +23281,13 @@ msgstr "Kdo smo"
 #. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Who are the main cast and crew, and what else are they known for?"
-msgstr ""
+msgstr "Kdo so glavni igralci in člani ekipe ter po čem so še znani?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Who is this person?"
-msgstr ""
+msgstr "Kdo je ta oseba?"
 
 # smartling.placeholder_format=C
 #. Header above a collection of privacy-related links.
@@ -23980,8 +23949,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
 msgid "You won't see this message again unless you clear your browser data."
-msgstr ""
-"Tega sporočila ne boste več videli, razen če počistite podatke brskalnika."
+msgstr "Tega sporočila ne boste več videli, razen če počistite podatke brskalnika."
 
 # smartling.placeholder_format=C
 #. The second paragraph of a pop up where we explain how to update the browser manually.
@@ -24073,8 +24041,7 @@ msgstr "Dosegli ste najdaljše trajanje glasovnega klepeta za eno sejo."
 msgctxt "voice chat limit modal"
 msgid ""
 "You've reached the voice chat limit for today. Please try again tomorrow."
-msgstr ""
-"Dosegli ste omejitev glasovnega klepeta za danes. Poskusite znova jutri."
+msgstr "Dosegli ste omejitev glasovnega klepeta za danes. Poskusite znova jutri."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
@@ -24504,15 +24471,13 @@ msgctxt "Error message for user limit"
 msgid ""
 "You’ve reached the maximum number of messages for one day. Please continue "
 "this chat tomorrow."
-msgstr ""
-"Dosegli ste največje število sporočil za en dan. Nadaljujte ta klepet jutri."
+msgstr "Dosegli ste največje število sporočil za en dan. Nadaljujte ta klepet jutri."
 
 # smartling.placeholder_format=C
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
 msgctxt "voice chat limit modal"
 msgid "You’ve reached the voice chat limit for now. Please try again later."
-msgstr ""
-"Dosegli ste trenutno omejitev glasovnega klepeta. Poskusite znova pozneje."
+msgstr "Dosegli ste trenutno omejitev glasovnega klepeta. Poskusite znova pozneje."
 
 # smartling.placeholder_format=C
 #. The name of the Yucatec Maya language
@@ -24595,8 +24560,7 @@ msgstr "od %1$s"
 #. Trust line shown at the bottom of the explainer panel, summarizing DuckDuckGo's reputation for online protection.
 msgctxt "Footer banner text in the How Duck.ai Works panel"
 msgid "by DuckDuckGo — online protection trusted by millions every day."
-msgstr ""
-"omogoča DuckDuckGo – spletna zaščita, ki ji vsak dan zaupajo milijoni ljudi."
+msgstr "omogoča DuckDuckGo – spletna zaščita, ki ji vsak dan zaupajo milijoni ljudi."
 
 # smartling.placeholder_format=C
 #. An abreviated unit of time indicating an age, e.g. "2d"
@@ -24809,8 +24773,7 @@ msgstr "uradno spletno stran"
 #. <em>%s</em> is for a hexadecimal color code as <em>#395323</em>, but it has to be safe encoded, and as <em>#</em> seems not safe, <em>%23</em> must be used in place of the sharp symbol, but they are the same for your browser.
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
-msgstr ""
-"ali pa vpišite kodo želene barve, npr. %1$s (%2$s je kodiran znak %3$s)."
+msgstr "ali pa vpišite kodo želene barve, npr. %1$s (%2$s je kodiran znak %3$s)."
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "

--- a/locales/sl_SI/LC_MESSAGES/duckduckgo.po
+++ b/locales/sl_SI/LC_MESSAGES/duckduckgo.po
@@ -2,15 +2,16 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: sl_SI\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=4; plural=n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || n%100==4 ? 2 : 3;\n"
+"Plural-Forms: nplurals=4; plural=n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || "
+"n%100==4 ? 2 : 3;\n"
 
 # smartling.gettext_line_width = normalized : 79
 # smartling.placeholder_format=C
@@ -489,13 +490,15 @@ msgstr ""
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "%sLong-press%s the DuckDuckGo app icon on the home screen"
-msgstr "%1$sDolgo pritisnite%2$s ikono aplikacije DuckDuckGo na začetnem zaslonu."
+msgstr ""
+"%1$sDolgo pritisnite%2$s ikono aplikacije DuckDuckGo na začetnem zaslonu."
 
 # smartling.placeholder_format=C
 #. A message displayed when there is an error loading content or no results on requery
 msgctxt "Error or no results message"
 msgid "%sOops!%s%sSomething went wrong. Please %srefresh%s and try again."
-msgstr "%1$sUps!%2$s%3$sNekaj je šlo narobe. %4$sOsvežite%5$s in poskusite znova."
+msgstr ""
+"%1$sUps!%2$s%3$sNekaj je šlo narobe. %4$sOsvežite%5$s in poskusite znova."
 
 # smartling.placeholder_format=C
 #. Tagline in a popover encouraging the user to download the DuckDuckGo browser
@@ -812,7 +815,8 @@ msgstr "Dosežena je 6-urna omejitev uporabe."
 #. Displayed when the user has reached a fixed 6-hour Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "6-hour usage limit reached. You can continue this chat after %s."
-msgstr "Dosežena je 6-urna omejitev uporabe. Ta klepet lahko nadaljujete po %1$s."
+msgstr ""
+"Dosežena je 6-urna omejitev uporabe. Ta klepet lahko nadaljujete po %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable 6-hour Duck.ai usage limit and can opt in to continue using the daily limit.
@@ -892,7 +896,8 @@ msgstr ""
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of Duck.ai is available! Please refresh this page to continue."
-msgstr "Na voljo je nova različica Duck.ai! Če želite nadaljevati, osvežite to stran."
+msgstr ""
+"Na voljo je nova različica Duck.ai! Če želite nadaljevati, osvežite to stran."
 
 # smartling.placeholder_format=C
 #. Shown when the Duck.ai desktop app has been open a long time and a newer version exists.
@@ -1437,6 +1442,12 @@ msgid "Address is incorrect"
 msgstr "Naslov ni pravilen"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Adjust the servings"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. as in multiple advertisements
 msgid "Ads"
 msgstr "Oglasi"
@@ -1648,6 +1659,14 @@ msgstr "Vsi klepeti so %1$s. Umetna inteligenca lahko dela napake."
 msgctxt "Empty state heading in Duck.ai chat mode"
 msgid "All chats are %sprivate%s"
 msgstr "Vsi klepeti so %1$szasebni%2$s"
+
+# smartling.placeholder_format=C
+#. Paragraph in the Privacy & Terms section of the About & Legal page in Duck.ai settings, summarizing how chats are anonymized and are not stored or used to train chat models.
+msgctxt "Privacy & Terms section description on the Duck.ai settings page"
+msgid ""
+"All chats are anonymized by DuckDuckGo, and your conversations are not used "
+"to train chat models by DuckDuckGo or the model providers"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1920,6 +1939,13 @@ msgid "Anonymous location enabled"
 msgstr "Anonimna lokacija je omogočena"
 
 # smartling.placeholder_format=C
+msgctxt "settings"
+msgid ""
+"Anonymously generates answers for search queries based on web content. "
+"Choose how often you want it to appear, or disable it completely."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Instant Answer tab name
 msgid "Answer"
 msgstr "Odgovor"
@@ -2078,7 +2104,8 @@ msgstr "Ali ste prepričani, da želite izbrisati ta pogovor in začeti novega?"
 #. Text asking the user to confirm if they want to delete their current chat, explaining that this action cannot be undone.
 msgctxt "Body text for delete chat confirmation modal"
 msgid "Are you sure you want to delete this chat? This cannot be undone."
-msgstr "Ste prepričani, da želite izbrisati ta klepet? Tega ni mogoče razveljaviti."
+msgstr ""
+"Ste prepričani, da želite izbrisati ta klepet? Tega ni mogoče razveljaviti."
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to disable chat history, with a warning that it will also delete currently saved chats including pinned chats.
@@ -2198,6 +2225,12 @@ msgstr "Postavi nadaljnje vprašanje"
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse
 msgid "Ask a follow-up with Duck.ai"
 msgstr "Zastavite nadaljnje vprašanje za Duck.ai"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
+msgctxt "Page suggestion chip label"
+msgid "Ask about this page"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2419,7 +2452,8 @@ msgstr "Samodejno odgovarjanje"
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid "Auto-generated based on listed sources. May contain inaccuracies."
-msgstr "Samodejno ustvarjeno na podlagi navedenih virov. Lahko vsebuje netočnosti."
+msgstr ""
+"Samodejno ustvarjeno na podlagi navedenih virov. Lahko vsebuje netočnosti."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
@@ -2615,6 +2649,12 @@ msgid "Barcode"
 msgstr "Črtna koda"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Based on this page, is this course worth taking?"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Basic"
 msgstr "Osnovno"
@@ -2653,6 +2693,14 @@ msgstr "Odbijalec"
 msgctxt "Assistant response placeholder"
 msgid "Before continuing..."
 msgstr "Pred nadaljevanjem ..."
+
+# smartling.placeholder_format=C
+#. Explains that before storing the report, DuckDuckGo will anonymize the conversation by removing PII like names, email addresses, and identifying metadata.
+msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
+msgid ""
+"Before storing this report, DuckDuckGo will anonymize your conversation by "
+"removing PII like names, email addresses, and identifying metadata."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -2794,7 +2842,8 @@ msgstr "Blokiraj to spletno mesto v vseh rezultatih"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Block trackers and take control of your personal data"
-msgstr "Blokirajte sledilnike in prevzemite nadzor nad svojimi osebnimi podatki"
+msgstr ""
+"Blokirajte sledilnike in prevzemite nadzor nad svojimi osebnimi podatki"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -2969,6 +3018,12 @@ msgstr "Brazilija"
 msgctxt "Sports module"
 msgid "Break Points Won"
 msgstr "Osvojene točke z odvzemom servisa"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Break this down into clear, numbered steps."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -3426,6 +3481,12 @@ msgid "Cast"
 msgstr "Predvajaj"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Cast & Crew"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
 msgctxt "Tone option label for Casual"
 msgid "Casual"
@@ -3664,8 +3725,8 @@ msgstr ""
 "klepeta z umetno inteligenco tretjih oseb, ki podpirajo modele OpenAI, "
 "Anthropic in druge. Če to nastavitev izklopiš, bodo gumbi in povezave za "
 "klepet v iskalniku DuckDuckGo skriti. Vendar pa lahko še vedno dostopaš do "
-"klepeta, ko je ta nastavitev izklopljena tako, da obiščeš "
-"%1$shttps://duck.ai%2$s neposredno."
+"klepeta, ko je ta nastavitev izklopljena tako, da obiščeš %1$shttps://duck."
+"ai%2$s neposredno."
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -4264,7 +4325,8 @@ msgstr "Kliknite %1$stukaj%2$s za prenos razširitve DuckDuckGo"
 # smartling.placeholder_format=C
 #. Link to download the DuckDuckGo browser extension.
 msgid "Click %sOpen%s to download and open the DuckDuckGo Safari extension"
-msgstr "Kliknite %1$sOdpri%2$s za prenos in odprite razširitev DuckDuckGo Safari"
+msgstr ""
+"Kliknite %1$sOdpri%2$s za prenos in odprite razširitev DuckDuckGo Safari"
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -4297,7 +4359,8 @@ msgstr "Kliknite %1$sNastavitve%2$s v spustnem meniju."
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
-msgstr "Kliknite %1$sUporabi trenutne strani%2$s, nato %3$skliknite V redu%4$s."
+msgstr ""
+"Kliknite %1$sUporabi trenutne strani%2$s, nato %3$skliknite V redu%4$s."
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -5016,7 +5079,8 @@ msgstr "Kopiraj"
 # smartling.placeholder_format=C
 #. Instructions on how to change the default search engine
 msgid "Copy &amp; paste %sabout:preferences#search%s into the address bar"
-msgstr "Kopirajte in prilepite %1$sabout:preferences#search%2$s v naslovno vrstico"
+msgstr ""
+"Kopirajte in prilepite %1$sabout:preferences#search%2$s v naslovno vrstico"
 
 # smartling.placeholder_format=C
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
@@ -5130,6 +5194,12 @@ msgstr "Ustvari sliko"
 msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr "Ustvari sliko"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Create a shopping list with quantities from this recipe."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed in the input field when starting a new image generation session.
@@ -5386,7 +5456,8 @@ msgstr "Dosežena je dnevna omejitev"
 #. Displayed when the user has reached a fixed daily Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Daily usage limit reached. You can continue this chat after %s."
-msgstr "Dosežena je dnevna omejitev uporabe. Ta klepet lahko nadaljujete po %1$s."
+msgstr ""
+"Dosežena je dnevna omejitev uporabe. Ta klepet lahko nadaljujete po %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable daily Duck.ai usage limit and can opt in to continue using the weekly limit.
@@ -5776,6 +5847,11 @@ msgid "Dictation limit reached"
 msgstr "Dosežena je omejitev narekovanja"
 
 # smartling.placeholder_format=C
+#. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
+msgid "Dictation temporarily unavailable"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
@@ -6078,6 +6154,22 @@ msgid "Done"
 msgstr "Končano"
 
 # smartling.placeholder_format=C
+#. Message shown in a modal after DuckDuckGo browser users disable AI features in Settings. The first two placeholders bold noai.duckduckgo.com. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
+"filtered out. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
+"and AI images filtered out. %sLearn more%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Double Faults"
@@ -6192,6 +6284,18 @@ msgstr ""
 "zahtevaš ponudbo za popravilo hladilnika na domu."
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Draft a cover letter"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Draft a cover letter for this job."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
 msgctxt "Full sentence for drafting a social media post"
 msgid ""
@@ -6279,7 +6383,8 @@ msgstr "Spustite svoje fotografije ali datoteke PDF"
 # smartling.placeholder_format=C
 #. A title explaining what Duck Player (DDG's feature to watch youtube videos more privately) does
 msgid "Duck Player lets you watch YouTube without targeted ads"
-msgstr "Predvajalnik Duck Player vam omogoča gledanje YouTuba brez ciljanih oglasov"
+msgstr ""
+"Predvajalnik Duck Player vam omogoča gledanje YouTuba brez ciljanih oglasov"
 
 # smartling.placeholder_format=C
 #. This is the DDG version of "Google it", meaning "search it".
@@ -6325,7 +6430,8 @@ msgstr "pogoji storitve Duck.ai"
 #. The HTML <title> for Duck.ai.
 msgctxt "duckai_seo"
 msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
-msgstr "Duck.ai by DuckDuckGo. Zasebni klepet z umetno inteligenco. Brezplačno."
+msgstr ""
+"Duck.ai by DuckDuckGo. Zasebni klepet z umetno inteligenco. Brezplačno."
 
 # smartling.placeholder_format=C
 #. Description explaining how the page context feature works in Duck.ai sidebar.
@@ -6365,7 +6471,17 @@ msgstr ""
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
-msgstr "Duck.ai najbolje deluje v našem zasebnem in brezplačnem brskalniku DuckDuckGo"
+msgstr ""
+"Duck.ai najbolje deluje v našem zasebnem in brezplačnem brskalniku DuckDuckGo"
+
+# smartling.placeholder_format=C
+#. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
+msgctxt "About section description on the Duck.ai settings page"
+msgid ""
+"Duck.ai is created by DuckDuckGo. We're an independent online protection "
+"company for anyone who wants to take back control of their personal "
+"information."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
@@ -6411,6 +6527,13 @@ msgstr "Duck.ai trenutno ni na voljo. Osvežite stran in poskusite znova."
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
 msgstr "Duck.ai trenutno ni na voljo. Poskusite znova pozneje."
+
+# smartling.placeholder_format=C
+msgctxt "settings"
+msgid ""
+"Duck.ai lets you chat privately with popular AI models. Disabling it hides "
+"Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6474,7 +6597,8 @@ msgstr "Duck.ai je nadgrajen!"
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
-msgstr "Duck.ai najbolje deluje v naši zasebni in brezplačni aplikaciji DuckDuckGo"
+msgstr ""
+"Duck.ai najbolje deluje v naši zasebni in brezplačni aplikaciji DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -6651,7 +6775,8 @@ msgctxt "Error message for VQD error"
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. Please refresh the page and "
 "try again."
-msgstr "DuckDuckGo AI Chat trenutno ni na voljo. Osvežite stran in poskusite znova."
+msgstr ""
+"DuckDuckGo AI Chat trenutno ni na voljo. Osvežite stran in poskusite znova."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -6999,7 +7124,8 @@ msgstr "Urejanje slike ..."
 msgctxt "Info text for the editing message feature"
 msgid ""
 "Editing your message will remove the response below and generate a new one."
-msgstr "Z urejanjem sporočila boste odstranili spodnji odgovor in ustvarili novega."
+msgstr ""
+"Z urejanjem sporočila boste odstranili spodnji odgovor in ustvarili novega."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of an editor in its responses.
@@ -7060,7 +7186,8 @@ msgstr "Omogoči funkcije UI"
 #. Text explaining how to enable the cloud save feature.
 msgctxt "cloudsave"
 msgid "Enable Cloud Save by entering your existing passphrase."
-msgstr "Omogočite storitev Cloud Save z vnosom svoje obstoječe varnostne fraze."
+msgstr ""
+"Omogočite storitev Cloud Save z vnosom svoje obstoječe varnostne fraze."
 
 # smartling.placeholder_format=C
 #. Primary button text in the dictation privacy consent modal to enable dictation.
@@ -7266,7 +7393,8 @@ msgstr "Prepričajte se, da so »Lokacijske storitve« %1$somogočene%2$s."
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location' is set to %sallow%s"
-msgstr "Prepričajte se, da je možnost »Lokacija« nastavljena na %1$sdovoli%2$s."
+msgstr ""
+"Prepričajte se, da je možnost »Lokacija« nastavljena na %1$sdovoli%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service.
@@ -7278,7 +7406,8 @@ msgstr "Preverite, ali je možnost »Lokacija« nastavljena na %1$sdovoli%2$s."
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure Location is set to %sAllow%s"
-msgstr "Prepričajte se, da je možnost »Lokacija« nastavljena na %1$sDovoli%2$s."
+msgstr ""
+"Prepričajte se, da je možnost »Lokacija« nastavljena na %1$sDovoli%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
@@ -7302,7 +7431,8 @@ msgstr "Prepričajte se, da ima brskalnik omogočen %1$sdostop do lokacije%2$s."
 #. Tells users how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed %slocation access%s."
-msgstr "Preverite, ali ima vaš brskalnik dovoljenje za %1$sdostop do lokacije%2$s."
+msgstr ""
+"Preverite, ali ima vaš brskalnik dovoljenje za %1$sdostop do lokacije%2$s."
 
 # smartling.placeholder_format=C
 #. Tells how to enable location service. Part of a list of instructions on how to enable location service.
@@ -7402,11 +7532,24 @@ msgstr "Ekvatorialna Gvineja"
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Erase your browsing data in a flash with our %sFire Button%s"
-msgstr "V trenutku izbrišite podatke o brskanju z našim gumbom %1$sFire Button%2$s"
+msgstr ""
+"V trenutku izbrišite podatke o brskanju z našim gumbom %1$sFire Button%2$s"
 
 # smartling.placeholder_format=C
 msgid "Eritrea"
 msgstr "Eritreja"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Estimate the nutrition"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Estimate the nutritional information for this recipe."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Estonia"
@@ -7463,11 +7606,59 @@ msgid "Expires in 1 day"
 msgstr "Poteče čez 1 dan"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain the accepted answer in simple terms."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
 msgstr "Pojasni mi temeljne koncepte črnih lukenj na srednješolski ravni."
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain the top answer"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this in simple, plain language."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this paper"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this repo"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this research paper in plain language."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this simply"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain what this repository does and how to use it."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label to show if song lyrics contain explicit content
@@ -7755,6 +7946,12 @@ msgstr ""
 "inteligenca. %1$sVeč o tem%2$s"
 
 # smartling.placeholder_format=C
+msgctxt "settings"
+msgid ""
+"Filters out known AI spam sites from image search results. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the final score of a sporting event.
 msgid "Final"
 msgstr "Končno"
@@ -7808,6 +8005,12 @@ msgstr "Poišči boljšo besedo"
 msgctxt "Subtitle for the Web Search tool entry in the Tools dropdown menu"
 msgid "Find current information"
 msgstr "Poiščite trenutne informacije"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Find me alternatives"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button that searches for results closer to the user's current location.
@@ -8006,7 +8209,8 @@ msgstr "Brezplačni in zasebni klepeti, ki jih anonimiziramo"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr "Brezplačni in zasebni klepeti, ki jih anonimiziramo. Račun ni potreben."
+msgstr ""
+"Brezplačni in zasebni klepeti, ki jih anonimiziramo. Račun ni potreben."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -8287,6 +8491,12 @@ msgstr "Ustvari sliko"
 #. Text for the button that generates more of an answer from duckassist when the answer has come from a collapsed state
 msgid "Generate More"
 msgstr "Ustvari več"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Generate a shopping list"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
@@ -8578,6 +8788,12 @@ msgstr "Preizkusi"
 msgctxt "Onboarding welcome screen button text"
 msgid "Give it a Try"
 msgstr "Preizkusi"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Give me a quick background on this person."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9024,6 +9240,18 @@ msgstr "Pomagajte širiti besedo o DuckDuckGo!"
 #. Link to a page with information about sharing DuckDuckGo with friends.
 msgid "Help Spread Privacy"
 msgstr "Pomagajte razširiti zasebnost"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Help me prep for the interview"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Help me tailor my resume for this job."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title of a SERP popup that invites users to take a survey (desktop only)
@@ -9478,7 +9706,8 @@ msgstr ""
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
 msgctxt "Duck.ai settings usage section"
 msgid "How much of your daily and weekly limits you've used so far."
-msgstr "Delež vaših dnevnih in tedenskih omejitev, ki ste jih doslej uporabili."
+msgstr ""
+"Delež vaših dnevnih in tedenskih omejitev, ki ste jih doslej uporabili."
 
 # smartling.placeholder_format=C
 #. A header for the feedback form in the assist negative feedback flow. The user is being asked to update how often they want AI-assisted answers to appear.
@@ -9545,6 +9774,14 @@ msgstr "Orkan"
 msgctxt "Onboarding terms screen button text"
 msgid "I Agree"
 msgstr "Strinjam se"
+
+# smartling.placeholder_format=C
+#. Text for the button that takes the user to the external DuckDuckGo login subscription page.
+msgctxt ""
+"Text for the I already have a subscription button in the Duck.ai settings "
+"page"
+msgid "I Already Have a Subscription"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the button that takes the user to the login subscription page.
@@ -9917,7 +10154,8 @@ msgstr "V zgornjem meniju izberite %1$sOrodja%2$s > %3$sNastavitve%4$s"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "In the popup, check %sMake this my default search provider%s"
-msgstr "V pojavnem oknu potrdite %1$sTo naj bo moj privzeti ponudnik iskanja%2$s"
+msgstr ""
+"V pojavnem oknu potrdite %1$sTo naj bo moj privzeti ponudnik iskanja%2$s"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -10123,6 +10361,12 @@ msgid "Install Mac Browser"
 msgstr "Namestitev brskalnika za Mac"
 
 # smartling.placeholder_format=C
+#. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
+msgctxt "settings"
+msgid "Install Now"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of a button to install the DuckDuckGo app
 msgctxt "Serp footer content"
 msgid "Install Our App"
@@ -10220,10 +10464,42 @@ msgid "Is deleted data really deleted?"
 msgstr "So izbrisani podatki zares izbrisani?"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is it worth taking?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this place any good?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"Is this place any good? Summarize its reputation based on reviews and "
+"ratings."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "Is this video helpful?"
 msgstr "Je ta video v pomoč?"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this worth watching?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Is this worth watching? Give me a spoiler-free take."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -10255,7 +10531,8 @@ msgstr "Je hiter, brezplačen in zagotavlja še večjo spletno zaščito."
 msgctxt "settings"
 msgid ""
 "It's okay to (very infrequently) ask me about my experience using DuckDuckGo"
-msgstr "Dovolim, da me (zelo redko) vprašate o mojih izkušnjah z uporabo DuckDuckGo"
+msgstr ""
+"Dovolim, da me (zelo redko) vprašate o mojih izkušnjah z uporabo DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. The name of the Italian language
@@ -10834,6 +11111,12 @@ msgid "Links:"
 msgstr "Povezave:"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "List the tools, materials, or prerequisites I need for this."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
 msgid "Listen"
 msgstr "Poslušaj"
@@ -11242,6 +11525,12 @@ msgstr "Upravljajte svojo naročnino"
 msgctxt "Exclusion message manage sites button"
 msgid "Manage blocked sites"
 msgstr "Upravljanje blokiranih spletnih mest"
+
+# smartling.placeholder_format=C
+#. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
+msgctxt "setting"
+msgid "Manage in Browser Settings"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to the site exclusion settings page
@@ -11693,7 +11982,8 @@ msgstr "Dosežena je mesečna omejitev"
 #. Displayed when the user has reached a fixed monthly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Monthly usage limit reached. You can continue this chat after %s."
-msgstr "Dosežena je mesečna omejitev uporabe. Ta klepet lahko nadaljujete po %1$s."
+msgstr ""
+"Dosežena je mesečna omejitev uporabe. Ta klepet lahko nadaljujete po %1$s."
 
 # smartling.placeholder_format=C
 #. Used to point to additional social networking profiles (in results).
@@ -11855,7 +12145,8 @@ msgstr "Več statističnih podatkov o medaljah je na voljo na %1$s"
 msgctxt ""
 "Note on the Olympics module as to where they can find more information"
 msgid "More medal stats on %solympics.com%s"
-msgstr "Več statističnih podatkov o medaljah je na voljo na %1$solympics.com%2$s"
+msgstr ""
+"Več statističnih podatkov o medaljah je na voljo na %1$solympics.com%2$s"
 
 # smartling.placeholder_format=C
 #. A link to more information on a topic. The placeholder is the name of a website. For example 'More on Wikipedia'.
@@ -13156,7 +13447,8 @@ msgstr "Odpri spletno mesto %1$s"
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open %sLocation%s, and ensure location is %senabled%s"
-msgstr "Odprite %1$sLokacija%2$s in se prepričajte, da je lokacija %3$somogočena%4$s."
+msgstr ""
+"Odprite %1$sLokacija%2$s in se prepričajte, da je lokacija %3$somogočena%4$s."
 
 #  Chrome/Firefox on Android/iOS
 # smartling.placeholder_format=C
@@ -14061,7 +14353,8 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this prompt was made by a "
 "human."
-msgstr "Rešite naslednji izziv in s tem potrdite, da je ta poziv ustvaril človek."
+msgstr ""
+"Rešite naslednji izziv in s tem potrdite, da je ta poziv ustvaril človek."
 
 # smartling.placeholder_format=C
 #. Bot challenge explanation
@@ -14069,7 +14362,14 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this search was made by a "
 "human."
-msgstr "Rešite naslednji izziv in s tem potrdite, da je to iskanje opravil človek."
+msgstr ""
+"Rešite naslednji izziv in s tem potrdite, da je to iskanje opravil človek."
+
+# smartling.placeholder_format=C
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
+msgctxt "Feedback prompt"
+msgid "Please describe why the chat response is harmful or illegal. (optional)"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
@@ -14098,6 +14398,14 @@ msgid ""
 msgstr ""
 "Upoštevajte: Če začnete nov klepet s katerim koli modelom, se izbriše vaša "
 "trenutna seja klepeta."
+
+# smartling.placeholder_format=C
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
+msgctxt "Feedback prompt"
+msgid ""
+"Please paste your prompt and the problematic output (with any personal "
+"information removed) and describe why the content is harmful or illegal."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -14567,6 +14875,12 @@ msgid "Privacy"
 msgstr "Zasebnost"
 
 # smartling.placeholder_format=C
+#. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
+msgctxt "Section heading on the Duck.ai settings page"
+msgid "Privacy & Terms"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Privacy Blog"
 msgstr "Spletni dnevnik o zasebnosti"
 
@@ -14635,6 +14949,12 @@ msgstr "Pravilnik o zasebnosti in pogoji uporabe"
 msgctxt "Copy used to compose link in sentences"
 msgid "Privacy Policy and Terms of Service"
 msgstr "Pravilnik o zasebnosti in pogoji storitve"
+
+# smartling.placeholder_format=C
+#. Text for a button that links to the terms of use and privacy policy page.
+msgctxt "Secondary button text in active privacy modal"
+msgid "Privacy Policy and Terms of Service"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title displayed on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
@@ -15084,7 +15404,8 @@ msgstr "Nedavni zavihki"
 #. Text explaining that this feature can be adjusted in the settings. Placeholder is for adding a link to 'Settings'. Example: 'Recent chat storage can be adjusted in Settings.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "Recent chat storage can be adjusted in %s."
-msgstr "Nastavitve shranjevanja nedavnih klepetov je mogoče prilagoditi v %1$s."
+msgstr ""
+"Nastavitve shranjevanja nedavnih klepetov je mogoče prilagoditi v %1$s."
 
 # smartling.placeholder_format=C
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -15138,6 +15459,30 @@ msgstr "Recepti za: %1$s%2$s%3$s"
 msgctxt "Brief for recommending a book"
 msgid "Recommend a book"
 msgstr "Priporoči knjigo"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar books"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar books."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar movies or shows."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar titles"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
@@ -15363,7 +15708,8 @@ msgstr "Zapomni si mojo izbiro"
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings
 msgid "Remember my choice (this can be changed in %s%s%sSettings%s)"
-msgstr "Zapomni si mojo odločitev (to lahko spremenite v %1$s%2$s%3$sNastavitvah%4$s)"
+msgstr ""
+"Zapomni si mojo odločitev (to lahko spremenite v %1$s%2$s%3$sNastavitvah%4$s)"
 
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
@@ -15544,6 +15890,15 @@ msgid "Republic of Moldova"
 msgstr "Republika Moldavija"
 
 # smartling.placeholder_format=C
+#. Note indicating that sharing the conversation is mandatory when reporting harmful or illegal content. Rendered alongside the standard share label (DUCKCHAT_RESPONSE_FEEDBACK_SHARE_PROMPT_RESPONSE_LABEL), not replacing it.
+msgctxt ""
+"Note shown under the share-content switch label on the Duck.ai response "
+"feedback form when the user has selected Harmful or Illegal as the feedback "
+"reason"
+msgid "Required for harmful or illegal reports"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
 msgctxt "Description for extended reasoning mode in Duck.ai"
 msgid "Researches before responding"
@@ -15711,7 +16066,8 @@ msgstr "Rezultati ne vključujejo informacij z blokiranih spletnih mest."
 #. Message that appears when results exclude blocked sites
 msgctxt "Blocked sites filter disclaimer"
 msgid "Results exclude your blocked sites, which you can manage in your %s."
-msgstr "Rezultati ne vključujejo blokiranih strani, ki jih lahko upravljate v: %1$s."
+msgstr ""
+"Rezultati ne vključujejo blokiranih strani, ki jih lahko upravljate v: %1$s."
 
 # smartling.placeholder_format=C
 #. A label showing the source of the results, e.g. "Results from Reddit"
@@ -15777,6 +16133,12 @@ msgstr "Ocene"
 msgctxt "maps_places"
 msgid "Reviews"
 msgstr "Ocene"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Rewrite this recipe scaled for a different number of servings."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Romania"
@@ -16062,7 +16424,8 @@ msgstr "Shrani do 30 vaših najnovejših klepetov lokalno v vaši napravi."
 msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
-msgstr "Shranite svoje klepete Duck.ai med napravami z uporabo celovitega šifriranja."
+msgstr ""
+"Shranite svoje klepete Duck.ai med napravami z uporabo celovitega šifriranja."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -16184,7 +16547,8 @@ msgstr "Pomaknite navzdol in kliknite %1$sPrikaži napredne nastavitve%2$s"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down and click %sView advanced settings%s."
-msgstr "Pomaknite stran navzdol in kliknite %1$sPrikaži napredne nastavitve%2$s."
+msgstr ""
+"Pomaknite stran navzdol in kliknite %1$sPrikaži napredne nastavitve%2$s."
 
 #  Edge Legacy default search engine instruction, obsolete?
 # smartling.placeholder_format=C
@@ -16763,8 +17127,8 @@ msgstr "V meniju Safari izberite %1$s»Nastavitev za to spletno mesto ...«%2$s.
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
 msgstr ""
-"Izberite %1$sPo meri%2$s in v vnosno polje vnesite "
-"%3$shttps://duckduckgo.com%4$s"
+"Izberite %1$sPo meri%2$s in v vnosno polje vnesite %3$shttps://duckduckgo."
+"com%4$s"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
@@ -17108,6 +17472,12 @@ msgid "Set Up Now"
 msgstr "Nastavi zdaj"
 
 # smartling.placeholder_format=C
+#. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
+msgctxt "Encrypted storage setup button shown in native browsers"
+msgid "Set Up Sync & Backup"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
 msgctxt "Title for the Sync & Backup intro screen"
 msgid "Set Up Sync & Backup"
@@ -17289,6 +17659,13 @@ msgid "Share positive feedback"
 msgstr "Delite pozitivne povratne informacije"
 
 # smartling.placeholder_format=C
+#. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
+msgctxt ""
+"Label beside the share-content switch on the Duck.ai response feedback form"
+msgid "Share this conversation with DuckDuckGo"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
 msgctxt ""
 "Label beside the share-content switch on the Duck.ai response feedback form"
@@ -17425,7 +17802,8 @@ msgstr "Pokaži DuckAssist <sup>BETA</sup>"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show DuckAssist more often. (You can also completely %sturn it off%s.)"
-msgstr "Pogosteje prikažite DuckAssist. (Lahko ga tudi popolnoma %1$sizklopite%2$s.)"
+msgstr ""
+"Pogosteje prikažite DuckAssist. (Lahko ga tudi popolnoma %1$sizklopite%2$s.)"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
@@ -17698,7 +18076,8 @@ msgstr "Prikaže občasne opomnike, da dodate DuckDuckGo v svoje naprave"
 msgctxt "settings"
 msgid ""
 "Shows occasional reminders to sign up for the DuckDuckGo privacy newsletters"
-msgstr "Prikaže občasne opomnike, da se prijavite na glasila o zasebnosti DuckDuckGo"
+msgstr ""
+"Prikaže občasne opomnike, da se prijavite na glasila o zasebnosti DuckDuckGo"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -17734,7 +18113,8 @@ msgstr "Prikaže pozdravno sporočilo na vrhu strani z rezultati iskanja"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message to EU Android preference menu users"
-msgstr "Prikaže pozdravno sporočilo uporabnikom v meniju z nastavitvami za EU Android"
+msgstr ""
+"Prikaže pozdravno sporočilo uporabnikom v meniju z nastavitvami za EU Android"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers sometimes.
@@ -18054,7 +18434,8 @@ msgstr ""
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr "Žal nismo mogli poslati vaših povratnih informacij. Poskusite znova pozneje."
+msgstr ""
+"Žal nismo mogli poslati vaših povratnih informacij. Poskusite znova pozneje."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -18359,7 +18740,8 @@ msgstr "Ustavi ustvarjanje"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop hidden trackers lurking on other websites."
-msgstr "Onemogočite skrite sledilnike, ki se skrivajo v drugih spletnih mestih."
+msgstr ""
+"Onemogočite skrite sledilnike, ki se skrivajo v drugih spletnih mestih."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -18536,6 +18918,24 @@ msgid "Suggest a title for a blog post"
 msgstr "Predlagaj naslov za objavo v spletnem dnevniku"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest related articles or topics worth exploring next."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Suggest related articles to explore"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest some alternatives to this product."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
 msgctxt "directions"
 msgid "Suggestions:"
@@ -18547,10 +18947,100 @@ msgid "Suggestions:"
 msgstr "Predlogi:"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Sum up the reviews"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A short title for the a message asking the AI to summarize a text.
 msgctxt "Title for the summarize message"
 msgid "Summarize"
 msgstr "Povzemi"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize the Q&As"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the background and notable work of this person."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the key details of this event."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the questions and answers on this page."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize their background"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this book"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this book."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this discussion"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this discussion thread."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this page"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this page."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this video"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this video."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize what the reviews say."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -18711,7 +19201,8 @@ msgstr "Preklopite na iskalnik, ki vam ne sledi. Nikoli."
 msgctxt "AI Chat warning when switching from an encrypted model"
 msgid ""
 "Switching will send your chat to a model without zero provider visibility"
-msgstr "S preklopom bo vaš klepet poslan modelu, ki nima nobene vidnosti ponudnika."
+msgstr ""
+"S preklopom bo vaš klepet poslan modelu, ki nima nobene vidnosti ponudnika."
 
 # smartling.placeholder_format=C
 msgid "Switzerland"
@@ -18876,6 +19367,12 @@ msgid "Syria"
 msgstr "Sirija"
 
 # smartling.placeholder_format=C
+#. Text for a button that enables the theme to follow the operating system's color scheme preference.
+msgctxt "System theme button for theme selector"
+msgid "System"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Abbreviation indicating this is the total score for a game
 msgctxt "Sports module"
 msgid "T"
@@ -18902,6 +19399,12 @@ msgstr "TV"
 msgctxt "language_name"
 msgid "Tahitian"
 msgstr "Tahitijščina"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Tailor my resume"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Taiwan"
@@ -18931,6 +19434,13 @@ msgstr "Prevzemite nadzor nad svojimi osebnimi podatki"
 msgctxt "homepage ATB modal"
 msgid "Take control of your personal data!"
 msgstr "Prevzemite nadzor nad svojimi osebnimi podatki!"
+
+# smartling.placeholder_format=C
+#. Description for the Feedback section of the Duck.ai settings page, asking the user to take an anonymous survey to let us know how we can make Duck.ai better.
+msgctxt "Feedback section description on the Duck.ai settings page"
+msgid ""
+"Take this anonymous survey to let us know how we can make Duck.ai better."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -19195,7 +19705,8 @@ msgstr ""
 msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider deletes any data associated with this chat within 30 days."
-msgstr "Ponudnik modela izbriše vse podatke, povezane s tem klepetom, v 30 dneh."
+msgstr ""
+"Ponudnik modela izbriše vse podatke, povezane s tem klepetom, v 30 dneh."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers.
@@ -19234,6 +19745,12 @@ msgstr "Strežnik je naletel na napako in ni mogel dokončati vaše zahteve."
 #. https://duck.co/media/files/theme.png
 msgid "Theme"
 msgstr "Tema"
+
+# smartling.placeholder_format=C
+#. Text for the theme selector label that allows users to switch between Light and dark theme.
+msgctxt "Label for the theme selector feature"
+msgid "Theme"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/LpFhb1e.png
@@ -19742,7 +20259,8 @@ msgstr "Nasveti"
 
 # smartling.placeholder_format=C
 msgid "Tired of being tracked online? %sWe can help.%s"
-msgstr "Utrujeni od tega, da vam sledijo na spletu? %1$sMi vam lahko pomagamo.%2$s"
+msgstr ""
+"Utrujeni od tega, da vam sledijo na spletu? %1$sMi vam lahko pomagamo.%2$s"
 
 # smartling.placeholder_format=C
 #. This is the name of a user setting
@@ -20065,7 +20583,8 @@ msgctxt "Full sentence for translating text"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr "Prevedi ta angleški stavek v francoščino: »Kako pridem do najbližjega kina?«"
+msgstr ""
+"Prevedi ta angleški stavek v francoščino: »Kako pridem do najbližjega kina?«"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for translating a sentence into another language. Translate the whole sentence and please use target language instead of 'English' and modify the sentence to translate into 'English' instead of 'French'. Example: 'Translate this {target language} sentence into English: “How do I get to the nearest movie theatre?”'
@@ -20073,7 +20592,20 @@ msgctxt "Full sentence for translating text prompt"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr "Prevedi ta slovenski stavek v angleščino: »Kako pridem do najbližjega kina?«"
+msgstr ""
+"Prevedi ta slovenski stavek v angleščino: »Kako pridem do najbližjega kina?«"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Translate this page"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
+msgctxt "Page suggestion prompt"
+msgid "Translate this page into %s."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder text for a region that will display translated text.
@@ -20219,6 +20751,12 @@ msgid "Try Free"
 msgstr "Poskusite brezplačno"
 
 # smartling.placeholder_format=C
+#. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
+msgctxt "settings"
+msgid "Try It Now"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
 msgctxt "Promotional CTA for new AI models"
 msgid "Try Now"
@@ -20257,7 +20795,8 @@ msgstr "Poskusi dodati mesto, državo ali poštno številko"
 #. Message to display during errors for users who have AI enabled to encourage them to use that feature while the site is having issues. Example: 'Try asking Duck.ai, our private AI chat service:'
 msgctxt "noresults"
 msgid "Try asking %s, our private AI chat service:"
-msgstr "Poskusite vprašati %1$s, našo zasebno storitev klepeta z umetno inteligenco:"
+msgstr ""
+"Poskusite vprašati %1$s, našo zasebno storitev klepeta z umetno inteligenco:"
 
 # smartling.placeholder_format=C
 #. A message suggesting that the user clears their filters and tries their search again when they get no results
@@ -20289,7 +20828,8 @@ msgstr "Preizkusite omogočiti anonimno lokacijo za natančnejše rezultate."
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr "Poskusite eksperimentirati z vsakim modelom – dobili boste različne odzive."
+msgstr ""
+"Poskusite eksperimentirati z vsakim modelom – dobili boste različne odzive."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
@@ -20427,7 +20967,8 @@ msgstr "Preizkusite nedavno dodana odprtokodna modela Llama 3.1 in Mixtral"
 #. Message displayed to suggest the user to try the provided prompts or enter their own.
 msgctxt "Prompt suggestion message"
 msgid "Try these prompts to get started or enter your own prompt below"
-msgstr "Če želite začeti, poskusite uporabiti te pozive ali spodaj vnesite svoj poziv"
+msgstr ""
+"Če želite začeti, poskusite uporabiti te pozive ali spodaj vnesite svoj poziv"
 
 # smartling.placeholder_format=C
 #. Description for the empty state displayed when searching recent chats in Duck.ai returns no results, suggesting the user rephrase their search query.
@@ -20453,6 +20994,22 @@ msgstr "Poskusite: %1$s"
 msgctxt "new user poll"
 msgid "Trying DuckDuckGo again"
 msgstr "Znova bom poskusil DuckDuckGo"
+
+# smartling.placeholder_format=C
+#. Message shown in a modal after supported third-party browser users disable AI features in Settings. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -20559,7 +21116,8 @@ msgstr "Za natančnejše rezultate vklopite %1$sNatančno lokacijo%2$s."
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
-msgstr "Vklopite predvajalnik Duck Player za gledanje YouTuba brez ciljanih oglasov"
+msgstr ""
+"Vklopite predvajalnik Duck Player za gledanje YouTuba brez ciljanih oglasov"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service.
@@ -20722,7 +21280,8 @@ msgstr "Povratnih informacij ni mogoče poslati"
 #. Message shown to the user when the voice chat failed to establish a connection, and they should try again later.
 msgctxt "voice chat"
 msgid "Unable to connect to voice chat, please try again later."
-msgstr "Povezave z glasovnim klepetom ni mogoče vzpostaviti. Poskusi znova pozneje."
+msgstr ""
+"Povezave z glasovnim klepetom ni mogoče vzpostaviti. Poskusi znova pozneje."
 
 # smartling.placeholder_format=C
 #. Message shown to the user when there was an issue connecting to their microphone.
@@ -20769,12 +21328,14 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sOpen with%s select %sA specific page or pages%s"
-msgstr "Za nastavitev %1$sOdpri z%2$s izberite %3$sDoločena stran ali strani%4$s"
+msgstr ""
+"Za nastavitev %1$sOdpri z%2$s izberite %3$sDoločena stran ali strani%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
-msgstr "Za nastavitev %1$sZAGON > Domača stran%2$s vnesite: https://duckduckgo.com"
+msgstr ""
+"Za nastavitev %1$sZAGON > Domača stran%2$s vnesite: https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -20921,7 +21482,8 @@ msgstr "Odklenite napredne modele umetne inteligence z naročnino %1$s"
 #. Tooltip text shown when the user hovers over the free badge telling the user that they can unlock advanced AI (Artificial Intelligence) models with a DuckDuckGo subscription.
 msgctxt "Tooltip for the free badge"
 msgid "Unlock advanced AI models with a DuckDuckGo subscription"
-msgstr "Odklenite napredne modele umetne inteligence z naročnino na DuckDuckGo."
+msgstr ""
+"Odklenite napredne modele umetne inteligence z naročnino na DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. A link to a blog post explaining the new AI benefits to a subscription. Please keep translations to 50 characters or less.
@@ -21207,6 +21769,12 @@ msgid "Uruguay"
 msgstr "Urugvaj"
 
 # smartling.placeholder_format=C
+#. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
+msgctxt "Navigation label on the Duck.ai settings page"
+msgid "Usage"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A feedback suggestion
 msgctxt "Feedback prompt"
 msgid "Usage limit"
@@ -21262,7 +21830,8 @@ msgstr "Uporabite DuckDuckGo Private Search"
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Use DuckDuckGo private search on your iPad, iPhone, or Android!"
-msgstr "Uporabite zasebno iskanje DuckDuckGo na svojem iPadu, iPhonu ali Androidu!"
+msgstr ""
+"Uporabite zasebno iskanje DuckDuckGo na svojem iPadu, iPhonu ali Androidu!"
 
 # smartling.placeholder_format=C
 #. User clicks this button to share their device's location
@@ -21656,6 +22225,12 @@ msgid "Wales"
 msgstr "Wales"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Walk me through the steps"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for walking directions on a map.
 msgctxt "directions"
 msgid "Walking"
@@ -21775,6 +22350,17 @@ msgstr ""
 "rezultate."
 
 # smartling.placeholder_format=C
+#. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
+msgctxt ""
+"Inline warning shown below the share-content toggle when the user selects "
+"Harmful or Illegal but has not enabled sharing"
+msgid ""
+"We can only fix what we can see. To report a harmful or illegal response, "
+"please share this conversation with DuckDuckGo so we can investigate and "
+"address the issue."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
 msgctxt ""
 "Inline warning shown below the share-content toggle when the user selects "
@@ -21801,7 +22387,8 @@ msgstr ""
 msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
-msgstr "Priloženih datotek ne moremo prebrati, ker je vsaj ena od njih šifrirana."
+msgstr ""
+"Priloženih datotek ne moremo prebrati, ker je vsaj ena od njih šifrirana."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -21981,7 +22568,8 @@ msgstr ""
 #. Message that appears after submitting a feedback form.
 msgctxt "feedback form"
 msgid "We use feedback like this to improve DuckDuckGo."
-msgstr "Uporabljamo takšne povratne informacije kot so te, za izboljšanje DuckDuckGo."
+msgstr ""
+"Uporabljamo takšne povratne informacije kot so te, za izboljšanje DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Placeholder can be Apple Maps, TripAdvisor, and/or Foursquare
@@ -22034,7 +22622,8 @@ msgctxt "duckai_migration"
 msgid ""
 "We're sorry for this inconvenience. We’re working hard to make your "
 "experience better."
-msgstr "Žal nam je za to nevšečnost. Prizadevamo si, da bi bila vaša izkušnja boljša."
+msgstr ""
+"Žal nam je za to nevšečnost. Prizadevamo si, da bi bila vaša izkušnja boljša."
 
 # smartling.placeholder_format=C
 #. Body text explaining the service update requires a page reload.
@@ -22138,7 +22727,8 @@ msgstr "Dosežena je tedenska omejitev"
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Weekly usage limit reached. You can continue this chat after %s."
-msgstr "Dosežena je tedenska omejitev uporabe. Ta klepet lahko nadaljujete po %1$s."
+msgstr ""
+"Dosežena je tedenska omejitev uporabe. Ta klepet lahko nadaljujete po %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable weekly Duck.ai usage limit and can opt in to continue using the monthly limit.
@@ -22283,7 +22873,8 @@ msgstr ""
 #. Text for a prompt suggestion for considering factors when purchasing a computer monitor.
 msgctxt "Full sentence for preparing for a purchase"
 msgid "What are some factors to consider when purchasing a computer monitor?"
-msgstr "Katere dejavnike je treba upoštevati pri nakupu računalniškega zaslona?"
+msgstr ""
+"Katere dejavnike je treba upoštevati pri nakupu računalniškega zaslona?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for asking about must-see attractions in Paris for a first-time visitor.
@@ -22323,6 +22914,103 @@ msgstr ""
 "na jasne razdelke z naslovi, s poudarkom na integracijah Duck.ai in zaščiti "
 "zasebnosti. Naj bo dokaj kratko, preprosto in lahko razumljivo za vse "
 "uporabnike ne glede na izkušenost na področju umetne inteligence ali tehnike."
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the counterarguments?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the hours & location?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key contributions of this paper?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key contributions?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key details?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key points covered in this video?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key points?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key takeaways from this article?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key takeaways?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key things I will learn from this course?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main counterarguments or criticisms of this?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main questions this page answers?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the must-try dishes here?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"What are the opening hours, location, and contact details for this place?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the pros and cons of this product?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the pros and cons?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
@@ -22425,6 +23113,12 @@ msgid "What does atria mean in the context of a medical article?"
 msgstr "Kaj pomeni atrija v kontekstu medicinskega članka?"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What does this answer?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
@@ -22435,6 +23129,12 @@ msgstr "Katero funkcijo bi želeli, da dodamo? (neobvezno)"
 msgctxt "cloudsave"
 msgid "What information gets saved?"
 msgstr "Katere informacije se shranijo?"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What interview questions might come up for this role?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -22451,6 +23151,12 @@ msgstr ""
 msgctxt "Full sentence for looking up basic facts"
 msgid "What is the capital city of Albania?"
 msgstr "Katero je glavno mesto Albanije?"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What is the overall verdict and rating for this?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to a page with additional information.
@@ -22475,6 +23181,12 @@ msgid "What people say:"
 msgstr "Kaj pravijo ljudje:"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What should I order?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
 msgctxt "feedback form"
 msgid "What stood out?"
@@ -22485,6 +23197,18 @@ msgstr "Kaj je izstopalo?"
 msgctxt "feedback form"
 msgid "What was wrong with the response? (optional)"
 msgstr "Kaj je bilo narobe z odzivom? (izbirno)"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I learn?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I need?"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -22504,6 +23228,12 @@ msgstr ""
 msgctxt "SERP footer content"
 msgid "What's New"
 msgstr "Kaj je novega"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What's the verdict?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -22541,7 +23271,8 @@ msgstr "Kje gledati: <strong>%1$s</strong>"
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Where it says Homepage click %sSet to Current Page%s."
-msgstr "Pri nastavitvi Domača Stran kliknite %1$sNastavi na trenutno stran%2$s."
+msgstr ""
+"Pri nastavitvi Domača Stran kliknite %1$sNastavi na trenutno stran%2$s."
 
 # smartling.placeholder_format=C
 #. Heading of a module showing what streaming services are showing a movie or series, e.g. Where to Watch The Matrix
@@ -22554,6 +23285,12 @@ msgstr "Kje gledati: <strong>%1$s</strong>"
 msgctxt "Feedback prompt"
 msgid "Which features are missing? (Optional)"
 msgstr "Katere funkcije manjkajo? (izbirno)"
+
+# smartling.placeholder_format=C
+#. An invitation for users to leave feedback
+msgctxt "Feedback prompt"
+msgid "Which features are missing? (optional)"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
@@ -22570,6 +23307,18 @@ msgstr "Bela"
 #. Link to an about us page.
 msgid "Who We Are"
 msgstr "Kdo smo"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Who are the main cast and crew, and what else are they known for?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Who is this person?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Header above a collection of privacy-related links.
@@ -23231,7 +23980,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
 msgid "You won't see this message again unless you clear your browser data."
-msgstr "Tega sporočila ne boste več videli, razen če počistite podatke brskalnika."
+msgstr ""
+"Tega sporočila ne boste več videli, razen če počistite podatke brskalnika."
 
 # smartling.placeholder_format=C
 #. The second paragraph of a pop up where we explain how to update the browser manually.
@@ -23323,7 +24073,8 @@ msgstr "Dosegli ste najdaljše trajanje glasovnega klepeta za eno sejo."
 msgctxt "voice chat limit modal"
 msgid ""
 "You've reached the voice chat limit for today. Please try again tomorrow."
-msgstr "Dosegli ste omejitev glasovnega klepeta za danes. Poskusite znova jutri."
+msgstr ""
+"Dosegli ste omejitev glasovnega klepeta za danes. Poskusite znova jutri."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
@@ -23753,13 +24504,15 @@ msgctxt "Error message for user limit"
 msgid ""
 "You’ve reached the maximum number of messages for one day. Please continue "
 "this chat tomorrow."
-msgstr "Dosegli ste največje število sporočil za en dan. Nadaljujte ta klepet jutri."
+msgstr ""
+"Dosegli ste največje število sporočil za en dan. Nadaljujte ta klepet jutri."
 
 # smartling.placeholder_format=C
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
 msgctxt "voice chat limit modal"
 msgid "You’ve reached the voice chat limit for now. Please try again later."
-msgstr "Dosegli ste trenutno omejitev glasovnega klepeta. Poskusite znova pozneje."
+msgstr ""
+"Dosegli ste trenutno omejitev glasovnega klepeta. Poskusite znova pozneje."
 
 # smartling.placeholder_format=C
 #. The name of the Yucatec Maya language
@@ -23842,7 +24595,8 @@ msgstr "od %1$s"
 #. Trust line shown at the bottom of the explainer panel, summarizing DuckDuckGo's reputation for online protection.
 msgctxt "Footer banner text in the How Duck.ai Works panel"
 msgid "by DuckDuckGo — online protection trusted by millions every day."
-msgstr "omogoča DuckDuckGo – spletna zaščita, ki ji vsak dan zaupajo milijoni ljudi."
+msgstr ""
+"omogoča DuckDuckGo – spletna zaščita, ki ji vsak dan zaupajo milijoni ljudi."
 
 # smartling.placeholder_format=C
 #. An abreviated unit of time indicating an age, e.g. "2d"
@@ -24055,7 +24809,8 @@ msgstr "uradno spletno stran"
 #. <em>%s</em> is for a hexadecimal color code as <em>#395323</em>, but it has to be safe encoded, and as <em>#</em> seems not safe, <em>%23</em> must be used in place of the sharp symbol, but they are the same for your browser.
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
-msgstr "ali pa vpišite kodo želene barve, npr. %1$s (%2$s je kodiran znak %3$s)."
+msgstr ""
+"ali pa vpišite kodo želene barve, npr. %1$s (%2$s je kodiran znak %3$s)."
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "

--- a/locales/sq_AL/LC_MESSAGES/duckduckgo.po
+++ b/locales/sq_AL/LC_MESSAGES/duckduckgo.po
@@ -1165,6 +1165,11 @@ msgctxt "feedback form"
 msgid "Address is incorrect"
 msgstr "Adresa është e pasaktë"
 
+#. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Adjust the servings"
+msgstr ""
+
 #. as in multiple advertisements
 msgid "Ads"
 msgstr "Reklama"
@@ -1338,6 +1343,13 @@ msgstr ""
 #. Heading shown on the empty chat screen. The text between the two %s markers is displayed inside a clickable privacy button. First %s renders a shield icon, second %s is an invisible end marker. Keep the word 'private' between both %s markers.
 msgctxt "Empty state heading in Duck.ai chat mode"
 msgid "All chats are %sprivate%s"
+msgstr ""
+
+#. Paragraph in the Privacy & Terms section of the About & Legal page in Duck.ai settings, summarizing how chats are anonymized and are not stored or used to train chat models.
+msgctxt "Privacy & Terms section description on the Duck.ai settings page"
+msgid ""
+"All chats are anonymized by DuckDuckGo, and your conversations are not used "
+"to train chat models by DuckDuckGo or the model providers"
 msgstr ""
 
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1553,6 +1565,12 @@ msgstr ""
 msgctxt "precise_user_location"
 msgid "Anonymous location enabled"
 msgstr "Vendndodhje anonime e aktivizuar"
+
+msgctxt "settings"
+msgid ""
+"Anonymously generates answers for search queries based on web content. "
+"Choose how often you want it to appear, or disable it completely."
+msgstr ""
 
 #. Instant Answer tab name
 msgid "Answer"
@@ -1777,6 +1795,11 @@ msgstr ""
 
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse
 msgid "Ask a follow-up with Duck.ai"
+msgstr ""
+
+#. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
+msgctxt "Page suggestion chip label"
+msgid "Ask about this page"
 msgstr ""
 
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2105,6 +2128,11 @@ msgstr ""
 msgid "Barcode"
 msgstr "Kod me vija"
 
+#. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Based on this page, is this course worth taking?"
+msgstr ""
+
 msgctxt "settings"
 msgid "Basic"
 msgstr "Elementare"
@@ -2136,6 +2164,13 @@ msgstr ""
 #. Placeholder text displayed while the assistant waits for the user to choose an action.
 msgctxt "Assistant response placeholder"
 msgid "Before continuing..."
+msgstr ""
+
+#. Explains that before storing the report, DuckDuckGo will anonymize the conversation by removing PII like names, email addresses, and identifying metadata.
+msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
+msgid ""
+"Before storing this report, DuckDuckGo will anonymize your conversation by "
+"removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
 #. Label that's displayed next to a past start date below a web search result.
@@ -2394,6 +2429,11 @@ msgstr "Brazil"
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Break Points Won"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Break this down into clear, numbered steps."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -2767,6 +2807,11 @@ msgstr "Punësime"
 #. Text of a button that performs a search for the cast of a particular movie or tv show
 msgctxt "Movie/TV Show Title instant answer"
 msgid "Cast"
+msgstr ""
+
+#. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Cast & Crew"
 msgstr ""
 
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -4161,6 +4206,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Create a shopping list with quantities from this recipe."
+msgstr ""
+
 #. Placeholder text displayed in the input field when starting a new image generation session.
 msgctxt "Placeholder text for the image generation input field"
 msgid "Create an image of a cute duck..."
@@ -4687,6 +4737,10 @@ msgstr ""
 msgid "Dictation limit reached"
 msgstr ""
 
+#. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
+msgid "Dictation temporarily unavailable"
+msgstr ""
+
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
@@ -4933,6 +4987,20 @@ msgctxt "precise_user_location"
 msgid "Done"
 msgstr "U bë"
 
+#. Message shown in a modal after DuckDuckGo browser users disable AI features in Settings. The first two placeholders bold noai.duckduckgo.com. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
+"filtered out. %sLearn More%s"
+msgstr ""
+
+#. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
+"and AI images filtered out. %sLearn more%s"
+msgstr ""
+
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Double Faults"
@@ -5023,6 +5091,16 @@ msgctxt "Full sentence for writing an email"
 msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
+msgstr ""
+
+#. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Draft a cover letter"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Draft a cover letter for this job."
 msgstr ""
 
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -5163,6 +5241,14 @@ msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
 msgstr ""
 
+#. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
+msgctxt "About section description on the Duck.ai settings page"
+msgid ""
+"Duck.ai is created by DuckDuckGo. We're an independent online protection "
+"company for anyone who wants to take back control of their personal "
+"information."
+msgstr ""
+
 #. Title shown when an update is required before proceeding.
 msgctxt "duckai_migration"
 msgid "Duck.ai is moving domains"
@@ -5196,6 +5282,12 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Duck.ai lets you chat privately with popular AI models. Disabling it hides "
+"Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
 
 msgctxt "settings"
@@ -5987,6 +6079,16 @@ msgstr ""
 msgid "Eritrea"
 msgstr ""
 
+#. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Estimate the nutrition"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Estimate the nutritional information for this recipe."
+msgstr ""
+
 msgid "Estonia"
 msgstr "Estoni"
 
@@ -6031,10 +6133,50 @@ msgctxt "merchant promotion product ad extension"
 msgid "Expires in 1 day"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain the accepted answer in simple terms."
+msgstr ""
+
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
+msgstr ""
+
+#. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain the top answer"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this in simple, plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this paper"
+msgstr ""
+
+#. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this repo"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this research paper in plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this simply"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain what this repository does and how to use it."
 msgstr ""
 
 #. Label to show if song lyrics contain explicit content
@@ -6269,6 +6411,11 @@ msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
 msgstr ""
 
+msgctxt "settings"
+msgid ""
+"Filters out known AI spam sites from image search results. %sLearn More%s"
+msgstr ""
+
 #. Label for the final score of a sporting event.
 msgid "Final"
 msgstr "Përfundimtare"
@@ -6312,6 +6459,11 @@ msgstr ""
 #. Short description shown below the 'Web Search' label in the Tools dropdown.
 msgctxt "Subtitle for the Web Search tool entry in the Tools dropdown menu"
 msgid "Find current information"
+msgstr ""
+
+#. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Find me alternatives"
 msgstr ""
 
 #. Button that searches for results closer to the user's current location.
@@ -6703,6 +6855,11 @@ msgstr ""
 msgid "Generate More"
 msgstr ""
 
+#. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Generate a shopping list"
+msgstr ""
+
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
 msgid "Generate a short answer from the web"
 msgstr ""
@@ -6939,6 +7096,11 @@ msgstr ""
 #. Text for a button inviting users to give it a try for the Duck.ai product. On click, they're taken to the Duck.ai page.
 msgctxt "Onboarding welcome screen button text"
 msgid "Give it a Try"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Give me a quick background on this person."
 msgstr ""
 
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -7304,6 +7466,16 @@ msgstr "Ndihmoni të Përhapet DuckDuckGo!"
 #. Link to a page with information about sharing DuckDuckGo with friends.
 msgid "Help Spread Privacy"
 msgstr "Ndihmoni të Përhapet Privatësia"
+
+#. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Help me prep for the interview"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Help me tailor my resume for this job."
+msgstr ""
 
 #. Title of a SERP popup that invites users to take a survey (desktop only)
 msgctxt "User survey popup"
@@ -7728,6 +7900,13 @@ msgstr "Uragan"
 #. Text displayed on the button on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
 msgctxt "Onboarding terms screen button text"
 msgid "I Agree"
+msgstr ""
+
+#. Text for the button that takes the user to the external DuckDuckGo login subscription page.
+msgctxt ""
+"Text for the I already have a subscription button in the Duck.ai settings "
+"page"
+msgid "I Already Have a Subscription"
 msgstr ""
 
 #. Text for the button that takes the user to the login subscription page.
@@ -8206,6 +8385,11 @@ msgctxt "Sidemenu browser promo"
 msgid "Install Mac Browser"
 msgstr "Instaloni Shfletuesin për Mac"
 
+#. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
+msgctxt "settings"
+msgid "Install Now"
+msgstr ""
+
 #. Text of a button to install the DuckDuckGo app
 msgctxt "Serp footer content"
 msgid "Install Our App"
@@ -8285,10 +8469,37 @@ msgctxt "cloudsave"
 msgid "Is deleted data really deleted?"
 msgstr "A fshihen vërtet të dhënat e fshira?"
 
+#. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is it worth taking?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this place any good?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"Is this place any good? Summarize its reputation based on reviews and "
+"ratings."
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "Is this video helpful?"
 msgstr "A është e dobishme kjo video?"
+
+#. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this worth watching?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Is this worth watching? Give me a spoiler-free take."
+msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
 msgctxt "Weather IA"
@@ -8792,6 +9003,11 @@ msgstr "Shkronja lidhjesh:"
 msgid "Links:"
 msgstr "Lidhje:"
 
+#. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "List the tools, materials, or prerequisites I need for this."
+msgstr ""
+
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
 msgid "Listen"
 msgstr "Dëgjojeni"
@@ -9127,6 +9343,11 @@ msgstr ""
 #. Label for linke navigating to site exclusion feature on Settings page
 msgctxt "Exclusion message manage sites button"
 msgid "Manage blocked sites"
+msgstr ""
+
+#. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
+msgctxt "setting"
+msgid "Manage in Browser Settings"
 msgstr ""
 
 #. Link to the site exclusion settings page
@@ -11446,6 +11667,11 @@ msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
+msgid "Please describe why the chat response is harmful or illegal. (optional)"
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
+msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
 msgstr ""
 
@@ -11464,6 +11690,13 @@ msgctxt "Modal disclaimer text"
 msgid ""
 "Please note: starting a new chat with any model will delete your current "
 "chat session."
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
+msgctxt "Feedback prompt"
+msgid ""
+"Please paste your prompt and the problematic output (with any personal "
+"information removed) and describe why the content is harmful or illegal."
 msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -11850,6 +12083,11 @@ msgctxt "settings"
 msgid "Privacy"
 msgstr "Privatësi"
 
+#. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
+msgctxt "Section heading on the Duck.ai settings page"
+msgid "Privacy & Terms"
+msgstr ""
+
 msgid "Privacy Blog"
 msgstr "Blog Privatësie"
 
@@ -11903,6 +12141,11 @@ msgstr ""
 
 #. Text used in other strings to link to the Privacy Policy and Terms of Service content.
 msgctxt "Copy used to compose link in sentences"
+msgid "Privacy Policy and Terms of Service"
+msgstr ""
+
+#. Text for a button that links to the terms of use and privacy policy page.
+msgctxt "Secondary button text in active privacy modal"
 msgid "Privacy Policy and Terms of Service"
 msgstr ""
 
@@ -12313,6 +12556,26 @@ msgctxt "Brief for recommending a book"
 msgid "Recommend a book"
 msgstr ""
 
+#. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar books"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar books."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar movies or shows."
+msgstr ""
+
+#. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar titles"
+msgstr ""
+
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
 msgid "Recording failed. Please try again."
 msgstr ""
@@ -12639,6 +12902,14 @@ msgstr ""
 msgid "Republic of Moldova"
 msgstr ""
 
+#. Note indicating that sharing the conversation is mandatory when reporting harmful or illegal content. Rendered alongside the standard share label (DUCKCHAT_RESPONSE_FEEDBACK_SHARE_PROMPT_RESPONSE_LABEL), not replacing it.
+msgctxt ""
+"Note shown under the share-content switch label on the Duck.ai response "
+"feedback form when the user has selected Harmful or Illegal as the feedback "
+"reason"
+msgid "Required for harmful or illegal reports"
+msgstr ""
+
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
 msgctxt "Description for extended reasoning mode in Duck.ai"
 msgid "Researches before responding"
@@ -12825,6 +13096,11 @@ msgstr "Shqyrtime"
 msgctxt "maps_places"
 msgid "Reviews"
 msgstr "Shqyrtime"
+
+#. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Rewrite this recipe scaled for a different number of servings."
+msgstr ""
 
 msgid "Romania"
 msgstr "Rumani"
@@ -13901,6 +14177,11 @@ msgctxt "Setup button for native sync flow"
 msgid "Set Up Now"
 msgstr ""
 
+#. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
+msgctxt "Encrypted storage setup button shown in native browsers"
+msgid "Set Up Sync & Backup"
+msgstr ""
+
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
 msgctxt "Title for the Sync & Backup intro screen"
 msgid "Set Up Sync & Backup"
@@ -14046,6 +14327,12 @@ msgstr ""
 msgctxt "feedback form"
 msgid "Share positive feedback"
 msgstr "Jepni përshtypje pozitive"
+
+#. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
+msgctxt ""
+"Label beside the share-content switch on the Duck.ai response feedback form"
+msgid "Share this conversation with DuckDuckGo"
+msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
 msgctxt ""
@@ -15069,6 +15356,21 @@ msgctxt "Brief for suggesting a blog post title"
 msgid "Suggest a title for a blog post"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest related articles or topics worth exploring next."
+msgstr ""
+
+#. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Suggest related articles to explore"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest some alternatives to this product."
+msgstr ""
+
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
 msgctxt "directions"
 msgid "Suggestions:"
@@ -15078,9 +15380,84 @@ msgctxt "noresults"
 msgid "Suggestions:"
 msgstr "Sugjerime:"
 
+#. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Sum up the reviews"
+msgstr ""
+
 #. A short title for the a message asking the AI to summarize a text.
 msgctxt "Title for the summarize message"
 msgid "Summarize"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize the Q&As"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the background and notable work of this person."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the key details of this event."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the questions and answers on this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize their background"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this book"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this book."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this discussion"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this discussion thread."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this video"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this video."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize what the reviews say."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -15335,6 +15712,11 @@ msgstr ""
 msgid "Syria"
 msgstr ""
 
+#. Text for a button that enables the theme to follow the operating system's color scheme preference.
+msgctxt "System theme button for theme selector"
+msgid "System"
+msgstr ""
+
 #. Abbreviation indicating this is the total score for a game
 msgctxt "Sports module"
 msgid "T"
@@ -15358,6 +15740,11 @@ msgctxt "language_name"
 msgid "Tahitian"
 msgstr "Tahitisht"
 
+#. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Tailor my resume"
+msgstr ""
+
 msgid "Taiwan"
 msgstr "Tajvan"
 
@@ -15380,6 +15767,12 @@ msgstr "Rimerrni kontrollin e të dhënave tuaja personale"
 msgctxt "homepage ATB modal"
 msgid "Take control of your personal data!"
 msgstr "Rimerrni kontrollin e të dhënave tuaja personale!"
+
+#. Description for the Feedback section of the Duck.ai settings page, asking the user to take an anonymous survey to let us know how we can make Duck.ai better.
+msgctxt "Feedback section description on the Duck.ai settings page"
+msgid ""
+"Take this anonymous survey to let us know how we can make Duck.ai better."
+msgstr ""
 
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
 msgctxt "Description for reasoning mode in Duck.ai"
@@ -15628,6 +16021,11 @@ msgstr ""
 #. https://duck.co/media/files/theme.png
 msgid "Theme"
 msgstr "Temë"
+
+#. Text for the theme selector label that allows users to switch between Light and dark theme.
+msgctxt "Label for the theme selector feature"
+msgid "Theme"
+msgstr ""
 
 #. http://i.imgur.com/LpFhb1e.png
 msgctxt "settings"
@@ -16293,6 +16691,16 @@ msgid ""
 "movie theatre?”"
 msgstr ""
 
+#. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Translate this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
+msgctxt "Page suggestion prompt"
+msgid "Translate this page into %s."
+msgstr ""
+
 #. Placeholder text for a region that will display translated text.
 msgctxt "translations_module"
 msgid "Translation"
@@ -16407,6 +16815,11 @@ msgstr ""
 #. Call-to-action button for the subscription promo in the SERP sidemenu.
 msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
+msgstr ""
+
+#. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
+msgctxt "settings"
+msgid "Try It Now"
 msgstr ""
 
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -16602,6 +17015,20 @@ msgstr "Provoni: %s"
 msgctxt "new user poll"
 msgid "Trying DuckDuckGo again"
 msgstr "Riprovim i DuckDuckGo-së"
+
+#. Message shown in a modal after supported third-party browser users disable AI features in Settings. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+#. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
 
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
 msgctxt "Assistant response placeholder"
@@ -17218,6 +17645,11 @@ msgstr "Urdisht"
 msgid "Uruguay"
 msgstr "Uruguai"
 
+#. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
+msgctxt "Navigation label on the Duck.ai settings page"
+msgid "Usage"
+msgstr ""
+
 #. A feedback suggestion
 msgctxt "Feedback prompt"
 msgid "Usage limit"
@@ -17570,6 +18002,11 @@ msgstr "Po pritet për Vendndodhje…"
 msgid "Wales"
 msgstr "Uells"
 
+#. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Walk me through the steps"
+msgstr ""
+
 #. Label for walking directions on a map.
 msgctxt "directions"
 msgid "Walking"
@@ -17667,6 +18104,16 @@ msgstr ""
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
+msgstr ""
+
+#. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
+msgctxt ""
+"Inline warning shown below the share-content toggle when the user selects "
+"Harmful or Illegal but has not enabled sharing"
+msgid ""
+"We can only fix what we can see. To report a harmful or illegal response, "
+"please share this conversation with DuckDuckGo so we can investigate and "
+"address the issue."
 msgstr ""
 
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -18105,6 +18552,87 @@ msgid ""
 "experience."
 msgstr ""
 
+#. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the counterarguments?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the hours & location?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key contributions of this paper?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key contributions?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key details?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key points covered in this video?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key points?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key takeaways from this article?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key takeaways?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key things I will learn from this course?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main counterarguments or criticisms of this?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main questions this page answers?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the must-try dishes here?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"What are the opening hours, location, and contact details for this place?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the pros and cons of this product?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the pros and cons?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
 msgctxt "feedback form"
 msgid "What bothered you most?"
@@ -18188,6 +18716,11 @@ msgctxt "Full sentence for defining a term"
 msgid "What does atria mean in the context of a medical article?"
 msgstr ""
 
+#. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What does this answer?"
+msgstr ""
+
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
@@ -18197,6 +18730,11 @@ msgstr ""
 msgctxt "cloudsave"
 msgid "What information gets saved?"
 msgstr "Ç’informacion ruhet?"
+
+#. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What interview questions might come up for this role?"
+msgstr ""
 
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
@@ -18210,6 +18748,11 @@ msgstr ""
 #. Text for a prompt suggestion for looking up the capital city of Albania.
 msgctxt "Full sentence for looking up basic facts"
 msgid "What is the capital city of Albania?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What is the overall verdict and rating for this?"
 msgstr ""
 
 #. Link to a page with additional information.
@@ -18230,6 +18773,11 @@ msgctxt "maps_places"
 msgid "What people say:"
 msgstr "Ç’thonë njerëzit:"
 
+#. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What should I order?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
 msgctxt "feedback form"
 msgid "What stood out?"
@@ -18238,6 +18786,16 @@ msgstr ""
 #. Question on a feedback form for a negative feedback response.
 msgctxt "feedback form"
 msgid "What was wrong with the response? (optional)"
+msgstr ""
+
+#. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I learn?"
+msgstr ""
+
+#. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I need?"
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -18252,6 +18810,11 @@ msgstr ""
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
 msgctxt "SERP footer content"
 msgid "What's New"
+msgstr ""
+
+#. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What's the verdict?"
 msgstr ""
 
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -18294,6 +18857,11 @@ msgctxt "Feedback prompt"
 msgid "Which features are missing? (Optional)"
 msgstr ""
 
+#. An invitation for users to leave feedback
+msgctxt "Feedback prompt"
+msgid "Which features are missing? (optional)"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
 msgid "White"
 msgstr "E bardhë"
@@ -18306,6 +18874,16 @@ msgstr "E bardhë"
 #. Link to an about us page.
 msgid "Who We Are"
 msgstr "Cilët Jemi"
+
+#. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Who are the main cast and crew, and what else are they known for?"
+msgstr ""
+
+#. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Who is this person?"
+msgstr ""
 
 #. Header above a collection of privacy-related links.
 msgid "Why Privacy"

--- a/locales/sr_RS/LC_MESSAGES/duckduckgo.po
+++ b/locales/sr_RS/LC_MESSAGES/duckduckgo.po
@@ -1165,6 +1165,11 @@ msgctxt "feedback form"
 msgid "Address is incorrect"
 msgstr ""
 
+#. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Adjust the servings"
+msgstr ""
+
 #. as in multiple advertisements
 msgid "Ads"
 msgstr "Рекламе"
@@ -1338,6 +1343,13 @@ msgstr ""
 #. Heading shown on the empty chat screen. The text between the two %s markers is displayed inside a clickable privacy button. First %s renders a shield icon, second %s is an invisible end marker. Keep the word 'private' between both %s markers.
 msgctxt "Empty state heading in Duck.ai chat mode"
 msgid "All chats are %sprivate%s"
+msgstr ""
+
+#. Paragraph in the Privacy & Terms section of the About & Legal page in Duck.ai settings, summarizing how chats are anonymized and are not stored or used to train chat models.
+msgctxt "Privacy & Terms section description on the Duck.ai settings page"
+msgid ""
+"All chats are anonymized by DuckDuckGo, and your conversations are not used "
+"to train chat models by DuckDuckGo or the model providers"
 msgstr ""
 
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1555,6 +1567,12 @@ msgstr ""
 msgctxt "precise_user_location"
 msgid "Anonymous location enabled"
 msgstr "Анонимна локација је омогућена "
+
+msgctxt "settings"
+msgid ""
+"Anonymously generates answers for search queries based on web content. "
+"Choose how often you want it to appear, or disable it completely."
+msgstr ""
 
 #. Instant Answer tab name
 msgid "Answer"
@@ -1778,6 +1796,11 @@ msgstr ""
 
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse
 msgid "Ask a follow-up with Duck.ai"
+msgstr ""
+
+#. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
+msgctxt "Page suggestion chip label"
+msgid "Ask about this page"
 msgstr ""
 
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2102,6 +2125,11 @@ msgstr ""
 msgid "Barcode"
 msgstr "Баркод"
 
+#. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Based on this page, is this course worth taking?"
+msgstr ""
+
 msgctxt "settings"
 msgid "Basic"
 msgstr "Основна подешавања"
@@ -2133,6 +2161,13 @@ msgstr ""
 #. Placeholder text displayed while the assistant waits for the user to choose an action.
 msgctxt "Assistant response placeholder"
 msgid "Before continuing..."
+msgstr ""
+
+#. Explains that before storing the report, DuckDuckGo will anonymize the conversation by removing PII like names, email addresses, and identifying metadata.
+msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
+msgid ""
+"Before storing this report, DuckDuckGo will anonymize your conversation by "
+"removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
 #. Label that's displayed next to a past start date below a web search result.
@@ -2391,6 +2426,11 @@ msgstr "Бразил"
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Break Points Won"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Break this down into clear, numbered steps."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -2762,6 +2802,11 @@ msgstr "Каријера"
 #. Text of a button that performs a search for the cast of a particular movie or tv show
 msgctxt "Movie/TV Show Title instant answer"
 msgid "Cast"
+msgstr ""
+
+#. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Cast & Crew"
 msgstr ""
 
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -4126,6 +4171,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Create a shopping list with quantities from this recipe."
+msgstr ""
+
 #. Placeholder text displayed in the input field when starting a new image generation session.
 msgctxt "Placeholder text for the image generation input field"
 msgid "Create an image of a cute duck..."
@@ -4652,6 +4702,10 @@ msgstr ""
 msgid "Dictation limit reached"
 msgstr ""
 
+#. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
+msgid "Dictation temporarily unavailable"
+msgstr ""
+
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
@@ -4896,6 +4950,20 @@ msgctxt "precise_user_location"
 msgid "Done"
 msgstr "Готово"
 
+#. Message shown in a modal after DuckDuckGo browser users disable AI features in Settings. The first two placeholders bold noai.duckduckgo.com. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
+"filtered out. %sLearn More%s"
+msgstr ""
+
+#. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
+"and AI images filtered out. %sLearn more%s"
+msgstr ""
+
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Double Faults"
@@ -4986,6 +5054,16 @@ msgctxt "Full sentence for writing an email"
 msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
+msgstr ""
+
+#. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Draft a cover letter"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Draft a cover letter for this job."
 msgstr ""
 
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -5125,6 +5203,14 @@ msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
 msgstr ""
 
+#. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
+msgctxt "About section description on the Duck.ai settings page"
+msgid ""
+"Duck.ai is created by DuckDuckGo. We're an independent online protection "
+"company for anyone who wants to take back control of their personal "
+"information."
+msgstr ""
+
 #. Title shown when an update is required before proceeding.
 msgctxt "duckai_migration"
 msgid "Duck.ai is moving domains"
@@ -5158,6 +5244,12 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Duck.ai lets you chat privately with popular AI models. Disabling it hides "
+"Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
 
 msgctxt "settings"
@@ -5940,6 +6032,16 @@ msgstr ""
 msgid "Eritrea"
 msgstr ""
 
+#. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Estimate the nutrition"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Estimate the nutritional information for this recipe."
+msgstr ""
+
 msgid "Estonia"
 msgstr "Естонија"
 
@@ -5984,10 +6086,50 @@ msgctxt "merchant promotion product ad extension"
 msgid "Expires in 1 day"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain the accepted answer in simple terms."
+msgstr ""
+
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
+msgstr ""
+
+#. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain the top answer"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this in simple, plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this paper"
+msgstr ""
+
+#. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this repo"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this research paper in plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this simply"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain what this repository does and how to use it."
 msgstr ""
 
 #. Label to show if song lyrics contain explicit content
@@ -6217,6 +6359,11 @@ msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
 msgstr ""
 
+msgctxt "settings"
+msgid ""
+"Filters out known AI spam sites from image search results. %sLearn More%s"
+msgstr ""
+
 #. Label for the final score of a sporting event.
 msgid "Final"
 msgstr "Коначно"
@@ -6259,6 +6406,11 @@ msgstr ""
 #. Short description shown below the 'Web Search' label in the Tools dropdown.
 msgctxt "Subtitle for the Web Search tool entry in the Tools dropdown menu"
 msgid "Find current information"
+msgstr ""
+
+#. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Find me alternatives"
 msgstr ""
 
 #. Button that searches for results closer to the user's current location.
@@ -6649,6 +6801,11 @@ msgstr ""
 msgid "Generate More"
 msgstr ""
 
+#. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Generate a shopping list"
+msgstr ""
+
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
 msgid "Generate a short answer from the web"
 msgstr ""
@@ -6886,6 +7043,11 @@ msgstr ""
 #. Text for a button inviting users to give it a try for the Duck.ai product. On click, they're taken to the Duck.ai page.
 msgctxt "Onboarding welcome screen button text"
 msgid "Give it a Try"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Give me a quick background on this person."
 msgstr ""
 
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -7249,6 +7411,16 @@ msgstr ""
 #. Link to a page with information about sharing DuckDuckGo with friends.
 msgid "Help Spread Privacy"
 msgstr "Помозите да се Приватност прошири"
+
+#. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Help me prep for the interview"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Help me tailor my resume for this job."
+msgstr ""
 
 #. Title of a SERP popup that invites users to take a survey (desktop only)
 msgctxt "User survey popup"
@@ -7673,6 +7845,13 @@ msgstr ""
 #. Text displayed on the button on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
 msgctxt "Onboarding terms screen button text"
 msgid "I Agree"
+msgstr ""
+
+#. Text for the button that takes the user to the external DuckDuckGo login subscription page.
+msgctxt ""
+"Text for the I already have a subscription button in the Duck.ai settings "
+"page"
+msgid "I Already Have a Subscription"
 msgstr ""
 
 #. Text for the button that takes the user to the login subscription page.
@@ -8143,6 +8322,11 @@ msgctxt "Sidemenu browser promo"
 msgid "Install Mac Browser"
 msgstr ""
 
+#. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
+msgctxt "settings"
+msgid "Install Now"
+msgstr ""
+
 #. Text of a button to install the DuckDuckGo app
 msgctxt "Serp footer content"
 msgid "Install Our App"
@@ -8222,10 +8406,37 @@ msgctxt "cloudsave"
 msgid "Is deleted data really deleted?"
 msgstr "Да ли су обрисани подаци заиста обрисани?"
 
+#. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is it worth taking?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this place any good?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"Is this place any good? Summarize its reputation based on reviews and "
+"ratings."
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "Is this video helpful?"
 msgstr "Да ли је овај снимак од помоћи?"
+
+#. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this worth watching?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Is this worth watching? Give me a spoiler-free take."
+msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
 msgctxt "Weather IA"
@@ -8724,6 +8935,11 @@ msgstr "Фонт везе"
 msgid "Links:"
 msgstr "Везе:"
 
+#. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "List the tools, materials, or prerequisites I need for this."
+msgstr ""
+
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
 msgid "Listen"
 msgstr "Преслушај"
@@ -9059,6 +9275,11 @@ msgstr ""
 #. Label for linke navigating to site exclusion feature on Settings page
 msgctxt "Exclusion message manage sites button"
 msgid "Manage blocked sites"
+msgstr ""
+
+#. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
+msgctxt "setting"
+msgid "Manage in Browser Settings"
 msgstr ""
 
 #. Link to the site exclusion settings page
@@ -11372,6 +11593,11 @@ msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
+msgid "Please describe why the chat response is harmful or illegal. (optional)"
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
+msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
 msgstr ""
 
@@ -11390,6 +11616,13 @@ msgctxt "Modal disclaimer text"
 msgid ""
 "Please note: starting a new chat with any model will delete your current "
 "chat session."
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
+msgctxt "Feedback prompt"
+msgid ""
+"Please paste your prompt and the problematic output (with any personal "
+"information removed) and describe why the content is harmful or illegal."
 msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -11774,6 +12007,11 @@ msgctxt "settings"
 msgid "Privacy"
 msgstr "Приватност"
 
+#. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
+msgctxt "Section heading on the Duck.ai settings page"
+msgid "Privacy & Terms"
+msgstr ""
+
 msgid "Privacy Blog"
 msgstr "Блог о приватности"
 
@@ -11827,6 +12065,11 @@ msgstr ""
 
 #. Text used in other strings to link to the Privacy Policy and Terms of Service content.
 msgctxt "Copy used to compose link in sentences"
+msgid "Privacy Policy and Terms of Service"
+msgstr ""
+
+#. Text for a button that links to the terms of use and privacy policy page.
+msgctxt "Secondary button text in active privacy modal"
 msgid "Privacy Policy and Terms of Service"
 msgstr ""
 
@@ -12235,6 +12478,26 @@ msgctxt "Brief for recommending a book"
 msgid "Recommend a book"
 msgstr ""
 
+#. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar books"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar books."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar movies or shows."
+msgstr ""
+
+#. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar titles"
+msgstr ""
+
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
 msgid "Recording failed. Please try again."
 msgstr ""
@@ -12554,6 +12817,14 @@ msgstr ""
 msgid "Republic of Moldova"
 msgstr ""
 
+#. Note indicating that sharing the conversation is mandatory when reporting harmful or illegal content. Rendered alongside the standard share label (DUCKCHAT_RESPONSE_FEEDBACK_SHARE_PROMPT_RESPONSE_LABEL), not replacing it.
+msgctxt ""
+"Note shown under the share-content switch label on the Duck.ai response "
+"feedback form when the user has selected Harmful or Illegal as the feedback "
+"reason"
+msgid "Required for harmful or illegal reports"
+msgstr ""
+
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
 msgctxt "Description for extended reasoning mode in Duck.ai"
 msgid "Researches before responding"
@@ -12740,6 +13011,11 @@ msgstr "Критике"
 msgctxt "maps_places"
 msgid "Reviews"
 msgstr "Коментари"
+
+#. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Rewrite this recipe scaled for a different number of servings."
+msgstr ""
 
 msgid "Romania"
 msgstr "Румунија"
@@ -13790,6 +14066,11 @@ msgctxt "Setup button for native sync flow"
 msgid "Set Up Now"
 msgstr ""
 
+#. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
+msgctxt "Encrypted storage setup button shown in native browsers"
+msgid "Set Up Sync & Backup"
+msgstr ""
+
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
 msgctxt "Title for the Sync & Backup intro screen"
 msgid "Set Up Sync & Backup"
@@ -13933,6 +14214,12 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
+msgctxt ""
+"Label beside the share-content switch on the Duck.ai response feedback form"
+msgid "Share this conversation with DuckDuckGo"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -14952,6 +15239,21 @@ msgctxt "Brief for suggesting a blog post title"
 msgid "Suggest a title for a blog post"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest related articles or topics worth exploring next."
+msgstr ""
+
+#. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Suggest related articles to explore"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest some alternatives to this product."
+msgstr ""
+
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
 msgctxt "directions"
 msgid "Suggestions:"
@@ -14961,9 +15263,84 @@ msgctxt "noresults"
 msgid "Suggestions:"
 msgstr "Предлози:"
 
+#. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Sum up the reviews"
+msgstr ""
+
 #. A short title for the a message asking the AI to summarize a text.
 msgctxt "Title for the summarize message"
 msgid "Summarize"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize the Q&As"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the background and notable work of this person."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the key details of this event."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the questions and answers on this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize their background"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this book"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this book."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this discussion"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this discussion thread."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this video"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this video."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize what the reviews say."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -15218,6 +15595,11 @@ msgstr ""
 msgid "Syria"
 msgstr ""
 
+#. Text for a button that enables the theme to follow the operating system's color scheme preference.
+msgctxt "System theme button for theme selector"
+msgid "System"
+msgstr ""
+
 #. Abbreviation indicating this is the total score for a game
 msgctxt "Sports module"
 msgid "T"
@@ -15241,6 +15623,11 @@ msgctxt "language_name"
 msgid "Tahitian"
 msgstr "Тахићански"
 
+#. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Tailor my resume"
+msgstr ""
+
 msgid "Taiwan"
 msgstr "Тајван"
 
@@ -15262,6 +15649,12 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "Take control of your personal data!"
+msgstr ""
+
+#. Description for the Feedback section of the Duck.ai settings page, asking the user to take an anonymous survey to let us know how we can make Duck.ai better.
+msgctxt "Feedback section description on the Duck.ai settings page"
+msgid ""
+"Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
 
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -15511,6 +15904,11 @@ msgstr ""
 #. https://duck.co/media/files/theme.png
 msgid "Theme"
 msgstr "Тема"
+
+#. Text for the theme selector label that allows users to switch between Light and dark theme.
+msgctxt "Label for the theme selector feature"
+msgid "Theme"
+msgstr ""
 
 #. http://i.imgur.com/LpFhb1e.png
 msgctxt "settings"
@@ -16171,6 +16569,16 @@ msgid ""
 "movie theatre?”"
 msgstr ""
 
+#. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Translate this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
+msgctxt "Page suggestion prompt"
+msgid "Translate this page into %s."
+msgstr ""
+
 #. Placeholder text for a region that will display translated text.
 msgctxt "translations_module"
 msgid "Translation"
@@ -16285,6 +16693,11 @@ msgstr ""
 #. Call-to-action button for the subscription promo in the SERP sidemenu.
 msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
+msgstr ""
+
+#. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
+msgctxt "settings"
+msgid "Try It Now"
 msgstr ""
 
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -16479,6 +16892,20 @@ msgstr "Пробајте: %s"
 msgctxt "new user poll"
 msgid "Trying DuckDuckGo again"
 msgstr "Пробајте DuckDuckGo поново"
+
+#. Message shown in a modal after supported third-party browser users disable AI features in Settings. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+#. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
 
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
 msgctxt "Assistant response placeholder"
@@ -17082,6 +17509,11 @@ msgstr "Урду"
 msgid "Uruguay"
 msgstr ""
 
+#. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
+msgctxt "Navigation label on the Duck.ai settings page"
+msgid "Usage"
+msgstr ""
+
 #. A feedback suggestion
 msgctxt "Feedback prompt"
 msgid "Usage limit"
@@ -17433,6 +17865,11 @@ msgstr "Чека се локација..."
 msgid "Wales"
 msgstr ""
 
+#. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Walk me through the steps"
+msgstr ""
+
 #. Label for walking directions on a map.
 msgctxt "directions"
 msgid "Walking"
@@ -17523,6 +17960,16 @@ msgstr ""
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
+msgstr ""
+
+#. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
+msgctxt ""
+"Inline warning shown below the share-content toggle when the user selects "
+"Harmful or Illegal but has not enabled sharing"
+msgid ""
+"We can only fix what we can see. To report a harmful or illegal response, "
+"please share this conversation with DuckDuckGo so we can investigate and "
+"address the issue."
 msgstr ""
 
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -17954,6 +18401,87 @@ msgid ""
 "experience."
 msgstr ""
 
+#. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the counterarguments?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the hours & location?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key contributions of this paper?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key contributions?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key details?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key points covered in this video?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key points?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key takeaways from this article?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key takeaways?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key things I will learn from this course?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main counterarguments or criticisms of this?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main questions this page answers?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the must-try dishes here?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"What are the opening hours, location, and contact details for this place?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the pros and cons of this product?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the pros and cons?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
 msgctxt "feedback form"
 msgid "What bothered you most?"
@@ -18037,6 +18565,11 @@ msgctxt "Full sentence for defining a term"
 msgid "What does atria mean in the context of a medical article?"
 msgstr ""
 
+#. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What does this answer?"
+msgstr ""
+
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
@@ -18046,6 +18579,11 @@ msgstr ""
 msgctxt "cloudsave"
 msgid "What information gets saved?"
 msgstr "Које информације се чувају?"
+
+#. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What interview questions might come up for this role?"
+msgstr ""
 
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
@@ -18059,6 +18597,11 @@ msgstr ""
 #. Text for a prompt suggestion for looking up the capital city of Albania.
 msgctxt "Full sentence for looking up basic facts"
 msgid "What is the capital city of Albania?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What is the overall verdict and rating for this?"
 msgstr ""
 
 #. Link to a page with additional information.
@@ -18079,6 +18622,11 @@ msgctxt "maps_places"
 msgid "What people say:"
 msgstr "Шта људи кажу:"
 
+#. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What should I order?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
 msgctxt "feedback form"
 msgid "What stood out?"
@@ -18087,6 +18635,16 @@ msgstr ""
 #. Question on a feedback form for a negative feedback response.
 msgctxt "feedback form"
 msgid "What was wrong with the response? (optional)"
+msgstr ""
+
+#. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I learn?"
+msgstr ""
+
+#. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I need?"
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -18101,6 +18659,11 @@ msgstr ""
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
 msgctxt "SERP footer content"
 msgid "What's New"
+msgstr ""
+
+#. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What's the verdict?"
 msgstr ""
 
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -18143,6 +18706,11 @@ msgctxt "Feedback prompt"
 msgid "Which features are missing? (Optional)"
 msgstr ""
 
+#. An invitation for users to leave feedback
+msgctxt "Feedback prompt"
+msgid "Which features are missing? (optional)"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
 msgid "White"
 msgstr "Бела"
@@ -18155,6 +18723,16 @@ msgstr "Бела"
 #. Link to an about us page.
 msgid "Who We Are"
 msgstr "Ко смо ми"
+
+#. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Who are the main cast and crew, and what else are they known for?"
+msgstr ""
+
+#. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Who is this person?"
+msgstr ""
 
 #. Header above a collection of privacy-related links.
 msgid "Why Privacy"

--- a/locales/sv_SE/LC_MESSAGES/duckduckgo.po
+++ b/locales/sv_SE/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: sv_SE\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -22,7 +22,8 @@ msgstr "!Bang-sökgenvägar"
 msgctxt ""
 "Body copy for the Remove Device confirmation modal; %s is the device name"
 msgid "\"%s\" will no longer be able to access your synced data."
-msgstr "”%1$s” kommer inte längre att få tillgång till dina synkroniserade data."
+msgstr ""
+"”%1$s” kommer inte längre att få tillgång till dina synkroniserade data."
 
 # smartling.placeholder_format=C
 #. Used to specify the rank of a team/player in a specific ranking in short form. This should be interpreted as 'Ranked number <rankNumber> in the <rankingName> ranking. Here you only need to translate the # symbol for ranked number. If your language doesn't provide a single-letter convention, please leave #.
@@ -416,7 +417,8 @@ msgstr "%1$s ord"
 #. Instructions on which buttons and options the user has to click in order to add the DuckDuckGo extension to their browser.
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
-msgstr "%1$sKlicka på %2$sLägg till%3$sMarkera %4$sTillåt%5$s och sedan på %6$sOK%7$s"
+msgstr ""
+"%1$sKlicka på %2$sLägg till%3$sMarkera %4$sTillåt%5$s och sedan på %6$sOK%7$s"
 
 # Firefox, obsolete
 # smartling.placeholder_format=C
@@ -1277,7 +1279,8 @@ msgstr "Installera tillägget DuckDuckGo"
 # smartling.placeholder_format=C
 msgid ""
 "Add DuckDuckGo Privacy Essentials to your browser for free with one download:"
-msgstr "Ladda ner DuckDuckGo Privacy Essentials utan kostnad för din webbläsare:"
+msgstr ""
+"Ladda ner DuckDuckGo Privacy Essentials utan kostnad för din webbläsare:"
 
 #  IE default search engine instruction
 # smartling.placeholder_format=C
@@ -1432,6 +1435,12 @@ msgid "Address is incorrect"
 msgstr "Adressen är fel"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Adjust the servings"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. as in multiple advertisements
 msgid "Ads"
 msgstr "Annonser"
@@ -1507,7 +1516,8 @@ msgstr "Afrikaans"
 # smartling.placeholder_format=C
 #. Instructions on how to install the DuckDuckGo browser extension after it downloads.
 msgid "After it downloads and opens, click %sInstall%s"
-msgstr "Efter att ha laddat ner och öppnat den klickar du på %1$sInstallera%2$s"
+msgstr ""
+"Efter att ha laddat ner och öppnat den klickar du på %1$sInstallera%2$s"
 
 # smartling.placeholder_format=C
 #. Instructions on how to install the DuckDuckGo browser extension after it downloads.
@@ -1645,6 +1655,14 @@ msgid "All chats are %sprivate%s"
 msgstr "Alla chattar är %1$sprivata%2$s"
 
 # smartling.placeholder_format=C
+#. Paragraph in the Privacy & Terms section of the About & Legal page in Duck.ai settings, summarizing how chats are anonymized and are not stored or used to train chat models.
+msgctxt "Privacy & Terms section description on the Duck.ai settings page"
+msgid ""
+"All chats are anonymized by DuckDuckGo, and your conversations are not used "
+"to train chat models by DuckDuckGo or the model providers"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
 msgctxt "Privacy modal header in Duck.ai chat"
 msgid "All chats are private"
@@ -1735,7 +1753,8 @@ msgstr "Tillåt annonser som respekterar integritet"
 # smartling.placeholder_format=C
 #. Title in a dialog informing the user how to disable their ad blocker for DuckDuckGo
 msgid "Allow privacy-respecting ads on DuckDuckGo Private Search"
-msgstr "Tillåt annonser som respekterar integritet på DuckDuckGo Private Search"
+msgstr ""
+"Tillåt annonser som respekterar integritet på DuckDuckGo Private Search"
 
 # smartling.placeholder_format=C
 #. Description explaining privacy implications of enabling web search on encrypted models. The first two placeholders are the full model name (e.g. 'gpt-oss 120B'). The third and fourth placeholders wrap a clickable link reading 'zero provider visibility' that opens the privacy modal, please keep those around the link text in your translation. An example full sentence would be: Allows gpt-oss 120B to search the web to improve responses to relevant prompts. Only sends AI-generated queries to a search engine with limited data retention. Prompts and responses with gpt-oss 120B still have zero provider visibility.
@@ -1915,6 +1934,13 @@ msgid "Anonymous location enabled"
 msgstr "Anonym plats aktiverad"
 
 # smartling.placeholder_format=C
+msgctxt "settings"
+msgid ""
+"Anonymously generates answers for search queries based on web content. "
+"Choose how often you want it to appear, or disable it completely."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Instant Answer tab name
 msgid "Answer"
 msgstr "Svar"
@@ -2059,19 +2085,22 @@ msgstr "Är du fortfarande där?"
 msgctxt "Body text for clear all chats confirmation modal"
 msgid ""
 "Are you sure you want to clear all of your chats? This cannot be undone."
-msgstr "Är du säker på att du vill rensa alla dina chattar? Detta kan inte ångras."
+msgstr ""
+"Är du säker på att du vill rensa alla dina chattar? Detta kan inte ångras."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that asks the user if they want to clear the conversation.
 msgctxt "Modal body for clearing conversation"
 msgid "Are you sure you want to clear this conversation and start a new one?"
-msgstr "Är du säker på att du vill rensa den här konversationen och starta en ny?"
+msgstr ""
+"Är du säker på att du vill rensa den här konversationen och starta en ny?"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to delete their current chat, explaining that this action cannot be undone.
 msgctxt "Body text for delete chat confirmation modal"
 msgid "Are you sure you want to delete this chat? This cannot be undone."
-msgstr "Är du säker på att du vill ta bort den här chatten? Detta kan inte ångras."
+msgstr ""
+"Är du säker på att du vill ta bort den här chatten? Detta kan inte ångras."
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to disable chat history, with a warning that it will also delete currently saved chats including pinned chats.
@@ -2193,6 +2222,12 @@ msgid "Ask a follow-up with Duck.ai"
 msgstr "Fråga Duck.ai om en uppföljning"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
+msgctxt "Page suggestion chip label"
+msgid "Ask about this page"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
 msgctxt "Title for the page context onboarding modal"
 msgid "Ask about this page"
@@ -2272,11 +2307,11 @@ msgid ""
 "to remember that responses are auto-generated from cited sources and based "
 "on %scrawling the web%s."
 msgstr ""
-"Assist är en valbar funktion i våra sökresultat som anonymt kan generera "
-"AI-assisterade svar på sökfrågor. För att göra detta skannar den webben "
-"efter relevant innehåll och använder sedan AI-driven naturlig språkteknologi "
-"för att generera ett kort svar baserat på relevant information som hittats. "
-"Det är viktigt att komma ihåg att svaren genereras automatiskt från citerade "
+"Assist är en valbar funktion i våra sökresultat som anonymt kan generera AI-"
+"assisterade svar på sökfrågor. För att göra detta skannar den webben efter "
+"relevant innehåll och använder sedan AI-driven naturlig språkteknologi för "
+"att generera ett kort svar baserat på relevant information som hittats. Det "
+"är viktigt att komma ihåg att svaren genereras automatiskt från citerade "
 "källor och baseras på %1$sgenomsökning av webben%2$s."
 
 # smartling.placeholder_format=C
@@ -2368,7 +2403,8 @@ msgstr "Ljud lagras inte av oss eller av OpenAI efter att chatten avslutats."
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat is transcribed."
-msgstr "Ljud lagras inte av oss eller av OpenAI efter att chatten har transkriberats."
+msgstr ""
+"Ljud lagras inte av oss eller av OpenAI efter att chatten har transkriberats."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when MediaRecorder API is unavailable.
@@ -2409,7 +2445,8 @@ msgstr "Autosvar"
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid "Auto-generated based on listed sources. May contain inaccuracies."
-msgstr "Automatiskt genererad baserat på angivna källor. Kan innehålla felaktigheter."
+msgstr ""
+"Automatiskt genererad baserat på angivna källor. Kan innehålla felaktigheter."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
@@ -2605,6 +2642,12 @@ msgid "Barcode"
 msgstr "Streckkod"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Based on this page, is this course worth taking?"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Basic"
 msgstr "Grundläggande"
@@ -2643,6 +2686,14 @@ msgstr "Slagman"
 msgctxt "Assistant response placeholder"
 msgid "Before continuing..."
 msgstr "Innan du fortsätter..."
+
+# smartling.placeholder_format=C
+#. Explains that before storing the report, DuckDuckGo will anonymize the conversation by removing PII like names, email addresses, and identifying metadata.
+msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
+msgid ""
+"Before storing this report, DuckDuckGo will anonymize your conversation by "
+"removing PII like names, email addresses, and identifying metadata."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -2961,6 +3012,12 @@ msgid "Break Points Won"
 msgstr "Vunna breakpoäng"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Break this down into clear, numbered steps."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
 msgctxt "Weather IA"
 msgid "Breezy"
@@ -3018,8 +3075,8 @@ msgid ""
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
 msgstr ""
 "Surfa som vanligt medan vi ger dig integritetsskydd. Vi har förenat vår "
-"sökmotor, spårningsblockerare och tvingande kryptering i ett "
-"%1$s%2$s-tillägg%3$s."
+"sökmotor, spårningsblockerare och tvingande kryptering i ett %1$s%2$s-"
+"tillägg%3$s."
 
 # smartling.placeholder_format=C
 msgid ""
@@ -3413,6 +3470,12 @@ msgid "Cast"
 msgstr "Skådespelare"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Cast & Crew"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
 msgctxt "Tone option label for Casual"
 msgid "Casual"
@@ -3647,12 +3710,12 @@ msgid ""
 "DuckDuckGo Search. However, you can still access Chat when this setting is "
 "off by visiting %shttps://duck.ai%s directly."
 msgstr ""
-"Med chatten (via vår tjänst Duck.ai) kan du ha anonyma konversationer med "
-"AI-chattmodeller från tredje part med stöd för modeller från OpenAI, "
-"Anthropic och fler. Om du stänger av den här inställningen döljs "
-"chattknappar och länkar på DuckDuckGo Search. Du kan dock fortfarande komma "
-"åt chatten när den här inställningen är avstängd genom att gå till "
-"%1$shttps://duck.ai%2$s direkt."
+"Med chatten (via vår tjänst Duck.ai) kan du ha anonyma konversationer med AI-"
+"chattmodeller från tredje part med stöd för modeller från OpenAI, Anthropic "
+"och fler. Om du stänger av den här inställningen döljs chattknappar och "
+"länkar på DuckDuckGo Search. Du kan dock fortfarande komma åt chatten när "
+"den här inställningen är avstängd genom att gå till %1$shttps://duck.ai%2$s "
+"direkt."
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -3875,7 +3938,8 @@ msgstr "Kontrollera stavningen"
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
 msgctxt "noresults"
 msgid "Check the DuckDuckGo subreddit for updates on this outage."
-msgstr "Kolla DuckDuckGos subreddit för att se uppdateringar om det här avbrottet."
+msgstr ""
+"Kolla DuckDuckGos subreddit för att se uppdateringar om det här avbrottet."
 
 # smartling.placeholder_format=C
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
@@ -4286,7 +4350,8 @@ msgstr "Klicka på %1$sInställningar%2$s i rullgardinsmenyn."
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
-msgstr "Klicka på %1$sAnvänd aktuella sidor%2$s och sedan på %3$sKlicka på OK%4$s."
+msgstr ""
+"Klicka på %1$sAnvänd aktuella sidor%2$s och sedan på %3$sKlicka på OK%4$s."
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -5123,6 +5188,12 @@ msgid "Create Image"
 msgstr "Skapa bild"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Create a shopping list with quantities from this recipe."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text displayed in the input field when starting a new image generation session.
 msgctxt "Placeholder text for the image generation input field"
 msgid "Create an image of a cute duck..."
@@ -5757,12 +5828,18 @@ msgstr "Diktering i Duck.ai"
 # smartling.placeholder_format=C
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
-msgstr "Diktering anonymiseras av oss och används aldrig för att träna AI-modeller."
+msgstr ""
+"Diktering anonymiseras av oss och används aldrig för att träna AI-modeller."
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
 msgid "Dictation limit reached"
 msgstr "Dikteringsgräns uppnådd"
+
+# smartling.placeholder_format=C
+#. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
+msgid "Dictation temporarily unavailable"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
@@ -6039,7 +6116,8 @@ msgstr "Ser du inte DuckDuckGo i listan?"
 #. Link to download a file again if the user can't find it on their computer.
 msgctxt "install-extension"
 msgid "Don't see it? %s%s%sClick here to re-download%s"
-msgstr "Hittar du inte filen? %1$s%2$s%3$sKlicka här för att ladda ner den igen%4$s"
+msgstr ""
+"Hittar du inte filen? %1$s%2$s%3$sKlicka här för att ladda ner den igen%4$s"
 
 #  IE < 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -6063,6 +6141,22 @@ msgstr "Klart"
 msgctxt "precise_user_location"
 msgid "Done"
 msgstr "Klart"
+
+# smartling.placeholder_format=C
+#. Message shown in a modal after DuckDuckGo browser users disable AI features in Settings. The first two placeholders bold noai.duckduckgo.com. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
+"filtered out. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
+"and AI images filtered out. %sLearn more%s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6177,6 +6271,18 @@ msgid ""
 msgstr ""
 "Skriv ett kortfattat och detaljerat e-postmeddelande till en leverantör och "
 "be om en offert på att få ett kylskåp reparerat i hemmet."
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Draft a cover letter"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Draft a cover letter for this job."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -6355,6 +6461,15 @@ msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
 msgstr "Duck.ai är bäst i vår privata och gratis DuckDuckGo-webbläsare!"
 
 # smartling.placeholder_format=C
+#. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
+msgctxt "About section description on the Duck.ai settings page"
+msgid ""
+"Duck.ai is created by DuckDuckGo. We're an independent online protection "
+"company for anyone who wants to take back control of their personal "
+"information."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
 msgctxt "duckai_migration"
 msgid "Duck.ai is moving domains"
@@ -6398,6 +6513,13 @@ msgstr "Duck.ai är inte tillgängligt just nu. Uppdatera sidan och försök ige
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
 msgstr "Duck.ai är inte tillgängligt just nu. Försök igen senare."
+
+# smartling.placeholder_format=C
+msgctxt "settings"
+msgid ""
+"Duck.ai lets you chat privately with popular AI models. Disabling it hides "
+"Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6471,9 +6593,9 @@ msgid ""
 "AI chat no sign up, OpenAI, Anthropic, Llama, Mistral, open source AI "
 "models, privacy focused AI, no account AI chat"
 msgstr ""
-"Duck.ai, DuckDuckGo AI, privat AI-chattbot, gratis AI-chatt, anonym "
-"AI-chatt, AI-chatt utan registrering, OpenAI, Anthropic, Llama, Mistral, "
-"AI-modeller med öppen källkod, integritetsfokuserad AI, AI-chatt utan konto"
+"Duck.ai, DuckDuckGo AI, privat AI-chattbot, gratis AI-chatt, anonym AI-"
+"chatt, AI-chatt utan registrering, OpenAI, Anthropic, Llama, Mistral, AI-"
+"modeller med öppen källkod, integritetsfokuserad AI, AI-chatt utan konto"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -6642,7 +6764,8 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr "DuckDuckGo AI Chat är inte tillgänglig för tillfället. Försök igen senare."
+msgstr ""
+"DuckDuckGo AI Chat är inte tillgänglig för tillfället. Försök igen senare."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -7393,6 +7516,18 @@ msgid "Eritrea"
 msgstr "Eritrea"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Estimate the nutrition"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Estimate the nutritional information for this recipe."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Estonia"
 msgstr "Estland"
 
@@ -7447,11 +7582,60 @@ msgid "Expires in 1 day"
 msgstr "Går ut om 1 dag"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain the accepted answer in simple terms."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
-msgstr "Förklara de grundläggande begreppen för svarta hål för mig på gymnasienivå."
+msgstr ""
+"Förklara de grundläggande begreppen för svarta hål för mig på gymnasienivå."
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain the top answer"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this in simple, plain language."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this paper"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this repo"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this research paper in plain language."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this simply"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain what this repository does and how to use it."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label to show if song lyrics contain explicit content
@@ -7628,7 +7812,8 @@ msgstr "Feedback har skickats"
 msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and improvements."
-msgstr "Din feedback påverkar direkt våra produktuppdateringar och förbättringar."
+msgstr ""
+"Din feedback påverkar direkt våra produktuppdateringar och förbättringar."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -7736,6 +7921,12 @@ msgstr ""
 "mer%2$s"
 
 # smartling.placeholder_format=C
+msgctxt "settings"
+msgid ""
+"Filters out known AI spam sites from image search results. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the final score of a sporting event.
 msgid "Final"
 msgstr "Slutgiltig"
@@ -7774,7 +7965,8 @@ msgstr "Hitta <b>%1$s</b> i din nedladdningsmapp"
 # smartling.placeholder_format=C
 #. Tells users how to change their default search engine to DuckDuckGo.
 msgid "Find DuckDuckGo in the displayed list and click %sMake Default%s"
-msgstr "Hitta DuckDuckGo i listan som visas och klicka på %1$sAnvänd som standard%2$s"
+msgstr ""
+"Hitta DuckDuckGo i listan som visas och klicka på %1$sAnvänd som standard%2$s"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for finding a better word.
@@ -7787,6 +7979,12 @@ msgstr "Hitta ett bättre ord"
 msgctxt "Subtitle for the Web Search tool entry in the Tools dropdown menu"
 msgid "Find current information"
 msgstr "Hitta aktuell information"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Find me alternatives"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button that searches for results closer to the user's current location.
@@ -7805,7 +8003,8 @@ msgstr "Hitta sökresultat närmare dig."
 msgctxt "Precise user location overlay"
 msgid ""
 "Find results near you. %sYour location stays private, secure, and anonymous."
-msgstr "Hitta resultat nära dig. %1$sDin plats förblir privat, säker och anonym."
+msgstr ""
+"Hitta resultat nära dig. %1$sDin plats förblir privat, säker och anonym."
 
 # smartling.placeholder_format=C
 #. Loading message shown while generating explore more follow-up questions
@@ -7981,7 +8180,8 @@ msgstr "Kostnadsfria och privata chattar, anonymiserade av oss"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr "Kostnadsfria och privata chattar, anonymiserade av oss. Inget konto behövs."
+msgstr ""
+"Kostnadsfria och privata chattar, anonymiserade av oss. Inget konto behövs."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -8264,6 +8464,12 @@ msgid "Generate More"
 msgstr "Generera mer"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Generate a shopping list"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
 msgid "Generate a short answer from the web"
 msgstr "Generera ett kort svar från webben"
@@ -8454,9 +8660,9 @@ msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"Få tillgång till avancerade AI-modeller i Duck.ai med ett "
-"DuckDuckGo-abonnemang, som även inkluderar vårt VPN och andra premiumskydd "
-"för integritet."
+"Få tillgång till avancerade AI-modeller i Duck.ai med ett DuckDuckGo-"
+"abonnemang, som även inkluderar vårt VPN och andra premiumskydd för "
+"integritet."
 
 # smartling.placeholder_format=C
 #. A button for users to generate an AI generated answer from their query on the duckassist module
@@ -8555,6 +8761,12 @@ msgstr "Prova det"
 msgctxt "Onboarding welcome screen button text"
 msgid "Give it a Try"
 msgstr "Prova det"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Give me a quick background on this person."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -8824,7 +9036,8 @@ msgstr "Guatemala"
 #. Text for a prompt suggestion for guiding through the basic steps of replacing a window wiper.
 msgctxt "Full sentence for learning a new skill"
 msgid "Guide me through the basic steps of replacing a window wiper."
-msgstr "Guida mig genom de grundläggande stegen för att byta ut en fönstertorkare."
+msgstr ""
+"Guida mig genom de grundläggande stegen för att byta ut en fönstertorkare."
 
 # smartling.placeholder_format=C
 msgid "Guinea"
@@ -9001,6 +9214,18 @@ msgstr "Hjälp till att sprida DuckDuckGo!"
 #. Link to a page with information about sharing DuckDuckGo with friends.
 msgid "Help Spread Privacy"
 msgstr "Hjälp till att sprida integritetsskydd"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Help me prep for the interview"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Help me tailor my resume for this job."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title of a SERP popup that invites users to take a survey (desktop only)
@@ -9520,6 +9745,14 @@ msgid "I Agree"
 msgstr "Jag instämmer"
 
 # smartling.placeholder_format=C
+#. Text for the button that takes the user to the external DuckDuckGo login subscription page.
+msgctxt ""
+"Text for the I already have a subscription button in the Duck.ai settings "
+"page"
+msgid "I Already Have a Subscription"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for the button that takes the user to the login subscription page.
 msgctxt "Text for the I have a subscription button"
 msgid "I Have a Subscription"
@@ -9685,7 +9918,8 @@ msgstr ""
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
-msgstr "Om du fortfarande vill stödja oss, %1$shjälp till sprida DuckDuckGo%2$s"
+msgstr ""
+"Om du fortfarande vill stödja oss, %1$shjälp till sprida DuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -10093,6 +10327,12 @@ msgid "Install Mac Browser"
 msgstr "Installera webbläsaren för Mac"
 
 # smartling.placeholder_format=C
+#. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
+msgctxt "settings"
+msgid "Install Now"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of a button to install the DuckDuckGo app
 msgctxt "Serp footer content"
 msgid "Install Our App"
@@ -10190,10 +10430,42 @@ msgid "Is deleted data really deleted?"
 msgstr "Tas data verkligen bort?"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is it worth taking?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this place any good?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"Is this place any good? Summarize its reputation based on reviews and "
+"ratings."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "Is this video helpful?"
 msgstr "Är den här videon till hjälp?"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this worth watching?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Is this worth watching? Give me a spoiler-free take."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -10225,7 +10497,8 @@ msgstr "Det är snabbt, gratis och ger dig ännu mer skydd online."
 msgctxt "settings"
 msgid ""
 "It's okay to (very infrequently) ask me about my experience using DuckDuckGo"
-msgstr "Det är okej att fråga mig om min upplevelse med DuckDuckGo (inte så ofta)"
+msgstr ""
+"Det är okej att fråga mig om min upplevelse med DuckDuckGo (inte så ofta)"
 
 # smartling.placeholder_format=C
 #. The name of the Italian language
@@ -10804,6 +11077,12 @@ msgid "Links:"
 msgstr "Länkar:"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "List the tools, materials, or prerequisites I need for this."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
 msgid "Listen"
 msgstr "Lyssna"
@@ -10912,7 +11191,8 @@ msgstr "Läser in fler sökresultat med bilder när du skrollar"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Loads more results in Images, Videos, and Shopping when scrolling"
-msgstr "Läser in fler sökresultat med bilder, videor och shopping när du skrollar"
+msgstr ""
+"Läser in fler sökresultat med bilder, videor och shopping när du skrollar"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/WTkvs9I.png
@@ -11208,6 +11488,12 @@ msgstr "Hantera din prenumeration"
 msgctxt "Exclusion message manage sites button"
 msgid "Manage blocked sites"
 msgstr "Hantera blockerade webbplatser"
+
+# smartling.placeholder_format=C
+#. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
+msgctxt "setting"
+msgid "Manage in Browser Settings"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to the site exclusion settings page
@@ -12182,11 +12468,10 @@ msgid ""
 "internet connection. Disabling chat history will delete pinned chats, and "
 "disable the temporary storage of new prompts and responses."
 msgstr ""
-"Nya promptar och svar krypteras och lagras tillfälligt på en "
-"DuckDuckGo-server efter att de har skickats, så att du kan återställa "
-"chatten om din internetanslutning bryts. Om du inaktiverar chatthistoriken "
-"raderas fästa chattar och tillfällig lagring av nya promptar och svar "
-"inaktiveras."
+"Nya promptar och svar krypteras och lagras tillfälligt på en DuckDuckGo-"
+"server efter att de har skickats, så att du kan återställa chatten om din "
+"internetanslutning bryts. Om du inaktiverar chatthistoriken raderas fästa "
+"chattar och tillfällig lagring av nya promptar och svar inaktiveras."
 
 # smartling.placeholder_format=C
 #. Question in a feedback form.
@@ -14025,7 +14310,8 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this prompt was made by a "
 "human."
-msgstr "Lös följande utmaning för att bekräfta att prompten görs av en människa."
+msgstr ""
+"Lös följande utmaning för att bekräfta att prompten görs av en människa."
 
 # smartling.placeholder_format=C
 #. Bot challenge explanation
@@ -14033,7 +14319,14 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this search was made by a "
 "human."
-msgstr "Lös följande utmaning för att bekräfta att sökningen görs av en människa."
+msgstr ""
+"Lös följande utmaning för att bekräfta att sökningen görs av en människa."
+
+# smartling.placeholder_format=C
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
+msgctxt "Feedback prompt"
+msgid "Please describe why the chat response is harmful or illegal. (optional)"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
@@ -14062,6 +14355,14 @@ msgid ""
 msgstr ""
 "OBS! Om du startar en ny chatt med en modell raderas din nuvarande "
 "chattsession."
+
+# smartling.placeholder_format=C
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
+msgctxt "Feedback prompt"
+msgid ""
+"Please paste your prompt and the problematic output (with any personal "
+"information removed) and describe why the content is harmful or illegal."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -14532,6 +14833,12 @@ msgid "Privacy"
 msgstr "Integritet"
 
 # smartling.placeholder_format=C
+#. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
+msgctxt "Section heading on the Duck.ai settings page"
+msgid "Privacy & Terms"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Privacy Blog"
 msgstr "Integritetsblogg"
 
@@ -14600,6 +14907,12 @@ msgstr "Integritetspolicy och användarvillkor"
 msgctxt "Copy used to compose link in sentences"
 msgid "Privacy Policy and Terms of Service"
 msgstr "Integritetspolicy och användarvillkor"
+
+# smartling.placeholder_format=C
+#. Text for a button that links to the terms of use and privacy policy page.
+msgctxt "Secondary button text in active privacy modal"
+msgid "Privacy Policy and Terms of Service"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title displayed on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
@@ -14773,7 +15086,8 @@ msgstr "Fråga mig"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Prompt me to use my approximate location to get nearby results."
-msgstr "Be mig använda min ungefärliga plats för att få sökresultat i närheten."
+msgstr ""
+"Be mig använda min ungefärliga plats för att få sökresultat i närheten."
 
 # smartling.placeholder_format=C
 #. DuckDuckGo Email Protection removes trackers from emails
@@ -15054,8 +15368,8 @@ msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
 msgstr ""
-"De senaste chattarna lagras lokalt på din enhet istället för på "
-"DuckDuckGo-servrar eller andra fjärrservrar."
+"De senaste chattarna lagras lokalt på din enhet istället för på DuckDuckGo-"
+"servrar eller andra fjärrservrar."
 
 # smartling.placeholder_format=C
 #. Text explaining that recent chats are stored locally on the user's device.
@@ -15064,8 +15378,8 @@ msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
 msgstr ""
-"De senaste chattarna lagras lokalt på din enhet istället för på "
-"DuckDuckGo-servrar eller andra fjärrservrar."
+"De senaste chattarna lagras lokalt på din enhet istället för på DuckDuckGo-"
+"servrar eller andra fjärrservrar."
 
 # smartling.placeholder_format=C
 #. Text explaining how recent chats are stored locally on the user's device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection.
@@ -15099,6 +15413,30 @@ msgstr "Recept för %1$s%2$s%3$s"
 msgctxt "Brief for recommending a book"
 msgid "Recommend a book"
 msgstr "Rekommendera en bok"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar books"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar books."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar movies or shows."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar titles"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
@@ -15501,6 +15839,15 @@ msgid "Republic of Moldova"
 msgstr "Republiken Moldavien"
 
 # smartling.placeholder_format=C
+#. Note indicating that sharing the conversation is mandatory when reporting harmful or illegal content. Rendered alongside the standard share label (DUCKCHAT_RESPONSE_FEEDBACK_SHARE_PROMPT_RESPONSE_LABEL), not replacing it.
+msgctxt ""
+"Note shown under the share-content switch label on the Duck.ai response "
+"feedback form when the user has selected Harmful or Illegal as the feedback "
+"reason"
+msgid "Required for harmful or illegal reports"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
 msgctxt "Description for extended reasoning mode in Duck.ai"
 msgid "Researches before responding"
@@ -15738,6 +16085,12 @@ msgstr "Recensioner"
 msgctxt "maps_places"
 msgid "Reviews"
 msgstr "Recensioner"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Rewrite this recipe scaled for a different number of servings."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Romania"
@@ -16023,7 +16376,8 @@ msgstr "Spara upp till 30 av dina senaste chattar lokalt på din enhet."
 msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
-msgstr "Spara dina Duck.ai-chattar mellan dina enheter med end-to-end-kryptering."
+msgstr ""
+"Spara dina Duck.ai-chattar mellan dina enheter med end-to-end-kryptering."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -16182,13 +16536,15 @@ msgstr "Skrolla nedåt och leta reda på %1$sdin webbläsare%2$s i listan."
 #. Tells users which setting to change to enable location service.
 msgctxt "precise_user_location"
 msgid "Scroll down to %sDuckDuckGo%s and allow it to use your location."
-msgstr "Skrolla ner till %1$sDuckDuckGo%2$s och ge tillåtelse att använda din plats."
+msgstr ""
+"Skrolla ner till %1$sDuckDuckGo%2$s och ge tillåtelse att använda din plats."
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down to the %sServices%s section and click %sAddress bar%s."
-msgstr "Skrolla ner till avsnittet %1$sTjänster%2$s och klicka på %3$sAdressfält%4$s."
+msgstr ""
+"Skrolla ner till avsnittet %1$sTjänster%2$s och klicka på %3$sAdressfält%4$s."
 
 # smartling.placeholder_format=C
 #. Rugby match stats
@@ -16518,7 +16874,8 @@ msgstr "Säsongsveckor"
 #. Description shown in the Sync & Backup settings section when sync is not yet enabled, explaining the feature.
 msgctxt "Description for sync and backup feature"
 msgid "Securely save and sync your chats across all your devices."
-msgstr "Spara och synkronisera dina chattar på ett säkert sätt på alla dina enheter."
+msgstr ""
+"Spara och synkronisera dina chattar på ett säkert sätt på alla dina enheter."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -16527,8 +16884,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
 msgstr ""
-"Lagra säkert nästan obegränsat antal chattar på vår server med "
-"end-to-end-kryptering och få åtkomst till dem från alla dina enheter."
+"Lagra säkert nästan obegränsat antal chattar på vår server med end-to-end-"
+"kryptering och få åtkomst till dem från alla dina enheter."
 
 # smartling.placeholder_format=C
 #. Text explaining that the Encrypted Storage feature stores the user's chats encrypted on their device.
@@ -16537,8 +16894,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
 msgstr ""
-"Lagra säkert nästan obegränsat antal chattar på vår server med "
-"end-to-end-kryptering och få åtkomst till dem från alla dina enheter."
+"Lagra säkert nästan obegränsat antal chattar på vår server med end-to-end-"
+"kryptering och få åtkomst till dem från alla dina enheter."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -16557,8 +16914,8 @@ msgid ""
 "Securely store your chats on our server using end-to-end encryption, and "
 "access them from all your devices."
 msgstr ""
-"Lagra dina chattar på ett säkert sätt på vår server med "
-"end-to-end-kryptering och få åtkomst till dem från alla dina enheter."
+"Lagra dina chattar på ett säkert sätt på vår server med end-to-end-"
+"kryptering och få åtkomst till dem från alla dina enheter."
 
 # smartling.placeholder_format=C
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
@@ -17061,6 +17418,12 @@ msgid "Set Up Now"
 msgstr "Ställ in nu"
 
 # smartling.placeholder_format=C
+#. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
+msgctxt "Encrypted storage setup button shown in native browsers"
+msgid "Set Up Sync & Backup"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
 msgctxt "Title for the Sync & Backup intro screen"
 msgid "Set Up Sync & Backup"
@@ -17096,7 +17459,8 @@ msgstr ""
 #. Prompt for the user to indicate their location on a map, to enable more relevant search results.
 msgctxt "precise_user_location"
 msgid "Set your location manually, or ensure Location Services is enabled."
-msgstr "Ställ in din plats manuellt eller se till att platstjänster är aktiverade."
+msgstr ""
+"Ställ in din plats manuellt eller se till att platstjänster är aktiverade."
 
 # smartling.placeholder_format=C
 #. In the top dropdown menu  ("More" > "Settings")
@@ -17237,6 +17601,13 @@ msgstr "Dela sidans URL"
 msgctxt "feedback form"
 msgid "Share positive feedback"
 msgstr "Dela positiv feedback"
+
+# smartling.placeholder_format=C
+#. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
+msgctxt ""
+"Label beside the share-content switch on the Duck.ai response feedback form"
+msgid "Share this conversation with DuckDuckGo"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -17639,12 +18010,14 @@ msgstr "Visar mest besökta länkar i ny flik"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your browser"
-msgstr "Visar påminnelser då och då om att lägga till DuckDuckGo i din webbläsare"
+msgstr ""
+"Visar påminnelser då och då om att lägga till DuckDuckGo i din webbläsare"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr "Visar påminnelser då och då om att lägga till DuckDuckGo i dina enheter"
+msgstr ""
+"Visar påminnelser då och då om att lägga till DuckDuckGo i dina enheter"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -17662,7 +18035,8 @@ msgstr "Visar sidnummer där sidan med sökresultat bryts"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows sign-up form for the DuckDuckGo privacy newsletters"
-msgstr "Visar registreringsformuläret för nyhetsbrevet om integritet från DuckDuckGo"
+msgstr ""
+"Visar registreringsformuläret för nyhetsbrevet om integritet från DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/94erFcS.png
@@ -17688,7 +18062,8 @@ msgstr "Visar välkomstmeddelande högst upp på sidan med sökresultat"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message to EU Android preference menu users"
-msgstr "Visar välkomstmeddelande till användare av inställningsmeny för Android i EU"
+msgstr ""
+"Visar välkomstmeddelande till användare av inställningsmeny för Android i EU"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers sometimes.
@@ -18488,6 +18863,24 @@ msgid "Suggest a title for a blog post"
 msgstr "Förslag på rubrik för ett blogginlägg"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest related articles or topics worth exploring next."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Suggest related articles to explore"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest some alternatives to this product."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
 msgctxt "directions"
 msgid "Suggestions:"
@@ -18499,10 +18892,100 @@ msgid "Suggestions:"
 msgstr "Förslag:"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Sum up the reviews"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A short title for the a message asking the AI to summarize a text.
 msgctxt "Title for the summarize message"
 msgid "Summarize"
 msgstr "Sammanfatta"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize the Q&As"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the background and notable work of this person."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the key details of this event."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the questions and answers on this page."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize their background"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this book"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this book."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this discussion"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this discussion thread."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this page"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this page."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this video"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this video."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize what the reviews say."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -18825,6 +19308,12 @@ msgid "Syria"
 msgstr "Syrien"
 
 # smartling.placeholder_format=C
+#. Text for a button that enables the theme to follow the operating system's color scheme preference.
+msgctxt "System theme button for theme selector"
+msgid "System"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Abbreviation indicating this is the total score for a game
 msgctxt "Sports module"
 msgid "T"
@@ -18851,6 +19340,12 @@ msgstr "TV"
 msgctxt "language_name"
 msgid "Tahitian"
 msgstr "Tahitiska"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Tailor my resume"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Taiwan"
@@ -18880,6 +19375,13 @@ msgstr "Ta kontroll över dina personuppgifter"
 msgctxt "homepage ATB modal"
 msgid "Take control of your personal data!"
 msgstr "Ta kontroll över dina personuppgifter!"
+
+# smartling.placeholder_format=C
+#. Description for the Feedback section of the Duck.ai settings page, asking the user to take an anonymous survey to let us know how we can make Duck.ai better.
+msgctxt "Feedback section description on the Duck.ai settings page"
+msgid ""
+"Take this anonymous survey to let us know how we can make Duck.ai better."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -19187,6 +19689,12 @@ msgid "Theme"
 msgstr "Tema"
 
 # smartling.placeholder_format=C
+#. Text for the theme selector label that allows users to switch between Light and dark theme.
+msgctxt "Label for the theme selector feature"
+msgid "Theme"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. http://i.imgur.com/LpFhb1e.png
 msgctxt "settings"
 msgid "Theme"
@@ -19237,7 +19745,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Error message for explore more questions when a retryable error occurs (timeout, network)
 msgid "There's been an issue loading this answer. Please try again."
-msgstr "Det uppstod ett problem när det här svaret skulle läsas in. Försök igen."
+msgstr ""
+"Det uppstod ett problem när det här svaret skulle läsas in. Försök igen."
 
 # smartling.placeholder_format=C
 #. Instant Answer Tab Name
@@ -19497,8 +20006,8 @@ msgstr "Denna sida kräver javascript för att fungera."
 msgctxt "Tooltip explaining that page content will be sent to Duck.ai"
 msgid "This page's content will be sent with your message to Duck.ai"
 msgstr ""
-"Innehållet på den här sidan kommer att skickas med ditt meddelande till "
-"Duck.ai"
+"Innehållet på den här sidan kommer att skickas med ditt meddelande till Duck."
+"ai"
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -19571,7 +20080,8 @@ msgstr "Denna video kan ännu inte visas här. Du kan titta på den på %1$s."
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr "Den här webbplats använder inte en säker, krypterad anslutning (HTTPS)."
+msgstr ""
+"Den här webbplats använder inte en säker, krypterad anslutning (HTTPS)."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -19756,8 +20266,8 @@ msgid ""
 "To transfer your chat history to Duck.ai, please update your DuckDuckGo "
 "browser to the latest version and try again."
 msgstr ""
-"För att överföra din chatthistorik till Duck.ai, uppdatera "
-"DuckDuckGo-webbläsaren till den senaste versionen och försök igen."
+"För att överföra din chatthistorik till Duck.ai, uppdatera DuckDuckGo-"
+"webbläsaren till den senaste versionen och försök igen."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
@@ -20019,6 +20529,18 @@ msgstr ""
 "närmaste biograf?”"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Translate this page"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
+msgctxt "Page suggestion prompt"
+msgid "Translate this page into %s."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text for a region that will display translated text.
 msgctxt "translations_module"
 msgid "Translation"
@@ -20158,6 +20680,12 @@ msgstr "Försök igen"
 msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
 msgstr "Prova gratis"
+
+# smartling.placeholder_format=C
+#. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
+msgctxt "settings"
+msgid "Try It Now"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -20396,6 +20924,22 @@ msgstr "Testa: %1$s"
 msgctxt "new user poll"
 msgid "Trying DuckDuckGo again"
 msgstr "Försöker använda DuckDuckGo igen"
+
+# smartling.placeholder_format=C
+#. Message shown in a modal after supported third-party browser users disable AI features in Settings. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -20707,13 +21251,14 @@ msgstr ""
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
 msgstr ""
-"Under %1$sVid uppstart%2$s, välj %3$sStartsida%4$s och skriv: "
-"https://duckduckgo.com"
+"Under %1$sVid uppstart%2$s, välj %3$sStartsida%4$s och skriv: https://"
+"duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sOpen with%s select %sA specific page or pages%s"
-msgstr "Under %1$sÖppna med%2$s, välj %3$sEn särskild sida eller grupp av sidor%4$s"
+msgstr ""
+"Under %1$sÖppna med%2$s, välj %3$sEn särskild sida eller grupp av sidor%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -20740,7 +21285,8 @@ msgstr "Under sektionen %1$sSök%2$s, klicka på %3$sHantera sökmotorer...%4$s"
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under On startup select %sOpen a specific page or set of pages%s"
-msgstr "Under Vid start, välj %1$sÖppna en särskild sida eller grupp av sidor%2$s"
+msgstr ""
+"Under Vid start, välj %1$sÖppna en särskild sida eller grupp av sidor%2$s"
 
 #  Opera default search engine instruction
 # smartling.placeholder_format=C
@@ -20847,8 +21393,8 @@ msgctxt "voice chat limit modal"
 msgid ""
 "Unlock advanced AI models and higher limits with a DuckDuckGo Subscription"
 msgstr ""
-"Lås upp avancerade AI-modeller och högre gränser med en "
-"DuckDuckGo-prenumeration"
+"Lås upp avancerade AI-modeller och högre gränser med en DuckDuckGo-"
+"prenumeration"
 
 # smartling.placeholder_format=C
 #. Text informing the user that advanced AI models can be unlocked with a subscription. The variable is used to insert a link that opens the subscription modal. Example: Unlock advanced AI models with a DuckDuckGo subscription.
@@ -21145,6 +21691,12 @@ msgid "Uruguay"
 msgstr "Uruguay"
 
 # smartling.placeholder_format=C
+#. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
+msgctxt "Navigation label on the Duck.ai settings page"
+msgid "Usage"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A feedback suggestion
 msgctxt "Feedback prompt"
 msgid "Usage limit"
@@ -21200,7 +21752,8 @@ msgstr "Använd DuckDuckGo Private Search"
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Use DuckDuckGo private search on your iPad, iPhone, or Android!"
-msgstr "Använd privat sökning från DuckDuckGo på din iPad, iPhone eller Android!"
+msgstr ""
+"Använd privat sökning från DuckDuckGo på din iPad, iPhone eller Android!"
 
 # smartling.placeholder_format=C
 #. User clicks this button to share their device's location
@@ -21476,10 +22029,9 @@ msgid ""
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
 msgstr ""
-"Gå till Duck.ai i din andra webbläsare eller DuckDuckGo-appen och öppna "
-"Duck.ai-inställningarna. Välj Aktivera under Sync & Backup och välj "
-"Synkronisera med en annan enhet. Eller skanna QR-koden på din "
-"återställnings-PDF."
+"Gå till Duck.ai i din andra webbläsare eller DuckDuckGo-appen och öppna Duck."
+"ai-inställningarna. Välj Aktivera under Sync & Backup och välj Synkronisera "
+"med en annan enhet. Eller skanna QR-koden på din återställnings-PDF."
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -21532,8 +22084,8 @@ msgstr "Röstchatt avslutad"
 msgctxt "voice chat"
 msgid "Voice chat is anonymized by us, and never used to train AI models."
 msgstr ""
-"Röstchatt är anonymiserad av oss och används aldrig för att träna "
-"AI-modeller."
+"Röstchatt är anonymiserad av oss och används aldrig för att träna AI-"
+"modeller."
 
 # smartling.placeholder_format=C
 #. Title of the modal shown when the user has reached their daily voice chat limit.
@@ -21592,6 +22144,12 @@ msgstr "Väntar på plats ..."
 # smartling.placeholder_format=C
 msgid "Wales"
 msgstr "Wales"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Walk me through the steps"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for walking directions on a map.
@@ -21707,7 +22265,19 @@ msgstr "Vi anonymiserar"
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
-msgstr "Vi kan anonymisera %1$sdin plats%2$s för att visa dig mer exakta resultat."
+msgstr ""
+"Vi kan anonymisera %1$sdin plats%2$s för att visa dig mer exakta resultat."
+
+# smartling.placeholder_format=C
+#. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
+msgctxt ""
+"Inline warning shown below the share-content toggle when the user selects "
+"Harmful or Illegal but has not enabled sharing"
+msgid ""
+"We can only fix what we can see. To report a harmful or illegal response, "
+"please share this conversation with DuckDuckGo so we can investigate and "
+"address the issue."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -21727,14 +22297,16 @@ msgstr ""
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can use your anonymous%s location%s to show you nearby results."
-msgstr "Vi kan använda din %1$splats%2$s anonymt för att visa resultat i närheten."
+msgstr ""
+"Vi kan använda din %1$splats%2$s anonymt för att visa resultat i närheten."
 
 # smartling.placeholder_format=C
 #. Error message displayed when one or more attached files are encrypted and cannot be read.
 msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
-msgstr "Vi kan inte läsa de bifogade filerna eftersom minst en av dem är krypterad."
+msgstr ""
+"Vi kan inte läsa de bifogade filerna eftersom minst en av dem är krypterad."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -21745,7 +22317,8 @@ msgstr "Vi förföljer dig inte med annonser."
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
 msgid "We don't store usernames or any personally identifiable information."
-msgstr "Vi lagrar inte användarnamn eller annan personligt identifierbar information."
+msgstr ""
+"Vi lagrar inte användarnamn eller annan personligt identifierbar information."
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -21776,7 +22349,8 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what brought you "
 "back today:"
-msgstr "Vi spårar dig inte, och vi vill gärna veta varför du kom tillbaka idag:"
+msgstr ""
+"Vi spårar dig inte, och vi vill gärna veta varför du kom tillbaka idag:"
 
 # smartling.placeholder_format=C
 #. Message prompting users to fill out a feedback form.
@@ -21928,7 +22502,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
-msgstr "Vi blockerar spårare som försöker samla in dina uppgifter medan du surfar."
+msgstr ""
+"Vi blockerar spårare som försöker samla in dina uppgifter medan du surfar."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -22123,7 +22698,8 @@ msgstr ""
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai! You can now import your downloaded chats."
-msgstr "Välkommen till nya Duck.ai! Du kan nu importera dina nedladdade chattar."
+msgstr ""
+"Välkommen till nya Duck.ai! Du kan nu importera dina nedladdade chattar."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -22218,7 +22794,8 @@ msgstr "Kan du ge några faktorer man ska tänka på när man köper en datorsk�
 #. Text for a prompt suggestion for asking about must-see attractions in Paris for a first-time visitor.
 msgctxt "Full sentence for planning a trip"
 msgid "What are some must-see attractions in Paris for a first-time visitor?"
-msgstr "Vilka är några sevärdheter man måste se första gången man besöker i Paris?"
+msgstr ""
+"Vilka är några sevärdheter man måste se första gången man besöker i Paris?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for finding options for the word 'better' in a specific context.
@@ -22253,6 +22830,103 @@ msgstr ""
 "på Duck.ai-integrationer och integritetsskydd. Håll det ganska kort, enkelt "
 "och lätt att förstå för personer med eller utan mycket AI- eller teknisk "
 "erfarenhet."
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the counterarguments?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the hours & location?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key contributions of this paper?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key contributions?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key details?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key points covered in this video?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key points?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key takeaways from this article?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key takeaways?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key things I will learn from this course?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main counterarguments or criticisms of this?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main questions this page answers?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the must-try dishes here?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"What are the opening hours, location, and contact details for this place?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the pros and cons of this product?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the pros and cons?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
@@ -22355,6 +23029,12 @@ msgid "What does atria mean in the context of a medical article?"
 msgstr "Vad betyder atria i samband med en medicinsk artikel?"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What does this answer?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
@@ -22365,6 +23045,12 @@ msgstr "Vilken funktion vill du att vi lägger till? (valfritt)"
 msgctxt "cloudsave"
 msgid "What information gets saved?"
 msgstr "Vilken information sparas?"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What interview questions might come up for this role?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -22381,6 +23067,12 @@ msgstr ""
 msgctxt "Full sentence for looking up basic facts"
 msgid "What is the capital city of Albania?"
 msgstr "Vad är huvudstaden i Albanien?"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What is the overall verdict and rating for this?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to a page with additional information.
@@ -22405,6 +23097,12 @@ msgid "What people say:"
 msgstr "Vad folk säger:"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What should I order?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
 msgctxt "feedback form"
 msgid "What stood out?"
@@ -22417,6 +23115,18 @@ msgid "What was wrong with the response? (optional)"
 msgstr "Vad var det för fel på svaret? (valfritt)"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I learn?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I need?"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid "What would you like to provide feedback on?"
 msgstr "Vad vill du ge feedback om?"
@@ -22425,13 +23135,20 @@ msgstr "Vad vill du ge feedback om?"
 #. Explains the benefits of using our custom video player, the Duck Player
 msgid ""
 "What you watch in DuckDuckGo won't influence your recommendations on YouTube."
-msgstr "Det du tittar på i DuckDuckGo påverkar inte dina rekommendationer på YouTube."
+msgstr ""
+"Det du tittar på i DuckDuckGo påverkar inte dina rekommendationer på YouTube."
 
 # smartling.placeholder_format=C
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
 msgctxt "SERP footer content"
 msgid "What's New"
 msgstr "Vad är nytt?"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What's the verdict?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -22451,7 +23168,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "When enabled, Duck.ai will show instant answers in the chat."
-msgstr "När det är aktiverat kommer Duck.ai att visa omedelbara svar i chatten."
+msgstr ""
+"När det är aktiverat kommer Duck.ai att visa omedelbara svar i chatten."
 
 # smartling.placeholder_format=C
 #. Text of a button that performs a search for the available streaming services that show a particular movie or tv show
@@ -22484,6 +23202,12 @@ msgid "Which features are missing? (Optional)"
 msgstr "Vilka funktioner saknas? (Valfritt)"
 
 # smartling.placeholder_format=C
+#. An invitation for users to leave feedback
+msgctxt "Feedback prompt"
+msgid "Which features are missing? (optional)"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
 msgid "White"
 msgstr "Vit"
@@ -22498,6 +23222,18 @@ msgstr "Vit"
 #. Link to an about us page.
 msgid "Who We Are"
 msgstr "Vilka är vi"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Who are the main cast and crew, and what else are they known for?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Who is this person?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Header above a collection of privacy-related links.
@@ -22868,7 +23604,8 @@ msgstr "Ja, ny användare!"
 msgctxt "cloudsave"
 msgid ""
 "Yes, we throw away data when you’re done with it, and it cannot be recovered."
-msgstr "Ja, vi slänger data när du är klar med dem och de kan inte återställas."
+msgstr ""
+"Ja, vi slänger data när du är klar med dem och de kan inte återställas."
 
 # smartling.placeholder_format=C
 #. Option for the filter-by-date search.
@@ -22887,7 +23624,8 @@ msgctxt "Disclaimer bellow chat input - desktop"
 msgid ""
 "You are chatting with %s. AI chats may display inaccurate or offensive "
 "information."
-msgstr "Du chattar med %1$s. AI-chattar kan visa felaktig eller stötande information."
+msgstr ""
+"Du chattar med %1$s. AI-chattar kan visa felaktig eller stötande information."
 
 # smartling.placeholder_format=C
 #. Provide users with the ability to retry their search on a different search engine. First placeholder will be a link with the text "try your search again" OR "try your search later". Second is a URL to the !bangs page: https://duckduckgo.com/bangs.
@@ -23054,7 +23792,8 @@ msgstr ""
 #. Text explaining the benefits of the cloud save feature.
 msgctxt "cloudsave"
 msgid "You can restore your settings after deleting cookies."
-msgstr "Du kan återställa dina inställningar efter att du har tagit bort kakor."
+msgstr ""
+"Du kan återställa dina inställningar efter att du har tagit bort kakor."
 
 # smartling.placeholder_format=C
 #. Text explaining the benefits of the cloud save feature.
@@ -23295,8 +24034,8 @@ msgid ""
 "YouTube (owned by Google) does not let you watch videos anonymously. As "
 "such, watching YouTube videos here will be tracked by YouTube/Google."
 msgstr ""
-"YouTube (som ägs av Google) låter dig inte titta på videor anonymt. "
-"YouTube-videor som visas här spåras därför av YouTube/Google."
+"YouTube (som ägs av Google) låter dig inte titta på videor anonymt. YouTube-"
+"videor som visas här spåras därför av YouTube/Google."
 
 # smartling.placeholder_format=C
 #. Label for a privacy disclaimer related to YouTube videos
@@ -23412,8 +24151,8 @@ msgstr "Dina chattar sparas nu."
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never saved or used to train AI models"
 msgstr ""
-"Dina chattar är privata, sparas aldrig och används inte för att träna "
-"AI-modeller"
+"Dina chattar är privata, sparas aldrig och används inte för att träna AI-"
+"modeller"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
@@ -23556,10 +24295,10 @@ msgid ""
 "browser. We save the settings file using the key as the name. DuckDuckGo "
 "never knows your passphrase."
 msgstr ""
-"Ditt lösenord genererar en 512-bitars nyckel med hjälp av Secure "
-"Hash-algoritmen %1$sSHA-2%2$s. Endast nyckeln och tillhörande "
-"inställningsfil lämnar din webbläsare. Vi sparar inställningsfilen med "
-"nyckeln som namn. DuckDuckGo känner aldrig till ditt lösenord."
+"Ditt lösenord genererar en 512-bitars nyckel med hjälp av Secure Hash-"
+"algoritmen %1$sSHA-2%2$s. Endast nyckeln och tillhörande inställningsfil "
+"lämnar din webbläsare. Vi sparar inställningsfilen med nyckeln som namn. "
+"DuckDuckGo känner aldrig till ditt lösenord."
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -23770,7 +24509,8 @@ msgstr "av %1$s"
 #. Trust line shown at the bottom of the explainer panel, summarizing DuckDuckGo's reputation for online protection.
 msgctxt "Footer banner text in the How Duck.ai Works panel"
 msgid "by DuckDuckGo — online protection trusted by millions every day."
-msgstr "av DuckDuckGo — onlineskydd som miljontals människor litar på varje dag."
+msgstr ""
+"av DuckDuckGo — onlineskydd som miljontals människor litar på varje dag."
 
 # smartling.placeholder_format=C
 #. An abreviated unit of time indicating an age, e.g. "2d"
@@ -23984,8 +24724,8 @@ msgstr "den officiella webbplatsen"
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
 msgstr ""
-"eller skriv koden för färgen du vill ha, t.ex. %1$s (%2$s är ett kodat "
-"%3$s-tecken)"
+"eller skriv koden för färgen du vill ha, t.ex. %1$s (%2$s är ett kodat %3$s-"
+"tecken)"
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "

--- a/locales/sv_SE/LC_MESSAGES/duckduckgo.po
+++ b/locales/sv_SE/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: sv_SE\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -22,8 +22,7 @@ msgstr "!Bang-sökgenvägar"
 msgctxt ""
 "Body copy for the Remove Device confirmation modal; %s is the device name"
 msgid "\"%s\" will no longer be able to access your synced data."
-msgstr ""
-"”%1$s” kommer inte längre att få tillgång till dina synkroniserade data."
+msgstr "”%1$s” kommer inte längre att få tillgång till dina synkroniserade data."
 
 # smartling.placeholder_format=C
 #. Used to specify the rank of a team/player in a specific ranking in short form. This should be interpreted as 'Ranked number <rankNumber> in the <rankingName> ranking. Here you only need to translate the # symbol for ranked number. If your language doesn't provide a single-letter convention, please leave #.
@@ -417,8 +416,7 @@ msgstr "%1$s ord"
 #. Instructions on which buttons and options the user has to click in order to add the DuckDuckGo extension to their browser.
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
-msgstr ""
-"%1$sKlicka på %2$sLägg till%3$sMarkera %4$sTillåt%5$s och sedan på %6$sOK%7$s"
+msgstr "%1$sKlicka på %2$sLägg till%3$sMarkera %4$sTillåt%5$s och sedan på %6$sOK%7$s"
 
 # Firefox, obsolete
 # smartling.placeholder_format=C
@@ -1279,8 +1277,7 @@ msgstr "Installera tillägget DuckDuckGo"
 # smartling.placeholder_format=C
 msgid ""
 "Add DuckDuckGo Privacy Essentials to your browser for free with one download:"
-msgstr ""
-"Ladda ner DuckDuckGo Privacy Essentials utan kostnad för din webbläsare:"
+msgstr "Ladda ner DuckDuckGo Privacy Essentials utan kostnad för din webbläsare:"
 
 #  IE default search engine instruction
 # smartling.placeholder_format=C
@@ -1438,7 +1435,7 @@ msgstr "Adressen är fel"
 #. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Adjust the servings"
-msgstr ""
+msgstr "Justera portionerna"
 
 # smartling.placeholder_format=C
 #. as in multiple advertisements
@@ -1516,8 +1513,7 @@ msgstr "Afrikaans"
 # smartling.placeholder_format=C
 #. Instructions on how to install the DuckDuckGo browser extension after it downloads.
 msgid "After it downloads and opens, click %sInstall%s"
-msgstr ""
-"Efter att ha laddat ner och öppnat den klickar du på %1$sInstallera%2$s"
+msgstr "Efter att ha laddat ner och öppnat den klickar du på %1$sInstallera%2$s"
 
 # smartling.placeholder_format=C
 #. Instructions on how to install the DuckDuckGo browser extension after it downloads.
@@ -1661,6 +1657,8 @@ msgid ""
 "All chats are anonymized by DuckDuckGo, and your conversations are not used "
 "to train chat models by DuckDuckGo or the model providers"
 msgstr ""
+"Alla chattar anonymiseras av DuckDuckGo, och dina konversationer används "
+"inte för att träna chattmodeller hos DuckDuckGo eller modellleverantörerna"
 
 # smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1753,8 +1751,7 @@ msgstr "Tillåt annonser som respekterar integritet"
 # smartling.placeholder_format=C
 #. Title in a dialog informing the user how to disable their ad blocker for DuckDuckGo
 msgid "Allow privacy-respecting ads on DuckDuckGo Private Search"
-msgstr ""
-"Tillåt annonser som respekterar integritet på DuckDuckGo Private Search"
+msgstr "Tillåt annonser som respekterar integritet på DuckDuckGo Private Search"
 
 # smartling.placeholder_format=C
 #. Description explaining privacy implications of enabling web search on encrypted models. The first two placeholders are the full model name (e.g. 'gpt-oss 120B'). The third and fourth placeholders wrap a clickable link reading 'zero provider visibility' that opens the privacy modal, please keep those around the link text in your translation. An example full sentence would be: Allows gpt-oss 120B to search the web to improve responses to relevant prompts. Only sends AI-generated queries to a search engine with limited data retention. Prompts and responses with gpt-oss 120B still have zero provider visibility.
@@ -1939,6 +1936,8 @@ msgid ""
 "Anonymously generates answers for search queries based on web content. "
 "Choose how often you want it to appear, or disable it completely."
 msgstr ""
+"Anonymt genererar svar på sökfrågor baserat på webbinnehåll. Välj hur ofta "
+"du vill att det ska visas, eller inaktivera det helt."
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -2085,22 +2084,19 @@ msgstr "Är du fortfarande där?"
 msgctxt "Body text for clear all chats confirmation modal"
 msgid ""
 "Are you sure you want to clear all of your chats? This cannot be undone."
-msgstr ""
-"Är du säker på att du vill rensa alla dina chattar? Detta kan inte ångras."
+msgstr "Är du säker på att du vill rensa alla dina chattar? Detta kan inte ångras."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that asks the user if they want to clear the conversation.
 msgctxt "Modal body for clearing conversation"
 msgid "Are you sure you want to clear this conversation and start a new one?"
-msgstr ""
-"Är du säker på att du vill rensa den här konversationen och starta en ny?"
+msgstr "Är du säker på att du vill rensa den här konversationen och starta en ny?"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to delete their current chat, explaining that this action cannot be undone.
 msgctxt "Body text for delete chat confirmation modal"
 msgid "Are you sure you want to delete this chat? This cannot be undone."
-msgstr ""
-"Är du säker på att du vill ta bort den här chatten? Detta kan inte ångras."
+msgstr "Är du säker på att du vill ta bort den här chatten? Detta kan inte ångras."
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to disable chat history, with a warning that it will also delete currently saved chats including pinned chats.
@@ -2225,7 +2221,7 @@ msgstr "Fråga Duck.ai om en uppföljning"
 #. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
 msgctxt "Page suggestion chip label"
 msgid "Ask about this page"
-msgstr ""
+msgstr "Fråga om den här sidan"
 
 # smartling.placeholder_format=C
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2307,11 +2303,11 @@ msgid ""
 "to remember that responses are auto-generated from cited sources and based "
 "on %scrawling the web%s."
 msgstr ""
-"Assist är en valbar funktion i våra sökresultat som anonymt kan generera AI-"
-"assisterade svar på sökfrågor. För att göra detta skannar den webben efter "
-"relevant innehåll och använder sedan AI-driven naturlig språkteknologi för "
-"att generera ett kort svar baserat på relevant information som hittats. Det "
-"är viktigt att komma ihåg att svaren genereras automatiskt från citerade "
+"Assist är en valbar funktion i våra sökresultat som anonymt kan generera "
+"AI-assisterade svar på sökfrågor. För att göra detta skannar den webben "
+"efter relevant innehåll och använder sedan AI-driven naturlig språkteknologi "
+"för att generera ett kort svar baserat på relevant information som hittats. "
+"Det är viktigt att komma ihåg att svaren genereras automatiskt från citerade "
 "källor och baseras på %1$sgenomsökning av webben%2$s."
 
 # smartling.placeholder_format=C
@@ -2403,8 +2399,7 @@ msgstr "Ljud lagras inte av oss eller av OpenAI efter att chatten avslutats."
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat is transcribed."
-msgstr ""
-"Ljud lagras inte av oss eller av OpenAI efter att chatten har transkriberats."
+msgstr "Ljud lagras inte av oss eller av OpenAI efter att chatten har transkriberats."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when MediaRecorder API is unavailable.
@@ -2445,8 +2440,7 @@ msgstr "Autosvar"
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid "Auto-generated based on listed sources. May contain inaccuracies."
-msgstr ""
-"Automatiskt genererad baserat på angivna källor. Kan innehålla felaktigheter."
+msgstr "Automatiskt genererad baserat på angivna källor. Kan innehålla felaktigheter."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
@@ -2645,7 +2639,7 @@ msgstr "Streckkod"
 #. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Based on this page, is this course worth taking?"
-msgstr ""
+msgstr "Är den här kursen värd att gå, baserat på den här sidan?"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2694,6 +2688,9 @@ msgid ""
 "Before storing this report, DuckDuckGo will anonymize your conversation by "
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
+"Innan denna rapport lagras kommer DuckDuckGo att anonymisera din "
+"konversation genom att ta bort personuppgifter som namn, e-postadresser och "
+"identifierande metadata."
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -3015,7 +3012,7 @@ msgstr "Vunna breakpoäng"
 #. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Break this down into clear, numbered steps."
-msgstr ""
+msgstr "Dela upp detta i tydliga, numrerade steg."
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -3075,8 +3072,8 @@ msgid ""
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
 msgstr ""
 "Surfa som vanligt medan vi ger dig integritetsskydd. Vi har förenat vår "
-"sökmotor, spårningsblockerare och tvingande kryptering i ett %1$s%2$s-"
-"tillägg%3$s."
+"sökmotor, spårningsblockerare och tvingande kryptering i ett "
+"%1$s%2$s-tillägg%3$s."
 
 # smartling.placeholder_format=C
 msgid ""
@@ -3473,7 +3470,7 @@ msgstr "Skådespelare"
 #. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Cast & Crew"
-msgstr ""
+msgstr "Medverkande"
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -3710,12 +3707,12 @@ msgid ""
 "DuckDuckGo Search. However, you can still access Chat when this setting is "
 "off by visiting %shttps://duck.ai%s directly."
 msgstr ""
-"Med chatten (via vår tjänst Duck.ai) kan du ha anonyma konversationer med AI-"
-"chattmodeller från tredje part med stöd för modeller från OpenAI, Anthropic "
-"och fler. Om du stänger av den här inställningen döljs chattknappar och "
-"länkar på DuckDuckGo Search. Du kan dock fortfarande komma åt chatten när "
-"den här inställningen är avstängd genom att gå till %1$shttps://duck.ai%2$s "
-"direkt."
+"Med chatten (via vår tjänst Duck.ai) kan du ha anonyma konversationer med "
+"AI-chattmodeller från tredje part med stöd för modeller från OpenAI, "
+"Anthropic och fler. Om du stänger av den här inställningen döljs "
+"chattknappar och länkar på DuckDuckGo Search. Du kan dock fortfarande komma "
+"åt chatten när den här inställningen är avstängd genom att gå till "
+"%1$shttps://duck.ai%2$s direkt."
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -3938,8 +3935,7 @@ msgstr "Kontrollera stavningen"
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
 msgctxt "noresults"
 msgid "Check the DuckDuckGo subreddit for updates on this outage."
-msgstr ""
-"Kolla DuckDuckGos subreddit för att se uppdateringar om det här avbrottet."
+msgstr "Kolla DuckDuckGos subreddit för att se uppdateringar om det här avbrottet."
 
 # smartling.placeholder_format=C
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
@@ -4350,8 +4346,7 @@ msgstr "Klicka på %1$sInställningar%2$s i rullgardinsmenyn."
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
-msgstr ""
-"Klicka på %1$sAnvänd aktuella sidor%2$s och sedan på %3$sKlicka på OK%4$s."
+msgstr "Klicka på %1$sAnvänd aktuella sidor%2$s och sedan på %3$sKlicka på OK%4$s."
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -5191,7 +5186,7 @@ msgstr "Skapa bild"
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
-msgstr ""
+msgstr "Skapa en inköpslista med mängder från det här receptet."
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed in the input field when starting a new image generation session.
@@ -5828,8 +5823,7 @@ msgstr "Diktering i Duck.ai"
 # smartling.placeholder_format=C
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
-msgstr ""
-"Diktering anonymiseras av oss och används aldrig för att träna AI-modeller."
+msgstr "Diktering anonymiseras av oss och används aldrig för att träna AI-modeller."
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
@@ -5839,7 +5833,7 @@ msgstr "Dikteringsgräns uppnådd"
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
 msgid "Dictation temporarily unavailable"
-msgstr ""
+msgstr "Diktering är inte tillgängligt just nu"
 
 # smartling.placeholder_format=C
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
@@ -6116,8 +6110,7 @@ msgstr "Ser du inte DuckDuckGo i listan?"
 #. Link to download a file again if the user can't find it on their computer.
 msgctxt "install-extension"
 msgid "Don't see it? %s%s%sClick here to re-download%s"
-msgstr ""
-"Hittar du inte filen? %1$s%2$s%3$sKlicka här för att ladda ner den igen%4$s"
+msgstr "Hittar du inte filen? %1$s%2$s%3$sKlicka här för att ladda ner den igen%4$s"
 
 #  IE < 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -6149,6 +6142,8 @@ msgid ""
 "Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
 "filtered out. %sLearn More%s"
 msgstr ""
+"Vill du inte ha AI? %1$s@noai.duckduckgo.com%2$s erbjuder inga AI-funktioner "
+"och AI-bilder filtreras bort. %3$sLäs mer%4$s"
 
 # smartling.placeholder_format=C
 #. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
@@ -6157,6 +6152,8 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
+"Vill du inte ha AI? Besök %1$snoai.duckduckgo.com%2$s för att söka utan "
+"AI-funktioner och med AI-bilder bortfiltrerade. %3$sLäs mer%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6276,13 +6273,13 @@ msgstr ""
 #. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Draft a cover letter"
-msgstr ""
+msgstr "Skriv ett personligt brev"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Draft a cover letter for this job."
-msgstr ""
+msgstr "Skapa ett personligt brev för det här jobbet."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -6468,6 +6465,9 @@ msgid ""
 "company for anyone who wants to take back control of their personal "
 "information."
 msgstr ""
+"Duck.ai är skapat av DuckDuckGo. Vi är ett oberoende företag inom "
+"integritetsskydd online för alla som vill ta tillbaka kontrollen över sin "
+"personliga information."
 
 # smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
@@ -6520,6 +6520,9 @@ msgid ""
 "Duck.ai lets you chat privately with popular AI models. Disabling it hides "
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
+"Duck.ai låter dig chatta privat med populära AI-modeller. Att inaktivera det "
+"döljer Duck.ai-knappar och länkar, men du kan fortfarande besöka "
+"%1$sduck.ai%2$s direkt."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6593,9 +6596,9 @@ msgid ""
 "AI chat no sign up, OpenAI, Anthropic, Llama, Mistral, open source AI "
 "models, privacy focused AI, no account AI chat"
 msgstr ""
-"Duck.ai, DuckDuckGo AI, privat AI-chattbot, gratis AI-chatt, anonym AI-"
-"chatt, AI-chatt utan registrering, OpenAI, Anthropic, Llama, Mistral, AI-"
-"modeller med öppen källkod, integritetsfokuserad AI, AI-chatt utan konto"
+"Duck.ai, DuckDuckGo AI, privat AI-chattbot, gratis AI-chatt, anonym "
+"AI-chatt, AI-chatt utan registrering, OpenAI, Anthropic, Llama, Mistral, "
+"AI-modeller med öppen källkod, integritetsfokuserad AI, AI-chatt utan konto"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -6764,8 +6767,7 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr ""
-"DuckDuckGo AI Chat är inte tillgänglig för tillfället. Försök igen senare."
+msgstr "DuckDuckGo AI Chat är inte tillgänglig för tillfället. Försök igen senare."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -7519,13 +7521,13 @@ msgstr "Eritrea"
 #. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Estimate the nutrition"
-msgstr ""
+msgstr "Uppskatta näringsinnehållet"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Estimate the nutritional information for this recipe."
-msgstr ""
+msgstr "Uppskatta näringsvärdet för det här receptet."
 
 # smartling.placeholder_format=C
 msgid "Estonia"
@@ -7585,57 +7587,56 @@ msgstr "Går ut om 1 dag"
 #. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain the accepted answer in simple terms."
-msgstr ""
+msgstr "Förklara det accepterade svaret med enkla ord."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
-msgstr ""
-"Förklara de grundläggande begreppen för svarta hål för mig på gymnasienivå."
+msgstr "Förklara de grundläggande begreppen för svarta hål för mig på gymnasienivå."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain the top answer"
-msgstr ""
+msgstr "Förklara det översta svaret"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain this in simple, plain language."
-msgstr ""
+msgstr "Förklara detta på ett enkelt och tydligt språk."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain this paper"
-msgstr ""
+msgstr "Förklara den här artikeln"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain this repo"
-msgstr ""
+msgstr "Förklara det här repot"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain this research paper in plain language."
-msgstr ""
+msgstr "Förklara den här forskningsartikeln på ett enkelt och tydligt språk."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain this simply"
-msgstr ""
+msgstr "Förklara detta enkelt"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain what this repository does and how to use it."
-msgstr ""
+msgstr "Förklara vad det här arkivet gör och hur man använder det."
 
 # smartling.placeholder_format=C
 #. Label to show if song lyrics contain explicit content
@@ -7812,8 +7813,7 @@ msgstr "Feedback har skickats"
 msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and improvements."
-msgstr ""
-"Din feedback påverkar direkt våra produktuppdateringar och förbättringar."
+msgstr "Din feedback påverkar direkt våra produktuppdateringar och förbättringar."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -7925,6 +7925,8 @@ msgctxt "settings"
 msgid ""
 "Filters out known AI spam sites from image search results. %sLearn More%s"
 msgstr ""
+"Filtrerar bort kända webbplatser med AI-spam från bildsökresultat. %1$sLäs "
+"mer%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the final score of a sporting event.
@@ -7965,8 +7967,7 @@ msgstr "Hitta <b>%1$s</b> i din nedladdningsmapp"
 # smartling.placeholder_format=C
 #. Tells users how to change their default search engine to DuckDuckGo.
 msgid "Find DuckDuckGo in the displayed list and click %sMake Default%s"
-msgstr ""
-"Hitta DuckDuckGo i listan som visas och klicka på %1$sAnvänd som standard%2$s"
+msgstr "Hitta DuckDuckGo i listan som visas och klicka på %1$sAnvänd som standard%2$s"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for finding a better word.
@@ -7984,7 +7985,7 @@ msgstr "Hitta aktuell information"
 #. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Find me alternatives"
-msgstr ""
+msgstr "Hitta alternativ åt mig"
 
 # smartling.placeholder_format=C
 #. Button that searches for results closer to the user's current location.
@@ -8003,8 +8004,7 @@ msgstr "Hitta sökresultat närmare dig."
 msgctxt "Precise user location overlay"
 msgid ""
 "Find results near you. %sYour location stays private, secure, and anonymous."
-msgstr ""
-"Hitta resultat nära dig. %1$sDin plats förblir privat, säker och anonym."
+msgstr "Hitta resultat nära dig. %1$sDin plats förblir privat, säker och anonym."
 
 # smartling.placeholder_format=C
 #. Loading message shown while generating explore more follow-up questions
@@ -8180,8 +8180,7 @@ msgstr "Kostnadsfria och privata chattar, anonymiserade av oss"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr ""
-"Kostnadsfria och privata chattar, anonymiserade av oss. Inget konto behövs."
+msgstr "Kostnadsfria och privata chattar, anonymiserade av oss. Inget konto behövs."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -8467,7 +8466,7 @@ msgstr "Generera mer"
 #. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Generate a shopping list"
-msgstr ""
+msgstr "Skapa en inköpslista"
 
 # smartling.placeholder_format=C
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
@@ -8660,9 +8659,9 @@ msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"Få tillgång till avancerade AI-modeller i Duck.ai med ett DuckDuckGo-"
-"abonnemang, som även inkluderar vårt VPN och andra premiumskydd för "
-"integritet."
+"Få tillgång till avancerade AI-modeller i Duck.ai med ett "
+"DuckDuckGo-abonnemang, som även inkluderar vårt VPN och andra premiumskydd "
+"för integritet."
 
 # smartling.placeholder_format=C
 #. A button for users to generate an AI generated answer from their query on the duckassist module
@@ -8766,7 +8765,7 @@ msgstr "Prova det"
 #. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Give me a quick background on this person."
-msgstr ""
+msgstr "Ge mig en snabb bakgrund om den här personen."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9036,8 +9035,7 @@ msgstr "Guatemala"
 #. Text for a prompt suggestion for guiding through the basic steps of replacing a window wiper.
 msgctxt "Full sentence for learning a new skill"
 msgid "Guide me through the basic steps of replacing a window wiper."
-msgstr ""
-"Guida mig genom de grundläggande stegen för att byta ut en fönstertorkare."
+msgstr "Guida mig genom de grundläggande stegen för att byta ut en fönstertorkare."
 
 # smartling.placeholder_format=C
 msgid "Guinea"
@@ -9219,13 +9217,13 @@ msgstr "Hjälp till att sprida integritetsskydd"
 #. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Help me prep for the interview"
-msgstr ""
+msgstr "Hjälp mig att förbereda mig för intervjun"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Help me tailor my resume for this job."
-msgstr ""
+msgstr "Hjälp mig att anpassa mitt CV för det här jobbet."
 
 # smartling.placeholder_format=C
 #. Title of a SERP popup that invites users to take a survey (desktop only)
@@ -9750,7 +9748,7 @@ msgctxt ""
 "Text for the I already have a subscription button in the Duck.ai settings "
 "page"
 msgid "I Already Have a Subscription"
-msgstr ""
+msgstr "Jag har redan ett abonnemang"
 
 # smartling.placeholder_format=C
 #. Text for the button that takes the user to the login subscription page.
@@ -9918,8 +9916,7 @@ msgstr ""
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
-msgstr ""
-"Om du fortfarande vill stödja oss, %1$shjälp till sprida DuckDuckGo%2$s"
+msgstr "Om du fortfarande vill stödja oss, %1$shjälp till sprida DuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -10330,7 +10327,7 @@ msgstr "Installera webbläsaren för Mac"
 #. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
 msgctxt "settings"
 msgid "Install Now"
-msgstr ""
+msgstr "Installera nu"
 
 # smartling.placeholder_format=C
 #. Text of a button to install the DuckDuckGo app
@@ -10433,13 +10430,13 @@ msgstr "Tas data verkligen bort?"
 #. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Is it worth taking?"
-msgstr ""
+msgstr "Är det värt att ta?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Is this place any good?"
-msgstr ""
+msgstr "Är det här stället bra?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
@@ -10448,6 +10445,8 @@ msgid ""
 "Is this place any good? Summarize its reputation based on reviews and "
 "ratings."
 msgstr ""
+"Är det här stället bra? Sammanfatta dess rykte baserat på recensioner och "
+"betyg."
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -10459,13 +10458,13 @@ msgstr "Är den här videon till hjälp?"
 #. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Is this worth watching?"
-msgstr ""
+msgstr "Är det värt att titta på?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Is this worth watching? Give me a spoiler-free take."
-msgstr ""
+msgstr "Är det värt att titta på? Ge mig en spoilerfri bedömning."
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -10497,8 +10496,7 @@ msgstr "Det är snabbt, gratis och ger dig ännu mer skydd online."
 msgctxt "settings"
 msgid ""
 "It's okay to (very infrequently) ask me about my experience using DuckDuckGo"
-msgstr ""
-"Det är okej att fråga mig om min upplevelse med DuckDuckGo (inte så ofta)"
+msgstr "Det är okej att fråga mig om min upplevelse med DuckDuckGo (inte så ofta)"
 
 # smartling.placeholder_format=C
 #. The name of the Italian language
@@ -11080,7 +11078,7 @@ msgstr "Länkar:"
 #. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
-msgstr ""
+msgstr "Lista verktygen, materialen eller förutsättningarna jag behöver för detta."
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -11191,8 +11189,7 @@ msgstr "Läser in fler sökresultat med bilder när du skrollar"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Loads more results in Images, Videos, and Shopping when scrolling"
-msgstr ""
-"Läser in fler sökresultat med bilder, videor och shopping när du skrollar"
+msgstr "Läser in fler sökresultat med bilder, videor och shopping när du skrollar"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/WTkvs9I.png
@@ -11493,7 +11490,7 @@ msgstr "Hantera blockerade webbplatser"
 #. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
 msgctxt "setting"
 msgid "Manage in Browser Settings"
-msgstr ""
+msgstr "Hantera i webbläsarinställningar"
 
 # smartling.placeholder_format=C
 #. Link to the site exclusion settings page
@@ -12468,10 +12465,11 @@ msgid ""
 "internet connection. Disabling chat history will delete pinned chats, and "
 "disable the temporary storage of new prompts and responses."
 msgstr ""
-"Nya promptar och svar krypteras och lagras tillfälligt på en DuckDuckGo-"
-"server efter att de har skickats, så att du kan återställa chatten om din "
-"internetanslutning bryts. Om du inaktiverar chatthistoriken raderas fästa "
-"chattar och tillfällig lagring av nya promptar och svar inaktiveras."
+"Nya promptar och svar krypteras och lagras tillfälligt på en "
+"DuckDuckGo-server efter att de har skickats, så att du kan återställa "
+"chatten om din internetanslutning bryts. Om du inaktiverar chatthistoriken "
+"raderas fästa chattar och tillfällig lagring av nya promptar och svar "
+"inaktiveras."
 
 # smartling.placeholder_format=C
 #. Question in a feedback form.
@@ -14310,8 +14308,7 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this prompt was made by a "
 "human."
-msgstr ""
-"Lös följande utmaning för att bekräfta att prompten görs av en människa."
+msgstr "Lös följande utmaning för att bekräfta att prompten görs av en människa."
 
 # smartling.placeholder_format=C
 #. Bot challenge explanation
@@ -14319,14 +14316,13 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this search was made by a "
 "human."
-msgstr ""
-"Lös följande utmaning för att bekräfta att sökningen görs av en människa."
+msgstr "Lös följande utmaning för att bekräfta att sökningen görs av en människa."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is harmful or illegal. (optional)"
-msgstr ""
+msgstr "Beskriv varför chattsvaret är skadligt eller olagligt. (valfritt)"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
@@ -14363,6 +14359,9 @@ msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is harmful or illegal."
 msgstr ""
+"Klistra in din prompt och den problematiska utdatan (med all personlig "
+"information borttagen) och beskriv varför innehållet är skadligt eller "
+"olagligt."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -14836,7 +14835,7 @@ msgstr "Integritet"
 #. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
 msgctxt "Section heading on the Duck.ai settings page"
 msgid "Privacy & Terms"
-msgstr ""
+msgstr "Integritet och villkor"
 
 # smartling.placeholder_format=C
 msgid "Privacy Blog"
@@ -14912,7 +14911,7 @@ msgstr "Integritetspolicy och användarvillkor"
 #. Text for a button that links to the terms of use and privacy policy page.
 msgctxt "Secondary button text in active privacy modal"
 msgid "Privacy Policy and Terms of Service"
-msgstr ""
+msgstr "Integritetspolicy och användarvillkor"
 
 # smartling.placeholder_format=C
 #. Title displayed on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
@@ -15086,8 +15085,7 @@ msgstr "Fråga mig"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Prompt me to use my approximate location to get nearby results."
-msgstr ""
-"Be mig använda min ungefärliga plats för att få sökresultat i närheten."
+msgstr "Be mig använda min ungefärliga plats för att få sökresultat i närheten."
 
 # smartling.placeholder_format=C
 #. DuckDuckGo Email Protection removes trackers from emails
@@ -15368,8 +15366,8 @@ msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
 msgstr ""
-"De senaste chattarna lagras lokalt på din enhet istället för på DuckDuckGo-"
-"servrar eller andra fjärrservrar."
+"De senaste chattarna lagras lokalt på din enhet istället för på "
+"DuckDuckGo-servrar eller andra fjärrservrar."
 
 # smartling.placeholder_format=C
 #. Text explaining that recent chats are stored locally on the user's device.
@@ -15378,8 +15376,8 @@ msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
 msgstr ""
-"De senaste chattarna lagras lokalt på din enhet istället för på DuckDuckGo-"
-"servrar eller andra fjärrservrar."
+"De senaste chattarna lagras lokalt på din enhet istället för på "
+"DuckDuckGo-servrar eller andra fjärrservrar."
 
 # smartling.placeholder_format=C
 #. Text explaining how recent chats are stored locally on the user's device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection.
@@ -15418,25 +15416,25 @@ msgstr "Rekommendera en bok"
 #. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Recommend similar books"
-msgstr ""
+msgstr "Rekommendera liknande böcker"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Recommend similar books."
-msgstr ""
+msgstr "Rekommendera liknande böcker."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Recommend similar movies or shows."
-msgstr ""
+msgstr "Rekommendera liknande filmer eller program."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Recommend similar titles"
-msgstr ""
+msgstr "Rekommendera liknande titlar"
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
@@ -15845,7 +15843,7 @@ msgctxt ""
 "feedback form when the user has selected Harmful or Illegal as the feedback "
 "reason"
 msgid "Required for harmful or illegal reports"
-msgstr ""
+msgstr "Krävs för skadliga eller olagliga rapporter"
 
 # smartling.placeholder_format=C
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
@@ -16090,7 +16088,7 @@ msgstr "Recensioner"
 #. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Rewrite this recipe scaled for a different number of servings."
-msgstr ""
+msgstr "Skriv om det här receptet anpassat för ett annat antal portioner."
 
 # smartling.placeholder_format=C
 msgid "Romania"
@@ -16376,8 +16374,7 @@ msgstr "Spara upp till 30 av dina senaste chattar lokalt på din enhet."
 msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
-msgstr ""
-"Spara dina Duck.ai-chattar mellan dina enheter med end-to-end-kryptering."
+msgstr "Spara dina Duck.ai-chattar mellan dina enheter med end-to-end-kryptering."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -16536,15 +16533,13 @@ msgstr "Skrolla nedåt och leta reda på %1$sdin webbläsare%2$s i listan."
 #. Tells users which setting to change to enable location service.
 msgctxt "precise_user_location"
 msgid "Scroll down to %sDuckDuckGo%s and allow it to use your location."
-msgstr ""
-"Skrolla ner till %1$sDuckDuckGo%2$s och ge tillåtelse att använda din plats."
+msgstr "Skrolla ner till %1$sDuckDuckGo%2$s och ge tillåtelse att använda din plats."
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down to the %sServices%s section and click %sAddress bar%s."
-msgstr ""
-"Skrolla ner till avsnittet %1$sTjänster%2$s och klicka på %3$sAdressfält%4$s."
+msgstr "Skrolla ner till avsnittet %1$sTjänster%2$s och klicka på %3$sAdressfält%4$s."
 
 # smartling.placeholder_format=C
 #. Rugby match stats
@@ -16874,8 +16869,7 @@ msgstr "Säsongsveckor"
 #. Description shown in the Sync & Backup settings section when sync is not yet enabled, explaining the feature.
 msgctxt "Description for sync and backup feature"
 msgid "Securely save and sync your chats across all your devices."
-msgstr ""
-"Spara och synkronisera dina chattar på ett säkert sätt på alla dina enheter."
+msgstr "Spara och synkronisera dina chattar på ett säkert sätt på alla dina enheter."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -16884,8 +16878,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
 msgstr ""
-"Lagra säkert nästan obegränsat antal chattar på vår server med end-to-end-"
-"kryptering och få åtkomst till dem från alla dina enheter."
+"Lagra säkert nästan obegränsat antal chattar på vår server med "
+"end-to-end-kryptering och få åtkomst till dem från alla dina enheter."
 
 # smartling.placeholder_format=C
 #. Text explaining that the Encrypted Storage feature stores the user's chats encrypted on their device.
@@ -16894,8 +16888,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
 msgstr ""
-"Lagra säkert nästan obegränsat antal chattar på vår server med end-to-end-"
-"kryptering och få åtkomst till dem från alla dina enheter."
+"Lagra säkert nästan obegränsat antal chattar på vår server med "
+"end-to-end-kryptering och få åtkomst till dem från alla dina enheter."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -16914,8 +16908,8 @@ msgid ""
 "Securely store your chats on our server using end-to-end encryption, and "
 "access them from all your devices."
 msgstr ""
-"Lagra dina chattar på ett säkert sätt på vår server med end-to-end-"
-"kryptering och få åtkomst till dem från alla dina enheter."
+"Lagra dina chattar på ett säkert sätt på vår server med "
+"end-to-end-kryptering och få åtkomst till dem från alla dina enheter."
 
 # smartling.placeholder_format=C
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
@@ -17421,7 +17415,7 @@ msgstr "Ställ in nu"
 #. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
 msgctxt "Encrypted storage setup button shown in native browsers"
 msgid "Set Up Sync & Backup"
-msgstr ""
+msgstr "Ställ in Sync & Backup"
 
 # smartling.placeholder_format=C
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
@@ -17459,8 +17453,7 @@ msgstr ""
 #. Prompt for the user to indicate their location on a map, to enable more relevant search results.
 msgctxt "precise_user_location"
 msgid "Set your location manually, or ensure Location Services is enabled."
-msgstr ""
-"Ställ in din plats manuellt eller se till att platstjänster är aktiverade."
+msgstr "Ställ in din plats manuellt eller se till att platstjänster är aktiverade."
 
 # smartling.placeholder_format=C
 #. In the top dropdown menu  ("More" > "Settings")
@@ -17607,7 +17600,7 @@ msgstr "Dela positiv feedback"
 msgctxt ""
 "Label beside the share-content switch on the Duck.ai response feedback form"
 msgid "Share this conversation with DuckDuckGo"
-msgstr ""
+msgstr "Dela den här konversationen med DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -18010,14 +18003,12 @@ msgstr "Visar mest besökta länkar i ny flik"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your browser"
-msgstr ""
-"Visar påminnelser då och då om att lägga till DuckDuckGo i din webbläsare"
+msgstr "Visar påminnelser då och då om att lägga till DuckDuckGo i din webbläsare"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr ""
-"Visar påminnelser då och då om att lägga till DuckDuckGo i dina enheter"
+msgstr "Visar påminnelser då och då om att lägga till DuckDuckGo i dina enheter"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18035,8 +18026,7 @@ msgstr "Visar sidnummer där sidan med sökresultat bryts"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows sign-up form for the DuckDuckGo privacy newsletters"
-msgstr ""
-"Visar registreringsformuläret för nyhetsbrevet om integritet från DuckDuckGo"
+msgstr "Visar registreringsformuläret för nyhetsbrevet om integritet från DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/94erFcS.png
@@ -18062,8 +18052,7 @@ msgstr "Visar välkomstmeddelande högst upp på sidan med sökresultat"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message to EU Android preference menu users"
-msgstr ""
-"Visar välkomstmeddelande till användare av inställningsmeny för Android i EU"
+msgstr "Visar välkomstmeddelande till användare av inställningsmeny för Android i EU"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers sometimes.
@@ -18866,19 +18855,19 @@ msgstr "Förslag på rubrik för ett blogginlägg"
 #. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Suggest related articles or topics worth exploring next."
-msgstr ""
+msgstr "Föreslå relaterade artiklar eller ämnen som är värda att utforska härnäst."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Suggest related articles to explore"
-msgstr ""
+msgstr "Föreslå relaterade artiklar att utforska"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Suggest some alternatives to this product."
-msgstr ""
+msgstr "Föreslå några alternativ till den här produkten."
 
 # smartling.placeholder_format=C
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
@@ -18895,7 +18884,7 @@ msgstr "Förslag:"
 #. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Sum up the reviews"
-msgstr ""
+msgstr "Summera recensionerna"
 
 # smartling.placeholder_format=C
 #. A short title for the a message asking the AI to summarize a text.
@@ -18907,85 +18896,85 @@ msgstr "Sammanfatta"
 #. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize the Q&As"
-msgstr ""
+msgstr "Sammanfatta frågorna och svaren"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the background and notable work of this person."
-msgstr ""
+msgstr "Sammanfatta den här personens bakgrund och anmärkningsvärda arbete."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the key details of this event."
-msgstr ""
+msgstr "Sammanfatta de viktigaste detaljerna om den här händelsen."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the questions and answers on this page."
-msgstr ""
+msgstr "Sammanfatta frågorna och svaren på den här sidan."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize their background"
-msgstr ""
+msgstr "Sammanfatta deras bakgrund"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this book"
-msgstr ""
+msgstr "Sammanfatta denna bok"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this book."
-msgstr ""
+msgstr "Sammanfatta denna bok."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this discussion"
-msgstr ""
+msgstr "Sammanfatta denna diskussion"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this discussion thread."
-msgstr ""
+msgstr "Sammanfatta denna diskussionstråd."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this page"
-msgstr ""
+msgstr "Sammanfatta denna sida"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this page."
-msgstr ""
+msgstr "Sammanfatta denna sida."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this video"
-msgstr ""
+msgstr "Sammanfatta denna video"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this video."
-msgstr ""
+msgstr "Sammanfatta denna video."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize what the reviews say."
-msgstr ""
+msgstr "Sammanfatta vad recensionerna säger."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -19311,7 +19300,7 @@ msgstr "Syrien"
 #. Text for a button that enables the theme to follow the operating system's color scheme preference.
 msgctxt "System theme button for theme selector"
 msgid "System"
-msgstr ""
+msgstr "System"
 
 # smartling.placeholder_format=C
 #. Abbreviation indicating this is the total score for a game
@@ -19345,7 +19334,7 @@ msgstr "Tahitiska"
 #. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Tailor my resume"
-msgstr ""
+msgstr "Anpassa mitt CV"
 
 # smartling.placeholder_format=C
 msgid "Taiwan"
@@ -19382,6 +19371,8 @@ msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
+"Delta i denna anonyma undersökning och berätta hur vi kan göra Duck.ai "
+"bättre."
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -19692,7 +19683,7 @@ msgstr "Tema"
 #. Text for the theme selector label that allows users to switch between Light and dark theme.
 msgctxt "Label for the theme selector feature"
 msgid "Theme"
-msgstr ""
+msgstr "Tema"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/LpFhb1e.png
@@ -19745,8 +19736,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Error message for explore more questions when a retryable error occurs (timeout, network)
 msgid "There's been an issue loading this answer. Please try again."
-msgstr ""
-"Det uppstod ett problem när det här svaret skulle läsas in. Försök igen."
+msgstr "Det uppstod ett problem när det här svaret skulle läsas in. Försök igen."
 
 # smartling.placeholder_format=C
 #. Instant Answer Tab Name
@@ -20006,8 +19996,8 @@ msgstr "Denna sida kräver javascript för att fungera."
 msgctxt "Tooltip explaining that page content will be sent to Duck.ai"
 msgid "This page's content will be sent with your message to Duck.ai"
 msgstr ""
-"Innehållet på den här sidan kommer att skickas med ditt meddelande till Duck."
-"ai"
+"Innehållet på den här sidan kommer att skickas med ditt meddelande till "
+"Duck.ai"
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -20080,8 +20070,7 @@ msgstr "Denna video kan ännu inte visas här. Du kan titta på den på %1$s."
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr ""
-"Den här webbplats använder inte en säker, krypterad anslutning (HTTPS)."
+msgstr "Den här webbplats använder inte en säker, krypterad anslutning (HTTPS)."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -20266,8 +20255,8 @@ msgid ""
 "To transfer your chat history to Duck.ai, please update your DuckDuckGo "
 "browser to the latest version and try again."
 msgstr ""
-"För att överföra din chatthistorik till Duck.ai, uppdatera DuckDuckGo-"
-"webbläsaren till den senaste versionen och försök igen."
+"För att överföra din chatthistorik till Duck.ai, uppdatera "
+"DuckDuckGo-webbläsaren till den senaste versionen och försök igen."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
@@ -20532,13 +20521,13 @@ msgstr ""
 #. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Translate this page"
-msgstr ""
+msgstr "Översätt den här sidan"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
 msgctxt "Page suggestion prompt"
 msgid "Translate this page into %s."
-msgstr ""
+msgstr "Översätt den här sidan till %1$s."
 
 # smartling.placeholder_format=C
 #. Placeholder text for a region that will display translated text.
@@ -20685,7 +20674,7 @@ msgstr "Prova gratis"
 #. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
 msgctxt "settings"
 msgid "Try It Now"
-msgstr ""
+msgstr "Prova nu"
 
 # smartling.placeholder_format=C
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -20932,6 +20921,8 @@ msgid ""
 "Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
+"Försöker du inaktivera AI-funktioner? Installera söktillägget %1$sDuckDuckGo "
+"No AI%2$s för att komma ihåg dina inställningar. %3$sLäs mer%4$s"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -20940,6 +20931,8 @@ msgid ""
 "Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
+"Försöker du inaktivera AI-funktioner? Byt till sök-tillägget %1$sDuckDuckGo "
+"No AI%2$s för att komma ihåg dina inställningar. %3$sLäs mer%4$s"
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -21251,14 +21244,13 @@ msgstr ""
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
 msgstr ""
-"Under %1$sVid uppstart%2$s, välj %3$sStartsida%4$s och skriv: https://"
-"duckduckgo.com"
+"Under %1$sVid uppstart%2$s, välj %3$sStartsida%4$s och skriv: "
+"https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sOpen with%s select %sA specific page or pages%s"
-msgstr ""
-"Under %1$sÖppna med%2$s, välj %3$sEn särskild sida eller grupp av sidor%4$s"
+msgstr "Under %1$sÖppna med%2$s, välj %3$sEn särskild sida eller grupp av sidor%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -21285,8 +21277,7 @@ msgstr "Under sektionen %1$sSök%2$s, klicka på %3$sHantera sökmotorer...%4$s"
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under On startup select %sOpen a specific page or set of pages%s"
-msgstr ""
-"Under Vid start, välj %1$sÖppna en särskild sida eller grupp av sidor%2$s"
+msgstr "Under Vid start, välj %1$sÖppna en särskild sida eller grupp av sidor%2$s"
 
 #  Opera default search engine instruction
 # smartling.placeholder_format=C
@@ -21393,8 +21384,8 @@ msgctxt "voice chat limit modal"
 msgid ""
 "Unlock advanced AI models and higher limits with a DuckDuckGo Subscription"
 msgstr ""
-"Lås upp avancerade AI-modeller och högre gränser med en DuckDuckGo-"
-"prenumeration"
+"Lås upp avancerade AI-modeller och högre gränser med en "
+"DuckDuckGo-prenumeration"
 
 # smartling.placeholder_format=C
 #. Text informing the user that advanced AI models can be unlocked with a subscription. The variable is used to insert a link that opens the subscription modal. Example: Unlock advanced AI models with a DuckDuckGo subscription.
@@ -21694,7 +21685,7 @@ msgstr "Uruguay"
 #. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
 msgctxt "Navigation label on the Duck.ai settings page"
 msgid "Usage"
-msgstr ""
+msgstr "Användning"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -21752,8 +21743,7 @@ msgstr "Använd DuckDuckGo Private Search"
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Use DuckDuckGo private search on your iPad, iPhone, or Android!"
-msgstr ""
-"Använd privat sökning från DuckDuckGo på din iPad, iPhone eller Android!"
+msgstr "Använd privat sökning från DuckDuckGo på din iPad, iPhone eller Android!"
 
 # smartling.placeholder_format=C
 #. User clicks this button to share their device's location
@@ -22029,9 +22019,10 @@ msgid ""
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
 msgstr ""
-"Gå till Duck.ai i din andra webbläsare eller DuckDuckGo-appen och öppna Duck."
-"ai-inställningarna. Välj Aktivera under Sync & Backup och välj Synkronisera "
-"med en annan enhet. Eller skanna QR-koden på din återställnings-PDF."
+"Gå till Duck.ai i din andra webbläsare eller DuckDuckGo-appen och öppna "
+"Duck.ai-inställningarna. Välj Aktivera under Sync & Backup och välj "
+"Synkronisera med en annan enhet. Eller skanna QR-koden på din "
+"återställnings-PDF."
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -22084,8 +22075,8 @@ msgstr "Röstchatt avslutad"
 msgctxt "voice chat"
 msgid "Voice chat is anonymized by us, and never used to train AI models."
 msgstr ""
-"Röstchatt är anonymiserad av oss och används aldrig för att träna AI-"
-"modeller."
+"Röstchatt är anonymiserad av oss och används aldrig för att träna "
+"AI-modeller."
 
 # smartling.placeholder_format=C
 #. Title of the modal shown when the user has reached their daily voice chat limit.
@@ -22149,7 +22140,7 @@ msgstr "Wales"
 #. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Walk me through the steps"
-msgstr ""
+msgstr "Gå igenom stegen"
 
 # smartling.placeholder_format=C
 #. Label for walking directions on a map.
@@ -22265,8 +22256,7 @@ msgstr "Vi anonymiserar"
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
-msgstr ""
-"Vi kan anonymisera %1$sdin plats%2$s för att visa dig mer exakta resultat."
+msgstr "Vi kan anonymisera %1$sdin plats%2$s för att visa dig mer exakta resultat."
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
@@ -22278,6 +22268,9 @@ msgid ""
 "please share this conversation with DuckDuckGo so we can investigate and "
 "address the issue."
 msgstr ""
+"Vi kan bara åtgärda sådant som vi kan se. Om du vill rapportera ett skadligt "
+"eller olagligt svar delar du den här konversationen med DuckDuckGo så att vi "
+"kan undersöka och åtgärda problemet."
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -22297,16 +22290,14 @@ msgstr ""
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can use your anonymous%s location%s to show you nearby results."
-msgstr ""
-"Vi kan använda din %1$splats%2$s anonymt för att visa resultat i närheten."
+msgstr "Vi kan använda din %1$splats%2$s anonymt för att visa resultat i närheten."
 
 # smartling.placeholder_format=C
 #. Error message displayed when one or more attached files are encrypted and cannot be read.
 msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
-msgstr ""
-"Vi kan inte läsa de bifogade filerna eftersom minst en av dem är krypterad."
+msgstr "Vi kan inte läsa de bifogade filerna eftersom minst en av dem är krypterad."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -22317,8 +22308,7 @@ msgstr "Vi förföljer dig inte med annonser."
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
 msgid "We don't store usernames or any personally identifiable information."
-msgstr ""
-"Vi lagrar inte användarnamn eller annan personligt identifierbar information."
+msgstr "Vi lagrar inte användarnamn eller annan personligt identifierbar information."
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -22349,8 +22339,7 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what brought you "
 "back today:"
-msgstr ""
-"Vi spårar dig inte, och vi vill gärna veta varför du kom tillbaka idag:"
+msgstr "Vi spårar dig inte, och vi vill gärna veta varför du kom tillbaka idag:"
 
 # smartling.placeholder_format=C
 #. Message prompting users to fill out a feedback form.
@@ -22502,8 +22491,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
-msgstr ""
-"Vi blockerar spårare som försöker samla in dina uppgifter medan du surfar."
+msgstr "Vi blockerar spårare som försöker samla in dina uppgifter medan du surfar."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -22698,8 +22686,7 @@ msgstr ""
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai! You can now import your downloaded chats."
-msgstr ""
-"Välkommen till nya Duck.ai! Du kan nu importera dina nedladdade chattar."
+msgstr "Välkommen till nya Duck.ai! Du kan nu importera dina nedladdade chattar."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -22794,8 +22781,7 @@ msgstr "Kan du ge några faktorer man ska tänka på när man köper en datorsk�
 #. Text for a prompt suggestion for asking about must-see attractions in Paris for a first-time visitor.
 msgctxt "Full sentence for planning a trip"
 msgid "What are some must-see attractions in Paris for a first-time visitor?"
-msgstr ""
-"Vilka är några sevärdheter man måste se första gången man besöker i Paris?"
+msgstr "Vilka är några sevärdheter man måste se första gången man besöker i Paris?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for finding options for the word 'better' in a specific context.
@@ -22835,98 +22821,98 @@ msgstr ""
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the counterarguments?"
-msgstr ""
+msgstr "Vilka är motargumenten?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the hours & location?"
-msgstr ""
+msgstr "Vilka är öppettiderna och platsen?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key contributions of this paper?"
-msgstr ""
+msgstr "Vilka är de viktigaste bidragen i den här artikeln?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key contributions?"
-msgstr ""
+msgstr "Vilka är de viktigaste bidragen?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key details?"
-msgstr ""
+msgstr "Vilka är de viktigaste detaljerna?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key points covered in this video?"
-msgstr ""
+msgstr "Vilka är de viktigaste punkterna som tas upp i den här videon?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key points?"
-msgstr ""
+msgstr "Vilka är de viktigaste punkterna?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key takeaways from this article?"
-msgstr ""
+msgstr "Vilka är de viktigaste lärdomarna från den här artikeln?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key takeaways?"
-msgstr ""
+msgstr "Vilka är de viktigaste lärdomarna?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key things I will learn from this course?"
-msgstr ""
+msgstr "Vilka är de viktigaste sakerna jag kommer att lära mig av den här kursen?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the main counterarguments or criticisms of this?"
-msgstr ""
+msgstr "Vilka är de främsta motargumenten eller invändningarna mot detta?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the main questions this page answers?"
-msgstr ""
+msgstr "Vilka är de viktigaste frågorna som den här sidan besvarar?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the must-try dishes here?"
-msgstr ""
+msgstr "Vilka är de mest rekommenderade rätterna här?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid ""
 "What are the opening hours, location, and contact details for this place?"
-msgstr ""
+msgstr "Vilka är öppettiderna, platsen och kontaktuppgifterna för det här stället?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the pros and cons of this product?"
-msgstr ""
+msgstr "Vilka är för- och nackdelarna med den här produkten?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the pros and cons?"
-msgstr ""
+msgstr "Vilka är för- och nackdelarna?"
 
 # smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
@@ -23032,7 +23018,7 @@ msgstr "Vad betyder atria i samband med en medicinsk artikel?"
 #. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What does this answer?"
-msgstr ""
+msgstr "Vad säger det här svaret?"
 
 # smartling.placeholder_format=C
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
@@ -23050,7 +23036,7 @@ msgstr "Vilken information sparas?"
 #. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What interview questions might come up for this role?"
-msgstr ""
+msgstr "Vilka intervjufrågor kan dyka upp för den här rollen?"
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -23072,7 +23058,7 @@ msgstr "Vad är huvudstaden i Albanien?"
 #. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What is the overall verdict and rating for this?"
-msgstr ""
+msgstr "Vad är det övergripande omdömet och betyget för detta?"
 
 # smartling.placeholder_format=C
 #. Link to a page with additional information.
@@ -23100,7 +23086,7 @@ msgstr "Vad folk säger:"
 #. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What should I order?"
-msgstr ""
+msgstr "Vad ska jag beställa?"
 
 # smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
@@ -23118,13 +23104,13 @@ msgstr "Vad var det för fel på svaret? (valfritt)"
 #. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What will I learn?"
-msgstr ""
+msgstr "Vad är slutsatsen?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What will I need?"
-msgstr ""
+msgstr "Vad behöver jag?"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -23135,8 +23121,7 @@ msgstr "Vad vill du ge feedback om?"
 #. Explains the benefits of using our custom video player, the Duck Player
 msgid ""
 "What you watch in DuckDuckGo won't influence your recommendations on YouTube."
-msgstr ""
-"Det du tittar på i DuckDuckGo påverkar inte dina rekommendationer på YouTube."
+msgstr "Det du tittar på i DuckDuckGo påverkar inte dina rekommendationer på YouTube."
 
 # smartling.placeholder_format=C
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
@@ -23148,7 +23133,7 @@ msgstr "Vad är nytt?"
 #. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What's the verdict?"
-msgstr ""
+msgstr "Vad är domen?"
 
 # smartling.placeholder_format=C
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -23168,8 +23153,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "When enabled, Duck.ai will show instant answers in the chat."
-msgstr ""
-"När det är aktiverat kommer Duck.ai att visa omedelbara svar i chatten."
+msgstr "När det är aktiverat kommer Duck.ai att visa omedelbara svar i chatten."
 
 # smartling.placeholder_format=C
 #. Text of a button that performs a search for the available streaming services that show a particular movie or tv show
@@ -23205,7 +23189,7 @@ msgstr "Vilka funktioner saknas? (Valfritt)"
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Which features are missing? (optional)"
-msgstr ""
+msgstr "Vilka funktioner saknas? (valfritt)"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
@@ -23227,13 +23211,13 @@ msgstr "Vilka är vi"
 #. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Who are the main cast and crew, and what else are they known for?"
-msgstr ""
+msgstr "Vilka ingår i rollistan och filmteamet, och vad är de annars kända för?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Who is this person?"
-msgstr ""
+msgstr "Vem är den här personen?"
 
 # smartling.placeholder_format=C
 #. Header above a collection of privacy-related links.
@@ -23604,8 +23588,7 @@ msgstr "Ja, ny användare!"
 msgctxt "cloudsave"
 msgid ""
 "Yes, we throw away data when you’re done with it, and it cannot be recovered."
-msgstr ""
-"Ja, vi slänger data när du är klar med dem och de kan inte återställas."
+msgstr "Ja, vi slänger data när du är klar med dem och de kan inte återställas."
 
 # smartling.placeholder_format=C
 #. Option for the filter-by-date search.
@@ -23624,8 +23607,7 @@ msgctxt "Disclaimer bellow chat input - desktop"
 msgid ""
 "You are chatting with %s. AI chats may display inaccurate or offensive "
 "information."
-msgstr ""
-"Du chattar med %1$s. AI-chattar kan visa felaktig eller stötande information."
+msgstr "Du chattar med %1$s. AI-chattar kan visa felaktig eller stötande information."
 
 # smartling.placeholder_format=C
 #. Provide users with the ability to retry their search on a different search engine. First placeholder will be a link with the text "try your search again" OR "try your search later". Second is a URL to the !bangs page: https://duckduckgo.com/bangs.
@@ -23792,8 +23774,7 @@ msgstr ""
 #. Text explaining the benefits of the cloud save feature.
 msgctxt "cloudsave"
 msgid "You can restore your settings after deleting cookies."
-msgstr ""
-"Du kan återställa dina inställningar efter att du har tagit bort kakor."
+msgstr "Du kan återställa dina inställningar efter att du har tagit bort kakor."
 
 # smartling.placeholder_format=C
 #. Text explaining the benefits of the cloud save feature.
@@ -24034,8 +24015,8 @@ msgid ""
 "YouTube (owned by Google) does not let you watch videos anonymously. As "
 "such, watching YouTube videos here will be tracked by YouTube/Google."
 msgstr ""
-"YouTube (som ägs av Google) låter dig inte titta på videor anonymt. YouTube-"
-"videor som visas här spåras därför av YouTube/Google."
+"YouTube (som ägs av Google) låter dig inte titta på videor anonymt. "
+"YouTube-videor som visas här spåras därför av YouTube/Google."
 
 # smartling.placeholder_format=C
 #. Label for a privacy disclaimer related to YouTube videos
@@ -24151,8 +24132,8 @@ msgstr "Dina chattar sparas nu."
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never saved or used to train AI models"
 msgstr ""
-"Dina chattar är privata, sparas aldrig och används inte för att träna AI-"
-"modeller"
+"Dina chattar är privata, sparas aldrig och används inte för att träna "
+"AI-modeller"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
@@ -24295,10 +24276,10 @@ msgid ""
 "browser. We save the settings file using the key as the name. DuckDuckGo "
 "never knows your passphrase."
 msgstr ""
-"Ditt lösenord genererar en 512-bitars nyckel med hjälp av Secure Hash-"
-"algoritmen %1$sSHA-2%2$s. Endast nyckeln och tillhörande inställningsfil "
-"lämnar din webbläsare. Vi sparar inställningsfilen med nyckeln som namn. "
-"DuckDuckGo känner aldrig till ditt lösenord."
+"Ditt lösenord genererar en 512-bitars nyckel med hjälp av Secure "
+"Hash-algoritmen %1$sSHA-2%2$s. Endast nyckeln och tillhörande "
+"inställningsfil lämnar din webbläsare. Vi sparar inställningsfilen med "
+"nyckeln som namn. DuckDuckGo känner aldrig till ditt lösenord."
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -24509,8 +24490,7 @@ msgstr "av %1$s"
 #. Trust line shown at the bottom of the explainer panel, summarizing DuckDuckGo's reputation for online protection.
 msgctxt "Footer banner text in the How Duck.ai Works panel"
 msgid "by DuckDuckGo — online protection trusted by millions every day."
-msgstr ""
-"av DuckDuckGo — onlineskydd som miljontals människor litar på varje dag."
+msgstr "av DuckDuckGo — onlineskydd som miljontals människor litar på varje dag."
 
 # smartling.placeholder_format=C
 #. An abreviated unit of time indicating an age, e.g. "2d"
@@ -24724,8 +24704,8 @@ msgstr "den officiella webbplatsen"
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
 msgstr ""
-"eller skriv koden för färgen du vill ha, t.ex. %1$s (%2$s är ett kodat %3$s-"
-"tecken)"
+"eller skriv koden för färgen du vill ha, t.ex. %1$s (%2$s är ett kodat "
+"%3$s-tecken)"
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "

--- a/locales/ta_IN/LC_MESSAGES/duckduckgo.po
+++ b/locales/ta_IN/LC_MESSAGES/duckduckgo.po
@@ -1165,6 +1165,11 @@ msgctxt "feedback form"
 msgid "Address is incorrect"
 msgstr "முகவரி தவரக உல்லது"
 
+#. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Adjust the servings"
+msgstr ""
+
 #. as in multiple advertisements
 msgid "Ads"
 msgstr "விளம்பரங்கள்"
@@ -1338,6 +1343,13 @@ msgstr ""
 #. Heading shown on the empty chat screen. The text between the two %s markers is displayed inside a clickable privacy button. First %s renders a shield icon, second %s is an invisible end marker. Keep the word 'private' between both %s markers.
 msgctxt "Empty state heading in Duck.ai chat mode"
 msgid "All chats are %sprivate%s"
+msgstr ""
+
+#. Paragraph in the Privacy & Terms section of the About & Legal page in Duck.ai settings, summarizing how chats are anonymized and are not stored or used to train chat models.
+msgctxt "Privacy & Terms section description on the Duck.ai settings page"
+msgid ""
+"All chats are anonymized by DuckDuckGo, and your conversations are not used "
+"to train chat models by DuckDuckGo or the model providers"
 msgstr ""
 
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1553,6 +1565,12 @@ msgstr ""
 msgctxt "precise_user_location"
 msgid "Anonymous location enabled"
 msgstr "பெயரில்லாத இடம் செயல்படுத்தப்பட்டது"
+
+msgctxt "settings"
+msgid ""
+"Anonymously generates answers for search queries based on web content. "
+"Choose how often you want it to appear, or disable it completely."
+msgstr ""
 
 #. Instant Answer tab name
 msgid "Answer"
@@ -1776,6 +1794,11 @@ msgstr ""
 
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse
 msgid "Ask a follow-up with Duck.ai"
+msgstr ""
+
+#. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
+msgctxt "Page suggestion chip label"
+msgid "Ask about this page"
 msgstr ""
 
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2100,6 +2123,11 @@ msgstr ""
 msgid "Barcode"
 msgstr "பார்கோடு"
 
+#. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Based on this page, is this course worth taking?"
+msgstr ""
+
 msgctxt "settings"
 msgid "Basic"
 msgstr "அடிப்படை"
@@ -2131,6 +2159,13 @@ msgstr ""
 #. Placeholder text displayed while the assistant waits for the user to choose an action.
 msgctxt "Assistant response placeholder"
 msgid "Before continuing..."
+msgstr ""
+
+#. Explains that before storing the report, DuckDuckGo will anonymize the conversation by removing PII like names, email addresses, and identifying metadata.
+msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
+msgid ""
+"Before storing this report, DuckDuckGo will anonymize your conversation by "
+"removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
 #. Label that's displayed next to a past start date below a web search result.
@@ -2389,6 +2424,11 @@ msgstr "பிரேசில்"
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Break Points Won"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Break this down into clear, numbered steps."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -2760,6 +2800,11 @@ msgstr "தொழில்"
 #. Text of a button that performs a search for the cast of a particular movie or tv show
 msgctxt "Movie/TV Show Title instant answer"
 msgid "Cast"
+msgstr ""
+
+#. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Cast & Crew"
 msgstr ""
 
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -4123,6 +4168,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Create a shopping list with quantities from this recipe."
+msgstr ""
+
 #. Placeholder text displayed in the input field when starting a new image generation session.
 msgctxt "Placeholder text for the image generation input field"
 msgid "Create an image of a cute duck..."
@@ -4649,6 +4699,10 @@ msgstr ""
 msgid "Dictation limit reached"
 msgstr ""
 
+#. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
+msgid "Dictation temporarily unavailable"
+msgstr ""
+
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
@@ -4894,6 +4948,20 @@ msgctxt "precise_user_location"
 msgid "Done"
 msgstr "முடிந்தது"
 
+#. Message shown in a modal after DuckDuckGo browser users disable AI features in Settings. The first two placeholders bold noai.duckduckgo.com. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
+"filtered out. %sLearn More%s"
+msgstr ""
+
+#. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
+"and AI images filtered out. %sLearn more%s"
+msgstr ""
+
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Double Faults"
@@ -4984,6 +5052,16 @@ msgctxt "Full sentence for writing an email"
 msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
+msgstr ""
+
+#. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Draft a cover letter"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Draft a cover letter for this job."
 msgstr ""
 
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -5123,6 +5201,14 @@ msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
 msgstr ""
 
+#. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
+msgctxt "About section description on the Duck.ai settings page"
+msgid ""
+"Duck.ai is created by DuckDuckGo. We're an independent online protection "
+"company for anyone who wants to take back control of their personal "
+"information."
+msgstr ""
+
 #. Title shown when an update is required before proceeding.
 msgctxt "duckai_migration"
 msgid "Duck.ai is moving domains"
@@ -5156,6 +5242,12 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Duck.ai lets you chat privately with popular AI models. Disabling it hides "
+"Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
 
 msgctxt "settings"
@@ -5947,6 +6039,16 @@ msgstr ""
 msgid "Eritrea"
 msgstr ""
 
+#. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Estimate the nutrition"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Estimate the nutritional information for this recipe."
+msgstr ""
+
 msgid "Estonia"
 msgstr "எஸ்டோனியா"
 
@@ -5991,10 +6093,50 @@ msgctxt "merchant promotion product ad extension"
 msgid "Expires in 1 day"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain the accepted answer in simple terms."
+msgstr ""
+
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
+msgstr ""
+
+#. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain the top answer"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this in simple, plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this paper"
+msgstr ""
+
+#. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this repo"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this research paper in plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this simply"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain what this repository does and how to use it."
 msgstr ""
 
 #. Label to show if song lyrics contain explicit content
@@ -6224,6 +6366,11 @@ msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
 msgstr ""
 
+msgctxt "settings"
+msgid ""
+"Filters out known AI spam sites from image search results. %sLearn More%s"
+msgstr ""
+
 #. Label for the final score of a sporting event.
 msgid "Final"
 msgstr "இறுதி"
@@ -6264,6 +6411,11 @@ msgstr ""
 #. Short description shown below the 'Web Search' label in the Tools dropdown.
 msgctxt "Subtitle for the Web Search tool entry in the Tools dropdown menu"
 msgid "Find current information"
+msgstr ""
+
+#. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Find me alternatives"
 msgstr ""
 
 #. Button that searches for results closer to the user's current location.
@@ -6654,6 +6806,11 @@ msgstr ""
 msgid "Generate More"
 msgstr ""
 
+#. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Generate a shopping list"
+msgstr ""
+
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
 msgid "Generate a short answer from the web"
 msgstr ""
@@ -6889,6 +7046,11 @@ msgstr ""
 #. Text for a button inviting users to give it a try for the Duck.ai product. On click, they're taken to the Duck.ai page.
 msgctxt "Onboarding welcome screen button text"
 msgid "Give it a Try"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Give me a quick background on this person."
 msgstr ""
 
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -7252,6 +7414,16 @@ msgstr ""
 #. Link to a page with information about sharing DuckDuckGo with friends.
 msgid "Help Spread Privacy"
 msgstr "தனியுரிமையைப் பரப்ப உதவுங்கள்"
+
+#. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Help me prep for the interview"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Help me tailor my resume for this job."
+msgstr ""
 
 #. Title of a SERP popup that invites users to take a survey (desktop only)
 msgctxt "User survey popup"
@@ -7674,6 +7846,13 @@ msgstr ""
 #. Text displayed on the button on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
 msgctxt "Onboarding terms screen button text"
 msgid "I Agree"
+msgstr ""
+
+#. Text for the button that takes the user to the external DuckDuckGo login subscription page.
+msgctxt ""
+"Text for the I already have a subscription button in the Duck.ai settings "
+"page"
+msgid "I Already Have a Subscription"
 msgstr ""
 
 #. Text for the button that takes the user to the login subscription page.
@@ -8142,6 +8321,11 @@ msgctxt "Sidemenu browser promo"
 msgid "Install Mac Browser"
 msgstr ""
 
+#. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
+msgctxt "settings"
+msgid "Install Now"
+msgstr ""
+
 #. Text of a button to install the DuckDuckGo app
 msgctxt "Serp footer content"
 msgid "Install Our App"
@@ -8221,10 +8405,37 @@ msgctxt "cloudsave"
 msgid "Is deleted data really deleted?"
 msgstr "அழிக்கப்பட்ட தகவல் உண்மையிலேயே முற்றிலும் அழிக்கப்பட்டுவிட்டதா?"
 
+#. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is it worth taking?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this place any good?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"Is this place any good? Summarize its reputation based on reviews and "
+"ratings."
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "Is this video helpful?"
 msgstr "இந்த வீடியோ பயனுள்ளதாக உள்ளதா?"
+
+#. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this worth watching?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Is this worth watching? Give me a spoiler-free take."
+msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
 msgctxt "Weather IA"
@@ -8724,6 +8935,11 @@ msgstr "இணைப்பு எழுத்துரு:"
 msgid "Links:"
 msgstr "இணைப்புகள்:"
 
+#. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "List the tools, materials, or prerequisites I need for this."
+msgstr ""
+
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
 msgid "Listen"
 msgstr "கேள்"
@@ -9059,6 +9275,11 @@ msgstr ""
 #. Label for linke navigating to site exclusion feature on Settings page
 msgctxt "Exclusion message manage sites button"
 msgid "Manage blocked sites"
+msgstr ""
+
+#. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
+msgctxt "setting"
+msgid "Manage in Browser Settings"
 msgstr ""
 
 #. Link to the site exclusion settings page
@@ -11373,6 +11594,11 @@ msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
+msgid "Please describe why the chat response is harmful or illegal. (optional)"
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
+msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
 msgstr ""
 
@@ -11391,6 +11617,13 @@ msgctxt "Modal disclaimer text"
 msgid ""
 "Please note: starting a new chat with any model will delete your current "
 "chat session."
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
+msgctxt "Feedback prompt"
+msgid ""
+"Please paste your prompt and the problematic output (with any personal "
+"information removed) and describe why the content is harmful or illegal."
 msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -11775,6 +12008,11 @@ msgctxt "settings"
 msgid "Privacy"
 msgstr "தனியுரிமை"
 
+#. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
+msgctxt "Section heading on the Duck.ai settings page"
+msgid "Privacy & Terms"
+msgstr ""
+
 msgid "Privacy Blog"
 msgstr "தனியுரிமை வலைப்பதிவு"
 
@@ -11828,6 +12066,11 @@ msgstr ""
 
 #. Text used in other strings to link to the Privacy Policy and Terms of Service content.
 msgctxt "Copy used to compose link in sentences"
+msgid "Privacy Policy and Terms of Service"
+msgstr ""
+
+#. Text for a button that links to the terms of use and privacy policy page.
+msgctxt "Secondary button text in active privacy modal"
 msgid "Privacy Policy and Terms of Service"
 msgstr ""
 
@@ -12238,6 +12481,26 @@ msgctxt "Brief for recommending a book"
 msgid "Recommend a book"
 msgstr ""
 
+#. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar books"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar books."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar movies or shows."
+msgstr ""
+
+#. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar titles"
+msgstr ""
+
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
 msgid "Recording failed. Please try again."
 msgstr ""
@@ -12560,6 +12823,14 @@ msgstr ""
 msgid "Republic of Moldova"
 msgstr ""
 
+#. Note indicating that sharing the conversation is mandatory when reporting harmful or illegal content. Rendered alongside the standard share label (DUCKCHAT_RESPONSE_FEEDBACK_SHARE_PROMPT_RESPONSE_LABEL), not replacing it.
+msgctxt ""
+"Note shown under the share-content switch label on the Duck.ai response "
+"feedback form when the user has selected Harmful or Illegal as the feedback "
+"reason"
+msgid "Required for harmful or illegal reports"
+msgstr ""
+
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
 msgctxt "Description for extended reasoning mode in Duck.ai"
 msgid "Researches before responding"
@@ -12746,6 +13017,11 @@ msgstr "விமர்சனங்கள்"
 msgctxt "maps_places"
 msgid "Reviews"
 msgstr "விமர்சனங்கள்"
+
+#. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Rewrite this recipe scaled for a different number of servings."
+msgstr ""
 
 msgid "Romania"
 msgstr "ருமேனியா"
@@ -13802,6 +14078,11 @@ msgctxt "Setup button for native sync flow"
 msgid "Set Up Now"
 msgstr ""
 
+#. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
+msgctxt "Encrypted storage setup button shown in native browsers"
+msgid "Set Up Sync & Backup"
+msgstr ""
+
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
 msgctxt "Title for the Sync & Backup intro screen"
 msgid "Set Up Sync & Backup"
@@ -13946,6 +14227,12 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
+msgctxt ""
+"Label beside the share-content switch on the Duck.ai response feedback form"
+msgid "Share this conversation with DuckDuckGo"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -14965,6 +15252,21 @@ msgctxt "Brief for suggesting a blog post title"
 msgid "Suggest a title for a blog post"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest related articles or topics worth exploring next."
+msgstr ""
+
+#. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Suggest related articles to explore"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest some alternatives to this product."
+msgstr ""
+
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
 msgctxt "directions"
 msgid "Suggestions:"
@@ -14974,9 +15276,84 @@ msgctxt "noresults"
 msgid "Suggestions:"
 msgstr "பரிந்துரைகள்:"
 
+#. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Sum up the reviews"
+msgstr ""
+
 #. A short title for the a message asking the AI to summarize a text.
 msgctxt "Title for the summarize message"
 msgid "Summarize"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize the Q&As"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the background and notable work of this person."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the key details of this event."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the questions and answers on this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize their background"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this book"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this book."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this discussion"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this discussion thread."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this video"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this video."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize what the reviews say."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -15231,6 +15608,11 @@ msgstr ""
 msgid "Syria"
 msgstr ""
 
+#. Text for a button that enables the theme to follow the operating system's color scheme preference.
+msgctxt "System theme button for theme selector"
+msgid "System"
+msgstr ""
+
 #. Abbreviation indicating this is the total score for a game
 msgctxt "Sports module"
 msgid "T"
@@ -15254,6 +15636,11 @@ msgctxt "language_name"
 msgid "Tahitian"
 msgstr "டஹிடியன்"
 
+#. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Tailor my resume"
+msgstr ""
+
 msgid "Taiwan"
 msgstr "தைவான்"
 
@@ -15275,6 +15662,12 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "Take control of your personal data!"
+msgstr ""
+
+#. Description for the Feedback section of the Duck.ai settings page, asking the user to take an anonymous survey to let us know how we can make Duck.ai better.
+msgctxt "Feedback section description on the Duck.ai settings page"
+msgid ""
+"Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
 
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -15524,6 +15917,11 @@ msgstr ""
 #. https://duck.co/media/files/theme.png
 msgid "Theme"
 msgstr "தீம்"
+
+#. Text for the theme selector label that allows users to switch between Light and dark theme.
+msgctxt "Label for the theme selector feature"
+msgid "Theme"
+msgstr ""
 
 #. http://i.imgur.com/LpFhb1e.png
 msgctxt "settings"
@@ -16183,6 +16581,16 @@ msgid ""
 "movie theatre?”"
 msgstr ""
 
+#. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Translate this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
+msgctxt "Page suggestion prompt"
+msgid "Translate this page into %s."
+msgstr ""
+
 #. Placeholder text for a region that will display translated text.
 msgctxt "translations_module"
 msgid "Translation"
@@ -16297,6 +16705,11 @@ msgstr ""
 #. Call-to-action button for the subscription promo in the SERP sidemenu.
 msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
+msgstr ""
+
+#. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
+msgctxt "settings"
+msgid "Try It Now"
 msgstr ""
 
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -16491,6 +16904,20 @@ msgstr "%s-ஐ முயற்சிக்கவும்"
 msgctxt "new user poll"
 msgid "Trying DuckDuckGo again"
 msgstr "மீண்டும் DuckDuckGo முயற்சிக்கிறேன்"
+
+#. Message shown in a modal after supported third-party browser users disable AI features in Settings. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+#. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
 
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
 msgctxt "Assistant response placeholder"
@@ -17096,6 +17523,11 @@ msgstr "உருது"
 msgid "Uruguay"
 msgstr ""
 
+#. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
+msgctxt "Navigation label on the Duck.ai settings page"
+msgid "Usage"
+msgstr ""
+
 #. A feedback suggestion
 msgctxt "Feedback prompt"
 msgid "Usage limit"
@@ -17447,6 +17879,11 @@ msgstr "இருப்பிடத்திற்காக காத்தி�
 msgid "Wales"
 msgstr ""
 
+#. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Walk me through the steps"
+msgstr ""
+
 #. Label for walking directions on a map.
 msgctxt "directions"
 msgid "Walking"
@@ -17537,6 +17974,16 @@ msgstr ""
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
+msgstr ""
+
+#. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
+msgctxt ""
+"Inline warning shown below the share-content toggle when the user selects "
+"Harmful or Illegal but has not enabled sharing"
+msgid ""
+"We can only fix what we can see. To report a harmful or illegal response, "
+"please share this conversation with DuckDuckGo so we can investigate and "
+"address the issue."
 msgstr ""
 
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -17972,6 +18419,87 @@ msgid ""
 "experience."
 msgstr ""
 
+#. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the counterarguments?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the hours & location?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key contributions of this paper?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key contributions?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key details?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key points covered in this video?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key points?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key takeaways from this article?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key takeaways?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key things I will learn from this course?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main counterarguments or criticisms of this?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main questions this page answers?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the must-try dishes here?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"What are the opening hours, location, and contact details for this place?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the pros and cons of this product?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the pros and cons?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
 msgctxt "feedback form"
 msgid "What bothered you most?"
@@ -18055,6 +18583,11 @@ msgctxt "Full sentence for defining a term"
 msgid "What does atria mean in the context of a medical article?"
 msgstr ""
 
+#. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What does this answer?"
+msgstr ""
+
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
@@ -18064,6 +18597,11 @@ msgstr ""
 msgctxt "cloudsave"
 msgid "What information gets saved?"
 msgstr "என்ன தகவல் சேமிக்கப்படும்?"
+
+#. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What interview questions might come up for this role?"
+msgstr ""
 
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
@@ -18077,6 +18615,11 @@ msgstr ""
 #. Text for a prompt suggestion for looking up the capital city of Albania.
 msgctxt "Full sentence for looking up basic facts"
 msgid "What is the capital city of Albania?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What is the overall verdict and rating for this?"
 msgstr ""
 
 #. Link to a page with additional information.
@@ -18097,6 +18640,11 @@ msgctxt "maps_places"
 msgid "What people say:"
 msgstr "மக்கள் என்ன சொல்கிறார்கள்:"
 
+#. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What should I order?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
 msgctxt "feedback form"
 msgid "What stood out?"
@@ -18105,6 +18653,16 @@ msgstr ""
 #. Question on a feedback form for a negative feedback response.
 msgctxt "feedback form"
 msgid "What was wrong with the response? (optional)"
+msgstr ""
+
+#. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I learn?"
+msgstr ""
+
+#. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I need?"
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -18119,6 +18677,11 @@ msgstr ""
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
 msgctxt "SERP footer content"
 msgid "What's New"
+msgstr ""
+
+#. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What's the verdict?"
 msgstr ""
 
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -18160,6 +18723,11 @@ msgctxt "Feedback prompt"
 msgid "Which features are missing? (Optional)"
 msgstr ""
 
+#. An invitation for users to leave feedback
+msgctxt "Feedback prompt"
+msgid "Which features are missing? (optional)"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
 msgid "White"
 msgstr "வெண்மையான"
@@ -18172,6 +18740,16 @@ msgstr "வெள்ளை"
 #. Link to an about us page.
 msgid "Who We Are"
 msgstr "நாங்கள் யார்"
+
+#. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Who are the main cast and crew, and what else are they known for?"
+msgstr ""
+
+#. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Who is this person?"
+msgstr ""
 
 #. Header above a collection of privacy-related links.
 msgid "Why Privacy"

--- a/locales/te_IN/LC_MESSAGES/duckduckgo.po
+++ b/locales/te_IN/LC_MESSAGES/duckduckgo.po
@@ -1159,6 +1159,11 @@ msgctxt "feedback form"
 msgid "Address is incorrect"
 msgstr ""
 
+#. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Adjust the servings"
+msgstr ""
+
 #. as in multiple advertisements
 msgid "Ads"
 msgstr ""
@@ -1331,6 +1336,13 @@ msgstr ""
 #. Heading shown on the empty chat screen. The text between the two %s markers is displayed inside a clickable privacy button. First %s renders a shield icon, second %s is an invisible end marker. Keep the word 'private' between both %s markers.
 msgctxt "Empty state heading in Duck.ai chat mode"
 msgid "All chats are %sprivate%s"
+msgstr ""
+
+#. Paragraph in the Privacy & Terms section of the About & Legal page in Duck.ai settings, summarizing how chats are anonymized and are not stored or used to train chat models.
+msgctxt "Privacy & Terms section description on the Duck.ai settings page"
+msgid ""
+"All chats are anonymized by DuckDuckGo, and your conversations are not used "
+"to train chat models by DuckDuckGo or the model providers"
 msgstr ""
 
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1543,6 +1555,12 @@ msgstr ""
 #. Confirmation message after location service is enabled.
 msgctxt "precise_user_location"
 msgid "Anonymous location enabled"
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Anonymously generates answers for search queries based on web content. "
+"Choose how often you want it to appear, or disable it completely."
 msgstr ""
 
 #. Instant Answer tab name
@@ -1767,6 +1785,11 @@ msgstr ""
 
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse
 msgid "Ask a follow-up with Duck.ai"
+msgstr ""
+
+#. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
+msgctxt "Page suggestion chip label"
+msgid "Ask about this page"
 msgstr ""
 
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2091,6 +2114,11 @@ msgstr ""
 msgid "Barcode"
 msgstr "బార్​కోడ్"
 
+#. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Based on this page, is this course worth taking?"
+msgstr ""
+
 msgctxt "settings"
 msgid "Basic"
 msgstr "ప్రాథమికం"
@@ -2122,6 +2150,13 @@ msgstr ""
 #. Placeholder text displayed while the assistant waits for the user to choose an action.
 msgctxt "Assistant response placeholder"
 msgid "Before continuing..."
+msgstr ""
+
+#. Explains that before storing the report, DuckDuckGo will anonymize the conversation by removing PII like names, email addresses, and identifying metadata.
+msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
+msgid ""
+"Before storing this report, DuckDuckGo will anonymize your conversation by "
+"removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
 #. Label that's displayed next to a past start date below a web search result.
@@ -2380,6 +2415,11 @@ msgstr "బ్రెజిల్"
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Break Points Won"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Break this down into clear, numbered steps."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -2739,6 +2779,11 @@ msgstr "ఉద్యోగాలు"
 #. Text of a button that performs a search for the cast of a particular movie or tv show
 msgctxt "Movie/TV Show Title instant answer"
 msgid "Cast"
+msgstr ""
+
+#. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Cast & Crew"
 msgstr ""
 
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -4089,6 +4134,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Create a shopping list with quantities from this recipe."
+msgstr ""
+
 #. Placeholder text displayed in the input field when starting a new image generation session.
 msgctxt "Placeholder text for the image generation input field"
 msgid "Create an image of a cute duck..."
@@ -4615,6 +4665,10 @@ msgstr ""
 msgid "Dictation limit reached"
 msgstr ""
 
+#. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
+msgid "Dictation temporarily unavailable"
+msgstr ""
+
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
@@ -4859,6 +4913,20 @@ msgctxt "precise_user_location"
 msgid "Done"
 msgstr "పూర్తయింది"
 
+#. Message shown in a modal after DuckDuckGo browser users disable AI features in Settings. The first two placeholders bold noai.duckduckgo.com. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
+"filtered out. %sLearn More%s"
+msgstr ""
+
+#. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
+"and AI images filtered out. %sLearn more%s"
+msgstr ""
+
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Double Faults"
@@ -4949,6 +5017,16 @@ msgctxt "Full sentence for writing an email"
 msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
+msgstr ""
+
+#. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Draft a cover letter"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Draft a cover letter for this job."
 msgstr ""
 
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -5088,6 +5166,14 @@ msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
 msgstr ""
 
+#. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
+msgctxt "About section description on the Duck.ai settings page"
+msgid ""
+"Duck.ai is created by DuckDuckGo. We're an independent online protection "
+"company for anyone who wants to take back control of their personal "
+"information."
+msgstr ""
+
 #. Title shown when an update is required before proceeding.
 msgctxt "duckai_migration"
 msgid "Duck.ai is moving domains"
@@ -5121,6 +5207,12 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Duck.ai lets you chat privately with popular AI models. Disabling it hides "
+"Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
 
 msgctxt "settings"
@@ -5886,6 +5978,16 @@ msgstr ""
 msgid "Eritrea"
 msgstr ""
 
+#. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Estimate the nutrition"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Estimate the nutritional information for this recipe."
+msgstr ""
+
 msgid "Estonia"
 msgstr "ఎస్టోనియా"
 
@@ -5930,10 +6032,50 @@ msgctxt "merchant promotion product ad extension"
 msgid "Expires in 1 day"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain the accepted answer in simple terms."
+msgstr ""
+
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
+msgstr ""
+
+#. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain the top answer"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this in simple, plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this paper"
+msgstr ""
+
+#. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this repo"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this research paper in plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this simply"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain what this repository does and how to use it."
 msgstr ""
 
 #. Label to show if song lyrics contain explicit content
@@ -6162,6 +6304,11 @@ msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
 msgstr ""
 
+msgctxt "settings"
+msgid ""
+"Filters out known AI spam sites from image search results. %sLearn More%s"
+msgstr ""
+
 #. Label for the final score of a sporting event.
 msgid "Final"
 msgstr ""
@@ -6201,6 +6348,11 @@ msgstr ""
 #. Short description shown below the 'Web Search' label in the Tools dropdown.
 msgctxt "Subtitle for the Web Search tool entry in the Tools dropdown menu"
 msgid "Find current information"
+msgstr ""
+
+#. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Find me alternatives"
 msgstr ""
 
 #. Button that searches for results closer to the user's current location.
@@ -6591,6 +6743,11 @@ msgstr ""
 msgid "Generate More"
 msgstr ""
 
+#. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Generate a shopping list"
+msgstr ""
+
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
 msgid "Generate a short answer from the web"
 msgstr ""
@@ -6825,6 +6982,11 @@ msgstr ""
 #. Text for a button inviting users to give it a try for the Duck.ai product. On click, they're taken to the Duck.ai page.
 msgctxt "Onboarding welcome screen button text"
 msgid "Give it a Try"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Give me a quick background on this person."
 msgstr ""
 
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -7187,6 +7349,16 @@ msgstr ""
 
 #. Link to a page with information about sharing DuckDuckGo with friends.
 msgid "Help Spread Privacy"
+msgstr ""
+
+#. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Help me prep for the interview"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Help me tailor my resume for this job."
 msgstr ""
 
 #. Title of a SERP popup that invites users to take a survey (desktop only)
@@ -7606,6 +7778,13 @@ msgstr ""
 #. Text displayed on the button on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
 msgctxt "Onboarding terms screen button text"
 msgid "I Agree"
+msgstr ""
+
+#. Text for the button that takes the user to the external DuckDuckGo login subscription page.
+msgctxt ""
+"Text for the I already have a subscription button in the Duck.ai settings "
+"page"
+msgid "I Already Have a Subscription"
 msgstr ""
 
 #. Text for the button that takes the user to the login subscription page.
@@ -8059,6 +8238,11 @@ msgctxt "Sidemenu browser promo"
 msgid "Install Mac Browser"
 msgstr ""
 
+#. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
+msgctxt "settings"
+msgid "Install Now"
+msgstr ""
+
 #. Text of a button to install the DuckDuckGo app
 msgctxt "Serp footer content"
 msgid "Install Our App"
@@ -8138,9 +8322,36 @@ msgctxt "cloudsave"
 msgid "Is deleted data really deleted?"
 msgstr "తొలగించిన డేటా నిజంగా తొలగించబడిందా?"
 
+#. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is it worth taking?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this place any good?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"Is this place any good? Summarize its reputation based on reviews and "
+"ratings."
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "Is this video helpful?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this worth watching?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Is this worth watching? Give me a spoiler-free take."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -8637,6 +8848,11 @@ msgstr "లంకె ఖతి:"
 msgid "Links:"
 msgstr "లంకెలు:"
 
+#. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "List the tools, materials, or prerequisites I need for this."
+msgstr ""
+
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
 msgid "Listen"
 msgstr "వినండి"
@@ -8969,6 +9185,11 @@ msgstr ""
 #. Label for linke navigating to site exclusion feature on Settings page
 msgctxt "Exclusion message manage sites button"
 msgid "Manage blocked sites"
+msgstr ""
+
+#. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
+msgctxt "setting"
+msgid "Manage in Browser Settings"
 msgstr ""
 
 #. Link to the site exclusion settings page
@@ -11268,6 +11489,11 @@ msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
+msgid "Please describe why the chat response is harmful or illegal. (optional)"
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
+msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
 msgstr ""
 
@@ -11286,6 +11512,13 @@ msgctxt "Modal disclaimer text"
 msgid ""
 "Please note: starting a new chat with any model will delete your current "
 "chat session."
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
+msgctxt "Feedback prompt"
+msgid ""
+"Please paste your prompt and the problematic output (with any personal "
+"information removed) and describe why the content is harmful or illegal."
 msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -11670,6 +11903,11 @@ msgctxt "settings"
 msgid "Privacy"
 msgstr "అంతరంగికత"
 
+#. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
+msgctxt "Section heading on the Duck.ai settings page"
+msgid "Privacy & Terms"
+msgstr ""
+
 msgid "Privacy Blog"
 msgstr ""
 
@@ -11723,6 +11961,11 @@ msgstr ""
 
 #. Text used in other strings to link to the Privacy Policy and Terms of Service content.
 msgctxt "Copy used to compose link in sentences"
+msgid "Privacy Policy and Terms of Service"
+msgstr ""
+
+#. Text for a button that links to the terms of use and privacy policy page.
+msgctxt "Secondary button text in active privacy modal"
 msgid "Privacy Policy and Terms of Service"
 msgstr ""
 
@@ -12131,6 +12374,26 @@ msgctxt "Brief for recommending a book"
 msgid "Recommend a book"
 msgstr ""
 
+#. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar books"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar books."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar movies or shows."
+msgstr ""
+
+#. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar titles"
+msgstr ""
+
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
 msgid "Recording failed. Please try again."
 msgstr ""
@@ -12450,6 +12713,14 @@ msgstr ""
 msgid "Republic of Moldova"
 msgstr ""
 
+#. Note indicating that sharing the conversation is mandatory when reporting harmful or illegal content. Rendered alongside the standard share label (DUCKCHAT_RESPONSE_FEEDBACK_SHARE_PROMPT_RESPONSE_LABEL), not replacing it.
+msgctxt ""
+"Note shown under the share-content switch label on the Duck.ai response "
+"feedback form when the user has selected Harmful or Illegal as the feedback "
+"reason"
+msgid "Required for harmful or illegal reports"
+msgstr ""
+
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
 msgctxt "Description for extended reasoning mode in Duck.ai"
 msgid "Researches before responding"
@@ -12636,6 +12907,11 @@ msgstr "సమీక్షలు"
 msgctxt "maps_places"
 msgid "Reviews"
 msgstr "సమీక్షలు"
+
+#. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Rewrite this recipe scaled for a different number of servings."
+msgstr ""
 
 msgid "Romania"
 msgstr "రొమేనియా"
@@ -13670,6 +13946,11 @@ msgctxt "Setup button for native sync flow"
 msgid "Set Up Now"
 msgstr ""
 
+#. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
+msgctxt "Encrypted storage setup button shown in native browsers"
+msgid "Set Up Sync & Backup"
+msgstr ""
+
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
 msgctxt "Title for the Sync & Backup intro screen"
 msgid "Set Up Sync & Backup"
@@ -13812,6 +14093,12 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
+msgctxt ""
+"Label beside the share-content switch on the Duck.ai response feedback form"
+msgid "Share this conversation with DuckDuckGo"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -14826,6 +15113,21 @@ msgctxt "Brief for suggesting a blog post title"
 msgid "Suggest a title for a blog post"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest related articles or topics worth exploring next."
+msgstr ""
+
+#. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Suggest related articles to explore"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest some alternatives to this product."
+msgstr ""
+
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
 msgctxt "directions"
 msgid "Suggestions:"
@@ -14835,9 +15137,84 @@ msgctxt "noresults"
 msgid "Suggestions:"
 msgstr "సూచనలు:"
 
+#. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Sum up the reviews"
+msgstr ""
+
 #. A short title for the a message asking the AI to summarize a text.
 msgctxt "Title for the summarize message"
 msgid "Summarize"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize the Q&As"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the background and notable work of this person."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the key details of this event."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the questions and answers on this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize their background"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this book"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this book."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this discussion"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this discussion thread."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this video"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this video."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize what the reviews say."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -15092,6 +15469,11 @@ msgstr ""
 msgid "Syria"
 msgstr ""
 
+#. Text for a button that enables the theme to follow the operating system's color scheme preference.
+msgctxt "System theme button for theme selector"
+msgid "System"
+msgstr ""
+
 #. Abbreviation indicating this is the total score for a game
 msgctxt "Sports module"
 msgid "T"
@@ -15115,6 +15497,11 @@ msgctxt "language_name"
 msgid "Tahitian"
 msgstr ""
 
+#. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Tailor my resume"
+msgstr ""
+
 msgid "Taiwan"
 msgstr "తైవాన్"
 
@@ -15136,6 +15523,12 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "Take control of your personal data!"
+msgstr ""
+
+#. Description for the Feedback section of the Duck.ai settings page, asking the user to take an anonymous survey to let us know how we can make Duck.ai better.
+msgctxt "Feedback section description on the Duck.ai settings page"
+msgid ""
+"Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
 
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -15380,6 +15773,11 @@ msgstr ""
 #. https://duck.co/media/files/theme.png
 msgid "Theme"
 msgstr "అలంకారం"
+
+#. Text for the theme selector label that allows users to switch between Light and dark theme.
+msgctxt "Label for the theme selector feature"
+msgid "Theme"
+msgstr ""
 
 #. http://i.imgur.com/LpFhb1e.png
 msgctxt "settings"
@@ -16031,6 +16429,16 @@ msgid ""
 "movie theatre?”"
 msgstr ""
 
+#. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Translate this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
+msgctxt "Page suggestion prompt"
+msgid "Translate this page into %s."
+msgstr ""
+
 #. Placeholder text for a region that will display translated text.
 msgctxt "translations_module"
 msgid "Translation"
@@ -16145,6 +16553,11 @@ msgstr ""
 #. Call-to-action button for the subscription promo in the SERP sidemenu.
 msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
+msgstr ""
+
+#. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
+msgctxt "settings"
+msgid "Try It Now"
 msgstr ""
 
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -16338,6 +16751,20 @@ msgstr "ప్రయత్నించండి: %s"
 #. Response a user can select in a feedback form, indicating that they're trying DuckDuckGo again.
 msgctxt "new user poll"
 msgid "Trying DuckDuckGo again"
+msgstr ""
+
+#. Message shown in a modal after supported third-party browser users disable AI features in Settings. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+#. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
 msgstr ""
 
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -16938,6 +17365,11 @@ msgstr ""
 msgid "Uruguay"
 msgstr ""
 
+#. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
+msgctxt "Navigation label on the Duck.ai settings page"
+msgid "Usage"
+msgstr ""
+
 #. A feedback suggestion
 msgctxt "Feedback prompt"
 msgid "Usage limit"
@@ -17286,6 +17718,11 @@ msgstr ""
 msgid "Wales"
 msgstr ""
 
+#. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Walk me through the steps"
+msgstr ""
+
 #. Label for walking directions on a map.
 msgctxt "directions"
 msgid "Walking"
@@ -17376,6 +17813,16 @@ msgstr ""
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
+msgstr ""
+
+#. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
+msgctxt ""
+"Inline warning shown below the share-content toggle when the user selects "
+"Harmful or Illegal but has not enabled sharing"
+msgid ""
+"We can only fix what we can see. To report a harmful or illegal response, "
+"please share this conversation with DuckDuckGo so we can investigate and "
+"address the issue."
 msgstr ""
 
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -17801,6 +18248,87 @@ msgid ""
 "experience."
 msgstr ""
 
+#. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the counterarguments?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the hours & location?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key contributions of this paper?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key contributions?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key details?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key points covered in this video?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key points?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key takeaways from this article?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key takeaways?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key things I will learn from this course?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main counterarguments or criticisms of this?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main questions this page answers?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the must-try dishes here?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"What are the opening hours, location, and contact details for this place?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the pros and cons of this product?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the pros and cons?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
 msgctxt "feedback form"
 msgid "What bothered you most?"
@@ -17884,6 +18412,11 @@ msgctxt "Full sentence for defining a term"
 msgid "What does atria mean in the context of a medical article?"
 msgstr ""
 
+#. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What does this answer?"
+msgstr ""
+
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
@@ -17893,6 +18426,11 @@ msgstr ""
 msgctxt "cloudsave"
 msgid "What information gets saved?"
 msgstr "ఏయే సమాచారం భద్రపరచబడుతుంది?"
+
+#. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What interview questions might come up for this role?"
+msgstr ""
 
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
@@ -17904,6 +18442,11 @@ msgstr ""
 #. Text for a prompt suggestion for looking up the capital city of Albania.
 msgctxt "Full sentence for looking up basic facts"
 msgid "What is the capital city of Albania?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What is the overall verdict and rating for this?"
 msgstr ""
 
 #. Link to a page with additional information.
@@ -17924,6 +18467,11 @@ msgctxt "maps_places"
 msgid "What people say:"
 msgstr "జనాలు ఏమంటున్నారు:"
 
+#. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What should I order?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
 msgctxt "feedback form"
 msgid "What stood out?"
@@ -17932,6 +18480,16 @@ msgstr ""
 #. Question on a feedback form for a negative feedback response.
 msgctxt "feedback form"
 msgid "What was wrong with the response? (optional)"
+msgstr ""
+
+#. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I learn?"
+msgstr ""
+
+#. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I need?"
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -17946,6 +18504,11 @@ msgstr ""
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
 msgctxt "SERP footer content"
 msgid "What's New"
+msgstr ""
+
+#. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What's the verdict?"
 msgstr ""
 
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -17987,6 +18550,11 @@ msgctxt "Feedback prompt"
 msgid "Which features are missing? (Optional)"
 msgstr ""
 
+#. An invitation for users to leave feedback
+msgctxt "Feedback prompt"
+msgid "Which features are missing? (optional)"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
 msgid "White"
 msgstr "తెలుపు"
@@ -17999,6 +18567,16 @@ msgstr "తెలుపు"
 #. Link to an about us page.
 msgid "Who We Are"
 msgstr "మేము ఎవరు"
+
+#. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Who are the main cast and crew, and what else are they known for?"
+msgstr ""
+
+#. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Who is this person?"
+msgstr ""
 
 #. Header above a collection of privacy-related links.
 msgid "Why Privacy"

--- a/locales/th_TH/LC_MESSAGES/duckduckgo.po
+++ b/locales/th_TH/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: th_TH\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -177,7 +177,8 @@ msgid ""
 "browser again to continue the chat, or switch to a Plus or free model."
 msgstr ""
 "%1$s ใช้ได้กับ Pro เท่านั้น อัปเกรดการสมัครสมาชิก DuckDuckGo "
-"ของคุณในเบราว์เซอร์นี้อีกครั้งเพื่อดำเนินการแชทต่อ หรือเปลี่ยนไปใช้โมเดล Plus หรือฟรี"
+"ของคุณในเบราว์เซอร์นี้อีกครั้งเพื่อดำเนินการแชทต่อ หรือเปลี่ยนไปใช้โมเดล "
+"Plus หรือฟรี"
 
 # smartling.placeholder_format=C
 #. Text for the disclaimer message that appears when a Plus subscriber tries to use a Pro-only model. %s is replaced with the model name. Example: Claude Opus 4.6 is only available with Pro. Upgrade your DuckDuckGo subscription in this browser again to continue the chat, or switch to a Plus or free model.
@@ -188,7 +189,8 @@ msgid ""
 "browser again to continue the chat, or switch to a Plus or free model."
 msgstr ""
 "%1$s ใช้ได้กับ Pro เท่านั้น อัปเกรดการสมัครสมาชิก DuckDuckGo "
-"ของคุณในเบราว์เซอร์นี้อีกครั้งเพื่อดำเนินการแชทต่อ หรือเปลี่ยนไปใช้โมเดล Plus หรือฟรี"
+"ของคุณในเบราว์เซอร์นี้อีกครั้งเพื่อดำเนินการแชทต่อ หรือเปลี่ยนไปใช้โมเดล "
+"Plus หรือฟรี"
 
 # smartling.placeholder_format=C
 #. Displayed when an AI (Artificial Intelligence) chat model is temporarily unavailable. Example: 'GPT 4o is only available with a DuckDuckGo subscription.'
@@ -205,7 +207,8 @@ msgid ""
 "model."
 msgstr ""
 "%1$s สามารถใช้ได้เฉพาะกับการสมัครใช้งาน DuckDuckGo เท่านั้น "
-"เปิดใช้งานการสมัครของคุณในเบราว์เซอร์นี้อีกครั้งเพื่อดำเนินการแชทต่อ หรือเปลี่ยนไปใช้โมเดลฟรี"
+"เปิดใช้งานการสมัครของคุณในเบราว์เซอร์นี้อีกครั้งเพื่อดำเนินการแชทต่อ "
+"หรือเปลี่ยนไปใช้โมเดลฟรี"
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is temporarily unavailable. Example: 'GPT 3.5 Turbo is temporarily unavailable. Please switch to a different model or try again later.'
@@ -213,7 +216,9 @@ msgctxt "Error message for model unavailability"
 msgid ""
 "%s is temporarily unavailable. Please switch to a different model or try "
 "again later."
-msgstr "%1$s ไม่สามารถใช้งานได้ชั่วคราว โปรดเปลี่ยนไปใช้รุ่นอื่นหรือลองอีกครั้งในภายหลัง"
+msgstr ""
+"%1$s ไม่สามารถใช้งานได้ชั่วคราว "
+"โปรดเปลี่ยนไปใช้รุ่นอื่นหรือลองอีกครั้งในภายหลัง"
 
 # smartling.placeholder_format=C
 #. Reddit's "fake internet points". https://support.reddithelp.com/hc/en-us/articles/204511829-What-is-karma
@@ -305,6 +310,7 @@ msgid ""
 "their servers."
 msgstr ""
 "%1$s ทํางานในสภาพแวดล้อมการดําเนินการที่เชื่อถือได้ "
+""
 "นี่หมายความว่าแม้แต่ผู้ให้บริการโมเดลก็ไม่สามารถดูคำแนะนำของคุณหรือการตอบสนองของโมเดล "
 "หรือบันทึกการแชทนี้บนเซิร์ฟเวอร์ของพวกเขา"
 
@@ -386,7 +392,8 @@ msgid ""
 "%s will be leaving Duck.ai in %s days (%s). After that, you can switch "
 "models to continue this chat."
 msgstr ""
-"%1$s จะออกจาก Duck.ai ใน %2$s วัน (%3$s) หลังจากนั้น คุณสามารถเปลี่ยนรุ่นเพื่อแชทต่อ"
+"%1$s จะออกจาก Duck.ai ใน %2$s วัน (%3$s) หลังจากนั้น "
+"คุณสามารถเปลี่ยนรุ่นเพื่อแชทต่อ"
 
 # smartling.placeholder_format=C
 #. Displayed in a saved chat when its AI model is about to be retired tomorrow. First placeholder is the friendly model name, second placeholder is the removal date formatted in the user's browser locale (e.g., 'June 15, 2026' in en-US). Singular-day form.
@@ -396,7 +403,9 @@ msgctxt ""
 msgid ""
 "%s will be leaving Duck.ai in 1 day (%s). After that, you can switch models "
 "to continue this chat."
-msgstr "%1$s จะออกจาก Duck.ai ใน 1 วัน (%2$s) หลังจากนั้น คุณสามารถเปลี่ยนรุ่นเพื่อแชทต่อ"
+msgstr ""
+"%1$s จะออกจาก Duck.ai ใน 1 วัน (%2$s) หลังจากนั้น "
+"คุณสามารถเปลี่ยนรุ่นเพื่อแชทต่อ"
 
 # smartling.placeholder_format=C
 #. Shown in a text selection chip when the selection contains multiple words. %s is replaced with the number of words, e.g. '142 words'.
@@ -416,7 +425,8 @@ msgstr "%1$sคลิก%2$sเพิ่ม%3$sเลือก%4$sอนุญ�
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAllow%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
 msgstr ""
-"%1$sคลิก%2$sอนุญาต%3$sคลิก%4$sเพิ่ม%5$sเลือก%6$sอนุญาต%7$s จากนั้นคลิก%8$sตกลง%9$s"
+"%1$sคลิก%2$sอนุญาต%3$sคลิก%4$sเพิ่ม%5$sเลือก%6$sอนุญาต%7$s "
+"จากนั้นคลิก%8$sตกลง%9$s"
 
 # Firefox
 # smartling.placeholder_format=C
@@ -461,13 +471,16 @@ msgctxt "Footer text for About Sync modal"
 msgid ""
 "%sLearn more%s about how chats are stored privately on DuckDuckGo's server."
 msgstr ""
-"%1$sเรียนรู้เพิ่มเติม%2$s เกี่ยวกับวิธีการจัดเก็บแชทอย่างเป็นส่วนตัวบนเซิร์ฟเวอร์ของ DuckDuckGo"
+"%1$sเรียนรู้เพิ่มเติม%2$s "
+"เกี่ยวกับวิธีการจัดเก็บแชทอย่างเป็นส่วนตัวบนเซิร์ฟเวอร์ของ DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "%sLearn more%s about how chats are stored privately on your device."
-msgstr "%1$sเรียนรู้เพิ่มเติม%2$s เกี่ยวกับวิธีการจัดเก็บแชทอย่างเป็นส่วนตัวบนอุปกรณ์ของคุณ"
+msgstr ""
+"%1$sเรียนรู้เพิ่มเติม%2$s "
+"เกี่ยวกับวิธีการจัดเก็บแชทอย่างเป็นส่วนตัวบนอุปกรณ์ของคุณ"
 
 # smartling.placeholder_format=C
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
@@ -911,8 +924,9 @@ msgid ""
 "aichat%s."
 msgstr ""
 "AI Chat ช่วยให้คุณสนทนาแบบไม่ต้องระบุชื่อด้วยโมเดลแชท AI ของบริษัทอื่น "
-"การปิดฟีเจอร์นี้จะซ่อนฟีเจอร์ AI Chat ใน DuckDuckGo Search คุณยังคงสามารถเข้าถึง AI Chat "
-"ได้เมื่อปิดการตั้งค่านี้โดยไปที่ %1$sduckduckgo.com/aichat%2$s"
+"การปิดฟีเจอร์นี้จะซ่อนฟีเจอร์ AI Chat ใน DuckDuckGo Search "
+"คุณยังคงสามารถเข้าถึง AI Chat ได้เมื่อปิดการตั้งค่านี้โดยไปที่ "
+"%1$sduckduckgo.com/aichat%2$s"
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -975,7 +989,8 @@ msgid ""
 msgstr ""
 "คำตอบที่ได้รับความช่วยเหลือจาก AI ขณะนี้ยังไม่รองรับคำถามที่ถามต่อโดยตรง "
 "แต่เรามีและมักจะเชื่อมโยงไปยัง %1$sDuck.ai%2$s สำหรับคำถามที่ถามต่อ "
-"ซึ่งเป็นบริการแชทส่วนตัวที่ใช้ AI และรองรับโมเดลแชทจาก OpenAI, Anthropic และอีกมากมาย"
+"ซึ่งเป็นบริการแชทส่วนตัวที่ใช้ AI และรองรับโมเดลแชทจาก OpenAI, Anthropic "
+"และอีกมากมาย"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has turned off AI features and will no longer see AI-assisted answers.
@@ -1160,7 +1175,8 @@ msgid ""
 "Activate your %s in this browser again to continue the chat, or switch to a "
 "free model."
 msgstr ""
-"เปิดใช้งาน %1$s ของคุณในเบราว์เซอร์นี้อีกครั้งเพื่อดำเนินการแชทต่อ หรือเปลี่ยนไปใช้โมเดลฟรี"
+"เปิดใช้งาน %1$s ของคุณในเบราว์เซอร์นี้อีกครั้งเพื่อดำเนินการแชทต่อ "
+"หรือเปลี่ยนไปใช้โมเดลฟรี"
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an active DuckDuckGo subscription.
@@ -1195,7 +1211,9 @@ msgstr "โฆษณา"
 #. An item in the ads tooltip that explains that ad clicks are managed by the ad network and are not used to profile you. The placeholder is the name of the ad network. For example: Microsoft
 msgid ""
 "Ad clicks are managed by %s’s ad network and are not used to profile you."
-msgstr "การคลิกโฆษณาจัดการโดยเครือข่ายโฆษณาของ %1$s และไม่ได้ใช้ในการสร้างโปรไฟล์ของคุณ"
+msgstr ""
+"การคลิกโฆษณาจัดการโดยเครือข่ายโฆษณาของ %1$s "
+"และไม่ได้ใช้ในการสร้างโปรไฟล์ของคุณ"
 
 # smartling.placeholder_format=C
 #. Information that ad clicks are managed by Microsoft.
@@ -1203,7 +1221,8 @@ msgid ""
 "Ad clicks are managed by Microsoft’s ad network and are not used to profile "
 "you."
 msgstr ""
-"การคลิกโฆษณาจัดการโดยเครือข่ายโฆษณาของ Microsoft และไม่ได้ใช้ในการสร้างโปรไฟล์ของคุณ"
+"การคลิกโฆษณาจัดการโดยเครือข่ายโฆษณาของ Microsoft "
+"และไม่ได้ใช้ในการสร้างโปรไฟล์ของคุณ"
 
 # smartling.placeholder_format=C
 #. An item in the ads tooltip that explains that ad clicks aren’t used to profile you.
@@ -1413,7 +1432,7 @@ msgstr "ที่อยู่ไม่ถูกต้อง"
 #. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Adjust the servings"
-msgstr ""
+msgstr "ปรับสัดส่วน"
 
 # smartling.placeholder_format=C
 #. as in multiple advertisements
@@ -1497,7 +1516,9 @@ msgstr "หลังจากดาวน์โหลดและเปิด �
 #. Instructions on how to install the DuckDuckGo browser extension after it downloads.
 msgid ""
 "After it downloads, locate the extension file and double-click it to install"
-msgstr "หลังจากที่ดาวน์โหลดเสร็จเรียบร้อย ให้ค้นหาไฟล์ส่วนขยายแล้วดับเบิลคลิกเพื่อติดตั้ง"
+msgstr ""
+"หลังจากที่ดาวน์โหลดเสร็จเรียบร้อย "
+"ให้ค้นหาไฟล์ส่วนขยายแล้วดับเบิลคลิกเพื่อติดตั้ง"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an age below a web search result.
@@ -1633,6 +1654,9 @@ msgid ""
 "All chats are anonymized by DuckDuckGo, and your conversations are not used "
 "to train chat models by DuckDuckGo or the model providers"
 msgstr ""
+"การแชททั้งหมดจะถูกทำให้ไม่ระบุชื่อโดย DuckDuckGo "
+"และการสนทนาของคุณจะไม่ถูกใช้ในการฝึกโมเดลการแชทโดย DuckDuckGo "
+"หรือผู้ให้บริการโมเดล"
 
 # smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1679,8 +1703,8 @@ msgid ""
 "All personal metadata (for example, your IP address) is removed before "
 "sending a chat to the AI provider."
 msgstr ""
-"ข้อมูลเมตาส่วนบุคคลทั้งหมด (เช่น ที่อยู่ IP ของคุณ) จะถูกลบออกก่อนที่จะส่งการแชทไปยังผู้ให้บริการ "
-"AI"
+"ข้อมูลเมตาส่วนบุคคลทั้งหมด (เช่น ที่อยู่ IP ของคุณ) "
+"จะถูกลบออกก่อนที่จะส่งการแชทไปยังผู้ให้บริการ AI"
 
 # smartling.placeholder_format=C
 #. A filter that shows search results from all countries.
@@ -1732,8 +1756,10 @@ msgid ""
 "Prompts and responses with %s still have %szero provider visibility%s."
 msgstr ""
 "อนุญาตให้ %1$s ค้นหาเว็บเพื่อปรับปรุงการตอบสนองต่อข้อความแจ้งที่เกี่ยวข้อง "
-"ส่งเฉพาะข้อความค้นหาที่สร้างโดย AI ไปยังเครื่องมือค้นหาที่มีการเก็บรักษาข้อมูลที่จํากัด "
-"คำแนะนำและการตอบสนองที่มี %2$s ยังคงมี %3$sการมองเห็นผู้ให้บริการเป็นศูนย์%4$s"
+"ส่งเฉพาะข้อความค้นหาที่สร้างโดย AI "
+"ไปยังเครื่องมือค้นหาที่มีการเก็บรักษาข้อมูลที่จํากัด "
+"คำแนะนำและการตอบสนองที่มี %2$s ยังคงมี "
+"%3$sการมองเห็นผู้ให้บริการเป็นศูนย์%4$s"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -1878,7 +1904,8 @@ msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
 msgstr ""
-"การเข้าถึงโมเดล AI ยอดนิยมแบบไม่ระบุชื่อ รวมถึง %1$s, %2$sและ %3$s และ %4$sโอเพ่นซอร์ส"
+"การเข้าถึงโมเดล AI ยอดนิยมแบบไม่ระบุชื่อ รวมถึง %1$s, %2$sและ %3$s และ "
+"%4$sโอเพ่นซอร์ส"
 
 # smartling.placeholder_format=C
 #. Text with information about Duck.ai and supported AI models, the placeholders list AI models. Example: 'Anonymous access to popular AI models, including GPT, Claude, and open-source Llama and Mistral.'
@@ -1887,7 +1914,8 @@ msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
 msgstr ""
-"การเข้าถึงโมเดล AI ยอดนิยมแบบไม่ระบุชื่อ รวมถึง %1$s, %2$sและ %3$s และ %4$sโอเพ่นซอร์ส"
+"การเข้าถึงโมเดล AI ยอดนิยมแบบไม่ระบุชื่อ รวมถึง %1$s, %2$sและ %3$s และ "
+"%4$sโอเพ่นซอร์ส"
 
 # smartling.placeholder_format=C
 #. Confirmation message after location service is enabled.
@@ -1901,6 +1929,8 @@ msgid ""
 "Anonymously generates answers for search queries based on web content. "
 "Choose how often you want it to appear, or disable it completely."
 msgstr ""
+"สร้างคำตอบสำหรับคำค้นหาโดยไม่ระบุตัวตนโดยอิงจากเนื้อหาบนเว็บ "
+"เลือกความถี่ที่คุณต้องการให้แสดง หรือปิดการใช้งานโดยสมบูรณ์"
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -1947,7 +1977,8 @@ msgid ""
 "Any additional instructions you want Duck.ai to follow. e.g. Always tell me "
 "facts about ducks"
 msgstr ""
-"คำแนะนำเพิ่มเติมที่เธอต้องการให้ Duck.ai ปฏิบัติตาม เช่น บอกข้อเท็จจริงเกี่ยวกับเป็ดให้ฉันรู้เสมอ"
+"คำแนะนำเพิ่มเติมที่เธอต้องการให้ Duck.ai ปฏิบัติตาม เช่น "
+"บอกข้อเท็จจริงเกี่ยวกับเป็ดให้ฉันรู้เสมอ"
 
 # smartling.placeholder_format=C
 #. Shown in video filtering. https://duckduckgo.com/?q=videos+of+cats&iax=videos&ia=videos
@@ -2067,7 +2098,8 @@ msgid ""
 "Are you sure you want to disable history? This will delete all chats, "
 "including pinned chats."
 msgstr ""
-"คุณแน่ใจหรือไม่ว่าต้องการปิดการใช้งานประวัติ การกระทำนี้จะลบแชททั้งหมด รวมถึงแชทที่ปักหมุดไว้ด้วย"
+"คุณแน่ใจหรือไม่ว่าต้องการปิดการใช้งานประวัติ การกระทำนี้จะลบแชททั้งหมด "
+"รวมถึงแชทที่ปักหมุดไว้ด้วย"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to disable recent chats, with a warning that it will also delete currently saved chats.
@@ -2076,7 +2108,8 @@ msgid ""
 "Are you sure you want to disable recent chats? This will also delete any "
 "recent chats that are currently saved."
 msgstr ""
-"คุณแน่ใจหรือไม่ว่าต้องการปิดการใช้งานแชทล่าสุด การดำเนินการนี้จะลบแชทล่าสุดที่มีการบันทึกไว้ด้วย"
+"คุณแน่ใจหรือไม่ว่าต้องการปิดการใช้งานแชทล่าสุด "
+"การดำเนินการนี้จะลบแชทล่าสุดที่มีการบันทึกไว้ด้วย"
 
 # smartling.placeholder_format=C
 #. Question asking user if they want to share the URL of the page they were on when giving feedback
@@ -2114,8 +2147,8 @@ msgid ""
 "As per our privacy policy, we do not collect or share any personal "
 "information ourselves. All of this privacy protection happens on your device."
 msgstr ""
-"ตามนโยบายความเป็นส่วนตัวของเรา เราจะไม่เก็บรวบรวมหรือแชร์ข้อมูลส่วนบุคคลใดๆ ด้วยตนเอง "
-"การปกป้องความเป็นส่วนตัวทั้งหมดนี้เกิดขึ้นบนอุปกรณ์ของคุณ"
+"ตามนโยบายความเป็นส่วนตัวของเรา เราจะไม่เก็บรวบรวมหรือแชร์ข้อมูลส่วนบุคคลใดๆ "
+"ด้วยตนเอง การปกป้องความเป็นส่วนตัวทั้งหมดนี้เกิดขึ้นบนอุปกรณ์ของคุณ"
 
 # smartling.placeholder_format=C
 #. A button to ask Duck.ai a question
@@ -2181,7 +2214,7 @@ msgstr "สอบถามข้อมูลติดตามกับ Duck.ai"
 #. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
 msgctxt "Page suggestion chip label"
 msgid "Ask about this page"
-msgstr ""
+msgstr "ถามเกี่ยวกับหน้านี้"
 
 # smartling.placeholder_format=C
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2246,12 +2279,16 @@ msgid ""
 "answers are only available in the U.S. (English) region."
 msgstr ""
 "Assist สามารถสร้างคำตอบที่ได้รับความช่วยเหลือจาก AI "
+""
 "โดยไม่ระบุตัวตนให้กับการค้นหาบางรายการโดยอิงจากการสรุปเนื้อหาเว็บที่เกี่ยวข้อง "
-"คุณสามารถเลือกได้ว่าต้องการให้ Assist ปรากฏบ่อยเพียงใด: ไม่แสดงเลย (ลบ Assist UI "
-"ออกจากผลการค้นหาทั้งหมด), ตามต้องการ (แสดงเฉพาะคำตอบที่ได้รับความช่วยเหลือจาก AI "
-"เมื่อคุณคลิกปุ่ม Assist), บางครั้ง (แสดงเฉพาะคำตอบที่ได้รับความช่วยเหลือจาก AI "
-"เมื่อมีความเกี่ยวข้องสูง) หรือบ่อยครั้ง (แสดงบ่อยขึ้นในการค้นหาที่มีช่วงกว้างกว่า) สำหรับตอนนี้ "
-"คำตอบที่ได้รับความช่วยเหลือจาก AI มีให้บริการเฉพาะในภูมิภาคสหรัฐอเมริกา (ภาษาอังกฤษ) เท่านั้น"
+"คุณสามารถเลือกได้ว่าต้องการให้ Assist ปรากฏบ่อยเพียงใด: ไม่แสดงเลย (ลบ "
+"Assist UI ออกจากผลการค้นหาทั้งหมด), ตามต้องการ "
+"(แสดงเฉพาะคำตอบที่ได้รับความช่วยเหลือจาก AI เมื่อคุณคลิกปุ่ม Assist), "
+"บางครั้ง (แสดงเฉพาะคำตอบที่ได้รับความช่วยเหลือจาก AI "
+"เมื่อมีความเกี่ยวข้องสูง) หรือบ่อยครั้ง "
+"(แสดงบ่อยขึ้นในการค้นหาที่มีช่วงกว้างกว่า) สำหรับตอนนี้ "
+"คำตอบที่ได้รับความช่วยเหลือจาก AI มีให้บริการเฉพาะในภูมิภาคสหรัฐอเมริกา "
+"(ภาษาอังกฤษ) เท่านั้น"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2263,9 +2300,14 @@ msgid ""
 "to remember that responses are auto-generated from cited sources and based "
 "on %scrawling the web%s."
 msgstr ""
-"Assist เป็นฟีเจอร์เสริมในผลการค้นหาของเราที่สามารถสร้างคำตอบที่ได้รับความช่วยเหลือจาก AI "
-"สำหรับคำค้นหาโดยไม่ระบุชื่อได้ ในการดำเนินการนี้ ระบบจะสแกนเว็บเพื่อหาเนื้อหาที่เกี่ยวข้อง "
-"จากนั้นใช้เทคโนโลยีภาษาธรรมชาติที่ใช้ AI เพื่อสร้างคำตอบสั้นๆ ตามข้อมูลที่เกี่ยวข้องที่พบ "
+"Assist "
+""
+"เป็นฟีเจอร์เสริมในผลการค้นหาของเราที่สามารถสร้างคำตอบที่ได้รับความช่วยเหลือจาก "
+"AI สำหรับคำค้นหาโดยไม่ระบุชื่อได้ ในการดำเนินการนี้ "
+"ระบบจะสแกนเว็บเพื่อหาเนื้อหาที่เกี่ยวข้อง "
+"จากนั้นใช้เทคโนโลยีภาษาธรรมชาติที่ใช้ AI เพื่อสร้างคำตอบสั้นๆ "
+"ตามข้อมูลที่เกี่ยวข้องที่พบ "
+""
 "สิ่งสำคัญคือต้องจำไว้ว่าคำตอบนั้นถูกสร้างขึ้นโดยอัตโนมัติจากแหล่งข้อมูลที่ใช้อ้างอิง "
 "และขึ้นอยู่กับ%1$sการรวบรวมข้อมูลเว็บ%2$s"
 
@@ -2431,8 +2473,8 @@ msgid ""
 "Assist is only available in English regions."
 msgstr ""
 "แสดง Assist โดยอัตโนมัติสำหรับการค้นหาที่เกี่ยวข้อง Assist "
-"สามารถค้นหาและสรุปข้อมูลโดยไม่ระบุตัวตนตามการค้นหาบางอย่าง สำหรับตอนนี้ Assist "
-"มีให้บริการเฉพาะในภูมิภาคที่ใช้ภาษาอังกฤษเท่านั้น"
+"สามารถค้นหาและสรุปข้อมูลโดยไม่ระบุตัวตนตามการค้นหาบางอย่าง สำหรับตอนนี้ "
+"Assist มีให้บริการเฉพาะในภูมิภาคที่ใช้ภาษาอังกฤษเท่านั้น"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2442,8 +2484,8 @@ msgid ""
 "For now, DuckAssist is only available in English regions."
 msgstr ""
 "แสดง DuckAssist โดยอัตโนมัติสำหรับการค้นหาที่เกี่ยวข้อง DuckAssist "
-"สามารถค้นหาและสรุปข้อมูลโดยไม่ระบุตัวตนตามการค้นหาบางอย่าง สำหรับตอนนี้ DuckAssist "
-"มีให้บริการเฉพาะในภูมิภาคที่ใช้ภาษาอังกฤษเท่านั้น"
+"สามารถค้นหาและสรุปข้อมูลโดยไม่ระบุตัวตนตามการค้นหาบางอย่าง สำหรับตอนนี้ "
+"DuckAssist มีให้บริการเฉพาะในภูมิภาคที่ใช้ภาษาอังกฤษเท่านั้น"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2594,7 +2636,7 @@ msgstr "บาร์โค้ด"
 #. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Based on this page, is this course worth taking?"
-msgstr ""
+msgstr "จากหน้านี้ หลักสูตรนี้น่าเรียนไหม?"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2643,6 +2685,8 @@ msgid ""
 "Before storing this report, DuckDuckGo will anonymize your conversation by "
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
+"ก่อนจัดเก็บรายงานนี้ DuckDuckGo จะทำให้การสนทนาของคุณไม่ระบุตัวตนโดยการลบ "
+"PII เช่น ชื่อ ที่อยู่อีเมล และเมตาดาต้าที่ระบุตัวตน"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -2964,7 +3008,7 @@ msgstr "เบรกพอยต์ที่ได้"
 #. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Break this down into clear, numbered steps."
-msgstr ""
+msgstr "แบ่งสิ่งนี้ออกเป็นขั้นตอนที่ชัดเจนและมีหมายเลขกำกับ"
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -3023,15 +3067,17 @@ msgid ""
 "Browse as usual while we add privacy protection. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
 msgstr ""
-"เรียกดูตามปกติขณะที่เราเพิ่มการปกป้องความเป็นส่วนตัวให้คุณ เรารวมเครื่องมือค้นหา "
-"เครื่องมือบล็อกตัวติดตาม และเครื่องมือบังคับใช้การเข้ารหัสไว้ด้วยกันใน%1$s%2$sส่วนขยาย%3$sเดียว"
+"เรียกดูตามปกติขณะที่เราเพิ่มการปกป้องความเป็นส่วนตัวให้คุณ "
+"เรารวมเครื่องมือค้นหา เครื่องมือบล็อกตัวติดตาม "
+"และเครื่องมือบังคับใช้การเข้ารหัสไว้ด้วยกันใน%1$s%2$sส่วนขยาย%3$sเดียว"
 
 # smartling.placeholder_format=C
 msgid ""
 "Browse as usual, and we'll take care of the rest. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
 msgstr ""
-"เรียกดูตามปกติ แล้วเราจะดูแลส่วนที่เหลือให้เอง เรารวมเครื่องมือค้นหา เครื่องมือบล็อกตัวติดตาม "
+"เรียกดูตามปกติ แล้วเราจะดูแลส่วนที่เหลือให้เอง เรารวมเครื่องมือค้นหา "
+"เครื่องมือบล็อกตัวติดตาม "
 "และเครื่องมือบังคับใช้การเข้ารหัสไว้ด้วยกันใน%1$s%2$sส่วนขยาย%3$sเดียว"
 
 # smartling.placeholder_format=C
@@ -3040,8 +3086,9 @@ msgid ""
 "search, tracker blocking, and site encryption, all in one download, for "
 "%smajor browsers%s."
 msgstr ""
-"เรียกดูตามปกติ แล้วเราจะดูแลส่วนที่เหลือให้เอง ดาวน์โหลดเพียงครั้งเดียวแล้วใช้งานได้ทั้ง Private "
-"Search, การบล็อกตัวติดตาม และการเข้ารหัสเว็บไซต์สำหรับ%1$sเบราว์เซอร์หลักๆ%2$s"
+"เรียกดูตามปกติ แล้วเราจะดูแลส่วนที่เหลือให้เอง "
+"ดาวน์โหลดเพียงครั้งเดียวแล้วใช้งานได้ทั้ง Private Search, การบล็อกตัวติดตาม "
+"และการเข้ารหัสเว็บไซต์สำหรับ%1$sเบราว์เซอร์หลักๆ%2$s"
 
 # smartling.placeholder_format=C
 #. Header for a call to action to browse with the DuckDuckGo browser
@@ -3148,9 +3195,11 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"ตามค่าเริ่มต้น การตั้งค่าจะได้รับการจัดเก็บอยู่ในคุกกี้เบราว์เซอร์ที่ไม่ใช่ส่วนบุคคล "
+"ตามค่าเริ่มต้น "
+"การตั้งค่าจะได้รับการจัดเก็บอยู่ในคุกกี้เบราว์เซอร์ที่ไม่ใช่ส่วนบุคคล "
 "(ในเบราว์เซอร์ของคุณ) คุณสามารถใช้ Cloud Save "
-"แบบไม่ระบุตัวตนเพื่อจัดเก็บข้อมูลการตั้งค่าอย่างถาวรยิ่งขึ้นได้ (บนเซิร์ฟเวอร์ระยะไกลในระบบคลาวด์) "
+"แบบไม่ระบุตัวตนเพื่อจัดเก็บข้อมูลการตั้งค่าอย่างถาวรยิ่งขึ้นได้ "
+"(บนเซิร์ฟเวอร์ระยะไกลในระบบคลาวด์) "
 "จะไม่มีการจัดเก็บข้อมูลที่สามารถระบุถึงตัวตนได้บนระบบคลาวด์และรหัสผ่านของคุณจะอยู่บนเบราว์เซอร์ของคุณเท่านั้น"
 
 # smartling.placeholder_format=C
@@ -3159,8 +3208,9 @@ msgid ""
 "By enabling dictation, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
 msgstr ""
-"โดยการเปิดใช้งานการป้อนข้อความด้วยเสียง คุณยินยอมให้ข้อมูลเสียงของคุณถูกส่งไปยัง OpenAI "
-"เพื่อใช้งานคุณลักษณะนี้ ดู %1$s ของเราก่อนเริ่มต้น"
+"โดยการเปิดใช้งานการป้อนข้อความด้วยเสียง "
+"คุณยินยอมให้ข้อมูลเสียงของคุณถูกส่งไปยัง OpenAI เพื่อใช้งานคุณลักษณะนี้ ดู "
+"%1$s ของเราก่อนเริ่มต้น"
 
 # smartling.placeholder_format=C
 #. Description for the 'enable voice chat' section of the voice chat consent modal. Placeholder for the voice chat help page link and text. Example: 'By enabling voice chat, you consent to your voice data being sent to OpenAI for the use of this feature. See our voice chat help page before getting started.'
@@ -3169,8 +3219,8 @@ msgid ""
 "By enabling voice chat, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
 msgstr ""
-"โดยการเปิดใช้งานการแชทด้วยเสียง คุณยินยอมให้ข้อมูลเสียงของคุณถูกส่งไปยัง OpenAI "
-"เพื่อใช้งานคุณลักษณะนี้ ดู %1$s ของเราก่อนเริ่มต้น"
+"โดยการเปิดใช้งานการแชทด้วยเสียง คุณยินยอมให้ข้อมูลเสียงของคุณถูกส่งไปยัง "
+"OpenAI เพื่อใช้งานคุณลักษณะนี้ ดู %1$s ของเราก่อนเริ่มต้น"
 
 # smartling.placeholder_format=C
 #. Golf leaderboard: player missed the cut
@@ -3419,7 +3469,7 @@ msgstr "นักแสดง"
 #. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Cast & Crew"
-msgstr ""
+msgstr "นักแสดง & ทีมงาน"
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -3657,7 +3707,8 @@ msgstr ""
 "Chat (ผ่านบริการ Duck.ai ของเรา) ให้คุณสนทนาแบบไม่ระบุตัวตนกับโมเดลแชท AI "
 "ของบุคคลที่สาม ซึ่งรองรับโมเดลจาก OpenAI, Anthropic และอีกมากมาย "
 "การปิดการตั้งค่านี้จะซ่อนปุ่ม Chat และลิงก์บน DuckDuckGo Search อย่างไรก็ตาม "
-"คุณยังสามารถเข้าถึง Chat ได้เมื่อปิดการตั้งค่านี้โดยไปที่ %1$shttps://duck.ai%2$s โดยตรง"
+"คุณยังสามารถเข้าถึง Chat ได้เมื่อปิดการตั้งค่านี้โดยไปที่ "
+"%1$shttps://duck.ai%2$s โดยตรง"
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -3782,8 +3833,8 @@ msgid ""
 "Chats are stored locally on your device instead of on DuckDuckGo servers or "
 "remote servers. Disabling chat history will delete pinned chats."
 msgstr ""
-"แชทจะถูกเก็บไว้ในอุปกรณ์ของคุณแทนที่จะอยู่บนเซิร์ฟเวอร์ของ DuckDuckGo หรือเซิร์ฟเวอร์ระยะไกล "
-"การปิดประวัติการแชทจะลบแชทที่ปักหมุด"
+"แชทจะถูกเก็บไว้ในอุปกรณ์ของคุณแทนที่จะอยู่บนเซิร์ฟเวอร์ของ DuckDuckGo "
+"หรือเซิร์ฟเวอร์ระยะไกล การปิดประวัติการแชทจะลบแชทที่ปักหมุด"
 
 # smartling.placeholder_format=C
 #. Text explaining how the Chat History feature stores the user's chats locally to their device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection. Also explains that disabling chat history will delete pinned chats.
@@ -3796,9 +3847,11 @@ msgid ""
 "prompts and responses."
 msgstr ""
 "แชทจะถูกจัดเก็บไว้ในอุปกรณ์ของคุณ "
-"คำแนะนำใหม่และการตอบกลับจะถูกเข้ารหัสและเก็บไว้ชั่วคราวบนเซิร์ฟเวอร์ DuckDuckGo "
-"หลังจากที่ส่งไปแล้ว เพื่อช่วยกู้คืนการแชทหากคุณสูญเสียการเชื่อมต่ออินเทอร์เน็ต "
-"การปิดประวัติการแชทจะลบแชทที่ปักหมุด และปิดใช้งานการเก็บคำแนะนำและการตอบสนองใหม่ชั่วคราว"
+"คำแนะนำใหม่และการตอบกลับจะถูกเข้ารหัสและเก็บไว้ชั่วคราวบนเซิร์ฟเวอร์ "
+"DuckDuckGo หลังจากที่ส่งไปแล้ว "
+"เพื่อช่วยกู้คืนการแชทหากคุณสูญเสียการเชื่อมต่ออินเทอร์เน็ต "
+"การปิดประวัติการแชทจะลบแชทที่ปักหมุด "
+"และปิดใช้งานการเก็บคำแนะนำและการตอบสนองใหม่ชั่วคราว"
 
 # smartling.placeholder_format=C
 #. Title shown above the body copy in the Duck.ai recent chats IndexedDB unavailable notice.
@@ -3872,7 +3925,9 @@ msgstr "ตรวจสอบการสะกดคำ"
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
 msgctxt "noresults"
 msgid "Check the DuckDuckGo subreddit for updates on this outage."
-msgstr "ตรวจสอบ subreddit ของ DuckDuckGo เพื่อรับข้อมูลอัปเดตเกี่ยวกับการหยุดให้บริการครั้งนี้"
+msgstr ""
+"ตรวจสอบ subreddit ของ DuckDuckGo "
+"เพื่อรับข้อมูลอัปเดตเกี่ยวกับการหยุดให้บริการครั้งนี้"
 
 # smartling.placeholder_format=C
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
@@ -4153,8 +4208,9 @@ msgid ""
 "indefinitely or auto-delete them after 7+ days of no AI Chat use."
 msgstr ""
 "การล้างข้อมูลเบราว์เซอร์จะลบแชท "
-"เบราว์เซอร์บางตัวอาจเก็บแชทล่าสุดไว้อย่างไม่มีกำหนดหรืออาจลบอัตโนมัติหลังจากไม่ได้ใช้งาน AI "
-"Chat เป็นเวลา 7 วันขึ้นไป"
+""
+"เบราว์เซอร์บางตัวอาจเก็บแชทล่าสุดไว้อย่างไม่มีกำหนดหรืออาจลบอัตโนมัติหลังจากไม่ได้ใช้งาน "
+"AI Chat เป็นเวลา 7 วันขึ้นไป"
 
 # smartling.placeholder_format=C
 #. Text explaining what happens to recent chats when browser data is cleared.
@@ -4165,8 +4221,8 @@ msgid ""
 "on your browser."
 msgstr ""
 "การล้างข้อมูลเบราว์เซอร์จะลบแชทล่าสุด "
-"แชทล่าสุดอาจถูกบันทึกไว้อย่างไม่มีกำหนดหรือลบอัตโนมัติหลังจาก 7 วันหากไม่ได้ใช้ Duck.ai "
-"ขึ้นอยู่กับเบราว์เซอร์ของคุณ"
+"แชทล่าสุดอาจถูกบันทึกไว้อย่างไม่มีกำหนดหรือลบอัตโนมัติหลังจาก 7 "
+"วันหากไม่ได้ใช้ Duck.ai ขึ้นอยู่กับเบราว์เซอร์ของคุณ"
 
 # smartling.placeholder_format=C
 #. Warning message shown on the Block domain success modal. Blocked sites are stored in localStorage which is cleared alongside cookies when users clear browser data. Followed by a linked 'our free browser' text.
@@ -4175,7 +4231,8 @@ msgid ""
 "Clearing browser data will reset your blocked sites. Save your block list "
 "permanently in"
 msgstr ""
-"การล้างข้อมูลเบราว์เซอร์จะรีเซ็ตไซต์ที่ถูกบล็อกของคุณ บันทึกรายการที่บล็อกของคุณอย่างถาวรใน"
+"การล้างข้อมูลเบราว์เซอร์จะรีเซ็ตไซต์ที่ถูกบล็อกของคุณ "
+"บันทึกรายการที่บล็อกของคุณอย่างถาวรใน"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -4184,8 +4241,8 @@ msgid ""
 "%sDuck.ai%s, our private AI chat service that supports chat models from "
 "OpenAI, Anthropic, and more."
 msgstr ""
-"คลิก \"เพิ่มเติม\" เพื่อเจาะลึกหัวข้อ และถามคำถามติดตามผ่าน %1$sDuck.ai%2$s บริการแชท AI "
-"ส่วนตัวของเราที่รองรับโมเดลแชทจาก OpenAI, Anthropic และอื่น ๆ"
+"คลิก \"เพิ่มเติม\" เพื่อเจาะลึกหัวข้อ และถามคำถามติดตามผ่าน %1$sDuck.ai%2$s "
+"บริการแชท AI ส่วนตัวของเราที่รองรับโมเดลแชทจาก OpenAI, Anthropic และอื่น ๆ"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4227,7 +4284,8 @@ msgid ""
 "Click %sEdit > Preferences%s (on Windows) %sSeaMonkey > Preferences%s (on "
 "Mac)"
 msgstr ""
-"คลิก%1$sแก้ไข > ค่ากำหนด%2$s (บน Windows) %3$sSeaMonkey > ค่ากำหนด%4$s (บน Mac)"
+"คลิก%1$sแก้ไข > ค่ากำหนด%2$s (บน Windows) %3$sSeaMonkey > ค่ากำหนด%4$s (บน "
+"Mac)"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -4258,7 +4316,8 @@ msgid ""
 "Click %sSafari%s in the top menu (On Windows, click the %sgears icon%s in "
 "the top right)"
 msgstr ""
-"คลิก %1$sSafari%2$s ในเมนูด้านบน (บน Windows ให้คลิก%3$sไอคอนเฟือง%4$sที่ด้านขวาบน)"
+"คลิก %1$sSafari%2$s ในเมนูด้านบน (บน Windows "
+"ให้คลิก%3$sไอคอนเฟือง%4$sที่ด้านขวาบน)"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4350,7 +4409,8 @@ msgid ""
 "it remains in your browser until you click/tap %sReset All Search Settings%s."
 msgstr ""
 "คลิกหรือแตะ %1$sลบข้อมูลของฉัน%2$s การดำเนินการนี้จะลบข้อมูลออกจากระบบคลาวด์ "
-"แต่จะยังคงอยู่ในเบราว์เซอร์จนกว่าคุณจะคลิก/แตะ %3$sรีเซ็ตการตั้งค่าการค้นหาทั้งหมด%4$s"
+"แต่จะยังคงอยู่ในเบราว์เซอร์จนกว่าคุณจะคลิก/แตะ "
+"%3$sรีเซ็ตการตั้งค่าการค้นหาทั้งหมด%4$s"
 
 # smartling.placeholder_format=C
 #. Tells users where to click in order to disable the cloud save feature and delete any data backed-up to the cloud.
@@ -4431,7 +4491,8 @@ msgid ""
 "Click the dropdown menu beside %sSearch engine used in the address bar%s and "
 "select %sDuckDuckGo%s."
 msgstr ""
-"คลิกเมนูดรอปดาวน์ข้าง%1$sเครื่องมือค้นหาที่ใช้ในแถบที่อยู่%2$s และเลือก %3$sDuckDuckGo%4$s"
+"คลิกเมนูดรอปดาวน์ข้าง%1$sเครื่องมือค้นหาที่ใช้ในแถบที่อยู่%2$s และเลือก "
+"%3$sDuckDuckGo%4$s"
 
 # smartling.placeholder_format=C
 #. First step in a list of steps to take to disable the user's ad blocker
@@ -4627,7 +4688,8 @@ msgid ""
 "Cloud Save lets you save your settings more permanently by entering a "
 "passphrase. It is entirely optional."
 msgstr ""
-"Cloud Save ช่วยให้คุณบันทึกการตั้งค่าของคุณอย่างถาวรยิ่งขึ้นได้โดยการป้อนรหัสผ่าน "
+"Cloud Save "
+"ช่วยให้คุณบันทึกการตั้งค่าของคุณอย่างถาวรยิ่งขึ้นได้โดยการป้อนรหัสผ่าน "
 "ซึ่งเป็นการดำเนินการที่ไม่บังคับ"
 
 # smartling.placeholder_format=C
@@ -5106,7 +5168,7 @@ msgstr "สร้างภาพ"
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
-msgstr ""
+msgstr "สร้างรายการซื้อของพร้อมระบุปริมาณจากสูตรอาหารนี้"
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed in the input field when starting a new image generation session.
@@ -5749,7 +5811,7 @@ msgstr "ถึงขีดจำกัดการป้อนข้อควา
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
 msgid "Dictation temporarily unavailable"
-msgstr ""
+msgstr "การพิมพ์ด้วยเสียงไม่สามารถใช้งานได้ชั่วคราว"
 
 # smartling.placeholder_format=C
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
@@ -6058,6 +6120,8 @@ msgid ""
 "Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
 "filtered out. %sLearn More%s"
 msgstr ""
+"ไม่ต้องการ AI ใช่ไหม %1$snoai.duckduckgo.com%2$s ไม่มีฟีเจอร์ AI และกรองภาพ "
+"AI ออกแล้ว %3$sศึกษาเพิ่มเติม%4$s"
 
 # smartling.placeholder_format=C
 #. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
@@ -6066,6 +6130,8 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
+"ไม่ต้องการ AI ใช่ไหม ไปที่ %1$snoai.duckduckgo.com%2$s "
+"เพื่อค้นหาโดยไม่มีฟีเจอร์ AI และกรองภาพ AI ออก %3$sศึกษาเพิ่มเติม%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6181,13 +6247,13 @@ msgstr "ร่างอีเมลที่กระชับและละเ
 #. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Draft a cover letter"
-msgstr ""
+msgstr "ร่างจดหมายสมัครงาน"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Draft a cover letter for this job."
-msgstr ""
+msgstr "ร่างจดหมายสมัครงานสำหรับงานนี้"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -6330,7 +6396,8 @@ msgid ""
 "pages automatically in Settings."
 msgstr ""
 "ตอนนี้ Duck.ai สามารถช่วยตอบคําถามเกี่ยวกับหน้าเว็บที่คุณกำลังดูอยู่ได้แล้ว "
-"เนื้อหาในหน้าจะถูกรวมเข้าไปเมื่อคุณแนบมัน ยกเว้นว่าคุณเลือกที่จะแนบหน้าโดยอัตโนมัติในการตั้งค่า"
+"เนื้อหาในหน้าจะถูกรวมเข้าไปเมื่อคุณแนบมัน "
+"ยกเว้นว่าคุณเลือกที่จะแนบหน้าโดยอัตโนมัติในการตั้งค่า"
 
 # smartling.placeholder_format=C
 #. Shown in the Duck.ai recent chats list on standalone when the browser API needed to store chats locally is missing or unavailable.
@@ -6365,6 +6432,8 @@ msgid ""
 "company for anyone who wants to take back control of their personal "
 "information."
 msgstr ""
+"Duck.ai สร้างสรรค์โดย DuckDuckGo "
+"เราเป็นบริษัทอิสระด้านการปกป้องออนไลน์สำหรับทุกคนที่ต้องการควบคุมข้อมูลส่วนบุคคลของตนกลับคืนมา"
 
 # smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
@@ -6379,8 +6448,8 @@ msgid ""
 "Duck.ai is still a DuckDuckGo product, but will now have an easier to "
 "remember home on the web: https://duck.ai"
 msgstr ""
-"Duck.ai ยังคงเป็นผลิตภัณฑ์ของ DuckDuckGo แต่ตอนนี้จะมีที่อยู่บนเว็บที่จดจำง่ายขึ้น: https://"
-"duck.ai"
+"Duck.ai ยังคงเป็นผลิตภัณฑ์ของ DuckDuckGo "
+"แต่ตอนนี้จะมีที่อยู่บนเว็บที่จดจำง่ายขึ้น: https://duck.ai"
 
 # smartling.placeholder_format=C
 #. Headline for domain change notice.
@@ -6395,7 +6464,8 @@ msgid ""
 "Duck.ai is temporarily unavailable. If this persists, please email this "
 "anonymous code %s to %s"
 msgstr ""
-"Duck.ai ไม่สามารถใช้งานได้ชั่วคราว หากยังคงอยู่ โปรดส่งอีเมลรหัสที่ไม่ระบุชื่อนี้ %1$s ไปที่ %2$s"
+"Duck.ai ไม่สามารถใช้งานได้ชั่วคราว หากยังคงอยู่ "
+"โปรดส่งอีเมลรหัสที่ไม่ระบุชื่อนี้ %1$s ไปที่ %2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -6416,6 +6486,9 @@ msgid ""
 "Duck.ai lets you chat privately with popular AI models. Disabling it hides "
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
+"Duck.ai ให้คุณแชทแบบส่วนตัวกับโมเดล AI ยอดนิยม "
+"การปิดใช้งานจะซ่อนปุ่มและลิงก์ของ Duck.ai แต่คุณยังสามารถไปที่ "
+"%1$sduck.ai%2$s โดยตรง"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6426,10 +6499,10 @@ msgid ""
 "can still access Duck.ai when this setting is off by visiting %shttps://duck."
 "ai%s directly."
 msgstr ""
-"Duck.ai ช่วยให้คุณสนทนาแบบไม่ระบุตัวตนกับโมเดลแชท AI ของบุคคลที่สาม รวมถึงโมเดลจาก "
-"OpenAI, Anthropic และอื่นๆ การปิดการตั้งค่านี้จะซ่อนปุ่ม Chat และลิงก์บน DuckDuckGo "
-"Search อย่างไรก็ตาม คุณยังสามารถเข้าถึง Duck.ai ได้เมื่อปิดการตั้งค่านี้โดยไปที่ %1$shttps://"
-"duck.ai%2$s โดยตรง"
+"Duck.ai ช่วยให้คุณสนทนาแบบไม่ระบุตัวตนกับโมเดลแชท AI ของบุคคลที่สาม "
+"รวมถึงโมเดลจาก OpenAI, Anthropic และอื่นๆ การปิดการตั้งค่านี้จะซ่อนปุ่ม Chat "
+"และลิงก์บน DuckDuckGo Search อย่างไรก็ตาม คุณยังสามารถเข้าถึง Duck.ai "
+"ได้เมื่อปิดการตั้งค่านี้โดยไปที่ %1$shttps://duck.ai%2$s โดยตรง"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
@@ -6484,9 +6557,9 @@ msgid ""
 "AI chat no sign up, OpenAI, Anthropic, Llama, Mistral, open source AI "
 "models, privacy focused AI, no account AI chat"
 msgstr ""
-"Duck.ai, DuckDuckGo AI, แชทบอท AI ส่วนตัว, แชท AI ฟรี, แชท AI แบบไม่ระบุตัวตน, แชท "
-"AI ไม่ต้องสมัคร, OpenAI, Anthropic, Llama, Mistral, โมเดล AI โอเพนซอร์ส, AI "
-"ที่เน้นความเป็นส่วนตัว, แชท AI ไม่ต้องมีบัญชี"
+"Duck.ai, DuckDuckGo AI, แชทบอท AI ส่วนตัว, แชท AI ฟรี, แชท AI "
+"แบบไม่ระบุตัวตน, แชท AI ไม่ต้องสมัคร, OpenAI, Anthropic, Llama, Mistral, "
+"โมเดล AI โอเพนซอร์ส, AI ที่เน้นความเป็นส่วนตัว, แชท AI ไม่ต้องมีบัญชี"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -6515,10 +6588,12 @@ msgid ""
 "For now, DuckAssist is only available in the U.S. (English) region."
 msgstr ""
 "DuckAssist สามารถค้นหาและสรุปข้อมูลโดยไม่ระบุตัวตนตามการค้นหาบางอย่าง "
-"คุณสามารถเลือกได้ว่าต้องการให้ DuckAssist ปรากฏบ่อยเพียงใด: ไม่แสดงเลย (ลบ DuckAssist "
-"UI ออกจากผลการค้นหาทั้งหมด), ตามต้องการ (แสดงเฉพาะเมื่อคุณคลิกปุ่ม Assist), บางครั้ง "
-"(แสดงเฉพาะเมื่อมีความเกี่ยวข้องสูง) หรือบ่อยครั้ง (แสดงบ่อยขึ้นในการค้นหาที่มีช่วงกว้าง) "
-"สำหรับตอนนี้ DuckAssist มีให้บริการเฉพาะในภูมิภาคสหรัฐอเมริกา (ภาษาอังกฤษ) เท่านั้น"
+"คุณสามารถเลือกได้ว่าต้องการให้ DuckAssist ปรากฏบ่อยเพียงใด: ไม่แสดงเลย (ลบ "
+"DuckAssist UI ออกจากผลการค้นหาทั้งหมด), ตามต้องการ "
+"(แสดงเฉพาะเมื่อคุณคลิกปุ่ม Assist), บางครั้ง "
+"(แสดงเฉพาะเมื่อมีความเกี่ยวข้องสูง) หรือบ่อยครั้ง "
+"(แสดงบ่อยขึ้นในการค้นหาที่มีช่วงกว้าง) สำหรับตอนนี้ DuckAssist "
+"มีให้บริการเฉพาะในภูมิภาคสหรัฐอเมริกา (ภาษาอังกฤษ) เท่านั้น"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6527,9 +6602,9 @@ msgid ""
 "%sDuckDuckGo AI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI, and Anthropic, and more."
 msgstr ""
-"DuckAssist ไม่สามารถตอบคำถามที่ตามมาได้ อย่างไรก็ตาม เรายังมี %1$sDuckDuckGo AI "
-"Chat%2$s ซึ่งเป็นบริการแชทส่วนตัวที่ใช้ AI และรองรับโมเดลการแชทจาก OpenAI, Anthropic "
-"และอื่นๆ อีกมากมาย"
+"DuckAssist ไม่สามารถตอบคำถามที่ตามมาได้ อย่างไรก็ตาม เรายังมี %1$sDuckDuckGo "
+"AI Chat%2$s ซึ่งเป็นบริการแชทส่วนตัวที่ใช้ AI และรองรับโมเดลการแชทจาก "
+"OpenAI, Anthropic และอื่นๆ อีกมากมาย"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6538,9 +6613,9 @@ msgid ""
 "DuckDuckGo %sAI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI and Anthropic."
 msgstr ""
-"DuckAssist ไม่สามารถตอบคำถามที่ถามต่อได้ อย่างไรก็ตาม เรายังมี DuckDuckGo %1$sAI "
-"Chat%2$s ซึ่งเป็นบริการแชทส่วนตัวที่ขับเคลื่อนด้วย AI ที่รองรับโมเดลการแชทจาก OpenAI และ "
-"Anthropic"
+"DuckAssist ไม่สามารถตอบคำถามที่ถามต่อได้ อย่างไรก็ตาม เรายังมี DuckDuckGo "
+"%1$sAI Chat%2$s ซึ่งเป็นบริการแชทส่วนตัวที่ขับเคลื่อนด้วย AI "
+"ที่รองรับโมเดลการแชทจาก OpenAI และ Anthropic"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6553,8 +6628,10 @@ msgid ""
 "checked for accuracy."
 msgstr ""
 "DuckAssist "
+""
 "เป็นคุณลักษณะใหม่ในผลการค้นหาของเราที่สามารถสร้างคำตอบสำหรับคำค้นหาโดยไม่ระบุชื่อได้ "
-"ในการดำเนินการนี้ ระบบจะสแกน Wikipedia และเว็บไซต์ที่เกี่ยวข้องเพื่อหาเนื้อหาที่เกี่ยวข้อง "
+"ในการดำเนินการนี้ ระบบจะสแกน Wikipedia "
+"และเว็บไซต์ที่เกี่ยวข้องเพื่อหาเนื้อหาที่เกี่ยวข้อง "
 "จากนั้นใช้เทคโนโลยีภาษาธรรมชาติที่ขับเคลื่อนด้วย AI เพื่อสร้างข้อมูลสรุป "
 "โปรดทราบว่าขณะนี้คำตอบนั้นอิงจาก Wikipedia และเนื้อหาที่เกี่ยวข้อง "
 "และไม่ได้มีการตรวจสอบความถูกต้อง"
@@ -6572,11 +6649,16 @@ msgid ""
 "sources and based on %scrawling the web%s."
 msgstr ""
 "DuckAssist "
+""
 "เป็นฟีเจอร์เสริมในผลการค้นหาของเราที่สามารถสร้างคำตอบสำหรับคำค้นหาโดยไม่ระบุชื่อได้ "
-"ในการดำเนินการนี้ ระบบจะสแกนเว็บเพื่อหาเนื้อหาที่เกี่ยวข้อง จากนั้นใช้เทคโนโลยีภาษาธรรมชาติที่ใช้ "
-"AI เพื่อสร้างคำตอบสั้นๆ ตามข้อมูลที่เกี่ยวข้องที่พบ คำตอบของ DuckAssist "
-"จะเชื่อมโยงโดยตรงกับแหล่งข้อมูลหนึ่งหรือสองแหล่งเสมอ โดยอ้างอิงแหล่งที่มาของคำตอบ "
+"ในการดำเนินการนี้ ระบบจะสแกนเว็บเพื่อหาเนื้อหาที่เกี่ยวข้อง "
+"จากนั้นใช้เทคโนโลยีภาษาธรรมชาติที่ใช้ AI เพื่อสร้างคำตอบสั้นๆ "
+"ตามข้อมูลที่เกี่ยวข้องที่พบ คำตอบของ DuckAssist "
+"จะเชื่อมโยงโดยตรงกับแหล่งข้อมูลหนึ่งหรือสองแหล่งเสมอ "
+"โดยอ้างอิงแหล่งที่มาของคำตอบ "
+""
 "เพื่อให้คุณสามารถไปยังแหล่งข้อมูลเพื่อดูข้อมูลโดยละเอียดเพิ่มเติมได้อย่างง่ายดาย "
+""
 "สิ่งสำคัญคือต้องจำไว้ว่าคำตอบนั้นถูกสร้างขึ้นโดยอัตโนมัติจากแหล่งข้อมูลที่ใช้อ้างอิง "
 "และขึ้นอยู่กับ%1$sการรวบรวมข้อมูลเว็บ%2$s"
 
@@ -6586,7 +6668,8 @@ msgid ""
 "DuckAssist responses are auto-generated based on listed sources and not "
 "checked for accuracy."
 msgstr ""
-"คำตอบ DuckAssist สร้างขึ้นโดยอัตโนมัติตามแหล่งที่มาที่ระบุไว้และไม่ได้ตรวจสอบความถูกต้อง"
+"คำตอบ DuckAssist "
+"สร้างขึ้นโดยอัตโนมัติตามแหล่งที่มาที่ระบุไว้และไม่ได้ตรวจสอบความถูกต้อง"
 
 # smartling.placeholder_format=C
 #. Displayed when the chat service has reached the maximum number of messages for one day.
@@ -6594,7 +6677,9 @@ msgctxt "Error message for service limit"
 msgid ""
 "DuckDuckGo AI Chat has reached the maximum number of messages for one day. "
 "Please continue this chat tomorrow."
-msgstr "DuckDuckGo AI Chat ถึงจำนวนข้อความสูงสุดในหนึ่งวันแล้ว โปรดแชทต่อในวันพรุ่งนี้"
+msgstr ""
+"DuckDuckGo AI Chat ถึงจำนวนข้อความสูงสุดในหนึ่งวันแล้ว "
+"โปรดแชทต่อในวันพรุ่งนี้"
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the AI chat service and supported AI models. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -6603,8 +6688,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"DuckDuckGo AI Chat เป็นบริการแชทส่วนตัวที่ขับเคลื่อนด้วย AI ซึ่งปัจจุบันรองรับโมเดลการแชท "
-"%2$s ของ %1$s และ %4$s ของ %3$s"
+"DuckDuckGo AI Chat เป็นบริการแชทส่วนตัวที่ขับเคลื่อนด้วย AI "
+"ซึ่งปัจจุบันรองรับโมเดลการแชท %2$s ของ %1$s และ %4$s ของ %3$s"
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the welcome screen of the onboarding. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -6613,8 +6698,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"DuckDuckGo AI Chat เป็นบริการแชทส่วนตัวที่ขับเคลื่อนด้วย AI ซึ่งปัจจุบันรองรับโมเดลการแชท "
-"%2$s ของ %1$s และ %4$s ของ %3$s"
+"DuckDuckGo AI Chat เป็นบริการแชทส่วนตัวที่ขับเคลื่อนด้วย AI "
+"ซึ่งปัจจุบันรองรับโมเดลการแชท %2$s ของ %1$s และ %4$s ของ %3$s"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding DuckDuckGo AI Chat.
@@ -6631,8 +6716,8 @@ msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. If this persists, please "
 "email this anonymous code %s to %s"
 msgstr ""
-"DuckDuckGo AI Chat ไม่สามารถใช้งานได้ชั่วคราว หากยังคงอยู่ โปรดส่งอีเมลรหัสที่ไม่ระบุชื่อนี้ "
-"%1$s ไปที่ %2$s"
+"DuckDuckGo AI Chat ไม่สามารถใช้งานได้ชั่วคราว หากยังคงอยู่ "
+"โปรดส่งอีเมลรหัสที่ไม่ระบุชื่อนี้ %1$s ไปที่ %2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -6640,7 +6725,9 @@ msgctxt "Error message for VQD error"
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. Please refresh the page and "
 "try again."
-msgstr "DuckDuckGo AI Chat ไม่สามารถใช้งานได้ชั่วคราว โปรดรีเฟรชหน้านี้แล้วลองอีกครั้ง"
+msgstr ""
+"DuckDuckGo AI Chat ไม่สามารถใช้งานได้ชั่วคราว "
+"โปรดรีเฟรชหน้านี้แล้วลองอีกครั้ง"
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -6765,8 +6852,8 @@ msgid ""
 "DuckDuckGo anonymizes these reports by automatically removing PII like "
 "names, email addresses, phone numbers, and identifying metadata."
 msgstr ""
-"DuckDuckGo ทำให้รายงานเหล่านี้ไม่ระบุตัวตนโดยการลบ PII โดยอัตโนมัติ เช่น ชื่อ ที่อยู่อีเมล "
-"หมายเลขโทรศัพท์ และเมตาดาต้าที่ระบุตัวตน"
+"DuckDuckGo ทำให้รายงานเหล่านี้ไม่ระบุตัวตนโดยการลบ PII โดยอัตโนมัติ เช่น "
+"ชื่อ ที่อยู่อีเมล หมายเลขโทรศัพท์ และเมตาดาต้าที่ระบุตัวตน"
 
 # smartling.placeholder_format=C
 #. The first %s is the agree button label ('Agree'). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. The leading sentence mirrors the drawer-style inline disclaimer (DUCKCHAT_TOS_INLINE_DISCLAIMER).
@@ -6774,7 +6861,8 @@ msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid ""
 "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to Duck.ai's %s."
 msgstr ""
-"DuckDuckGo ทําให้แชทของคุณไม่เปิดเผยตัวตน เมื่อคลิก '%1$s' คุณยอมรับ %2$s ของ Duck.ai"
+"DuckDuckGo ทําให้แชทของคุณไม่เปิดเผยตัวตน เมื่อคลิก '%1$s' คุณยอมรับ %2$s "
+"ของ Duck.ai"
 
 # smartling.placeholder_format=C
 #. Shown below the input on the empty state when the user has not yet accepted the terms of service. The first %s is the action button label ('Ask' for chat, 'Create' for image generation). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. Clicking the action button both accepts the terms and submits the prompt.
@@ -6783,7 +6871,8 @@ msgctxt ""
 "users"
 msgid "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to our %s."
 msgstr ""
-"DuckDuckGo ทําให้แชทของคุณไม่เปิดเผยตัวตน เมื่อคลิก '%1$s' แสดงว่าคุณยอมรับ %2$s ของเรา"
+"DuckDuckGo ทําให้แชทของคุณไม่เปิดเผยตัวตน เมื่อคลิก '%1$s' แสดงว่าคุณยอมรับ "
+"%2$s ของเรา"
 
 # smartling.placeholder_format=C
 #. An information popup explaining that we block trackers
@@ -6792,8 +6881,9 @@ msgid ""
 "companies like Google and Facebook, who often try to track you on other "
 "websites."
 msgstr ""
-"DuckDuckGo จะบล็อกตัวติดตามบนเว็บไซต์ที่คุณเยี่ยมชม รวมถึงตัวติดตามจากบริษัทต่างๆ เช่น Google "
-"และ Facebook ซึ่งมักจะพยายามติดตามคุณบนเว็บไซต์อื่นๆ"
+"DuckDuckGo จะบล็อกตัวติดตามบนเว็บไซต์ที่คุณเยี่ยมชม "
+"รวมถึงตัวติดตามจากบริษัทต่างๆ เช่น Google และ Facebook "
+"ซึ่งมักจะพยายามติดตามคุณบนเว็บไซต์อื่นๆ"
 
 # smartling.placeholder_format=C
 #. Description of how DuckDuckGo keeps a user's location anonymous while the user searches on a map of their area.
@@ -6805,9 +6895,11 @@ msgid ""
 "away, such that you remain anonymous. %sLearn more about how we designed "
 "this technology to protect your privacy%s."
 msgstr ""
-"DuckDuckGo ให้ความสำคัญกับความเป็นส่วนตัวตั้งแต่ขั้นตอนการออกแบบ เมื่อคุณเปิดใช้งานตำแหน่งที่ตั้ง "
+"DuckDuckGo ให้ความสำคัญกับความเป็นส่วนตัวตั้งแต่ขั้นตอนการออกแบบ "
+"เมื่อคุณเปิดใช้งานตำแหน่งที่ตั้ง "
 "ข้อมูลดังกล่าวจะได้รับการจัดเก็บไว้บนอุปกรณ์ของคุณเท่านั้น เมื่อคุณค้นหา "
-"อุปกรณ์ของคุณจึงจะส่งข้อมูลตำแหน่งที่ตั้งมาให้เรา ซึ่งเราจะใช้เพื่อปรับปรุงผลการค้นหาดังกล่าว "
+"อุปกรณ์ของคุณจึงจะส่งข้อมูลตำแหน่งที่ตั้งมาให้เรา "
+"ซึ่งเราจะใช้เพื่อปรับปรุงผลการค้นหาดังกล่าว "
 "จากนั้นเราจะทิ้งข้อมูลดังกล่าวในทันทีเพื่อให้ไม่มีการระบุตัวตนของคุณได้ "
 "%1$sดูข้อมูลเพิ่มเติมเกี่ยวกับวิธีที่เราออกแบบเทคโนโลยีนี้เพื่อปกป้องความเป็นส่วนตัวของคุณ%2$s"
 
@@ -6829,8 +6921,9 @@ msgid ""
 "DuckDuckGo only uses your approximate location. That's all we need to "
 "deliver better results, closer to you. %sLearn more%s."
 msgstr ""
-"DuckDuckGo ใช้เฉพาะตำแหน่งที่ตั้งโดยประมาณของคุณ ซึ่งเราต้องการเพียงเพื่อให้ได้ผลลัพธ์ที่ดีขึ้น "
-"และใกล้คุณมากขึ้น %1$sดูข้อมูลเพิ่มเติม%2$s"
+"DuckDuckGo ใช้เฉพาะตำแหน่งที่ตั้งโดยประมาณของคุณ "
+"ซึ่งเราต้องการเพียงเพื่อให้ได้ผลลัพธ์ที่ดีขึ้น และใกล้คุณมากขึ้น "
+"%1$sดูข้อมูลเพิ่มเติม%2$s"
 
 # smartling.placeholder_format=C
 msgid "DuckDuckGo search"
@@ -6916,8 +7009,9 @@ msgid ""
 "random words from that list, ensuring that the passphrase is at least 18-20 "
 "characters long."
 msgstr ""
-"ทุกครั้งที่คุณขอให้แนะนำรหัสผ่าน เราจะได้รับรายการคำสุ่มหลายคำจากเซิร์ฟเวอร์ของ DuckDuckGo "
-"จากนั้นเราจะสุ่มคำ 4 - 5 คำจากรายการดังกล่าวในเบราว์เซอร์ "
+"ทุกครั้งที่คุณขอให้แนะนำรหัสผ่าน "
+"เราจะได้รับรายการคำสุ่มหลายคำจากเซิร์ฟเวอร์ของ DuckDuckGo จากนั้นเราจะสุ่มคำ "
+"4 - 5 คำจากรายการดังกล่าวในเบราว์เซอร์ "
 "เพื่อให้มั่นใจว่ารหัสผ่านมีความยาวอักขระอย่างน้อย 18-20 ตัว"
 
 # smartling.placeholder_format=C
@@ -7113,7 +7207,9 @@ msgstr "เปิดใช้งานการค้นหาเว็บ"
 msgid ""
 "Enable anonymous location for more accurate results. You can always change "
 "your mind later."
-msgstr "เปิดใช้ตำแหน่งที่ตั้งแบบไม่ระบุตัวตนเพื่อผลลัพธ์ที่แม่นยำยิ่งขึ้น คุณสามารถเปลี่ยนใจได้ในภายหลัง"
+msgstr ""
+"เปิดใช้ตำแหน่งที่ตั้งแบบไม่ระบุตัวตนเพื่อผลลัพธ์ที่แม่นยำยิ่งขึ้น "
+"คุณสามารถเปลี่ยนใจได้ในภายหลัง"
 
 # smartling.placeholder_format=C
 #. Title of the dictation privacy consent modal shown on first use.
@@ -7319,7 +7415,8 @@ msgid ""
 "Enter a new passphrase and click/tap %sSave Settings%s. This will save your "
 "data under your new passphrase."
 msgstr ""
-"ป้อนรหัสผ่านใหม่แล้วคลิก/แตะ%1$sบันทึกการตั้งค่า%2$s การดำเนินการนี้จะบันทึกข้อมูลในรหัสผ่านใหม่"
+"ป้อนรหัสผ่านใหม่แล้วคลิก/แตะ%1$sบันทึกการตั้งค่า%2$s "
+"การดำเนินการนี้จะบันทึกข้อมูลในรหัสผ่านใหม่"
 
 # smartling.placeholder_format=C
 #. Label for the field where a user enters their passphrase.
@@ -7345,7 +7442,8 @@ msgstr "ป้อนข้อความ"
 msgid ""
 "Enter the following details: %sName%s: DuckDuckGo%s URL%s: %s Alias%s: d%s"
 msgstr ""
-"ป้อนรายละเอียดต่อไปนี้: %1$sชื่อ%2$s: DuckDuckGo%3$s URL%4$s: %5$s นามแฝง%6$s: d%7$s"
+"ป้อนรายละเอียดต่อไปนี้: %1$sชื่อ%2$s: DuckDuckGo%3$s URL%4$s: %5$s "
+"นามแฝง%6$s: d%7$s"
 
 # smartling.placeholder_format=C
 #. Prompt to enter a destination for driving directions.
@@ -7389,13 +7487,13 @@ msgstr "เอริเทรีย"
 #. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Estimate the nutrition"
-msgstr ""
+msgstr "ประมาณการโภชนาการ"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Estimate the nutritional information for this recipe."
-msgstr ""
+msgstr "ประมาณการข้อมูลทางโภชนาการสำหรับสูตรอาหารนี้"
 
 # smartling.placeholder_format=C
 msgid "Estonia"
@@ -7455,7 +7553,7 @@ msgstr "หมดอายุใน 1 วัน"
 #. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain the accepted answer in simple terms."
-msgstr ""
+msgstr "อธิบายคำตอบที่ได้รับการยอมรับด้วยภาษาที่เข้าใจง่าย"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
@@ -7468,43 +7566,43 @@ msgstr "อธิบายแนวคิดพื้นฐานของหล
 #. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain the top answer"
-msgstr ""
+msgstr "อธิบายคำตอบที่ดีที่สุด"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain this in simple, plain language."
-msgstr ""
+msgstr "อธิบายเรื่องนี้ด้วยภาษาที่เข้าใจง่าย"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain this paper"
-msgstr ""
+msgstr "อธิบายบทความนี้"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain this repo"
-msgstr ""
+msgstr "อธิบายรีโพนี้"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain this research paper in plain language."
-msgstr ""
+msgstr "อธิบายงานวิจัยนี้ด้วยภาษาที่เข้าใจง่าย"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain this simply"
-msgstr ""
+msgstr "อธิบายเรื่องนี้แบบง่ายๆ"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain what this repository does and how to use it."
-msgstr ""
+msgstr "อธิบายว่าสิ่งที่รีโพซิทอรีนี้ทำมีดังนี้และวิธีใช้งาน"
 
 # smartling.placeholder_format=C
 #. Label to show if song lyrics contain explicit content
@@ -7698,7 +7796,9 @@ msgstr ""
 msgid ""
 "Feel free to adjust the settings below. Then, just copy and paste the code "
 "into your website."
-msgstr "โปรดปรับเปลี่ยนการตั้งค่าด้านล่าง จากนั้นเพียงแค่คัดลอกและวางโค้ดลงในเว็บไซต์ของคุณ"
+msgstr ""
+"โปรดปรับเปลี่ยนการตั้งค่าด้านล่าง "
+"จากนั้นเพียงแค่คัดลอกและวางโค้ดลงในเว็บไซต์ของคุณ"
 
 # smartling.placeholder_format=C
 msgid "Fiji"
@@ -7788,6 +7888,8 @@ msgctxt "settings"
 msgid ""
 "Filters out known AI spam sites from image search results. %sLearn More%s"
 msgstr ""
+"กรองเว็บไซต์สแปม AI ที่รู้จักออกจากผลลัพธ์การค้นหารูปภาพ "
+"%1$sดูข้อมูลเพิ่มเติม%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the final score of a sporting event.
@@ -7846,7 +7948,7 @@ msgstr "ค้นหาข้อมูลปัจจุบัน"
 #. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Find me alternatives"
-msgstr ""
+msgstr "หาทางเลือกอื่นให้ฉันหน่อย"
 
 # smartling.placeholder_format=C
 #. Button that searches for results closer to the user's current location.
@@ -8053,7 +8155,7 @@ msgstr "แก้ไข แชร์ และใช้ได้อย่าง�
 #. a filter for images with the CC BY usage license
 msgctxt "image-licence"
 msgid "Free to Modify, Share, and Use Commercially"
-msgstr "แก้ไข แชร์ และใช้ในเชิงพาณิชย์"
+msgstr "แก้ไข แชร์ และใช้ในเชิงพาณิชย์ ได้อย่างอิสระ"
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC-ND usage license
@@ -8153,7 +8255,8 @@ msgid ""
 "strong>."
 msgstr ""
 "จากแถบเมนูแอปบน Mac ให้เลือก <strong>DuckDuckGo</strong> &gt; "
-"<strong>ตรวจสอบการอัปเดต...</strong> จากนั้นเลือก <strong>ติดตั้งการอัปเดต</strong>"
+"<strong>ตรวจสอบการอัปเดต...</strong> จากนั้นเลือก "
+"<strong>ติดตั้งการอัปเดต</strong>"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -8324,7 +8427,7 @@ msgstr "สร้างมากขึ้น"
 #. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Generate a shopping list"
-msgstr ""
+msgstr "สร้างรายการซื้อของ"
 
 # smartling.placeholder_format=C
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
@@ -8489,7 +8592,9 @@ msgstr "เริ่ม"
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the Privacy Pro subscription.
 msgctxt "SERP footer content"
 msgid "Get a VPN + two more protections in one easy subscription."
-msgstr "รับ VPN + การป้องกันเพิ่มเติมอีกสองรายการในการสมัครสมาชิกง่ายๆ เพียงครั้งเดียว"
+msgstr ""
+"รับ VPN + การป้องกันเพิ่มเติมอีกสองรายการในการสมัครสมาชิกง่ายๆ "
+"เพียงครั้งเดียว"
 
 # smartling.placeholder_format=C
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
@@ -8504,8 +8609,8 @@ msgid ""
 "Get access to advanced AI models in Duck.ai by subscribing to DuckDuckGo, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"เข้าถึงโมเดล AI ขั้นสูงใน Duck.ai ได้โดยการสมัครสมาชิก DuckDuckGo ซึ่งยังรวมถึง VPN "
-"และการปกป้องความเป็นส่วนตัวระดับพรีเมียมอื่นๆ ของเรา"
+"เข้าถึงโมเดล AI ขั้นสูงใน Duck.ai ได้โดยการสมัครสมาชิก DuckDuckGo "
+"ซึ่งยังรวมถึง VPN และการปกป้องความเป็นส่วนตัวระดับพรีเมียมอื่นๆ ของเรา"
 
 # smartling.placeholder_format=C
 #. Description for the subscription setting where users can subscribe to DuckDuckGo.
@@ -8516,8 +8621,8 @@ msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"เข้าถึงโมเดล AI ขั้นสูงใน Duck.ai ด้วยการสมัครสมาชิก DuckDuckGo ซึ่งยังรวมถึง VPN "
-"และการปกป้องความเป็นส่วนตัวระดับพรีเมียมอื่นๆ ของเรา"
+"เข้าถึงโมเดล AI ขั้นสูงใน Duck.ai ด้วยการสมัครสมาชิก DuckDuckGo "
+"ซึ่งยังรวมถึง VPN และการปกป้องความเป็นส่วนตัวระดับพรีเมียมอื่นๆ ของเรา"
 
 # smartling.placeholder_format=C
 #. A button for users to generate an AI generated answer from their query on the duckassist module
@@ -8619,7 +8724,7 @@ msgstr "ลองดูสิ"
 #. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Give me a quick background on this person."
-msgstr ""
+msgstr "ขอข้อมูลภูมิหลังคร่าวๆ ของบุคคลนี้หน่อย"
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -8635,7 +8740,8 @@ msgid ""
 "“Location Services” is turned on."
 msgstr ""
 "ไปที่ %1$sการตั้งค่า > ความเป็นส่วนตัวและความปลอดภัย > "
-"บริการหาตําแหน่งที่ตั้ง%2$sและตรวจสอบให้แน่ใจว่า \"บริการหาตําแหน่งที่ตั้ง\" เปิดอยู่"
+"บริการหาตําแหน่งที่ตั้ง%2$sและตรวจสอบให้แน่ใจว่า \"บริการหาตําแหน่งที่ตั้ง\" "
+"เปิดอยู่"
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -8644,8 +8750,8 @@ msgid ""
 "Go to %sSettings > Privacy > Permission manager > Location%s and scroll down "
 "to %sDuckDuckGo%s."
 msgstr ""
-"ไปที่ %1$sการตั้งค่า > ความเป็นส่วนตัวและความปลอดภัย > บริการหาตําแหน่งที่ตั้ง%2$s "
-"แล้วเลื่อนลงไปที่ %3$sDuckDuckGo%4$s"
+"ไปที่ %1$sการตั้งค่า > ความเป็นส่วนตัวและความปลอดภัย > "
+"บริการหาตําแหน่งที่ตั้ง%2$s แล้วเลื่อนลงไปที่ %3$sDuckDuckGo%4$s"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9071,13 +9177,13 @@ msgstr "ช่วยกระจายความเป็นส่วนตั
 #. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Help me prep for the interview"
-msgstr ""
+msgstr "ช่วยฉันเตรียมตัวสัมภาษณ์งานหน่อย"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Help me tailor my resume for this job."
-msgstr ""
+msgstr "ช่วยฉันปรับแต่งประวัติย่อสำหรับงานนี้"
 
 # smartling.placeholder_format=C
 #. Title of a SERP popup that invites users to take a survey (desktop only)
@@ -9315,7 +9421,9 @@ msgctxt "settings"
 msgid ""
 "Highlights key facts in Search Assist answers to help you find important "
 "information faster."
-msgstr "เน้นข้อเท็จจริงสำคัญในคำตอบของ Search Assist เพื่อช่วยให้คุณค้นหาข้อมูลสำคัญได้เร็วขึ้น"
+msgstr ""
+"เน้นข้อเท็จจริงสำคัญในคำตอบของ Search Assist "
+"เพื่อช่วยให้คุณค้นหาข้อมูลสำคัญได้เร็วขึ้น"
 
 # smartling.placeholder_format=C
 #. The name of the Hindi language
@@ -9408,7 +9516,8 @@ msgid ""
 "Hotel ad clicks are managed by Tripadvisor’s ad network and are not used to "
 "profile you."
 msgstr ""
-"การคลิกโฆษณาจัดการโดยเครือข่ายโฆษณาของ Tripadvisor และไม่ได้ใช้ในการสร้างโปรไฟล์ของคุณ"
+"การคลิกโฆษณาจัดการโดยเครือข่ายโฆษณาของ Tripadvisor "
+"และไม่ได้ใช้ในการสร้างโปรไฟล์ของคุณ"
 
 # smartling.placeholder_format=C
 #. Refers to hours of operation for a business.
@@ -9550,6 +9659,7 @@ msgid ""
 "How should I tactfully approach a colleague about their constant pencil "
 "tapping and what should I say?"
 msgstr ""
+""
 "ฉันจะบอกเพื่อนร่วมงานอย่างมีไหวพริบเกี่ยวกับการเคาะดินสออย่างต่อเนื่องได้อย่างไร "
 "และฉันควรจะพูดว่าอะไร"
 
@@ -9597,7 +9707,7 @@ msgctxt ""
 "Text for the I already have a subscription button in the Duck.ai settings "
 "page"
 msgid "I Already Have a Subscription"
-msgstr ""
+msgstr "ฉันมีการสมัครใช้งานอยู่แล้ว"
 
 # smartling.placeholder_format=C
 #. Text for the button that takes the user to the login subscription page.
@@ -9672,7 +9782,9 @@ msgctxt "Full sentence for recommending a book"
 msgid ""
 "I like the book Name of the Wind. What are some other good books/series most "
 "like it and why?"
-msgstr "ฉันชอบหนังสือชื่อ Name of the Wind มีหนังสือ/ซีรีส์ดีๆ ที่คล้ายกันหรือไม่และเพราะเหตุใด"
+msgstr ""
+"ฉันชอบหนังสือชื่อ Name of the Wind มีหนังสือ/ซีรีส์ดีๆ "
+"ที่คล้ายกันหรือไม่และเพราะเหตุใด"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the user needs more help or information on how to use the chat.
@@ -9707,8 +9819,8 @@ msgid ""
 "If the browser location remains unavailable, then go to %sSettings > General "
 "> Reset > 'Reset Location & Privacy'%s."
 msgstr ""
-"หากตำแหน่งที่ตั้งของเบราว์เซอร์ยังไม่พร้อมใช้งาน ให้ไปที่%1$sการตั้งค่า > ทั่วไป > รีเซ็ต > "
-"\"รีเซ็ตตำแหน่งที่ตั้งและความเป็นส่วนตัว\"%2$s"
+"หากตำแหน่งที่ตั้งของเบราว์เซอร์ยังไม่พร้อมใช้งาน ให้ไปที่%1$sการตั้งค่า > "
+"ทั่วไป > รีเซ็ต > \"รีเซ็ตตำแหน่งที่ตั้งและความเป็นส่วนตัว\"%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -9718,9 +9830,9 @@ msgid ""
 "> Menu > Settings > Site settings > Location%s, and ensure DuckDuckGo is "
 "allowed location access."
 msgstr ""
-"หากตำแหน่งที่ตั้งของเบราว์เซอร์ยังไม่พร้อมใช้งาน จากเบราว์เซอร์ของคุณ ให้ไปที่ %1$s⋮ > เมนู > "
-"การตั้งค่า > การตั้งค่าเว็บไซต์ > ตำแหน่งที่ตั้ง%2$s และตรวจสอบว่า DuckDuckGo "
-"ได้รับอนุญาตให้เข้าถึงตำแหน่งที่ตั้ง"
+"หากตำแหน่งที่ตั้งของเบราว์เซอร์ยังไม่พร้อมใช้งาน จากเบราว์เซอร์ของคุณ "
+"ให้ไปที่ %1$s⋮ > เมนู > การตั้งค่า > การตั้งค่าเว็บไซต์ > ตำแหน่งที่ตั้ง%2$s "
+"และตรวจสอบว่า DuckDuckGo ได้รับอนุญาตให้เข้าถึงตำแหน่งที่ตั้ง"
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -9755,7 +9867,8 @@ msgid ""
 "If you lose access to your devices, you will need this code to recover your "
 "saved chats. You can save this code to your device as a text file."
 msgstr ""
-"หากคุณไม่สามารถเข้าถึงอุปกรณ์ของคุณได้ คุณจะต้องใช้รหัสนี้เพื่อกู้คืนแชทที่บันทึกไว้ "
+"หากคุณไม่สามารถเข้าถึงอุปกรณ์ของคุณได้ "
+"คุณจะต้องใช้รหัสนี้เพื่อกู้คืนแชทที่บันทึกไว้ "
 "คุณสามารถบันทึกโค้ดนี้ลงในอุปกรณ์ของคุณเป็นไฟล์ข้อความได้"
 
 # smartling.placeholder_format=C
@@ -9772,7 +9885,8 @@ msgid ""
 "If you want to use DuckDuckGo without JavaScript, please use our %s or %s "
 "versions."
 msgstr ""
-"หากคุณต้องการใช้ DuckDuckGo แบบไม่มี JavaScript โปรดใช้เวอร์ชัน %1$s หรือ %2$s ของเรา"
+"หากคุณต้องการใช้ DuckDuckGo แบบไม่มี JavaScript โปรดใช้เวอร์ชัน %1$s หรือ "
+"%2$s ของเรา"
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -9780,7 +9894,8 @@ msgstr ""
 msgid ""
 "If you want, select Home Page next to New windows and New tabs (open with)."
 msgstr ""
-"หากคุณต้องการ ให้เลือก \"หน้าแรก\" ถัดจาก \"หน้าต่างใหม่\" และ \"แท็บใหม่\" (เปิดด้วย)"
+"หากคุณต้องการ ให้เลือก \"หน้าแรก\" ถัดจาก \"หน้าต่างใหม่\" และ \"แท็บใหม่\" "
+"(เปิดด้วย)"
 
 # smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that adds an image to the AI chat message being composed.
@@ -9922,6 +10037,7 @@ msgid ""
 "server to prevent search leakage. %sLearn more%s."
 msgstr ""
 "ในเบราว์เซอร์เก่ากว่าบางรายการ "
+""
 "เราจำเป็นต้องเปลี่ยนเส้นทางการคลิกของคุณผ่านเซิร์ฟเวอร์ของเราเพื่อป้องกันการรั่วไหลของข้อมูลการค้นหา "
 "%1$sดูข้อมูลเพิ่มเติม%2$s"
 
@@ -10170,7 +10286,7 @@ msgstr "ติดตั้งเบราว์เซอร์ Mac"
 #. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
 msgctxt "settings"
 msgid "Install Now"
-msgstr ""
+msgstr "ติดตั้งเดี๋ยวนี้"
 
 # smartling.placeholder_format=C
 #. Text of a button to install the DuckDuckGo app
@@ -10273,13 +10389,13 @@ msgstr "ข้อมูลจะถูกลบออกจริงหรือ
 #. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Is it worth taking?"
-msgstr ""
+msgstr "น่าเรียนไหม?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Is this place any good?"
-msgstr ""
+msgstr "สถานที่นี้ดีไหม"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
@@ -10287,7 +10403,7 @@ msgctxt "Page suggestion prompt"
 msgid ""
 "Is this place any good? Summarize its reputation based on reviews and "
 "ratings."
-msgstr ""
+msgstr "สถานที่นี้ดีไหม? สรุปชื่อเสียงของสถานที่นี้จากรีวิวและคะแนน"
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -10299,13 +10415,13 @@ msgstr "วิดีโอนี้มีประโยชน์หรือไ
 #. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Is this worth watching?"
-msgstr ""
+msgstr "เรื่องนี้น่าดูไหม?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Is this worth watching? Give me a spoiler-free take."
-msgstr ""
+msgstr "เรื่องนี้น่าดูไหม? ขอความเห็นแบบไม่สปอยล์หน่อย"
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -10357,9 +10473,11 @@ msgid ""
 "pages and unlike ads, DuckDuckGo is not compensated for these results."
 msgstr ""
 "รายการต่างๆ "
+""
 "ได้รับการจัดลำดับตามความเกี่ยวข้องกับข้อความค้นหาของคุณและจัดส่งผ่านเครือข่ายโฆษณาของ "
-"Microsoft การคลิกนำไปสู่หน้า Landing Page ของผู้ค้าโดยตรงและไม่เหมือนกับโฆษณา "
-"DuckDuckGo ไม่ได้รับการชดเชยสำหรับผลลัพธ์เหล่านี้"
+"Microsoft การคลิกนำไปสู่หน้า Landing Page "
+"ของผู้ค้าโดยตรงและไม่เหมือนกับโฆษณา DuckDuckGo "
+"ไม่ได้รับการชดเชยสำหรับผลลัพธ์เหล่านี้"
 
 # smartling.placeholder_format=C
 #. Text explaining why passphrases use a series of words instead of random numbers and letters.
@@ -10368,7 +10486,8 @@ msgid ""
 "It’s easier to remember 4-5 words than 10 random letters and numbers, and "
 "far more secure."
 msgstr ""
-"การจดจำคำ 4 - 5 คำจะง่ายกว่าการจำตัวอักษรและตัวเลขแบบสุ่ม 10 ตัว และมีความปลอดภัยมากกว่า"
+"การจดจำคำ 4 - 5 คำจะง่ายกว่าการจำตัวอักษรและตัวเลขแบบสุ่ม 10 ตัว "
+"และมีความปลอดภัยมากกว่า"
 
 # smartling.placeholder_format=C
 msgid "Ivory Coast"
@@ -10918,7 +11037,7 @@ msgstr "ลิงก์"
 #. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
-msgstr ""
+msgstr "แสดงรายการเครื่องมือ วัสดุ หรือสิ่งที่ฉันต้องมีก่อนสำหรับสิ่งนี้"
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -11330,7 +11449,7 @@ msgstr "จัดการเว็บไซต์ที่ถูกบล็อ
 #. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
 msgctxt "setting"
 msgid "Manage in Browser Settings"
-msgstr ""
+msgstr "จัดการในการตั้งค่าเบราว์เซอร์"
 
 # smartling.placeholder_format=C
 #. Link to the site exclusion settings page
@@ -12303,9 +12422,11 @@ msgid ""
 "internet connection. Disabling chat history will delete pinned chats, and "
 "disable the temporary storage of new prompts and responses."
 msgstr ""
-"คำแนะนำใหม่และการตอบกลับจะถูกเข้ารหัสและเก็บไว้ชั่วคราวบนเซิร์ฟเวอร์ DuckDuckGo "
-"หลังจากที่ส่งไปแล้ว เพื่อช่วยกู้คืนการแชทหากคุณสูญเสียการเชื่อมต่ออินเทอร์เน็ต "
-"การปิดประวัติการแชทจะลบแชทที่ปักหมุด และปิดใช้งานการเก็บคำแนะนำและการตอบสนองใหม่ชั่วคราว"
+"คำแนะนำใหม่และการตอบกลับจะถูกเข้ารหัสและเก็บไว้ชั่วคราวบนเซิร์ฟเวอร์ "
+"DuckDuckGo หลังจากที่ส่งไปแล้ว "
+"เพื่อช่วยกู้คืนการแชทหากคุณสูญเสียการเชื่อมต่ออินเทอร์เน็ต "
+"การปิดประวัติการแชทจะลบแชทที่ปักหมุด "
+"และปิดใช้งานการเก็บคำแนะนำและการตอบสนองใหม่ชั่วคราว"
 
 # smartling.placeholder_format=C
 #. Question in a feedback form.
@@ -13121,8 +13242,8 @@ msgid ""
 "On Mac, %sClick Maxthon > Preferences%s, On Windows, %sClick the %s icon > "
 "Settings%s"
 msgstr ""
-"สำหรับ Mac %1$sให้คลิก Maxthon > ค่ากำหนด%2$s สำหรับ Windows %3$sให้คลิกไอคอน %4$s "
-"> การตั้งค่า%5$s"
+"สำหรับ Mac %1$sให้คลิก Maxthon > ค่ากำหนด%2$s สำหรับ Windows "
+"%3$sให้คลิกไอคอน %4$s > การตั้งค่า%5$s"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
@@ -13144,7 +13265,8 @@ msgid ""
 "One of the files attached has more pages than we support. Please upload "
 "files with %s pages or fewer."
 msgstr ""
-"ไฟล์ที่แนบมาไฟล์ใดไฟล์หนึ่งมีหน้าเว็บมากกว่าที่เรารองรับ โปรดอัปโหลดไฟล์ที่มี %1$s หน้าหรือน้อยกว่า"
+"ไฟล์ที่แนบมาไฟล์ใดไฟล์หนึ่งมีหน้าเว็บมากกว่าที่เรารองรับ "
+"โปรดอัปโหลดไฟล์ที่มี %1$s หน้าหรือน้อยกว่า"
 
 # smartling.placeholder_format=C
 #. Response a user can select in a feedback form, indicating that they heard about DuckDuckGo in an online article.
@@ -13170,7 +13292,9 @@ msgctxt "cloudsave"
 msgid ""
 "Only the settings that you have changed. They are detailed on the %sURL "
 "Parameters%s page."
-msgstr "เฉพาะการตั้งค่าที่คุณเปลี่ยนแปลงเท่านั้น มีรายละเอียดอยู่ในหน้า%1$sพารามิเตอร์ URL%2$s"
+msgstr ""
+"เฉพาะการตั้งค่าที่คุณเปลี่ยนแปลงเท่านั้น "
+"มีรายละเอียดอยู่ในหน้า%1$sพารามิเตอร์ URL%2$s"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers only when the user clicks the Assist button.
@@ -13501,7 +13625,8 @@ msgid ""
 "Other search engines track your searches even when you’re in private "
 "browsing mode. We don’t track you &mdash; period."
 msgstr ""
-"เครื่องมือค้นหาอื่นๆ จะติดตามการค้นหาของคุณแม้ว่าคุณจะอยู่ในโหมดการท่องเว็บแบบส่วนตัว "
+"เครื่องมือค้นหาอื่นๆ "
+"จะติดตามการค้นหาของคุณแม้ว่าคุณจะอยู่ในโหมดการท่องเว็บแบบส่วนตัว "
 "แต่เราไม่ติดตามคุณอย่างแน่นอน"
 
 # smartling.placeholder_format=C
@@ -13515,7 +13640,8 @@ msgid ""
 "Our privacy policy is simple: we don’t collect or share any of your personal "
 "information."
 msgstr ""
-"นโยบายความเป็นส่วนตัวของเราเป็นเรื่องง่าย: เราไม่ได้เก็บรวบรวมหรือแชร์ข้อมูลส่วนบุคคลของคุณ"
+"นโยบายความเป็นส่วนตัวของเราเป็นเรื่องง่าย: "
+"เราไม่ได้เก็บรวบรวมหรือแชร์ข้อมูลส่วนบุคคลของคุณ"
 
 # smartling.placeholder_format=C
 msgid ""
@@ -13523,8 +13649,9 @@ msgid ""
 "tracker blocker, encryption enforcer, and more. Available on %siOS & "
 "Android%s."
 msgstr ""
-"เบราว์เซอร์ส่วนตัวสำหรับอุปกรณ์มือถือของเรานั้นมาพร้อมกับเครื่องมือค้นหา เครื่องมือบล็อกตัวติดตาม "
-"เครื่องมือบังคับใช้การเข้ารหัส และอื่นๆ อีกมากมาย พร้อมใช้งานบน %1$siOS และ Android%2$s"
+"เบราว์เซอร์ส่วนตัวสำหรับอุปกรณ์มือถือของเรานั้นมาพร้อมกับเครื่องมือค้นหา "
+"เครื่องมือบล็อกตัวติดตาม เครื่องมือบังคับใช้การเข้ารหัส และอื่นๆ อีกมากมาย "
+"พร้อมใช้งานบน %1$siOS และ Android%2$s"
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the information was out of date.
@@ -13777,8 +13904,8 @@ msgid ""
 "Passphrases cannot be recovered as we don't associate your IP address, "
 "browser fingerprint, or any other information with the file."
 msgstr ""
-"ไม่สามารถกู้คืนรหัสผ่านได้เนื่องจากเราไม่ได้เชื่อมโยงที่อยู่ IP, ลายนิ้วมือจากเบราว์เซอร์ "
-"หรือข้อมูลอื่นใดเกี่ยวกับไฟล์"
+"ไม่สามารถกู้คืนรหัสผ่านได้เนื่องจากเราไม่ได้เชื่อมโยงที่อยู่ IP, "
+"ลายนิ้วมือจากเบราว์เซอร์ หรือข้อมูลอื่นใดเกี่ยวกับไฟล์"
 
 # smartling.placeholder_format=C
 #. Label for the section of recent chats that were edited in the past 7 days.
@@ -13972,9 +14099,10 @@ msgid ""
 "answers. To turn them off and hide the Assist button visit %sSearch "
 "Settings%s."
 msgstr ""
+""
 "การเรียงถ้อยคำในการค้นหาให้เป็นคำถามและเป็นประโยคสมบูรณ์ทำให้คำตอบที่ได้รับความช่วยเหลือจาก "
-"AI มีแนวโน้มที่จะปรากฏขึ้นโดยอัตโนมัติและมักจะให้คำตอบได้ดีกว่า หากต้องการปิดและซ่อนปุ่ม Assist "
-"ให้ไปที่ %1$sการตั้งค่าการค้นหา%2$s"
+"AI มีแนวโน้มที่จะปรากฏขึ้นโดยอัตโนมัติและมักจะให้คำตอบได้ดีกว่า "
+"หากต้องการปิดและซ่อนปุ่ม Assist ให้ไปที่ %1$sการตั้งค่าการค้นหา%2$s"
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -13984,8 +14112,9 @@ msgid ""
 "how this feature works, or to turn it off, visit %sDuckAssist Settings%s."
 msgstr ""
 "การเรียงถ้อยคำในการค้นหาให้เป็นคำถามและเป็นประโยคสมบูรณ์ทำให้ DuckAssist "
-"มีแนวโน้มที่จะปรากฏขึ้นและมักจะให้คำตอบที่ดีกว่า หากต้องการปรับวิธีการทํางานของคุณลักษณะนี้หรือปิด "
-"ให้ไปที่%1$sการตั้งค่า DuckAssist%2$s"
+"มีแนวโน้มที่จะปรากฏขึ้นและมักจะให้คำตอบที่ดีกว่า "
+"หากต้องการปรับวิธีการทํางานของคุณลักษณะนี้หรือปิด ให้ไปที่%1$sการตั้งค่า "
+"DuckAssist%2$s"
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -13996,8 +14125,8 @@ msgid ""
 "Settings%s."
 msgstr ""
 "การเรียงถ้อยคำในการค้นหาให้เป็นคำถามและเป็นประโยคสมบูรณ์ทำให้ DuckAssist "
-"มีแนวโน้มที่จะปรากฏขึ้นโดยอัตโนมัติและมักจะให้คำตอบได้ดีกว่า หากต้องการปิดและซ่อนปุ่ม Assist "
-"โปรดไปที่%1$sการตั้งค่า DuckAssist%2$s"
+"มีแนวโน้มที่จะปรากฏขึ้นโดยอัตโนมัติและมักจะให้คำตอบได้ดีกว่า "
+"หากต้องการปิดและซ่อนปุ่ม Assist โปรดไปที่%1$sการตั้งค่า DuckAssist%2$s"
 
 # smartling.placeholder_format=C
 #. Button that allows users to manually select a location on a map.
@@ -14045,7 +14174,9 @@ msgctxt "Third party map app picker"
 msgid ""
 "Pick a service to navigate to your destination. External apps won’t come "
 "with DuckDuckGo protections."
-msgstr "เลือกบริการเพื่อนำทางไปยังจุดหมายของคุณ แอปภายนอกจะไม่มีการป้องกันของ DuckDuckGo"
+msgstr ""
+"เลือกบริการเพื่อนำทางไปยังจุดหมายของคุณ แอปภายนอกจะไม่มีการป้องกันของ "
+"DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Label for a list of problems on a feedback form.
@@ -14141,7 +14272,7 @@ msgstr "โปรดทําชาเลนจ์ต่อไปนี้ให
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is harmful or illegal. (optional)"
-msgstr ""
+msgstr "ช่วยบอกหน่อยว่าทำไมการตอบกลับแชทถึงเป็นอันตรายหรือผิดกฎหมาย (ไม่บังคับ)"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
@@ -14176,6 +14307,8 @@ msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is harmful or illegal."
 msgstr ""
+"โปรดวางพรอมต์และเอาต์พุตที่มีปัญหาของคุณ (โดยลบข้อมูลส่วนบุคคลออก) "
+"และอธิบายว่าเนื้อหานั้นเป็นอันตรายหรือผิดกฎหมายเหตุใด"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -14646,7 +14779,7 @@ msgstr "ความเป็นส่วนตัว"
 #. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
 msgctxt "Section heading on the Duck.ai settings page"
 msgid "Privacy & Terms"
-msgstr ""
+msgstr "ความเป็นส่วนตัว & ข้อกำหนด"
 
 # smartling.placeholder_format=C
 msgid "Privacy Blog"
@@ -14722,7 +14855,7 @@ msgstr "นโยบายความเป็นส่วนตัวและ
 #. Text for a button that links to the terms of use and privacy policy page.
 msgctxt "Secondary button text in active privacy modal"
 msgid "Privacy Policy and Terms of Service"
-msgstr ""
+msgstr "นโยบายความเป็นส่วนตัวและข้อกำหนดในการให้บริการ"
 
 # smartling.placeholder_format=C
 #. Title displayed on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
@@ -14938,7 +15071,9 @@ msgctxt "Full sentence for critiquing writing"
 msgid ""
 "Provide a few suggestions to make the following text more concise. [Insert "
 "your own text here.]"
-msgstr "ให้คำแนะนำสองสามข้อเพื่อให้ข้อความต่อไปนี้กระชับมากขึ้น [แทรกข้อความของคุณเองที่นี่]"
+msgstr ""
+"ให้คำแนะนำสองสามข้อเพื่อให้ข้อความต่อไปนี้กระชับมากขึ้น "
+"[แทรกข้อความของคุณเองที่นี่]"
 
 # smartling.placeholder_format=C
 #. In the context of a standings table for NHL (hockey), column title that abbreviates 'Total Points' (the total points of this team)
@@ -15197,8 +15332,9 @@ msgid ""
 "sent, to help recover a chat if you lose your internet connection."
 msgstr ""
 "การแชทล่าสุดจะถูกจัดเก็บไว้ในอุปกรณ์ของคุณ "
-"คำแนะนำใหม่และการตอบกลับจะถูกเข้ารหัสและเก็บไว้ชั่วคราวบนเซิร์ฟเวอร์ของ DuckDuckGo "
-"หลังจากที่ส่งไปแล้ว เพื่อช่วยกู้คืนการแชทหากคุณสูญเสียการเชื่อมต่ออินเทอร์เน็ต"
+"คำแนะนำใหม่และการตอบกลับจะถูกเข้ารหัสและเก็บไว้ชั่วคราวบนเซิร์ฟเวอร์ของ "
+"DuckDuckGo หลังจากที่ส่งไปแล้ว "
+"เพื่อช่วยกู้คืนการแชทหากคุณสูญเสียการเชื่อมต่ออินเทอร์เน็ต"
 
 # smartling.placeholder_format=C
 msgctxt "region filter"
@@ -15225,25 +15361,25 @@ msgstr "แนะนำหนังสือ"
 #. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Recommend similar books"
-msgstr ""
+msgstr "แนะนำหนังสือที่คล้ายกัน"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Recommend similar books."
-msgstr ""
+msgstr "แนะนำหนังสือที่คล้ายกัน"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Recommend similar movies or shows."
-msgstr ""
+msgstr "แนะนำภาพยนตร์หรือรายการที่คล้ายกัน"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Recommend similar titles"
-msgstr ""
+msgstr "แนะนำรายการที่คล้ายกัน"
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
@@ -15456,8 +15592,8 @@ msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
 msgstr ""
-"รีโหลด DuckDuckGo โดยทำตามคำแนะนำ หรือคลิกปุ่ม &quot;รีเฟรช&quot; หรือ &quot;"
-"รีโหลด&quot; ของเบราว์เซอร์ของคุณ"
+"รีโหลด DuckDuckGo โดยทำตามคำแนะนำ หรือคลิกปุ่ม &quot;รีเฟรช&quot; หรือ "
+"&quot;รีโหลด&quot; ของเบราว์เซอร์ของคุณ"
 
 # smartling.placeholder_format=C
 #. checkbox label that allows the user to save the setting
@@ -15547,7 +15683,8 @@ msgid ""
 "Removes the \"Ask\" button so answers appear automatically in response to "
 "relevant searches. Cached answers always display automatically."
 msgstr ""
-"นำปุ่ม \"ถาม\" ออก เพื่อให้คำตอบปรากฏขึ้นโดยอัตโนมัติตามการค้นหาที่เกี่ยวข้อง "
+"นำปุ่ม \"ถาม\" ออก "
+"เพื่อให้คำตอบปรากฏขึ้นโดยอัตโนมัติตามการค้นหาที่เกี่ยวข้อง "
 "คำตอบที่เก็บไว้จะแสดงโดยอัตโนมัติเสมอ"
 
 # smartling.placeholder_format=C
@@ -15556,7 +15693,8 @@ msgid ""
 "Removes the \"Generate\" button so answers appear automatically in response "
 "to relevant searches. Cached answers always display automatically."
 msgstr ""
-"นำปุ่ม \"สร้าง\" ออก เพื่อให้คำตอบปรากฏขึ้นโดยอัตโนมัติตามการค้นหาที่เกี่ยวข้อง "
+"นำปุ่ม \"สร้าง\" ออก "
+"เพื่อให้คำตอบปรากฏขึ้นโดยอัตโนมัติตามการค้นหาที่เกี่ยวข้อง "
 "คำตอบที่เก็บไว้จะแสดงโดยอัตโนมัติเสมอ"
 
 # smartling.placeholder_format=C
@@ -15615,8 +15753,9 @@ msgid ""
 "service. Your anonymous feedback is also shared with %s to help improve "
 "their services."
 msgstr ""
-"การรายงานจะไม่ระบุชื่อและส่งไปยัง DuckDuckGo เพื่อช่วยปรับปรุงบริการค้นหาของเรา "
-"ข้อเสนอแนะที่ไม่ระบุตัวตนของคุณจะแชร์กับ %1$s เพื่อช่วยปรับปรุงบริการ"
+"การรายงานจะไม่ระบุชื่อและส่งไปยัง DuckDuckGo "
+"เพื่อช่วยปรับปรุงบริการค้นหาของเรา ข้อเสนอแนะที่ไม่ระบุตัวตนของคุณจะแชร์กับ "
+"%1$s เพื่อช่วยปรับปรุงบริการ"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -15624,8 +15763,8 @@ msgid ""
 "Reports sent to DuckDuckGo are anonymous. Please do not include any personal "
 "or identifying information in your feedback."
 msgstr ""
-"รายงานที่ส่งไปยัง DuckDuckGo จะไม่ระบุชื่อ โปรดอย่าใส่ข้อมูลส่วนตัวหรือข้อมูลระบุตัวตนใดๆ "
-"ลงในข้อเสนอแนะของคุณ"
+"รายงานที่ส่งไปยัง DuckDuckGo จะไม่ระบุชื่อ "
+"โปรดอย่าใส่ข้อมูลส่วนตัวหรือข้อมูลระบุตัวตนใดๆ ลงในข้อเสนอแนะของคุณ"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -15634,8 +15773,9 @@ msgid ""
 "translate during this page load, and are anonymous. Please do not include "
 "any personal or identifying information in your feedback."
 msgstr ""
-"รายงานที่ส่งไปยัง DuckDuckGo รวมข้อความทั้งหมดที่คุณขอให้เราแปลในระหว่างการโหลดหน้านี้ "
-"และจะไม่ระบุตัวตน โปรดอย่าใส่ข้อมูลส่วนตัวหรือข้อมูลระบุตัวตนใด ๆ ลงในข้อเสนอแนะของคุณ"
+"รายงานที่ส่งไปยัง DuckDuckGo "
+"รวมข้อความทั้งหมดที่คุณขอให้เราแปลในระหว่างการโหลดหน้านี้ และจะไม่ระบุตัวตน "
+"โปรดอย่าใส่ข้อมูลส่วนตัวหรือข้อมูลระบุตัวตนใด ๆ ลงในข้อเสนอแนะของคุณ"
 
 # smartling.placeholder_format=C
 msgid "Republic of Moldova"
@@ -15648,7 +15788,7 @@ msgctxt ""
 "feedback form when the user has selected Harmful or Illegal as the feedback "
 "reason"
 msgid "Required for harmful or illegal reports"
-msgstr ""
+msgstr "จำเป็นสำหรับการรายงานเนื้อหาที่เป็นอันตรายหรือผิดกฎหมาย"
 
 # smartling.placeholder_format=C
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
@@ -15715,8 +15855,9 @@ msgid ""
 "legal, financial, investment, or other professional advice. AI-assisted "
 "answers are subject to our %sTerms of Service%s."
 msgstr ""
-"คำตอบเหล่านี้มีวัตถุประสงค์เพื่อการศึกษาเท่านั้น และไม่มีเจตนาให้เป็นคำแนะนำทางการแพทย์ กฎหมาย "
-"การเงิน การลงทุน หรือคำแนะนำทางวิชาชีพอื่นๆ คำตอบที่ได้รับความช่วยเหลือจาก AI อยู่ภายใต้ "
+"คำตอบเหล่านี้มีวัตถุประสงค์เพื่อการศึกษาเท่านั้น "
+"และไม่มีเจตนาให้เป็นคำแนะนำทางการแพทย์ กฎหมาย การเงิน การลงทุน "
+"หรือคำแนะนำทางวิชาชีพอื่นๆ คำตอบที่ได้รับความช่วยเหลือจาก AI อยู่ภายใต้ "
 "%1$sข้อกำหนดในการให้บริการ%2$sของเรา"
 
 # smartling.placeholder_format=C
@@ -15726,8 +15867,9 @@ msgid ""
 "legal, financial, investment, or other professional advice. DuckAssist is "
 "subject to our %sTerms of Service%s."
 msgstr ""
-"คำตอบเหล่านี้มีวัตถุประสงค์เพื่อการศึกษาเท่านั้น และไม่มีเจตนาให้เป็นคำแนะนำทางการแพทย์ กฎหมาย "
-"การเงิน การลงทุน หรือคำแนะนำทางวิชาชีพอื่นๆ DuckAssist "
+"คำตอบเหล่านี้มีวัตถุประสงค์เพื่อการศึกษาเท่านั้น "
+"และไม่มีเจตนาให้เป็นคำแนะนำทางการแพทย์ กฎหมาย การเงิน การลงทุน "
+"หรือคำแนะนำทางวิชาชีพอื่นๆ DuckAssist "
 "อยู่ภายใต้%1$sข้อกำหนดในการให้บริการ%2$sของเรา"
 
 # smartling.placeholder_format=C
@@ -15738,10 +15880,11 @@ msgid ""
 "generated based on web content and may contain inaccuracies. Search Assist "
 "is subject to our %sTerms of Service%s."
 msgstr ""
-"คำตอบเหล่านี้มีวัตถุประสงค์เพื่อการศึกษาเท่านั้น และไม่มีเจตนาให้เป็นคำแนะนำทางการแพทย์ กฎหมาย "
-"การเงิน การลงทุน หรือคำแนะนำทางวิชาชีพอื่น ๆ "
-"ข้อมูลเหล่านี้ถูกสร้างขึ้นจากเนื้อหาบนเว็บและอาจมีความไม่ถูกต้อง Search Assist อยู่ภายใต้ "
-"%1$sข้อกำหนดการให้บริการ%2$sของเรา"
+"คำตอบเหล่านี้มีวัตถุประสงค์เพื่อการศึกษาเท่านั้น "
+"และไม่มีเจตนาให้เป็นคำแนะนำทางการแพทย์ กฎหมาย การเงิน การลงทุน "
+"หรือคำแนะนำทางวิชาชีพอื่น ๆ "
+"ข้อมูลเหล่านี้ถูกสร้างขึ้นจากเนื้อหาบนเว็บและอาจมีความไม่ถูกต้อง Search "
+"Assist อยู่ภายใต้ %1$sข้อกำหนดการให้บริการ%2$sของเรา"
 
 # smartling.placeholder_format=C
 #. Label on the button for restoring all previous website data.
@@ -15888,7 +16031,7 @@ msgstr "รีวิว"
 #. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Rewrite this recipe scaled for a different number of servings."
-msgstr ""
+msgstr "เขียนสูตรอาหารนี้ใหม่โดยปรับสัดส่วนตามจำนวนที่เสิร์ฟที่ต้องการ"
 
 # smartling.placeholder_format=C
 msgid "Romania"
@@ -16304,7 +16447,8 @@ msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)"
 msgstr ""
-"เลื่อนลงและมองหา%1$sค้นหาในแถบที่อยู่%2$s คลิกที่%3$sเปลี่ยนแปลง%4$s (หรือ%5$sเพิ่มใหม่%6$s)"
+"เลื่อนลงและมองหา%1$sค้นหาในแถบที่อยู่%2$s คลิกที่%3$sเปลี่ยนแปลง%4$s "
+"(หรือ%5$sเพิ่มใหม่%6$s)"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
@@ -16313,7 +16457,8 @@ msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)."
 msgstr ""
-"เลื่อนลงและมองหา%1$sค้นหาในแถบที่อยู่%2$s คลิกที่%3$sเปลี่ยนแปลง%4$s (หรือ %5$sเพิ่มใหม่%6$s)"
+"เลื่อนลงและมองหา%1$sค้นหาในแถบที่อยู่%2$s คลิกที่%3$sเปลี่ยนแปลง%4$s (หรือ "
+"%5$sเพิ่มใหม่%6$s)"
 
 # smartling.placeholder_format=C
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -16386,10 +16531,11 @@ msgid ""
 "subset of English speaking regions."
 msgstr ""
 "Search Assist สร้างคำตอบสำหรับคำค้นหาโดยไม่ระบุชื่อ ในการดำเนินการนี้ "
-"ระบบจะสแกนเว็บเพื่อหาเนื้อหาที่เกี่ยวข้อง จากนั้นใช้ AI เพื่อสร้างคำตอบสั้น ๆ "
-"คุณสามารถเลือกได้ว่าต้องการให้มันปรากฏบ่อยแค่ไหน: ไม่เคย, ตามต้องการ (เฉพาะเมื่อคลิก "
-"Assist), บางครั้ง (เมื่อมีความเกี่ยวข้องสูง) หรือบ่อยครั้ง (ในการค้นหาที่หลากหลาย) สำหรับตอนนี้ "
-"Search Assist มีให้บริการเฉพาะในบางภูมิภาคที่ใช้ภาษาอังกฤษเท่านั้น"
+"ระบบจะสแกนเว็บเพื่อหาเนื้อหาที่เกี่ยวข้อง จากนั้นใช้ AI เพื่อสร้างคำตอบสั้น "
+"ๆ คุณสามารถเลือกได้ว่าต้องการให้มันปรากฏบ่อยแค่ไหน: ไม่เคย, ตามต้องการ "
+"(เฉพาะเมื่อคลิก Assist), บางครั้ง (เมื่อมีความเกี่ยวข้องสูง) หรือบ่อยครั้ง "
+"(ในการค้นหาที่หลากหลาย) สำหรับตอนนี้ Search Assist "
+"มีให้บริการเฉพาะในบางภูมิภาคที่ใช้ภาษาอังกฤษเท่านั้น"
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI) when the answer is not found and the answer is unsourced or with no sources
@@ -16397,7 +16543,8 @@ msgid ""
 "Search Assist couldn't find enough reliable information to generate an "
 "answer for this question. Try another search."
 msgstr ""
-"Search Assist ไม่พบข้อมูลที่เชื่อถือได้เพียงพอเพื่อสร้างคำตอบสำหรับคำถามนี้ ลองค้นหาอีกครั้ง"
+"Search Assist ไม่พบข้อมูลที่เชื่อถือได้เพียงพอเพื่อสร้างคำตอบสำหรับคำถามนี้ "
+"ลองค้นหาอีกครั้ง"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -16406,9 +16553,9 @@ msgid ""
 "search queries. To do this, it %sscans the web%s for relevant content and "
 "then uses AI to generate a brief answer based on information found."
 msgstr ""
-"Search Assist เป็นฟีเจอร์เสริมที่สร้างคำตอบสำหรับคำค้นหาโดยไม่ระบุชื่อ ในการทำเช่นนี้ "
-"ระบบจะสแกนเว็บเพื่อหาเนื้อหาที่เกี่ยวข้อง %1$s%2$s จากนั้นใช้ AI เพื่อสร้างคำตอบสั้น ๆ "
-"ตามข้อมูลที่พบ"
+"Search Assist เป็นฟีเจอร์เสริมที่สร้างคำตอบสำหรับคำค้นหาโดยไม่ระบุชื่อ "
+"ในการทำเช่นนี้ ระบบจะสแกนเว็บเพื่อหาเนื้อหาที่เกี่ยวข้อง %1$s%2$s จากนั้นใช้ "
+"AI เพื่อสร้างคำตอบสั้น ๆ ตามข้อมูลที่พบ"
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/search_box. top header
@@ -16529,8 +16676,8 @@ msgid ""
 "Search other sites with %s shortcuts: a search for ”!w ducks” will search "
 "for “ducks” directly on Wikipedia."
 msgstr ""
-"ค้นหาเว็บไซต์อื่นด้วยทางลัด %1$s: การค้นหา \"!w ducks\" จะค้นหา \"ducks\" โดยตรงบน "
-"Wikipedia"
+"ค้นหาเว็บไซต์อื่นด้วยทางลัด %1$s: การค้นหา \"!w ducks\" จะค้นหา \"ducks\" "
+"โดยตรงบน Wikipedia"
 
 # smartling.placeholder_format=C
 #. Placeholder text for the search form when no text has been entered
@@ -16550,8 +16697,8 @@ msgid ""
 "favorite browser, or search directly at %sduckduckgo.com%s."
 msgstr ""
 "ค้นหาอย่างเป็นส่วนตัวด้วยแอปหรือส่วนขยายของเรา "
-"เพิ่มการค้นหาเว็บแบบส่วนตัวลงในเบราว์เซอร์โปรดของคุณ หรือค้นหาโดยตรงที่ %1$sduckduckgo."
-"com%2$s"
+"เพิ่มการค้นหาเว็บแบบส่วนตัวลงในเบราว์เซอร์โปรดของคุณ หรือค้นหาโดยตรงที่ "
+"%1$sduckduckgo.com%2$s"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/6LZAoqH.png
@@ -16570,8 +16717,10 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
+""
 "การตั้งค่าการค้นหาจะถูกเก็บไว้ในคุกกี้เบราว์เซอร์ที่ไม่ใช่ส่วนบุคคลและที่เก็บข้อมูลภายในในเบราว์เซอร์ของคุณ "
 "แต่คุณยังสามารถใช้ Cloud Save "
+""
 "เพื่อจัดเก็บการตั้งค่าของคุณโดยไม่ระบุตัวตนบนเซิร์ฟเวอร์ระยะไกลในคลาวด์ได้อีกด้วย "
 "จะไม่มีการจัดเก็บข้อมูลที่สามารถระบุถึงตัวบุคคลได้บนระบบคลาวด์ "
 "และวลีรหัสผ่านของคุณจะอยู่บนเบราว์เซอร์ของคุณเท่านั้น"
@@ -16687,6 +16836,7 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your synced devices."
 msgstr ""
+""
 "จัดเก็บแชทได้เกือบไม่จำกัดบนเซิร์ฟเวอร์ของเราอย่างปลอดภัยด้วยการเข้ารหัสแบบครบวงจร "
 "และเข้าถึงได้จากอุปกรณ์ที่ซิงค์ทั้งหมดของคุณ"
 
@@ -16859,7 +17009,8 @@ msgstr "เลือก %1$s\"การตั้งค่าสำหรับ�
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
 msgstr ""
-"เลือก%1$sกำหนดเอง%2$s และป้อน %3$shttps://duckduckgo.com%4$s ลงในช่องการป้อนข้อมูล"
+"เลือก%1$sกำหนดเอง%2$s และป้อน %3$shttps://duckduckgo.com%4$s "
+"ลงในช่องการป้อนข้อมูล"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
@@ -16924,7 +17075,8 @@ msgstr "เลือก%1$sจัดการส่วนเสริม%2$sจ�
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sMenu > Settings%s (on Windows)"
 msgstr ""
-"เลือก %1$sOpera > ค่ากำหนด%2$s (บน Mac) หรือ%3$sเมนู > การตั้งค่า%4$s (บน Windows)"
+"เลือก %1$sOpera > ค่ากำหนด%2$s (บน Mac) หรือ%3$sเมนู > การตั้งค่า%4$s (บน "
+"Windows)"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -16932,7 +17084,8 @@ msgstr ""
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sOpera > Options%s (on Windows)"
 msgstr ""
-"เลือก %1$sOpera > ค่ากำหนด%2$s (บน Mac) หรือ %3$sOpera > ตัวเลือก%4$s (บน Windows)"
+"เลือก %1$sOpera > ค่ากำหนด%2$s (บน Mac) หรือ %3$sOpera > ตัวเลือก%4$s (บน "
+"Windows)"
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -16996,7 +17149,9 @@ msgstr "เลือก%1$sการตั้งค่า%2$s จากนั้
 msgid ""
 "Select %sUse this webpage as your only home page%s (or one of the other "
 "options if you prefer)"
-msgstr "เลือก%1$sใช้หน้าเว็บนี้เป็นหน้าหลักเดียวของคุณ%2$s (หรือหนึ่งในตัวเลือกอื่นๆ ตามต้องการ)"
+msgstr ""
+"เลือก%1$sใช้หน้าเว็บนี้เป็นหน้าหลักเดียวของคุณ%2$s (หรือหนึ่งในตัวเลือกอื่นๆ "
+"ตามต้องการ)"
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
@@ -17118,7 +17273,8 @@ msgid ""
 "respond. These instructions will apply to all of your conversations going "
 "forward."
 msgstr ""
-"ส่งพรอมต์ไปยังโมเดล AI พร้อมกับข้อความของคุณและคำแนะนำเกี่ยวกับวิธีการตอบกลับ "
+"ส่งพรอมต์ไปยังโมเดล AI "
+"พร้อมกับข้อความของคุณและคำแนะนำเกี่ยวกับวิธีการตอบกลับ "
 "คำแนะนำเหล่านี้จะใช้กับการสนทนาทั้งหมดของคุณต่อไป"
 
 # smartling.placeholder_format=C
@@ -17198,7 +17354,7 @@ msgstr "ตั้งค่าตอนนี้"
 #. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
 msgctxt "Encrypted storage setup button shown in native browsers"
 msgid "Set Up Sync & Backup"
-msgstr ""
+msgstr "ตั้งค่า Sync & Backup"
 
 # smartling.placeholder_format=C
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
@@ -17229,13 +17385,16 @@ msgid ""
 "Set up Sync & Backup after turning on Chat History to keep your chats synced "
 "across devices."
 msgstr ""
-"ตั้งค่า Sync & Backup หลังจากเปิดประวัติการแชทเพื่อให้การแชทของคุณซิงค์กันระหว่างอุปกรณ์ต่างๆ"
+"ตั้งค่า Sync & Backup "
+"หลังจากเปิดประวัติการแชทเพื่อให้การแชทของคุณซิงค์กันระหว่างอุปกรณ์ต่างๆ"
 
 # smartling.placeholder_format=C
 #. Prompt for the user to indicate their location on a map, to enable more relevant search results.
 msgctxt "precise_user_location"
 msgid "Set your location manually, or ensure Location Services is enabled."
-msgstr "ตั้งค่าตำแหน่งที่ตั้งของคุณด้วยตนเอง หรือตรวจสอบให้แน่ใจว่าได้เปิดใช้งานบริการตำแหน่งที่ตั้ง"
+msgstr ""
+"ตั้งค่าตำแหน่งที่ตั้งของคุณด้วยตนเอง "
+"หรือตรวจสอบให้แน่ใจว่าได้เปิดใช้งานบริการตำแหน่งที่ตั้ง"
 
 # smartling.placeholder_format=C
 #. In the top dropdown menu  ("More" > "Settings")
@@ -17382,7 +17541,7 @@ msgstr "แชร์ข้อเสนอแนะเชิงบวก"
 msgctxt ""
 "Label beside the share-content switch on the Duck.ai response feedback form"
 msgid "Share this conversation with DuckDuckGo"
-msgstr ""
+msgstr "แบ่งปันการสนทนานี้กับ DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -17795,7 +17954,8 @@ msgctxt "settings"
 msgid ""
 "Shows occasional reminders to sign up for the DuckDuckGo privacy newsletters"
 msgstr ""
-"แสดงการแจ้งเตือนเป็นครั้งคราวให้สมัครรับจดหมายข่าวเกี่ยวกับความเป็นส่วนตัวของ DuckDuckGo"
+"แสดงการแจ้งเตือนเป็นครั้งคราวให้สมัครรับจดหมายข่าวเกี่ยวกับความเป็นส่วนตัวของ "
+"DuckDuckGo"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18137,7 +18297,9 @@ msgctxt "noresults"
 msgid ""
 "Sorry, we ran into an error displaying these results. %sClick here%s to try "
 "again."
-msgstr "ขออภัย เราพบข้อผิดพลาดในการแสดงผลลัพธ์เหล่านี้ %1$sคลิกที่นี่%2$s เพื่อลองอีกครั้ง"
+msgstr ""
+"ขออภัย เราพบข้อผิดพลาดในการแสดงผลลัพธ์เหล่านี้ %1$sคลิกที่นี่%2$s "
+"เพื่อลองอีกครั้ง"
 
 # smartling.placeholder_format=C
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
@@ -18610,7 +18772,9 @@ msgctxt "Full sentence for composing a card"
 msgid ""
 "Suggest a phrase to write on a get-well card for someone recovering from a "
 "surgery?"
-msgstr "เสนอแนะวลีที่จะเขียนลงในการ์ดอวยพรให้หายไว ๆ สำหรับผู้ที่ฟื้นตัวจากการผ่าตัดหรือไม่"
+msgstr ""
+"เสนอแนะวลีที่จะเขียนลงในการ์ดอวยพรให้หายไว ๆ "
+"สำหรับผู้ที่ฟื้นตัวจากการผ่าตัดหรือไม่"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for asking for a suggestion of a blog post title.
@@ -18622,19 +18786,19 @@ msgstr "แนะนําชื่อสําหรับบล็อกโพ
 #. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Suggest related articles or topics worth exploring next."
-msgstr ""
+msgstr "แนะนำบทความหรือหัวข้อที่เกี่ยวข้องซึ่งน่าสนใจให้ลองอ่านต่อ"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Suggest related articles to explore"
-msgstr ""
+msgstr "แนะนำบทความที่เกี่ยวข้องให้สำรวจ"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Suggest some alternatives to this product."
-msgstr ""
+msgstr "แนะนำทางเลือกอื่นสำหรับผลิตภัณฑ์นี้หน่อย"
 
 # smartling.placeholder_format=C
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
@@ -18651,7 +18815,7 @@ msgstr "คำแนะนำ:"
 #. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Sum up the reviews"
-msgstr ""
+msgstr "สรุปรีวิว"
 
 # smartling.placeholder_format=C
 #. A short title for the a message asking the AI to summarize a text.
@@ -18663,85 +18827,85 @@ msgstr "สรุป"
 #. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize the Q&As"
-msgstr ""
+msgstr "สรุปคำถามและคำตอบ"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the background and notable work of this person."
-msgstr ""
+msgstr "สรุปภูมิหลังและผลงานที่โดดเด่นของบุคคลนี้"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the key details of this event."
-msgstr ""
+msgstr "สรุปรายละเอียดสำคัญของเหตุการณ์นี้"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the questions and answers on this page."
-msgstr ""
+msgstr "สรุปคำถามและคำตอบในหน้านี้"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize their background"
-msgstr ""
+msgstr "สรุปภูมิหลังของพวกเขา"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this book"
-msgstr ""
+msgstr "สรุปหนังสือเล่มนี้"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this book."
-msgstr ""
+msgstr "สรุปหนังสือเล่มนี้"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this discussion"
-msgstr ""
+msgstr "สรุปการสนทนานี้"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this discussion thread."
-msgstr ""
+msgstr "สรุปกระทู้สนทนานี้"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this page"
-msgstr ""
+msgstr "สรุปหน้านี้"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this page."
-msgstr ""
+msgstr "สรุปหน้านี้"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this video"
-msgstr ""
+msgstr "สรุปวิดีโอนี้"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this video."
-msgstr ""
+msgstr "สรุปวิดีโอนี้"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize what the reviews say."
-msgstr ""
+msgstr "สรุปสิ่งที่รีวิวบอก"
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -19005,8 +19169,9 @@ msgid ""
 msgstr ""
 "รหัสกู้คืนการซิงค์\n"
 "\n"
-"รหัสกู้คืนช่วยให้คุณสามารถซิงค์รหัสผ่าน ข้อมูลการกรอกอัตโนมัติ และการแชท Duck.ai "
-"ของคุณระหว่างอุปกรณ์หลายเครื่อง และกู้คืนข้อมูลที่ซิงค์ไว้หากคุณสูญเสียการเข้าถึงอุปกรณ์\n"
+"รหัสกู้คืนช่วยให้คุณสามารถซิงค์รหัสผ่าน ข้อมูลการกรอกอัตโนมัติ และการแชท "
+"Duck.ai ของคุณระหว่างอุปกรณ์หลายเครื่อง "
+"และกู้คืนข้อมูลที่ซิงค์ไว้หากคุณสูญเสียการเข้าถึงอุปกรณ์\n"
 "\n"
 "เก็บรักษาข้อมูลนี้ให้ปลอดภัย\n"
 "ทุกคนที่มีสิทธิ์เข้าถึงรหัสนี้สามารถเข้าถึงข้อมูลที่ซิงค์ของคุณ\n"
@@ -19016,9 +19181,11 @@ msgstr ""
 "วิธีการทำงานของโค้ดนี้คืออะไร?\n"
 "1. ไปที่ Duck.ai ในเบราว์เซอร์ของคุณ แล้วเปิดการตั้งค่า Duck.ai\n"
 "2. เลือก \"เปิดใช้งาน Sync & Backup\" จากนั้นเลือก \"Recover Synced Data\"\n"
-"3. คัดลอกรหัสการกู้คืนด้านบนและวางลงในช่องที่ระบุว่า \"Paste your code here\"\n"
+"3. คัดลอกรหัสการกู้คืนด้านบนและวางลงในช่องที่ระบุว่า \"Paste your code "
+"here\"\n"
 "\n"
-"หากคุณไม่ได้ใช้เบราว์เซอร์ DuckDuckGo ที่มี Sync & Backup เปิดใช้งานเป็นเวลาเกิน 18 เดือน "
+"หากคุณไม่ได้ใช้เบราว์เซอร์ DuckDuckGo ที่มี Sync & Backup "
+"เปิดใช้งานเป็นเวลาเกิน 18 เดือน "
 "ข้อมูลของคุณจะถูกลบออกจากเซิร์ฟเวอร์และไม่สามารถกู้คืนได้"
 
 # smartling.placeholder_format=C
@@ -19065,7 +19232,7 @@ msgstr "ซีเรีย"
 #. Text for a button that enables the theme to follow the operating system's color scheme preference.
 msgctxt "System theme button for theme selector"
 msgid "System"
-msgstr ""
+msgstr "ระบบ"
 
 # smartling.placeholder_format=C
 #. Abbreviation indicating this is the total score for a game
@@ -19099,7 +19266,7 @@ msgstr "ตาฮีตี"
 #. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Tailor my resume"
-msgstr ""
+msgstr "ปรับแต่งเรซูเม่ของฉัน"
 
 # smartling.placeholder_format=C
 msgid "Taiwan"
@@ -19136,6 +19303,8 @@ msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
+"ทำแบบสำรวจที่ไม่ระบุตัวตนนี้เพื่อบอกให้เรารู้ว่าเราจะทำให้ Duck.ai "
+"ดีขึ้นได้อย่างไรบ้าง"
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -19350,6 +19519,7 @@ msgid ""
 "link is at increased risk of being intercepted by a third party. In rare "
 "cases this includes passwords, or payment details."
 msgstr ""
+""
 "นั่นหมายความว่าข้อมูลที่ส่งระหว่างอุปกรณ์ของคุณกับหน้าเว็บเบื้องหลังลิงก์นี้มีความเสี่ยงมากขึ้นต่อการถูกดักข้อมูลโดยบุคคลที่สาม "
 "ในบางกรณีซึ่งเกิดขึ้นไม่บ่อย ข้อมูลนี้รวมถึงรหัสผ่านหรือรายละเอียดการชำระเงิน"
 
@@ -19391,6 +19561,7 @@ msgid ""
 "The encryption key is only saved in your browser's local storage, and only "
 "you can access it."
 msgstr ""
+""
 "คีย์การเข้ารหัสจะถูกบันทึกไว้เฉพาะในที่เก็บข้อมูลในเครื่องของเบราว์เซอร์ของคุณ "
 "และมีเพียงคุณเท่านั้นที่สามารถเข้าถึงได้"
 
@@ -19413,7 +19584,9 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider does not save this chat or any associated data on their "
 "servers."
-msgstr "ผู้ให้บริการโมเดลไม่บันทึกการแชทนี้หรือข้อมูลที่เกี่ยวข้องใดๆ บนเซิร์ฟเวอร์ของเขา"
+msgstr ""
+"ผู้ให้บริการโมเดลไม่บันทึกการแชทนี้หรือข้อมูลที่เกี่ยวข้องใดๆ "
+"บนเซิร์ฟเวอร์ของเขา"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19441,7 +19614,7 @@ msgstr "ธีม"
 #. Text for the theme selector label that allows users to switch between Light and dark theme.
 msgctxt "Label for the theme selector feature"
 msgid "Theme"
-msgstr ""
+msgstr "ธีม"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/LpFhb1e.png
@@ -19506,6 +19679,7 @@ msgid ""
 "visit by blocking hidden trackers, encrypting connections where possible, "
 "and by making DuckDuckGo your default search engine."
 msgstr ""
+""
 "สิทธิ์ของเบราว์เซอร์เหล่านี้ใช้เพื่อเพิ่มการปกป้องความเป็นส่วนตัวบนเว็บไซต์ที่คุณเยี่ยมชมโดยการบล็อกตัวติดตามที่ซ่อนอยู่ "
 "การเข้ารหัสการเชื่อมต่อเมื่อสามารถทำได้ และการตั้งค่าให้ DuckDuckGo "
 "เป็นเครื่องมือค้นหาเริ่มต้นของคุณ"
@@ -19553,7 +19727,9 @@ msgctxt "AI Chat: Error message for when a model is deprecated"
 msgid ""
 "This AI model version is no longer supported. Try starting a new chat with "
 "the latest version of this model."
-msgstr "เวอร์ชันของโมเดล AI นี้ไม่ได้รับการสนับสนุนอีกต่อไป ลองเริ่มแชทใหม่ด้วยโมเดลรุ่นล่าสุด"
+msgstr ""
+"เวอร์ชันของโมเดล AI นี้ไม่ได้รับการสนับสนุนอีกต่อไป "
+"ลองเริ่มแชทใหม่ด้วยโมเดลรุ่นล่าสุด"
 
 # smartling.placeholder_format=C
 #. Appears below a type of search results called 'Instant Answers'
@@ -19612,8 +19788,9 @@ msgid ""
 "Model. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
 msgstr ""
-"การสนทนานี้สร้างขึ้นด้วย DuckDuckGo AI Chat (%1$s) โดยใช้โมเดล %3$s ของ %2$s แชท AI "
-"อาจแสดงข้อมูลที่ไม่ถูกต้องหรือไม่เหมาะสม (ดู %4$s สำหรับข้อมูลเพิ่มเติม)"
+"การสนทนานี้สร้างขึ้นด้วย DuckDuckGo AI Chat (%1$s) โดยใช้โมเดล %3$s ของ %2$s "
+"แชท AI อาจแสดงข้อมูลที่ไม่ถูกต้องหรือไม่เหมาะสม (ดู %4$s "
+"สำหรับข้อมูลเพิ่มเติม)"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
@@ -19717,8 +19894,8 @@ msgid ""
 "This model provider deletes data associated with this chat within 30 days. "
 "Other model providers follow a zero data retention model."
 msgstr ""
-"ผู้ให้บริการโมเดลจะลบข้อมูลที่เกี่ยวข้องกับแชทนี้ภายใน 30 วัน ผู้ให้บริการโมเดลอื่นๆ "
-"เป็นไปตามโมเดลการเก็บรักษาข้อมูลเป็นศูนย์"
+"ผู้ให้บริการโมเดลจะลบข้อมูลที่เกี่ยวข้องกับแชทนี้ภายใน 30 วัน "
+"ผู้ให้บริการโมเดลอื่นๆ เป็นไปตามโมเดลการเก็บรักษาข้อมูลเป็นศูนย์"
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers, and that other providers may retain chat data for a limited time instead.
@@ -19727,8 +19904,8 @@ msgid ""
 "This model provider does not store any data associated with this chat. Other "
 "model providers follow a limited data retention model."
 msgstr ""
-"ผู้ให้บริการโมเดลนี้ไม่ได้เก็บข้อมูลใดๆ ที่เกี่ยวข้องกับการแชทนี้ ผู้ให้บริการโมเดลอื่นๆ "
-"ใช้โมเดลการเก็บรักษาข้อมูลที่จํากัด"
+"ผู้ให้บริการโมเดลนี้ไม่ได้เก็บข้อมูลใดๆ ที่เกี่ยวข้องกับการแชทนี้ "
+"ผู้ให้บริการโมเดลอื่นๆ ใช้โมเดลการเก็บรักษาข้อมูลที่จํากัด"
 
 # smartling.placeholder_format=C
 #. Info that page may refresh during update.
@@ -19765,6 +19942,7 @@ msgid ""
 "This saves your chats with end-to-end encryption on DuckDuckGo's secure "
 "server, which later can be accessed from any browser."
 msgstr ""
+""
 "การดำเนินการนี้จะบันทึกการแชทของคุณด้วยการเข้ารหัสแบบครบวงจรบนเซิร์ฟเวอร์ที่ปลอดภัยของ "
 "DuckDuckGo ซึ่งต่อมาสามารถเข้าถึงได้จากเบราว์เซอร์ใดก็ตาม"
 
@@ -19775,8 +19953,9 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again."
 msgstr ""
-"การตั้งค่านี้ถูกเก็บไว้ในเบราว์เซอร์ของคุณ ซึ่งหมายความว่าถ้าคุณล้างข้อมูลเบราว์เซอร์บน "
-"duckduckgo.com คุณอาจเห็นคำตอบที่ได้รับความช่วยเหลือจาก AI อีกครั้ง"
+"การตั้งค่านี้ถูกเก็บไว้ในเบราว์เซอร์ของคุณ "
+"ซึ่งหมายความว่าถ้าคุณล้างข้อมูลเบราว์เซอร์บน duckduckgo.com "
+"คุณอาจเห็นคำตอบที่ได้รับความช่วยเหลือจาก AI อีกครั้ง"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -19786,8 +19965,9 @@ msgid ""
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
 msgstr ""
-"การตั้งค่านี้ถูกเก็บไว้ในเบราว์เซอร์ของคุณ ซึ่งหมายความว่าถ้าคุณล้างข้อมูลเบราว์เซอร์บน "
-"duckduckgo.com คุณอาจเห็นคำตอบที่ได้รับความช่วยเหลือจาก AI อีกครั้ง อย่างไรก็ตาม "
+"การตั้งค่านี้ถูกเก็บไว้ในเบราว์เซอร์ของคุณ "
+"ซึ่งหมายความว่าถ้าคุณล้างข้อมูลเบราว์เซอร์บน duckduckgo.com "
+"คุณอาจเห็นคำตอบที่ได้รับความช่วยเหลือจาก AI อีกครั้ง อย่างไรก็ตาม "
 "เรามีหน้าเริ่มต้นที่ไม่แสดงคำตอบที่ได้รับความช่วยเหลือจาก AI ด้วยที่ %1$s"
 
 # smartling.placeholder_format=C
@@ -19827,8 +20007,9 @@ msgid ""
 "Sync & Backup. You'll still be able to access your chats in other browsers "
 "connected to Sync & Backup."
 msgstr ""
-"การกระทำนี้จะลบการแชท Duck.ai ทั้งหมดจากเบราว์เซอร์นี้ และตัดการเชื่อมต่อ Sync & Backup "
-"คุณยังสามารถเข้าถึงการแชทของคุณในเบราว์เซอร์อื่นๆ ที่เชื่อมต่อกับ Sync & Backup"
+"การกระทำนี้จะลบการแชท Duck.ai ทั้งหมดจากเบราว์เซอร์นี้ และตัดการเชื่อมต่อ "
+"Sync & Backup คุณยังสามารถเข้าถึงการแชทของคุณในเบราว์เซอร์อื่นๆ "
+"ที่เชื่อมต่อกับ Sync & Backup"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to clear all recentchats, with a warning that this action cannot be undone.
@@ -19837,8 +20018,8 @@ msgid ""
 "This will delete all your recent chats, unless they're pinned. This cannot "
 "be undone."
 msgstr ""
-"การดำเนินการนี้จะลบการแชททั้งหมดของคุณเมื่อเร็วๆ นี้ เว้นแต่ว่าจะมีการปักหมุดไว้ "
-"การกระทำนี้ย้อนกลับไม่ได้"
+"การดำเนินการนี้จะลบการแชททั้งหมดของคุณเมื่อเร็วๆ นี้ "
+"เว้นแต่ว่าจะมีการปักหมุดไว้ การกระทำนี้ย้อนกลับไม่ได้"
 
 # smartling.placeholder_format=C
 #. Message explaining what will happen when the user deletes an image.
@@ -19856,7 +20037,9 @@ msgstr "การตั้งค่าทั้งหมดของคุณจ
 #. Confirmation message asking if the user is sure they want to reset all of their settings.
 msgctxt "settings"
 msgid "This will reset your saved settings to default values. Continue?"
-msgstr "การดำเนินการนี้จะรีเซ็ตการตั้งค่าที่บันทึกไว้เป็นค่าเริ่มต้น ดำเนินการต่อหรือไม่"
+msgstr ""
+"การดำเนินการนี้จะรีเซ็ตการตั้งค่าที่บันทึกไว้เป็นค่าเริ่มต้น "
+"ดำเนินการต่อหรือไม่"
 
 # smartling.placeholder_format=C
 #. Golf leaderboard column: holes completed in current round
@@ -19975,9 +20158,7 @@ msgctxt "directions"
 msgid ""
 "To print directions:%sGo back to the map.%sSelect the route you want to "
 "print.%sClick the print icon.%s"
-msgstr ""
-"วิธีการพิมพ์เส้นทาง:"
-"%1$sกลับไปยังแผนที่%2$sเลือกเส้นทางที่ต้องการพิมพ์%3$sเลือกไอคอนเครื่องพิมพ์%4$s"
+msgstr "วิธีการพิมพ์เส้นทาง:%1$sกลับไปยังแผนที่%2$sเลือกเส้นทางที่ต้องการพิมพ์%3$sเลือกไอคอนเครื่องพิมพ์%4$s"
 
 # smartling.placeholder_format=C
 #. Explains where the user can find their recovery code. Figma frame 3703-44420.
@@ -19987,7 +20168,8 @@ msgid ""
 "you first set up Sync. This code may have been saved as a PDF on the device "
 "you originally used to set up Sync."
 msgstr ""
-"เพื่อกู้คืนข้อมูลที่ซิงค์ของคุณ คุณจำเป็นต้องมีรหัสกู้คืนที่คุณบันทึกไว้เมื่อคุณตั้งค่า Sync เป็นครั้งแรก "
+"เพื่อกู้คืนข้อมูลที่ซิงค์ของคุณ "
+"คุณจำเป็นต้องมีรหัสกู้คืนที่คุณบันทึกไว้เมื่อคุณตั้งค่า Sync เป็นครั้งแรก "
 "รหัสนี้อาจถูกบันทึกเป็น PDF บนอุปกรณ์ที่คุณใช้ตั้งค่าการซิงค์ในตอนแรก"
 
 # smartling.placeholder_format=C
@@ -20243,7 +20425,9 @@ msgctxt "Full sentence for translating text"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr "แปลประโยคภาษาอังกฤษนี้เป็นภาษาฝรั่งเศส: “ฉันจะไปโรงภาพยนตร์ที่ใกล้ที่สุดได้อย่างไร?”"
+msgstr ""
+"แปลประโยคภาษาอังกฤษนี้เป็นภาษาฝรั่งเศส: "
+"“ฉันจะไปโรงภาพยนตร์ที่ใกล้ที่สุดได้อย่างไร?”"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for translating a sentence into another language. Translate the whole sentence and please use target language instead of 'English' and modify the sentence to translate into 'English' instead of 'French'. Example: 'Translate this {target language} sentence into English: “How do I get to the nearest movie theatre?”'
@@ -20251,19 +20435,21 @@ msgctxt "Full sentence for translating text prompt"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr "แปลประโยคภาษาไทยนี้เป็นภาษาอังกฤษ: “ฉันจะไปโรงภาพยนตร์ที่ใกล้ที่สุดได้อย่างไร?”"
+msgstr ""
+"แปลประโยคภาษาไทยนี้เป็นภาษาอังกฤษ: "
+"“ฉันจะไปโรงภาพยนตร์ที่ใกล้ที่สุดได้อย่างไร?”"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Translate this page"
-msgstr ""
+msgstr "แปลหน้านี้"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
 msgctxt "Page suggestion prompt"
 msgid "Translate this page into %s."
-msgstr ""
+msgstr "แปลหน้านี้เป็นภาษา %1$s"
 
 # smartling.placeholder_format=C
 #. Placeholder text for a region that will display translated text.
@@ -20410,7 +20596,7 @@ msgstr "ลองใช้ฟรี"
 #. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
 msgctxt "settings"
 msgid "Try It Now"
-msgstr ""
+msgstr "ลองเลยตอนนี้"
 
 # smartling.placeholder_format=C
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -20651,6 +20837,8 @@ msgid ""
 "Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
+"กำลังพยายามปิดใช้งานฟีเจอร์ AI อยู่ใช่ไหม ติดตั้งส่วนขยายการค้นหา "
+"%1$sDuckDuckGo No AI%2$s เพื่อจดจำการตั้งค่าของคุณ %3$sศึกษาเพิ่มเติม%4$s"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -20659,6 +20847,8 @@ msgid ""
 "Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
+"กำลังพยายามปิดใช้งานฟีเจอร์ AI อยู่ใช่ไหม เปลี่ยนไปใช้ส่วนขยายการค้นหา "
+"%1$sDuckDuckGo No AI%2$s เพื่อจดจำการตั้งค่าของคุณ %3$sศึกษาเพิ่มเติม%4$s"
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -20960,7 +21150,8 @@ msgid ""
 "Under %sOn startup%s, click %sOpen a specific page%s then click %sSet "
 "Pages%s."
 msgstr ""
-"ภายใต้%1$sเมื่อเริ่มต้น%2$s ให้คลิก%3$sเปิดหน้าที่เฉพาะเจาะจง%4$s จากนั้นคลิก%5$sตั้งค่าหน้า%6$s"
+"ภายใต้%1$sเมื่อเริ่มต้น%2$s ให้คลิก%3$sเปิดหน้าที่เฉพาะเจาะจง%4$s "
+"จากนั้นคลิก%5$sตั้งค่าหน้า%6$s"
 
 #  Maxthon homepage instruction
 # smartling.placeholder_format=C
@@ -20968,7 +21159,8 @@ msgstr ""
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
 msgstr ""
-"ภายใต้%1$sเมื่อเริ่มต้น%2$s ให้เลือก%3$sหน้าแรก%4$s และป้อน: https://duckduckgo.com"
+"ภายใต้%1$sเมื่อเริ่มต้น%2$s ให้เลือก%3$sหน้าแรก%4$s และป้อน: "
+"https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -21084,8 +21276,8 @@ msgid ""
 "Unlock %s, higher AI reasoning, and 2x higher usage limits than the Plus "
 "plan by upgrading to Pro."
 msgstr ""
-"ปลดล็อก %1$s, การให้เหตุผล AI ที่สูงขึ้น, และขีดจำกัดการใช้งานสูงกว่า Plus ถึง 2 เท่า "
-"โดยการอัปเกรดเป็น Pro"
+"ปลดล็อก %1$s, การให้เหตุผล AI ที่สูงขึ้น, และขีดจำกัดการใช้งานสูงกว่า Plus "
+"ถึง 2 เท่า โดยการอัปเกรดเป็น Pro"
 
 # smartling.placeholder_format=C
 #. Title for the subscription promo shown in the SERP sidemenu.
@@ -21219,7 +21411,8 @@ msgid ""
 "Update the DuckDuckGo browser to activate your subscription in Duck.ai and "
 "access advanced models"
 msgstr ""
-"อัปเดตเบราว์เซอร์ DuckDuckGo เพื่อเปิดใช้งานการสมัครสมาชิกใน Duck.ai และเข้าถึงโมเดลขั้นสูง"
+"อัปเดตเบราว์เซอร์ DuckDuckGo เพื่อเปิดใช้งานการสมัครสมาชิกใน Duck.ai "
+"และเข้าถึงโมเดลขั้นสูง"
 
 # smartling.placeholder_format=C
 #. The placeholder indicates a formatted date (e.g., 'Updated 2 days ago')
@@ -21403,7 +21596,7 @@ msgstr "อุรุกวัย"
 #. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
 msgctxt "Navigation label on the Duck.ai settings page"
 msgid "Usage"
-msgstr ""
+msgstr "การใช้งาน"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -21447,8 +21640,9 @@ msgid ""
 "Use ChatGPT, Claude, and other AIs, privately. Protect chats from hackers, "
 "scammers, and companies. Keep info confidential. Free. No account required."
 msgstr ""
-"ใช้ ChatGPT, Claude และ AI อื่นๆ อย่างเป็นส่วนตัว ปกป้องแชทจากแฮกเกอร์ นักต้มตุ๋น "
-"และบริษัทต่าง ๆ เก็บข้อมูลให้เป็นความลับ ไม่มีค่าใช้จ่าย ไม่จำเป็นต้องมีบัญชี"
+"ใช้ ChatGPT, Claude และ AI อื่นๆ อย่างเป็นส่วนตัว ปกป้องแชทจากแฮกเกอร์ "
+"นักต้มตุ๋น และบริษัทต่าง ๆ เก็บข้อมูลให้เป็นความลับ ไม่มีค่าใช้จ่าย "
+"ไม่จำเป็นต้องมีบัญชี"
 
 # smartling.placeholder_format=C
 #. Header above instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -21661,7 +21855,9 @@ msgstr "หมู่เกาะเวอร์จิน"
 msgctxt "duckassist"
 msgid ""
 "Visit %sAssist Settings%s to adjust how this feature works or turn it off."
-msgstr "ไปที่ %1$sการตั้งค่า Assist%2$s เพื่อปรับวิธีการทำงานของคุณลักษณะนี้หรือปิดการใช้งาน"
+msgstr ""
+"ไปที่ %1$sการตั้งค่า Assist%2$s "
+"เพื่อปรับวิธีการทำงานของคุณลักษณะนี้หรือปิดการใช้งาน"
 
 # smartling.placeholder_format=C
 #. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
@@ -21669,7 +21865,9 @@ msgctxt "duckassist"
 msgid ""
 "Visit %sDuckAssist Settings%s to adjust how this feature works or turn it "
 "off."
-msgstr "ไปที่ %1$sการตั้งค่า DuckAssist%2$s เพื่อปรับวิธีการทำงานของฟีเจอร์นี้หรือปิดการใช้งาน"
+msgstr ""
+"ไปที่ %1$sการตั้งค่า DuckAssist%2$s "
+"เพื่อปรับวิธีการทำงานของฟีเจอร์นี้หรือปิดการใช้งาน"
 
 # smartling.placeholder_format=C
 #. Prompt to visit DuckDuckGo on another device.
@@ -21692,8 +21890,9 @@ msgid ""
 "Visit Duck.ai in your other browser and go to %sDuck.ai Settings%s > %sSync "
 "& Backup%s > %sManage%s then select %sSync With Another Device%s."
 msgstr ""
-"เข้าไปที่ Duck.ai ในเบราว์เซอร์อื่นของคุณ แล้วไปที่ %1$sDuck.ai Settings%2$s > %3$sSync "
-"& Backup%4$s > %5$sManage%6$s จากนั้นเลือก %7$sSync With Another Device%8$s"
+"เข้าไปที่ Duck.ai ในเบราว์เซอร์อื่นของคุณ แล้วไปที่ %1$sDuck.ai Settings%2$s "
+"> %3$sSync & Backup%4$s > %5$sManage%6$s จากนั้นเลือก %7$sSync With Another "
+"Device%8$s"
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -21703,8 +21902,9 @@ msgid ""
 "On” under Sync & Backup and select “Sync With Another Device”. Or scan the "
 "QR on your Recovery PDF."
 msgstr ""
-"ไปที่ Duck.ai ในเบราว์เซอร์อื่นของคุณ แล้วเปิดการตั้งค่า Duck.ai เลือก \"เปิด\" ภายใต้ Sync "
-"& Backup และเลือก \"ซิงค์กับอุปกรณ์อื่น\" หรือสแกนคิวอาร์บน PDF การกู้คืนของคุณ"
+"ไปที่ Duck.ai ในเบราว์เซอร์อื่นของคุณ แล้วเปิดการตั้งค่า Duck.ai เลือก "
+"\"เปิด\" ภายใต้ Sync & Backup และเลือก \"ซิงค์กับอุปกรณ์อื่น\" "
+"หรือสแกนคิวอาร์บน PDF การกู้คืนของคุณ"
 
 # smartling.placeholder_format=C
 #. Shared body copy for every screen in the Sync Another Device flow (QR display, camera scan, camera-unavailable fallback, manual entry). Bold tags wrap navigation breadcrumbs. Render with <Translate /> so the HTML is interpreted; plain `translate()` will trip the html-string warning.
@@ -21714,9 +21914,9 @@ msgid ""
 "ai Settings%s > %sSync & Backup%s > %sManage%s then select %sSync With "
 "Another Device%s."
 msgstr ""
-"เข้าไปที่ Duck.ai ในเบราว์เซอร์อื่นของคุณหรือแอป DuckDuckGo แล้วไปที่ %1$sDuck.ai "
-"Settings%2$s > %3$sSync & Backup%4$s > %5$sManage%6$s จากนั้นเลือก %7$sSync "
-"With Another Device%8$s"
+"เข้าไปที่ Duck.ai ในเบราว์เซอร์อื่นของคุณหรือแอป DuckDuckGo แล้วไปที่ "
+"%1$sDuck.ai Settings%2$s > %3$sSync & Backup%4$s > %5$sManage%6$s "
+"จากนั้นเลือก %7$sSync With Another Device%8$s"
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -21726,9 +21926,9 @@ msgid ""
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
 msgstr ""
-"ไปที่ Duck.ai ในเบราว์เซอร์อื่นของคุณหรือแอป DuckDuckGo แล้วเปิดการตั้งค่า Duck.ai เลือก "
-"\"เปิด\" ภายใต้ Sync & Backup และเลือก \"ซิงค์กับอุปกรณ์อื่น\" หรือสแกนคิวอาร์บน PDF "
-"การกู้คืนของคุณ"
+"ไปที่ Duck.ai ในเบราว์เซอร์อื่นของคุณหรือแอป DuckDuckGo แล้วเปิดการตั้งค่า "
+"Duck.ai เลือก \"เปิด\" ภายใต้ Sync & Backup และเลือก \"ซิงค์กับอุปกรณ์อื่น\" "
+"หรือสแกนคิวอาร์บน PDF การกู้คืนของคุณ"
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -21780,7 +21980,10 @@ msgstr "แชทด้วยเสียงสิ้นสุดลง"
 #. Description in consent disclaimer informing that voice chats with the AI (Artificial Intelligence) are anonymized by us, and are never used to train AI models.
 msgctxt "voice chat"
 msgid "Voice chat is anonymized by us, and never used to train AI models."
-msgstr "เราจะทำให้การแชทด้วยเสียงไม่ถูกระบุชื่อและจะไม่มีการใช้การแชทด้วยเสียงเพื่อฝึกโมเดล AI"
+msgstr ""
+""
+"เราจะทำให้การแชทด้วยเสียงไม่ถูกระบุชื่อและจะไม่มีการใช้การแชทด้วยเสียงเพื่อฝึกโมเดล "
+"AI"
 
 # smartling.placeholder_format=C
 #. Title of the modal shown when the user has reached their daily voice chat limit.
@@ -21844,7 +22047,7 @@ msgstr "เวลส์"
 #. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Walk me through the steps"
-msgstr ""
+msgstr "แนะนำฉันตลอดขั้นตอน"
 
 # smartling.placeholder_format=C
 #. Label for walking directions on a map.
@@ -21945,8 +22148,10 @@ msgid ""
 "independent company and has no relationship with YouTube, where most videos "
 "are hosted."
 msgstr ""
-"การดูวิดีโอที่นี่หมายความว่าเว็บไซต์ที่โฮสต์นั้นสามารถติดตามคุณได้ เพราะเราต้องสตรีมเนื้อหาจากที่นั่น "
-"DuckDuckGo เป็นบริษัทอิสระและไม่มีความสัมพันธ์กับ YouTube ซึ่งวิดีโอส่วนใหญ่โฮสต์อยู่ที่นั่น"
+"การดูวิดีโอที่นี่หมายความว่าเว็บไซต์ที่โฮสต์นั้นสามารถติดตามคุณได้ "
+"เพราะเราต้องสตรีมเนื้อหาจากที่นั่น DuckDuckGo "
+"เป็นบริษัทอิสระและไม่มีความสัมพันธ์กับ YouTube "
+"ซึ่งวิดีโอส่วนใหญ่โฮสต์อยู่ที่นั่น"
 
 # smartling.placeholder_format=C
 #. Heading for the highlight card explaining anonymized prompt delivery.
@@ -21958,7 +22163,9 @@ msgstr "เราทำให้ไม่ระบุตัวตน"
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
-msgstr "เราสามารถเปิดใช้%1$s ตำแหน่งของคุณ%2$s แบบไม่ระบุตัวตนเพื่อแสดงผลลัพธ์ที่แม่นยำยิ่งขึ้น"
+msgstr ""
+"เราสามารถเปิดใช้%1$s ตำแหน่งของคุณ%2$s "
+"แบบไม่ระบุตัวตนเพื่อแสดงผลลัพธ์ที่แม่นยำยิ่งขึ้น"
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
@@ -21970,6 +22177,9 @@ msgid ""
 "please share this conversation with DuckDuckGo so we can investigate and "
 "address the issue."
 msgstr ""
+"เราสามารถแก้ไขได้เฉพาะสิ่งที่เราเห็นเท่านั้น "
+"เพื่อรายงานการตอบสนองที่เป็นอันตรายหรือผิดกฎหมาย โปรดแชร์การสนทนานี้กับ "
+"DuckDuckGo เพื่อที่เราจะสามารถสอบสวนและแก้ไขปัญหานี้"
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -21981,7 +22191,8 @@ msgid ""
 "please share your prompt and response so we can investigate and address the "
 "issue."
 msgstr ""
-"เราสามารถแก้ไขได้เฉพาะสิ่งที่เราเห็นเท่านั้น เพื่อรายงานการตอบสนองที่เป็นอันตรายหรือผิดกฎหมาย "
+"เราสามารถแก้ไขได้เฉพาะสิ่งที่เราเห็นเท่านั้น "
+"เพื่อรายงานการตอบสนองที่เป็นอันตรายหรือผิดกฎหมาย "
 "โปรดแชร์คำแนะนำและการตอบสนองของคุณเพื่อที่เราจะสามารถสอบสวนและแก้ไขปัญหานี้"
 
 # smartling.placeholder_format=C
@@ -21995,7 +22206,9 @@ msgstr "เราสามารถใช้%1$sตำแหน่งที่�
 msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
-msgstr "เราไม่สามารถอ่านไฟล์ที่แนบมาได้ เนื่องจากอย่างน้อยหนึ่งในนั้นได้รับการเข้ารหัส"
+msgstr ""
+"เราไม่สามารถอ่านไฟล์ที่แนบมาได้ "
+"เนื่องจากอย่างน้อยหนึ่งในนั้นได้รับการเข้ารหัส"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -22023,7 +22236,8 @@ msgid ""
 "We don't store your personal info. We don't follow you around with ads. We "
 "don't track you. Ever."
 msgstr ""
-"เราไม่จัดเก็บข้อมูลส่วนบุคคลของคุณ เราจะไม่แสดงโฆษณาแก่คุณในทุกๆ ที่ เราไม่ติดตามคุณ อย่างแน่นอน"
+"เราไม่จัดเก็บข้อมูลส่วนบุคคลของคุณ เราจะไม่แสดงโฆษณาแก่คุณในทุกๆ ที่ "
+"เราไม่ติดตามคุณ อย่างแน่นอน"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -22036,7 +22250,9 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what brought you "
 "back today:"
-msgstr "เนื่องจากเราไม่ได้ติดตามคุณ เราจึงอยากให้คุณช่วยบอกว่าสิ่งใดทำให้คุณกลับมาในวันนี้:"
+msgstr ""
+"เนื่องจากเราไม่ได้ติดตามคุณ "
+"เราจึงอยากให้คุณช่วยบอกว่าสิ่งใดทำให้คุณกลับมาในวันนี้:"
 
 # smartling.placeholder_format=C
 #. Message prompting users to fill out a feedback form.
@@ -22045,7 +22261,8 @@ msgid ""
 "We don't track you, so we could use your help telling us what convinced you "
 "to try us out today:"
 msgstr ""
-"เนื่องจากเราไม่ได้ติดตามคุณ เราจึงอยากให้คุณช่วยบอกว่าสิ่งใดทำให้คุณสนใจลองใช้บริการเราในวันนี้:"
+"เนื่องจากเราไม่ได้ติดตามคุณ "
+"เราจึงอยากให้คุณช่วยบอกว่าสิ่งใดทำให้คุณสนใจลองใช้บริการเราในวันนี้:"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -22112,7 +22329,8 @@ msgid ""
 "We have agreements with all AI providers to ensure your chats aren't used to "
 "train AIs."
 msgstr ""
-"เรามีข้อตกลงกับผู้ให้บริการ AI ทุกรายเพื่อให้มั่นใจว่าการแชทของคุณจะไม่ถูกใช้ในการฝึกฝน AI"
+"เรามีข้อตกลงกับผู้ให้บริการ AI "
+"ทุกรายเพื่อให้มั่นใจว่าการแชทของคุณจะไม่ถูกใช้ในการฝึกฝน AI"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -22147,6 +22365,7 @@ msgid ""
 "We only use your anonymous location to deliver better results, closer to "
 "you. You can always change your mind later."
 msgstr ""
+""
 "เราใช้ตำแหน่งที่ตั้งแบบไม่ระบุตัวตนของคุณเพียงเพื่อให้ได้ผลลัพธ์ที่แม่นยำยิ่งขึ้นและใกล้คุณมากขึ้นเท่านั้น "
 "คุณสามารถเปลี่ยนใจได้เสมอในภายหลัง"
 
@@ -22154,7 +22373,9 @@ msgstr ""
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
-msgstr "เราพึ่งพาคำติชมที่ไม่ระบุชื่อของคุณเพื่อปรับปรุง DuckDuckGo ให้ดียิ่งขึ้นสำหรับทุกคน"
+msgstr ""
+"เราพึ่งพาคำติชมที่ไม่ระบุชื่อของคุณเพื่อปรับปรุง DuckDuckGo "
+"ให้ดียิ่งขึ้นสำหรับทุกคน"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -22190,7 +22411,8 @@ msgid ""
 "We're aware of this issue and are currently working to resolve it. If you "
 "continue to see this error, please reach out to %s."
 msgstr ""
-"เราทราบถึงปัญหานี้แล้วและกำลังดำเนินการแก้ไขอยู่ ถ้าคุณยังเห็นข้อผิดพลาดนี้อยู่ กรุณาติดต่อ %1$s"
+"เราทราบถึงปัญหานี้แล้วและกำลังดำเนินการแก้ไขอยู่ "
+"ถ้าคุณยังเห็นข้อผิดพลาดนี้อยู่ กรุณาติดต่อ %1$s"
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -22223,7 +22445,8 @@ msgid ""
 "We've updated the Duck.ai service. For the change to take effect, we need to "
 "reload the page."
 msgstr ""
-"เราได้อัปเดตบริการ Duck.ai แล้ว เพื่อให้การเปลี่ยนแปลงมีผล เราจำเป็นต้องโหลดหน้านี้อีกครั้ง"
+"เราได้อัปเดตบริการ Duck.ai แล้ว เพื่อให้การเปลี่ยนแปลงมีผล "
+"เราจำเป็นต้องโหลดหน้านี้อีกครั้ง"
 
 # smartling.placeholder_format=C
 #. Instant Answer Tab Name
@@ -22325,7 +22548,9 @@ msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "Weekly usage limit reached. You can keep chatting by using your monthly "
 "limit."
-msgstr "ถึงขีดจำกัดการใช้งานรายสัปดาห์แล้ว คุณสามารถแชทต่อโดยใช้ขีดจำกัดรายเดือนของคุณ"
+msgstr ""
+"ถึงขีดจำกัดการใช้งานรายสัปดาห์แล้ว "
+"คุณสามารถแชทต่อโดยใช้ขีดจำกัดรายเดือนของคุณ"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -22339,7 +22564,8 @@ msgid ""
 "Welcome to Duck.ai! All of your chats here are private, anonymized by us and "
 "not used to train AI models."
 msgstr ""
-"ยินดีต้อนรับสู่ Duck.ai การแชททั้งหมดที่นี่เป็นแบบส่วนตัว เราไม่ระบุชื่อและจะไม่ถูกใช้เพื่อฝึกโมเดล AI"
+"ยินดีต้อนรับสู่ Duck.ai การแชททั้งหมดที่นี่เป็นแบบส่วนตัว "
+"เราไม่ระบุชื่อและจะไม่ถูกใช้เพื่อฝึกโมเดล AI"
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened.
@@ -22360,7 +22586,8 @@ msgid ""
 "to train AI models."
 msgstr ""
 "ยินดีต้อนรับสู่ DuckDuckGo AI Chat! เซสชันแชทนี้ขับเคลื่อนโดย %2$s ของ %1$s "
-"การแชททั้งหมดของคุณที่นี่เป็นแบบส่วนตัว และจะไม่ถูกจัดเก็บโดย DuckDuckGo หรือใช้เพื่อฝึกโมเดล AI"
+"การแชททั้งหมดของคุณที่นี่เป็นแบบส่วนตัว และจะไม่ถูกจัดเก็บโดย DuckDuckGo "
+"หรือใช้เพื่อฝึกโมเดล AI"
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -22467,7 +22694,9 @@ msgctxt "Full sentence for finding a better word"
 msgid ""
 "What are some options for the word ‘better’ in the context of “We really "
 "need to do better.”"
-msgstr "มีตัวเลือกใดบ้างสำหรับคำว่า 'ดีกว่านี้' ในบริบทของ \"เราต้องทำให้ได้ดีกว่านี้\""
+msgstr ""
+"มีตัวเลือกใดบ้างสำหรับคำว่า 'ดีกว่านี้' ในบริบทของ "
+"\"เราต้องทำให้ได้ดีกว่านี้\""
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
@@ -22486,107 +22715,108 @@ msgid ""
 "easy to understand for people with or without much AI, or technical, "
 "experience."
 msgstr ""
-"คุณจะได้ประโยชน์อะไรบ้างจากการดาวน์โหลดเบราว์เซอร์ DuckDuckGo สำหรับผู้ที่สนใจใช้ Duck.ai "
-"อ้างอิงเฉพาะแหล่งข้อมูลอย่างเป็นทางการของ DuckDuckGo เท่านั้น แบ่งคำตอบออกเป็นส่วนๆ "
-"ที่ชัดเจนพร้อมชื่อหัวข้อ โดยเน้นที่การบูรณาการ Duck.ai และการปกป้องความเป็นส่วนตัว ทำให้สั้น "
-"ง่าย และเข้าใจได้ง่ายสำหรับคนที่มีหรือไม่มีประสบการณ์ด้าน AI หรือเทคนิคมากนัก"
+"คุณจะได้ประโยชน์อะไรบ้างจากการดาวน์โหลดเบราว์เซอร์ DuckDuckGo "
+"สำหรับผู้ที่สนใจใช้ Duck.ai อ้างอิงเฉพาะแหล่งข้อมูลอย่างเป็นทางการของ "
+"DuckDuckGo เท่านั้น แบ่งคำตอบออกเป็นส่วนๆ ที่ชัดเจนพร้อมชื่อหัวข้อ "
+"โดยเน้นที่การบูรณาการ Duck.ai และการปกป้องความเป็นส่วนตัว ทำให้สั้น ง่าย "
+"และเข้าใจได้ง่ายสำหรับคนที่มีหรือไม่มีประสบการณ์ด้าน AI หรือเทคนิคมากนัก"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the counterarguments?"
-msgstr ""
+msgstr "มีข้อโต้แย้งอะไรบ้าง?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the hours & location?"
-msgstr ""
+msgstr "เวลาทำการ & สถานที่ตั้งคือที่ไหน"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key contributions of this paper?"
-msgstr ""
+msgstr "ประเด็นสำคัญของบทความวิจัยนี้มีอะไรบ้าง"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key contributions?"
-msgstr ""
+msgstr "สิ่งที่มีส่วนสำคัญมีอะไรบ้าง"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key details?"
-msgstr ""
+msgstr "รายละเอียดสำคัญมีอะไรบ้าง"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key points covered in this video?"
-msgstr ""
+msgstr "ประเด็นสำคัญที่ครอบคลุมในวิดีโอนี้มีอะไรบ้าง"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key points?"
-msgstr ""
+msgstr "ประเด็นสำคัญมีอะไรบ้าง"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key takeaways from this article?"
-msgstr ""
+msgstr "ประเด็นสำคัญจากบทความนี้มีอะไรบ้าง"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key takeaways?"
-msgstr ""
+msgstr "ประเด็นสำคัญมีอะไรบ้าง"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key things I will learn from this course?"
-msgstr ""
+msgstr "สิ่งสำคัญที่ฉันจะได้เรียนรู้จากหลักสูตรนี้มีอะไรบ้าง"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the main counterarguments or criticisms of this?"
-msgstr ""
+msgstr "ข้อโต้แย้งหรือคำวิจารณ์หลักของเรื่องนี้คืออะไร?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the main questions this page answers?"
-msgstr ""
+msgstr "คำถามหลักที่หน้านี้ตอบคืออะไรบ้าง"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the must-try dishes here?"
-msgstr ""
+msgstr "อาหารที่ต้องลองที่นี่มีอะไรบ้าง"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid ""
 "What are the opening hours, location, and contact details for this place?"
-msgstr ""
+msgstr "สถานที่นี้มีเวลาทำการ ที่ตั้ง และข้อมูลการติดต่ออย่างไรบ้าง?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the pros and cons of this product?"
-msgstr ""
+msgstr "ข้อดีและข้อเสียของผลิตภัณฑ์นี้มีอะไรบ้าง"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the pros and cons?"
-msgstr ""
+msgstr "ข้อดีและข้อเสียมีอะไรบ้าง"
 
 # smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
@@ -22692,7 +22922,7 @@ msgstr "atria หมายถึงอะไรในบริบทของบ
 #. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What does this answer?"
-msgstr ""
+msgstr "คำตอบนี้หมายถึงอะไร"
 
 # smartling.placeholder_format=C
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
@@ -22710,7 +22940,7 @@ msgstr "ข้อมูลอะไรบ้างที่ได้รับก
 #. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What interview questions might come up for this role?"
-msgstr ""
+msgstr "คำถามสัมภาษณ์อะไรบ้างที่อาจจะถูกถามสำหรับบทบาทนี้"
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -22732,7 +22962,7 @@ msgstr "เมืองหลวงของประเทศแอลเบเ
 #. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What is the overall verdict and rating for this?"
-msgstr ""
+msgstr "บทสรุปและคะแนนโดยรวมของสิ่งนี้คืออะไร?"
 
 # smartling.placeholder_format=C
 #. Link to a page with additional information.
@@ -22760,7 +22990,7 @@ msgstr "ความคิดเห็นของผู้ใช้:"
 #. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What should I order?"
-msgstr ""
+msgstr "ฉันควรสั่งอะไรดี"
 
 # smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
@@ -22778,13 +23008,13 @@ msgstr "คำตอบมีปัญหาอย่างไรบ้าง (�
 #. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What will I learn?"
-msgstr ""
+msgstr "ฉันจะได้เรียนรู้อะไรบ้าง"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What will I need?"
-msgstr ""
+msgstr "ฉันต้องใช้อะไรบ้าง?"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -22807,7 +23037,7 @@ msgstr "มีอะไรใหม่"
 #. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What's the verdict?"
-msgstr ""
+msgstr "บทสรุปคืออะไร"
 
 # smartling.placeholder_format=C
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -22861,7 +23091,7 @@ msgstr "ขาดฟีเจอร์ใดบ้าง (ไม่บังค�
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Which features are missing? (optional)"
-msgstr ""
+msgstr "ขาดฟีเจอร์ใดบ้าง (ไม่บังคับ)"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
@@ -22883,13 +23113,13 @@ msgstr "ข้อมูลเกี่ยวกับเรา"
 #. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Who are the main cast and crew, and what else are they known for?"
-msgstr ""
+msgstr "นักแสดงและทีมงานหลักมีใครบ้าง และพวกเขามีผลงานอื่นอะไรอีกที่น่าสนใจ?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Who is this person?"
-msgstr ""
+msgstr "คนนี้คือใคร"
 
 # smartling.placeholder_format=C
 #. Header above a collection of privacy-related links.
@@ -23302,7 +23532,9 @@ msgstr "คุณสามารถเข้าถึง DuckDuckGo AI Chat ไ�
 msgctxt "duckassist"
 msgid ""
 "You can adjust how %s works or turn it off anytime in %sSearch Settings%s."
-msgstr "คุณสามารถปรับวิธีการทำงานของ %1$s หรือปิดได้ตลอดเวลาใน %2$sการตั้งค่าการค้นหา%3$s"
+msgstr ""
+"คุณสามารถปรับวิธีการทำงานของ %1$s หรือปิดได้ตลอดเวลาใน "
+"%2$sการตั้งค่าการค้นหา%3$s"
 
 # smartling.placeholder_format=C
 #. Assist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate Assist.
@@ -23311,7 +23543,8 @@ msgid ""
 "You can adjust how Assist works or turn it off anytime in %sSearch "
 "Settings%s."
 msgstr ""
-"คุณสามารถปรับวิธีการทำงานของ Assist หรือปิดได้ตลอดเวลาใน %1$sการตั้งค่าการค้นหา%2$s"
+"คุณสามารถปรับวิธีการทำงานของ Assist หรือปิดได้ตลอดเวลาใน "
+"%1$sการตั้งค่าการค้นหา%2$s"
 
 # smartling.placeholder_format=C
 msgid "You can also use %sDuck.ai%s to answer questions or summarize text."
@@ -23431,7 +23664,9 @@ msgctxt "Organic result context menu"
 msgid ""
 "You can only block up to %s sites. To block %s, you'll need to unblock "
 "another site first."
-msgstr "คุณสามารถบล็อกได้เพียง %1$s ไซต์เท่านั้น ในการบล็อก %2$s คุณต้องเลิกบล็อกไซต์อื่นก่อน"
+msgstr ""
+"คุณสามารถบล็อกได้เพียง %1$s ไซต์เท่านั้น ในการบล็อก %2$s "
+"คุณต้องเลิกบล็อกไซต์อื่นก่อน"
 
 # smartling.placeholder_format=C
 #. Text explaining the benefits of the cloud save feature.
@@ -23488,8 +23723,8 @@ msgid ""
 "You now have access to %s, higher AI reasoning, and 2x higher usage limits "
 "than Plus."
 msgstr ""
-"ตอนนี้คุณมีการเข้าถึง %1$s, การให้เหตุผล AI ที่สูงขึ้น, และขีดจำกัดการใช้งานสูงกว่า Plus ถึง 2 "
-"เท่า"
+"ตอนนี้คุณมีการเข้าถึง %1$s, การให้เหตุผล AI ที่สูงขึ้น, "
+"และขีดจำกัดการใช้งานสูงกว่า Plus ถึง 2 เท่า"
 
 # smartling.placeholder_format=C
 #. Description text for the welcome modal displayed after the user subscribes to DuckDuckGo.
@@ -23558,7 +23793,8 @@ msgid ""
 "browse privately too. It’s already installed and can:"
 msgstr ""
 "ตอนนี้คุณกำลังค้นหาแบบเป็นส่วนตัวใน Chrome ใช้แอปของเราแทน Chrome "
-"เพื่อเรียกดูแบบเป็นส่วนตัวได้เช่นกัน แอปได้รับการติดตั้งไว้เรียบร้อยแล้วและสามารถ:"
+"เพื่อเรียกดูแบบเป็นส่วนตัวได้เช่นกัน "
+"แอปได้รับการติดตั้งไว้เรียบร้อยแล้วและสามารถ:"
 
 # smartling.placeholder_format=C
 #. Confirmation message that appears after the DuckDuckGo browser extension is installed.
@@ -23571,7 +23807,8 @@ msgid ""
 "You're now searching with privacy. %sGet tips to reduce your footprint even "
 "more."
 msgstr ""
-"ตอนนี้คุณทำการกำลังค้นหาแบบมีความเป็นส่วนตัว %1$sดูเคล็ดลับเพื่อลดร่องรอยทางออนไลน์ให้มากยิ่งขึ้น"
+"ตอนนี้คุณทำการกำลังค้นหาแบบมีความเป็นส่วนตัว "
+"%1$sดูเคล็ดลับเพื่อลดร่องรอยทางออนไลน์ให้มากยิ่งขึ้น"
 
 # smartling.placeholder_format=C
 #. Title of a notice thanking the user for turning off their adblocker
@@ -23641,8 +23878,8 @@ msgid ""
 "You've run out of Sync & Backup storage for Duck.ai chats with attachments. "
 "Delete the %s oldest chats to resume Sync. Pinned chats will not be deleted."
 msgstr ""
-"คุณใช้พื้นที่จัดเก็บ Sync & Backup สำหรับการแชท Duck.ai พร้อมไฟล์แนบเต็มแล้ว ลบแชทที่เก่าที่สุด "
-"%1$s แชทเพื่อซิงค์ต่อ แชทที่ปักหมุดไว้จะไม่ถูกลบ"
+"คุณใช้พื้นที่จัดเก็บ Sync & Backup สำหรับการแชท Duck.ai พร้อมไฟล์แนบเต็มแล้ว "
+"ลบแชทที่เก่าที่สุด %1$s แชทเพื่อซิงค์ต่อ แชทที่ปักหมุดไว้จะไม่ถูกลบ"
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -23652,8 +23889,9 @@ msgid ""
 "oldest chats with attachments to resume Sync. Pinned chats will not be "
 "deleted."
 msgstr ""
-"คุณหมดพื้นที่จัดเก็บข้อมูลสำรอง Sync & Backup สำหรับแชท Duck.ai แล้ว ลบแชท %1$s "
-"รายการที่เก่าที่สุดที่มีไฟล์แนบเพื่อดำเนินการ Sync ต่อ แชทที่ปักหมุดไว้จะไม่ถูกลบ"
+"คุณหมดพื้นที่จัดเก็บข้อมูลสำรอง Sync & Backup สำหรับแชท Duck.ai แล้ว ลบแชท "
+"%1$s รายการที่เก่าที่สุดที่มีไฟล์แนบเพื่อดำเนินการ Sync ต่อ "
+"แชทที่ปักหมุดไว้จะไม่ถูกลบ"
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the sync storage limit.
@@ -23667,8 +23905,8 @@ msgid ""
 "YouTube (owned by Google) does not let you watch videos anonymously. As "
 "such, watching YouTube videos here will be tracked by YouTube/Google."
 msgstr ""
-"YouTube (Google เป็นเจ้าของ) ไม่อนุญาตให้คุณดูวิดีโอแบบไม่ระบุตัวตน การดูวิดีโอ YouTube "
-"ที่นี่จะถูกติดตามโดย YouTube/Google"
+"YouTube (Google เป็นเจ้าของ) ไม่อนุญาตให้คุณดูวิดีโอแบบไม่ระบุตัวตน "
+"การดูวิดีโอ YouTube ที่นี่จะถูกติดตามโดย YouTube/Google"
 
 # smartling.placeholder_format=C
 #. Label for a privacy disclaimer related to YouTube videos
@@ -23751,14 +23989,17 @@ msgid ""
 "Your browser provides a list of your most-visited sites. DuckDuckGo never "
 "has access to this data."
 msgstr ""
-"เบราว์เซอร์ของคุณแสดงรายการไซต์ที่คุณเยี่ยมชมบ่อยที่สุดDuckDuckGo ไม่มีสิทธิ์เข้าถึงข้อมูลนี้เด็ดขาด"
+"เบราว์เซอร์ของคุณแสดงรายการไซต์ที่คุณเยี่ยมชมบ่อยที่สุดDuckDuckGo "
+"ไม่มีสิทธิ์เข้าถึงข้อมูลนี้เด็ดขาด"
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
 msgid ""
 "Your browser provides the list of most-visited sites. DuckDuckGo never has "
 "access to this data."
-msgstr "เบราว์เซอร์ของคุณแสดงรายชื่อเว็บไซต์ที่เยี่ยมชมบ่อยที่สุด DuckDuckGo ไม่เคยเข้าถึงข้อมูลนี้"
+msgstr ""
+"เบราว์เซอร์ของคุณแสดงรายชื่อเว็บไซต์ที่เยี่ยมชมบ่อยที่สุด DuckDuckGo "
+"ไม่เคยเข้าถึงข้อมูลนี้"
 
 # smartling.placeholder_format=C
 #. Disclaimer text shown bellow chat input. Example: 'You are chatting with GPT-3. AI chats may display inaccurate or offensive information.'
@@ -23806,7 +24047,8 @@ msgctxt "Menu item description"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
 msgstr ""
-"การแชทของคุณเป็นแบบส่วนตัว เราจะไมบันทึกและใช้การแชทของคุณในการฝึกโมเดล AI เด็ดขาด"
+"การแชทของคุณเป็นแบบส่วนตัว เราจะไมบันทึกและใช้การแชทของคุณในการฝึกโมเดล AI "
+"เด็ดขาด"
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the active privacy protection.
@@ -23814,7 +24056,8 @@ msgctxt "Modal body for privacy"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
 msgstr ""
-"การแชทของคุณเป็นแบบส่วนตัว เราจะไม่บันทึกและใช้การแชทของคุณในการฝึกโมเดล AI เด็ดขาด"
+"การแชทของคุณเป็นแบบส่วนตัว เราจะไม่บันทึกและใช้การแชทของคุณในการฝึกโมเดล AI "
+"เด็ดขาด"
 
 # smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that chats are stored locally on the user's device.
@@ -23914,7 +24157,8 @@ msgid ""
 "browser. We save the settings file using the key as the name. DuckDuckGo "
 "never knows your passphrase."
 msgstr ""
-"รหัสผ่านของคุณสร้างคีย์ 512 บิตโดยใช้อัลกอริทึมการแฮชที่ปลอดภัยที่เรียกว่า %1$sSHA-2%2$s "
+"รหัสผ่านของคุณสร้างคีย์ 512 บิตโดยใช้อัลกอริทึมการแฮชที่ปลอดภัยที่เรียกว่า "
+"%1$sSHA-2%2$s "
 "เฉพาะคีย์และไฟล์การตั้งค่าที่เกี่ยวข้องเท่านั้นที่ออกจากเบราว์เซอร์ของคุณ "
 "เราบันทึกไฟล์การตั้งค่าโดยใช้คีย์เป็นชื่อ DuckDuckGo จะไม่ทราบรหัสผ่านของคุณ"
 
@@ -23931,7 +24175,8 @@ msgid ""
 "personally identifiable metadata, so model providers can't tie your "
 "conversations back to you."
 msgstr ""
-"คำสั่งของเธอถูกส่งต่อผ่านเซิร์ฟเวอร์ DuckDuckGo และข้อมูลเมตาที่ระบุตัวตนส่วนบุคคลจะถูกลบออก "
+"คำสั่งของเธอถูกส่งต่อผ่านเซิร์ฟเวอร์ DuckDuckGo "
+"และข้อมูลเมตาที่ระบุตัวตนส่วนบุคคลจะถูกลบออก "
 "เพื่อให้ผู้ให้บริการโมเดลไม่สามารถเชื่อมโยงการสนทนาของคุณกลับไปยังคุณ"
 
 # smartling.placeholder_format=C
@@ -24331,7 +24576,9 @@ msgstr "เว็บไซต์อย่างเป็นทางการ"
 #. <em>%s</em> is for a hexadecimal color code as <em>#395323</em>, but it has to be safe encoded, and as <em>#</em> seems not safe, <em>%23</em> must be used in place of the sharp symbol, but they are the same for your browser.
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
-msgstr "หรือพิมพ์รหัสสีที่คุณต้องการ เช่น %1$s (%2$s เป็นรหัสอักขระ %3$s ตัวที่เข้ารหัสแล้ว)"
+msgstr ""
+"หรือพิมพ์รหัสสีที่คุณต้องการ เช่น %1$s (%2$s เป็นรหัสอักขระ %3$s "
+"ตัวที่เข้ารหัสแล้ว)"
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "

--- a/locales/th_TH/LC_MESSAGES/duckduckgo.po
+++ b/locales/th_TH/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: th_TH\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -177,8 +177,7 @@ msgid ""
 "browser again to continue the chat, or switch to a Plus or free model."
 msgstr ""
 "%1$s ใช้ได้กับ Pro เท่านั้น อัปเกรดการสมัครสมาชิก DuckDuckGo "
-"ของคุณในเบราว์เซอร์นี้อีกครั้งเพื่อดำเนินการแชทต่อ หรือเปลี่ยนไปใช้โมเดล "
-"Plus หรือฟรี"
+"ของคุณในเบราว์เซอร์นี้อีกครั้งเพื่อดำเนินการแชทต่อ หรือเปลี่ยนไปใช้โมเดล Plus หรือฟรี"
 
 # smartling.placeholder_format=C
 #. Text for the disclaimer message that appears when a Plus subscriber tries to use a Pro-only model. %s is replaced with the model name. Example: Claude Opus 4.6 is only available with Pro. Upgrade your DuckDuckGo subscription in this browser again to continue the chat, or switch to a Plus or free model.
@@ -189,8 +188,7 @@ msgid ""
 "browser again to continue the chat, or switch to a Plus or free model."
 msgstr ""
 "%1$s ใช้ได้กับ Pro เท่านั้น อัปเกรดการสมัครสมาชิก DuckDuckGo "
-"ของคุณในเบราว์เซอร์นี้อีกครั้งเพื่อดำเนินการแชทต่อ หรือเปลี่ยนไปใช้โมเดล "
-"Plus หรือฟรี"
+"ของคุณในเบราว์เซอร์นี้อีกครั้งเพื่อดำเนินการแชทต่อ หรือเปลี่ยนไปใช้โมเดล Plus หรือฟรี"
 
 # smartling.placeholder_format=C
 #. Displayed when an AI (Artificial Intelligence) chat model is temporarily unavailable. Example: 'GPT 4o is only available with a DuckDuckGo subscription.'
@@ -207,8 +205,7 @@ msgid ""
 "model."
 msgstr ""
 "%1$s สามารถใช้ได้เฉพาะกับการสมัครใช้งาน DuckDuckGo เท่านั้น "
-"เปิดใช้งานการสมัครของคุณในเบราว์เซอร์นี้อีกครั้งเพื่อดำเนินการแชทต่อ "
-"หรือเปลี่ยนไปใช้โมเดลฟรี"
+"เปิดใช้งานการสมัครของคุณในเบราว์เซอร์นี้อีกครั้งเพื่อดำเนินการแชทต่อ หรือเปลี่ยนไปใช้โมเดลฟรี"
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is temporarily unavailable. Example: 'GPT 3.5 Turbo is temporarily unavailable. Please switch to a different model or try again later.'
@@ -216,9 +213,7 @@ msgctxt "Error message for model unavailability"
 msgid ""
 "%s is temporarily unavailable. Please switch to a different model or try "
 "again later."
-msgstr ""
-"%1$s ไม่สามารถใช้งานได้ชั่วคราว "
-"โปรดเปลี่ยนไปใช้รุ่นอื่นหรือลองอีกครั้งในภายหลัง"
+msgstr "%1$s ไม่สามารถใช้งานได้ชั่วคราว โปรดเปลี่ยนไปใช้รุ่นอื่นหรือลองอีกครั้งในภายหลัง"
 
 # smartling.placeholder_format=C
 #. Reddit's "fake internet points". https://support.reddithelp.com/hc/en-us/articles/204511829-What-is-karma
@@ -310,7 +305,6 @@ msgid ""
 "their servers."
 msgstr ""
 "%1$s ทํางานในสภาพแวดล้อมการดําเนินการที่เชื่อถือได้ "
-""
 "นี่หมายความว่าแม้แต่ผู้ให้บริการโมเดลก็ไม่สามารถดูคำแนะนำของคุณหรือการตอบสนองของโมเดล "
 "หรือบันทึกการแชทนี้บนเซิร์ฟเวอร์ของพวกเขา"
 
@@ -392,8 +386,7 @@ msgid ""
 "%s will be leaving Duck.ai in %s days (%s). After that, you can switch "
 "models to continue this chat."
 msgstr ""
-"%1$s จะออกจาก Duck.ai ใน %2$s วัน (%3$s) หลังจากนั้น "
-"คุณสามารถเปลี่ยนรุ่นเพื่อแชทต่อ"
+"%1$s จะออกจาก Duck.ai ใน %2$s วัน (%3$s) หลังจากนั้น คุณสามารถเปลี่ยนรุ่นเพื่อแชทต่อ"
 
 # smartling.placeholder_format=C
 #. Displayed in a saved chat when its AI model is about to be retired tomorrow. First placeholder is the friendly model name, second placeholder is the removal date formatted in the user's browser locale (e.g., 'June 15, 2026' in en-US). Singular-day form.
@@ -403,9 +396,7 @@ msgctxt ""
 msgid ""
 "%s will be leaving Duck.ai in 1 day (%s). After that, you can switch models "
 "to continue this chat."
-msgstr ""
-"%1$s จะออกจาก Duck.ai ใน 1 วัน (%2$s) หลังจากนั้น "
-"คุณสามารถเปลี่ยนรุ่นเพื่อแชทต่อ"
+msgstr "%1$s จะออกจาก Duck.ai ใน 1 วัน (%2$s) หลังจากนั้น คุณสามารถเปลี่ยนรุ่นเพื่อแชทต่อ"
 
 # smartling.placeholder_format=C
 #. Shown in a text selection chip when the selection contains multiple words. %s is replaced with the number of words, e.g. '142 words'.
@@ -425,8 +416,7 @@ msgstr "%1$sคลิก%2$sเพิ่ม%3$sเลือก%4$sอนุญ�
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAllow%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
 msgstr ""
-"%1$sคลิก%2$sอนุญาต%3$sคลิก%4$sเพิ่ม%5$sเลือก%6$sอนุญาต%7$s "
-"จากนั้นคลิก%8$sตกลง%9$s"
+"%1$sคลิก%2$sอนุญาต%3$sคลิก%4$sเพิ่ม%5$sเลือก%6$sอนุญาต%7$s จากนั้นคลิก%8$sตกลง%9$s"
 
 # Firefox
 # smartling.placeholder_format=C
@@ -471,16 +461,13 @@ msgctxt "Footer text for About Sync modal"
 msgid ""
 "%sLearn more%s about how chats are stored privately on DuckDuckGo's server."
 msgstr ""
-"%1$sเรียนรู้เพิ่มเติม%2$s "
-"เกี่ยวกับวิธีการจัดเก็บแชทอย่างเป็นส่วนตัวบนเซิร์ฟเวอร์ของ DuckDuckGo"
+"%1$sเรียนรู้เพิ่มเติม%2$s เกี่ยวกับวิธีการจัดเก็บแชทอย่างเป็นส่วนตัวบนเซิร์ฟเวอร์ของ DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "%sLearn more%s about how chats are stored privately on your device."
-msgstr ""
-"%1$sเรียนรู้เพิ่มเติม%2$s "
-"เกี่ยวกับวิธีการจัดเก็บแชทอย่างเป็นส่วนตัวบนอุปกรณ์ของคุณ"
+msgstr "%1$sเรียนรู้เพิ่มเติม%2$s เกี่ยวกับวิธีการจัดเก็บแชทอย่างเป็นส่วนตัวบนอุปกรณ์ของคุณ"
 
 # smartling.placeholder_format=C
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
@@ -924,9 +911,8 @@ msgid ""
 "aichat%s."
 msgstr ""
 "AI Chat ช่วยให้คุณสนทนาแบบไม่ต้องระบุชื่อด้วยโมเดลแชท AI ของบริษัทอื่น "
-"การปิดฟีเจอร์นี้จะซ่อนฟีเจอร์ AI Chat ใน DuckDuckGo Search "
-"คุณยังคงสามารถเข้าถึง AI Chat ได้เมื่อปิดการตั้งค่านี้โดยไปที่ "
-"%1$sduckduckgo.com/aichat%2$s"
+"การปิดฟีเจอร์นี้จะซ่อนฟีเจอร์ AI Chat ใน DuckDuckGo Search คุณยังคงสามารถเข้าถึง AI Chat "
+"ได้เมื่อปิดการตั้งค่านี้โดยไปที่ %1$sduckduckgo.com/aichat%2$s"
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -989,8 +975,7 @@ msgid ""
 msgstr ""
 "คำตอบที่ได้รับความช่วยเหลือจาก AI ขณะนี้ยังไม่รองรับคำถามที่ถามต่อโดยตรง "
 "แต่เรามีและมักจะเชื่อมโยงไปยัง %1$sDuck.ai%2$s สำหรับคำถามที่ถามต่อ "
-"ซึ่งเป็นบริการแชทส่วนตัวที่ใช้ AI และรองรับโมเดลแชทจาก OpenAI, Anthropic "
-"และอีกมากมาย"
+"ซึ่งเป็นบริการแชทส่วนตัวที่ใช้ AI และรองรับโมเดลแชทจาก OpenAI, Anthropic และอีกมากมาย"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has turned off AI features and will no longer see AI-assisted answers.
@@ -1175,8 +1160,7 @@ msgid ""
 "Activate your %s in this browser again to continue the chat, or switch to a "
 "free model."
 msgstr ""
-"เปิดใช้งาน %1$s ของคุณในเบราว์เซอร์นี้อีกครั้งเพื่อดำเนินการแชทต่อ "
-"หรือเปลี่ยนไปใช้โมเดลฟรี"
+"เปิดใช้งาน %1$s ของคุณในเบราว์เซอร์นี้อีกครั้งเพื่อดำเนินการแชทต่อ หรือเปลี่ยนไปใช้โมเดลฟรี"
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an active DuckDuckGo subscription.
@@ -1211,9 +1195,7 @@ msgstr "โฆษณา"
 #. An item in the ads tooltip that explains that ad clicks are managed by the ad network and are not used to profile you. The placeholder is the name of the ad network. For example: Microsoft
 msgid ""
 "Ad clicks are managed by %s’s ad network and are not used to profile you."
-msgstr ""
-"การคลิกโฆษณาจัดการโดยเครือข่ายโฆษณาของ %1$s "
-"และไม่ได้ใช้ในการสร้างโปรไฟล์ของคุณ"
+msgstr "การคลิกโฆษณาจัดการโดยเครือข่ายโฆษณาของ %1$s และไม่ได้ใช้ในการสร้างโปรไฟล์ของคุณ"
 
 # smartling.placeholder_format=C
 #. Information that ad clicks are managed by Microsoft.
@@ -1221,8 +1203,7 @@ msgid ""
 "Ad clicks are managed by Microsoft’s ad network and are not used to profile "
 "you."
 msgstr ""
-"การคลิกโฆษณาจัดการโดยเครือข่ายโฆษณาของ Microsoft "
-"และไม่ได้ใช้ในการสร้างโปรไฟล์ของคุณ"
+"การคลิกโฆษณาจัดการโดยเครือข่ายโฆษณาของ Microsoft และไม่ได้ใช้ในการสร้างโปรไฟล์ของคุณ"
 
 # smartling.placeholder_format=C
 #. An item in the ads tooltip that explains that ad clicks aren’t used to profile you.
@@ -1429,6 +1410,12 @@ msgid "Address is incorrect"
 msgstr "ที่อยู่ไม่ถูกต้อง"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Adjust the servings"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. as in multiple advertisements
 msgid "Ads"
 msgstr "โฆษณา"
@@ -1510,9 +1497,7 @@ msgstr "หลังจากดาวน์โหลดและเปิด �
 #. Instructions on how to install the DuckDuckGo browser extension after it downloads.
 msgid ""
 "After it downloads, locate the extension file and double-click it to install"
-msgstr ""
-"หลังจากที่ดาวน์โหลดเสร็จเรียบร้อย "
-"ให้ค้นหาไฟล์ส่วนขยายแล้วดับเบิลคลิกเพื่อติดตั้ง"
+msgstr "หลังจากที่ดาวน์โหลดเสร็จเรียบร้อย ให้ค้นหาไฟล์ส่วนขยายแล้วดับเบิลคลิกเพื่อติดตั้ง"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an age below a web search result.
@@ -1642,6 +1627,14 @@ msgid "All chats are %sprivate%s"
 msgstr "แชททั้งหมดเป็น %1$sแบบส่วนตัว%2$s"
 
 # smartling.placeholder_format=C
+#. Paragraph in the Privacy & Terms section of the About & Legal page in Duck.ai settings, summarizing how chats are anonymized and are not stored or used to train chat models.
+msgctxt "Privacy & Terms section description on the Duck.ai settings page"
+msgid ""
+"All chats are anonymized by DuckDuckGo, and your conversations are not used "
+"to train chat models by DuckDuckGo or the model providers"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
 msgctxt "Privacy modal header in Duck.ai chat"
 msgid "All chats are private"
@@ -1686,8 +1679,8 @@ msgid ""
 "All personal metadata (for example, your IP address) is removed before "
 "sending a chat to the AI provider."
 msgstr ""
-"ข้อมูลเมตาส่วนบุคคลทั้งหมด (เช่น ที่อยู่ IP ของคุณ) "
-"จะถูกลบออกก่อนที่จะส่งการแชทไปยังผู้ให้บริการ AI"
+"ข้อมูลเมตาส่วนบุคคลทั้งหมด (เช่น ที่อยู่ IP ของคุณ) จะถูกลบออกก่อนที่จะส่งการแชทไปยังผู้ให้บริการ "
+"AI"
 
 # smartling.placeholder_format=C
 #. A filter that shows search results from all countries.
@@ -1739,10 +1732,8 @@ msgid ""
 "Prompts and responses with %s still have %szero provider visibility%s."
 msgstr ""
 "อนุญาตให้ %1$s ค้นหาเว็บเพื่อปรับปรุงการตอบสนองต่อข้อความแจ้งที่เกี่ยวข้อง "
-"ส่งเฉพาะข้อความค้นหาที่สร้างโดย AI "
-"ไปยังเครื่องมือค้นหาที่มีการเก็บรักษาข้อมูลที่จํากัด "
-"คำแนะนำและการตอบสนองที่มี %2$s ยังคงมี "
-"%3$sการมองเห็นผู้ให้บริการเป็นศูนย์%4$s"
+"ส่งเฉพาะข้อความค้นหาที่สร้างโดย AI ไปยังเครื่องมือค้นหาที่มีการเก็บรักษาข้อมูลที่จํากัด "
+"คำแนะนำและการตอบสนองที่มี %2$s ยังคงมี %3$sการมองเห็นผู้ให้บริการเป็นศูนย์%4$s"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -1887,8 +1878,7 @@ msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
 msgstr ""
-"การเข้าถึงโมเดล AI ยอดนิยมแบบไม่ระบุชื่อ รวมถึง %1$s, %2$sและ %3$s และ "
-"%4$sโอเพ่นซอร์ส"
+"การเข้าถึงโมเดล AI ยอดนิยมแบบไม่ระบุชื่อ รวมถึง %1$s, %2$sและ %3$s และ %4$sโอเพ่นซอร์ส"
 
 # smartling.placeholder_format=C
 #. Text with information about Duck.ai and supported AI models, the placeholders list AI models. Example: 'Anonymous access to popular AI models, including GPT, Claude, and open-source Llama and Mistral.'
@@ -1897,14 +1887,20 @@ msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
 msgstr ""
-"การเข้าถึงโมเดล AI ยอดนิยมแบบไม่ระบุชื่อ รวมถึง %1$s, %2$sและ %3$s และ "
-"%4$sโอเพ่นซอร์ส"
+"การเข้าถึงโมเดล AI ยอดนิยมแบบไม่ระบุชื่อ รวมถึง %1$s, %2$sและ %3$s และ %4$sโอเพ่นซอร์ส"
 
 # smartling.placeholder_format=C
 #. Confirmation message after location service is enabled.
 msgctxt "precise_user_location"
 msgid "Anonymous location enabled"
 msgstr "เปิดใช้ตำแหน่งที่ตั้งแบบไม่ระบุตัวตนแล้ว"
+
+# smartling.placeholder_format=C
+msgctxt "settings"
+msgid ""
+"Anonymously generates answers for search queries based on web content. "
+"Choose how often you want it to appear, or disable it completely."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -1951,8 +1947,7 @@ msgid ""
 "Any additional instructions you want Duck.ai to follow. e.g. Always tell me "
 "facts about ducks"
 msgstr ""
-"คำแนะนำเพิ่มเติมที่เธอต้องการให้ Duck.ai ปฏิบัติตาม เช่น "
-"บอกข้อเท็จจริงเกี่ยวกับเป็ดให้ฉันรู้เสมอ"
+"คำแนะนำเพิ่มเติมที่เธอต้องการให้ Duck.ai ปฏิบัติตาม เช่น บอกข้อเท็จจริงเกี่ยวกับเป็ดให้ฉันรู้เสมอ"
 
 # smartling.placeholder_format=C
 #. Shown in video filtering. https://duckduckgo.com/?q=videos+of+cats&iax=videos&ia=videos
@@ -2072,8 +2067,7 @@ msgid ""
 "Are you sure you want to disable history? This will delete all chats, "
 "including pinned chats."
 msgstr ""
-"คุณแน่ใจหรือไม่ว่าต้องการปิดการใช้งานประวัติ การกระทำนี้จะลบแชททั้งหมด "
-"รวมถึงแชทที่ปักหมุดไว้ด้วย"
+"คุณแน่ใจหรือไม่ว่าต้องการปิดการใช้งานประวัติ การกระทำนี้จะลบแชททั้งหมด รวมถึงแชทที่ปักหมุดไว้ด้วย"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to disable recent chats, with a warning that it will also delete currently saved chats.
@@ -2082,8 +2076,7 @@ msgid ""
 "Are you sure you want to disable recent chats? This will also delete any "
 "recent chats that are currently saved."
 msgstr ""
-"คุณแน่ใจหรือไม่ว่าต้องการปิดการใช้งานแชทล่าสุด "
-"การดำเนินการนี้จะลบแชทล่าสุดที่มีการบันทึกไว้ด้วย"
+"คุณแน่ใจหรือไม่ว่าต้องการปิดการใช้งานแชทล่าสุด การดำเนินการนี้จะลบแชทล่าสุดที่มีการบันทึกไว้ด้วย"
 
 # smartling.placeholder_format=C
 #. Question asking user if they want to share the URL of the page they were on when giving feedback
@@ -2121,8 +2114,8 @@ msgid ""
 "As per our privacy policy, we do not collect or share any personal "
 "information ourselves. All of this privacy protection happens on your device."
 msgstr ""
-"ตามนโยบายความเป็นส่วนตัวของเรา เราจะไม่เก็บรวบรวมหรือแชร์ข้อมูลส่วนบุคคลใดๆ "
-"ด้วยตนเอง การปกป้องความเป็นส่วนตัวทั้งหมดนี้เกิดขึ้นบนอุปกรณ์ของคุณ"
+"ตามนโยบายความเป็นส่วนตัวของเรา เราจะไม่เก็บรวบรวมหรือแชร์ข้อมูลส่วนบุคคลใดๆ ด้วยตนเอง "
+"การปกป้องความเป็นส่วนตัวทั้งหมดนี้เกิดขึ้นบนอุปกรณ์ของคุณ"
 
 # smartling.placeholder_format=C
 #. A button to ask Duck.ai a question
@@ -2183,6 +2176,12 @@ msgstr "ถามคำถามเพิ่มเติม"
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse
 msgid "Ask a follow-up with Duck.ai"
 msgstr "สอบถามข้อมูลติดตามกับ Duck.ai"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
+msgctxt "Page suggestion chip label"
+msgid "Ask about this page"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2247,16 +2246,12 @@ msgid ""
 "answers are only available in the U.S. (English) region."
 msgstr ""
 "Assist สามารถสร้างคำตอบที่ได้รับความช่วยเหลือจาก AI "
-""
 "โดยไม่ระบุตัวตนให้กับการค้นหาบางรายการโดยอิงจากการสรุปเนื้อหาเว็บที่เกี่ยวข้อง "
-"คุณสามารถเลือกได้ว่าต้องการให้ Assist ปรากฏบ่อยเพียงใด: ไม่แสดงเลย (ลบ "
-"Assist UI ออกจากผลการค้นหาทั้งหมด), ตามต้องการ "
-"(แสดงเฉพาะคำตอบที่ได้รับความช่วยเหลือจาก AI เมื่อคุณคลิกปุ่ม Assist), "
-"บางครั้ง (แสดงเฉพาะคำตอบที่ได้รับความช่วยเหลือจาก AI "
-"เมื่อมีความเกี่ยวข้องสูง) หรือบ่อยครั้ง "
-"(แสดงบ่อยขึ้นในการค้นหาที่มีช่วงกว้างกว่า) สำหรับตอนนี้ "
-"คำตอบที่ได้รับความช่วยเหลือจาก AI มีให้บริการเฉพาะในภูมิภาคสหรัฐอเมริกา "
-"(ภาษาอังกฤษ) เท่านั้น"
+"คุณสามารถเลือกได้ว่าต้องการให้ Assist ปรากฏบ่อยเพียงใด: ไม่แสดงเลย (ลบ Assist UI "
+"ออกจากผลการค้นหาทั้งหมด), ตามต้องการ (แสดงเฉพาะคำตอบที่ได้รับความช่วยเหลือจาก AI "
+"เมื่อคุณคลิกปุ่ม Assist), บางครั้ง (แสดงเฉพาะคำตอบที่ได้รับความช่วยเหลือจาก AI "
+"เมื่อมีความเกี่ยวข้องสูง) หรือบ่อยครั้ง (แสดงบ่อยขึ้นในการค้นหาที่มีช่วงกว้างกว่า) สำหรับตอนนี้ "
+"คำตอบที่ได้รับความช่วยเหลือจาก AI มีให้บริการเฉพาะในภูมิภาคสหรัฐอเมริกา (ภาษาอังกฤษ) เท่านั้น"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2268,14 +2263,9 @@ msgid ""
 "to remember that responses are auto-generated from cited sources and based "
 "on %scrawling the web%s."
 msgstr ""
-"Assist "
-""
-"เป็นฟีเจอร์เสริมในผลการค้นหาของเราที่สามารถสร้างคำตอบที่ได้รับความช่วยเหลือจาก "
-"AI สำหรับคำค้นหาโดยไม่ระบุชื่อได้ ในการดำเนินการนี้ "
-"ระบบจะสแกนเว็บเพื่อหาเนื้อหาที่เกี่ยวข้อง "
-"จากนั้นใช้เทคโนโลยีภาษาธรรมชาติที่ใช้ AI เพื่อสร้างคำตอบสั้นๆ "
-"ตามข้อมูลที่เกี่ยวข้องที่พบ "
-""
+"Assist เป็นฟีเจอร์เสริมในผลการค้นหาของเราที่สามารถสร้างคำตอบที่ได้รับความช่วยเหลือจาก AI "
+"สำหรับคำค้นหาโดยไม่ระบุชื่อได้ ในการดำเนินการนี้ ระบบจะสแกนเว็บเพื่อหาเนื้อหาที่เกี่ยวข้อง "
+"จากนั้นใช้เทคโนโลยีภาษาธรรมชาติที่ใช้ AI เพื่อสร้างคำตอบสั้นๆ ตามข้อมูลที่เกี่ยวข้องที่พบ "
 "สิ่งสำคัญคือต้องจำไว้ว่าคำตอบนั้นถูกสร้างขึ้นโดยอัตโนมัติจากแหล่งข้อมูลที่ใช้อ้างอิง "
 "และขึ้นอยู่กับ%1$sการรวบรวมข้อมูลเว็บ%2$s"
 
@@ -2441,8 +2431,8 @@ msgid ""
 "Assist is only available in English regions."
 msgstr ""
 "แสดง Assist โดยอัตโนมัติสำหรับการค้นหาที่เกี่ยวข้อง Assist "
-"สามารถค้นหาและสรุปข้อมูลโดยไม่ระบุตัวตนตามการค้นหาบางอย่าง สำหรับตอนนี้ "
-"Assist มีให้บริการเฉพาะในภูมิภาคที่ใช้ภาษาอังกฤษเท่านั้น"
+"สามารถค้นหาและสรุปข้อมูลโดยไม่ระบุตัวตนตามการค้นหาบางอย่าง สำหรับตอนนี้ Assist "
+"มีให้บริการเฉพาะในภูมิภาคที่ใช้ภาษาอังกฤษเท่านั้น"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2452,8 +2442,8 @@ msgid ""
 "For now, DuckAssist is only available in English regions."
 msgstr ""
 "แสดง DuckAssist โดยอัตโนมัติสำหรับการค้นหาที่เกี่ยวข้อง DuckAssist "
-"สามารถค้นหาและสรุปข้อมูลโดยไม่ระบุตัวตนตามการค้นหาบางอย่าง สำหรับตอนนี้ "
-"DuckAssist มีให้บริการเฉพาะในภูมิภาคที่ใช้ภาษาอังกฤษเท่านั้น"
+"สามารถค้นหาและสรุปข้อมูลโดยไม่ระบุตัวตนตามการค้นหาบางอย่าง สำหรับตอนนี้ DuckAssist "
+"มีให้บริการเฉพาะในภูมิภาคที่ใช้ภาษาอังกฤษเท่านั้น"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2601,6 +2591,12 @@ msgid "Barcode"
 msgstr "บาร์โค้ด"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Based on this page, is this course worth taking?"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Basic"
 msgstr "ทั่วไป"
@@ -2639,6 +2635,14 @@ msgstr "แป้งเหลว"
 msgctxt "Assistant response placeholder"
 msgid "Before continuing..."
 msgstr "ก่อนที่จะดำเนินการต่อ..."
+
+# smartling.placeholder_format=C
+#. Explains that before storing the report, DuckDuckGo will anonymize the conversation by removing PII like names, email addresses, and identifying metadata.
+msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
+msgid ""
+"Before storing this report, DuckDuckGo will anonymize your conversation by "
+"removing PII like names, email addresses, and identifying metadata."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -2957,6 +2961,12 @@ msgid "Break Points Won"
 msgstr "เบรกพอยต์ที่ได้"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Break this down into clear, numbered steps."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
 msgctxt "Weather IA"
 msgid "Breezy"
@@ -3013,17 +3023,15 @@ msgid ""
 "Browse as usual while we add privacy protection. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
 msgstr ""
-"เรียกดูตามปกติขณะที่เราเพิ่มการปกป้องความเป็นส่วนตัวให้คุณ "
-"เรารวมเครื่องมือค้นหา เครื่องมือบล็อกตัวติดตาม "
-"และเครื่องมือบังคับใช้การเข้ารหัสไว้ด้วยกันใน%1$s%2$sส่วนขยาย%3$sเดียว"
+"เรียกดูตามปกติขณะที่เราเพิ่มการปกป้องความเป็นส่วนตัวให้คุณ เรารวมเครื่องมือค้นหา "
+"เครื่องมือบล็อกตัวติดตาม และเครื่องมือบังคับใช้การเข้ารหัสไว้ด้วยกันใน%1$s%2$sส่วนขยาย%3$sเดียว"
 
 # smartling.placeholder_format=C
 msgid ""
 "Browse as usual, and we'll take care of the rest. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
 msgstr ""
-"เรียกดูตามปกติ แล้วเราจะดูแลส่วนที่เหลือให้เอง เรารวมเครื่องมือค้นหา "
-"เครื่องมือบล็อกตัวติดตาม "
+"เรียกดูตามปกติ แล้วเราจะดูแลส่วนที่เหลือให้เอง เรารวมเครื่องมือค้นหา เครื่องมือบล็อกตัวติดตาม "
 "และเครื่องมือบังคับใช้การเข้ารหัสไว้ด้วยกันใน%1$s%2$sส่วนขยาย%3$sเดียว"
 
 # smartling.placeholder_format=C
@@ -3032,9 +3040,8 @@ msgid ""
 "search, tracker blocking, and site encryption, all in one download, for "
 "%smajor browsers%s."
 msgstr ""
-"เรียกดูตามปกติ แล้วเราจะดูแลส่วนที่เหลือให้เอง "
-"ดาวน์โหลดเพียงครั้งเดียวแล้วใช้งานได้ทั้ง Private Search, การบล็อกตัวติดตาม "
-"และการเข้ารหัสเว็บไซต์สำหรับ%1$sเบราว์เซอร์หลักๆ%2$s"
+"เรียกดูตามปกติ แล้วเราจะดูแลส่วนที่เหลือให้เอง ดาวน์โหลดเพียงครั้งเดียวแล้วใช้งานได้ทั้ง Private "
+"Search, การบล็อกตัวติดตาม และการเข้ารหัสเว็บไซต์สำหรับ%1$sเบราว์เซอร์หลักๆ%2$s"
 
 # smartling.placeholder_format=C
 #. Header for a call to action to browse with the DuckDuckGo browser
@@ -3141,11 +3148,9 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"ตามค่าเริ่มต้น "
-"การตั้งค่าจะได้รับการจัดเก็บอยู่ในคุกกี้เบราว์เซอร์ที่ไม่ใช่ส่วนบุคคล "
+"ตามค่าเริ่มต้น การตั้งค่าจะได้รับการจัดเก็บอยู่ในคุกกี้เบราว์เซอร์ที่ไม่ใช่ส่วนบุคคล "
 "(ในเบราว์เซอร์ของคุณ) คุณสามารถใช้ Cloud Save "
-"แบบไม่ระบุตัวตนเพื่อจัดเก็บข้อมูลการตั้งค่าอย่างถาวรยิ่งขึ้นได้ "
-"(บนเซิร์ฟเวอร์ระยะไกลในระบบคลาวด์) "
+"แบบไม่ระบุตัวตนเพื่อจัดเก็บข้อมูลการตั้งค่าอย่างถาวรยิ่งขึ้นได้ (บนเซิร์ฟเวอร์ระยะไกลในระบบคลาวด์) "
 "จะไม่มีการจัดเก็บข้อมูลที่สามารถระบุถึงตัวตนได้บนระบบคลาวด์และรหัสผ่านของคุณจะอยู่บนเบราว์เซอร์ของคุณเท่านั้น"
 
 # smartling.placeholder_format=C
@@ -3154,9 +3159,8 @@ msgid ""
 "By enabling dictation, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
 msgstr ""
-"โดยการเปิดใช้งานการป้อนข้อความด้วยเสียง "
-"คุณยินยอมให้ข้อมูลเสียงของคุณถูกส่งไปยัง OpenAI เพื่อใช้งานคุณลักษณะนี้ ดู "
-"%1$s ของเราก่อนเริ่มต้น"
+"โดยการเปิดใช้งานการป้อนข้อความด้วยเสียง คุณยินยอมให้ข้อมูลเสียงของคุณถูกส่งไปยัง OpenAI "
+"เพื่อใช้งานคุณลักษณะนี้ ดู %1$s ของเราก่อนเริ่มต้น"
 
 # smartling.placeholder_format=C
 #. Description for the 'enable voice chat' section of the voice chat consent modal. Placeholder for the voice chat help page link and text. Example: 'By enabling voice chat, you consent to your voice data being sent to OpenAI for the use of this feature. See our voice chat help page before getting started.'
@@ -3165,8 +3169,8 @@ msgid ""
 "By enabling voice chat, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
 msgstr ""
-"โดยการเปิดใช้งานการแชทด้วยเสียง คุณยินยอมให้ข้อมูลเสียงของคุณถูกส่งไปยัง "
-"OpenAI เพื่อใช้งานคุณลักษณะนี้ ดู %1$s ของเราก่อนเริ่มต้น"
+"โดยการเปิดใช้งานการแชทด้วยเสียง คุณยินยอมให้ข้อมูลเสียงของคุณถูกส่งไปยัง OpenAI "
+"เพื่อใช้งานคุณลักษณะนี้ ดู %1$s ของเราก่อนเริ่มต้น"
 
 # smartling.placeholder_format=C
 #. Golf leaderboard: player missed the cut
@@ -3412,6 +3416,12 @@ msgid "Cast"
 msgstr "นักแสดง"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Cast & Crew"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
 msgctxt "Tone option label for Casual"
 msgid "Casual"
@@ -3647,8 +3657,7 @@ msgstr ""
 "Chat (ผ่านบริการ Duck.ai ของเรา) ให้คุณสนทนาแบบไม่ระบุตัวตนกับโมเดลแชท AI "
 "ของบุคคลที่สาม ซึ่งรองรับโมเดลจาก OpenAI, Anthropic และอีกมากมาย "
 "การปิดการตั้งค่านี้จะซ่อนปุ่ม Chat และลิงก์บน DuckDuckGo Search อย่างไรก็ตาม "
-"คุณยังสามารถเข้าถึง Chat ได้เมื่อปิดการตั้งค่านี้โดยไปที่ "
-"%1$shttps://duck.ai%2$s โดยตรง"
+"คุณยังสามารถเข้าถึง Chat ได้เมื่อปิดการตั้งค่านี้โดยไปที่ %1$shttps://duck.ai%2$s โดยตรง"
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -3773,8 +3782,8 @@ msgid ""
 "Chats are stored locally on your device instead of on DuckDuckGo servers or "
 "remote servers. Disabling chat history will delete pinned chats."
 msgstr ""
-"แชทจะถูกเก็บไว้ในอุปกรณ์ของคุณแทนที่จะอยู่บนเซิร์ฟเวอร์ของ DuckDuckGo "
-"หรือเซิร์ฟเวอร์ระยะไกล การปิดประวัติการแชทจะลบแชทที่ปักหมุด"
+"แชทจะถูกเก็บไว้ในอุปกรณ์ของคุณแทนที่จะอยู่บนเซิร์ฟเวอร์ของ DuckDuckGo หรือเซิร์ฟเวอร์ระยะไกล "
+"การปิดประวัติการแชทจะลบแชทที่ปักหมุด"
 
 # smartling.placeholder_format=C
 #. Text explaining how the Chat History feature stores the user's chats locally to their device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection. Also explains that disabling chat history will delete pinned chats.
@@ -3787,11 +3796,9 @@ msgid ""
 "prompts and responses."
 msgstr ""
 "แชทจะถูกจัดเก็บไว้ในอุปกรณ์ของคุณ "
-"คำแนะนำใหม่และการตอบกลับจะถูกเข้ารหัสและเก็บไว้ชั่วคราวบนเซิร์ฟเวอร์ "
-"DuckDuckGo หลังจากที่ส่งไปแล้ว "
-"เพื่อช่วยกู้คืนการแชทหากคุณสูญเสียการเชื่อมต่ออินเทอร์เน็ต "
-"การปิดประวัติการแชทจะลบแชทที่ปักหมุด "
-"และปิดใช้งานการเก็บคำแนะนำและการตอบสนองใหม่ชั่วคราว"
+"คำแนะนำใหม่และการตอบกลับจะถูกเข้ารหัสและเก็บไว้ชั่วคราวบนเซิร์ฟเวอร์ DuckDuckGo "
+"หลังจากที่ส่งไปแล้ว เพื่อช่วยกู้คืนการแชทหากคุณสูญเสียการเชื่อมต่ออินเทอร์เน็ต "
+"การปิดประวัติการแชทจะลบแชทที่ปักหมุด และปิดใช้งานการเก็บคำแนะนำและการตอบสนองใหม่ชั่วคราว"
 
 # smartling.placeholder_format=C
 #. Title shown above the body copy in the Duck.ai recent chats IndexedDB unavailable notice.
@@ -3865,9 +3872,7 @@ msgstr "ตรวจสอบการสะกดคำ"
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
 msgctxt "noresults"
 msgid "Check the DuckDuckGo subreddit for updates on this outage."
-msgstr ""
-"ตรวจสอบ subreddit ของ DuckDuckGo "
-"เพื่อรับข้อมูลอัปเดตเกี่ยวกับการหยุดให้บริการครั้งนี้"
+msgstr "ตรวจสอบ subreddit ของ DuckDuckGo เพื่อรับข้อมูลอัปเดตเกี่ยวกับการหยุดให้บริการครั้งนี้"
 
 # smartling.placeholder_format=C
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
@@ -4148,9 +4153,8 @@ msgid ""
 "indefinitely or auto-delete them after 7+ days of no AI Chat use."
 msgstr ""
 "การล้างข้อมูลเบราว์เซอร์จะลบแชท "
-""
-"เบราว์เซอร์บางตัวอาจเก็บแชทล่าสุดไว้อย่างไม่มีกำหนดหรืออาจลบอัตโนมัติหลังจากไม่ได้ใช้งาน "
-"AI Chat เป็นเวลา 7 วันขึ้นไป"
+"เบราว์เซอร์บางตัวอาจเก็บแชทล่าสุดไว้อย่างไม่มีกำหนดหรืออาจลบอัตโนมัติหลังจากไม่ได้ใช้งาน AI "
+"Chat เป็นเวลา 7 วันขึ้นไป"
 
 # smartling.placeholder_format=C
 #. Text explaining what happens to recent chats when browser data is cleared.
@@ -4161,8 +4165,8 @@ msgid ""
 "on your browser."
 msgstr ""
 "การล้างข้อมูลเบราว์เซอร์จะลบแชทล่าสุด "
-"แชทล่าสุดอาจถูกบันทึกไว้อย่างไม่มีกำหนดหรือลบอัตโนมัติหลังจาก 7 "
-"วันหากไม่ได้ใช้ Duck.ai ขึ้นอยู่กับเบราว์เซอร์ของคุณ"
+"แชทล่าสุดอาจถูกบันทึกไว้อย่างไม่มีกำหนดหรือลบอัตโนมัติหลังจาก 7 วันหากไม่ได้ใช้ Duck.ai "
+"ขึ้นอยู่กับเบราว์เซอร์ของคุณ"
 
 # smartling.placeholder_format=C
 #. Warning message shown on the Block domain success modal. Blocked sites are stored in localStorage which is cleared alongside cookies when users clear browser data. Followed by a linked 'our free browser' text.
@@ -4171,8 +4175,7 @@ msgid ""
 "Clearing browser data will reset your blocked sites. Save your block list "
 "permanently in"
 msgstr ""
-"การล้างข้อมูลเบราว์เซอร์จะรีเซ็ตไซต์ที่ถูกบล็อกของคุณ "
-"บันทึกรายการที่บล็อกของคุณอย่างถาวรใน"
+"การล้างข้อมูลเบราว์เซอร์จะรีเซ็ตไซต์ที่ถูกบล็อกของคุณ บันทึกรายการที่บล็อกของคุณอย่างถาวรใน"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -4181,8 +4184,8 @@ msgid ""
 "%sDuck.ai%s, our private AI chat service that supports chat models from "
 "OpenAI, Anthropic, and more."
 msgstr ""
-"คลิก \"เพิ่มเติม\" เพื่อเจาะลึกหัวข้อ และถามคำถามติดตามผ่าน %1$sDuck.ai%2$s "
-"บริการแชท AI ส่วนตัวของเราที่รองรับโมเดลแชทจาก OpenAI, Anthropic และอื่น ๆ"
+"คลิก \"เพิ่มเติม\" เพื่อเจาะลึกหัวข้อ และถามคำถามติดตามผ่าน %1$sDuck.ai%2$s บริการแชท AI "
+"ส่วนตัวของเราที่รองรับโมเดลแชทจาก OpenAI, Anthropic และอื่น ๆ"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4224,8 +4227,7 @@ msgid ""
 "Click %sEdit > Preferences%s (on Windows) %sSeaMonkey > Preferences%s (on "
 "Mac)"
 msgstr ""
-"คลิก%1$sแก้ไข > ค่ากำหนด%2$s (บน Windows) %3$sSeaMonkey > ค่ากำหนด%4$s (บน "
-"Mac)"
+"คลิก%1$sแก้ไข > ค่ากำหนด%2$s (บน Windows) %3$sSeaMonkey > ค่ากำหนด%4$s (บน Mac)"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -4256,8 +4258,7 @@ msgid ""
 "Click %sSafari%s in the top menu (On Windows, click the %sgears icon%s in "
 "the top right)"
 msgstr ""
-"คลิก %1$sSafari%2$s ในเมนูด้านบน (บน Windows "
-"ให้คลิก%3$sไอคอนเฟือง%4$sที่ด้านขวาบน)"
+"คลิก %1$sSafari%2$s ในเมนูด้านบน (บน Windows ให้คลิก%3$sไอคอนเฟือง%4$sที่ด้านขวาบน)"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4349,8 +4350,7 @@ msgid ""
 "it remains in your browser until you click/tap %sReset All Search Settings%s."
 msgstr ""
 "คลิกหรือแตะ %1$sลบข้อมูลของฉัน%2$s การดำเนินการนี้จะลบข้อมูลออกจากระบบคลาวด์ "
-"แต่จะยังคงอยู่ในเบราว์เซอร์จนกว่าคุณจะคลิก/แตะ "
-"%3$sรีเซ็ตการตั้งค่าการค้นหาทั้งหมด%4$s"
+"แต่จะยังคงอยู่ในเบราว์เซอร์จนกว่าคุณจะคลิก/แตะ %3$sรีเซ็ตการตั้งค่าการค้นหาทั้งหมด%4$s"
 
 # smartling.placeholder_format=C
 #. Tells users where to click in order to disable the cloud save feature and delete any data backed-up to the cloud.
@@ -4431,8 +4431,7 @@ msgid ""
 "Click the dropdown menu beside %sSearch engine used in the address bar%s and "
 "select %sDuckDuckGo%s."
 msgstr ""
-"คลิกเมนูดรอปดาวน์ข้าง%1$sเครื่องมือค้นหาที่ใช้ในแถบที่อยู่%2$s และเลือก "
-"%3$sDuckDuckGo%4$s"
+"คลิกเมนูดรอปดาวน์ข้าง%1$sเครื่องมือค้นหาที่ใช้ในแถบที่อยู่%2$s และเลือก %3$sDuckDuckGo%4$s"
 
 # smartling.placeholder_format=C
 #. First step in a list of steps to take to disable the user's ad blocker
@@ -4628,8 +4627,7 @@ msgid ""
 "Cloud Save lets you save your settings more permanently by entering a "
 "passphrase. It is entirely optional."
 msgstr ""
-"Cloud Save "
-"ช่วยให้คุณบันทึกการตั้งค่าของคุณอย่างถาวรยิ่งขึ้นได้โดยการป้อนรหัสผ่าน "
+"Cloud Save ช่วยให้คุณบันทึกการตั้งค่าของคุณอย่างถาวรยิ่งขึ้นได้โดยการป้อนรหัสผ่าน "
 "ซึ่งเป็นการดำเนินการที่ไม่บังคับ"
 
 # smartling.placeholder_format=C
@@ -5103,6 +5101,12 @@ msgstr "สร้างภาพ"
 msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr "สร้างภาพ"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Create a shopping list with quantities from this recipe."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed in the input field when starting a new image generation session.
@@ -5743,6 +5747,11 @@ msgid "Dictation limit reached"
 msgstr "ถึงขีดจำกัดการป้อนข้อความด้วยเสียงแล้ว"
 
 # smartling.placeholder_format=C
+#. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
+msgid "Dictation temporarily unavailable"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
@@ -6043,6 +6052,22 @@ msgid "Done"
 msgstr "เสร็จเรียบร้อย"
 
 # smartling.placeholder_format=C
+#. Message shown in a modal after DuckDuckGo browser users disable AI features in Settings. The first two placeholders bold noai.duckduckgo.com. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
+"filtered out. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
+"and AI images filtered out. %sLearn more%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Double Faults"
@@ -6151,6 +6176,18 @@ msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
 msgstr "ร่างอีเมลที่กระชับและละเอียดไปหาผู้จำหน่ายเพื่อขอใบเสนอราคาสำหรับบริการซ่อมตู้เย็น"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Draft a cover letter"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Draft a cover letter for this job."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -6293,8 +6330,7 @@ msgid ""
 "pages automatically in Settings."
 msgstr ""
 "ตอนนี้ Duck.ai สามารถช่วยตอบคําถามเกี่ยวกับหน้าเว็บที่คุณกำลังดูอยู่ได้แล้ว "
-"เนื้อหาในหน้าจะถูกรวมเข้าไปเมื่อคุณแนบมัน "
-"ยกเว้นว่าคุณเลือกที่จะแนบหน้าโดยอัตโนมัติในการตั้งค่า"
+"เนื้อหาในหน้าจะถูกรวมเข้าไปเมื่อคุณแนบมัน ยกเว้นว่าคุณเลือกที่จะแนบหน้าโดยอัตโนมัติในการตั้งค่า"
 
 # smartling.placeholder_format=C
 #. Shown in the Duck.ai recent chats list on standalone when the browser API needed to store chats locally is missing or unavailable.
@@ -6322,6 +6358,15 @@ msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
 msgstr "Duck.ai ดีที่สุดในเบราว์เซอร์ DuckDuckGo ส่วนตัวและฟรีของเรา!"
 
 # smartling.placeholder_format=C
+#. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
+msgctxt "About section description on the Duck.ai settings page"
+msgid ""
+"Duck.ai is created by DuckDuckGo. We're an independent online protection "
+"company for anyone who wants to take back control of their personal "
+"information."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
 msgctxt "duckai_migration"
 msgid "Duck.ai is moving domains"
@@ -6334,8 +6379,8 @@ msgid ""
 "Duck.ai is still a DuckDuckGo product, but will now have an easier to "
 "remember home on the web: https://duck.ai"
 msgstr ""
-"Duck.ai ยังคงเป็นผลิตภัณฑ์ของ DuckDuckGo "
-"แต่ตอนนี้จะมีที่อยู่บนเว็บที่จดจำง่ายขึ้น: https://duck.ai"
+"Duck.ai ยังคงเป็นผลิตภัณฑ์ของ DuckDuckGo แต่ตอนนี้จะมีที่อยู่บนเว็บที่จดจำง่ายขึ้น: https://"
+"duck.ai"
 
 # smartling.placeholder_format=C
 #. Headline for domain change notice.
@@ -6350,8 +6395,7 @@ msgid ""
 "Duck.ai is temporarily unavailable. If this persists, please email this "
 "anonymous code %s to %s"
 msgstr ""
-"Duck.ai ไม่สามารถใช้งานได้ชั่วคราว หากยังคงอยู่ "
-"โปรดส่งอีเมลรหัสที่ไม่ระบุชื่อนี้ %1$s ไปที่ %2$s"
+"Duck.ai ไม่สามารถใช้งานได้ชั่วคราว หากยังคงอยู่ โปรดส่งอีเมลรหัสที่ไม่ระบุชื่อนี้ %1$s ไปที่ %2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -6369,16 +6413,23 @@ msgstr "Duck.ai ไม่สามารถใช้งานได้ชั่�
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
+"Duck.ai lets you chat privately with popular AI models. Disabling it hides "
+"Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
+msgstr ""
+
+# smartling.placeholder_format=C
+msgctxt "settings"
+msgid ""
 "Duck.ai lets you have anonymous conversations with 3rd-party AI chat models, "
 "including models from OpenAI, Anthropic, and others. Turning this setting "
 "off will hide Duck.ai buttons and links on DuckDuckGo Search. However, you "
 "can still access Duck.ai when this setting is off by visiting %shttps://duck."
 "ai%s directly."
 msgstr ""
-"Duck.ai ช่วยให้คุณสนทนาแบบไม่ระบุตัวตนกับโมเดลแชท AI ของบุคคลที่สาม "
-"รวมถึงโมเดลจาก OpenAI, Anthropic และอื่นๆ การปิดการตั้งค่านี้จะซ่อนปุ่ม Chat "
-"และลิงก์บน DuckDuckGo Search อย่างไรก็ตาม คุณยังสามารถเข้าถึง Duck.ai "
-"ได้เมื่อปิดการตั้งค่านี้โดยไปที่ %1$shttps://duck.ai%2$s โดยตรง"
+"Duck.ai ช่วยให้คุณสนทนาแบบไม่ระบุตัวตนกับโมเดลแชท AI ของบุคคลที่สาม รวมถึงโมเดลจาก "
+"OpenAI, Anthropic และอื่นๆ การปิดการตั้งค่านี้จะซ่อนปุ่ม Chat และลิงก์บน DuckDuckGo "
+"Search อย่างไรก็ตาม คุณยังสามารถเข้าถึง Duck.ai ได้เมื่อปิดการตั้งค่านี้โดยไปที่ %1$shttps://"
+"duck.ai%2$s โดยตรง"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
@@ -6433,9 +6484,9 @@ msgid ""
 "AI chat no sign up, OpenAI, Anthropic, Llama, Mistral, open source AI "
 "models, privacy focused AI, no account AI chat"
 msgstr ""
-"Duck.ai, DuckDuckGo AI, แชทบอท AI ส่วนตัว, แชท AI ฟรี, แชท AI "
-"แบบไม่ระบุตัวตน, แชท AI ไม่ต้องสมัคร, OpenAI, Anthropic, Llama, Mistral, "
-"โมเดล AI โอเพนซอร์ส, AI ที่เน้นความเป็นส่วนตัว, แชท AI ไม่ต้องมีบัญชี"
+"Duck.ai, DuckDuckGo AI, แชทบอท AI ส่วนตัว, แชท AI ฟรี, แชท AI แบบไม่ระบุตัวตน, แชท "
+"AI ไม่ต้องสมัคร, OpenAI, Anthropic, Llama, Mistral, โมเดล AI โอเพนซอร์ส, AI "
+"ที่เน้นความเป็นส่วนตัว, แชท AI ไม่ต้องมีบัญชี"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -6464,12 +6515,10 @@ msgid ""
 "For now, DuckAssist is only available in the U.S. (English) region."
 msgstr ""
 "DuckAssist สามารถค้นหาและสรุปข้อมูลโดยไม่ระบุตัวตนตามการค้นหาบางอย่าง "
-"คุณสามารถเลือกได้ว่าต้องการให้ DuckAssist ปรากฏบ่อยเพียงใด: ไม่แสดงเลย (ลบ "
-"DuckAssist UI ออกจากผลการค้นหาทั้งหมด), ตามต้องการ "
-"(แสดงเฉพาะเมื่อคุณคลิกปุ่ม Assist), บางครั้ง "
-"(แสดงเฉพาะเมื่อมีความเกี่ยวข้องสูง) หรือบ่อยครั้ง "
-"(แสดงบ่อยขึ้นในการค้นหาที่มีช่วงกว้าง) สำหรับตอนนี้ DuckAssist "
-"มีให้บริการเฉพาะในภูมิภาคสหรัฐอเมริกา (ภาษาอังกฤษ) เท่านั้น"
+"คุณสามารถเลือกได้ว่าต้องการให้ DuckAssist ปรากฏบ่อยเพียงใด: ไม่แสดงเลย (ลบ DuckAssist "
+"UI ออกจากผลการค้นหาทั้งหมด), ตามต้องการ (แสดงเฉพาะเมื่อคุณคลิกปุ่ม Assist), บางครั้ง "
+"(แสดงเฉพาะเมื่อมีความเกี่ยวข้องสูง) หรือบ่อยครั้ง (แสดงบ่อยขึ้นในการค้นหาที่มีช่วงกว้าง) "
+"สำหรับตอนนี้ DuckAssist มีให้บริการเฉพาะในภูมิภาคสหรัฐอเมริกา (ภาษาอังกฤษ) เท่านั้น"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6478,9 +6527,9 @@ msgid ""
 "%sDuckDuckGo AI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI, and Anthropic, and more."
 msgstr ""
-"DuckAssist ไม่สามารถตอบคำถามที่ตามมาได้ อย่างไรก็ตาม เรายังมี %1$sDuckDuckGo "
-"AI Chat%2$s ซึ่งเป็นบริการแชทส่วนตัวที่ใช้ AI และรองรับโมเดลการแชทจาก "
-"OpenAI, Anthropic และอื่นๆ อีกมากมาย"
+"DuckAssist ไม่สามารถตอบคำถามที่ตามมาได้ อย่างไรก็ตาม เรายังมี %1$sDuckDuckGo AI "
+"Chat%2$s ซึ่งเป็นบริการแชทส่วนตัวที่ใช้ AI และรองรับโมเดลการแชทจาก OpenAI, Anthropic "
+"และอื่นๆ อีกมากมาย"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6489,9 +6538,9 @@ msgid ""
 "DuckDuckGo %sAI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI and Anthropic."
 msgstr ""
-"DuckAssist ไม่สามารถตอบคำถามที่ถามต่อได้ อย่างไรก็ตาม เรายังมี DuckDuckGo "
-"%1$sAI Chat%2$s ซึ่งเป็นบริการแชทส่วนตัวที่ขับเคลื่อนด้วย AI "
-"ที่รองรับโมเดลการแชทจาก OpenAI และ Anthropic"
+"DuckAssist ไม่สามารถตอบคำถามที่ถามต่อได้ อย่างไรก็ตาม เรายังมี DuckDuckGo %1$sAI "
+"Chat%2$s ซึ่งเป็นบริการแชทส่วนตัวที่ขับเคลื่อนด้วย AI ที่รองรับโมเดลการแชทจาก OpenAI และ "
+"Anthropic"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6504,10 +6553,8 @@ msgid ""
 "checked for accuracy."
 msgstr ""
 "DuckAssist "
-""
 "เป็นคุณลักษณะใหม่ในผลการค้นหาของเราที่สามารถสร้างคำตอบสำหรับคำค้นหาโดยไม่ระบุชื่อได้ "
-"ในการดำเนินการนี้ ระบบจะสแกน Wikipedia "
-"และเว็บไซต์ที่เกี่ยวข้องเพื่อหาเนื้อหาที่เกี่ยวข้อง "
+"ในการดำเนินการนี้ ระบบจะสแกน Wikipedia และเว็บไซต์ที่เกี่ยวข้องเพื่อหาเนื้อหาที่เกี่ยวข้อง "
 "จากนั้นใช้เทคโนโลยีภาษาธรรมชาติที่ขับเคลื่อนด้วย AI เพื่อสร้างข้อมูลสรุป "
 "โปรดทราบว่าขณะนี้คำตอบนั้นอิงจาก Wikipedia และเนื้อหาที่เกี่ยวข้อง "
 "และไม่ได้มีการตรวจสอบความถูกต้อง"
@@ -6525,16 +6572,11 @@ msgid ""
 "sources and based on %scrawling the web%s."
 msgstr ""
 "DuckAssist "
-""
 "เป็นฟีเจอร์เสริมในผลการค้นหาของเราที่สามารถสร้างคำตอบสำหรับคำค้นหาโดยไม่ระบุชื่อได้ "
-"ในการดำเนินการนี้ ระบบจะสแกนเว็บเพื่อหาเนื้อหาที่เกี่ยวข้อง "
-"จากนั้นใช้เทคโนโลยีภาษาธรรมชาติที่ใช้ AI เพื่อสร้างคำตอบสั้นๆ "
-"ตามข้อมูลที่เกี่ยวข้องที่พบ คำตอบของ DuckAssist "
-"จะเชื่อมโยงโดยตรงกับแหล่งข้อมูลหนึ่งหรือสองแหล่งเสมอ "
-"โดยอ้างอิงแหล่งที่มาของคำตอบ "
-""
+"ในการดำเนินการนี้ ระบบจะสแกนเว็บเพื่อหาเนื้อหาที่เกี่ยวข้อง จากนั้นใช้เทคโนโลยีภาษาธรรมชาติที่ใช้ "
+"AI เพื่อสร้างคำตอบสั้นๆ ตามข้อมูลที่เกี่ยวข้องที่พบ คำตอบของ DuckAssist "
+"จะเชื่อมโยงโดยตรงกับแหล่งข้อมูลหนึ่งหรือสองแหล่งเสมอ โดยอ้างอิงแหล่งที่มาของคำตอบ "
 "เพื่อให้คุณสามารถไปยังแหล่งข้อมูลเพื่อดูข้อมูลโดยละเอียดเพิ่มเติมได้อย่างง่ายดาย "
-""
 "สิ่งสำคัญคือต้องจำไว้ว่าคำตอบนั้นถูกสร้างขึ้นโดยอัตโนมัติจากแหล่งข้อมูลที่ใช้อ้างอิง "
 "และขึ้นอยู่กับ%1$sการรวบรวมข้อมูลเว็บ%2$s"
 
@@ -6544,8 +6586,7 @@ msgid ""
 "DuckAssist responses are auto-generated based on listed sources and not "
 "checked for accuracy."
 msgstr ""
-"คำตอบ DuckAssist "
-"สร้างขึ้นโดยอัตโนมัติตามแหล่งที่มาที่ระบุไว้และไม่ได้ตรวจสอบความถูกต้อง"
+"คำตอบ DuckAssist สร้างขึ้นโดยอัตโนมัติตามแหล่งที่มาที่ระบุไว้และไม่ได้ตรวจสอบความถูกต้อง"
 
 # smartling.placeholder_format=C
 #. Displayed when the chat service has reached the maximum number of messages for one day.
@@ -6553,9 +6594,7 @@ msgctxt "Error message for service limit"
 msgid ""
 "DuckDuckGo AI Chat has reached the maximum number of messages for one day. "
 "Please continue this chat tomorrow."
-msgstr ""
-"DuckDuckGo AI Chat ถึงจำนวนข้อความสูงสุดในหนึ่งวันแล้ว "
-"โปรดแชทต่อในวันพรุ่งนี้"
+msgstr "DuckDuckGo AI Chat ถึงจำนวนข้อความสูงสุดในหนึ่งวันแล้ว โปรดแชทต่อในวันพรุ่งนี้"
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the AI chat service and supported AI models. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -6564,8 +6603,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"DuckDuckGo AI Chat เป็นบริการแชทส่วนตัวที่ขับเคลื่อนด้วย AI "
-"ซึ่งปัจจุบันรองรับโมเดลการแชท %2$s ของ %1$s และ %4$s ของ %3$s"
+"DuckDuckGo AI Chat เป็นบริการแชทส่วนตัวที่ขับเคลื่อนด้วย AI ซึ่งปัจจุบันรองรับโมเดลการแชท "
+"%2$s ของ %1$s และ %4$s ของ %3$s"
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the welcome screen of the onboarding. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -6574,8 +6613,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"DuckDuckGo AI Chat เป็นบริการแชทส่วนตัวที่ขับเคลื่อนด้วย AI "
-"ซึ่งปัจจุบันรองรับโมเดลการแชท %2$s ของ %1$s และ %4$s ของ %3$s"
+"DuckDuckGo AI Chat เป็นบริการแชทส่วนตัวที่ขับเคลื่อนด้วย AI ซึ่งปัจจุบันรองรับโมเดลการแชท "
+"%2$s ของ %1$s และ %4$s ของ %3$s"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding DuckDuckGo AI Chat.
@@ -6592,8 +6631,8 @@ msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. If this persists, please "
 "email this anonymous code %s to %s"
 msgstr ""
-"DuckDuckGo AI Chat ไม่สามารถใช้งานได้ชั่วคราว หากยังคงอยู่ "
-"โปรดส่งอีเมลรหัสที่ไม่ระบุชื่อนี้ %1$s ไปที่ %2$s"
+"DuckDuckGo AI Chat ไม่สามารถใช้งานได้ชั่วคราว หากยังคงอยู่ โปรดส่งอีเมลรหัสที่ไม่ระบุชื่อนี้ "
+"%1$s ไปที่ %2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -6601,9 +6640,7 @@ msgctxt "Error message for VQD error"
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. Please refresh the page and "
 "try again."
-msgstr ""
-"DuckDuckGo AI Chat ไม่สามารถใช้งานได้ชั่วคราว "
-"โปรดรีเฟรชหน้านี้แล้วลองอีกครั้ง"
+msgstr "DuckDuckGo AI Chat ไม่สามารถใช้งานได้ชั่วคราว โปรดรีเฟรชหน้านี้แล้วลองอีกครั้ง"
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -6728,8 +6765,8 @@ msgid ""
 "DuckDuckGo anonymizes these reports by automatically removing PII like "
 "names, email addresses, phone numbers, and identifying metadata."
 msgstr ""
-"DuckDuckGo ทำให้รายงานเหล่านี้ไม่ระบุตัวตนโดยการลบ PII โดยอัตโนมัติ เช่น "
-"ชื่อ ที่อยู่อีเมล หมายเลขโทรศัพท์ และเมตาดาต้าที่ระบุตัวตน"
+"DuckDuckGo ทำให้รายงานเหล่านี้ไม่ระบุตัวตนโดยการลบ PII โดยอัตโนมัติ เช่น ชื่อ ที่อยู่อีเมล "
+"หมายเลขโทรศัพท์ และเมตาดาต้าที่ระบุตัวตน"
 
 # smartling.placeholder_format=C
 #. The first %s is the agree button label ('Agree'). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. The leading sentence mirrors the drawer-style inline disclaimer (DUCKCHAT_TOS_INLINE_DISCLAIMER).
@@ -6737,8 +6774,7 @@ msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid ""
 "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to Duck.ai's %s."
 msgstr ""
-"DuckDuckGo ทําให้แชทของคุณไม่เปิดเผยตัวตน เมื่อคลิก '%1$s' คุณยอมรับ %2$s "
-"ของ Duck.ai"
+"DuckDuckGo ทําให้แชทของคุณไม่เปิดเผยตัวตน เมื่อคลิก '%1$s' คุณยอมรับ %2$s ของ Duck.ai"
 
 # smartling.placeholder_format=C
 #. Shown below the input on the empty state when the user has not yet accepted the terms of service. The first %s is the action button label ('Ask' for chat, 'Create' for image generation). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. Clicking the action button both accepts the terms and submits the prompt.
@@ -6747,8 +6783,7 @@ msgctxt ""
 "users"
 msgid "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to our %s."
 msgstr ""
-"DuckDuckGo ทําให้แชทของคุณไม่เปิดเผยตัวตน เมื่อคลิก '%1$s' แสดงว่าคุณยอมรับ "
-"%2$s ของเรา"
+"DuckDuckGo ทําให้แชทของคุณไม่เปิดเผยตัวตน เมื่อคลิก '%1$s' แสดงว่าคุณยอมรับ %2$s ของเรา"
 
 # smartling.placeholder_format=C
 #. An information popup explaining that we block trackers
@@ -6757,9 +6792,8 @@ msgid ""
 "companies like Google and Facebook, who often try to track you on other "
 "websites."
 msgstr ""
-"DuckDuckGo จะบล็อกตัวติดตามบนเว็บไซต์ที่คุณเยี่ยมชม "
-"รวมถึงตัวติดตามจากบริษัทต่างๆ เช่น Google และ Facebook "
-"ซึ่งมักจะพยายามติดตามคุณบนเว็บไซต์อื่นๆ"
+"DuckDuckGo จะบล็อกตัวติดตามบนเว็บไซต์ที่คุณเยี่ยมชม รวมถึงตัวติดตามจากบริษัทต่างๆ เช่น Google "
+"และ Facebook ซึ่งมักจะพยายามติดตามคุณบนเว็บไซต์อื่นๆ"
 
 # smartling.placeholder_format=C
 #. Description of how DuckDuckGo keeps a user's location anonymous while the user searches on a map of their area.
@@ -6771,11 +6805,9 @@ msgid ""
 "away, such that you remain anonymous. %sLearn more about how we designed "
 "this technology to protect your privacy%s."
 msgstr ""
-"DuckDuckGo ให้ความสำคัญกับความเป็นส่วนตัวตั้งแต่ขั้นตอนการออกแบบ "
-"เมื่อคุณเปิดใช้งานตำแหน่งที่ตั้ง "
+"DuckDuckGo ให้ความสำคัญกับความเป็นส่วนตัวตั้งแต่ขั้นตอนการออกแบบ เมื่อคุณเปิดใช้งานตำแหน่งที่ตั้ง "
 "ข้อมูลดังกล่าวจะได้รับการจัดเก็บไว้บนอุปกรณ์ของคุณเท่านั้น เมื่อคุณค้นหา "
-"อุปกรณ์ของคุณจึงจะส่งข้อมูลตำแหน่งที่ตั้งมาให้เรา "
-"ซึ่งเราจะใช้เพื่อปรับปรุงผลการค้นหาดังกล่าว "
+"อุปกรณ์ของคุณจึงจะส่งข้อมูลตำแหน่งที่ตั้งมาให้เรา ซึ่งเราจะใช้เพื่อปรับปรุงผลการค้นหาดังกล่าว "
 "จากนั้นเราจะทิ้งข้อมูลดังกล่าวในทันทีเพื่อให้ไม่มีการระบุตัวตนของคุณได้ "
 "%1$sดูข้อมูลเพิ่มเติมเกี่ยวกับวิธีที่เราออกแบบเทคโนโลยีนี้เพื่อปกป้องความเป็นส่วนตัวของคุณ%2$s"
 
@@ -6797,9 +6829,8 @@ msgid ""
 "DuckDuckGo only uses your approximate location. That's all we need to "
 "deliver better results, closer to you. %sLearn more%s."
 msgstr ""
-"DuckDuckGo ใช้เฉพาะตำแหน่งที่ตั้งโดยประมาณของคุณ "
-"ซึ่งเราต้องการเพียงเพื่อให้ได้ผลลัพธ์ที่ดีขึ้น และใกล้คุณมากขึ้น "
-"%1$sดูข้อมูลเพิ่มเติม%2$s"
+"DuckDuckGo ใช้เฉพาะตำแหน่งที่ตั้งโดยประมาณของคุณ ซึ่งเราต้องการเพียงเพื่อให้ได้ผลลัพธ์ที่ดีขึ้น "
+"และใกล้คุณมากขึ้น %1$sดูข้อมูลเพิ่มเติม%2$s"
 
 # smartling.placeholder_format=C
 msgid "DuckDuckGo search"
@@ -6885,9 +6916,8 @@ msgid ""
 "random words from that list, ensuring that the passphrase is at least 18-20 "
 "characters long."
 msgstr ""
-"ทุกครั้งที่คุณขอให้แนะนำรหัสผ่าน "
-"เราจะได้รับรายการคำสุ่มหลายคำจากเซิร์ฟเวอร์ของ DuckDuckGo จากนั้นเราจะสุ่มคำ "
-"4 - 5 คำจากรายการดังกล่าวในเบราว์เซอร์ "
+"ทุกครั้งที่คุณขอให้แนะนำรหัสผ่าน เราจะได้รับรายการคำสุ่มหลายคำจากเซิร์ฟเวอร์ของ DuckDuckGo "
+"จากนั้นเราจะสุ่มคำ 4 - 5 คำจากรายการดังกล่าวในเบราว์เซอร์ "
 "เพื่อให้มั่นใจว่ารหัสผ่านมีความยาวอักขระอย่างน้อย 18-20 ตัว"
 
 # smartling.placeholder_format=C
@@ -7083,9 +7113,7 @@ msgstr "เปิดใช้งานการค้นหาเว็บ"
 msgid ""
 "Enable anonymous location for more accurate results. You can always change "
 "your mind later."
-msgstr ""
-"เปิดใช้ตำแหน่งที่ตั้งแบบไม่ระบุตัวตนเพื่อผลลัพธ์ที่แม่นยำยิ่งขึ้น "
-"คุณสามารถเปลี่ยนใจได้ในภายหลัง"
+msgstr "เปิดใช้ตำแหน่งที่ตั้งแบบไม่ระบุตัวตนเพื่อผลลัพธ์ที่แม่นยำยิ่งขึ้น คุณสามารถเปลี่ยนใจได้ในภายหลัง"
 
 # smartling.placeholder_format=C
 #. Title of the dictation privacy consent modal shown on first use.
@@ -7291,8 +7319,7 @@ msgid ""
 "Enter a new passphrase and click/tap %sSave Settings%s. This will save your "
 "data under your new passphrase."
 msgstr ""
-"ป้อนรหัสผ่านใหม่แล้วคลิก/แตะ%1$sบันทึกการตั้งค่า%2$s "
-"การดำเนินการนี้จะบันทึกข้อมูลในรหัสผ่านใหม่"
+"ป้อนรหัสผ่านใหม่แล้วคลิก/แตะ%1$sบันทึกการตั้งค่า%2$s การดำเนินการนี้จะบันทึกข้อมูลในรหัสผ่านใหม่"
 
 # smartling.placeholder_format=C
 #. Label for the field where a user enters their passphrase.
@@ -7318,8 +7345,7 @@ msgstr "ป้อนข้อความ"
 msgid ""
 "Enter the following details: %sName%s: DuckDuckGo%s URL%s: %s Alias%s: d%s"
 msgstr ""
-"ป้อนรายละเอียดต่อไปนี้: %1$sชื่อ%2$s: DuckDuckGo%3$s URL%4$s: %5$s "
-"นามแฝง%6$s: d%7$s"
+"ป้อนรายละเอียดต่อไปนี้: %1$sชื่อ%2$s: DuckDuckGo%3$s URL%4$s: %5$s นามแฝง%6$s: d%7$s"
 
 # smartling.placeholder_format=C
 #. Prompt to enter a destination for driving directions.
@@ -7358,6 +7384,18 @@ msgstr "ลบข้อมูลการท่องเว็บของคุ
 # smartling.placeholder_format=C
 msgid "Eritrea"
 msgstr "เอริเทรีย"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Estimate the nutrition"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Estimate the nutritional information for this recipe."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Estonia"
@@ -7414,11 +7452,59 @@ msgid "Expires in 1 day"
 msgstr "หมดอายุใน 1 วัน"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain the accepted answer in simple terms."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
 msgstr "อธิบายแนวคิดพื้นฐานของหลุมดำให้ฉันฟังในระดับมัธยมปลาย"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain the top answer"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this in simple, plain language."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this paper"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this repo"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this research paper in plain language."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this simply"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain what this repository does and how to use it."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label to show if song lyrics contain explicit content
@@ -7612,9 +7698,7 @@ msgstr ""
 msgid ""
 "Feel free to adjust the settings below. Then, just copy and paste the code "
 "into your website."
-msgstr ""
-"โปรดปรับเปลี่ยนการตั้งค่าด้านล่าง "
-"จากนั้นเพียงแค่คัดลอกและวางโค้ดลงในเว็บไซต์ของคุณ"
+msgstr "โปรดปรับเปลี่ยนการตั้งค่าด้านล่าง จากนั้นเพียงแค่คัดลอกและวางโค้ดลงในเว็บไซต์ของคุณ"
 
 # smartling.placeholder_format=C
 msgid "Fiji"
@@ -7700,6 +7784,12 @@ msgid ""
 msgstr "กรองภาพที่สร้างโดย AI จากผลลัพธ์การค้นหาภาพ %1$sดูข้อมูลเพิ่มเติม%2$s"
 
 # smartling.placeholder_format=C
+msgctxt "settings"
+msgid ""
+"Filters out known AI spam sites from image search results. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the final score of a sporting event.
 msgid "Final"
 msgstr "รอบชิงชนะเลิศ"
@@ -7751,6 +7841,12 @@ msgstr "หาคำที่ดีกว่า"
 msgctxt "Subtitle for the Web Search tool entry in the Tools dropdown menu"
 msgid "Find current information"
 msgstr "ค้นหาข้อมูลปัจจุบัน"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Find me alternatives"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button that searches for results closer to the user's current location.
@@ -7957,7 +8053,7 @@ msgstr "แก้ไข แชร์ และใช้ได้อย่าง�
 #. a filter for images with the CC BY usage license
 msgctxt "image-licence"
 msgid "Free to Modify, Share, and Use Commercially"
-msgstr "แก้ไข แชร์ และใช้ในเชิงพาณิชย์ ได้อย่างอิสระ"
+msgstr "แก้ไข แชร์ และใช้ในเชิงพาณิชย์"
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC-ND usage license
@@ -8057,8 +8153,7 @@ msgid ""
 "strong>."
 msgstr ""
 "จากแถบเมนูแอปบน Mac ให้เลือก <strong>DuckDuckGo</strong> &gt; "
-"<strong>ตรวจสอบการอัปเดต...</strong> จากนั้นเลือก "
-"<strong>ติดตั้งการอัปเดต</strong>"
+"<strong>ตรวจสอบการอัปเดต...</strong> จากนั้นเลือก <strong>ติดตั้งการอัปเดต</strong>"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -8226,6 +8321,12 @@ msgid "Generate More"
 msgstr "สร้างมากขึ้น"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Generate a shopping list"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
 msgid "Generate a short answer from the web"
 msgstr "สร้างคำตอบสั้นๆ จากเว็บไซต์"
@@ -8388,9 +8489,7 @@ msgstr "เริ่ม"
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the Privacy Pro subscription.
 msgctxt "SERP footer content"
 msgid "Get a VPN + two more protections in one easy subscription."
-msgstr ""
-"รับ VPN + การป้องกันเพิ่มเติมอีกสองรายการในการสมัครสมาชิกง่ายๆ "
-"เพียงครั้งเดียว"
+msgstr "รับ VPN + การป้องกันเพิ่มเติมอีกสองรายการในการสมัครสมาชิกง่ายๆ เพียงครั้งเดียว"
 
 # smartling.placeholder_format=C
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
@@ -8405,8 +8504,8 @@ msgid ""
 "Get access to advanced AI models in Duck.ai by subscribing to DuckDuckGo, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"เข้าถึงโมเดล AI ขั้นสูงใน Duck.ai ได้โดยการสมัครสมาชิก DuckDuckGo "
-"ซึ่งยังรวมถึง VPN และการปกป้องความเป็นส่วนตัวระดับพรีเมียมอื่นๆ ของเรา"
+"เข้าถึงโมเดล AI ขั้นสูงใน Duck.ai ได้โดยการสมัครสมาชิก DuckDuckGo ซึ่งยังรวมถึง VPN "
+"และการปกป้องความเป็นส่วนตัวระดับพรีเมียมอื่นๆ ของเรา"
 
 # smartling.placeholder_format=C
 #. Description for the subscription setting where users can subscribe to DuckDuckGo.
@@ -8417,8 +8516,8 @@ msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"เข้าถึงโมเดล AI ขั้นสูงใน Duck.ai ด้วยการสมัครสมาชิก DuckDuckGo "
-"ซึ่งยังรวมถึง VPN และการปกป้องความเป็นส่วนตัวระดับพรีเมียมอื่นๆ ของเรา"
+"เข้าถึงโมเดล AI ขั้นสูงใน Duck.ai ด้วยการสมัครสมาชิก DuckDuckGo ซึ่งยังรวมถึง VPN "
+"และการปกป้องความเป็นส่วนตัวระดับพรีเมียมอื่นๆ ของเรา"
 
 # smartling.placeholder_format=C
 #. A button for users to generate an AI generated answer from their query on the duckassist module
@@ -8517,6 +8616,12 @@ msgid "Give it a Try"
 msgstr "ลองดูสิ"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Give me a quick background on this person."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
@@ -8530,8 +8635,7 @@ msgid ""
 "“Location Services” is turned on."
 msgstr ""
 "ไปที่ %1$sการตั้งค่า > ความเป็นส่วนตัวและความปลอดภัย > "
-"บริการหาตําแหน่งที่ตั้ง%2$sและตรวจสอบให้แน่ใจว่า \"บริการหาตําแหน่งที่ตั้ง\" "
-"เปิดอยู่"
+"บริการหาตําแหน่งที่ตั้ง%2$sและตรวจสอบให้แน่ใจว่า \"บริการหาตําแหน่งที่ตั้ง\" เปิดอยู่"
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -8540,8 +8644,8 @@ msgid ""
 "Go to %sSettings > Privacy > Permission manager > Location%s and scroll down "
 "to %sDuckDuckGo%s."
 msgstr ""
-"ไปที่ %1$sการตั้งค่า > ความเป็นส่วนตัวและความปลอดภัย > "
-"บริการหาตําแหน่งที่ตั้ง%2$s แล้วเลื่อนลงไปที่ %3$sDuckDuckGo%4$s"
+"ไปที่ %1$sการตั้งค่า > ความเป็นส่วนตัวและความปลอดภัย > บริการหาตําแหน่งที่ตั้ง%2$s "
+"แล้วเลื่อนลงไปที่ %3$sDuckDuckGo%4$s"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -8964,6 +9068,18 @@ msgid "Help Spread Privacy"
 msgstr "ช่วยกระจายความเป็นส่วนตัว"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Help me prep for the interview"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Help me tailor my resume for this job."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title of a SERP popup that invites users to take a survey (desktop only)
 msgctxt "User survey popup"
 msgid "Help us improve DuckDuckGo"
@@ -9199,9 +9315,7 @@ msgctxt "settings"
 msgid ""
 "Highlights key facts in Search Assist answers to help you find important "
 "information faster."
-msgstr ""
-"เน้นข้อเท็จจริงสำคัญในคำตอบของ Search Assist "
-"เพื่อช่วยให้คุณค้นหาข้อมูลสำคัญได้เร็วขึ้น"
+msgstr "เน้นข้อเท็จจริงสำคัญในคำตอบของ Search Assist เพื่อช่วยให้คุณค้นหาข้อมูลสำคัญได้เร็วขึ้น"
 
 # smartling.placeholder_format=C
 #. The name of the Hindi language
@@ -9294,8 +9408,7 @@ msgid ""
 "Hotel ad clicks are managed by Tripadvisor’s ad network and are not used to "
 "profile you."
 msgstr ""
-"การคลิกโฆษณาจัดการโดยเครือข่ายโฆษณาของ Tripadvisor "
-"และไม่ได้ใช้ในการสร้างโปรไฟล์ของคุณ"
+"การคลิกโฆษณาจัดการโดยเครือข่ายโฆษณาของ Tripadvisor และไม่ได้ใช้ในการสร้างโปรไฟล์ของคุณ"
 
 # smartling.placeholder_format=C
 #. Refers to hours of operation for a business.
@@ -9437,7 +9550,6 @@ msgid ""
 "How should I tactfully approach a colleague about their constant pencil "
 "tapping and what should I say?"
 msgstr ""
-""
 "ฉันจะบอกเพื่อนร่วมงานอย่างมีไหวพริบเกี่ยวกับการเคาะดินสออย่างต่อเนื่องได้อย่างไร "
 "และฉันควรจะพูดว่าอะไร"
 
@@ -9478,6 +9590,14 @@ msgstr "พายุเฮอริเคน"
 msgctxt "Onboarding terms screen button text"
 msgid "I Agree"
 msgstr "ฉันเห็นด้วย"
+
+# smartling.placeholder_format=C
+#. Text for the button that takes the user to the external DuckDuckGo login subscription page.
+msgctxt ""
+"Text for the I already have a subscription button in the Duck.ai settings "
+"page"
+msgid "I Already Have a Subscription"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the button that takes the user to the login subscription page.
@@ -9552,9 +9672,7 @@ msgctxt "Full sentence for recommending a book"
 msgid ""
 "I like the book Name of the Wind. What are some other good books/series most "
 "like it and why?"
-msgstr ""
-"ฉันชอบหนังสือชื่อ Name of the Wind มีหนังสือ/ซีรีส์ดีๆ "
-"ที่คล้ายกันหรือไม่และเพราะเหตุใด"
+msgstr "ฉันชอบหนังสือชื่อ Name of the Wind มีหนังสือ/ซีรีส์ดีๆ ที่คล้ายกันหรือไม่และเพราะเหตุใด"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the user needs more help or information on how to use the chat.
@@ -9589,8 +9707,8 @@ msgid ""
 "If the browser location remains unavailable, then go to %sSettings > General "
 "> Reset > 'Reset Location & Privacy'%s."
 msgstr ""
-"หากตำแหน่งที่ตั้งของเบราว์เซอร์ยังไม่พร้อมใช้งาน ให้ไปที่%1$sการตั้งค่า > "
-"ทั่วไป > รีเซ็ต > \"รีเซ็ตตำแหน่งที่ตั้งและความเป็นส่วนตัว\"%2$s"
+"หากตำแหน่งที่ตั้งของเบราว์เซอร์ยังไม่พร้อมใช้งาน ให้ไปที่%1$sการตั้งค่า > ทั่วไป > รีเซ็ต > "
+"\"รีเซ็ตตำแหน่งที่ตั้งและความเป็นส่วนตัว\"%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -9600,9 +9718,9 @@ msgid ""
 "> Menu > Settings > Site settings > Location%s, and ensure DuckDuckGo is "
 "allowed location access."
 msgstr ""
-"หากตำแหน่งที่ตั้งของเบราว์เซอร์ยังไม่พร้อมใช้งาน จากเบราว์เซอร์ของคุณ "
-"ให้ไปที่ %1$s⋮ > เมนู > การตั้งค่า > การตั้งค่าเว็บไซต์ > ตำแหน่งที่ตั้ง%2$s "
-"และตรวจสอบว่า DuckDuckGo ได้รับอนุญาตให้เข้าถึงตำแหน่งที่ตั้ง"
+"หากตำแหน่งที่ตั้งของเบราว์เซอร์ยังไม่พร้อมใช้งาน จากเบราว์เซอร์ของคุณ ให้ไปที่ %1$s⋮ > เมนู > "
+"การตั้งค่า > การตั้งค่าเว็บไซต์ > ตำแหน่งที่ตั้ง%2$s และตรวจสอบว่า DuckDuckGo "
+"ได้รับอนุญาตให้เข้าถึงตำแหน่งที่ตั้ง"
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -9637,8 +9755,7 @@ msgid ""
 "If you lose access to your devices, you will need this code to recover your "
 "saved chats. You can save this code to your device as a text file."
 msgstr ""
-"หากคุณไม่สามารถเข้าถึงอุปกรณ์ของคุณได้ "
-"คุณจะต้องใช้รหัสนี้เพื่อกู้คืนแชทที่บันทึกไว้ "
+"หากคุณไม่สามารถเข้าถึงอุปกรณ์ของคุณได้ คุณจะต้องใช้รหัสนี้เพื่อกู้คืนแชทที่บันทึกไว้ "
 "คุณสามารถบันทึกโค้ดนี้ลงในอุปกรณ์ของคุณเป็นไฟล์ข้อความได้"
 
 # smartling.placeholder_format=C
@@ -9655,8 +9772,7 @@ msgid ""
 "If you want to use DuckDuckGo without JavaScript, please use our %s or %s "
 "versions."
 msgstr ""
-"หากคุณต้องการใช้ DuckDuckGo แบบไม่มี JavaScript โปรดใช้เวอร์ชัน %1$s หรือ "
-"%2$s ของเรา"
+"หากคุณต้องการใช้ DuckDuckGo แบบไม่มี JavaScript โปรดใช้เวอร์ชัน %1$s หรือ %2$s ของเรา"
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -9664,8 +9780,7 @@ msgstr ""
 msgid ""
 "If you want, select Home Page next to New windows and New tabs (open with)."
 msgstr ""
-"หากคุณต้องการ ให้เลือก \"หน้าแรก\" ถัดจาก \"หน้าต่างใหม่\" และ \"แท็บใหม่\" "
-"(เปิดด้วย)"
+"หากคุณต้องการ ให้เลือก \"หน้าแรก\" ถัดจาก \"หน้าต่างใหม่\" และ \"แท็บใหม่\" (เปิดด้วย)"
 
 # smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that adds an image to the AI chat message being composed.
@@ -9807,7 +9922,6 @@ msgid ""
 "server to prevent search leakage. %sLearn more%s."
 msgstr ""
 "ในเบราว์เซอร์เก่ากว่าบางรายการ "
-""
 "เราจำเป็นต้องเปลี่ยนเส้นทางการคลิกของคุณผ่านเซิร์ฟเวอร์ของเราเพื่อป้องกันการรั่วไหลของข้อมูลการค้นหา "
 "%1$sดูข้อมูลเพิ่มเติม%2$s"
 
@@ -10053,6 +10167,12 @@ msgid "Install Mac Browser"
 msgstr "ติดตั้งเบราว์เซอร์ Mac"
 
 # smartling.placeholder_format=C
+#. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
+msgctxt "settings"
+msgid "Install Now"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of a button to install the DuckDuckGo app
 msgctxt "Serp footer content"
 msgid "Install Our App"
@@ -10150,10 +10270,42 @@ msgid "Is deleted data really deleted?"
 msgstr "ข้อมูลจะถูกลบออกจริงหรือไม่"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is it worth taking?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this place any good?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"Is this place any good? Summarize its reputation based on reviews and "
+"ratings."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "Is this video helpful?"
 msgstr "วิดีโอนี้มีประโยชน์หรือไม่"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this worth watching?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Is this worth watching? Give me a spoiler-free take."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -10205,11 +10357,9 @@ msgid ""
 "pages and unlike ads, DuckDuckGo is not compensated for these results."
 msgstr ""
 "รายการต่างๆ "
-""
 "ได้รับการจัดลำดับตามความเกี่ยวข้องกับข้อความค้นหาของคุณและจัดส่งผ่านเครือข่ายโฆษณาของ "
-"Microsoft การคลิกนำไปสู่หน้า Landing Page "
-"ของผู้ค้าโดยตรงและไม่เหมือนกับโฆษณา DuckDuckGo "
-"ไม่ได้รับการชดเชยสำหรับผลลัพธ์เหล่านี้"
+"Microsoft การคลิกนำไปสู่หน้า Landing Page ของผู้ค้าโดยตรงและไม่เหมือนกับโฆษณา "
+"DuckDuckGo ไม่ได้รับการชดเชยสำหรับผลลัพธ์เหล่านี้"
 
 # smartling.placeholder_format=C
 #. Text explaining why passphrases use a series of words instead of random numbers and letters.
@@ -10218,8 +10368,7 @@ msgid ""
 "It’s easier to remember 4-5 words than 10 random letters and numbers, and "
 "far more secure."
 msgstr ""
-"การจดจำคำ 4 - 5 คำจะง่ายกว่าการจำตัวอักษรและตัวเลขแบบสุ่ม 10 ตัว "
-"และมีความปลอดภัยมากกว่า"
+"การจดจำคำ 4 - 5 คำจะง่ายกว่าการจำตัวอักษรและตัวเลขแบบสุ่ม 10 ตัว และมีความปลอดภัยมากกว่า"
 
 # smartling.placeholder_format=C
 msgid "Ivory Coast"
@@ -10766,6 +10915,12 @@ msgid "Links:"
 msgstr "ลิงก์"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "List the tools, materials, or prerequisites I need for this."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
 msgid "Listen"
 msgstr "ฟัง"
@@ -11170,6 +11325,12 @@ msgstr "จัดการการสมัครของคุณ"
 msgctxt "Exclusion message manage sites button"
 msgid "Manage blocked sites"
 msgstr "จัดการเว็บไซต์ที่ถูกบล็อก"
+
+# smartling.placeholder_format=C
+#. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
+msgctxt "setting"
+msgid "Manage in Browser Settings"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to the site exclusion settings page
@@ -12142,11 +12303,9 @@ msgid ""
 "internet connection. Disabling chat history will delete pinned chats, and "
 "disable the temporary storage of new prompts and responses."
 msgstr ""
-"คำแนะนำใหม่และการตอบกลับจะถูกเข้ารหัสและเก็บไว้ชั่วคราวบนเซิร์ฟเวอร์ "
-"DuckDuckGo หลังจากที่ส่งไปแล้ว "
-"เพื่อช่วยกู้คืนการแชทหากคุณสูญเสียการเชื่อมต่ออินเทอร์เน็ต "
-"การปิดประวัติการแชทจะลบแชทที่ปักหมุด "
-"และปิดใช้งานการเก็บคำแนะนำและการตอบสนองใหม่ชั่วคราว"
+"คำแนะนำใหม่และการตอบกลับจะถูกเข้ารหัสและเก็บไว้ชั่วคราวบนเซิร์ฟเวอร์ DuckDuckGo "
+"หลังจากที่ส่งไปแล้ว เพื่อช่วยกู้คืนการแชทหากคุณสูญเสียการเชื่อมต่ออินเทอร์เน็ต "
+"การปิดประวัติการแชทจะลบแชทที่ปักหมุด และปิดใช้งานการเก็บคำแนะนำและการตอบสนองใหม่ชั่วคราว"
 
 # smartling.placeholder_format=C
 #. Question in a feedback form.
@@ -12962,8 +13121,8 @@ msgid ""
 "On Mac, %sClick Maxthon > Preferences%s, On Windows, %sClick the %s icon > "
 "Settings%s"
 msgstr ""
-"สำหรับ Mac %1$sให้คลิก Maxthon > ค่ากำหนด%2$s สำหรับ Windows "
-"%3$sให้คลิกไอคอน %4$s > การตั้งค่า%5$s"
+"สำหรับ Mac %1$sให้คลิก Maxthon > ค่ากำหนด%2$s สำหรับ Windows %3$sให้คลิกไอคอน %4$s "
+"> การตั้งค่า%5$s"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
@@ -12985,8 +13144,7 @@ msgid ""
 "One of the files attached has more pages than we support. Please upload "
 "files with %s pages or fewer."
 msgstr ""
-"ไฟล์ที่แนบมาไฟล์ใดไฟล์หนึ่งมีหน้าเว็บมากกว่าที่เรารองรับ "
-"โปรดอัปโหลดไฟล์ที่มี %1$s หน้าหรือน้อยกว่า"
+"ไฟล์ที่แนบมาไฟล์ใดไฟล์หนึ่งมีหน้าเว็บมากกว่าที่เรารองรับ โปรดอัปโหลดไฟล์ที่มี %1$s หน้าหรือน้อยกว่า"
 
 # smartling.placeholder_format=C
 #. Response a user can select in a feedback form, indicating that they heard about DuckDuckGo in an online article.
@@ -13012,9 +13170,7 @@ msgctxt "cloudsave"
 msgid ""
 "Only the settings that you have changed. They are detailed on the %sURL "
 "Parameters%s page."
-msgstr ""
-"เฉพาะการตั้งค่าที่คุณเปลี่ยนแปลงเท่านั้น "
-"มีรายละเอียดอยู่ในหน้า%1$sพารามิเตอร์ URL%2$s"
+msgstr "เฉพาะการตั้งค่าที่คุณเปลี่ยนแปลงเท่านั้น มีรายละเอียดอยู่ในหน้า%1$sพารามิเตอร์ URL%2$s"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers only when the user clicks the Assist button.
@@ -13345,8 +13501,7 @@ msgid ""
 "Other search engines track your searches even when you’re in private "
 "browsing mode. We don’t track you &mdash; period."
 msgstr ""
-"เครื่องมือค้นหาอื่นๆ "
-"จะติดตามการค้นหาของคุณแม้ว่าคุณจะอยู่ในโหมดการท่องเว็บแบบส่วนตัว "
+"เครื่องมือค้นหาอื่นๆ จะติดตามการค้นหาของคุณแม้ว่าคุณจะอยู่ในโหมดการท่องเว็บแบบส่วนตัว "
 "แต่เราไม่ติดตามคุณอย่างแน่นอน"
 
 # smartling.placeholder_format=C
@@ -13360,8 +13515,7 @@ msgid ""
 "Our privacy policy is simple: we don’t collect or share any of your personal "
 "information."
 msgstr ""
-"นโยบายความเป็นส่วนตัวของเราเป็นเรื่องง่าย: "
-"เราไม่ได้เก็บรวบรวมหรือแชร์ข้อมูลส่วนบุคคลของคุณ"
+"นโยบายความเป็นส่วนตัวของเราเป็นเรื่องง่าย: เราไม่ได้เก็บรวบรวมหรือแชร์ข้อมูลส่วนบุคคลของคุณ"
 
 # smartling.placeholder_format=C
 msgid ""
@@ -13369,9 +13523,8 @@ msgid ""
 "tracker blocker, encryption enforcer, and more. Available on %siOS & "
 "Android%s."
 msgstr ""
-"เบราว์เซอร์ส่วนตัวสำหรับอุปกรณ์มือถือของเรานั้นมาพร้อมกับเครื่องมือค้นหา "
-"เครื่องมือบล็อกตัวติดตาม เครื่องมือบังคับใช้การเข้ารหัส และอื่นๆ อีกมากมาย "
-"พร้อมใช้งานบน %1$siOS และ Android%2$s"
+"เบราว์เซอร์ส่วนตัวสำหรับอุปกรณ์มือถือของเรานั้นมาพร้อมกับเครื่องมือค้นหา เครื่องมือบล็อกตัวติดตาม "
+"เครื่องมือบังคับใช้การเข้ารหัส และอื่นๆ อีกมากมาย พร้อมใช้งานบน %1$siOS และ Android%2$s"
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the information was out of date.
@@ -13624,8 +13777,8 @@ msgid ""
 "Passphrases cannot be recovered as we don't associate your IP address, "
 "browser fingerprint, or any other information with the file."
 msgstr ""
-"ไม่สามารถกู้คืนรหัสผ่านได้เนื่องจากเราไม่ได้เชื่อมโยงที่อยู่ IP, "
-"ลายนิ้วมือจากเบราว์เซอร์ หรือข้อมูลอื่นใดเกี่ยวกับไฟล์"
+"ไม่สามารถกู้คืนรหัสผ่านได้เนื่องจากเราไม่ได้เชื่อมโยงที่อยู่ IP, ลายนิ้วมือจากเบราว์เซอร์ "
+"หรือข้อมูลอื่นใดเกี่ยวกับไฟล์"
 
 # smartling.placeholder_format=C
 #. Label for the section of recent chats that were edited in the past 7 days.
@@ -13819,10 +13972,9 @@ msgid ""
 "answers. To turn them off and hide the Assist button visit %sSearch "
 "Settings%s."
 msgstr ""
-""
 "การเรียงถ้อยคำในการค้นหาให้เป็นคำถามและเป็นประโยคสมบูรณ์ทำให้คำตอบที่ได้รับความช่วยเหลือจาก "
-"AI มีแนวโน้มที่จะปรากฏขึ้นโดยอัตโนมัติและมักจะให้คำตอบได้ดีกว่า "
-"หากต้องการปิดและซ่อนปุ่ม Assist ให้ไปที่ %1$sการตั้งค่าการค้นหา%2$s"
+"AI มีแนวโน้มที่จะปรากฏขึ้นโดยอัตโนมัติและมักจะให้คำตอบได้ดีกว่า หากต้องการปิดและซ่อนปุ่ม Assist "
+"ให้ไปที่ %1$sการตั้งค่าการค้นหา%2$s"
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -13832,9 +13984,8 @@ msgid ""
 "how this feature works, or to turn it off, visit %sDuckAssist Settings%s."
 msgstr ""
 "การเรียงถ้อยคำในการค้นหาให้เป็นคำถามและเป็นประโยคสมบูรณ์ทำให้ DuckAssist "
-"มีแนวโน้มที่จะปรากฏขึ้นและมักจะให้คำตอบที่ดีกว่า "
-"หากต้องการปรับวิธีการทํางานของคุณลักษณะนี้หรือปิด ให้ไปที่%1$sการตั้งค่า "
-"DuckAssist%2$s"
+"มีแนวโน้มที่จะปรากฏขึ้นและมักจะให้คำตอบที่ดีกว่า หากต้องการปรับวิธีการทํางานของคุณลักษณะนี้หรือปิด "
+"ให้ไปที่%1$sการตั้งค่า DuckAssist%2$s"
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -13845,8 +13996,8 @@ msgid ""
 "Settings%s."
 msgstr ""
 "การเรียงถ้อยคำในการค้นหาให้เป็นคำถามและเป็นประโยคสมบูรณ์ทำให้ DuckAssist "
-"มีแนวโน้มที่จะปรากฏขึ้นโดยอัตโนมัติและมักจะให้คำตอบได้ดีกว่า "
-"หากต้องการปิดและซ่อนปุ่ม Assist โปรดไปที่%1$sการตั้งค่า DuckAssist%2$s"
+"มีแนวโน้มที่จะปรากฏขึ้นโดยอัตโนมัติและมักจะให้คำตอบได้ดีกว่า หากต้องการปิดและซ่อนปุ่ม Assist "
+"โปรดไปที่%1$sการตั้งค่า DuckAssist%2$s"
 
 # smartling.placeholder_format=C
 #. Button that allows users to manually select a location on a map.
@@ -13894,9 +14045,7 @@ msgctxt "Third party map app picker"
 msgid ""
 "Pick a service to navigate to your destination. External apps won’t come "
 "with DuckDuckGo protections."
-msgstr ""
-"เลือกบริการเพื่อนำทางไปยังจุดหมายของคุณ แอปภายนอกจะไม่มีการป้องกันของ "
-"DuckDuckGo"
+msgstr "เลือกบริการเพื่อนำทางไปยังจุดหมายของคุณ แอปภายนอกจะไม่มีการป้องกันของ DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Label for a list of problems on a feedback form.
@@ -13991,6 +14140,12 @@ msgstr "โปรดทําชาเลนจ์ต่อไปนี้ให
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
+msgid "Please describe why the chat response is harmful or illegal. (optional)"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
+msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
 msgstr "ช่วยบอกหน่อยว่าทำไมการตอบกลับแชทถึงผิดกฎหมายหรือเป็นอันตราย (ไม่บังคับ)"
 
@@ -14013,6 +14168,14 @@ msgid ""
 "Please note: starting a new chat with any model will delete your current "
 "chat session."
 msgstr "โปรดทราบ: การเริ่มแชทใหม่กับโมเดลใดๆ จะเป็นการลบเซสชันการแชทปัจจุบันของคุณ"
+
+# smartling.placeholder_format=C
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
+msgctxt "Feedback prompt"
+msgid ""
+"Please paste your prompt and the problematic output (with any personal "
+"information removed) and describe why the content is harmful or illegal."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -14480,6 +14643,12 @@ msgid "Privacy"
 msgstr "ความเป็นส่วนตัว"
 
 # smartling.placeholder_format=C
+#. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
+msgctxt "Section heading on the Duck.ai settings page"
+msgid "Privacy & Terms"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Privacy Blog"
 msgstr "บล็อกเกี่ยวกับความเป็นส่วนตัว"
 
@@ -14548,6 +14717,12 @@ msgstr "นโยบายความเป็นส่วนตัวและ
 msgctxt "Copy used to compose link in sentences"
 msgid "Privacy Policy and Terms of Service"
 msgstr "นโยบายความเป็นส่วนตัวและข้อกำหนดในการให้บริการ"
+
+# smartling.placeholder_format=C
+#. Text for a button that links to the terms of use and privacy policy page.
+msgctxt "Secondary button text in active privacy modal"
+msgid "Privacy Policy and Terms of Service"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title displayed on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
@@ -14763,9 +14938,7 @@ msgctxt "Full sentence for critiquing writing"
 msgid ""
 "Provide a few suggestions to make the following text more concise. [Insert "
 "your own text here.]"
-msgstr ""
-"ให้คำแนะนำสองสามข้อเพื่อให้ข้อความต่อไปนี้กระชับมากขึ้น "
-"[แทรกข้อความของคุณเองที่นี่]"
+msgstr "ให้คำแนะนำสองสามข้อเพื่อให้ข้อความต่อไปนี้กระชับมากขึ้น [แทรกข้อความของคุณเองที่นี่]"
 
 # smartling.placeholder_format=C
 #. In the context of a standings table for NHL (hockey), column title that abbreviates 'Total Points' (the total points of this team)
@@ -15024,9 +15197,8 @@ msgid ""
 "sent, to help recover a chat if you lose your internet connection."
 msgstr ""
 "การแชทล่าสุดจะถูกจัดเก็บไว้ในอุปกรณ์ของคุณ "
-"คำแนะนำใหม่และการตอบกลับจะถูกเข้ารหัสและเก็บไว้ชั่วคราวบนเซิร์ฟเวอร์ของ "
-"DuckDuckGo หลังจากที่ส่งไปแล้ว "
-"เพื่อช่วยกู้คืนการแชทหากคุณสูญเสียการเชื่อมต่ออินเทอร์เน็ต"
+"คำแนะนำใหม่และการตอบกลับจะถูกเข้ารหัสและเก็บไว้ชั่วคราวบนเซิร์ฟเวอร์ของ DuckDuckGo "
+"หลังจากที่ส่งไปแล้ว เพื่อช่วยกู้คืนการแชทหากคุณสูญเสียการเชื่อมต่ออินเทอร์เน็ต"
 
 # smartling.placeholder_format=C
 msgctxt "region filter"
@@ -15048,6 +15220,30 @@ msgstr "สูตรสําหรับ %1$s%2$s%3$s"
 msgctxt "Brief for recommending a book"
 msgid "Recommend a book"
 msgstr "แนะนำหนังสือ"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar books"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar books."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar movies or shows."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar titles"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
@@ -15260,8 +15456,8 @@ msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
 msgstr ""
-"รีโหลด DuckDuckGo โดยทำตามคำแนะนำ หรือคลิกปุ่ม &quot;รีเฟรช&quot; หรือ "
-"&quot;รีโหลด&quot; ของเบราว์เซอร์ของคุณ"
+"รีโหลด DuckDuckGo โดยทำตามคำแนะนำ หรือคลิกปุ่ม &quot;รีเฟรช&quot; หรือ &quot;"
+"รีโหลด&quot; ของเบราว์เซอร์ของคุณ"
 
 # smartling.placeholder_format=C
 #. checkbox label that allows the user to save the setting
@@ -15351,8 +15547,7 @@ msgid ""
 "Removes the \"Ask\" button so answers appear automatically in response to "
 "relevant searches. Cached answers always display automatically."
 msgstr ""
-"นำปุ่ม \"ถาม\" ออก "
-"เพื่อให้คำตอบปรากฏขึ้นโดยอัตโนมัติตามการค้นหาที่เกี่ยวข้อง "
+"นำปุ่ม \"ถาม\" ออก เพื่อให้คำตอบปรากฏขึ้นโดยอัตโนมัติตามการค้นหาที่เกี่ยวข้อง "
 "คำตอบที่เก็บไว้จะแสดงโดยอัตโนมัติเสมอ"
 
 # smartling.placeholder_format=C
@@ -15361,8 +15556,7 @@ msgid ""
 "Removes the \"Generate\" button so answers appear automatically in response "
 "to relevant searches. Cached answers always display automatically."
 msgstr ""
-"นำปุ่ม \"สร้าง\" ออก "
-"เพื่อให้คำตอบปรากฏขึ้นโดยอัตโนมัติตามการค้นหาที่เกี่ยวข้อง "
+"นำปุ่ม \"สร้าง\" ออก เพื่อให้คำตอบปรากฏขึ้นโดยอัตโนมัติตามการค้นหาที่เกี่ยวข้อง "
 "คำตอบที่เก็บไว้จะแสดงโดยอัตโนมัติเสมอ"
 
 # smartling.placeholder_format=C
@@ -15421,9 +15615,8 @@ msgid ""
 "service. Your anonymous feedback is also shared with %s to help improve "
 "their services."
 msgstr ""
-"การรายงานจะไม่ระบุชื่อและส่งไปยัง DuckDuckGo "
-"เพื่อช่วยปรับปรุงบริการค้นหาของเรา ข้อเสนอแนะที่ไม่ระบุตัวตนของคุณจะแชร์กับ "
-"%1$s เพื่อช่วยปรับปรุงบริการ"
+"การรายงานจะไม่ระบุชื่อและส่งไปยัง DuckDuckGo เพื่อช่วยปรับปรุงบริการค้นหาของเรา "
+"ข้อเสนอแนะที่ไม่ระบุตัวตนของคุณจะแชร์กับ %1$s เพื่อช่วยปรับปรุงบริการ"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -15431,8 +15624,8 @@ msgid ""
 "Reports sent to DuckDuckGo are anonymous. Please do not include any personal "
 "or identifying information in your feedback."
 msgstr ""
-"รายงานที่ส่งไปยัง DuckDuckGo จะไม่ระบุชื่อ "
-"โปรดอย่าใส่ข้อมูลส่วนตัวหรือข้อมูลระบุตัวตนใดๆ ลงในข้อเสนอแนะของคุณ"
+"รายงานที่ส่งไปยัง DuckDuckGo จะไม่ระบุชื่อ โปรดอย่าใส่ข้อมูลส่วนตัวหรือข้อมูลระบุตัวตนใดๆ "
+"ลงในข้อเสนอแนะของคุณ"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -15441,13 +15634,21 @@ msgid ""
 "translate during this page load, and are anonymous. Please do not include "
 "any personal or identifying information in your feedback."
 msgstr ""
-"รายงานที่ส่งไปยัง DuckDuckGo "
-"รวมข้อความทั้งหมดที่คุณขอให้เราแปลในระหว่างการโหลดหน้านี้ และจะไม่ระบุตัวตน "
-"โปรดอย่าใส่ข้อมูลส่วนตัวหรือข้อมูลระบุตัวตนใด ๆ ลงในข้อเสนอแนะของคุณ"
+"รายงานที่ส่งไปยัง DuckDuckGo รวมข้อความทั้งหมดที่คุณขอให้เราแปลในระหว่างการโหลดหน้านี้ "
+"และจะไม่ระบุตัวตน โปรดอย่าใส่ข้อมูลส่วนตัวหรือข้อมูลระบุตัวตนใด ๆ ลงในข้อเสนอแนะของคุณ"
 
 # smartling.placeholder_format=C
 msgid "Republic of Moldova"
 msgstr "สาธารณรัฐมอลโดวา"
+
+# smartling.placeholder_format=C
+#. Note indicating that sharing the conversation is mandatory when reporting harmful or illegal content. Rendered alongside the standard share label (DUCKCHAT_RESPONSE_FEEDBACK_SHARE_PROMPT_RESPONSE_LABEL), not replacing it.
+msgctxt ""
+"Note shown under the share-content switch label on the Duck.ai response "
+"feedback form when the user has selected Harmful or Illegal as the feedback "
+"reason"
+msgid "Required for harmful or illegal reports"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
@@ -15514,9 +15715,8 @@ msgid ""
 "legal, financial, investment, or other professional advice. AI-assisted "
 "answers are subject to our %sTerms of Service%s."
 msgstr ""
-"คำตอบเหล่านี้มีวัตถุประสงค์เพื่อการศึกษาเท่านั้น "
-"และไม่มีเจตนาให้เป็นคำแนะนำทางการแพทย์ กฎหมาย การเงิน การลงทุน "
-"หรือคำแนะนำทางวิชาชีพอื่นๆ คำตอบที่ได้รับความช่วยเหลือจาก AI อยู่ภายใต้ "
+"คำตอบเหล่านี้มีวัตถุประสงค์เพื่อการศึกษาเท่านั้น และไม่มีเจตนาให้เป็นคำแนะนำทางการแพทย์ กฎหมาย "
+"การเงิน การลงทุน หรือคำแนะนำทางวิชาชีพอื่นๆ คำตอบที่ได้รับความช่วยเหลือจาก AI อยู่ภายใต้ "
 "%1$sข้อกำหนดในการให้บริการ%2$sของเรา"
 
 # smartling.placeholder_format=C
@@ -15526,9 +15726,8 @@ msgid ""
 "legal, financial, investment, or other professional advice. DuckAssist is "
 "subject to our %sTerms of Service%s."
 msgstr ""
-"คำตอบเหล่านี้มีวัตถุประสงค์เพื่อการศึกษาเท่านั้น "
-"และไม่มีเจตนาให้เป็นคำแนะนำทางการแพทย์ กฎหมาย การเงิน การลงทุน "
-"หรือคำแนะนำทางวิชาชีพอื่นๆ DuckAssist "
+"คำตอบเหล่านี้มีวัตถุประสงค์เพื่อการศึกษาเท่านั้น และไม่มีเจตนาให้เป็นคำแนะนำทางการแพทย์ กฎหมาย "
+"การเงิน การลงทุน หรือคำแนะนำทางวิชาชีพอื่นๆ DuckAssist "
 "อยู่ภายใต้%1$sข้อกำหนดในการให้บริการ%2$sของเรา"
 
 # smartling.placeholder_format=C
@@ -15539,11 +15738,10 @@ msgid ""
 "generated based on web content and may contain inaccuracies. Search Assist "
 "is subject to our %sTerms of Service%s."
 msgstr ""
-"คำตอบเหล่านี้มีวัตถุประสงค์เพื่อการศึกษาเท่านั้น "
-"และไม่มีเจตนาให้เป็นคำแนะนำทางการแพทย์ กฎหมาย การเงิน การลงทุน "
-"หรือคำแนะนำทางวิชาชีพอื่น ๆ "
-"ข้อมูลเหล่านี้ถูกสร้างขึ้นจากเนื้อหาบนเว็บและอาจมีความไม่ถูกต้อง Search "
-"Assist อยู่ภายใต้ %1$sข้อกำหนดการให้บริการ%2$sของเรา"
+"คำตอบเหล่านี้มีวัตถุประสงค์เพื่อการศึกษาเท่านั้น และไม่มีเจตนาให้เป็นคำแนะนำทางการแพทย์ กฎหมาย "
+"การเงิน การลงทุน หรือคำแนะนำทางวิชาชีพอื่น ๆ "
+"ข้อมูลเหล่านี้ถูกสร้างขึ้นจากเนื้อหาบนเว็บและอาจมีความไม่ถูกต้อง Search Assist อยู่ภายใต้ "
+"%1$sข้อกำหนดการให้บริการ%2$sของเรา"
 
 # smartling.placeholder_format=C
 #. Label on the button for restoring all previous website data.
@@ -15685,6 +15883,12 @@ msgstr "รีวิว"
 msgctxt "maps_places"
 msgid "Reviews"
 msgstr "รีวิว"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Rewrite this recipe scaled for a different number of servings."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Romania"
@@ -16100,8 +16304,7 @@ msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)"
 msgstr ""
-"เลื่อนลงและมองหา%1$sค้นหาในแถบที่อยู่%2$s คลิกที่%3$sเปลี่ยนแปลง%4$s "
-"(หรือ%5$sเพิ่มใหม่%6$s)"
+"เลื่อนลงและมองหา%1$sค้นหาในแถบที่อยู่%2$s คลิกที่%3$sเปลี่ยนแปลง%4$s (หรือ%5$sเพิ่มใหม่%6$s)"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
@@ -16110,8 +16313,7 @@ msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)."
 msgstr ""
-"เลื่อนลงและมองหา%1$sค้นหาในแถบที่อยู่%2$s คลิกที่%3$sเปลี่ยนแปลง%4$s (หรือ "
-"%5$sเพิ่มใหม่%6$s)"
+"เลื่อนลงและมองหา%1$sค้นหาในแถบที่อยู่%2$s คลิกที่%3$sเปลี่ยนแปลง%4$s (หรือ %5$sเพิ่มใหม่%6$s)"
 
 # smartling.placeholder_format=C
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -16184,11 +16386,10 @@ msgid ""
 "subset of English speaking regions."
 msgstr ""
 "Search Assist สร้างคำตอบสำหรับคำค้นหาโดยไม่ระบุชื่อ ในการดำเนินการนี้ "
-"ระบบจะสแกนเว็บเพื่อหาเนื้อหาที่เกี่ยวข้อง จากนั้นใช้ AI เพื่อสร้างคำตอบสั้น "
-"ๆ คุณสามารถเลือกได้ว่าต้องการให้มันปรากฏบ่อยแค่ไหน: ไม่เคย, ตามต้องการ "
-"(เฉพาะเมื่อคลิก Assist), บางครั้ง (เมื่อมีความเกี่ยวข้องสูง) หรือบ่อยครั้ง "
-"(ในการค้นหาที่หลากหลาย) สำหรับตอนนี้ Search Assist "
-"มีให้บริการเฉพาะในบางภูมิภาคที่ใช้ภาษาอังกฤษเท่านั้น"
+"ระบบจะสแกนเว็บเพื่อหาเนื้อหาที่เกี่ยวข้อง จากนั้นใช้ AI เพื่อสร้างคำตอบสั้น ๆ "
+"คุณสามารถเลือกได้ว่าต้องการให้มันปรากฏบ่อยแค่ไหน: ไม่เคย, ตามต้องการ (เฉพาะเมื่อคลิก "
+"Assist), บางครั้ง (เมื่อมีความเกี่ยวข้องสูง) หรือบ่อยครั้ง (ในการค้นหาที่หลากหลาย) สำหรับตอนนี้ "
+"Search Assist มีให้บริการเฉพาะในบางภูมิภาคที่ใช้ภาษาอังกฤษเท่านั้น"
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI) when the answer is not found and the answer is unsourced or with no sources
@@ -16196,8 +16397,7 @@ msgid ""
 "Search Assist couldn't find enough reliable information to generate an "
 "answer for this question. Try another search."
 msgstr ""
-"Search Assist ไม่พบข้อมูลที่เชื่อถือได้เพียงพอเพื่อสร้างคำตอบสำหรับคำถามนี้ "
-"ลองค้นหาอีกครั้ง"
+"Search Assist ไม่พบข้อมูลที่เชื่อถือได้เพียงพอเพื่อสร้างคำตอบสำหรับคำถามนี้ ลองค้นหาอีกครั้ง"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -16206,9 +16406,9 @@ msgid ""
 "search queries. To do this, it %sscans the web%s for relevant content and "
 "then uses AI to generate a brief answer based on information found."
 msgstr ""
-"Search Assist เป็นฟีเจอร์เสริมที่สร้างคำตอบสำหรับคำค้นหาโดยไม่ระบุชื่อ "
-"ในการทำเช่นนี้ ระบบจะสแกนเว็บเพื่อหาเนื้อหาที่เกี่ยวข้อง %1$s%2$s จากนั้นใช้ "
-"AI เพื่อสร้างคำตอบสั้น ๆ ตามข้อมูลที่พบ"
+"Search Assist เป็นฟีเจอร์เสริมที่สร้างคำตอบสำหรับคำค้นหาโดยไม่ระบุชื่อ ในการทำเช่นนี้ "
+"ระบบจะสแกนเว็บเพื่อหาเนื้อหาที่เกี่ยวข้อง %1$s%2$s จากนั้นใช้ AI เพื่อสร้างคำตอบสั้น ๆ "
+"ตามข้อมูลที่พบ"
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/search_box. top header
@@ -16329,8 +16529,8 @@ msgid ""
 "Search other sites with %s shortcuts: a search for ”!w ducks” will search "
 "for “ducks” directly on Wikipedia."
 msgstr ""
-"ค้นหาเว็บไซต์อื่นด้วยทางลัด %1$s: การค้นหา \"!w ducks\" จะค้นหา \"ducks\" "
-"โดยตรงบน Wikipedia"
+"ค้นหาเว็บไซต์อื่นด้วยทางลัด %1$s: การค้นหา \"!w ducks\" จะค้นหา \"ducks\" โดยตรงบน "
+"Wikipedia"
 
 # smartling.placeholder_format=C
 #. Placeholder text for the search form when no text has been entered
@@ -16350,8 +16550,8 @@ msgid ""
 "favorite browser, or search directly at %sduckduckgo.com%s."
 msgstr ""
 "ค้นหาอย่างเป็นส่วนตัวด้วยแอปหรือส่วนขยายของเรา "
-"เพิ่มการค้นหาเว็บแบบส่วนตัวลงในเบราว์เซอร์โปรดของคุณ หรือค้นหาโดยตรงที่ "
-"%1$sduckduckgo.com%2$s"
+"เพิ่มการค้นหาเว็บแบบส่วนตัวลงในเบราว์เซอร์โปรดของคุณ หรือค้นหาโดยตรงที่ %1$sduckduckgo."
+"com%2$s"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/6LZAoqH.png
@@ -16370,10 +16570,8 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-""
 "การตั้งค่าการค้นหาจะถูกเก็บไว้ในคุกกี้เบราว์เซอร์ที่ไม่ใช่ส่วนบุคคลและที่เก็บข้อมูลภายในในเบราว์เซอร์ของคุณ "
 "แต่คุณยังสามารถใช้ Cloud Save "
-""
 "เพื่อจัดเก็บการตั้งค่าของคุณโดยไม่ระบุตัวตนบนเซิร์ฟเวอร์ระยะไกลในคลาวด์ได้อีกด้วย "
 "จะไม่มีการจัดเก็บข้อมูลที่สามารถระบุถึงตัวบุคคลได้บนระบบคลาวด์ "
 "และวลีรหัสผ่านของคุณจะอยู่บนเบราว์เซอร์ของคุณเท่านั้น"
@@ -16489,7 +16687,6 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your synced devices."
 msgstr ""
-""
 "จัดเก็บแชทได้เกือบไม่จำกัดบนเซิร์ฟเวอร์ของเราอย่างปลอดภัยด้วยการเข้ารหัสแบบครบวงจร "
 "และเข้าถึงได้จากอุปกรณ์ที่ซิงค์ทั้งหมดของคุณ"
 
@@ -16662,8 +16859,7 @@ msgstr "เลือก %1$s\"การตั้งค่าสำหรับ�
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
 msgstr ""
-"เลือก%1$sกำหนดเอง%2$s และป้อน %3$shttps://duckduckgo.com%4$s "
-"ลงในช่องการป้อนข้อมูล"
+"เลือก%1$sกำหนดเอง%2$s และป้อน %3$shttps://duckduckgo.com%4$s ลงในช่องการป้อนข้อมูล"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
@@ -16728,8 +16924,7 @@ msgstr "เลือก%1$sจัดการส่วนเสริม%2$sจ�
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sMenu > Settings%s (on Windows)"
 msgstr ""
-"เลือก %1$sOpera > ค่ากำหนด%2$s (บน Mac) หรือ%3$sเมนู > การตั้งค่า%4$s (บน "
-"Windows)"
+"เลือก %1$sOpera > ค่ากำหนด%2$s (บน Mac) หรือ%3$sเมนู > การตั้งค่า%4$s (บน Windows)"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -16737,8 +16932,7 @@ msgstr ""
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sOpera > Options%s (on Windows)"
 msgstr ""
-"เลือก %1$sOpera > ค่ากำหนด%2$s (บน Mac) หรือ %3$sOpera > ตัวเลือก%4$s (บน "
-"Windows)"
+"เลือก %1$sOpera > ค่ากำหนด%2$s (บน Mac) หรือ %3$sOpera > ตัวเลือก%4$s (บน Windows)"
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -16802,9 +16996,7 @@ msgstr "เลือก%1$sการตั้งค่า%2$s จากนั้
 msgid ""
 "Select %sUse this webpage as your only home page%s (or one of the other "
 "options if you prefer)"
-msgstr ""
-"เลือก%1$sใช้หน้าเว็บนี้เป็นหน้าหลักเดียวของคุณ%2$s (หรือหนึ่งในตัวเลือกอื่นๆ "
-"ตามต้องการ)"
+msgstr "เลือก%1$sใช้หน้าเว็บนี้เป็นหน้าหลักเดียวของคุณ%2$s (หรือหนึ่งในตัวเลือกอื่นๆ ตามต้องการ)"
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
@@ -16926,8 +17118,7 @@ msgid ""
 "respond. These instructions will apply to all of your conversations going "
 "forward."
 msgstr ""
-"ส่งพรอมต์ไปยังโมเดล AI "
-"พร้อมกับข้อความของคุณและคำแนะนำเกี่ยวกับวิธีการตอบกลับ "
+"ส่งพรอมต์ไปยังโมเดล AI พร้อมกับข้อความของคุณและคำแนะนำเกี่ยวกับวิธีการตอบกลับ "
 "คำแนะนำเหล่านี้จะใช้กับการสนทนาทั้งหมดของคุณต่อไป"
 
 # smartling.placeholder_format=C
@@ -17004,6 +17195,12 @@ msgid "Set Up Now"
 msgstr "ตั้งค่าตอนนี้"
 
 # smartling.placeholder_format=C
+#. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
+msgctxt "Encrypted storage setup button shown in native browsers"
+msgid "Set Up Sync & Backup"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
 msgctxt "Title for the Sync & Backup intro screen"
 msgid "Set Up Sync & Backup"
@@ -17032,16 +17229,13 @@ msgid ""
 "Set up Sync & Backup after turning on Chat History to keep your chats synced "
 "across devices."
 msgstr ""
-"ตั้งค่า Sync & Backup "
-"หลังจากเปิดประวัติการแชทเพื่อให้การแชทของคุณซิงค์กันระหว่างอุปกรณ์ต่างๆ"
+"ตั้งค่า Sync & Backup หลังจากเปิดประวัติการแชทเพื่อให้การแชทของคุณซิงค์กันระหว่างอุปกรณ์ต่างๆ"
 
 # smartling.placeholder_format=C
 #. Prompt for the user to indicate their location on a map, to enable more relevant search results.
 msgctxt "precise_user_location"
 msgid "Set your location manually, or ensure Location Services is enabled."
-msgstr ""
-"ตั้งค่าตำแหน่งที่ตั้งของคุณด้วยตนเอง "
-"หรือตรวจสอบให้แน่ใจว่าได้เปิดใช้งานบริการตำแหน่งที่ตั้ง"
+msgstr "ตั้งค่าตำแหน่งที่ตั้งของคุณด้วยตนเอง หรือตรวจสอบให้แน่ใจว่าได้เปิดใช้งานบริการตำแหน่งที่ตั้ง"
 
 # smartling.placeholder_format=C
 #. In the top dropdown menu  ("More" > "Settings")
@@ -17182,6 +17376,13 @@ msgstr "แชร์ URL ของหน้า"
 msgctxt "feedback form"
 msgid "Share positive feedback"
 msgstr "แชร์ข้อเสนอแนะเชิงบวก"
+
+# smartling.placeholder_format=C
+#. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
+msgctxt ""
+"Label beside the share-content switch on the Duck.ai response feedback form"
+msgid "Share this conversation with DuckDuckGo"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -17594,8 +17795,7 @@ msgctxt "settings"
 msgid ""
 "Shows occasional reminders to sign up for the DuckDuckGo privacy newsletters"
 msgstr ""
-"แสดงการแจ้งเตือนเป็นครั้งคราวให้สมัครรับจดหมายข่าวเกี่ยวกับความเป็นส่วนตัวของ "
-"DuckDuckGo"
+"แสดงการแจ้งเตือนเป็นครั้งคราวให้สมัครรับจดหมายข่าวเกี่ยวกับความเป็นส่วนตัวของ DuckDuckGo"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -17937,9 +18137,7 @@ msgctxt "noresults"
 msgid ""
 "Sorry, we ran into an error displaying these results. %sClick here%s to try "
 "again."
-msgstr ""
-"ขออภัย เราพบข้อผิดพลาดในการแสดงผลลัพธ์เหล่านี้ %1$sคลิกที่นี่%2$s "
-"เพื่อลองอีกครั้ง"
+msgstr "ขออภัย เราพบข้อผิดพลาดในการแสดงผลลัพธ์เหล่านี้ %1$sคลิกที่นี่%2$s เพื่อลองอีกครั้ง"
 
 # smartling.placeholder_format=C
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
@@ -18412,15 +18610,31 @@ msgctxt "Full sentence for composing a card"
 msgid ""
 "Suggest a phrase to write on a get-well card for someone recovering from a "
 "surgery?"
-msgstr ""
-"เสนอแนะวลีที่จะเขียนลงในการ์ดอวยพรให้หายไว ๆ "
-"สำหรับผู้ที่ฟื้นตัวจากการผ่าตัดหรือไม่"
+msgstr "เสนอแนะวลีที่จะเขียนลงในการ์ดอวยพรให้หายไว ๆ สำหรับผู้ที่ฟื้นตัวจากการผ่าตัดหรือไม่"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for asking for a suggestion of a blog post title.
 msgctxt "Brief for suggesting a blog post title"
 msgid "Suggest a title for a blog post"
 msgstr "แนะนําชื่อสําหรับบล็อกโพสต์"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest related articles or topics worth exploring next."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Suggest related articles to explore"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest some alternatives to this product."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
@@ -18434,10 +18648,100 @@ msgid "Suggestions:"
 msgstr "คำแนะนำ:"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Sum up the reviews"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A short title for the a message asking the AI to summarize a text.
 msgctxt "Title for the summarize message"
 msgid "Summarize"
 msgstr "สรุป"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize the Q&As"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the background and notable work of this person."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the key details of this event."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the questions and answers on this page."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize their background"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this book"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this book."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this discussion"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this discussion thread."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this page"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this page."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this video"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this video."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize what the reviews say."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -18701,9 +19005,8 @@ msgid ""
 msgstr ""
 "รหัสกู้คืนการซิงค์\n"
 "\n"
-"รหัสกู้คืนช่วยให้คุณสามารถซิงค์รหัสผ่าน ข้อมูลการกรอกอัตโนมัติ และการแชท "
-"Duck.ai ของคุณระหว่างอุปกรณ์หลายเครื่อง "
-"และกู้คืนข้อมูลที่ซิงค์ไว้หากคุณสูญเสียการเข้าถึงอุปกรณ์\n"
+"รหัสกู้คืนช่วยให้คุณสามารถซิงค์รหัสผ่าน ข้อมูลการกรอกอัตโนมัติ และการแชท Duck.ai "
+"ของคุณระหว่างอุปกรณ์หลายเครื่อง และกู้คืนข้อมูลที่ซิงค์ไว้หากคุณสูญเสียการเข้าถึงอุปกรณ์\n"
 "\n"
 "เก็บรักษาข้อมูลนี้ให้ปลอดภัย\n"
 "ทุกคนที่มีสิทธิ์เข้าถึงรหัสนี้สามารถเข้าถึงข้อมูลที่ซิงค์ของคุณ\n"
@@ -18713,11 +19016,9 @@ msgstr ""
 "วิธีการทำงานของโค้ดนี้คืออะไร?\n"
 "1. ไปที่ Duck.ai ในเบราว์เซอร์ของคุณ แล้วเปิดการตั้งค่า Duck.ai\n"
 "2. เลือก \"เปิดใช้งาน Sync & Backup\" จากนั้นเลือก \"Recover Synced Data\"\n"
-"3. คัดลอกรหัสการกู้คืนด้านบนและวางลงในช่องที่ระบุว่า \"Paste your code "
-"here\"\n"
+"3. คัดลอกรหัสการกู้คืนด้านบนและวางลงในช่องที่ระบุว่า \"Paste your code here\"\n"
 "\n"
-"หากคุณไม่ได้ใช้เบราว์เซอร์ DuckDuckGo ที่มี Sync & Backup "
-"เปิดใช้งานเป็นเวลาเกิน 18 เดือน "
+"หากคุณไม่ได้ใช้เบราว์เซอร์ DuckDuckGo ที่มี Sync & Backup เปิดใช้งานเป็นเวลาเกิน 18 เดือน "
 "ข้อมูลของคุณจะถูกลบออกจากเซิร์ฟเวอร์และไม่สามารถกู้คืนได้"
 
 # smartling.placeholder_format=C
@@ -18761,6 +19062,12 @@ msgid "Syria"
 msgstr "ซีเรีย"
 
 # smartling.placeholder_format=C
+#. Text for a button that enables the theme to follow the operating system's color scheme preference.
+msgctxt "System theme button for theme selector"
+msgid "System"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Abbreviation indicating this is the total score for a game
 msgctxt "Sports module"
 msgid "T"
@@ -18787,6 +19094,12 @@ msgstr "ทีวี"
 msgctxt "language_name"
 msgid "Tahitian"
 msgstr "ตาฮีตี"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Tailor my resume"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Taiwan"
@@ -18816,6 +19129,13 @@ msgstr "คุณควบคุมข้อมูลส่วนตัวขอ
 msgctxt "homepage ATB modal"
 msgid "Take control of your personal data!"
 msgstr "ควบคุมข้อมูลส่วนบุคคลของคุณเองได้"
+
+# smartling.placeholder_format=C
+#. Description for the Feedback section of the Duck.ai settings page, asking the user to take an anonymous survey to let us know how we can make Duck.ai better.
+msgctxt "Feedback section description on the Duck.ai settings page"
+msgid ""
+"Take this anonymous survey to let us know how we can make Duck.ai better."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -19030,7 +19350,6 @@ msgid ""
 "link is at increased risk of being intercepted by a third party. In rare "
 "cases this includes passwords, or payment details."
 msgstr ""
-""
 "นั่นหมายความว่าข้อมูลที่ส่งระหว่างอุปกรณ์ของคุณกับหน้าเว็บเบื้องหลังลิงก์นี้มีความเสี่ยงมากขึ้นต่อการถูกดักข้อมูลโดยบุคคลที่สาม "
 "ในบางกรณีซึ่งเกิดขึ้นไม่บ่อย ข้อมูลนี้รวมถึงรหัสผ่านหรือรายละเอียดการชำระเงิน"
 
@@ -19072,7 +19391,6 @@ msgid ""
 "The encryption key is only saved in your browser's local storage, and only "
 "you can access it."
 msgstr ""
-""
 "คีย์การเข้ารหัสจะถูกบันทึกไว้เฉพาะในที่เก็บข้อมูลในเครื่องของเบราว์เซอร์ของคุณ "
 "และมีเพียงคุณเท่านั้นที่สามารถเข้าถึงได้"
 
@@ -19095,9 +19413,7 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider does not save this chat or any associated data on their "
 "servers."
-msgstr ""
-"ผู้ให้บริการโมเดลไม่บันทึกการแชทนี้หรือข้อมูลที่เกี่ยวข้องใดๆ "
-"บนเซิร์ฟเวอร์ของเขา"
+msgstr "ผู้ให้บริการโมเดลไม่บันทึกการแชทนี้หรือข้อมูลที่เกี่ยวข้องใดๆ บนเซิร์ฟเวอร์ของเขา"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19120,6 +19436,12 @@ msgstr "เซิร์ฟเวอร์พบข้อผิดพลาด �
 #. https://duck.co/media/files/theme.png
 msgid "Theme"
 msgstr "ธีม"
+
+# smartling.placeholder_format=C
+#. Text for the theme selector label that allows users to switch between Light and dark theme.
+msgctxt "Label for the theme selector feature"
+msgid "Theme"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/LpFhb1e.png
@@ -19184,7 +19506,6 @@ msgid ""
 "visit by blocking hidden trackers, encrypting connections where possible, "
 "and by making DuckDuckGo your default search engine."
 msgstr ""
-""
 "สิทธิ์ของเบราว์เซอร์เหล่านี้ใช้เพื่อเพิ่มการปกป้องความเป็นส่วนตัวบนเว็บไซต์ที่คุณเยี่ยมชมโดยการบล็อกตัวติดตามที่ซ่อนอยู่ "
 "การเข้ารหัสการเชื่อมต่อเมื่อสามารถทำได้ และการตั้งค่าให้ DuckDuckGo "
 "เป็นเครื่องมือค้นหาเริ่มต้นของคุณ"
@@ -19232,9 +19553,7 @@ msgctxt "AI Chat: Error message for when a model is deprecated"
 msgid ""
 "This AI model version is no longer supported. Try starting a new chat with "
 "the latest version of this model."
-msgstr ""
-"เวอร์ชันของโมเดล AI นี้ไม่ได้รับการสนับสนุนอีกต่อไป "
-"ลองเริ่มแชทใหม่ด้วยโมเดลรุ่นล่าสุด"
+msgstr "เวอร์ชันของโมเดล AI นี้ไม่ได้รับการสนับสนุนอีกต่อไป ลองเริ่มแชทใหม่ด้วยโมเดลรุ่นล่าสุด"
 
 # smartling.placeholder_format=C
 #. Appears below a type of search results called 'Instant Answers'
@@ -19293,9 +19612,8 @@ msgid ""
 "Model. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
 msgstr ""
-"การสนทนานี้สร้างขึ้นด้วย DuckDuckGo AI Chat (%1$s) โดยใช้โมเดล %3$s ของ %2$s "
-"แชท AI อาจแสดงข้อมูลที่ไม่ถูกต้องหรือไม่เหมาะสม (ดู %4$s "
-"สำหรับข้อมูลเพิ่มเติม)"
+"การสนทนานี้สร้างขึ้นด้วย DuckDuckGo AI Chat (%1$s) โดยใช้โมเดล %3$s ของ %2$s แชท AI "
+"อาจแสดงข้อมูลที่ไม่ถูกต้องหรือไม่เหมาะสม (ดู %4$s สำหรับข้อมูลเพิ่มเติม)"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
@@ -19399,8 +19717,8 @@ msgid ""
 "This model provider deletes data associated with this chat within 30 days. "
 "Other model providers follow a zero data retention model."
 msgstr ""
-"ผู้ให้บริการโมเดลจะลบข้อมูลที่เกี่ยวข้องกับแชทนี้ภายใน 30 วัน "
-"ผู้ให้บริการโมเดลอื่นๆ เป็นไปตามโมเดลการเก็บรักษาข้อมูลเป็นศูนย์"
+"ผู้ให้บริการโมเดลจะลบข้อมูลที่เกี่ยวข้องกับแชทนี้ภายใน 30 วัน ผู้ให้บริการโมเดลอื่นๆ "
+"เป็นไปตามโมเดลการเก็บรักษาข้อมูลเป็นศูนย์"
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers, and that other providers may retain chat data for a limited time instead.
@@ -19409,8 +19727,8 @@ msgid ""
 "This model provider does not store any data associated with this chat. Other "
 "model providers follow a limited data retention model."
 msgstr ""
-"ผู้ให้บริการโมเดลนี้ไม่ได้เก็บข้อมูลใดๆ ที่เกี่ยวข้องกับการแชทนี้ "
-"ผู้ให้บริการโมเดลอื่นๆ ใช้โมเดลการเก็บรักษาข้อมูลที่จํากัด"
+"ผู้ให้บริการโมเดลนี้ไม่ได้เก็บข้อมูลใดๆ ที่เกี่ยวข้องกับการแชทนี้ ผู้ให้บริการโมเดลอื่นๆ "
+"ใช้โมเดลการเก็บรักษาข้อมูลที่จํากัด"
 
 # smartling.placeholder_format=C
 #. Info that page may refresh during update.
@@ -19447,7 +19765,6 @@ msgid ""
 "This saves your chats with end-to-end encryption on DuckDuckGo's secure "
 "server, which later can be accessed from any browser."
 msgstr ""
-""
 "การดำเนินการนี้จะบันทึกการแชทของคุณด้วยการเข้ารหัสแบบครบวงจรบนเซิร์ฟเวอร์ที่ปลอดภัยของ "
 "DuckDuckGo ซึ่งต่อมาสามารถเข้าถึงได้จากเบราว์เซอร์ใดก็ตาม"
 
@@ -19458,9 +19775,8 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again."
 msgstr ""
-"การตั้งค่านี้ถูกเก็บไว้ในเบราว์เซอร์ของคุณ "
-"ซึ่งหมายความว่าถ้าคุณล้างข้อมูลเบราว์เซอร์บน duckduckgo.com "
-"คุณอาจเห็นคำตอบที่ได้รับความช่วยเหลือจาก AI อีกครั้ง"
+"การตั้งค่านี้ถูกเก็บไว้ในเบราว์เซอร์ของคุณ ซึ่งหมายความว่าถ้าคุณล้างข้อมูลเบราว์เซอร์บน "
+"duckduckgo.com คุณอาจเห็นคำตอบที่ได้รับความช่วยเหลือจาก AI อีกครั้ง"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -19470,9 +19786,8 @@ msgid ""
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
 msgstr ""
-"การตั้งค่านี้ถูกเก็บไว้ในเบราว์เซอร์ของคุณ "
-"ซึ่งหมายความว่าถ้าคุณล้างข้อมูลเบราว์เซอร์บน duckduckgo.com "
-"คุณอาจเห็นคำตอบที่ได้รับความช่วยเหลือจาก AI อีกครั้ง อย่างไรก็ตาม "
+"การตั้งค่านี้ถูกเก็บไว้ในเบราว์เซอร์ของคุณ ซึ่งหมายความว่าถ้าคุณล้างข้อมูลเบราว์เซอร์บน "
+"duckduckgo.com คุณอาจเห็นคำตอบที่ได้รับความช่วยเหลือจาก AI อีกครั้ง อย่างไรก็ตาม "
 "เรามีหน้าเริ่มต้นที่ไม่แสดงคำตอบที่ได้รับความช่วยเหลือจาก AI ด้วยที่ %1$s"
 
 # smartling.placeholder_format=C
@@ -19512,9 +19827,8 @@ msgid ""
 "Sync & Backup. You'll still be able to access your chats in other browsers "
 "connected to Sync & Backup."
 msgstr ""
-"การกระทำนี้จะลบการแชท Duck.ai ทั้งหมดจากเบราว์เซอร์นี้ และตัดการเชื่อมต่อ "
-"Sync & Backup คุณยังสามารถเข้าถึงการแชทของคุณในเบราว์เซอร์อื่นๆ "
-"ที่เชื่อมต่อกับ Sync & Backup"
+"การกระทำนี้จะลบการแชท Duck.ai ทั้งหมดจากเบราว์เซอร์นี้ และตัดการเชื่อมต่อ Sync & Backup "
+"คุณยังสามารถเข้าถึงการแชทของคุณในเบราว์เซอร์อื่นๆ ที่เชื่อมต่อกับ Sync & Backup"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to clear all recentchats, with a warning that this action cannot be undone.
@@ -19523,8 +19837,8 @@ msgid ""
 "This will delete all your recent chats, unless they're pinned. This cannot "
 "be undone."
 msgstr ""
-"การดำเนินการนี้จะลบการแชททั้งหมดของคุณเมื่อเร็วๆ นี้ "
-"เว้นแต่ว่าจะมีการปักหมุดไว้ การกระทำนี้ย้อนกลับไม่ได้"
+"การดำเนินการนี้จะลบการแชททั้งหมดของคุณเมื่อเร็วๆ นี้ เว้นแต่ว่าจะมีการปักหมุดไว้ "
+"การกระทำนี้ย้อนกลับไม่ได้"
 
 # smartling.placeholder_format=C
 #. Message explaining what will happen when the user deletes an image.
@@ -19542,9 +19856,7 @@ msgstr "การตั้งค่าทั้งหมดของคุณจ
 #. Confirmation message asking if the user is sure they want to reset all of their settings.
 msgctxt "settings"
 msgid "This will reset your saved settings to default values. Continue?"
-msgstr ""
-"การดำเนินการนี้จะรีเซ็ตการตั้งค่าที่บันทึกไว้เป็นค่าเริ่มต้น "
-"ดำเนินการต่อหรือไม่"
+msgstr "การดำเนินการนี้จะรีเซ็ตการตั้งค่าที่บันทึกไว้เป็นค่าเริ่มต้น ดำเนินการต่อหรือไม่"
 
 # smartling.placeholder_format=C
 #. Golf leaderboard column: holes completed in current round
@@ -19663,7 +19975,9 @@ msgctxt "directions"
 msgid ""
 "To print directions:%sGo back to the map.%sSelect the route you want to "
 "print.%sClick the print icon.%s"
-msgstr "วิธีการพิมพ์เส้นทาง:%1$sกลับไปยังแผนที่%2$sเลือกเส้นทางที่ต้องการพิมพ์%3$sเลือกไอคอนเครื่องพิมพ์%4$s"
+msgstr ""
+"วิธีการพิมพ์เส้นทาง:"
+"%1$sกลับไปยังแผนที่%2$sเลือกเส้นทางที่ต้องการพิมพ์%3$sเลือกไอคอนเครื่องพิมพ์%4$s"
 
 # smartling.placeholder_format=C
 #. Explains where the user can find their recovery code. Figma frame 3703-44420.
@@ -19673,8 +19987,7 @@ msgid ""
 "you first set up Sync. This code may have been saved as a PDF on the device "
 "you originally used to set up Sync."
 msgstr ""
-"เพื่อกู้คืนข้อมูลที่ซิงค์ของคุณ "
-"คุณจำเป็นต้องมีรหัสกู้คืนที่คุณบันทึกไว้เมื่อคุณตั้งค่า Sync เป็นครั้งแรก "
+"เพื่อกู้คืนข้อมูลที่ซิงค์ของคุณ คุณจำเป็นต้องมีรหัสกู้คืนที่คุณบันทึกไว้เมื่อคุณตั้งค่า Sync เป็นครั้งแรก "
 "รหัสนี้อาจถูกบันทึกเป็น PDF บนอุปกรณ์ที่คุณใช้ตั้งค่าการซิงค์ในตอนแรก"
 
 # smartling.placeholder_format=C
@@ -19930,9 +20243,7 @@ msgctxt "Full sentence for translating text"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr ""
-"แปลประโยคภาษาอังกฤษนี้เป็นภาษาฝรั่งเศส: "
-"“ฉันจะไปโรงภาพยนตร์ที่ใกล้ที่สุดได้อย่างไร?”"
+msgstr "แปลประโยคภาษาอังกฤษนี้เป็นภาษาฝรั่งเศส: “ฉันจะไปโรงภาพยนตร์ที่ใกล้ที่สุดได้อย่างไร?”"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for translating a sentence into another language. Translate the whole sentence and please use target language instead of 'English' and modify the sentence to translate into 'English' instead of 'French'. Example: 'Translate this {target language} sentence into English: “How do I get to the nearest movie theatre?”'
@@ -19940,9 +20251,19 @@ msgctxt "Full sentence for translating text prompt"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
+msgstr "แปลประโยคภาษาไทยนี้เป็นภาษาอังกฤษ: “ฉันจะไปโรงภาพยนตร์ที่ใกล้ที่สุดได้อย่างไร?”"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Translate this page"
 msgstr ""
-"แปลประโยคภาษาไทยนี้เป็นภาษาอังกฤษ: "
-"“ฉันจะไปโรงภาพยนตร์ที่ใกล้ที่สุดได้อย่างไร?”"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
+msgctxt "Page suggestion prompt"
+msgid "Translate this page into %s."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder text for a region that will display translated text.
@@ -20084,6 +20405,12 @@ msgstr "ลองใอีกครั้ง"
 msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
 msgstr "ลองใช้ฟรี"
+
+# smartling.placeholder_format=C
+#. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
+msgctxt "settings"
+msgid "Try It Now"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -20316,6 +20643,22 @@ msgstr "ลอง %1$s"
 msgctxt "new user poll"
 msgid "Trying DuckDuckGo again"
 msgstr "ลองใช้ DuckDuckGo อีกครั้ง"
+
+# smartling.placeholder_format=C
+#. Message shown in a modal after supported third-party browser users disable AI features in Settings. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -20617,8 +20960,7 @@ msgid ""
 "Under %sOn startup%s, click %sOpen a specific page%s then click %sSet "
 "Pages%s."
 msgstr ""
-"ภายใต้%1$sเมื่อเริ่มต้น%2$s ให้คลิก%3$sเปิดหน้าที่เฉพาะเจาะจง%4$s "
-"จากนั้นคลิก%5$sตั้งค่าหน้า%6$s"
+"ภายใต้%1$sเมื่อเริ่มต้น%2$s ให้คลิก%3$sเปิดหน้าที่เฉพาะเจาะจง%4$s จากนั้นคลิก%5$sตั้งค่าหน้า%6$s"
 
 #  Maxthon homepage instruction
 # smartling.placeholder_format=C
@@ -20626,8 +20968,7 @@ msgstr ""
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
 msgstr ""
-"ภายใต้%1$sเมื่อเริ่มต้น%2$s ให้เลือก%3$sหน้าแรก%4$s และป้อน: "
-"https://duckduckgo.com"
+"ภายใต้%1$sเมื่อเริ่มต้น%2$s ให้เลือก%3$sหน้าแรก%4$s และป้อน: https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -20743,8 +21084,8 @@ msgid ""
 "Unlock %s, higher AI reasoning, and 2x higher usage limits than the Plus "
 "plan by upgrading to Pro."
 msgstr ""
-"ปลดล็อก %1$s, การให้เหตุผล AI ที่สูงขึ้น, และขีดจำกัดการใช้งานสูงกว่า Plus "
-"ถึง 2 เท่า โดยการอัปเกรดเป็น Pro"
+"ปลดล็อก %1$s, การให้เหตุผล AI ที่สูงขึ้น, และขีดจำกัดการใช้งานสูงกว่า Plus ถึง 2 เท่า "
+"โดยการอัปเกรดเป็น Pro"
 
 # smartling.placeholder_format=C
 #. Title for the subscription promo shown in the SERP sidemenu.
@@ -20878,8 +21219,7 @@ msgid ""
 "Update the DuckDuckGo browser to activate your subscription in Duck.ai and "
 "access advanced models"
 msgstr ""
-"อัปเดตเบราว์เซอร์ DuckDuckGo เพื่อเปิดใช้งานการสมัครสมาชิกใน Duck.ai "
-"และเข้าถึงโมเดลขั้นสูง"
+"อัปเดตเบราว์เซอร์ DuckDuckGo เพื่อเปิดใช้งานการสมัครสมาชิกใน Duck.ai และเข้าถึงโมเดลขั้นสูง"
 
 # smartling.placeholder_format=C
 #. The placeholder indicates a formatted date (e.g., 'Updated 2 days ago')
@@ -21060,6 +21400,12 @@ msgid "Uruguay"
 msgstr "อุรุกวัย"
 
 # smartling.placeholder_format=C
+#. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
+msgctxt "Navigation label on the Duck.ai settings page"
+msgid "Usage"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A feedback suggestion
 msgctxt "Feedback prompt"
 msgid "Usage limit"
@@ -21101,9 +21447,8 @@ msgid ""
 "Use ChatGPT, Claude, and other AIs, privately. Protect chats from hackers, "
 "scammers, and companies. Keep info confidential. Free. No account required."
 msgstr ""
-"ใช้ ChatGPT, Claude และ AI อื่นๆ อย่างเป็นส่วนตัว ปกป้องแชทจากแฮกเกอร์ "
-"นักต้มตุ๋น และบริษัทต่าง ๆ เก็บข้อมูลให้เป็นความลับ ไม่มีค่าใช้จ่าย "
-"ไม่จำเป็นต้องมีบัญชี"
+"ใช้ ChatGPT, Claude และ AI อื่นๆ อย่างเป็นส่วนตัว ปกป้องแชทจากแฮกเกอร์ นักต้มตุ๋น "
+"และบริษัทต่าง ๆ เก็บข้อมูลให้เป็นความลับ ไม่มีค่าใช้จ่าย ไม่จำเป็นต้องมีบัญชี"
 
 # smartling.placeholder_format=C
 #. Header above instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -21316,9 +21661,7 @@ msgstr "หมู่เกาะเวอร์จิน"
 msgctxt "duckassist"
 msgid ""
 "Visit %sAssist Settings%s to adjust how this feature works or turn it off."
-msgstr ""
-"ไปที่ %1$sการตั้งค่า Assist%2$s "
-"เพื่อปรับวิธีการทำงานของคุณลักษณะนี้หรือปิดการใช้งาน"
+msgstr "ไปที่ %1$sการตั้งค่า Assist%2$s เพื่อปรับวิธีการทำงานของคุณลักษณะนี้หรือปิดการใช้งาน"
 
 # smartling.placeholder_format=C
 #. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
@@ -21326,9 +21669,7 @@ msgctxt "duckassist"
 msgid ""
 "Visit %sDuckAssist Settings%s to adjust how this feature works or turn it "
 "off."
-msgstr ""
-"ไปที่ %1$sการตั้งค่า DuckAssist%2$s "
-"เพื่อปรับวิธีการทำงานของฟีเจอร์นี้หรือปิดการใช้งาน"
+msgstr "ไปที่ %1$sการตั้งค่า DuckAssist%2$s เพื่อปรับวิธีการทำงานของฟีเจอร์นี้หรือปิดการใช้งาน"
 
 # smartling.placeholder_format=C
 #. Prompt to visit DuckDuckGo on another device.
@@ -21351,9 +21692,8 @@ msgid ""
 "Visit Duck.ai in your other browser and go to %sDuck.ai Settings%s > %sSync "
 "& Backup%s > %sManage%s then select %sSync With Another Device%s."
 msgstr ""
-"เข้าไปที่ Duck.ai ในเบราว์เซอร์อื่นของคุณ แล้วไปที่ %1$sDuck.ai Settings%2$s "
-"> %3$sSync & Backup%4$s > %5$sManage%6$s จากนั้นเลือก %7$sSync With Another "
-"Device%8$s"
+"เข้าไปที่ Duck.ai ในเบราว์เซอร์อื่นของคุณ แล้วไปที่ %1$sDuck.ai Settings%2$s > %3$sSync "
+"& Backup%4$s > %5$sManage%6$s จากนั้นเลือก %7$sSync With Another Device%8$s"
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -21363,9 +21703,8 @@ msgid ""
 "On” under Sync & Backup and select “Sync With Another Device”. Or scan the "
 "QR on your Recovery PDF."
 msgstr ""
-"ไปที่ Duck.ai ในเบราว์เซอร์อื่นของคุณ แล้วเปิดการตั้งค่า Duck.ai เลือก "
-"\"เปิด\" ภายใต้ Sync & Backup และเลือก \"ซิงค์กับอุปกรณ์อื่น\" "
-"หรือสแกนคิวอาร์บน PDF การกู้คืนของคุณ"
+"ไปที่ Duck.ai ในเบราว์เซอร์อื่นของคุณ แล้วเปิดการตั้งค่า Duck.ai เลือก \"เปิด\" ภายใต้ Sync "
+"& Backup และเลือก \"ซิงค์กับอุปกรณ์อื่น\" หรือสแกนคิวอาร์บน PDF การกู้คืนของคุณ"
 
 # smartling.placeholder_format=C
 #. Shared body copy for every screen in the Sync Another Device flow (QR display, camera scan, camera-unavailable fallback, manual entry). Bold tags wrap navigation breadcrumbs. Render with <Translate /> so the HTML is interpreted; plain `translate()` will trip the html-string warning.
@@ -21375,9 +21714,9 @@ msgid ""
 "ai Settings%s > %sSync & Backup%s > %sManage%s then select %sSync With "
 "Another Device%s."
 msgstr ""
-"เข้าไปที่ Duck.ai ในเบราว์เซอร์อื่นของคุณหรือแอป DuckDuckGo แล้วไปที่ "
-"%1$sDuck.ai Settings%2$s > %3$sSync & Backup%4$s > %5$sManage%6$s "
-"จากนั้นเลือก %7$sSync With Another Device%8$s"
+"เข้าไปที่ Duck.ai ในเบราว์เซอร์อื่นของคุณหรือแอป DuckDuckGo แล้วไปที่ %1$sDuck.ai "
+"Settings%2$s > %3$sSync & Backup%4$s > %5$sManage%6$s จากนั้นเลือก %7$sSync "
+"With Another Device%8$s"
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -21387,9 +21726,9 @@ msgid ""
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
 msgstr ""
-"ไปที่ Duck.ai ในเบราว์เซอร์อื่นของคุณหรือแอป DuckDuckGo แล้วเปิดการตั้งค่า "
-"Duck.ai เลือก \"เปิด\" ภายใต้ Sync & Backup และเลือก \"ซิงค์กับอุปกรณ์อื่น\" "
-"หรือสแกนคิวอาร์บน PDF การกู้คืนของคุณ"
+"ไปที่ Duck.ai ในเบราว์เซอร์อื่นของคุณหรือแอป DuckDuckGo แล้วเปิดการตั้งค่า Duck.ai เลือก "
+"\"เปิด\" ภายใต้ Sync & Backup และเลือก \"ซิงค์กับอุปกรณ์อื่น\" หรือสแกนคิวอาร์บน PDF "
+"การกู้คืนของคุณ"
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -21441,10 +21780,7 @@ msgstr "แชทด้วยเสียงสิ้นสุดลง"
 #. Description in consent disclaimer informing that voice chats with the AI (Artificial Intelligence) are anonymized by us, and are never used to train AI models.
 msgctxt "voice chat"
 msgid "Voice chat is anonymized by us, and never used to train AI models."
-msgstr ""
-""
-"เราจะทำให้การแชทด้วยเสียงไม่ถูกระบุชื่อและจะไม่มีการใช้การแชทด้วยเสียงเพื่อฝึกโมเดล "
-"AI"
+msgstr "เราจะทำให้การแชทด้วยเสียงไม่ถูกระบุชื่อและจะไม่มีการใช้การแชทด้วยเสียงเพื่อฝึกโมเดล AI"
 
 # smartling.placeholder_format=C
 #. Title of the modal shown when the user has reached their daily voice chat limit.
@@ -21503,6 +21839,12 @@ msgstr "กำลังรอตำแหน่งที่ตั้ง..."
 # smartling.placeholder_format=C
 msgid "Wales"
 msgstr "เวลส์"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Walk me through the steps"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for walking directions on a map.
@@ -21603,10 +21945,8 @@ msgid ""
 "independent company and has no relationship with YouTube, where most videos "
 "are hosted."
 msgstr ""
-"การดูวิดีโอที่นี่หมายความว่าเว็บไซต์ที่โฮสต์นั้นสามารถติดตามคุณได้ "
-"เพราะเราต้องสตรีมเนื้อหาจากที่นั่น DuckDuckGo "
-"เป็นบริษัทอิสระและไม่มีความสัมพันธ์กับ YouTube "
-"ซึ่งวิดีโอส่วนใหญ่โฮสต์อยู่ที่นั่น"
+"การดูวิดีโอที่นี่หมายความว่าเว็บไซต์ที่โฮสต์นั้นสามารถติดตามคุณได้ เพราะเราต้องสตรีมเนื้อหาจากที่นั่น "
+"DuckDuckGo เป็นบริษัทอิสระและไม่มีความสัมพันธ์กับ YouTube ซึ่งวิดีโอส่วนใหญ่โฮสต์อยู่ที่นั่น"
 
 # smartling.placeholder_format=C
 #. Heading for the highlight card explaining anonymized prompt delivery.
@@ -21618,9 +21958,18 @@ msgstr "เราทำให้ไม่ระบุตัวตน"
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
+msgstr "เราสามารถเปิดใช้%1$s ตำแหน่งของคุณ%2$s แบบไม่ระบุตัวตนเพื่อแสดงผลลัพธ์ที่แม่นยำยิ่งขึ้น"
+
+# smartling.placeholder_format=C
+#. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
+msgctxt ""
+"Inline warning shown below the share-content toggle when the user selects "
+"Harmful or Illegal but has not enabled sharing"
+msgid ""
+"We can only fix what we can see. To report a harmful or illegal response, "
+"please share this conversation with DuckDuckGo so we can investigate and "
+"address the issue."
 msgstr ""
-"เราสามารถเปิดใช้%1$s ตำแหน่งของคุณ%2$s "
-"แบบไม่ระบุตัวตนเพื่อแสดงผลลัพธ์ที่แม่นยำยิ่งขึ้น"
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -21632,8 +21981,7 @@ msgid ""
 "please share your prompt and response so we can investigate and address the "
 "issue."
 msgstr ""
-"เราสามารถแก้ไขได้เฉพาะสิ่งที่เราเห็นเท่านั้น "
-"เพื่อรายงานการตอบสนองที่เป็นอันตรายหรือผิดกฎหมาย "
+"เราสามารถแก้ไขได้เฉพาะสิ่งที่เราเห็นเท่านั้น เพื่อรายงานการตอบสนองที่เป็นอันตรายหรือผิดกฎหมาย "
 "โปรดแชร์คำแนะนำและการตอบสนองของคุณเพื่อที่เราจะสามารถสอบสวนและแก้ไขปัญหานี้"
 
 # smartling.placeholder_format=C
@@ -21647,9 +21995,7 @@ msgstr "เราสามารถใช้%1$sตำแหน่งที่�
 msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
-msgstr ""
-"เราไม่สามารถอ่านไฟล์ที่แนบมาได้ "
-"เนื่องจากอย่างน้อยหนึ่งในนั้นได้รับการเข้ารหัส"
+msgstr "เราไม่สามารถอ่านไฟล์ที่แนบมาได้ เนื่องจากอย่างน้อยหนึ่งในนั้นได้รับการเข้ารหัส"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -21677,8 +22023,7 @@ msgid ""
 "We don't store your personal info. We don't follow you around with ads. We "
 "don't track you. Ever."
 msgstr ""
-"เราไม่จัดเก็บข้อมูลส่วนบุคคลของคุณ เราจะไม่แสดงโฆษณาแก่คุณในทุกๆ ที่ "
-"เราไม่ติดตามคุณ อย่างแน่นอน"
+"เราไม่จัดเก็บข้อมูลส่วนบุคคลของคุณ เราจะไม่แสดงโฆษณาแก่คุณในทุกๆ ที่ เราไม่ติดตามคุณ อย่างแน่นอน"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -21691,9 +22036,7 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what brought you "
 "back today:"
-msgstr ""
-"เนื่องจากเราไม่ได้ติดตามคุณ "
-"เราจึงอยากให้คุณช่วยบอกว่าสิ่งใดทำให้คุณกลับมาในวันนี้:"
+msgstr "เนื่องจากเราไม่ได้ติดตามคุณ เราจึงอยากให้คุณช่วยบอกว่าสิ่งใดทำให้คุณกลับมาในวันนี้:"
 
 # smartling.placeholder_format=C
 #. Message prompting users to fill out a feedback form.
@@ -21702,8 +22045,7 @@ msgid ""
 "We don't track you, so we could use your help telling us what convinced you "
 "to try us out today:"
 msgstr ""
-"เนื่องจากเราไม่ได้ติดตามคุณ "
-"เราจึงอยากให้คุณช่วยบอกว่าสิ่งใดทำให้คุณสนใจลองใช้บริการเราในวันนี้:"
+"เนื่องจากเราไม่ได้ติดตามคุณ เราจึงอยากให้คุณช่วยบอกว่าสิ่งใดทำให้คุณสนใจลองใช้บริการเราในวันนี้:"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -21770,8 +22112,7 @@ msgid ""
 "We have agreements with all AI providers to ensure your chats aren't used to "
 "train AIs."
 msgstr ""
-"เรามีข้อตกลงกับผู้ให้บริการ AI "
-"ทุกรายเพื่อให้มั่นใจว่าการแชทของคุณจะไม่ถูกใช้ในการฝึกฝน AI"
+"เรามีข้อตกลงกับผู้ให้บริการ AI ทุกรายเพื่อให้มั่นใจว่าการแชทของคุณจะไม่ถูกใช้ในการฝึกฝน AI"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -21806,7 +22147,6 @@ msgid ""
 "We only use your anonymous location to deliver better results, closer to "
 "you. You can always change your mind later."
 msgstr ""
-""
 "เราใช้ตำแหน่งที่ตั้งแบบไม่ระบุตัวตนของคุณเพียงเพื่อให้ได้ผลลัพธ์ที่แม่นยำยิ่งขึ้นและใกล้คุณมากขึ้นเท่านั้น "
 "คุณสามารถเปลี่ยนใจได้เสมอในภายหลัง"
 
@@ -21814,9 +22154,7 @@ msgstr ""
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
-msgstr ""
-"เราพึ่งพาคำติชมที่ไม่ระบุชื่อของคุณเพื่อปรับปรุง DuckDuckGo "
-"ให้ดียิ่งขึ้นสำหรับทุกคน"
+msgstr "เราพึ่งพาคำติชมที่ไม่ระบุชื่อของคุณเพื่อปรับปรุง DuckDuckGo ให้ดียิ่งขึ้นสำหรับทุกคน"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -21852,8 +22190,7 @@ msgid ""
 "We're aware of this issue and are currently working to resolve it. If you "
 "continue to see this error, please reach out to %s."
 msgstr ""
-"เราทราบถึงปัญหานี้แล้วและกำลังดำเนินการแก้ไขอยู่ "
-"ถ้าคุณยังเห็นข้อผิดพลาดนี้อยู่ กรุณาติดต่อ %1$s"
+"เราทราบถึงปัญหานี้แล้วและกำลังดำเนินการแก้ไขอยู่ ถ้าคุณยังเห็นข้อผิดพลาดนี้อยู่ กรุณาติดต่อ %1$s"
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -21886,8 +22223,7 @@ msgid ""
 "We've updated the Duck.ai service. For the change to take effect, we need to "
 "reload the page."
 msgstr ""
-"เราได้อัปเดตบริการ Duck.ai แล้ว เพื่อให้การเปลี่ยนแปลงมีผล "
-"เราจำเป็นต้องโหลดหน้านี้อีกครั้ง"
+"เราได้อัปเดตบริการ Duck.ai แล้ว เพื่อให้การเปลี่ยนแปลงมีผล เราจำเป็นต้องโหลดหน้านี้อีกครั้ง"
 
 # smartling.placeholder_format=C
 #. Instant Answer Tab Name
@@ -21989,9 +22325,7 @@ msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "Weekly usage limit reached. You can keep chatting by using your monthly "
 "limit."
-msgstr ""
-"ถึงขีดจำกัดการใช้งานรายสัปดาห์แล้ว "
-"คุณสามารถแชทต่อโดยใช้ขีดจำกัดรายเดือนของคุณ"
+msgstr "ถึงขีดจำกัดการใช้งานรายสัปดาห์แล้ว คุณสามารถแชทต่อโดยใช้ขีดจำกัดรายเดือนของคุณ"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -22005,8 +22339,7 @@ msgid ""
 "Welcome to Duck.ai! All of your chats here are private, anonymized by us and "
 "not used to train AI models."
 msgstr ""
-"ยินดีต้อนรับสู่ Duck.ai การแชททั้งหมดที่นี่เป็นแบบส่วนตัว "
-"เราไม่ระบุชื่อและจะไม่ถูกใช้เพื่อฝึกโมเดล AI"
+"ยินดีต้อนรับสู่ Duck.ai การแชททั้งหมดที่นี่เป็นแบบส่วนตัว เราไม่ระบุชื่อและจะไม่ถูกใช้เพื่อฝึกโมเดล AI"
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened.
@@ -22027,8 +22360,7 @@ msgid ""
 "to train AI models."
 msgstr ""
 "ยินดีต้อนรับสู่ DuckDuckGo AI Chat! เซสชันแชทนี้ขับเคลื่อนโดย %2$s ของ %1$s "
-"การแชททั้งหมดของคุณที่นี่เป็นแบบส่วนตัว และจะไม่ถูกจัดเก็บโดย DuckDuckGo "
-"หรือใช้เพื่อฝึกโมเดล AI"
+"การแชททั้งหมดของคุณที่นี่เป็นแบบส่วนตัว และจะไม่ถูกจัดเก็บโดย DuckDuckGo หรือใช้เพื่อฝึกโมเดล AI"
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -22135,9 +22467,7 @@ msgctxt "Full sentence for finding a better word"
 msgid ""
 "What are some options for the word ‘better’ in the context of “We really "
 "need to do better.”"
-msgstr ""
-"มีตัวเลือกใดบ้างสำหรับคำว่า 'ดีกว่านี้' ในบริบทของ "
-"\"เราต้องทำให้ได้ดีกว่านี้\""
+msgstr "มีตัวเลือกใดบ้างสำหรับคำว่า 'ดีกว่านี้' ในบริบทของ \"เราต้องทำให้ได้ดีกว่านี้\""
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
@@ -22156,11 +22486,107 @@ msgid ""
 "easy to understand for people with or without much AI, or technical, "
 "experience."
 msgstr ""
-"คุณจะได้ประโยชน์อะไรบ้างจากการดาวน์โหลดเบราว์เซอร์ DuckDuckGo "
-"สำหรับผู้ที่สนใจใช้ Duck.ai อ้างอิงเฉพาะแหล่งข้อมูลอย่างเป็นทางการของ "
-"DuckDuckGo เท่านั้น แบ่งคำตอบออกเป็นส่วนๆ ที่ชัดเจนพร้อมชื่อหัวข้อ "
-"โดยเน้นที่การบูรณาการ Duck.ai และการปกป้องความเป็นส่วนตัว ทำให้สั้น ง่าย "
-"และเข้าใจได้ง่ายสำหรับคนที่มีหรือไม่มีประสบการณ์ด้าน AI หรือเทคนิคมากนัก"
+"คุณจะได้ประโยชน์อะไรบ้างจากการดาวน์โหลดเบราว์เซอร์ DuckDuckGo สำหรับผู้ที่สนใจใช้ Duck.ai "
+"อ้างอิงเฉพาะแหล่งข้อมูลอย่างเป็นทางการของ DuckDuckGo เท่านั้น แบ่งคำตอบออกเป็นส่วนๆ "
+"ที่ชัดเจนพร้อมชื่อหัวข้อ โดยเน้นที่การบูรณาการ Duck.ai และการปกป้องความเป็นส่วนตัว ทำให้สั้น "
+"ง่าย และเข้าใจได้ง่ายสำหรับคนที่มีหรือไม่มีประสบการณ์ด้าน AI หรือเทคนิคมากนัก"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the counterarguments?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the hours & location?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key contributions of this paper?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key contributions?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key details?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key points covered in this video?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key points?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key takeaways from this article?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key takeaways?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key things I will learn from this course?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main counterarguments or criticisms of this?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main questions this page answers?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the must-try dishes here?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"What are the opening hours, location, and contact details for this place?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the pros and cons of this product?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the pros and cons?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
@@ -22263,6 +22689,12 @@ msgid "What does atria mean in the context of a medical article?"
 msgstr "atria หมายถึงอะไรในบริบทของบทความทางการแพทย์"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What does this answer?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
@@ -22273,6 +22705,12 @@ msgstr "คุณอยากให้เราเพิ่มฟีเจอร
 msgctxt "cloudsave"
 msgid "What information gets saved?"
 msgstr "ข้อมูลอะไรบ้างที่ได้รับการบันทึก"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What interview questions might come up for this role?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -22289,6 +22727,12 @@ msgstr ""
 msgctxt "Full sentence for looking up basic facts"
 msgid "What is the capital city of Albania?"
 msgstr "เมืองหลวงของประเทศแอลเบเนียคืออะไร"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What is the overall verdict and rating for this?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to a page with additional information.
@@ -22313,6 +22757,12 @@ msgid "What people say:"
 msgstr "ความคิดเห็นของผู้ใช้:"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What should I order?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
 msgctxt "feedback form"
 msgid "What stood out?"
@@ -22323,6 +22773,18 @@ msgstr "อะไรที่โดดเด่นบ้าง?"
 msgctxt "feedback form"
 msgid "What was wrong with the response? (optional)"
 msgstr "คำตอบมีปัญหาอย่างไรบ้าง (ไม่บังคับ)"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I learn?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I need?"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -22340,6 +22802,12 @@ msgstr "สิ่งที่คุณดูใน DuckDuckGo จะไม่ส
 msgctxt "SERP footer content"
 msgid "What's New"
 msgstr "มีอะไรใหม่"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What's the verdict?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -22390,6 +22858,12 @@ msgid "Which features are missing? (Optional)"
 msgstr "ขาดฟีเจอร์ใดบ้าง (ไม่บังคับ)"
 
 # smartling.placeholder_format=C
+#. An invitation for users to leave feedback
+msgctxt "Feedback prompt"
+msgid "Which features are missing? (optional)"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
 msgid "White"
 msgstr "สีขาว"
@@ -22404,6 +22878,18 @@ msgstr "สีขาว"
 #. Link to an about us page.
 msgid "Who We Are"
 msgstr "ข้อมูลเกี่ยวกับเรา"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Who are the main cast and crew, and what else are they known for?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Who is this person?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Header above a collection of privacy-related links.
@@ -22816,9 +23302,7 @@ msgstr "คุณสามารถเข้าถึง DuckDuckGo AI Chat ไ�
 msgctxt "duckassist"
 msgid ""
 "You can adjust how %s works or turn it off anytime in %sSearch Settings%s."
-msgstr ""
-"คุณสามารถปรับวิธีการทำงานของ %1$s หรือปิดได้ตลอดเวลาใน "
-"%2$sการตั้งค่าการค้นหา%3$s"
+msgstr "คุณสามารถปรับวิธีการทำงานของ %1$s หรือปิดได้ตลอดเวลาใน %2$sการตั้งค่าการค้นหา%3$s"
 
 # smartling.placeholder_format=C
 #. Assist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate Assist.
@@ -22827,8 +23311,7 @@ msgid ""
 "You can adjust how Assist works or turn it off anytime in %sSearch "
 "Settings%s."
 msgstr ""
-"คุณสามารถปรับวิธีการทำงานของ Assist หรือปิดได้ตลอดเวลาใน "
-"%1$sการตั้งค่าการค้นหา%2$s"
+"คุณสามารถปรับวิธีการทำงานของ Assist หรือปิดได้ตลอดเวลาใน %1$sการตั้งค่าการค้นหา%2$s"
 
 # smartling.placeholder_format=C
 msgid "You can also use %sDuck.ai%s to answer questions or summarize text."
@@ -22948,9 +23431,7 @@ msgctxt "Organic result context menu"
 msgid ""
 "You can only block up to %s sites. To block %s, you'll need to unblock "
 "another site first."
-msgstr ""
-"คุณสามารถบล็อกได้เพียง %1$s ไซต์เท่านั้น ในการบล็อก %2$s "
-"คุณต้องเลิกบล็อกไซต์อื่นก่อน"
+msgstr "คุณสามารถบล็อกได้เพียง %1$s ไซต์เท่านั้น ในการบล็อก %2$s คุณต้องเลิกบล็อกไซต์อื่นก่อน"
 
 # smartling.placeholder_format=C
 #. Text explaining the benefits of the cloud save feature.
@@ -23007,8 +23488,8 @@ msgid ""
 "You now have access to %s, higher AI reasoning, and 2x higher usage limits "
 "than Plus."
 msgstr ""
-"ตอนนี้คุณมีการเข้าถึง %1$s, การให้เหตุผล AI ที่สูงขึ้น, "
-"และขีดจำกัดการใช้งานสูงกว่า Plus ถึง 2 เท่า"
+"ตอนนี้คุณมีการเข้าถึง %1$s, การให้เหตุผล AI ที่สูงขึ้น, และขีดจำกัดการใช้งานสูงกว่า Plus ถึง 2 "
+"เท่า"
 
 # smartling.placeholder_format=C
 #. Description text for the welcome modal displayed after the user subscribes to DuckDuckGo.
@@ -23077,8 +23558,7 @@ msgid ""
 "browse privately too. It’s already installed and can:"
 msgstr ""
 "ตอนนี้คุณกำลังค้นหาแบบเป็นส่วนตัวใน Chrome ใช้แอปของเราแทน Chrome "
-"เพื่อเรียกดูแบบเป็นส่วนตัวได้เช่นกัน "
-"แอปได้รับการติดตั้งไว้เรียบร้อยแล้วและสามารถ:"
+"เพื่อเรียกดูแบบเป็นส่วนตัวได้เช่นกัน แอปได้รับการติดตั้งไว้เรียบร้อยแล้วและสามารถ:"
 
 # smartling.placeholder_format=C
 #. Confirmation message that appears after the DuckDuckGo browser extension is installed.
@@ -23091,8 +23571,7 @@ msgid ""
 "You're now searching with privacy. %sGet tips to reduce your footprint even "
 "more."
 msgstr ""
-"ตอนนี้คุณทำการกำลังค้นหาแบบมีความเป็นส่วนตัว "
-"%1$sดูเคล็ดลับเพื่อลดร่องรอยทางออนไลน์ให้มากยิ่งขึ้น"
+"ตอนนี้คุณทำการกำลังค้นหาแบบมีความเป็นส่วนตัว %1$sดูเคล็ดลับเพื่อลดร่องรอยทางออนไลน์ให้มากยิ่งขึ้น"
 
 # smartling.placeholder_format=C
 #. Title of a notice thanking the user for turning off their adblocker
@@ -23162,8 +23641,8 @@ msgid ""
 "You've run out of Sync & Backup storage for Duck.ai chats with attachments. "
 "Delete the %s oldest chats to resume Sync. Pinned chats will not be deleted."
 msgstr ""
-"คุณใช้พื้นที่จัดเก็บ Sync & Backup สำหรับการแชท Duck.ai พร้อมไฟล์แนบเต็มแล้ว "
-"ลบแชทที่เก่าที่สุด %1$s แชทเพื่อซิงค์ต่อ แชทที่ปักหมุดไว้จะไม่ถูกลบ"
+"คุณใช้พื้นที่จัดเก็บ Sync & Backup สำหรับการแชท Duck.ai พร้อมไฟล์แนบเต็มแล้ว ลบแชทที่เก่าที่สุด "
+"%1$s แชทเพื่อซิงค์ต่อ แชทที่ปักหมุดไว้จะไม่ถูกลบ"
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -23173,9 +23652,8 @@ msgid ""
 "oldest chats with attachments to resume Sync. Pinned chats will not be "
 "deleted."
 msgstr ""
-"คุณหมดพื้นที่จัดเก็บข้อมูลสำรอง Sync & Backup สำหรับแชท Duck.ai แล้ว ลบแชท "
-"%1$s รายการที่เก่าที่สุดที่มีไฟล์แนบเพื่อดำเนินการ Sync ต่อ "
-"แชทที่ปักหมุดไว้จะไม่ถูกลบ"
+"คุณหมดพื้นที่จัดเก็บข้อมูลสำรอง Sync & Backup สำหรับแชท Duck.ai แล้ว ลบแชท %1$s "
+"รายการที่เก่าที่สุดที่มีไฟล์แนบเพื่อดำเนินการ Sync ต่อ แชทที่ปักหมุดไว้จะไม่ถูกลบ"
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the sync storage limit.
@@ -23189,8 +23667,8 @@ msgid ""
 "YouTube (owned by Google) does not let you watch videos anonymously. As "
 "such, watching YouTube videos here will be tracked by YouTube/Google."
 msgstr ""
-"YouTube (Google เป็นเจ้าของ) ไม่อนุญาตให้คุณดูวิดีโอแบบไม่ระบุตัวตน "
-"การดูวิดีโอ YouTube ที่นี่จะถูกติดตามโดย YouTube/Google"
+"YouTube (Google เป็นเจ้าของ) ไม่อนุญาตให้คุณดูวิดีโอแบบไม่ระบุตัวตน การดูวิดีโอ YouTube "
+"ที่นี่จะถูกติดตามโดย YouTube/Google"
 
 # smartling.placeholder_format=C
 #. Label for a privacy disclaimer related to YouTube videos
@@ -23273,17 +23751,14 @@ msgid ""
 "Your browser provides a list of your most-visited sites. DuckDuckGo never "
 "has access to this data."
 msgstr ""
-"เบราว์เซอร์ของคุณแสดงรายการไซต์ที่คุณเยี่ยมชมบ่อยที่สุดDuckDuckGo "
-"ไม่มีสิทธิ์เข้าถึงข้อมูลนี้เด็ดขาด"
+"เบราว์เซอร์ของคุณแสดงรายการไซต์ที่คุณเยี่ยมชมบ่อยที่สุดDuckDuckGo ไม่มีสิทธิ์เข้าถึงข้อมูลนี้เด็ดขาด"
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
 msgid ""
 "Your browser provides the list of most-visited sites. DuckDuckGo never has "
 "access to this data."
-msgstr ""
-"เบราว์เซอร์ของคุณแสดงรายชื่อเว็บไซต์ที่เยี่ยมชมบ่อยที่สุด DuckDuckGo "
-"ไม่เคยเข้าถึงข้อมูลนี้"
+msgstr "เบราว์เซอร์ของคุณแสดงรายชื่อเว็บไซต์ที่เยี่ยมชมบ่อยที่สุด DuckDuckGo ไม่เคยเข้าถึงข้อมูลนี้"
 
 # smartling.placeholder_format=C
 #. Disclaimer text shown bellow chat input. Example: 'You are chatting with GPT-3. AI chats may display inaccurate or offensive information.'
@@ -23331,8 +23806,7 @@ msgctxt "Menu item description"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
 msgstr ""
-"การแชทของคุณเป็นแบบส่วนตัว เราจะไมบันทึกและใช้การแชทของคุณในการฝึกโมเดล AI "
-"เด็ดขาด"
+"การแชทของคุณเป็นแบบส่วนตัว เราจะไมบันทึกและใช้การแชทของคุณในการฝึกโมเดล AI เด็ดขาด"
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the active privacy protection.
@@ -23340,8 +23814,7 @@ msgctxt "Modal body for privacy"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
 msgstr ""
-"การแชทของคุณเป็นแบบส่วนตัว เราจะไม่บันทึกและใช้การแชทของคุณในการฝึกโมเดล AI "
-"เด็ดขาด"
+"การแชทของคุณเป็นแบบส่วนตัว เราจะไม่บันทึกและใช้การแชทของคุณในการฝึกโมเดล AI เด็ดขาด"
 
 # smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that chats are stored locally on the user's device.
@@ -23441,8 +23914,7 @@ msgid ""
 "browser. We save the settings file using the key as the name. DuckDuckGo "
 "never knows your passphrase."
 msgstr ""
-"รหัสผ่านของคุณสร้างคีย์ 512 บิตโดยใช้อัลกอริทึมการแฮชที่ปลอดภัยที่เรียกว่า "
-"%1$sSHA-2%2$s "
+"รหัสผ่านของคุณสร้างคีย์ 512 บิตโดยใช้อัลกอริทึมการแฮชที่ปลอดภัยที่เรียกว่า %1$sSHA-2%2$s "
 "เฉพาะคีย์และไฟล์การตั้งค่าที่เกี่ยวข้องเท่านั้นที่ออกจากเบราว์เซอร์ของคุณ "
 "เราบันทึกไฟล์การตั้งค่าโดยใช้คีย์เป็นชื่อ DuckDuckGo จะไม่ทราบรหัสผ่านของคุณ"
 
@@ -23459,8 +23931,7 @@ msgid ""
 "personally identifiable metadata, so model providers can't tie your "
 "conversations back to you."
 msgstr ""
-"คำสั่งของเธอถูกส่งต่อผ่านเซิร์ฟเวอร์ DuckDuckGo "
-"และข้อมูลเมตาที่ระบุตัวตนส่วนบุคคลจะถูกลบออก "
+"คำสั่งของเธอถูกส่งต่อผ่านเซิร์ฟเวอร์ DuckDuckGo และข้อมูลเมตาที่ระบุตัวตนส่วนบุคคลจะถูกลบออก "
 "เพื่อให้ผู้ให้บริการโมเดลไม่สามารถเชื่อมโยงการสนทนาของคุณกลับไปยังคุณ"
 
 # smartling.placeholder_format=C
@@ -23860,9 +24331,7 @@ msgstr "เว็บไซต์อย่างเป็นทางการ"
 #. <em>%s</em> is for a hexadecimal color code as <em>#395323</em>, but it has to be safe encoded, and as <em>#</em> seems not safe, <em>%23</em> must be used in place of the sharp symbol, but they are the same for your browser.
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
-msgstr ""
-"หรือพิมพ์รหัสสีที่คุณต้องการ เช่น %1$s (%2$s เป็นรหัสอักขระ %3$s "
-"ตัวที่เข้ารหัสแล้ว)"
+msgstr "หรือพิมพ์รหัสสีที่คุณต้องการ เช่น %1$s (%2$s เป็นรหัสอักขระ %3$s ตัวที่เข้ารหัสแล้ว)"
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "

--- a/locales/tl_PH/LC_MESSAGES/duckduckgo.po
+++ b/locales/tl_PH/LC_MESSAGES/duckduckgo.po
@@ -1159,6 +1159,11 @@ msgctxt "feedback form"
 msgid "Address is incorrect"
 msgstr ""
 
+#. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Adjust the servings"
+msgstr ""
+
 #. as in multiple advertisements
 msgid "Ads"
 msgstr ""
@@ -1330,6 +1335,13 @@ msgstr ""
 #. Heading shown on the empty chat screen. The text between the two %s markers is displayed inside a clickable privacy button. First %s renders a shield icon, second %s is an invisible end marker. Keep the word 'private' between both %s markers.
 msgctxt "Empty state heading in Duck.ai chat mode"
 msgid "All chats are %sprivate%s"
+msgstr ""
+
+#. Paragraph in the Privacy & Terms section of the About & Legal page in Duck.ai settings, summarizing how chats are anonymized and are not stored or used to train chat models.
+msgctxt "Privacy & Terms section description on the Duck.ai settings page"
+msgid ""
+"All chats are anonymized by DuckDuckGo, and your conversations are not used "
+"to train chat models by DuckDuckGo or the model providers"
 msgstr ""
 
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1542,6 +1554,12 @@ msgstr ""
 #. Confirmation message after location service is enabled.
 msgctxt "precise_user_location"
 msgid "Anonymous location enabled"
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Anonymously generates answers for search queries based on web content. "
+"Choose how often you want it to appear, or disable it completely."
 msgstr ""
 
 #. Instant Answer tab name
@@ -1764,6 +1782,11 @@ msgstr ""
 
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse
 msgid "Ask a follow-up with Duck.ai"
+msgstr ""
+
+#. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
+msgctxt "Page suggestion chip label"
+msgid "Ask about this page"
 msgstr ""
 
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2088,6 +2111,11 @@ msgstr ""
 msgid "Barcode"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Based on this page, is this course worth taking?"
+msgstr ""
+
 msgctxt "settings"
 msgid "Basic"
 msgstr ""
@@ -2119,6 +2147,13 @@ msgstr ""
 #. Placeholder text displayed while the assistant waits for the user to choose an action.
 msgctxt "Assistant response placeholder"
 msgid "Before continuing..."
+msgstr ""
+
+#. Explains that before storing the report, DuckDuckGo will anonymize the conversation by removing PII like names, email addresses, and identifying metadata.
+msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
+msgid ""
+"Before storing this report, DuckDuckGo will anonymize your conversation by "
+"removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
 #. Label that's displayed next to a past start date below a web search result.
@@ -2377,6 +2412,11 @@ msgstr ""
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Break Points Won"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Break this down into clear, numbered steps."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -2736,6 +2776,11 @@ msgstr ""
 #. Text of a button that performs a search for the cast of a particular movie or tv show
 msgctxt "Movie/TV Show Title instant answer"
 msgid "Cast"
+msgstr ""
+
+#. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Cast & Crew"
 msgstr ""
 
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -4087,6 +4132,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Create a shopping list with quantities from this recipe."
+msgstr ""
+
 #. Placeholder text displayed in the input field when starting a new image generation session.
 msgctxt "Placeholder text for the image generation input field"
 msgid "Create an image of a cute duck..."
@@ -4613,6 +4663,10 @@ msgstr ""
 msgid "Dictation limit reached"
 msgstr ""
 
+#. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
+msgid "Dictation temporarily unavailable"
+msgstr ""
+
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
@@ -4857,6 +4911,20 @@ msgctxt "precise_user_location"
 msgid "Done"
 msgstr ""
 
+#. Message shown in a modal after DuckDuckGo browser users disable AI features in Settings. The first two placeholders bold noai.duckduckgo.com. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
+"filtered out. %sLearn More%s"
+msgstr ""
+
+#. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
+"and AI images filtered out. %sLearn more%s"
+msgstr ""
+
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Double Faults"
@@ -4947,6 +5015,16 @@ msgctxt "Full sentence for writing an email"
 msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
+msgstr ""
+
+#. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Draft a cover letter"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Draft a cover letter for this job."
 msgstr ""
 
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -5086,6 +5164,14 @@ msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
 msgstr ""
 
+#. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
+msgctxt "About section description on the Duck.ai settings page"
+msgid ""
+"Duck.ai is created by DuckDuckGo. We're an independent online protection "
+"company for anyone who wants to take back control of their personal "
+"information."
+msgstr ""
+
 #. Title shown when an update is required before proceeding.
 msgctxt "duckai_migration"
 msgid "Duck.ai is moving domains"
@@ -5119,6 +5205,12 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Duck.ai lets you chat privately with popular AI models. Disabling it hides "
+"Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
 
 msgctxt "settings"
@@ -5884,6 +5976,16 @@ msgstr ""
 msgid "Eritrea"
 msgstr ""
 
+#. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Estimate the nutrition"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Estimate the nutritional information for this recipe."
+msgstr ""
+
 msgid "Estonia"
 msgstr ""
 
@@ -5928,10 +6030,50 @@ msgctxt "merchant promotion product ad extension"
 msgid "Expires in 1 day"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain the accepted answer in simple terms."
+msgstr ""
+
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
+msgstr ""
+
+#. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain the top answer"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this in simple, plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this paper"
+msgstr ""
+
+#. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this repo"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this research paper in plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this simply"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain what this repository does and how to use it."
 msgstr ""
 
 #. Label to show if song lyrics contain explicit content
@@ -6162,6 +6304,11 @@ msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
 msgstr ""
 
+msgctxt "settings"
+msgid ""
+"Filters out known AI spam sites from image search results. %sLearn More%s"
+msgstr ""
+
 #. Label for the final score of a sporting event.
 msgid "Final"
 msgstr ""
@@ -6201,6 +6348,11 @@ msgstr ""
 #. Short description shown below the 'Web Search' label in the Tools dropdown.
 msgctxt "Subtitle for the Web Search tool entry in the Tools dropdown menu"
 msgid "Find current information"
+msgstr ""
+
+#. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Find me alternatives"
 msgstr ""
 
 #. Button that searches for results closer to the user's current location.
@@ -6591,6 +6743,11 @@ msgstr ""
 msgid "Generate More"
 msgstr ""
 
+#. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Generate a shopping list"
+msgstr ""
+
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
 msgid "Generate a short answer from the web"
 msgstr ""
@@ -6825,6 +6982,11 @@ msgstr ""
 #. Text for a button inviting users to give it a try for the Duck.ai product. On click, they're taken to the Duck.ai page.
 msgctxt "Onboarding welcome screen button text"
 msgid "Give it a Try"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Give me a quick background on this person."
 msgstr ""
 
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -7187,6 +7349,16 @@ msgstr ""
 
 #. Link to a page with information about sharing DuckDuckGo with friends.
 msgid "Help Spread Privacy"
+msgstr ""
+
+#. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Help me prep for the interview"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Help me tailor my resume for this job."
 msgstr ""
 
 #. Title of a SERP popup that invites users to take a survey (desktop only)
@@ -7606,6 +7778,13 @@ msgstr ""
 #. Text displayed on the button on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
 msgctxt "Onboarding terms screen button text"
 msgid "I Agree"
+msgstr ""
+
+#. Text for the button that takes the user to the external DuckDuckGo login subscription page.
+msgctxt ""
+"Text for the I already have a subscription button in the Duck.ai settings "
+"page"
+msgid "I Already Have a Subscription"
 msgstr ""
 
 #. Text for the button that takes the user to the login subscription page.
@@ -8060,6 +8239,11 @@ msgctxt "Sidemenu browser promo"
 msgid "Install Mac Browser"
 msgstr ""
 
+#. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
+msgctxt "settings"
+msgid "Install Now"
+msgstr ""
+
 #. Text of a button to install the DuckDuckGo app
 msgctxt "Serp footer content"
 msgid "Install Our App"
@@ -8139,9 +8323,36 @@ msgctxt "cloudsave"
 msgid "Is deleted data really deleted?"
 msgstr "Ang nabura bang data ay talagang nabura?"
 
+#. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is it worth taking?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this place any good?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"Is this place any good? Summarize its reputation based on reviews and "
+"ratings."
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "Is this video helpful?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this worth watching?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Is this worth watching? Give me a spoiler-free take."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -8638,6 +8849,11 @@ msgstr "Link font"
 msgid "Links:"
 msgstr "Mga link"
 
+#. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "List the tools, materials, or prerequisites I need for this."
+msgstr ""
+
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
 msgid "Listen"
 msgstr "Pakinggan"
@@ -8970,6 +9186,11 @@ msgstr ""
 #. Label for linke navigating to site exclusion feature on Settings page
 msgctxt "Exclusion message manage sites button"
 msgid "Manage blocked sites"
+msgstr ""
+
+#. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
+msgctxt "setting"
+msgid "Manage in Browser Settings"
 msgstr ""
 
 #. Link to the site exclusion settings page
@@ -11267,6 +11488,11 @@ msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
+msgid "Please describe why the chat response is harmful or illegal. (optional)"
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
+msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
 msgstr ""
 
@@ -11285,6 +11511,13 @@ msgctxt "Modal disclaimer text"
 msgid ""
 "Please note: starting a new chat with any model will delete your current "
 "chat session."
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
+msgctxt "Feedback prompt"
+msgid ""
+"Please paste your prompt and the problematic output (with any personal "
+"information removed) and describe why the content is harmful or illegal."
 msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -11669,6 +11902,11 @@ msgctxt "settings"
 msgid "Privacy"
 msgstr ""
 
+#. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
+msgctxt "Section heading on the Duck.ai settings page"
+msgid "Privacy & Terms"
+msgstr ""
+
 msgid "Privacy Blog"
 msgstr ""
 
@@ -11722,6 +11960,11 @@ msgstr ""
 
 #. Text used in other strings to link to the Privacy Policy and Terms of Service content.
 msgctxt "Copy used to compose link in sentences"
+msgid "Privacy Policy and Terms of Service"
+msgstr ""
+
+#. Text for a button that links to the terms of use and privacy policy page.
+msgctxt "Secondary button text in active privacy modal"
 msgid "Privacy Policy and Terms of Service"
 msgstr ""
 
@@ -12130,6 +12373,26 @@ msgctxt "Brief for recommending a book"
 msgid "Recommend a book"
 msgstr ""
 
+#. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar books"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar books."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar movies or shows."
+msgstr ""
+
+#. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar titles"
+msgstr ""
+
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
 msgid "Recording failed. Please try again."
 msgstr ""
@@ -12449,6 +12712,14 @@ msgstr ""
 msgid "Republic of Moldova"
 msgstr ""
 
+#. Note indicating that sharing the conversation is mandatory when reporting harmful or illegal content. Rendered alongside the standard share label (DUCKCHAT_RESPONSE_FEEDBACK_SHARE_PROMPT_RESPONSE_LABEL), not replacing it.
+msgctxt ""
+"Note shown under the share-content switch label on the Duck.ai response "
+"feedback form when the user has selected Harmful or Illegal as the feedback "
+"reason"
+msgid "Required for harmful or illegal reports"
+msgstr ""
+
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
 msgctxt "Description for extended reasoning mode in Duck.ai"
 msgid "Researches before responding"
@@ -12634,6 +12905,11 @@ msgstr "Mga pagrerepaso"
 #. Label above a list of customer reviews of a business.
 msgctxt "maps_places"
 msgid "Reviews"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Rewrite this recipe scaled for a different number of servings."
 msgstr ""
 
 msgid "Romania"
@@ -13671,6 +13947,11 @@ msgctxt "Setup button for native sync flow"
 msgid "Set Up Now"
 msgstr ""
 
+#. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
+msgctxt "Encrypted storage setup button shown in native browsers"
+msgid "Set Up Sync & Backup"
+msgstr ""
+
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
 msgctxt "Title for the Sync & Backup intro screen"
 msgid "Set Up Sync & Backup"
@@ -13813,6 +14094,12 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
+msgctxt ""
+"Label beside the share-content switch on the Duck.ai response feedback form"
+msgid "Share this conversation with DuckDuckGo"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -14827,6 +15114,21 @@ msgctxt "Brief for suggesting a blog post title"
 msgid "Suggest a title for a blog post"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest related articles or topics worth exploring next."
+msgstr ""
+
+#. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Suggest related articles to explore"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest some alternatives to this product."
+msgstr ""
+
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
 msgctxt "directions"
 msgid "Suggestions:"
@@ -14836,9 +15138,84 @@ msgctxt "noresults"
 msgid "Suggestions:"
 msgstr ""
 
+#. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Sum up the reviews"
+msgstr ""
+
 #. A short title for the a message asking the AI to summarize a text.
 msgctxt "Title for the summarize message"
 msgid "Summarize"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize the Q&As"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the background and notable work of this person."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the key details of this event."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the questions and answers on this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize their background"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this book"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this book."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this discussion"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this discussion thread."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this video"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this video."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize what the reviews say."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -15093,6 +15470,11 @@ msgstr ""
 msgid "Syria"
 msgstr ""
 
+#. Text for a button that enables the theme to follow the operating system's color scheme preference.
+msgctxt "System theme button for theme selector"
+msgid "System"
+msgstr ""
+
 #. Abbreviation indicating this is the total score for a game
 msgctxt "Sports module"
 msgid "T"
@@ -15116,6 +15498,11 @@ msgctxt "language_name"
 msgid "Tahitian"
 msgstr ""
 
+#. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Tailor my resume"
+msgstr ""
+
 msgid "Taiwan"
 msgstr ""
 
@@ -15137,6 +15524,12 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "Take control of your personal data!"
+msgstr ""
+
+#. Description for the Feedback section of the Duck.ai settings page, asking the user to take an anonymous survey to let us know how we can make Duck.ai better.
+msgctxt "Feedback section description on the Duck.ai settings page"
+msgid ""
+"Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
 
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -15381,6 +15774,11 @@ msgstr ""
 #. https://duck.co/media/files/theme.png
 msgid "Theme"
 msgstr "Tema"
+
+#. Text for the theme selector label that allows users to switch between Light and dark theme.
+msgctxt "Label for the theme selector feature"
+msgid "Theme"
+msgstr ""
 
 #. http://i.imgur.com/LpFhb1e.png
 msgctxt "settings"
@@ -16032,6 +16430,16 @@ msgid ""
 "movie theatre?”"
 msgstr ""
 
+#. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Translate this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
+msgctxt "Page suggestion prompt"
+msgid "Translate this page into %s."
+msgstr ""
+
 #. Placeholder text for a region that will display translated text.
 msgctxt "translations_module"
 msgid "Translation"
@@ -16146,6 +16554,11 @@ msgstr ""
 #. Call-to-action button for the subscription promo in the SERP sidemenu.
 msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
+msgstr ""
+
+#. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
+msgctxt "settings"
+msgid "Try It Now"
 msgstr ""
 
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -16339,6 +16752,20 @@ msgstr "Subukan: %s"
 #. Response a user can select in a feedback form, indicating that they're trying DuckDuckGo again.
 msgctxt "new user poll"
 msgid "Trying DuckDuckGo again"
+msgstr ""
+
+#. Message shown in a modal after supported third-party browser users disable AI features in Settings. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+#. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
 msgstr ""
 
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -16939,6 +17366,11 @@ msgstr ""
 msgid "Uruguay"
 msgstr ""
 
+#. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
+msgctxt "Navigation label on the Duck.ai settings page"
+msgid "Usage"
+msgstr ""
+
 #. A feedback suggestion
 msgctxt "Feedback prompt"
 msgid "Usage limit"
@@ -17287,6 +17719,11 @@ msgstr ""
 msgid "Wales"
 msgstr ""
 
+#. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Walk me through the steps"
+msgstr ""
+
 #. Label for walking directions on a map.
 msgctxt "directions"
 msgid "Walking"
@@ -17377,6 +17814,16 @@ msgstr ""
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
+msgstr ""
+
+#. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
+msgctxt ""
+"Inline warning shown below the share-content toggle when the user selects "
+"Harmful or Illegal but has not enabled sharing"
+msgid ""
+"We can only fix what we can see. To report a harmful or illegal response, "
+"please share this conversation with DuckDuckGo so we can investigate and "
+"address the issue."
 msgstr ""
 
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -17796,6 +18243,87 @@ msgid ""
 "experience."
 msgstr ""
 
+#. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the counterarguments?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the hours & location?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key contributions of this paper?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key contributions?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key details?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key points covered in this video?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key points?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key takeaways from this article?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key takeaways?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key things I will learn from this course?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main counterarguments or criticisms of this?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main questions this page answers?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the must-try dishes here?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"What are the opening hours, location, and contact details for this place?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the pros and cons of this product?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the pros and cons?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
 msgctxt "feedback form"
 msgid "What bothered you most?"
@@ -17879,6 +18407,11 @@ msgctxt "Full sentence for defining a term"
 msgid "What does atria mean in the context of a medical article?"
 msgstr ""
 
+#. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What does this answer?"
+msgstr ""
+
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
@@ -17888,6 +18421,11 @@ msgstr ""
 msgctxt "cloudsave"
 msgid "What information gets saved?"
 msgstr "Anong impormasyon ang nasa-save?"
+
+#. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What interview questions might come up for this role?"
+msgstr ""
 
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
@@ -17899,6 +18437,11 @@ msgstr ""
 #. Text for a prompt suggestion for looking up the capital city of Albania.
 msgctxt "Full sentence for looking up basic facts"
 msgid "What is the capital city of Albania?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What is the overall verdict and rating for this?"
 msgstr ""
 
 #. Link to a page with additional information.
@@ -17919,6 +18462,11 @@ msgctxt "maps_places"
 msgid "What people say:"
 msgstr ""
 
+#. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What should I order?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
 msgctxt "feedback form"
 msgid "What stood out?"
@@ -17927,6 +18475,16 @@ msgstr ""
 #. Question on a feedback form for a negative feedback response.
 msgctxt "feedback form"
 msgid "What was wrong with the response? (optional)"
+msgstr ""
+
+#. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I learn?"
+msgstr ""
+
+#. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I need?"
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -17941,6 +18499,11 @@ msgstr ""
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
 msgctxt "SERP footer content"
 msgid "What's New"
+msgstr ""
+
+#. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What's the verdict?"
 msgstr ""
 
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -17982,6 +18545,11 @@ msgctxt "Feedback prompt"
 msgid "Which features are missing? (Optional)"
 msgstr ""
 
+#. An invitation for users to leave feedback
+msgctxt "Feedback prompt"
+msgid "Which features are missing? (optional)"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
 msgid "White"
 msgstr "Puti"
@@ -17993,6 +18561,16 @@ msgstr ""
 
 #. Link to an about us page.
 msgid "Who We Are"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Who are the main cast and crew, and what else are they known for?"
+msgstr ""
+
+#. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Who is this person?"
 msgstr ""
 
 #. Header above a collection of privacy-related links.

--- a/locales/tokipona_XX/LC_MESSAGES/duckduckgo.po
+++ b/locales/tokipona_XX/LC_MESSAGES/duckduckgo.po
@@ -1163,6 +1163,11 @@ msgctxt "feedback form"
 msgid "Address is incorrect"
 msgstr ""
 
+#. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Adjust the servings"
+msgstr ""
+
 #. as in multiple advertisements
 msgid "Ads"
 msgstr ""
@@ -1336,6 +1341,13 @@ msgstr ""
 #. Heading shown on the empty chat screen. The text between the two %s markers is displayed inside a clickable privacy button. First %s renders a shield icon, second %s is an invisible end marker. Keep the word 'private' between both %s markers.
 msgctxt "Empty state heading in Duck.ai chat mode"
 msgid "All chats are %sprivate%s"
+msgstr ""
+
+#. Paragraph in the Privacy & Terms section of the About & Legal page in Duck.ai settings, summarizing how chats are anonymized and are not stored or used to train chat models.
+msgctxt "Privacy & Terms section description on the Duck.ai settings page"
+msgid ""
+"All chats are anonymized by DuckDuckGo, and your conversations are not used "
+"to train chat models by DuckDuckGo or the model providers"
 msgstr ""
 
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1549,6 +1561,12 @@ msgstr ""
 #. Confirmation message after location service is enabled.
 msgctxt "precise_user_location"
 msgid "Anonymous location enabled"
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Anonymously generates answers for search queries based on web content. "
+"Choose how often you want it to appear, or disable it completely."
 msgstr ""
 
 #. Instant Answer tab name
@@ -1771,6 +1789,11 @@ msgstr ""
 
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse
 msgid "Ask a follow-up with Duck.ai"
+msgstr ""
+
+#. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
+msgctxt "Page suggestion chip label"
+msgid "Ask about this page"
 msgstr ""
 
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2095,6 +2118,11 @@ msgstr ""
 msgid "Barcode"
 msgstr "ilo sitelen supa"
 
+#. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Based on this page, is this course worth taking?"
+msgstr ""
+
 msgctxt "settings"
 msgid "Basic"
 msgstr "lili"
@@ -2126,6 +2154,13 @@ msgstr ""
 #. Placeholder text displayed while the assistant waits for the user to choose an action.
 msgctxt "Assistant response placeholder"
 msgid "Before continuing..."
+msgstr ""
+
+#. Explains that before storing the report, DuckDuckGo will anonymize the conversation by removing PII like names, email addresses, and identifying metadata.
+msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
+msgid ""
+"Before storing this report, DuckDuckGo will anonymize your conversation by "
+"removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
 #. Label that's displayed next to a past start date below a web search result.
@@ -2384,6 +2419,11 @@ msgstr "ma Pasila"
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Break Points Won"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Break this down into clear, numbered steps."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -2743,6 +2783,11 @@ msgstr "pali tawa jan"
 #. Text of a button that performs a search for the cast of a particular movie or tv show
 msgctxt "Movie/TV Show Title instant answer"
 msgid "Cast"
+msgstr ""
+
+#. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Cast & Crew"
 msgstr ""
 
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -4102,6 +4147,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Create a shopping list with quantities from this recipe."
+msgstr ""
+
 #. Placeholder text displayed in the input field when starting a new image generation session.
 msgctxt "Placeholder text for the image generation input field"
 msgid "Create an image of a cute duck..."
@@ -4628,6 +4678,10 @@ msgstr ""
 msgid "Dictation limit reached"
 msgstr ""
 
+#. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
+msgid "Dictation temporarily unavailable"
+msgstr ""
+
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
@@ -4873,6 +4927,20 @@ msgctxt "precise_user_location"
 msgid "Done"
 msgstr ""
 
+#. Message shown in a modal after DuckDuckGo browser users disable AI features in Settings. The first two placeholders bold noai.duckduckgo.com. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
+"filtered out. %sLearn More%s"
+msgstr ""
+
+#. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
+"and AI images filtered out. %sLearn more%s"
+msgstr ""
+
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Double Faults"
@@ -4963,6 +5031,16 @@ msgctxt "Full sentence for writing an email"
 msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
+msgstr ""
+
+#. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Draft a cover letter"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Draft a cover letter for this job."
 msgstr ""
 
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -5102,6 +5180,14 @@ msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
 msgstr ""
 
+#. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
+msgctxt "About section description on the Duck.ai settings page"
+msgid ""
+"Duck.ai is created by DuckDuckGo. We're an independent online protection "
+"company for anyone who wants to take back control of their personal "
+"information."
+msgstr ""
+
 #. Title shown when an update is required before proceeding.
 msgctxt "duckai_migration"
 msgid "Duck.ai is moving domains"
@@ -5135,6 +5221,12 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Duck.ai lets you chat privately with popular AI models. Disabling it hides "
+"Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
 
 msgctxt "settings"
@@ -5900,6 +5992,16 @@ msgstr ""
 msgid "Eritrea"
 msgstr ""
 
+#. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Estimate the nutrition"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Estimate the nutritional information for this recipe."
+msgstr ""
+
 msgid "Estonia"
 msgstr "ma Esi"
 
@@ -5944,10 +6046,50 @@ msgctxt "merchant promotion product ad extension"
 msgid "Expires in 1 day"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain the accepted answer in simple terms."
+msgstr ""
+
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
+msgstr ""
+
+#. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain the top answer"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this in simple, plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this paper"
+msgstr ""
+
+#. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this repo"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this research paper in plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this simply"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain what this repository does and how to use it."
 msgstr ""
 
 #. Label to show if song lyrics contain explicit content
@@ -6178,6 +6320,11 @@ msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
 msgstr ""
 
+msgctxt "settings"
+msgid ""
+"Filters out known AI spam sites from image search results. %sLearn More%s"
+msgstr ""
+
 #. Label for the final score of a sporting event.
 msgid "Final"
 msgstr "ijo open ala"
@@ -6219,6 +6366,11 @@ msgstr ""
 #. Short description shown below the 'Web Search' label in the Tools dropdown.
 msgctxt "Subtitle for the Web Search tool entry in the Tools dropdown menu"
 msgid "Find current information"
+msgstr ""
+
+#. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Find me alternatives"
 msgstr ""
 
 #. Button that searches for results closer to the user's current location.
@@ -6609,6 +6761,11 @@ msgstr ""
 msgid "Generate More"
 msgstr ""
 
+#. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Generate a shopping list"
+msgstr ""
+
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
 msgid "Generate a short answer from the web"
 msgstr ""
@@ -6844,6 +7001,11 @@ msgstr ""
 #. Text for a button inviting users to give it a try for the Duck.ai product. On click, they're taken to the Duck.ai page.
 msgctxt "Onboarding welcome screen button text"
 msgid "Give it a Try"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Give me a quick background on this person."
 msgstr ""
 
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -7207,6 +7369,16 @@ msgstr ""
 #. Link to a page with information about sharing DuckDuckGo with friends.
 msgid "Help Spread Privacy"
 msgstr "o toki tawa len"
+
+#. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Help me prep for the interview"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Help me tailor my resume for this job."
+msgstr ""
 
 #. Title of a SERP popup that invites users to take a survey (desktop only)
 msgctxt "User survey popup"
@@ -7627,6 +7799,13 @@ msgstr ""
 #. Text displayed on the button on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
 msgctxt "Onboarding terms screen button text"
 msgid "I Agree"
+msgstr ""
+
+#. Text for the button that takes the user to the external DuckDuckGo login subscription page.
+msgctxt ""
+"Text for the I already have a subscription button in the Duck.ai settings "
+"page"
+msgid "I Already Have a Subscription"
 msgstr ""
 
 #. Text for the button that takes the user to the login subscription page.
@@ -8085,6 +8264,11 @@ msgctxt "Sidemenu browser promo"
 msgid "Install Mac Browser"
 msgstr ""
 
+#. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
+msgctxt "settings"
+msgid "Install Now"
+msgstr ""
+
 #. Text of a button to install the DuckDuckGo app
 msgctxt "Serp footer content"
 msgid "Install Our App"
@@ -8164,9 +8348,36 @@ msgctxt "cloudsave"
 msgid "Is deleted data really deleted?"
 msgstr "sitelen mute li moli ala moli?"
 
+#. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is it worth taking?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this place any good?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"Is this place any good? Summarize its reputation based on reviews and "
+"ratings."
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "Is this video helpful?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this worth watching?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Is this worth watching? Give me a spoiler-free take."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -8663,6 +8874,11 @@ msgstr "sitelen nimi pi nimi tawa:"
 msgid "Links:"
 msgstr "nasin:"
 
+#. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "List the tools, materials, or prerequisites I need for this."
+msgstr ""
+
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
 msgid "Listen"
 msgstr "o kute"
@@ -8995,6 +9211,11 @@ msgstr ""
 #. Label for linke navigating to site exclusion feature on Settings page
 msgctxt "Exclusion message manage sites button"
 msgid "Manage blocked sites"
+msgstr ""
+
+#. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
+msgctxt "setting"
+msgid "Manage in Browser Settings"
 msgstr ""
 
 #. Link to the site exclusion settings page
@@ -11298,6 +11519,11 @@ msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
+msgid "Please describe why the chat response is harmful or illegal. (optional)"
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
+msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
 msgstr ""
 
@@ -11316,6 +11542,13 @@ msgctxt "Modal disclaimer text"
 msgid ""
 "Please note: starting a new chat with any model will delete your current "
 "chat session."
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
+msgctxt "Feedback prompt"
+msgid ""
+"Please paste your prompt and the problematic output (with any personal "
+"information removed) and describe why the content is harmful or illegal."
 msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -11701,6 +11934,11 @@ msgctxt "settings"
 msgid "Privacy"
 msgstr "sona sina taso"
 
+#. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
+msgctxt "Section heading on the Duck.ai settings page"
+msgid "Privacy & Terms"
+msgstr ""
+
 msgid "Privacy Blog"
 msgstr "lipu jan pi len"
 
@@ -11754,6 +11992,11 @@ msgstr ""
 
 #. Text used in other strings to link to the Privacy Policy and Terms of Service content.
 msgctxt "Copy used to compose link in sentences"
+msgid "Privacy Policy and Terms of Service"
+msgstr ""
+
+#. Text for a button that links to the terms of use and privacy policy page.
+msgctxt "Secondary button text in active privacy modal"
 msgid "Privacy Policy and Terms of Service"
 msgstr ""
 
@@ -12162,6 +12405,26 @@ msgctxt "Brief for recommending a book"
 msgid "Recommend a book"
 msgstr ""
 
+#. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar books"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar books."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar movies or shows."
+msgstr ""
+
+#. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar titles"
+msgstr ""
+
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
 msgid "Recording failed. Please try again."
 msgstr ""
@@ -12481,6 +12744,14 @@ msgstr ""
 msgid "Republic of Moldova"
 msgstr ""
 
+#. Note indicating that sharing the conversation is mandatory when reporting harmful or illegal content. Rendered alongside the standard share label (DUCKCHAT_RESPONSE_FEEDBACK_SHARE_PROMPT_RESPONSE_LABEL), not replacing it.
+msgctxt ""
+"Note shown under the share-content switch label on the Duck.ai response "
+"feedback form when the user has selected Harmful or Illegal as the feedback "
+"reason"
+msgid "Required for harmful or illegal reports"
+msgstr ""
+
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
 msgctxt "Description for extended reasoning mode in Duck.ai"
 msgid "Researches before responding"
@@ -12666,6 +12937,11 @@ msgstr "ijo li pona anu seme?"
 #. Label above a list of customer reviews of a business.
 msgctxt "maps_places"
 msgid "Reviews"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Rewrite this recipe scaled for a different number of servings."
 msgstr ""
 
 msgid "Romania"
@@ -13715,6 +13991,11 @@ msgctxt "Setup button for native sync flow"
 msgid "Set Up Now"
 msgstr ""
 
+#. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
+msgctxt "Encrypted storage setup button shown in native browsers"
+msgid "Set Up Sync & Backup"
+msgstr ""
+
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
 msgctxt "Title for the Sync & Backup intro screen"
 msgid "Set Up Sync & Backup"
@@ -13857,6 +14138,12 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
+msgctxt ""
+"Label beside the share-content switch on the Duck.ai response feedback form"
+msgid "Share this conversation with DuckDuckGo"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -14871,6 +15158,21 @@ msgctxt "Brief for suggesting a blog post title"
 msgid "Suggest a title for a blog post"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest related articles or topics worth exploring next."
+msgstr ""
+
+#. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Suggest related articles to explore"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest some alternatives to this product."
+msgstr ""
+
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
 msgctxt "directions"
 msgid "Suggestions:"
@@ -14880,9 +15182,84 @@ msgctxt "noresults"
 msgid "Suggestions:"
 msgstr "ijo pona tawa:"
 
+#. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Sum up the reviews"
+msgstr ""
+
 #. A short title for the a message asking the AI to summarize a text.
 msgctxt "Title for the summarize message"
 msgid "Summarize"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize the Q&As"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the background and notable work of this person."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the key details of this event."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the questions and answers on this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize their background"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this book"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this book."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this discussion"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this discussion thread."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this video"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this video."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize what the reviews say."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -15137,6 +15514,11 @@ msgstr ""
 msgid "Syria"
 msgstr ""
 
+#. Text for a button that enables the theme to follow the operating system's color scheme preference.
+msgctxt "System theme button for theme selector"
+msgid "System"
+msgstr ""
+
 #. Abbreviation indicating this is the total score for a game
 msgctxt "Sports module"
 msgid "T"
@@ -15160,6 +15542,11 @@ msgctxt "language_name"
 msgid "Tahitian"
 msgstr ""
 
+#. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Tailor my resume"
+msgstr ""
+
 msgid "Taiwan"
 msgstr "ma Tawan"
 
@@ -15181,6 +15568,12 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "Take control of your personal data!"
+msgstr ""
+
+#. Description for the Feedback section of the Duck.ai settings page, asking the user to take an anonymous survey to let us know how we can make Duck.ai better.
+msgctxt "Feedback section description on the Duck.ai settings page"
+msgid ""
+"Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
 
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -15425,6 +15818,11 @@ msgstr ""
 #. https://duck.co/media/files/theme.png
 msgid "Theme"
 msgstr "nasin lukin"
+
+#. Text for the theme selector label that allows users to switch between Light and dark theme.
+msgctxt "Label for the theme selector feature"
+msgid "Theme"
+msgstr ""
 
 #. http://i.imgur.com/LpFhb1e.png
 msgctxt "settings"
@@ -16080,6 +16478,16 @@ msgid ""
 "movie theatre?”"
 msgstr ""
 
+#. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Translate this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
+msgctxt "Page suggestion prompt"
+msgid "Translate this page into %s."
+msgstr ""
+
 #. Placeholder text for a region that will display translated text.
 msgctxt "translations_module"
 msgid "Translation"
@@ -16194,6 +16602,11 @@ msgstr ""
 #. Call-to-action button for the subscription promo in the SERP sidemenu.
 msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
+msgstr ""
+
+#. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
+msgctxt "settings"
+msgid "Try It Now"
 msgstr ""
 
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -16388,6 +16801,20 @@ msgstr "o kepeken e ni: ijo %s"
 msgctxt "new user poll"
 msgid "Trying DuckDuckGo again"
 msgstr "pali e lipu DuckDuckGo lon tenpo sin"
+
+#. Message shown in a modal after supported third-party browser users disable AI features in Settings. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+#. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
 
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
 msgctxt "Assistant response placeholder"
@@ -16991,6 +17418,11 @@ msgstr ""
 msgid "Uruguay"
 msgstr ""
 
+#. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
+msgctxt "Navigation label on the Duck.ai settings page"
+msgid "Usage"
+msgstr ""
+
 #. A feedback suggestion
 msgctxt "Feedback prompt"
 msgid "Usage limit"
@@ -17341,6 +17773,11 @@ msgstr ""
 msgid "Wales"
 msgstr ""
 
+#. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Walk me through the steps"
+msgstr ""
+
 #. Label for walking directions on a map.
 msgctxt "directions"
 msgid "Walking"
@@ -17431,6 +17868,16 @@ msgstr ""
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
+msgstr ""
+
+#. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
+msgctxt ""
+"Inline warning shown below the share-content toggle when the user selects "
+"Harmful or Illegal but has not enabled sharing"
+msgid ""
+"We can only fix what we can see. To report a harmful or illegal response, "
+"please share this conversation with DuckDuckGo so we can investigate and "
+"address the issue."
 msgstr ""
 
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -17854,6 +18301,87 @@ msgid ""
 "experience."
 msgstr ""
 
+#. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the counterarguments?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the hours & location?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key contributions of this paper?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key contributions?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key details?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key points covered in this video?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key points?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key takeaways from this article?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key takeaways?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key things I will learn from this course?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main counterarguments or criticisms of this?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main questions this page answers?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the must-try dishes here?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"What are the opening hours, location, and contact details for this place?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the pros and cons of this product?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the pros and cons?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
 msgctxt "feedback form"
 msgid "What bothered you most?"
@@ -17937,6 +18465,11 @@ msgctxt "Full sentence for defining a term"
 msgid "What does atria mean in the context of a medical article?"
 msgstr ""
 
+#. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What does this answer?"
+msgstr ""
+
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
@@ -17946,6 +18479,11 @@ msgstr ""
 msgctxt "cloudsave"
 msgid "What information gets saved?"
 msgstr "seme sitelen walo li awen?"
+
+#. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What interview questions might come up for this role?"
+msgstr ""
 
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
@@ -17957,6 +18495,11 @@ msgstr ""
 #. Text for a prompt suggestion for looking up the capital city of Albania.
 msgctxt "Full sentence for looking up basic facts"
 msgid "What is the capital city of Albania?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What is the overall verdict and rating for this?"
 msgstr ""
 
 #. Link to a page with additional information.
@@ -17977,6 +18520,11 @@ msgctxt "maps_places"
 msgid "What people say:"
 msgstr ""
 
+#. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What should I order?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
 msgctxt "feedback form"
 msgid "What stood out?"
@@ -17985,6 +18533,16 @@ msgstr ""
 #. Question on a feedback form for a negative feedback response.
 msgctxt "feedback form"
 msgid "What was wrong with the response? (optional)"
+msgstr ""
+
+#. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I learn?"
+msgstr ""
+
+#. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I need?"
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -17999,6 +18557,11 @@ msgstr ""
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
 msgctxt "SERP footer content"
 msgid "What's New"
+msgstr ""
+
+#. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What's the verdict?"
 msgstr ""
 
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -18042,6 +18605,11 @@ msgctxt "Feedback prompt"
 msgid "Which features are missing? (Optional)"
 msgstr ""
 
+#. An invitation for users to leave feedback
+msgctxt "Feedback prompt"
+msgid "Which features are missing? (optional)"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
 msgid "White"
 msgstr "walo"
@@ -18054,6 +18622,16 @@ msgstr "walo"
 #. Link to an about us page.
 msgid "Who We Are"
 msgstr "seme mi?"
+
+#. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Who are the main cast and crew, and what else are they known for?"
+msgstr ""
+
+#. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Who is this person?"
+msgstr ""
 
 #. Header above a collection of privacy-related links.
 msgid "Why Privacy"

--- a/locales/tpi_PG/LC_MESSAGES/duckduckgo.po
+++ b/locales/tpi_PG/LC_MESSAGES/duckduckgo.po
@@ -1159,6 +1159,11 @@ msgctxt "feedback form"
 msgid "Address is incorrect"
 msgstr ""
 
+#. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Adjust the servings"
+msgstr ""
+
 #. as in multiple advertisements
 msgid "Ads"
 msgstr ""
@@ -1330,6 +1335,13 @@ msgstr ""
 #. Heading shown on the empty chat screen. The text between the two %s markers is displayed inside a clickable privacy button. First %s renders a shield icon, second %s is an invisible end marker. Keep the word 'private' between both %s markers.
 msgctxt "Empty state heading in Duck.ai chat mode"
 msgid "All chats are %sprivate%s"
+msgstr ""
+
+#. Paragraph in the Privacy & Terms section of the About & Legal page in Duck.ai settings, summarizing how chats are anonymized and are not stored or used to train chat models.
+msgctxt "Privacy & Terms section description on the Duck.ai settings page"
+msgid ""
+"All chats are anonymized by DuckDuckGo, and your conversations are not used "
+"to train chat models by DuckDuckGo or the model providers"
 msgstr ""
 
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1542,6 +1554,12 @@ msgstr ""
 #. Confirmation message after location service is enabled.
 msgctxt "precise_user_location"
 msgid "Anonymous location enabled"
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Anonymously generates answers for search queries based on web content. "
+"Choose how often you want it to appear, or disable it completely."
 msgstr ""
 
 #. Instant Answer tab name
@@ -1764,6 +1782,11 @@ msgstr ""
 
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse
 msgid "Ask a follow-up with Duck.ai"
+msgstr ""
+
+#. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
+msgctxt "Page suggestion chip label"
+msgid "Ask about this page"
 msgstr ""
 
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2088,6 +2111,11 @@ msgstr ""
 msgid "Barcode"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Based on this page, is this course worth taking?"
+msgstr ""
+
 msgctxt "settings"
 msgid "Basic"
 msgstr ""
@@ -2119,6 +2147,13 @@ msgstr ""
 #. Placeholder text displayed while the assistant waits for the user to choose an action.
 msgctxt "Assistant response placeholder"
 msgid "Before continuing..."
+msgstr ""
+
+#. Explains that before storing the report, DuckDuckGo will anonymize the conversation by removing PII like names, email addresses, and identifying metadata.
+msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
+msgid ""
+"Before storing this report, DuckDuckGo will anonymize your conversation by "
+"removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
 #. Label that's displayed next to a past start date below a web search result.
@@ -2377,6 +2412,11 @@ msgstr ""
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Break Points Won"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Break this down into clear, numbered steps."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -2736,6 +2776,11 @@ msgstr ""
 #. Text of a button that performs a search for the cast of a particular movie or tv show
 msgctxt "Movie/TV Show Title instant answer"
 msgid "Cast"
+msgstr ""
+
+#. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Cast & Crew"
 msgstr ""
 
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -4085,6 +4130,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Create a shopping list with quantities from this recipe."
+msgstr ""
+
 #. Placeholder text displayed in the input field when starting a new image generation session.
 msgctxt "Placeholder text for the image generation input field"
 msgid "Create an image of a cute duck..."
@@ -4611,6 +4661,10 @@ msgstr ""
 msgid "Dictation limit reached"
 msgstr ""
 
+#. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
+msgid "Dictation temporarily unavailable"
+msgstr ""
+
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
@@ -4855,6 +4909,20 @@ msgctxt "precise_user_location"
 msgid "Done"
 msgstr ""
 
+#. Message shown in a modal after DuckDuckGo browser users disable AI features in Settings. The first two placeholders bold noai.duckduckgo.com. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
+"filtered out. %sLearn More%s"
+msgstr ""
+
+#. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
+"and AI images filtered out. %sLearn more%s"
+msgstr ""
+
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Double Faults"
@@ -4945,6 +5013,16 @@ msgctxt "Full sentence for writing an email"
 msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
+msgstr ""
+
+#. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Draft a cover letter"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Draft a cover letter for this job."
 msgstr ""
 
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -5084,6 +5162,14 @@ msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
 msgstr ""
 
+#. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
+msgctxt "About section description on the Duck.ai settings page"
+msgid ""
+"Duck.ai is created by DuckDuckGo. We're an independent online protection "
+"company for anyone who wants to take back control of their personal "
+"information."
+msgstr ""
+
 #. Title shown when an update is required before proceeding.
 msgctxt "duckai_migration"
 msgid "Duck.ai is moving domains"
@@ -5117,6 +5203,12 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Duck.ai lets you chat privately with popular AI models. Disabling it hides "
+"Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
 
 msgctxt "settings"
@@ -5882,6 +5974,16 @@ msgstr ""
 msgid "Eritrea"
 msgstr ""
 
+#. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Estimate the nutrition"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Estimate the nutritional information for this recipe."
+msgstr ""
+
 msgid "Estonia"
 msgstr ""
 
@@ -5926,10 +6028,50 @@ msgctxt "merchant promotion product ad extension"
 msgid "Expires in 1 day"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain the accepted answer in simple terms."
+msgstr ""
+
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
+msgstr ""
+
+#. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain the top answer"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this in simple, plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this paper"
+msgstr ""
+
+#. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this repo"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this research paper in plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this simply"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain what this repository does and how to use it."
 msgstr ""
 
 #. Label to show if song lyrics contain explicit content
@@ -6158,6 +6300,11 @@ msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
 msgstr ""
 
+msgctxt "settings"
+msgid ""
+"Filters out known AI spam sites from image search results. %sLearn More%s"
+msgstr ""
+
 #. Label for the final score of a sporting event.
 msgid "Final"
 msgstr ""
@@ -6197,6 +6344,11 @@ msgstr ""
 #. Short description shown below the 'Web Search' label in the Tools dropdown.
 msgctxt "Subtitle for the Web Search tool entry in the Tools dropdown menu"
 msgid "Find current information"
+msgstr ""
+
+#. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Find me alternatives"
 msgstr ""
 
 #. Button that searches for results closer to the user's current location.
@@ -6587,6 +6739,11 @@ msgstr ""
 msgid "Generate More"
 msgstr ""
 
+#. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Generate a shopping list"
+msgstr ""
+
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
 msgid "Generate a short answer from the web"
 msgstr ""
@@ -6821,6 +6978,11 @@ msgstr ""
 #. Text for a button inviting users to give it a try for the Duck.ai product. On click, they're taken to the Duck.ai page.
 msgctxt "Onboarding welcome screen button text"
 msgid "Give it a Try"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Give me a quick background on this person."
 msgstr ""
 
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -7183,6 +7345,16 @@ msgstr ""
 
 #. Link to a page with information about sharing DuckDuckGo with friends.
 msgid "Help Spread Privacy"
+msgstr ""
+
+#. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Help me prep for the interview"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Help me tailor my resume for this job."
 msgstr ""
 
 #. Title of a SERP popup that invites users to take a survey (desktop only)
@@ -7602,6 +7774,13 @@ msgstr ""
 #. Text displayed on the button on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
 msgctxt "Onboarding terms screen button text"
 msgid "I Agree"
+msgstr ""
+
+#. Text for the button that takes the user to the external DuckDuckGo login subscription page.
+msgctxt ""
+"Text for the I already have a subscription button in the Duck.ai settings "
+"page"
+msgid "I Already Have a Subscription"
 msgstr ""
 
 #. Text for the button that takes the user to the login subscription page.
@@ -8052,6 +8231,11 @@ msgctxt "Sidemenu browser promo"
 msgid "Install Mac Browser"
 msgstr ""
 
+#. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
+msgctxt "settings"
+msgid "Install Now"
+msgstr ""
+
 #. Text of a button to install the DuckDuckGo app
 msgctxt "Serp footer content"
 msgid "Install Our App"
@@ -8131,9 +8315,36 @@ msgctxt "cloudsave"
 msgid "Is deleted data really deleted?"
 msgstr ""
 
+#. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is it worth taking?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this place any good?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"Is this place any good? Summarize its reputation based on reviews and "
+"ratings."
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "Is this video helpful?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this worth watching?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Is this worth watching? Give me a spoiler-free take."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -8630,6 +8841,11 @@ msgstr ""
 msgid "Links:"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "List the tools, materials, or prerequisites I need for this."
+msgstr ""
+
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
 msgid "Listen"
 msgstr "Harim"
@@ -8962,6 +9178,11 @@ msgstr ""
 #. Label for linke navigating to site exclusion feature on Settings page
 msgctxt "Exclusion message manage sites button"
 msgid "Manage blocked sites"
+msgstr ""
+
+#. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
+msgctxt "setting"
+msgid "Manage in Browser Settings"
 msgstr ""
 
 #. Link to the site exclusion settings page
@@ -11259,6 +11480,11 @@ msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
+msgid "Please describe why the chat response is harmful or illegal. (optional)"
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
+msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
 msgstr ""
 
@@ -11277,6 +11503,13 @@ msgctxt "Modal disclaimer text"
 msgid ""
 "Please note: starting a new chat with any model will delete your current "
 "chat session."
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
+msgctxt "Feedback prompt"
+msgid ""
+"Please paste your prompt and the problematic output (with any personal "
+"information removed) and describe why the content is harmful or illegal."
 msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -11661,6 +11894,11 @@ msgctxt "settings"
 msgid "Privacy"
 msgstr ""
 
+#. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
+msgctxt "Section heading on the Duck.ai settings page"
+msgid "Privacy & Terms"
+msgstr ""
+
 msgid "Privacy Blog"
 msgstr ""
 
@@ -11714,6 +11952,11 @@ msgstr ""
 
 #. Text used in other strings to link to the Privacy Policy and Terms of Service content.
 msgctxt "Copy used to compose link in sentences"
+msgid "Privacy Policy and Terms of Service"
+msgstr ""
+
+#. Text for a button that links to the terms of use and privacy policy page.
+msgctxt "Secondary button text in active privacy modal"
 msgid "Privacy Policy and Terms of Service"
 msgstr ""
 
@@ -12122,6 +12365,26 @@ msgctxt "Brief for recommending a book"
 msgid "Recommend a book"
 msgstr ""
 
+#. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar books"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar books."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar movies or shows."
+msgstr ""
+
+#. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar titles"
+msgstr ""
+
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
 msgid "Recording failed. Please try again."
 msgstr ""
@@ -12441,6 +12704,14 @@ msgstr ""
 msgid "Republic of Moldova"
 msgstr ""
 
+#. Note indicating that sharing the conversation is mandatory when reporting harmful or illegal content. Rendered alongside the standard share label (DUCKCHAT_RESPONSE_FEEDBACK_SHARE_PROMPT_RESPONSE_LABEL), not replacing it.
+msgctxt ""
+"Note shown under the share-content switch label on the Duck.ai response "
+"feedback form when the user has selected Harmful or Illegal as the feedback "
+"reason"
+msgid "Required for harmful or illegal reports"
+msgstr ""
+
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
 msgctxt "Description for extended reasoning mode in Duck.ai"
 msgid "Researches before responding"
@@ -12626,6 +12897,11 @@ msgstr "Tingting ya"
 #. Label above a list of customer reviews of a business.
 msgctxt "maps_places"
 msgid "Reviews"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Rewrite this recipe scaled for a different number of servings."
 msgstr ""
 
 msgid "Romania"
@@ -13661,6 +13937,11 @@ msgctxt "Setup button for native sync flow"
 msgid "Set Up Now"
 msgstr ""
 
+#. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
+msgctxt "Encrypted storage setup button shown in native browsers"
+msgid "Set Up Sync & Backup"
+msgstr ""
+
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
 msgctxt "Title for the Sync & Backup intro screen"
 msgid "Set Up Sync & Backup"
@@ -13803,6 +14084,12 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
+msgctxt ""
+"Label beside the share-content switch on the Duck.ai response feedback form"
+msgid "Share this conversation with DuckDuckGo"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -14817,6 +15104,21 @@ msgctxt "Brief for suggesting a blog post title"
 msgid "Suggest a title for a blog post"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest related articles or topics worth exploring next."
+msgstr ""
+
+#. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Suggest related articles to explore"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest some alternatives to this product."
+msgstr ""
+
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
 msgctxt "directions"
 msgid "Suggestions:"
@@ -14826,9 +15128,84 @@ msgctxt "noresults"
 msgid "Suggestions:"
 msgstr ""
 
+#. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Sum up the reviews"
+msgstr ""
+
 #. A short title for the a message asking the AI to summarize a text.
 msgctxt "Title for the summarize message"
 msgid "Summarize"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize the Q&As"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the background and notable work of this person."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the key details of this event."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the questions and answers on this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize their background"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this book"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this book."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this discussion"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this discussion thread."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this video"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this video."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize what the reviews say."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -15083,6 +15460,11 @@ msgstr ""
 msgid "Syria"
 msgstr ""
 
+#. Text for a button that enables the theme to follow the operating system's color scheme preference.
+msgctxt "System theme button for theme selector"
+msgid "System"
+msgstr ""
+
 #. Abbreviation indicating this is the total score for a game
 msgctxt "Sports module"
 msgid "T"
@@ -15106,6 +15488,11 @@ msgctxt "language_name"
 msgid "Tahitian"
 msgstr ""
 
+#. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Tailor my resume"
+msgstr ""
+
 msgid "Taiwan"
 msgstr ""
 
@@ -15127,6 +15514,12 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "Take control of your personal data!"
+msgstr ""
+
+#. Description for the Feedback section of the Duck.ai settings page, asking the user to take an anonymous survey to let us know how we can make Duck.ai better.
+msgctxt "Feedback section description on the Duck.ai settings page"
+msgid ""
+"Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
 
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -15369,6 +15762,11 @@ msgstr ""
 
 #. Title for the theme menu:
 #. https://duck.co/media/files/theme.png
+msgid "Theme"
+msgstr ""
+
+#. Text for the theme selector label that allows users to switch between Light and dark theme.
+msgctxt "Label for the theme selector feature"
 msgid "Theme"
 msgstr ""
 
@@ -16022,6 +16420,16 @@ msgid ""
 "movie theatre?”"
 msgstr ""
 
+#. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Translate this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
+msgctxt "Page suggestion prompt"
+msgid "Translate this page into %s."
+msgstr ""
+
 #. Placeholder text for a region that will display translated text.
 msgctxt "translations_module"
 msgid "Translation"
@@ -16136,6 +16544,11 @@ msgstr ""
 #. Call-to-action button for the subscription promo in the SERP sidemenu.
 msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
+msgstr ""
+
+#. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
+msgctxt "settings"
+msgid "Try It Now"
 msgstr ""
 
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -16329,6 +16742,20 @@ msgstr ""
 #. Response a user can select in a feedback form, indicating that they're trying DuckDuckGo again.
 msgctxt "new user poll"
 msgid "Trying DuckDuckGo again"
+msgstr ""
+
+#. Message shown in a modal after supported third-party browser users disable AI features in Settings. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+#. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
 msgstr ""
 
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -16929,6 +17356,11 @@ msgstr ""
 msgid "Uruguay"
 msgstr ""
 
+#. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
+msgctxt "Navigation label on the Duck.ai settings page"
+msgid "Usage"
+msgstr ""
+
 #. A feedback suggestion
 msgctxt "Feedback prompt"
 msgid "Usage limit"
@@ -17277,6 +17709,11 @@ msgstr ""
 msgid "Wales"
 msgstr ""
 
+#. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Walk me through the steps"
+msgstr ""
+
 #. Label for walking directions on a map.
 msgctxt "directions"
 msgid "Walking"
@@ -17367,6 +17804,16 @@ msgstr ""
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
+msgstr ""
+
+#. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
+msgctxt ""
+"Inline warning shown below the share-content toggle when the user selects "
+"Harmful or Illegal but has not enabled sharing"
+msgid ""
+"We can only fix what we can see. To report a harmful or illegal response, "
+"please share this conversation with DuckDuckGo so we can investigate and "
+"address the issue."
 msgstr ""
 
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -17786,6 +18233,87 @@ msgid ""
 "experience."
 msgstr ""
 
+#. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the counterarguments?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the hours & location?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key contributions of this paper?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key contributions?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key details?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key points covered in this video?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key points?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key takeaways from this article?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key takeaways?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key things I will learn from this course?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main counterarguments or criticisms of this?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main questions this page answers?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the must-try dishes here?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"What are the opening hours, location, and contact details for this place?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the pros and cons of this product?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the pros and cons?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
 msgctxt "feedback form"
 msgid "What bothered you most?"
@@ -17869,6 +18397,11 @@ msgctxt "Full sentence for defining a term"
 msgid "What does atria mean in the context of a medical article?"
 msgstr ""
 
+#. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What does this answer?"
+msgstr ""
+
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
@@ -17877,6 +18410,11 @@ msgstr ""
 #. Header above a list of types of information that gets saved by the cloud save feature.
 msgctxt "cloudsave"
 msgid "What information gets saved?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What interview questions might come up for this role?"
 msgstr ""
 
 #. Text explaining how the cloud save feature works.
@@ -17889,6 +18427,11 @@ msgstr ""
 #. Text for a prompt suggestion for looking up the capital city of Albania.
 msgctxt "Full sentence for looking up basic facts"
 msgid "What is the capital city of Albania?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What is the overall verdict and rating for this?"
 msgstr ""
 
 #. Link to a page with additional information.
@@ -17909,6 +18452,11 @@ msgctxt "maps_places"
 msgid "What people say:"
 msgstr ""
 
+#. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What should I order?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
 msgctxt "feedback form"
 msgid "What stood out?"
@@ -17917,6 +18465,16 @@ msgstr ""
 #. Question on a feedback form for a negative feedback response.
 msgctxt "feedback form"
 msgid "What was wrong with the response? (optional)"
+msgstr ""
+
+#. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I learn?"
+msgstr ""
+
+#. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I need?"
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -17931,6 +18489,11 @@ msgstr ""
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
 msgctxt "SERP footer content"
 msgid "What's New"
+msgstr ""
+
+#. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What's the verdict?"
 msgstr ""
 
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -17972,6 +18535,11 @@ msgctxt "Feedback prompt"
 msgid "Which features are missing? (Optional)"
 msgstr ""
 
+#. An invitation for users to leave feedback
+msgctxt "Feedback prompt"
+msgid "Which features are missing? (optional)"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
 msgid "White"
 msgstr ""
@@ -17983,6 +18551,16 @@ msgstr ""
 
 #. Link to an about us page.
 msgid "Who We Are"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Who are the main cast and crew, and what else are they known for?"
+msgstr ""
+
+#. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Who is this person?"
 msgstr ""
 
 #. Header above a collection of privacy-related links.

--- a/locales/tr_TR/LC_MESSAGES/duckduckgo.po
+++ b/locales/tr_TR/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: tr_TR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -898,8 +898,7 @@ msgstr ""
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of Duck.ai is available! Please refresh this page to continue."
-msgstr ""
-"Duck.ai'ın yeni sürümü yayında! Devam etmek için lütfen bu sayfayı yenileyin."
+msgstr "Duck.ai'ın yeni sürümü yayında! Devam etmek için lütfen bu sayfayı yenileyin."
 
 # smartling.placeholder_format=C
 #. Shown when the Duck.ai desktop app has been open a long time and a newer version exists.
@@ -1447,7 +1446,7 @@ msgstr "Adres yanlış"
 #. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Adjust the servings"
-msgstr ""
+msgstr "Porsiyonları ayarla"
 
 # smartling.placeholder_format=C
 #. as in multiple advertisements
@@ -1531,8 +1530,7 @@ msgstr "İndirdikten ve açtıktan sonra %1$sYükle%2$s seçeneğine tıklayın"
 #. Instructions on how to install the DuckDuckGo browser extension after it downloads.
 msgid ""
 "After it downloads, locate the extension file and double-click it to install"
-msgstr ""
-"İndirdikten sonra uzantı dosyasını bulun ve yüklemek için çift tıklayın"
+msgstr "İndirdikten sonra uzantı dosyasını bulun ve yüklemek için çift tıklayın"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an age below a web search result.
@@ -1668,6 +1666,9 @@ msgid ""
 "All chats are anonymized by DuckDuckGo, and your conversations are not used "
 "to train chat models by DuckDuckGo or the model providers"
 msgstr ""
+"Tüm sohbetler DuckDuckGo tarafından anonimleştirilir ve konuşmalarınız "
+"DuckDuckGo veya model sağlayıcılar tarafından sohbet modellerini eğitmek "
+"için kullanılmaz"
 
 # smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1813,8 +1814,7 @@ msgstr "Zaten senkronize edildi."
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Also search privately on your iPad, iPhone, or Android!"
-msgstr ""
-"Ayrıca iPad, iPhone veya Android cihazınızda gizli arama yapabilirsiniz!"
+msgstr "Ayrıca iPad, iPhone veya Android cihazınızda gizli arama yapabilirsiniz!"
 
 # smartling.placeholder_format=C
 #. Keyboard shortcut for Duck.ai
@@ -1947,6 +1947,9 @@ msgid ""
 "Anonymously generates answers for search queries based on web content. "
 "Choose how often you want it to appear, or disable it completely."
 msgstr ""
+"Web içeriğine dayalı olarak arama sorguları için anonim şekilde yanıtlar "
+"üretir. Ne sıklıkta görünmesini istediğinizi seçin veya tamamen devre dışı "
+"bırakın."
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -2101,8 +2104,7 @@ msgstr ""
 #. Body text of the modal that asks the user if they want to clear the conversation.
 msgctxt "Modal body for clearing conversation"
 msgid "Are you sure you want to clear this conversation and start a new one?"
-msgstr ""
-"Bu konuşmayı silip yeni bir konuşma başlatmak istediğinizden emin misiniz?"
+msgstr "Bu konuşmayı silip yeni bir konuşma başlatmak istediğinizden emin misiniz?"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to delete their current chat, explaining that this action cannot be undone.
@@ -2234,7 +2236,7 @@ msgstr "Duck.ai'a takip sorusu sor"
 #. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
 msgctxt "Page suggestion chip label"
 msgid "Ask about this page"
-msgstr ""
+msgstr "Bu sayfa hakkında soru sorun"
 
 # smartling.placeholder_format=C
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2403,15 +2405,13 @@ msgstr "Ses"
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat ends."
-msgstr ""
-"Sohbet sona erdikten sonra ses tarafımızdan veya OpenAI tarafından saklanmaz."
+msgstr "Sohbet sona erdikten sonra ses tarafımızdan veya OpenAI tarafından saklanmaz."
 
 # smartling.placeholder_format=C
 #. Description in consent disclaimer informing that audio from the voice chat session is not stored by us or by OpenAI after the voice chat ends.
 msgctxt "voice chat"
 msgid "Audio is not stored by us or by OpenAI after the chat ends."
-msgstr ""
-"Sohbet sona erdikten sonra ses tarafımızdan veya OpenAI tarafından saklanmaz."
+msgstr "Sohbet sona erdikten sonra ses tarafımızdan veya OpenAI tarafından saklanmaz."
 
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
@@ -2660,7 +2660,7 @@ msgstr "Barkod"
 #. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Based on this page, is this course worth taking?"
-msgstr ""
+msgstr "Bu sayfaya dayalı olarak bu kursa katılmaya değer mi?"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2709,6 +2709,9 @@ msgid ""
 "Before storing this report, DuckDuckGo will anonymize your conversation by "
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
+"DuckDuckGo, bu raporu kaydetmeden önce isimler, e-posta adresleri ve "
+"tanımlayıcı meta veriler gibi kişiyi açığa çıkarabilecek bilgileri (PII) "
+"kaldırarak konuşmanızı anonim hale getirecektir."
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -2850,8 +2853,7 @@ msgstr "Bu siteyi tüm sonuçlarda engelleyin"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Block trackers and take control of your personal data"
-msgstr ""
-"Takip edicileri engelleyin ve kişisel verilerinizin kontrolünü elinize alın"
+msgstr "Takip edicileri engelleyin ve kişisel verilerinizin kontrolünü elinize alın"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -3031,7 +3033,7 @@ msgstr "Kazanılan Servis Kırma Puanları"
 #. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Break this down into clear, numbered steps."
-msgstr ""
+msgstr "Bunu net, numaralandırılmış adımlara böl."
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -3278,8 +3280,7 @@ msgstr "Kamerun"
 #. Text for a prompt suggestion for creating a few simple recipes using chicken, broccoli, and rice.
 msgctxt "Full sentence for crafting a recipe"
 msgid "Can you create a few simple recipes using chicken, broccoli, and rice?"
-msgstr ""
-"Tavuk, brokoli ve pirinci kullanarak birkaç basit tarif hazırlayabilir misin?"
+msgstr "Tavuk, brokoli ve pirinci kullanarak birkaç basit tarif hazırlayabilir misin?"
 
 # smartling.placeholder_format=C
 msgid "Canada"
@@ -3493,7 +3494,7 @@ msgstr "Oyuncular"
 #. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Cast & Crew"
-msgstr ""
+msgstr "Oyuncular ve Ekip"
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -4308,8 +4309,7 @@ msgstr "%1$sEkle%2$s seçeneğine tıklayın"
 #. Instructions on which buttons the user has to click in order to add the DuckDuckGo extension to their browser.
 msgctxt "install-duckduckgo"
 msgid "Click %sAllow%s, then %sAdd%s."
-msgstr ""
-"%1$sİzin Ver%2$s seçeneğine, ardından %3$sEkle%4$s seçeneğine tıklayın."
+msgstr "%1$sİzin Ver%2$s seçeneğine, ardından %3$sEkle%4$s seçeneğine tıklayın."
 
 #  Firefox 33
 # smartling.placeholder_format=C
@@ -4422,15 +4422,13 @@ msgstr "Açılır menüden %1$sArama Ayarlarını Değiştir%2$s seçeneğine t�
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click on %sSet as Default%s towards the bottom"
-msgstr ""
-"Alta doğru yer alan %1$sVarsayılan Olarak Ayarla%2$s seçeneğine tıklayın"
+msgstr "Alta doğru yer alan %1$sVarsayılan Olarak Ayarla%2$s seçeneğine tıklayın"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click on the %sSearch Providers%s under Add-on Types"
-msgstr ""
-"Eklenti Türleri bölümündeki %1$sArama Sağlayıcıları%2$s seçeneğine tıklayın"
+msgstr "Eklenti Türleri bölümündeki %1$sArama Sağlayıcıları%2$s seçeneğine tıklayın"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -4511,8 +4509,7 @@ msgstr "Adres çubuğundaki %1$sizinler simgesine%2$s tıklayın"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to search using DuckDuckGo.
 msgid "Click the Duck icon at the top of your browser to search!"
-msgstr ""
-"Arama yapmak için tarayıcınızın üst kısmındaki ördek simgesine tıklayın!"
+msgstr "Arama yapmak için tarayıcınızın üst kısmındaki ördek simgesine tıklayın!"
 
 #  UC Browser on Android
 # smartling.placeholder_format=C
@@ -4564,8 +4561,7 @@ msgstr "Arama çubuğundaki büyüteç simgesine tıklayın"
 #. Tells users what icon to click in order to make DuckDuckGo the default engine in their browser.
 msgid ""
 "Click the magnifying glass in the search box (at the top of the browser)"
-msgstr ""
-"Arama kutusundaki büyüteç simgesine tıklayın (tarayıcının üst tarafında)"
+msgstr "Arama kutusundaki büyüteç simgesine tıklayın (tarayıcının üst tarafında)"
 
 #  IE default search engine instruction
 # smartling.placeholder_format=C
@@ -5222,7 +5218,7 @@ msgstr "Görsel Oluştur"
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
-msgstr ""
+msgstr "Bu tariften miktarlarıyla birlikte bir alışveriş listesi oluştur."
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed in the input field when starting a new image generation session.
@@ -5479,8 +5475,7 @@ msgstr "Günlük limit doldu"
 #. Displayed when the user has reached a fixed daily Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Daily usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Günlük kullanım limiti doldu. Bu sohbete %1$s sonrasında devam edebilirsiniz."
+msgstr "Günlük kullanım limiti doldu. Bu sohbete %1$s sonrasında devam edebilirsiniz."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable daily Duck.ai usage limit and can opt in to continue using the weekly limit.
@@ -5870,7 +5865,7 @@ msgstr "Dikte limiti doldu"
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
 msgid "Dictation temporarily unavailable"
-msgstr ""
+msgstr "Dikte geçici olarak kullanılamıyor"
 
 # smartling.placeholder_format=C
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
@@ -6149,8 +6144,7 @@ msgstr "DuckDuckGo'yu listede göremiyor musunuz?"
 #. Link to download a file again if the user can't find it on their computer.
 msgctxt "install-extension"
 msgid "Don't see it? %s%s%sClick here to re-download%s"
-msgstr ""
-"Göremiyor musunuz? %1$s%2$s%3$sTekrar indirmek için buraya tıklayın%4$s"
+msgstr "Göremiyor musunuz? %1$s%2$s%3$sTekrar indirmek için buraya tıklayın%4$s"
 
 #  IE < 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -6182,6 +6176,9 @@ msgid ""
 "Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
 "filtered out. %sLearn More%s"
 msgstr ""
+"Yapay zeka istemiyor musunuz? %1$snoai.duckduckgo.com%2$s hiçbir yapay zeka "
+"özelliği sunmaz ve yapay zeka görselleri filtrelenir. %3$sDaha Fazla "
+"Bilgi%4$s"
 
 # smartling.placeholder_format=C
 #. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
@@ -6190,6 +6187,9 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
+"Yapay zeka istemiyor musunuz? %1$snoai.duckduckgo.com%2$s adresini ziyaret "
+"edip yapay zekâ özellikleri olmadan ve yapay zeka görselleri filtrelenmiş "
+"şekilde arama yapabilirsiniz. %3$sDaha fazla bilgi%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6309,13 +6309,13 @@ msgstr ""
 #. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Draft a cover letter"
-msgstr ""
+msgstr "Bir ön yazı taslağı hazırla"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Draft a cover letter for this job."
-msgstr ""
+msgstr "Bu pozisyon için bir ön yazı taslağı hazırla."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -6501,6 +6501,9 @@ msgid ""
 "company for anyone who wants to take back control of their personal "
 "information."
 msgstr ""
+"Duck.ai, DuckDuckGo tarafından geliştirilmiştir. Kişisel bilgilerinin "
+"kontrolünü geri almak isteyen herkes için bağımsız bir online koruma "
+"şirketiyiz."
 
 # smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
@@ -6547,8 +6550,7 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
-msgstr ""
-"Duck.ai geçici olarak kullanılamıyor. Lütfen daha sonra tekrar deneyin."
+msgstr "Duck.ai geçici olarak kullanılamıyor. Lütfen daha sonra tekrar deneyin."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6556,6 +6558,9 @@ msgid ""
 "Duck.ai lets you chat privately with popular AI models. Disabling it hides "
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
+"Duck.ai, popüler yapay zeka modelleriyle gizlice sohbet etmenizi sağlar. "
+"Bunu devre dışı bırakmak Duck.ai düğmelerini ve bağlantılarını gizler, ancak "
+"yine de %1$sduck.ai%2$s adresini doğrudan ziyaret edebilirsiniz."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6601,8 +6606,7 @@ msgstr ""
 msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
-msgstr ""
-"Duck.ai yanıtları belirli kaynaklara dayanmaz ve doğruluğu kontrol edilmez."
+msgstr "Duck.ai yanıtları belirli kaynaklara dayanmaz ve doğruluğu kontrol edilmez."
 
 # smartling.placeholder_format=C
 #. Title shown when native app needs to reload for service update.
@@ -6620,8 +6624,7 @@ msgstr "Duck.ai aboneliği yükseltildi!"
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
-msgstr ""
-"Duck.ai, gizli ve ücretsiz DuckDuckGo uygulamasında en iyi şekilde çalışır!"
+msgstr "Duck.ai, gizli ve ücretsiz DuckDuckGo uygulamasında en iyi şekilde çalışır!"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -7296,8 +7299,7 @@ msgstr "Duck.ai'da sesli dikte özelliğini etkinleştir"
 #. Prompt to enable location service so that search results can be displayed near the user's current location.
 msgctxt "precise_user_location"
 msgid "Enable location settings on your device to use anonymous location"
-msgstr ""
-"Anonim konumu kullanmak için cihazınızdan konum ayarlarını etkinleştirin"
+msgstr "Anonim konumu kullanmak için cihazınızdan konum ayarlarını etkinleştirin"
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -7406,8 +7408,7 @@ msgstr "Duck.ai'ı beğeniyor musunuz?"
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure %s'Allow'%s is selected for the 'Location' setting."
-msgstr ""
-"'Konum' ayarı için %1$s'İzin Ver'%2$s ögesinin seçili olduğundan emin olun."
+msgstr "'Konum' ayarı için %1$s'İzin Ver'%2$s ögesinin seçili olduğundan emin olun."
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
@@ -7565,13 +7566,13 @@ msgstr "Eritre"
 #. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Estimate the nutrition"
-msgstr ""
+msgstr "Besin değerlerini tahmin et"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Estimate the nutritional information for this recipe."
-msgstr ""
+msgstr "Bu tarifin besin değerlerini tahmin et."
 
 # smartling.placeholder_format=C
 msgid "Estonia"
@@ -7631,7 +7632,7 @@ msgstr "1 gün içinde sona eriyor"
 #. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain the accepted answer in simple terms."
-msgstr ""
+msgstr "Kabul edilen yanıtı basit terimlerle açıkla."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
@@ -7644,43 +7645,43 @@ msgstr "Bana lise düzeyinde kara deliklerin temel kavramlarını açıkla."
 #. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain the top answer"
-msgstr ""
+msgstr "En üstteki yanıtı açıkla"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain this in simple, plain language."
-msgstr ""
+msgstr "Bunu basit ve anlaşılır bir dille açıkla."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain this paper"
-msgstr ""
+msgstr "Bu makaleyi açıkla"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain this repo"
-msgstr ""
+msgstr "Bu depoyu açıkla"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain this research paper in plain language."
-msgstr ""
+msgstr "Bu araştırma makalesini sade bir dille açıkla."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain this simply"
-msgstr ""
+msgstr "Bunu basitçe açıkla"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain what this repository does and how to use it."
-msgstr ""
+msgstr "Bu deponun ne işe yaradığını ve nasıl kullanılacağını açıkla."
 
 # smartling.placeholder_format=C
 #. Label to show if song lyrics contain explicit content
@@ -7973,6 +7974,8 @@ msgctxt "settings"
 msgid ""
 "Filters out known AI spam sites from image search results. %sLearn More%s"
 msgstr ""
+"Görsel arama sonuçlarından bilinen yapay zeka spam sitelerini filtreler. "
+"%1$sDaha Fazla Bilgi%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the final score of a sporting event.
@@ -8001,8 +8004,7 @@ msgstr "Finansal danışman"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Find %sDuckDuckGo%s and click%sMake default%s"
-msgstr ""
-"%1$sDuckDuckGo%2$s'yu bulun ve %3$sVarsayılan yap%4$s seçeneğine tıklayın"
+msgstr "%1$sDuckDuckGo%2$s'yu bulun ve %3$sVarsayılan yap%4$s seçeneğine tıklayın"
 
 # smartling.placeholder_format=C
 #. Sentence shown after export, includes a placeholder for one or more filenames with bold formatting for the filename(s).
@@ -8034,7 +8036,7 @@ msgstr "Güncel bilgilere erişin"
 #. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Find me alternatives"
-msgstr ""
+msgstr "Bana alternatifler bul"
 
 # smartling.placeholder_format=C
 #. Button that searches for results closer to the user's current location.
@@ -8053,8 +8055,7 @@ msgstr "Size daha yakın sonuçlar bulun."
 msgctxt "Precise user location overlay"
 msgid ""
 "Find results near you. %sYour location stays private, secure, and anonymous."
-msgstr ""
-"Yakınınızdan sonuçlar bulun. %1$sKonumunuz gizli, güvende ve anonim kalır."
+msgstr "Yakınınızdan sonuçlar bulun. %1$sKonumunuz gizli, güvende ve anonim kalır."
 
 # smartling.placeholder_format=C
 #. Loading message shown while generating explore more follow-up questions
@@ -8230,8 +8231,7 @@ msgstr "Tarafımızdan anonimleştirilmiş ücretsiz ve gizli sohbetler"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr ""
-"Tarafımızdan anonimleştirilmiş ücretsiz ve gizli sohbetler. Hesap gerekmez."
+msgstr "Tarafımızdan anonimleştirilmiş ücretsiz ve gizli sohbetler. Hesap gerekmez."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -8243,8 +8243,7 @@ msgstr "Ücretsiz Değiştirilebilen, Paylaşılabilen ve Kullanılabilen"
 #. a filter for images with the CC BY usage license
 msgctxt "image-licence"
 msgid "Free to Modify, Share, and Use Commercially"
-msgstr ""
-"Ücretsiz Değiştirilebilen, Paylaşılabilen ve Ticari Olarak Kullanılabilen"
+msgstr "Ücretsiz Değiştirilebilen, Paylaşılabilen ve Ticari Olarak Kullanılabilen"
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC-ND usage license
@@ -8516,7 +8515,7 @@ msgstr "Daha Fazla Oluştur"
 #. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Generate a shopping list"
-msgstr ""
+msgstr "Alışveriş listesi oluştur"
 
 # smartling.placeholder_format=C
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
@@ -8813,7 +8812,7 @@ msgstr "Deneyin"
 #. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Give me a quick background on this person."
-msgstr ""
+msgstr "Bu kişinin geçmişi hakkında kısaca bilgi ver."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9265,13 +9264,13 @@ msgstr "Gizliliğin Yaygınlaşmasına Yardımcı Olun"
 #. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Help me prep for the interview"
-msgstr ""
+msgstr "Mülakata hazırlanmama yardım et"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Help me tailor my resume for this job."
-msgstr ""
+msgstr "Bu iş için özgeçmişimi uyarlamama yardım et."
 
 # smartling.placeholder_format=C
 #. Title of a SERP popup that invites users to take a survey (desktop only)
@@ -9283,8 +9282,7 @@ msgstr "DuckDuckGo'yu geliştirmemize yardımcı olun"
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Help us improve DuckDuckGo searches with your feedback"
-msgstr ""
-"Geri bildirimlerinizle DuckDuckGo aramalarını geliştirmemize yardımcı olun"
+msgstr "Geri bildirimlerinizle DuckDuckGo aramalarını geliştirmemize yardımcı olun"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -9342,8 +9340,7 @@ msgstr "Arkadaşlarınızın ve ailenizin Duck Side'a katılmalarına yardımcı
 #. Text description for the Spread card in the SERP footer
 msgctxt "footer_card"
 msgid "Help your friends and family take back their privacy!"
-msgstr ""
-"Arkadaşlarınızın ve ailenizin gizliliklerini geri almalarına yardımcı olun!"
+msgstr "Arkadaşlarınızın ve ailenizin gizliliklerini geri almalarına yardımcı olun!"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -9474,8 +9471,7 @@ msgstr "E-posta adresinizi gizleyin"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Hides search term from being shown in browser tab/history"
-msgstr ""
-"Arama ifadesinin tarayıcı sekmesinde/geçmişinde gösterilmesini engeller"
+msgstr "Arama ifadesinin tarayıcı sekmesinde/geçmişinde gösterilmesini engeller"
 
 # smartling.placeholder_format=C
 #. The highest stock price in a day
@@ -9723,8 +9719,7 @@ msgstr "Yapay zeka destekli cevapların ne kadar görünmesini istiyorsun?"
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
 msgctxt "Duck.ai settings usage section"
 msgid "How much of your daily and weekly limits you've used so far."
-msgstr ""
-"Şimdiye kadar günlük ve haftalık limitlerinizin ne kadarını kullandığınız."
+msgstr "Şimdiye kadar günlük ve haftalık limitlerinizin ne kadarını kullandığınız."
 
 # smartling.placeholder_format=C
 #. A header for the feedback form in the assist negative feedback flow. The user is being asked to update how often they want AI-assisted answers to appear.
@@ -9798,7 +9793,7 @@ msgctxt ""
 "Text for the I already have a subscription button in the Duck.ai settings "
 "page"
 msgid "I Already Have a Subscription"
-msgstr ""
+msgstr "Zaten Aboneliğim Var"
 
 # smartling.placeholder_format=C
 #. Text for the button that takes the user to the login subscription page.
@@ -9874,15 +9869,14 @@ msgid ""
 "I like the book Name of the Wind. What are some other good books/series most "
 "like it and why?"
 msgstr ""
-"Rüzgârın Adı kitabını severim. Buna en çok benzeyen diğer iyi kitaplar/"
-"diziler nelerdir ve neden?"
+"Rüzgârın Adı kitabını severim. Buna en çok benzeyen diğer iyi "
+"kitaplar/diziler nelerdir ve neden?"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the user needs more help or information on how to use the chat.
 msgctxt "Feedback option for difficulty in using chat"
 msgid "I need more help/info on how to use Chat"
-msgstr ""
-"Sohbeti nasıl kullanacağıma dair daha fazla yardım/bilgiye ihtiyacım var"
+msgstr "Sohbeti nasıl kullanacağıma dair daha fazla yardım/bilgiye ihtiyacım var"
 
 # smartling.placeholder_format=C
 msgid "IR Iran"
@@ -10383,7 +10377,7 @@ msgstr "Mac Tarayıcısını Yükle"
 #. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
 msgctxt "settings"
 msgid "Install Now"
-msgstr ""
+msgstr "Şimdi Yükle"
 
 # smartling.placeholder_format=C
 #. Text of a button to install the DuckDuckGo app
@@ -10486,13 +10480,13 @@ msgstr "Silinen veriler gerçekten siliniyor mu?"
 #. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Is it worth taking?"
-msgstr ""
+msgstr "Katılmaya değer mi?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Is this place any good?"
-msgstr ""
+msgstr "Bu yer iyi mi?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
@@ -10500,7 +10494,7 @@ msgctxt "Page suggestion prompt"
 msgid ""
 "Is this place any good? Summarize its reputation based on reviews and "
 "ratings."
-msgstr ""
+msgstr "Bu yer iyi mi? İncelemelere ve puanlara dayanarak itibarını özetle."
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -10512,13 +10506,13 @@ msgstr "Bu video yararlı oldu mu?"
 #. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Is this worth watching?"
-msgstr ""
+msgstr "Bunu izlemeye değer mi?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Is this worth watching? Give me a spoiler-free take."
-msgstr ""
+msgstr "Bunu izlemeye değer mi? Bana spoiler vermeden özetle."
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -11134,7 +11128,7 @@ msgstr "Bağlantılar:"
 #. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
-msgstr ""
+msgstr "Bunun için ihtiyacım olan araçları, malzemeleri veya ön koşulları listele."
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -11550,7 +11544,7 @@ msgstr "Engellenen siteleri yönetin"
 #. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
 msgctxt "setting"
 msgid "Manage in Browser Settings"
-msgstr ""
+msgstr "Tarayıcı Ayarlarından Yönet"
 
 # smartling.placeholder_format=C
 #. Link to the site exclusion settings page
@@ -12002,8 +11996,7 @@ msgstr "Aylık limit doldu"
 #. Displayed when the user has reached a fixed monthly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Monthly usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Aylık kullanım limiti doldu. Bu sohbete %1$s sonrasında devam edebilirsiniz."
+msgstr "Aylık kullanım limiti doldu. Bu sohbete %1$s sonrasında devam edebilirsiniz."
 
 # smartling.placeholder_format=C
 #. Used to point to additional social networking profiles (in results).
@@ -12153,8 +12146,7 @@ msgstr "Daha fazla bilgiyi %1$s %2$s makalesinde bulabilirsiniz."
 # smartling.placeholder_format=C
 #. Source (section, article and site) of the answer generated by duckassist (an instant answer based on generative AI)
 msgid "More info in the %s section of the %s %s article."
-msgstr ""
-"Daha fazla bilgiyi %2$s %3$s makalesinin %1$s bölümünde bulabilirsiniz."
+msgstr "Daha fazla bilgiyi %2$s %3$s makalesinin %1$s bölümünde bulabilirsiniz."
 
 # smartling.placeholder_format=C
 msgctxt ""
@@ -14390,6 +14382,8 @@ msgstr ""
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is harmful or illegal. (optional)"
 msgstr ""
+"Lütfen sohbet yanıtının neden zararlı veya yasa dışı olduğunu açıklayın. "
+"(isteğe bağlı)"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
@@ -14428,6 +14422,9 @@ msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is harmful or illegal."
 msgstr ""
+"Lütfen komut isteminizi ve sorunlu çıktıyı (kişisel bilgiler çıkarılmış "
+"olarak) yapıştırın ve içeriğin neden zararlı veya yasa dışı olduğunu "
+"açıklayın."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -14583,16 +14580,14 @@ msgstr "Lütfen bekleyin..."
 #. Tagline for the subscription promo shown in the SERP sidemenu.
 msgctxt "Sidemenu subscription promo"
 msgid "Plus more premium features with a DuckDuckGo subscription."
-msgstr ""
-"DuckDuckGo aboneliğiyle daha birçok premium özelliğe sahip olabilirsiniz."
+msgstr "DuckDuckGo aboneliğiyle daha birçok premium özelliğe sahip olabilirsiniz."
 
 # smartling.placeholder_format=C
 #. A description to provide more detail on what Duck Player does (Duck Player is DDG's feature to watch youtube videos more privately)
 msgid ""
 "Plus, what you watch in Duck Player won’t influence your recommendations on "
 "YouTube."
-msgstr ""
-"Ayrıca, Duck Player'da izledikleriniz YouTube'daki önerilerinizi etkilemez."
+msgstr "Ayrıca, Duck Player'da izledikleriniz YouTube'daki önerilerinizi etkilemez."
 
 # smartling.placeholder_format=C
 #. A link to the Substack page (https://insideduckduckgo.substack.com/?showWelcome=true)
@@ -14901,7 +14896,7 @@ msgstr "Gizlilik"
 #. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
 msgctxt "Section heading on the Duck.ai settings page"
 msgid "Privacy & Terms"
-msgstr ""
+msgstr "Gizlilik ve Koşullar"
 
 # smartling.placeholder_format=C
 msgid "Privacy Blog"
@@ -14977,7 +14972,7 @@ msgstr "Gizlilik Politikası ve Hizmet Koşulları"
 #. Text for a button that links to the terms of use and privacy policy page.
 msgctxt "Secondary button text in active privacy modal"
 msgid "Privacy Policy and Terms of Service"
-msgstr ""
+msgstr "Gizlilik Politikası ve Hizmet Koşulları"
 
 # smartling.placeholder_format=C
 #. Title displayed on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
@@ -15151,8 +15146,7 @@ msgstr "Bana sor"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Prompt me to use my approximate location to get nearby results."
-msgstr ""
-"Yakınımdaki sonuçları almak için yaklaşık konumumu kullanmamı hatırlat."
+msgstr "Yakınımdaki sonuçları almak için yaklaşık konumumu kullanmamı hatırlat."
 
 # smartling.placeholder_format=C
 #. DuckDuckGo Email Protection removes trackers from emails
@@ -15486,25 +15480,25 @@ msgstr "Bir kitap tavsiye et"
 #. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Recommend similar books"
-msgstr ""
+msgstr "Benzer kitaplar öner"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Recommend similar books."
-msgstr ""
+msgstr "Benzer kitaplar öner."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Recommend similar movies or shows."
-msgstr ""
+msgstr "Benzer filmler veya diziler öner."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Recommend similar titles"
-msgstr ""
+msgstr "Benzer başlıklar öner"
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
@@ -15719,8 +15713,9 @@ msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
 msgstr ""
-"Talimatları izleyerek veya tarayıcınızın &quot;Yenile&quot; veya &quot;"
-"Yeniden Yükle&quot; düğmesine tıklayarak DuckDuckGo'yu yeniden yükleyin."
+"Talimatları izleyerek veya tarayıcınızın &quot;Yenile&quot; veya "
+"&quot;Yeniden Yükle&quot; düğmesine tıklayarak DuckDuckGo'yu yeniden "
+"yükleyin."
 
 # smartling.placeholder_format=C
 #. checkbox label that allows the user to save the setting
@@ -15917,7 +15912,7 @@ msgctxt ""
 "feedback form when the user has selected Harmful or Illegal as the feedback "
 "reason"
 msgid "Required for harmful or illegal reports"
-msgstr ""
+msgstr "Zararlı veya yasa dışı içerik bildirimleri için zorunludur"
 
 # smartling.placeholder_format=C
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
@@ -16086,8 +16081,7 @@ msgstr "Sonuçlar, engellenmiş sitelerden gelen bilgileri içermez."
 #. Message that appears when results exclude blocked sites
 msgctxt "Blocked sites filter disclaimer"
 msgid "Results exclude your blocked sites, which you can manage in your %s."
-msgstr ""
-"Sonuçlar, %1$s bölümünden yönetebileceğin engellenmiş sitelerini içermez."
+msgstr "Sonuçlar, %1$s bölümünden yönetebileceğin engellenmiş sitelerini içermez."
 
 # smartling.placeholder_format=C
 #. A label showing the source of the results, e.g. "Results from Reddit"
@@ -16158,7 +16152,7 @@ msgstr "İncelemeler"
 #. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Rewrite this recipe scaled for a different number of servings."
-msgstr ""
+msgstr "Bu tarifi farklı bir porsiyon sayısına göre yeniden yaz."
 
 # smartling.placeholder_format=C
 msgid "Romania"
@@ -16444,8 +16438,7 @@ msgstr "En son 30 sohbetinizi cihazınıza yerel olarak kaydedin."
 msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
-msgstr ""
-"Duck.ai sohbetlerinizi cihazlar arasında uçtan uca şifreleme ile kaydedin"
+msgstr "Duck.ai sohbetlerinizi cihazlar arasında uçtan uca şifreleme ile kaydedin"
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -16640,8 +16633,7 @@ msgstr "Ara"
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
 msgid "Search %s to find results closer to you?"
-msgstr ""
-"Size daha yakın sonuçları bulmak için %1$s ifadesiyle arama yapılsın mı?"
+msgstr "Size daha yakın sonuçları bulmak için %1$s ifadesiyle arama yapılsın mı?"
 
 # smartling.placeholder_format=C
 msgid "Search Anonymously"
@@ -16907,8 +16899,7 @@ msgstr "DuckDuckGo ile Ara"
 #. Text for a promotional card encouraging third-party browser users to download the DuckDuckGo browser. Not shown in the DuckDuckGo browser or on Linux.
 msgctxt "Promotional text"
 msgid "Search, browse, and chat privately in our free browser"
-msgstr ""
-"Ücretsiz tarayıcımızda gizli şekilde arama yapın, gezinin ve sohbet edin"
+msgstr "Ücretsiz tarayıcımızda gizli şekilde arama yapın, gezinin ve sohbet edin"
 
 # smartling.placeholder_format=C
 #. Message displayed sometimes at top of results (for bang syntax), e.g. <a href="https://duckduckgo.com/?q=twitter+test">https://duckduckgo.com/?q=twitter+test</a>
@@ -17125,8 +17116,7 @@ msgstr "En son güncellemelerimizden bazılarını gör"
 #. Link to a page with more information about how user settings are stored in a URL.
 msgctxt "settings"
 msgid "See the %sURL Parameter Reference page%s for more details."
-msgstr ""
-"Daha fazla bilgi için %1$sURL Parametre Referansı sayfasına%2$s göz atın."
+msgstr "Daha fazla bilgi için %1$sURL Parametre Referansı sayfasına%2$s göz atın."
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the context menu of a chat in chat history, that allows the user to select the chat and begin batch selection mode.
@@ -17195,8 +17185,7 @@ msgstr "Varsayılan Arama Motoru açılır menüsünden %1$sDuckDuckGo%2$s'yu se
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %sDuckDuckGo%s in the list and %sallow%s location access"
-msgstr ""
-"Listeden %1$sDuckDuckGo%2$s'yu seçin ve konum erişimine %3$sizin verin%4$s"
+msgstr "Listeden %1$sDuckDuckGo%2$s'yu seçin ve konum erişimine %3$sizin verin%4$s"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -17262,8 +17251,7 @@ msgstr "%1$sArama Motoru%2$s bölümünü seçin"
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"
-msgstr ""
-"%1$sArama motoru%2$s bölümünü, ardından %3$sDiğerleri..%4$s ögesini seçin"
+msgstr "%1$sArama motoru%2$s bölümünü, ardından %3$sDiğerleri..%4$s ögesini seçin"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -17288,8 +17276,7 @@ msgstr "Açılır menüden %1$sSeçenekler%2$s ögesini seçin."
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sAdvanced settings%s"
-msgstr ""
-"%1$sAyarlar%2$s bölümünü, ardından %3$sGelişmiş ayarlar%4$s bölümünü seçin"
+msgstr "%1$sAyarlar%2$s bölümünü, ardından %3$sGelişmiş ayarlar%4$s bölümünü seçin"
 
 # smartling.placeholder_format=C
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -17319,8 +17306,7 @@ msgstr ""
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %syour browser%s in the list and %sallow%s location access"
-msgstr ""
-"Listeden %1$starayıcınızı%2$s seçin ve konum erişimine %3$sizin verin%4$s"
+msgstr "Listeden %1$starayıcınızı%2$s seçin ve konum erişimine %3$sizin verin%4$s"
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the modal for deleting all recent chats, that allows the user to select the chats to delete.
@@ -17517,7 +17503,7 @@ msgstr "Şimdi Ayarla"
 #. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
 msgctxt "Encrypted storage setup button shown in native browsers"
 msgid "Set Up Sync & Backup"
-msgstr ""
+msgstr "Sync & Backup'ı ayarlayın"
 
 # smartling.placeholder_format=C
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
@@ -17707,7 +17693,7 @@ msgstr "Olumlu geri bildirim paylaşın"
 msgctxt ""
 "Label beside the share-content switch on the Duck.ai response feedback form"
 msgid "Share this conversation with DuckDuckGo"
-msgstr ""
+msgstr "Bu sohbeti DuckDuckGo ile paylaşın"
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -17846,8 +17832,7 @@ msgstr "DuckAssist <sup>BETA'</sup>yı göster"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show DuckAssist more often. (You can also completely %sturn it off%s.)"
-msgstr ""
-"DuckAssist'i daha sık göster. (Ayrıca tamamen %1$skapatabilirsiniz%2$s.)"
+msgstr "DuckAssist'i daha sık göster. (Ayrıca tamamen %1$skapatabilirsiniz%2$s.)"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
@@ -17964,8 +17949,7 @@ msgstr "Tüm sonuçları gösterin"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show answers more often. (You can also %sturn them off%s.)"
-msgstr ""
-"Yanıtları daha sık göster. (İsterseniz %1$sbunları kapatabilirsiniz%2$s.)"
+msgstr "Yanıtları daha sık göster. (İsterseniz %1$sbunları kapatabilirsiniz%2$s.)"
 
 # smartling.placeholder_format=C
 #. Accessible label for the button that reveals a popover listing multiple citation sources in Duck.ai chat responses.
@@ -18113,14 +18097,12 @@ msgstr "En çok ziyaret edilen bağlantıları yeni sekme sayfasında gösterir"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your browser"
-msgstr ""
-"Tarayıcınıza DuckDuckGo'yu eklemeniz için zaman zaman anımsatıcılar gösterir"
+msgstr "Tarayıcınıza DuckDuckGo'yu eklemeniz için zaman zaman anımsatıcılar gösterir"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr ""
-"Cihazlarınıza DuckDuckGo'yu eklemeniz için zaman zaman anımsatıcılar gösterir"
+msgstr "Cihazlarınıza DuckDuckGo'yu eklemeniz için zaman zaman anımsatıcılar gösterir"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18149,8 +18131,7 @@ msgstr "Siz yazarken arama kutusunun altında öneriler gösterir"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows the privacy benefits of using DuckDuckGo on the homepage"
-msgstr ""
-"Giriş sayfasında DuckDuckGo'nun gizlilik açısından avantajlarını gösterir"
+msgstr "Giriş sayfasında DuckDuckGo'nun gizlilik açısından avantajlarını gösterir"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18237,8 +18218,7 @@ msgstr "Site İsimleri"
 #. A message saying that site filters are not currently working
 msgctxt "Site filter message"
 msgid "Site search is temporarily unavailable. We are working on a fix."
-msgstr ""
-"Site araması geçici olarak kullanılamıyor. Bir çözüm üzerinde çalışıyoruz."
+msgstr "Site araması geçici olarak kullanılamıyor. Bir çözüm üzerinde çalışıyoruz."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18454,8 +18434,7 @@ msgctxt "Error message when an uploaded image cannot be decoded or processed"
 msgid ""
 "Sorry, the uploaded image couldn't be processed. Please try a different "
 "image or format."
-msgstr ""
-"Üzgünüz, yüklenen görsel işlenemedi. Farklı bir görsel veya format deneyin."
+msgstr "Üzgünüz, yüklenen görsel işlenemedi. Farklı bir görsel veya format deneyin."
 
 # smartling.placeholder_format=C
 #. Body copy shown when a scanned or pasted pairing payload fails schema validation.
@@ -18489,8 +18468,7 @@ msgstr ""
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr ""
-"Üzgünüz, geri bildiriminizi gönderemedik. Lütfen daha sonra tekrar deneyin."
+msgstr "Üzgünüz, geri bildiriminizi gönderemedik. Lütfen daha sonra tekrar deneyin."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -18544,8 +18522,7 @@ msgstr "Kaynak metin temizlendi"
 msgctxt "Error message for summary selection input limit"
 msgid ""
 "Source text is too long to summarize. Try again with a shorter selection."
-msgstr ""
-"Kaynak metin özetlenemeyecek kadar uzun. Daha kısa bir seçimle tekrar dene."
+msgstr "Kaynak metin özetlenemeyecek kadar uzun. Daha kısa bir seçimle tekrar dene."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under Interface Settings.in the end. It is a header
@@ -18799,8 +18776,7 @@ msgstr "Diğer web sitelerinde sizi bekleyen gizli takip edicileri engelleyin."
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop most hidden trackers lurking on other websites."
-msgstr ""
-"Diğer web sitelerinde sizi bekleyen gizli takip edicilerin çoğunu engelleyin."
+msgstr "Diğer web sitelerinde sizi bekleyen gizli takip edicilerin çoğunu engelleyin."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18973,19 +18949,19 @@ msgstr "Bir blog yazısı için başlık önerin"
 #. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Suggest related articles or topics worth exploring next."
-msgstr ""
+msgstr "Sonraki adımda göz atmaya değer ilgili makaleler veya konular öner."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Suggest related articles to explore"
-msgstr ""
+msgstr "Keşfetmek için ilgili makaleler öner"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Suggest some alternatives to this product."
-msgstr ""
+msgstr "Bu ürün için bazı alternatifler öner."
 
 # smartling.placeholder_format=C
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
@@ -19002,7 +18978,7 @@ msgstr "Öneriler:"
 #. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Sum up the reviews"
-msgstr ""
+msgstr "İncelemeleri özetle"
 
 # smartling.placeholder_format=C
 #. A short title for the a message asking the AI to summarize a text.
@@ -19014,85 +18990,85 @@ msgstr "Özetle"
 #. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize the Q&As"
-msgstr ""
+msgstr "Soru-Cevapları özetle"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the background and notable work of this person."
-msgstr ""
+msgstr "Bu kişinin geçmişini ve önemli çalışmalarını özetle."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the key details of this event."
-msgstr ""
+msgstr "Bu etkinliğin önemli ayrıntılarını özetle."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the questions and answers on this page."
-msgstr ""
+msgstr "Bu sayfadaki soru ve cevapları özetle."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize their background"
-msgstr ""
+msgstr "Geçmişlerini özetle"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this book"
-msgstr ""
+msgstr "Bu kitabı özetle"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this book."
-msgstr ""
+msgstr "Bu kitabı özetle."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this discussion"
-msgstr ""
+msgstr "Bu tartışmayı özetle"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this discussion thread."
-msgstr ""
+msgstr "Bu tartışma başlığını özetle."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this page"
-msgstr ""
+msgstr "Bu Sayfayı Özetle"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this page."
-msgstr ""
+msgstr "Bu sayfayı özetle."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this video"
-msgstr ""
+msgstr "Bu videoyu özetle"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this video."
-msgstr ""
+msgstr "Bu videoyu özetle."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize what the reviews say."
-msgstr ""
+msgstr "İncelemelerde anlatılanları özetle."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -19422,7 +19398,7 @@ msgstr "Suriye"
 #. Text for a button that enables the theme to follow the operating system's color scheme preference.
 msgctxt "System theme button for theme selector"
 msgid "System"
-msgstr ""
+msgstr "Sistem"
 
 # smartling.placeholder_format=C
 #. Abbreviation indicating this is the total score for a game
@@ -19456,7 +19432,7 @@ msgstr "Tahitice"
 #. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Tailor my resume"
-msgstr ""
+msgstr "Özgeçmişimi düzenle"
 
 # smartling.placeholder_format=C
 msgid "Taiwan"
@@ -19493,6 +19469,8 @@ msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
+"Duck.ai'ı nasıl daha iyi hale getirebileceğimizi bize bildirmek için bu "
+"anonim ankete katılın."
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -19760,8 +19738,7 @@ msgstr ""
 msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider deletes any data associated with this chat within 30 days."
-msgstr ""
-"Model sağlayıcı, bu sohbetle ilişkili tüm verileri 30 gün içinde siler."
+msgstr "Model sağlayıcı, bu sohbetle ilişkili tüm verileri 30 gün içinde siler."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers.
@@ -19805,7 +19782,7 @@ msgstr "Tema"
 #. Text for the theme selector label that allows users to switch between Light and dark theme.
 msgctxt "Label for the theme selector feature"
 msgid "Theme"
-msgstr ""
+msgstr "Tema"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/LpFhb1e.png
@@ -19930,8 +19907,7 @@ msgstr ""
 #. Appears below a type of search results called 'Instant Answers'
 msgctxt "attribution"
 msgid "This Instant Answer was made by the %sDuckDuckHack%s Community."
-msgstr ""
-"Bu Anında Yanıt, %1$sDuckDuckHack%2$s Topluluğu tarafından hazırlanmıştır."
+msgstr "Bu Anında Yanıt, %1$sDuckDuckHack%2$s Topluluğu tarafından hazırlanmıştır."
 
 # smartling.placeholder_format=C
 #. Label for the monthly usage row in the Usage section of Duck.ai settings.
@@ -20197,8 +20173,7 @@ msgstr "Bu video henüz burada izlenemiyor. %1$s üzerinden izleyebilirsiniz."
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr ""
-"Bu web sayfası, güvenli ve şifrelenmiş bir bağlantı (HTTPS) kullanmıyor."
+msgstr "Bu web sayfası, güvenli ve şifrelenmiş bir bağlantı (HTTPS) kullanmıyor."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -20218,8 +20193,7 @@ msgctxt "Body text for clear all recent chats confirmation modal"
 msgid ""
 "This will delete all your recent chats, unless they're pinned. This cannot "
 "be undone."
-msgstr ""
-"Bu işlem, sabitlenmemiş tüm son sohbetlerinizi siler. Bu işlem geri alınamaz."
+msgstr "Bu işlem, sabitlenmemiş tüm son sohbetlerinizi siler. Bu işlem geri alınamaz."
 
 # smartling.placeholder_format=C
 #. Message explaining what will happen when the user deletes an image.
@@ -20237,8 +20211,7 @@ msgstr "Tüm ayarlarınız silinecek. Devam edilsin mi?"
 #. Confirmation message asking if the user is sure they want to reset all of their settings.
 msgctxt "settings"
 msgid "This will reset your saved settings to default values. Continue?"
-msgstr ""
-"Kayıtlı tüm ayarlarınız varsayılan değerlere sıfırlanacak. Devam edilsin mi?"
+msgstr "Kayıtlı tüm ayarlarınız varsayılan değerlere sıfırlanacak. Devam edilsin mi?"
 
 # smartling.placeholder_format=C
 #. Golf leaderboard column: holes completed in current round
@@ -20312,8 +20285,7 @@ msgstr "İpuçları"
 
 # smartling.placeholder_format=C
 msgid "Tired of being tracked online? %sWe can help.%s"
-msgstr ""
-"İnternette takip edilmekten bıktınız mı? %1$sSize yardımcı olabiliriz.%2$s"
+msgstr "İnternette takip edilmekten bıktınız mı? %1$sSize yardımcı olabiliriz.%2$s"
 
 # smartling.placeholder_format=C
 #. This is the name of a user setting
@@ -20345,8 +20317,7 @@ msgstr ""
 msgctxt ""
 "Copy stating agreement to Duck.ai Privacy Policy and Terms of Service."
 msgid "To continue, you must agree to Duck.ai’s %s and %s"
-msgstr ""
-"Devam etmek için Duck.ai'ın %1$s ve %2$skoşullarını kabul etmeniz gerekiyor"
+msgstr "Devam etmek için Duck.ai'ın %1$s ve %2$skoşullarını kabul etmeniz gerekiyor"
 
 # smartling.placeholder_format=C
 #. Text stating agreement to AI Chat Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'To continue, you must agree to DuckDuckGo AI Chat’s Privacy Policy and Terms of Service'
@@ -20594,8 +20565,7 @@ msgstr ""
 #. Placeholder for when we cannot report any blocked trackers yet
 msgctxt "tracker_stats"
 msgid "Tracking attempts blocked by DuckDuckGo will appear here"
-msgstr ""
-"DuckDuckGo tarafından engellenen izleme girişimleri burada görünecektir"
+msgstr "DuckDuckGo tarafından engellenen izleme girişimleri burada görünecektir"
 
 # smartling.placeholder_format=C
 #. Tooltip and accessible label for the confirm (checkmark) button that stops recording and sends audio for transcription.
@@ -20654,13 +20624,13 @@ msgstr ""
 #. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Translate this page"
-msgstr ""
+msgstr "Bu sayfayı çevir"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
 msgctxt "Page suggestion prompt"
 msgid "Translate this page into %s."
-msgstr ""
+msgstr "Bu sayfayı %1$s diline çevir."
 
 # smartling.placeholder_format=C
 #. Placeholder text for a region that will display translated text.
@@ -20762,8 +20732,7 @@ msgstr "Bu tür mesajları görmeyi durdurmak için %1$s'u deneyin."
 #. Text for a promotional card that encourages users to try the encrypted AI model whose inference runs in a confidential environment so the model provider cannot access user data. %s is replaced with the model's full display name (e.g. 'GPT-OSS 120B').
 msgctxt "Promotional text for encrypted AI model"
 msgid "Try %s, our first model with zero provider visibility."
-msgstr ""
-"Sıfır sağlayıcı görünürlüğüne sahip ilk modelimiz olan %1$s modelini deneyin."
+msgstr "Sıfır sağlayıcı görünürlüğüne sahip ilk modelimiz olan %1$s modelini deneyin."
 
 # smartling.placeholder_format=C
 msgid "Try %sDuck.ai%s, our private AI chat service:"
@@ -20808,7 +20777,7 @@ msgstr "Ücretsiz Deneyin"
 #. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
 msgctxt "settings"
 msgid "Try It Now"
-msgstr ""
+msgstr "Şimdi Dene"
 
 # smartling.placeholder_format=C
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -21053,6 +21022,9 @@ msgid ""
 "Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
+"AI özelliklerini devre dışı bırakmaya mı çalışıyorsunuz? Ayarlarınızı "
+"hatırlaması için %1$sDuckDuckGo No AI%2$s arama uzantısını yükleyin. "
+"%3$sDaha Fazla Bilgi%4$s"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -21061,6 +21033,9 @@ msgid ""
 "Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
+"AI özelliklerini devre dışı bırakmaya mı çalışıyorsunuz? Ayarlarınızı "
+"hatırlaması için %1$sDuckDuckGo No AI%2$s arama uzantısına geçin. %3$sDaha "
+"Fazla Bilgi%4$s"
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -21167,8 +21142,7 @@ msgstr "Daha doğru sonuçlar için %1$sKesin Konum%2$s'u açın"
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
-msgstr ""
-"YouTube'u hedeflenmiş reklamlar olmadan izlemek için Duck Player'ı açın"
+msgstr "YouTube'u hedeflenmiş reklamlar olmadan izlemek için Duck Player'ı açın"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service.
@@ -21180,8 +21154,7 @@ msgstr "Daha doğru sonuçlar için \"Kesin Konum\"u açın."
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on “Use precise location” for more accurate results."
-msgstr ""
-"Daha doğru sonuçlar için \"Kesin konumu kullan\" özelliğini etkinleştirin."
+msgstr "Daha doğru sonuçlar için \"Kesin konumu kullan\" özelliğini etkinleştirin."
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Create Image' label in the Tools dropdown.
@@ -21387,8 +21360,8 @@ msgstr ""
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
 msgstr ""
-"%1$sBAŞLANGIÇ > Giriş sayfası%2$s bölümünde şunu girin: https://duckduckgo."
-"com"
+"%1$sBAŞLANGIÇ > Giriş sayfası%2$s bölümünde şunu girin: "
+"https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -21422,8 +21395,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine
 msgid "Under Search click the drop down and select %sDuckDuckGo%s"
-msgstr ""
-"Arama bölümündeki açılır menüye tıklayın ve %1$sDuckDuckGo%2$s'yu seçin"
+msgstr "Arama bölümündeki açılır menüye tıklayın ve %1$sDuckDuckGo%2$s'yu seçin"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings" header
@@ -21827,7 +21799,7 @@ msgstr "Uruguay"
 #. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
 msgctxt "Navigation label on the Duck.ai settings page"
 msgid "Usage"
-msgstr ""
+msgstr "Kullanım"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -21885,8 +21857,7 @@ msgstr "DuckDuckGo Private Search'ü kullanın"
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Use DuckDuckGo private search on your iPad, iPhone, or Android!"
-msgstr ""
-"iPad', iPhone ya da Android'inizde DuckDuckGo private search'ü kullanın!"
+msgstr "iPad', iPhone ya da Android'inizde DuckDuckGo private search'ü kullanın!"
 
 # smartling.placeholder_format=C
 #. User clicks this button to share their device's location
@@ -22283,7 +22254,7 @@ msgstr "Galler"
 #. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Walk me through the steps"
-msgstr ""
+msgstr "Adımları bana anlat"
 
 # smartling.placeholder_format=C
 #. Label for walking directions on a map.
@@ -22413,6 +22384,9 @@ msgid ""
 "please share this conversation with DuckDuckGo so we can investigate and "
 "address the issue."
 msgstr ""
+"Sadece görebildiğimiz şeyleri düzeltebiliriz. Zararlı veya yasa dışı bir "
+"yanıtı bildirmek için lütfen bu konuşmayı DuckDuckGo ile paylaşın; böylece "
+"sorunu inceleyebilir ve gerekli önlemleri alabiliriz."
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -22441,8 +22415,7 @@ msgstr ""
 msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
-msgstr ""
-"En az birinin şifrelenmiş olması nedeniyle ekli dosyaları okuyamıyoruz."
+msgstr "En az birinin şifrelenmiş olması nedeniyle ekli dosyaları okuyamıyoruz."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -22544,8 +22517,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don’t track you in or out of private browsing mode."
-msgstr ""
-"Gizli gezinme modunu kullansanız da kullanmasınız da sizi takip etmiyoruz."
+msgstr "Gizli gezinme modunu kullansanız da kullanmasınız da sizi takip etmiyoruz."
 
 # smartling.placeholder_format=C
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with an Agree button is shown below.
@@ -22624,8 +22596,7 @@ msgstr "Biz dahil hiç kimse arama geçmişinize ulaşamaz."
 #. Message that appears after submitting a feedback form.
 msgctxt "feedback form"
 msgid "We use feedback like this to improve DuckDuckGo."
-msgstr ""
-"Bunun gibi geri bildirimleri DuckDuckGo'yu geliştirmek için kullanıyoruz."
+msgstr "Bunun gibi geri bildirimleri DuckDuckGo'yu geliştirmek için kullanıyoruz."
 
 # smartling.placeholder_format=C
 #. Placeholder can be Apple Maps, TripAdvisor, and/or Foursquare
@@ -22982,98 +22953,98 @@ msgstr ""
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the counterarguments?"
-msgstr ""
+msgstr "Karşı argümanlar nelerdir?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the hours & location?"
-msgstr ""
+msgstr "Çalışma saatleri ve konum nedir?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key contributions of this paper?"
-msgstr ""
+msgstr "Bu makalenin temel katkıları nelerdir?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key contributions?"
-msgstr ""
+msgstr "Temel katkılar nelerdir?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key details?"
-msgstr ""
+msgstr "Temel ayrıntılar nelerdir?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key points covered in this video?"
-msgstr ""
+msgstr "Bu videoda ele alınan ana noktalar nelerdir?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key points?"
-msgstr ""
+msgstr "Önemli noktalar nelerdir?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key takeaways from this article?"
-msgstr ""
+msgstr "Bu makaledeki önemli noktalar nelerdir?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key takeaways?"
-msgstr ""
+msgstr "Temel çıkarımlar nelerdir?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key things I will learn from this course?"
-msgstr ""
+msgstr "Bu kurstan öğreneceğim temel şeyler nelerdir?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the main counterarguments or criticisms of this?"
-msgstr ""
+msgstr "Bunun temel karşı argümanları veya eleştirileri nelerdir?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the main questions this page answers?"
-msgstr ""
+msgstr "Bu sayfanın yanıtladığı temel sorular nelerdir?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the must-try dishes here?"
-msgstr ""
+msgstr "Burada mutlaka denemen gereken yemekler neler?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid ""
 "What are the opening hours, location, and contact details for this place?"
-msgstr ""
+msgstr "Bu yerin çalışma saatleri, konumu ve iletişim bilgileri nelerdir?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the pros and cons of this product?"
-msgstr ""
+msgstr "Bu ürünün artıları ve eksileri nelerdir?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the pros and cons?"
-msgstr ""
+msgstr "Artıları ve eksileri nelerdir?"
 
 # smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
@@ -23179,7 +23150,7 @@ msgstr "Tıbbi bir makale bağlamında atriyum ne anlama geliyor?"
 #. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What does this answer?"
-msgstr ""
+msgstr "Bu neyi yanıtlıyor?"
 
 # smartling.placeholder_format=C
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
@@ -23197,7 +23168,7 @@ msgstr "Hangi bilgiler kaydedilir?"
 #. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What interview questions might come up for this role?"
-msgstr ""
+msgstr "Bu pozisyon için hangi mülakat soruları gelebilir?"
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -23219,7 +23190,7 @@ msgstr "Arnavutluk'un başkenti neresidir?"
 #. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What is the overall verdict and rating for this?"
-msgstr ""
+msgstr "Bunun için genel değerlendirme ve puan nedir?"
 
 # smartling.placeholder_format=C
 #. Link to a page with additional information.
@@ -23247,7 +23218,7 @@ msgstr "Yapılan yorumlar:"
 #. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What should I order?"
-msgstr ""
+msgstr "Ne sipariş etmeliyim?"
 
 # smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
@@ -23265,13 +23236,13 @@ msgstr "Yanıtta ne yanlıştı? (isteğe bağlı)"
 #. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What will I learn?"
-msgstr ""
+msgstr "Neler öğreneceğim?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What will I need?"
-msgstr ""
+msgstr "Nelere ihtiyacım olacak?"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -23294,7 +23265,7 @@ msgstr "Yenilikler"
 #. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What's the verdict?"
-msgstr ""
+msgstr "Sonuç ne?"
 
 # smartling.placeholder_format=C
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -23332,8 +23303,7 @@ msgstr "<strong>%1$s</strong>Nerede İzlenir?"
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Where it says Homepage click %sSet to Current Page%s."
-msgstr ""
-"Giriş sayfası yazan yerde %1$sMevcut Sayfaya Ayarla%2$s seçeneğine tıklayın."
+msgstr "Giriş sayfası yazan yerde %1$sMevcut Sayfaya Ayarla%2$s seçeneğine tıklayın."
 
 # smartling.placeholder_format=C
 #. Heading of a module showing what streaming services are showing a movie or series, e.g. Where to Watch The Matrix
@@ -23351,7 +23321,7 @@ msgstr "Hangi özellikler eksik? (İsteğe Bağlı)"
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Which features are missing? (optional)"
-msgstr ""
+msgstr "Hangi özellikler eksik? (isteğe bağlı)"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
@@ -23374,12 +23344,14 @@ msgstr "Biz Kimiz?"
 msgctxt "Page suggestion prompt"
 msgid "Who are the main cast and crew, and what else are they known for?"
 msgstr ""
+"Ana oyuncu kadrosu ve ekip kimlerden oluşuyor ve başka hangi işlerle "
+"tanınıyorlar?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Who is this person?"
-msgstr ""
+msgstr "Bu kişi kim?"
 
 # smartling.placeholder_format=C
 #. Header above a collection of privacy-related links.
@@ -23874,8 +23846,7 @@ msgstr "Bu hatırlatmayı %1$sArama Ayarları%2$s'ndan gizleyebilirsiniz"
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
-msgstr ""
-"Artık bu cihazda 100'e kadar sohbeti kaydedebilirsiniz. Sohbete başlayın!"
+msgstr "Artık bu cihazda 100'e kadar sohbeti kaydedebilirsiniz. Sohbete başlayın!"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -24136,8 +24107,7 @@ msgstr "Tek bir oturum için maksimum sesli sohbet süresine ulaştınız."
 msgctxt "voice chat limit modal"
 msgid ""
 "You've reached the voice chat limit for today. Please try again tomorrow."
-msgstr ""
-"Bugünlük sesli sohbet limitinize ulaştınız. Lütfen yarın tekrar deneyin."
+msgstr "Bugünlük sesli sohbet limitinize ulaştınız. Lütfen yarın tekrar deneyin."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
@@ -24367,8 +24337,7 @@ msgctxt "duckai_migration"
 msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
-msgstr ""
-"Sohbetleriniz içeri aktarıldı. Hadi, Duck.ai'da kaldığınız yerden devam edin."
+msgstr "Sohbetleriniz içeri aktarıldı. Hadi, Duck.ai'da kaldığınız yerden devam edin."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.
@@ -24415,8 +24384,7 @@ msgctxt ""
 "Subtitle of the one-time popover shown above the thumbs up/down buttons on "
 "an AI response"
 msgid "Your feedback is anonymized and not used to train AI."
-msgstr ""
-"Geri bildiriminiz anonimleştirilmiş ve yapay zekayı eğitmek için kullanılmaz."
+msgstr "Geri bildiriminiz anonimleştirilmiş ve yapay zekayı eğitmek için kullanılmaz."
 
 # smartling.placeholder_format=C
 #. Explains that the User's Location is always private to DuckDuckGo.
@@ -24532,8 +24500,7 @@ msgctxt "Error message for input limit"
 msgid ""
 "You’ve exceeded the maximum message size. Please shorten your message and "
 "try again."
-msgstr ""
-"Maksimum mesaj boyutunu aştınız. Lütfen mesajınızı kısaltıp tekrar deneyin."
+msgstr "Maksimum mesaj boyutunu aştınız. Lütfen mesajınızı kısaltıp tekrar deneyin."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -24575,8 +24542,7 @@ msgstr ""
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
 msgctxt "voice chat limit modal"
 msgid "You’ve reached the voice chat limit for now. Please try again later."
-msgstr ""
-"Şimdilik sesli sohbet limitinize ulaştınız. Lütfen daha sonra tekrar deneyin."
+msgstr "Şimdilik sesli sohbet limitinize ulaştınız. Lütfen daha sonra tekrar deneyin."
 
 # smartling.placeholder_format=C
 #. The name of the Yucatec Maya language
@@ -24659,8 +24625,7 @@ msgstr "(bir %1$s ürünü)"
 #. Trust line shown at the bottom of the explainer panel, summarizing DuckDuckGo's reputation for online protection.
 msgctxt "Footer banner text in the How Duck.ai Works panel"
 msgid "by DuckDuckGo — online protection trusted by millions every day."
-msgstr ""
-"DuckDuckGo'dan — her gün milyonlarca kişinin güvendiği çevrimiçi koruma."
+msgstr "DuckDuckGo'dan — her gün milyonlarca kişinin güvendiği çevrimiçi koruma."
 
 # smartling.placeholder_format=C
 #. An abreviated unit of time indicating an age, e.g. "2d"

--- a/locales/tr_TR/LC_MESSAGES/duckduckgo.po
+++ b/locales/tr_TR/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: tr_TR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -898,7 +898,8 @@ msgstr ""
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of Duck.ai is available! Please refresh this page to continue."
-msgstr "Duck.ai'ın yeni sürümü yayında! Devam etmek için lütfen bu sayfayı yenileyin."
+msgstr ""
+"Duck.ai'ın yeni sürümü yayında! Devam etmek için lütfen bu sayfayı yenileyin."
 
 # smartling.placeholder_format=C
 #. Shown when the Duck.ai desktop app has been open a long time and a newer version exists.
@@ -1443,6 +1444,12 @@ msgid "Address is incorrect"
 msgstr "Adres yanlış"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Adjust the servings"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. as in multiple advertisements
 msgid "Ads"
 msgstr "Reklamlar"
@@ -1524,7 +1531,8 @@ msgstr "İndirdikten ve açtıktan sonra %1$sYükle%2$s seçeneğine tıklayın"
 #. Instructions on how to install the DuckDuckGo browser extension after it downloads.
 msgid ""
 "After it downloads, locate the extension file and double-click it to install"
-msgstr "İndirdikten sonra uzantı dosyasını bulun ve yüklemek için çift tıklayın"
+msgstr ""
+"İndirdikten sonra uzantı dosyasını bulun ve yüklemek için çift tıklayın"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an age below a web search result.
@@ -1652,6 +1660,14 @@ msgstr "Tüm sohbetler %1$s. AI hata yapabilir."
 msgctxt "Empty state heading in Duck.ai chat mode"
 msgid "All chats are %sprivate%s"
 msgstr "Tüm sohbetler %1$sgizlidir%2$s"
+
+# smartling.placeholder_format=C
+#. Paragraph in the Privacy & Terms section of the About & Legal page in Duck.ai settings, summarizing how chats are anonymized and are not stored or used to train chat models.
+msgctxt "Privacy & Terms section description on the Duck.ai settings page"
+msgid ""
+"All chats are anonymized by DuckDuckGo, and your conversations are not used "
+"to train chat models by DuckDuckGo or the model providers"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1797,7 +1813,8 @@ msgstr "Zaten senkronize edildi."
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Also search privately on your iPad, iPhone, or Android!"
-msgstr "Ayrıca iPad, iPhone veya Android cihazınızda gizli arama yapabilirsiniz!"
+msgstr ""
+"Ayrıca iPad, iPhone veya Android cihazınızda gizli arama yapabilirsiniz!"
 
 # smartling.placeholder_format=C
 #. Keyboard shortcut for Duck.ai
@@ -1923,6 +1940,13 @@ msgstr ""
 msgctxt "precise_user_location"
 msgid "Anonymous location enabled"
 msgstr "Anonim konum etkinleştirildi"
+
+# smartling.placeholder_format=C
+msgctxt "settings"
+msgid ""
+"Anonymously generates answers for search queries based on web content. "
+"Choose how often you want it to appear, or disable it completely."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -2077,7 +2101,8 @@ msgstr ""
 #. Body text of the modal that asks the user if they want to clear the conversation.
 msgctxt "Modal body for clearing conversation"
 msgid "Are you sure you want to clear this conversation and start a new one?"
-msgstr "Bu konuşmayı silip yeni bir konuşma başlatmak istediğinizden emin misiniz?"
+msgstr ""
+"Bu konuşmayı silip yeni bir konuşma başlatmak istediğinizden emin misiniz?"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to delete their current chat, explaining that this action cannot be undone.
@@ -2204,6 +2229,12 @@ msgstr "Takip sorusu sor"
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse
 msgid "Ask a follow-up with Duck.ai"
 msgstr "Duck.ai'a takip sorusu sor"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
+msgctxt "Page suggestion chip label"
+msgid "Ask about this page"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2372,13 +2403,15 @@ msgstr "Ses"
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat ends."
-msgstr "Sohbet sona erdikten sonra ses tarafımızdan veya OpenAI tarafından saklanmaz."
+msgstr ""
+"Sohbet sona erdikten sonra ses tarafımızdan veya OpenAI tarafından saklanmaz."
 
 # smartling.placeholder_format=C
 #. Description in consent disclaimer informing that audio from the voice chat session is not stored by us or by OpenAI after the voice chat ends.
 msgctxt "voice chat"
 msgid "Audio is not stored by us or by OpenAI after the chat ends."
-msgstr "Sohbet sona erdikten sonra ses tarafımızdan veya OpenAI tarafından saklanmaz."
+msgstr ""
+"Sohbet sona erdikten sonra ses tarafımızdan veya OpenAI tarafından saklanmaz."
 
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
@@ -2624,6 +2657,12 @@ msgid "Barcode"
 msgstr "Barkod"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Based on this page, is this course worth taking?"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Basic"
 msgstr "Temel"
@@ -2662,6 +2701,14 @@ msgstr "Vurucu"
 msgctxt "Assistant response placeholder"
 msgid "Before continuing..."
 msgstr "Devam etmeden önce..."
+
+# smartling.placeholder_format=C
+#. Explains that before storing the report, DuckDuckGo will anonymize the conversation by removing PII like names, email addresses, and identifying metadata.
+msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
+msgid ""
+"Before storing this report, DuckDuckGo will anonymize your conversation by "
+"removing PII like names, email addresses, and identifying metadata."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -2803,7 +2850,8 @@ msgstr "Bu siteyi tüm sonuçlarda engelleyin"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Block trackers and take control of your personal data"
-msgstr "Takip edicileri engelleyin ve kişisel verilerinizin kontrolünü elinize alın"
+msgstr ""
+"Takip edicileri engelleyin ve kişisel verilerinizin kontrolünü elinize alın"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -2978,6 +3026,12 @@ msgstr "Brezilya"
 msgctxt "Sports module"
 msgid "Break Points Won"
 msgstr "Kazanılan Servis Kırma Puanları"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Break this down into clear, numbered steps."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -3224,7 +3278,8 @@ msgstr "Kamerun"
 #. Text for a prompt suggestion for creating a few simple recipes using chicken, broccoli, and rice.
 msgctxt "Full sentence for crafting a recipe"
 msgid "Can you create a few simple recipes using chicken, broccoli, and rice?"
-msgstr "Tavuk, brokoli ve pirinci kullanarak birkaç basit tarif hazırlayabilir misin?"
+msgstr ""
+"Tavuk, brokoli ve pirinci kullanarak birkaç basit tarif hazırlayabilir misin?"
 
 # smartling.placeholder_format=C
 msgid "Canada"
@@ -3433,6 +3488,12 @@ msgstr "Kariyer"
 msgctxt "Movie/TV Show Title instant answer"
 msgid "Cast"
 msgstr "Oyuncular"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Cast & Crew"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -4247,7 +4308,8 @@ msgstr "%1$sEkle%2$s seçeneğine tıklayın"
 #. Instructions on which buttons the user has to click in order to add the DuckDuckGo extension to their browser.
 msgctxt "install-duckduckgo"
 msgid "Click %sAllow%s, then %sAdd%s."
-msgstr "%1$sİzin Ver%2$s seçeneğine, ardından %3$sEkle%4$s seçeneğine tıklayın."
+msgstr ""
+"%1$sİzin Ver%2$s seçeneğine, ardından %3$sEkle%4$s seçeneğine tıklayın."
 
 #  Firefox 33
 # smartling.placeholder_format=C
@@ -4360,13 +4422,15 @@ msgstr "Açılır menüden %1$sArama Ayarlarını Değiştir%2$s seçeneğine t�
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click on %sSet as Default%s towards the bottom"
-msgstr "Alta doğru yer alan %1$sVarsayılan Olarak Ayarla%2$s seçeneğine tıklayın"
+msgstr ""
+"Alta doğru yer alan %1$sVarsayılan Olarak Ayarla%2$s seçeneğine tıklayın"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click on the %sSearch Providers%s under Add-on Types"
-msgstr "Eklenti Türleri bölümündeki %1$sArama Sağlayıcıları%2$s seçeneğine tıklayın"
+msgstr ""
+"Eklenti Türleri bölümündeki %1$sArama Sağlayıcıları%2$s seçeneğine tıklayın"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -4447,7 +4511,8 @@ msgstr "Adres çubuğundaki %1$sizinler simgesine%2$s tıklayın"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to search using DuckDuckGo.
 msgid "Click the Duck icon at the top of your browser to search!"
-msgstr "Arama yapmak için tarayıcınızın üst kısmındaki ördek simgesine tıklayın!"
+msgstr ""
+"Arama yapmak için tarayıcınızın üst kısmındaki ördek simgesine tıklayın!"
 
 #  UC Browser on Android
 # smartling.placeholder_format=C
@@ -4499,7 +4564,8 @@ msgstr "Arama çubuğundaki büyüteç simgesine tıklayın"
 #. Tells users what icon to click in order to make DuckDuckGo the default engine in their browser.
 msgid ""
 "Click the magnifying glass in the search box (at the top of the browser)"
-msgstr "Arama kutusundaki büyüteç simgesine tıklayın (tarayıcının üst tarafında)"
+msgstr ""
+"Arama kutusundaki büyüteç simgesine tıklayın (tarayıcının üst tarafında)"
 
 #  IE default search engine instruction
 # smartling.placeholder_format=C
@@ -5153,6 +5219,12 @@ msgid "Create Image"
 msgstr "Görsel Oluştur"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Create a shopping list with quantities from this recipe."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text displayed in the input field when starting a new image generation session.
 msgctxt "Placeholder text for the image generation input field"
 msgid "Create an image of a cute duck..."
@@ -5407,7 +5479,8 @@ msgstr "Günlük limit doldu"
 #. Displayed when the user has reached a fixed daily Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Daily usage limit reached. You can continue this chat after %s."
-msgstr "Günlük kullanım limiti doldu. Bu sohbete %1$s sonrasında devam edebilirsiniz."
+msgstr ""
+"Günlük kullanım limiti doldu. Bu sohbete %1$s sonrasında devam edebilirsiniz."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable daily Duck.ai usage limit and can opt in to continue using the weekly limit.
@@ -5795,6 +5868,11 @@ msgid "Dictation limit reached"
 msgstr "Dikte limiti doldu"
 
 # smartling.placeholder_format=C
+#. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
+msgid "Dictation temporarily unavailable"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
@@ -6071,7 +6149,8 @@ msgstr "DuckDuckGo'yu listede göremiyor musunuz?"
 #. Link to download a file again if the user can't find it on their computer.
 msgctxt "install-extension"
 msgid "Don't see it? %s%s%sClick here to re-download%s"
-msgstr "Göremiyor musunuz? %1$s%2$s%3$sTekrar indirmek için buraya tıklayın%4$s"
+msgstr ""
+"Göremiyor musunuz? %1$s%2$s%3$sTekrar indirmek için buraya tıklayın%4$s"
 
 #  IE < 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -6095,6 +6174,22 @@ msgstr "Bitti"
 msgctxt "precise_user_location"
 msgid "Done"
 msgstr "Bitti"
+
+# smartling.placeholder_format=C
+#. Message shown in a modal after DuckDuckGo browser users disable AI features in Settings. The first two placeholders bold noai.duckduckgo.com. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
+"filtered out. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
+"and AI images filtered out. %sLearn more%s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6209,6 +6304,18 @@ msgid ""
 msgstr ""
 "Ev tipi buzdolabı onarım hizmetleri için fiyat teklifi isteyen bir satıcıya "
 "kısa ve ayrıntılı bir e-posta taslağı hazırla."
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Draft a cover letter"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Draft a cover letter for this job."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -6387,6 +6494,15 @@ msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
 msgstr "Duck.ai, gizli ve ücretsiz DuckDuckGo tarayıcımızda en iyisi!"
 
 # smartling.placeholder_format=C
+#. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
+msgctxt "About section description on the Duck.ai settings page"
+msgid ""
+"Duck.ai is created by DuckDuckGo. We're an independent online protection "
+"company for anyone who wants to take back control of their personal "
+"information."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
 msgctxt "duckai_migration"
 msgid "Duck.ai is moving domains"
@@ -6431,7 +6547,15 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
-msgstr "Duck.ai geçici olarak kullanılamıyor. Lütfen daha sonra tekrar deneyin."
+msgstr ""
+"Duck.ai geçici olarak kullanılamıyor. Lütfen daha sonra tekrar deneyin."
+
+# smartling.placeholder_format=C
+msgctxt "settings"
+msgid ""
+"Duck.ai lets you chat privately with popular AI models. Disabling it hides "
+"Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6477,7 +6601,8 @@ msgstr ""
 msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
-msgstr "Duck.ai yanıtları belirli kaynaklara dayanmaz ve doğruluğu kontrol edilmez."
+msgstr ""
+"Duck.ai yanıtları belirli kaynaklara dayanmaz ve doğruluğu kontrol edilmez."
 
 # smartling.placeholder_format=C
 #. Title shown when native app needs to reload for service update.
@@ -6495,7 +6620,8 @@ msgstr "Duck.ai aboneliği yükseltildi!"
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
-msgstr "Duck.ai, gizli ve ücretsiz DuckDuckGo uygulamasında en iyi şekilde çalışır!"
+msgstr ""
+"Duck.ai, gizli ve ücretsiz DuckDuckGo uygulamasında en iyi şekilde çalışır!"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -7170,7 +7296,8 @@ msgstr "Duck.ai'da sesli dikte özelliğini etkinleştir"
 #. Prompt to enable location service so that search results can be displayed near the user's current location.
 msgctxt "precise_user_location"
 msgid "Enable location settings on your device to use anonymous location"
-msgstr "Anonim konumu kullanmak için cihazınızdan konum ayarlarını etkinleştirin"
+msgstr ""
+"Anonim konumu kullanmak için cihazınızdan konum ayarlarını etkinleştirin"
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -7279,7 +7406,8 @@ msgstr "Duck.ai'ı beğeniyor musunuz?"
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure %s'Allow'%s is selected for the 'Location' setting."
-msgstr "'Konum' ayarı için %1$s'İzin Ver'%2$s ögesinin seçili olduğundan emin olun."
+msgstr ""
+"'Konum' ayarı için %1$s'İzin Ver'%2$s ögesinin seçili olduğundan emin olun."
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
@@ -7434,6 +7562,18 @@ msgid "Eritrea"
 msgstr "Eritre"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Estimate the nutrition"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Estimate the nutritional information for this recipe."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Estonia"
 msgstr "Estonya"
 
@@ -7488,11 +7628,59 @@ msgid "Expires in 1 day"
 msgstr "1 gün içinde sona eriyor"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain the accepted answer in simple terms."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
 msgstr "Bana lise düzeyinde kara deliklerin temel kavramlarını açıkla."
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain the top answer"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this in simple, plain language."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this paper"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this repo"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this research paper in plain language."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this simply"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain what this repository does and how to use it."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label to show if song lyrics contain explicit content
@@ -7781,6 +7969,12 @@ msgstr ""
 "filtreler. %1$sDaha fazla bilgi%2$s"
 
 # smartling.placeholder_format=C
+msgctxt "settings"
+msgid ""
+"Filters out known AI spam sites from image search results. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the final score of a sporting event.
 msgid "Final"
 msgstr "Son"
@@ -7807,7 +8001,8 @@ msgstr "Finansal danışman"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Find %sDuckDuckGo%s and click%sMake default%s"
-msgstr "%1$sDuckDuckGo%2$s'yu bulun ve %3$sVarsayılan yap%4$s seçeneğine tıklayın"
+msgstr ""
+"%1$sDuckDuckGo%2$s'yu bulun ve %3$sVarsayılan yap%4$s seçeneğine tıklayın"
 
 # smartling.placeholder_format=C
 #. Sentence shown after export, includes a placeholder for one or more filenames with bold formatting for the filename(s).
@@ -7836,6 +8031,12 @@ msgid "Find current information"
 msgstr "Güncel bilgilere erişin"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Find me alternatives"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Button that searches for results closer to the user's current location.
 msgctxt "precise_user_location"
 msgid "Find results closer to you"
@@ -7852,7 +8053,8 @@ msgstr "Size daha yakın sonuçlar bulun."
 msgctxt "Precise user location overlay"
 msgid ""
 "Find results near you. %sYour location stays private, secure, and anonymous."
-msgstr "Yakınınızdan sonuçlar bulun. %1$sKonumunuz gizli, güvende ve anonim kalır."
+msgstr ""
+"Yakınınızdan sonuçlar bulun. %1$sKonumunuz gizli, güvende ve anonim kalır."
 
 # smartling.placeholder_format=C
 #. Loading message shown while generating explore more follow-up questions
@@ -8028,7 +8230,8 @@ msgstr "Tarafımızdan anonimleştirilmiş ücretsiz ve gizli sohbetler"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr "Tarafımızdan anonimleştirilmiş ücretsiz ve gizli sohbetler. Hesap gerekmez."
+msgstr ""
+"Tarafımızdan anonimleştirilmiş ücretsiz ve gizli sohbetler. Hesap gerekmez."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -8040,7 +8243,8 @@ msgstr "Ücretsiz Değiştirilebilen, Paylaşılabilen ve Kullanılabilen"
 #. a filter for images with the CC BY usage license
 msgctxt "image-licence"
 msgid "Free to Modify, Share, and Use Commercially"
-msgstr "Ücretsiz Değiştirilebilen, Paylaşılabilen ve Ticari Olarak Kullanılabilen"
+msgstr ""
+"Ücretsiz Değiştirilebilen, Paylaşılabilen ve Ticari Olarak Kullanılabilen"
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC-ND usage license
@@ -8307,6 +8511,12 @@ msgstr "Görsel Oluştur"
 #. Text for the button that generates more of an answer from duckassist when the answer has come from a collapsed state
 msgid "Generate More"
 msgstr "Daha Fazla Oluştur"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Generate a shopping list"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
@@ -8598,6 +8808,12 @@ msgstr "Deneyin"
 msgctxt "Onboarding welcome screen button text"
 msgid "Give it a Try"
 msgstr "Deneyin"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Give me a quick background on this person."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9046,6 +9262,18 @@ msgid "Help Spread Privacy"
 msgstr "Gizliliğin Yaygınlaşmasına Yardımcı Olun"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Help me prep for the interview"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Help me tailor my resume for this job."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title of a SERP popup that invites users to take a survey (desktop only)
 msgctxt "User survey popup"
 msgid "Help us improve DuckDuckGo"
@@ -9055,7 +9283,8 @@ msgstr "DuckDuckGo'yu geliştirmemize yardımcı olun"
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Help us improve DuckDuckGo searches with your feedback"
-msgstr "Geri bildirimlerinizle DuckDuckGo aramalarını geliştirmemize yardımcı olun"
+msgstr ""
+"Geri bildirimlerinizle DuckDuckGo aramalarını geliştirmemize yardımcı olun"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -9113,7 +9342,8 @@ msgstr "Arkadaşlarınızın ve ailenizin Duck Side'a katılmalarına yardımcı
 #. Text description for the Spread card in the SERP footer
 msgctxt "footer_card"
 msgid "Help your friends and family take back their privacy!"
-msgstr "Arkadaşlarınızın ve ailenizin gizliliklerini geri almalarına yardımcı olun!"
+msgstr ""
+"Arkadaşlarınızın ve ailenizin gizliliklerini geri almalarına yardımcı olun!"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -9244,7 +9474,8 @@ msgstr "E-posta adresinizi gizleyin"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Hides search term from being shown in browser tab/history"
-msgstr "Arama ifadesinin tarayıcı sekmesinde/geçmişinde gösterilmesini engeller"
+msgstr ""
+"Arama ifadesinin tarayıcı sekmesinde/geçmişinde gösterilmesini engeller"
 
 # smartling.placeholder_format=C
 #. The highest stock price in a day
@@ -9492,7 +9723,8 @@ msgstr "Yapay zeka destekli cevapların ne kadar görünmesini istiyorsun?"
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
 msgctxt "Duck.ai settings usage section"
 msgid "How much of your daily and weekly limits you've used so far."
-msgstr "Şimdiye kadar günlük ve haftalık limitlerinizin ne kadarını kullandığınız."
+msgstr ""
+"Şimdiye kadar günlük ve haftalık limitlerinizin ne kadarını kullandığınız."
 
 # smartling.placeholder_format=C
 #. A header for the feedback form in the assist negative feedback flow. The user is being asked to update how often they want AI-assisted answers to appear.
@@ -9559,6 +9791,14 @@ msgstr "Kasırga"
 msgctxt "Onboarding terms screen button text"
 msgid "I Agree"
 msgstr "Katılıyorum"
+
+# smartling.placeholder_format=C
+#. Text for the button that takes the user to the external DuckDuckGo login subscription page.
+msgctxt ""
+"Text for the I already have a subscription button in the Duck.ai settings "
+"page"
+msgid "I Already Have a Subscription"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the button that takes the user to the login subscription page.
@@ -9634,14 +9874,15 @@ msgid ""
 "I like the book Name of the Wind. What are some other good books/series most "
 "like it and why?"
 msgstr ""
-"Rüzgârın Adı kitabını severim. Buna en çok benzeyen diğer iyi "
-"kitaplar/diziler nelerdir ve neden?"
+"Rüzgârın Adı kitabını severim. Buna en çok benzeyen diğer iyi kitaplar/"
+"diziler nelerdir ve neden?"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the user needs more help or information on how to use the chat.
 msgctxt "Feedback option for difficulty in using chat"
 msgid "I need more help/info on how to use Chat"
-msgstr "Sohbeti nasıl kullanacağıma dair daha fazla yardım/bilgiye ihtiyacım var"
+msgstr ""
+"Sohbeti nasıl kullanacağıma dair daha fazla yardım/bilgiye ihtiyacım var"
 
 # smartling.placeholder_format=C
 msgid "IR Iran"
@@ -10139,6 +10380,12 @@ msgid "Install Mac Browser"
 msgstr "Mac Tarayıcısını Yükle"
 
 # smartling.placeholder_format=C
+#. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
+msgctxt "settings"
+msgid "Install Now"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of a button to install the DuckDuckGo app
 msgctxt "Serp footer content"
 msgid "Install Our App"
@@ -10236,10 +10483,42 @@ msgid "Is deleted data really deleted?"
 msgstr "Silinen veriler gerçekten siliniyor mu?"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is it worth taking?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this place any good?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"Is this place any good? Summarize its reputation based on reviews and "
+"ratings."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "Is this video helpful?"
 msgstr "Bu video yararlı oldu mu?"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this worth watching?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Is this worth watching? Give me a spoiler-free take."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -10852,6 +11131,12 @@ msgid "Links:"
 msgstr "Bağlantılar:"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "List the tools, materials, or prerequisites I need for this."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
 msgid "Listen"
 msgstr "Dinle"
@@ -11260,6 +11545,12 @@ msgstr "Aboneliğinizi Yönetin"
 msgctxt "Exclusion message manage sites button"
 msgid "Manage blocked sites"
 msgstr "Engellenen siteleri yönetin"
+
+# smartling.placeholder_format=C
+#. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
+msgctxt "setting"
+msgid "Manage in Browser Settings"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to the site exclusion settings page
@@ -11711,7 +12002,8 @@ msgstr "Aylık limit doldu"
 #. Displayed when the user has reached a fixed monthly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Monthly usage limit reached. You can continue this chat after %s."
-msgstr "Aylık kullanım limiti doldu. Bu sohbete %1$s sonrasında devam edebilirsiniz."
+msgstr ""
+"Aylık kullanım limiti doldu. Bu sohbete %1$s sonrasında devam edebilirsiniz."
 
 # smartling.placeholder_format=C
 #. Used to point to additional social networking profiles (in results).
@@ -11861,7 +12153,8 @@ msgstr "Daha fazla bilgiyi %1$s %2$s makalesinde bulabilirsiniz."
 # smartling.placeholder_format=C
 #. Source (section, article and site) of the answer generated by duckassist (an instant answer based on generative AI)
 msgid "More info in the %s section of the %s %s article."
-msgstr "Daha fazla bilgiyi %2$s %3$s makalesinin %1$s bölümünde bulabilirsiniz."
+msgstr ""
+"Daha fazla bilgiyi %2$s %3$s makalesinin %1$s bölümünde bulabilirsiniz."
 
 # smartling.placeholder_format=C
 msgctxt ""
@@ -14095,6 +14388,12 @@ msgstr ""
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
+msgid "Please describe why the chat response is harmful or illegal. (optional)"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
+msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
 msgstr ""
 "Lütfen sohbet yanıtının neden yasa dışı veya zararlı olduğunu açıklayın. "
@@ -14121,6 +14420,14 @@ msgid ""
 msgstr ""
 "Lütfen unutmayın: herhangi bir modelle yeni bir sohbet başlatmak mevcut "
 "sohbet oturumunuzu silecektir."
+
+# smartling.placeholder_format=C
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
+msgctxt "Feedback prompt"
+msgid ""
+"Please paste your prompt and the problematic output (with any personal "
+"information removed) and describe why the content is harmful or illegal."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -14276,14 +14583,16 @@ msgstr "Lütfen bekleyin..."
 #. Tagline for the subscription promo shown in the SERP sidemenu.
 msgctxt "Sidemenu subscription promo"
 msgid "Plus more premium features with a DuckDuckGo subscription."
-msgstr "DuckDuckGo aboneliğiyle daha birçok premium özelliğe sahip olabilirsiniz."
+msgstr ""
+"DuckDuckGo aboneliğiyle daha birçok premium özelliğe sahip olabilirsiniz."
 
 # smartling.placeholder_format=C
 #. A description to provide more detail on what Duck Player does (Duck Player is DDG's feature to watch youtube videos more privately)
 msgid ""
 "Plus, what you watch in Duck Player won’t influence your recommendations on "
 "YouTube."
-msgstr "Ayrıca, Duck Player'da izledikleriniz YouTube'daki önerilerinizi etkilemez."
+msgstr ""
+"Ayrıca, Duck Player'da izledikleriniz YouTube'daki önerilerinizi etkilemez."
 
 # smartling.placeholder_format=C
 #. A link to the Substack page (https://insideduckduckgo.substack.com/?showWelcome=true)
@@ -14589,6 +14898,12 @@ msgid "Privacy"
 msgstr "Gizlilik"
 
 # smartling.placeholder_format=C
+#. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
+msgctxt "Section heading on the Duck.ai settings page"
+msgid "Privacy & Terms"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Privacy Blog"
 msgstr "Gizlilik Bloğu"
 
@@ -14657,6 +14972,12 @@ msgstr "Gizlilik Politikası ve Kullanım Koşulları"
 msgctxt "Copy used to compose link in sentences"
 msgid "Privacy Policy and Terms of Service"
 msgstr "Gizlilik Politikası ve Hizmet Koşulları"
+
+# smartling.placeholder_format=C
+#. Text for a button that links to the terms of use and privacy policy page.
+msgctxt "Secondary button text in active privacy modal"
+msgid "Privacy Policy and Terms of Service"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title displayed on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
@@ -14830,7 +15151,8 @@ msgstr "Bana sor"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Prompt me to use my approximate location to get nearby results."
-msgstr "Yakınımdaki sonuçları almak için yaklaşık konumumu kullanmamı hatırlat."
+msgstr ""
+"Yakınımdaki sonuçları almak için yaklaşık konumumu kullanmamı hatırlat."
 
 # smartling.placeholder_format=C
 #. DuckDuckGo Email Protection removes trackers from emails
@@ -15161,6 +15483,30 @@ msgid "Recommend a book"
 msgstr "Bir kitap tavsiye et"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar books"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar books."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar movies or shows."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar titles"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
 msgid "Recording failed. Please try again."
 msgstr "Kayıt başarısız oldu. Lütfen tekrar deneyin."
@@ -15373,9 +15719,8 @@ msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
 msgstr ""
-"Talimatları izleyerek veya tarayıcınızın &quot;Yenile&quot; veya "
-"&quot;Yeniden Yükle&quot; düğmesine tıklayarak DuckDuckGo'yu yeniden "
-"yükleyin."
+"Talimatları izleyerek veya tarayıcınızın &quot;Yenile&quot; veya &quot;"
+"Yeniden Yükle&quot; düğmesine tıklayarak DuckDuckGo'yu yeniden yükleyin."
 
 # smartling.placeholder_format=C
 #. checkbox label that allows the user to save the setting
@@ -15566,6 +15911,15 @@ msgid "Republic of Moldova"
 msgstr "Moldova Cumhuriyeti"
 
 # smartling.placeholder_format=C
+#. Note indicating that sharing the conversation is mandatory when reporting harmful or illegal content. Rendered alongside the standard share label (DUCKCHAT_RESPONSE_FEEDBACK_SHARE_PROMPT_RESPONSE_LABEL), not replacing it.
+msgctxt ""
+"Note shown under the share-content switch label on the Duck.ai response "
+"feedback form when the user has selected Harmful or Illegal as the feedback "
+"reason"
+msgid "Required for harmful or illegal reports"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
 msgctxt "Description for extended reasoning mode in Duck.ai"
 msgid "Researches before responding"
@@ -15732,7 +16086,8 @@ msgstr "Sonuçlar, engellenmiş sitelerden gelen bilgileri içermez."
 #. Message that appears when results exclude blocked sites
 msgctxt "Blocked sites filter disclaimer"
 msgid "Results exclude your blocked sites, which you can manage in your %s."
-msgstr "Sonuçlar, %1$s bölümünden yönetebileceğin engellenmiş sitelerini içermez."
+msgstr ""
+"Sonuçlar, %1$s bölümünden yönetebileceğin engellenmiş sitelerini içermez."
 
 # smartling.placeholder_format=C
 #. A label showing the source of the results, e.g. "Results from Reddit"
@@ -15798,6 +16153,12 @@ msgstr "İncelemeler"
 msgctxt "maps_places"
 msgid "Reviews"
 msgstr "İncelemeler"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Rewrite this recipe scaled for a different number of servings."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Romania"
@@ -16083,7 +16444,8 @@ msgstr "En son 30 sohbetinizi cihazınıza yerel olarak kaydedin."
 msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
-msgstr "Duck.ai sohbetlerinizi cihazlar arasında uçtan uca şifreleme ile kaydedin"
+msgstr ""
+"Duck.ai sohbetlerinizi cihazlar arasında uçtan uca şifreleme ile kaydedin"
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -16278,7 +16640,8 @@ msgstr "Ara"
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
 msgid "Search %s to find results closer to you?"
-msgstr "Size daha yakın sonuçları bulmak için %1$s ifadesiyle arama yapılsın mı?"
+msgstr ""
+"Size daha yakın sonuçları bulmak için %1$s ifadesiyle arama yapılsın mı?"
 
 # smartling.placeholder_format=C
 msgid "Search Anonymously"
@@ -16544,7 +16907,8 @@ msgstr "DuckDuckGo ile Ara"
 #. Text for a promotional card encouraging third-party browser users to download the DuckDuckGo browser. Not shown in the DuckDuckGo browser or on Linux.
 msgctxt "Promotional text"
 msgid "Search, browse, and chat privately in our free browser"
-msgstr "Ücretsiz tarayıcımızda gizli şekilde arama yapın, gezinin ve sohbet edin"
+msgstr ""
+"Ücretsiz tarayıcımızda gizli şekilde arama yapın, gezinin ve sohbet edin"
 
 # smartling.placeholder_format=C
 #. Message displayed sometimes at top of results (for bang syntax), e.g. <a href="https://duckduckgo.com/?q=twitter+test">https://duckduckgo.com/?q=twitter+test</a>
@@ -16761,7 +17125,8 @@ msgstr "En son güncellemelerimizden bazılarını gör"
 #. Link to a page with more information about how user settings are stored in a URL.
 msgctxt "settings"
 msgid "See the %sURL Parameter Reference page%s for more details."
-msgstr "Daha fazla bilgi için %1$sURL Parametre Referansı sayfasına%2$s göz atın."
+msgstr ""
+"Daha fazla bilgi için %1$sURL Parametre Referansı sayfasına%2$s göz atın."
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the context menu of a chat in chat history, that allows the user to select the chat and begin batch selection mode.
@@ -16830,7 +17195,8 @@ msgstr "Varsayılan Arama Motoru açılır menüsünden %1$sDuckDuckGo%2$s'yu se
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %sDuckDuckGo%s in the list and %sallow%s location access"
-msgstr "Listeden %1$sDuckDuckGo%2$s'yu seçin ve konum erişimine %3$sizin verin%4$s"
+msgstr ""
+"Listeden %1$sDuckDuckGo%2$s'yu seçin ve konum erişimine %3$sizin verin%4$s"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -16896,7 +17262,8 @@ msgstr "%1$sArama Motoru%2$s bölümünü seçin"
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"
-msgstr "%1$sArama motoru%2$s bölümünü, ardından %3$sDiğerleri..%4$s ögesini seçin"
+msgstr ""
+"%1$sArama motoru%2$s bölümünü, ardından %3$sDiğerleri..%4$s ögesini seçin"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -16921,7 +17288,8 @@ msgstr "Açılır menüden %1$sSeçenekler%2$s ögesini seçin."
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sAdvanced settings%s"
-msgstr "%1$sAyarlar%2$s bölümünü, ardından %3$sGelişmiş ayarlar%4$s bölümünü seçin"
+msgstr ""
+"%1$sAyarlar%2$s bölümünü, ardından %3$sGelişmiş ayarlar%4$s bölümünü seçin"
 
 # smartling.placeholder_format=C
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -16951,7 +17319,8 @@ msgstr ""
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %syour browser%s in the list and %sallow%s location access"
-msgstr "Listeden %1$starayıcınızı%2$s seçin ve konum erişimine %3$sizin verin%4$s"
+msgstr ""
+"Listeden %1$starayıcınızı%2$s seçin ve konum erişimine %3$sizin verin%4$s"
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the modal for deleting all recent chats, that allows the user to select the chats to delete.
@@ -17145,6 +17514,12 @@ msgid "Set Up Now"
 msgstr "Şimdi Ayarla"
 
 # smartling.placeholder_format=C
+#. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
+msgctxt "Encrypted storage setup button shown in native browsers"
+msgid "Set Up Sync & Backup"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
 msgctxt "Title for the Sync & Backup intro screen"
 msgid "Set Up Sync & Backup"
@@ -17328,6 +17703,13 @@ msgid "Share positive feedback"
 msgstr "Olumlu geri bildirim paylaşın"
 
 # smartling.placeholder_format=C
+#. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
+msgctxt ""
+"Label beside the share-content switch on the Duck.ai response feedback form"
+msgid "Share this conversation with DuckDuckGo"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
 msgctxt ""
 "Label beside the share-content switch on the Duck.ai response feedback form"
@@ -17464,7 +17846,8 @@ msgstr "DuckAssist <sup>BETA'</sup>yı göster"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show DuckAssist more often. (You can also completely %sturn it off%s.)"
-msgstr "DuckAssist'i daha sık göster. (Ayrıca tamamen %1$skapatabilirsiniz%2$s.)"
+msgstr ""
+"DuckAssist'i daha sık göster. (Ayrıca tamamen %1$skapatabilirsiniz%2$s.)"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
@@ -17581,7 +17964,8 @@ msgstr "Tüm sonuçları gösterin"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show answers more often. (You can also %sturn them off%s.)"
-msgstr "Yanıtları daha sık göster. (İsterseniz %1$sbunları kapatabilirsiniz%2$s.)"
+msgstr ""
+"Yanıtları daha sık göster. (İsterseniz %1$sbunları kapatabilirsiniz%2$s.)"
 
 # smartling.placeholder_format=C
 #. Accessible label for the button that reveals a popover listing multiple citation sources in Duck.ai chat responses.
@@ -17729,12 +18113,14 @@ msgstr "En çok ziyaret edilen bağlantıları yeni sekme sayfasında gösterir"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your browser"
-msgstr "Tarayıcınıza DuckDuckGo'yu eklemeniz için zaman zaman anımsatıcılar gösterir"
+msgstr ""
+"Tarayıcınıza DuckDuckGo'yu eklemeniz için zaman zaman anımsatıcılar gösterir"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr "Cihazlarınıza DuckDuckGo'yu eklemeniz için zaman zaman anımsatıcılar gösterir"
+msgstr ""
+"Cihazlarınıza DuckDuckGo'yu eklemeniz için zaman zaman anımsatıcılar gösterir"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -17763,7 +18149,8 @@ msgstr "Siz yazarken arama kutusunun altında öneriler gösterir"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows the privacy benefits of using DuckDuckGo on the homepage"
-msgstr "Giriş sayfasında DuckDuckGo'nun gizlilik açısından avantajlarını gösterir"
+msgstr ""
+"Giriş sayfasında DuckDuckGo'nun gizlilik açısından avantajlarını gösterir"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -17850,7 +18237,8 @@ msgstr "Site İsimleri"
 #. A message saying that site filters are not currently working
 msgctxt "Site filter message"
 msgid "Site search is temporarily unavailable. We are working on a fix."
-msgstr "Site araması geçici olarak kullanılamıyor. Bir çözüm üzerinde çalışıyoruz."
+msgstr ""
+"Site araması geçici olarak kullanılamıyor. Bir çözüm üzerinde çalışıyoruz."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18066,7 +18454,8 @@ msgctxt "Error message when an uploaded image cannot be decoded or processed"
 msgid ""
 "Sorry, the uploaded image couldn't be processed. Please try a different "
 "image or format."
-msgstr "Üzgünüz, yüklenen görsel işlenemedi. Farklı bir görsel veya format deneyin."
+msgstr ""
+"Üzgünüz, yüklenen görsel işlenemedi. Farklı bir görsel veya format deneyin."
 
 # smartling.placeholder_format=C
 #. Body copy shown when a scanned or pasted pairing payload fails schema validation.
@@ -18100,7 +18489,8 @@ msgstr ""
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr "Üzgünüz, geri bildiriminizi gönderemedik. Lütfen daha sonra tekrar deneyin."
+msgstr ""
+"Üzgünüz, geri bildiriminizi gönderemedik. Lütfen daha sonra tekrar deneyin."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -18154,7 +18544,8 @@ msgstr "Kaynak metin temizlendi"
 msgctxt "Error message for summary selection input limit"
 msgid ""
 "Source text is too long to summarize. Try again with a shorter selection."
-msgstr "Kaynak metin özetlenemeyecek kadar uzun. Daha kısa bir seçimle tekrar dene."
+msgstr ""
+"Kaynak metin özetlenemeyecek kadar uzun. Daha kısa bir seçimle tekrar dene."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under Interface Settings.in the end. It is a header
@@ -18408,7 +18799,8 @@ msgstr "Diğer web sitelerinde sizi bekleyen gizli takip edicileri engelleyin."
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop most hidden trackers lurking on other websites."
-msgstr "Diğer web sitelerinde sizi bekleyen gizli takip edicilerin çoğunu engelleyin."
+msgstr ""
+"Diğer web sitelerinde sizi bekleyen gizli takip edicilerin çoğunu engelleyin."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18578,6 +18970,24 @@ msgid "Suggest a title for a blog post"
 msgstr "Bir blog yazısı için başlık önerin"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest related articles or topics worth exploring next."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Suggest related articles to explore"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest some alternatives to this product."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
 msgctxt "directions"
 msgid "Suggestions:"
@@ -18589,10 +18999,100 @@ msgid "Suggestions:"
 msgstr "Öneriler:"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Sum up the reviews"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A short title for the a message asking the AI to summarize a text.
 msgctxt "Title for the summarize message"
 msgid "Summarize"
 msgstr "Özetle"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize the Q&As"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the background and notable work of this person."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the key details of this event."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the questions and answers on this page."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize their background"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this book"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this book."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this discussion"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this discussion thread."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this page"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this page."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this video"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this video."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize what the reviews say."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -18919,6 +19419,12 @@ msgid "Syria"
 msgstr "Suriye"
 
 # smartling.placeholder_format=C
+#. Text for a button that enables the theme to follow the operating system's color scheme preference.
+msgctxt "System theme button for theme selector"
+msgid "System"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Abbreviation indicating this is the total score for a game
 msgctxt "Sports module"
 msgid "T"
@@ -18945,6 +19451,12 @@ msgstr "TV"
 msgctxt "language_name"
 msgid "Tahitian"
 msgstr "Tahitice"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Tailor my resume"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Taiwan"
@@ -18974,6 +19486,13 @@ msgstr "Kişisel verilerinizin kontrolünü elinize alın"
 msgctxt "homepage ATB modal"
 msgid "Take control of your personal data!"
 msgstr "Kişisel verilerinizin kontrolünü elinize alın!"
+
+# smartling.placeholder_format=C
+#. Description for the Feedback section of the Duck.ai settings page, asking the user to take an anonymous survey to let us know how we can make Duck.ai better.
+msgctxt "Feedback section description on the Duck.ai settings page"
+msgid ""
+"Take this anonymous survey to let us know how we can make Duck.ai better."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -19241,7 +19760,8 @@ msgstr ""
 msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider deletes any data associated with this chat within 30 days."
-msgstr "Model sağlayıcı, bu sohbetle ilişkili tüm verileri 30 gün içinde siler."
+msgstr ""
+"Model sağlayıcı, bu sohbetle ilişkili tüm verileri 30 gün içinde siler."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers.
@@ -19280,6 +19800,12 @@ msgstr "Sunucu bir hatayla karşılaştı ve isteğinizi tamamlayamadı."
 #. https://duck.co/media/files/theme.png
 msgid "Theme"
 msgstr "Tema"
+
+# smartling.placeholder_format=C
+#. Text for the theme selector label that allows users to switch between Light and dark theme.
+msgctxt "Label for the theme selector feature"
+msgid "Theme"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/LpFhb1e.png
@@ -19404,7 +19930,8 @@ msgstr ""
 #. Appears below a type of search results called 'Instant Answers'
 msgctxt "attribution"
 msgid "This Instant Answer was made by the %sDuckDuckHack%s Community."
-msgstr "Bu Anında Yanıt, %1$sDuckDuckHack%2$s Topluluğu tarafından hazırlanmıştır."
+msgstr ""
+"Bu Anında Yanıt, %1$sDuckDuckHack%2$s Topluluğu tarafından hazırlanmıştır."
 
 # smartling.placeholder_format=C
 #. Label for the monthly usage row in the Usage section of Duck.ai settings.
@@ -19670,7 +20197,8 @@ msgstr "Bu video henüz burada izlenemiyor. %1$s üzerinden izleyebilirsiniz."
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr "Bu web sayfası, güvenli ve şifrelenmiş bir bağlantı (HTTPS) kullanmıyor."
+msgstr ""
+"Bu web sayfası, güvenli ve şifrelenmiş bir bağlantı (HTTPS) kullanmıyor."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -19690,7 +20218,8 @@ msgctxt "Body text for clear all recent chats confirmation modal"
 msgid ""
 "This will delete all your recent chats, unless they're pinned. This cannot "
 "be undone."
-msgstr "Bu işlem, sabitlenmemiş tüm son sohbetlerinizi siler. Bu işlem geri alınamaz."
+msgstr ""
+"Bu işlem, sabitlenmemiş tüm son sohbetlerinizi siler. Bu işlem geri alınamaz."
 
 # smartling.placeholder_format=C
 #. Message explaining what will happen when the user deletes an image.
@@ -19708,7 +20237,8 @@ msgstr "Tüm ayarlarınız silinecek. Devam edilsin mi?"
 #. Confirmation message asking if the user is sure they want to reset all of their settings.
 msgctxt "settings"
 msgid "This will reset your saved settings to default values. Continue?"
-msgstr "Kayıtlı tüm ayarlarınız varsayılan değerlere sıfırlanacak. Devam edilsin mi?"
+msgstr ""
+"Kayıtlı tüm ayarlarınız varsayılan değerlere sıfırlanacak. Devam edilsin mi?"
 
 # smartling.placeholder_format=C
 #. Golf leaderboard column: holes completed in current round
@@ -19782,7 +20312,8 @@ msgstr "İpuçları"
 
 # smartling.placeholder_format=C
 msgid "Tired of being tracked online? %sWe can help.%s"
-msgstr "İnternette takip edilmekten bıktınız mı? %1$sSize yardımcı olabiliriz.%2$s"
+msgstr ""
+"İnternette takip edilmekten bıktınız mı? %1$sSize yardımcı olabiliriz.%2$s"
 
 # smartling.placeholder_format=C
 #. This is the name of a user setting
@@ -19814,7 +20345,8 @@ msgstr ""
 msgctxt ""
 "Copy stating agreement to Duck.ai Privacy Policy and Terms of Service."
 msgid "To continue, you must agree to Duck.ai’s %s and %s"
-msgstr "Devam etmek için Duck.ai'ın %1$s ve %2$skoşullarını kabul etmeniz gerekiyor"
+msgstr ""
+"Devam etmek için Duck.ai'ın %1$s ve %2$skoşullarını kabul etmeniz gerekiyor"
 
 # smartling.placeholder_format=C
 #. Text stating agreement to AI Chat Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'To continue, you must agree to DuckDuckGo AI Chat’s Privacy Policy and Terms of Service'
@@ -20062,7 +20594,8 @@ msgstr ""
 #. Placeholder for when we cannot report any blocked trackers yet
 msgctxt "tracker_stats"
 msgid "Tracking attempts blocked by DuckDuckGo will appear here"
-msgstr "DuckDuckGo tarafından engellenen izleme girişimleri burada görünecektir"
+msgstr ""
+"DuckDuckGo tarafından engellenen izleme girişimleri burada görünecektir"
 
 # smartling.placeholder_format=C
 #. Tooltip and accessible label for the confirm (checkmark) button that stops recording and sends audio for transcription.
@@ -20116,6 +20649,18 @@ msgid ""
 msgstr ""
 "Bu Türkçe cümleyi İngilizceye çevir: \"En yakın sinema salonuna nasıl "
 "gidebilirim?\""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Translate this page"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
+msgctxt "Page suggestion prompt"
+msgid "Translate this page into %s."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder text for a region that will display translated text.
@@ -20217,7 +20762,8 @@ msgstr "Bu tür mesajları görmeyi durdurmak için %1$s'u deneyin."
 #. Text for a promotional card that encourages users to try the encrypted AI model whose inference runs in a confidential environment so the model provider cannot access user data. %s is replaced with the model's full display name (e.g. 'GPT-OSS 120B').
 msgctxt "Promotional text for encrypted AI model"
 msgid "Try %s, our first model with zero provider visibility."
-msgstr "Sıfır sağlayıcı görünürlüğüne sahip ilk modelimiz olan %1$s modelini deneyin."
+msgstr ""
+"Sıfır sağlayıcı görünürlüğüne sahip ilk modelimiz olan %1$s modelini deneyin."
 
 # smartling.placeholder_format=C
 msgid "Try %sDuck.ai%s, our private AI chat service:"
@@ -20257,6 +20803,12 @@ msgstr "Tekrar Dene"
 msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
 msgstr "Ücretsiz Deneyin"
+
+# smartling.placeholder_format=C
+#. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
+msgctxt "settings"
+msgid "Try It Now"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -20495,6 +21047,22 @@ msgid "Trying DuckDuckGo again"
 msgstr "DuckDuckGo'yu yeniden deniyorum"
 
 # smartling.placeholder_format=C
+#. Message shown in a modal after supported third-party browser users disable AI features in Settings. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
 msgctxt "Assistant response placeholder"
 msgid "Trying with %s"
@@ -20599,7 +21167,8 @@ msgstr "Daha doğru sonuçlar için %1$sKesin Konum%2$s'u açın"
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
-msgstr "YouTube'u hedeflenmiş reklamlar olmadan izlemek için Duck Player'ı açın"
+msgstr ""
+"YouTube'u hedeflenmiş reklamlar olmadan izlemek için Duck Player'ı açın"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service.
@@ -20611,7 +21180,8 @@ msgstr "Daha doğru sonuçlar için \"Kesin Konum\"u açın."
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on “Use precise location” for more accurate results."
-msgstr "Daha doğru sonuçlar için \"Kesin konumu kullan\" özelliğini etkinleştirin."
+msgstr ""
+"Daha doğru sonuçlar için \"Kesin konumu kullan\" özelliğini etkinleştirin."
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Create Image' label in the Tools dropdown.
@@ -20817,8 +21387,8 @@ msgstr ""
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
 msgstr ""
-"%1$sBAŞLANGIÇ > Giriş sayfası%2$s bölümünde şunu girin: "
-"https://duckduckgo.com"
+"%1$sBAŞLANGIÇ > Giriş sayfası%2$s bölümünde şunu girin: https://duckduckgo."
+"com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -20852,7 +21422,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine
 msgid "Under Search click the drop down and select %sDuckDuckGo%s"
-msgstr "Arama bölümündeki açılır menüye tıklayın ve %1$sDuckDuckGo%2$s'yu seçin"
+msgstr ""
+"Arama bölümündeki açılır menüye tıklayın ve %1$sDuckDuckGo%2$s'yu seçin"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings" header
@@ -21253,6 +21824,12 @@ msgid "Uruguay"
 msgstr "Uruguay"
 
 # smartling.placeholder_format=C
+#. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
+msgctxt "Navigation label on the Duck.ai settings page"
+msgid "Usage"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A feedback suggestion
 msgctxt "Feedback prompt"
 msgid "Usage limit"
@@ -21308,7 +21885,8 @@ msgstr "DuckDuckGo Private Search'ü kullanın"
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Use DuckDuckGo private search on your iPad, iPhone, or Android!"
-msgstr "iPad', iPhone ya da Android'inizde DuckDuckGo private search'ü kullanın!"
+msgstr ""
+"iPad', iPhone ya da Android'inizde DuckDuckGo private search'ü kullanın!"
 
 # smartling.placeholder_format=C
 #. User clicks this button to share their device's location
@@ -21702,6 +22280,12 @@ msgid "Wales"
 msgstr "Galler"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Walk me through the steps"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for walking directions on a map.
 msgctxt "directions"
 msgid "Walking"
@@ -21820,6 +22404,17 @@ msgstr ""
 "anonimleştirebiliriz."
 
 # smartling.placeholder_format=C
+#. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
+msgctxt ""
+"Inline warning shown below the share-content toggle when the user selects "
+"Harmful or Illegal but has not enabled sharing"
+msgid ""
+"We can only fix what we can see. To report a harmful or illegal response, "
+"please share this conversation with DuckDuckGo so we can investigate and "
+"address the issue."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
 msgctxt ""
 "Inline warning shown below the share-content toggle when the user selects "
@@ -21846,7 +22441,8 @@ msgstr ""
 msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
-msgstr "En az birinin şifrelenmiş olması nedeniyle ekli dosyaları okuyamıyoruz."
+msgstr ""
+"En az birinin şifrelenmiş olması nedeniyle ekli dosyaları okuyamıyoruz."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -21948,7 +22544,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don’t track you in or out of private browsing mode."
-msgstr "Gizli gezinme modunu kullansanız da kullanmasınız da sizi takip etmiyoruz."
+msgstr ""
+"Gizli gezinme modunu kullansanız da kullanmasınız da sizi takip etmiyoruz."
 
 # smartling.placeholder_format=C
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with an Agree button is shown below.
@@ -22027,7 +22624,8 @@ msgstr "Biz dahil hiç kimse arama geçmişinize ulaşamaz."
 #. Message that appears after submitting a feedback form.
 msgctxt "feedback form"
 msgid "We use feedback like this to improve DuckDuckGo."
-msgstr "Bunun gibi geri bildirimleri DuckDuckGo'yu geliştirmek için kullanıyoruz."
+msgstr ""
+"Bunun gibi geri bildirimleri DuckDuckGo'yu geliştirmek için kullanıyoruz."
 
 # smartling.placeholder_format=C
 #. Placeholder can be Apple Maps, TripAdvisor, and/or Foursquare
@@ -22381,6 +22979,103 @@ msgstr ""
 "olsun."
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the counterarguments?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the hours & location?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key contributions of this paper?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key contributions?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key details?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key points covered in this video?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key points?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key takeaways from this article?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key takeaways?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key things I will learn from this course?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main counterarguments or criticisms of this?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main questions this page answers?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the must-try dishes here?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"What are the opening hours, location, and contact details for this place?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the pros and cons of this product?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the pros and cons?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
 msgctxt "feedback form"
 msgid "What bothered you most?"
@@ -22481,6 +23176,12 @@ msgid "What does atria mean in the context of a medical article?"
 msgstr "Tıbbi bir makale bağlamında atriyum ne anlama geliyor?"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What does this answer?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
@@ -22491,6 +23192,12 @@ msgstr "Hangi özelliği eklememizi istersiniz? (isteğe bağlı)"
 msgctxt "cloudsave"
 msgid "What information gets saved?"
 msgstr "Hangi bilgiler kaydedilir?"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What interview questions might come up for this role?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -22507,6 +23214,12 @@ msgstr ""
 msgctxt "Full sentence for looking up basic facts"
 msgid "What is the capital city of Albania?"
 msgstr "Arnavutluk'un başkenti neresidir?"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What is the overall verdict and rating for this?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to a page with additional information.
@@ -22531,6 +23244,12 @@ msgid "What people say:"
 msgstr "Yapılan yorumlar:"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What should I order?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
 msgctxt "feedback form"
 msgid "What stood out?"
@@ -22541,6 +23260,18 @@ msgstr "Dikkat çeken neydi?"
 msgctxt "feedback form"
 msgid "What was wrong with the response? (optional)"
 msgstr "Yanıtta ne yanlıştı? (isteğe bağlı)"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I learn?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I need?"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -22558,6 +23289,12 @@ msgstr "DuckDuckGo'da izledikleriniz YouTube'daki önerilerinizi etkilemez."
 msgctxt "SERP footer content"
 msgid "What's New"
 msgstr "Yenilikler"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What's the verdict?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -22595,7 +23332,8 @@ msgstr "<strong>%1$s</strong>Nerede İzlenir?"
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Where it says Homepage click %sSet to Current Page%s."
-msgstr "Giriş sayfası yazan yerde %1$sMevcut Sayfaya Ayarla%2$s seçeneğine tıklayın."
+msgstr ""
+"Giriş sayfası yazan yerde %1$sMevcut Sayfaya Ayarla%2$s seçeneğine tıklayın."
 
 # smartling.placeholder_format=C
 #. Heading of a module showing what streaming services are showing a movie or series, e.g. Where to Watch The Matrix
@@ -22608,6 +23346,12 @@ msgstr "<strong>%1$s</strong>Nerede İzlenir?"
 msgctxt "Feedback prompt"
 msgid "Which features are missing? (Optional)"
 msgstr "Hangi özellikler eksik? (İsteğe Bağlı)"
+
+# smartling.placeholder_format=C
+#. An invitation for users to leave feedback
+msgctxt "Feedback prompt"
+msgid "Which features are missing? (optional)"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
@@ -22624,6 +23368,18 @@ msgstr "Beyaz"
 #. Link to an about us page.
 msgid "Who We Are"
 msgstr "Biz Kimiz?"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Who are the main cast and crew, and what else are they known for?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Who is this person?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Header above a collection of privacy-related links.
@@ -23118,7 +23874,8 @@ msgstr "Bu hatırlatmayı %1$sArama Ayarları%2$s'ndan gizleyebilirsiniz"
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
-msgstr "Artık bu cihazda 100'e kadar sohbeti kaydedebilirsiniz. Sohbete başlayın!"
+msgstr ""
+"Artık bu cihazda 100'e kadar sohbeti kaydedebilirsiniz. Sohbete başlayın!"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -23379,7 +24136,8 @@ msgstr "Tek bir oturum için maksimum sesli sohbet süresine ulaştınız."
 msgctxt "voice chat limit modal"
 msgid ""
 "You've reached the voice chat limit for today. Please try again tomorrow."
-msgstr "Bugünlük sesli sohbet limitinize ulaştınız. Lütfen yarın tekrar deneyin."
+msgstr ""
+"Bugünlük sesli sohbet limitinize ulaştınız. Lütfen yarın tekrar deneyin."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
@@ -23609,7 +24367,8 @@ msgctxt "duckai_migration"
 msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
-msgstr "Sohbetleriniz içeri aktarıldı. Hadi, Duck.ai'da kaldığınız yerden devam edin."
+msgstr ""
+"Sohbetleriniz içeri aktarıldı. Hadi, Duck.ai'da kaldığınız yerden devam edin."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.
@@ -23656,7 +24415,8 @@ msgctxt ""
 "Subtitle of the one-time popover shown above the thumbs up/down buttons on "
 "an AI response"
 msgid "Your feedback is anonymized and not used to train AI."
-msgstr "Geri bildiriminiz anonimleştirilmiş ve yapay zekayı eğitmek için kullanılmaz."
+msgstr ""
+"Geri bildiriminiz anonimleştirilmiş ve yapay zekayı eğitmek için kullanılmaz."
 
 # smartling.placeholder_format=C
 #. Explains that the User's Location is always private to DuckDuckGo.
@@ -23772,7 +24532,8 @@ msgctxt "Error message for input limit"
 msgid ""
 "You’ve exceeded the maximum message size. Please shorten your message and "
 "try again."
-msgstr "Maksimum mesaj boyutunu aştınız. Lütfen mesajınızı kısaltıp tekrar deneyin."
+msgstr ""
+"Maksimum mesaj boyutunu aştınız. Lütfen mesajınızı kısaltıp tekrar deneyin."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -23814,7 +24575,8 @@ msgstr ""
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
 msgctxt "voice chat limit modal"
 msgid "You’ve reached the voice chat limit for now. Please try again later."
-msgstr "Şimdilik sesli sohbet limitinize ulaştınız. Lütfen daha sonra tekrar deneyin."
+msgstr ""
+"Şimdilik sesli sohbet limitinize ulaştınız. Lütfen daha sonra tekrar deneyin."
 
 # smartling.placeholder_format=C
 #. The name of the Yucatec Maya language
@@ -23897,7 +24659,8 @@ msgstr "(bir %1$s ürünü)"
 #. Trust line shown at the bottom of the explainer panel, summarizing DuckDuckGo's reputation for online protection.
 msgctxt "Footer banner text in the How Duck.ai Works panel"
 msgid "by DuckDuckGo — online protection trusted by millions every day."
-msgstr "DuckDuckGo'dan — her gün milyonlarca kişinin güvendiği çevrimiçi koruma."
+msgstr ""
+"DuckDuckGo'dan — her gün milyonlarca kişinin güvendiği çevrimiçi koruma."
 
 # smartling.placeholder_format=C
 #. An abreviated unit of time indicating an age, e.g. "2d"

--- a/locales/uk_UA/LC_MESSAGES/duckduckgo.po
+++ b/locales/uk_UA/LC_MESSAGES/duckduckgo.po
@@ -2,15 +2,16 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: uk_UA\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 
 # smartling.gettext_line_width = normalized : 79
 # smartling.placeholder_format=C
@@ -22,7 +23,8 @@ msgstr "Пошукові ярлики !Bang"
 msgctxt ""
 "Body copy for the Remove Device confirmation modal; %s is the device name"
 msgid "\"%s\" will no longer be able to access your synced data."
-msgstr "\"%1$s\" більше не зможе отримати доступ до ваших синхронізованих даних."
+msgstr ""
+"\"%1$s\" більше не зможе отримати доступ до ваших синхронізованих даних."
 
 # smartling.placeholder_format=C
 #. Used to specify the rank of a team/player in a specific ranking in short form. This should be interpreted as 'Ranked number <rankNumber> in the <rankingName> ranking. Here you only need to translate the # symbol for ranked number. If your language doesn't provide a single-letter convention, please leave #.
@@ -473,7 +475,8 @@ msgstr "%1$sДізнайтеся, як ми зберігаємо приватн�
 msgctxt "Footer text for About Sync modal"
 msgid ""
 "%sLearn more%s about how chats are stored privately on DuckDuckGo's server."
-msgstr "%1$sДокладніше%2$s про захищене зберігання чатів на сервері DuckDuckGo."
+msgstr ""
+"%1$sДокладніше%2$s про захищене зберігання чатів на сервері DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
@@ -883,7 +886,8 @@ msgstr ""
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of AI Chat is available! Please refresh this page to continue."
-msgstr "Доступна нова версія чату AI Chat! Оновіть цю сторінку, щоб продовжити."
+msgstr ""
+"Доступна нова версія чату AI Chat! Оновіть цю сторінку, щоб продовжити."
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of Duck.ai is available and they need to refresh the page.
@@ -993,10 +997,9 @@ msgid ""
 "models from OpenAI, and Anthropic, and more."
 msgstr ""
 "Наразі можливість ставити подальші запитання штучному інтелекту не "
-"підтримується. Однак ми також пропонуємо і часто посилаємось на "
-"%1$sDuck.ai%2$s для отримання відповідей на уточнювальні запитання. Duck.ai "
-"— це наша служба приватних чатів із ШІ на базі моделей OpenAI, Anthropic "
-"тощо."
+"підтримується. Однак ми також пропонуємо і часто посилаємось на %1$sDuck."
+"ai%2$s для отримання відповідей на уточнювальні запитання. Duck.ai — це наша "
+"служба приватних чатів із ШІ на базі моделей OpenAI, Anthropic тощо."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has turned off AI features and will no longer see AI-assisted answers.
@@ -1435,6 +1438,12 @@ msgid "Address is incorrect"
 msgstr "Неправильна адреса"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Adjust the servings"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. as in multiple advertisements
 msgid "Ads"
 msgstr "Реклама"
@@ -1648,6 +1657,14 @@ msgid "All chats are %sprivate%s"
 msgstr "Усі чати — %1$sприватні%2$s"
 
 # smartling.placeholder_format=C
+#. Paragraph in the Privacy & Terms section of the About & Legal page in Duck.ai settings, summarizing how chats are anonymized and are not stored or used to train chat models.
+msgctxt "Privacy & Terms section description on the Duck.ai settings page"
+msgid ""
+"All chats are anonymized by DuckDuckGo, and your conversations are not used "
+"to train chat models by DuckDuckGo or the model providers"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
 msgctxt "Privacy modal header in Duck.ai chat"
 msgid "All chats are private"
@@ -1736,7 +1753,8 @@ msgstr "Дозволити рекламу, що поважає приватні�
 # smartling.placeholder_format=C
 #. Title in a dialog informing the user how to disable their ad blocker for DuckDuckGo
 msgid "Allow privacy-respecting ads on DuckDuckGo Private Search"
-msgstr "Дозволити рекламу, що поважає конфіденційність, у DuckDuckGo Private Search"
+msgstr ""
+"Дозволити рекламу, що поважає конфіденційність, у DuckDuckGo Private Search"
 
 # smartling.placeholder_format=C
 #. Description explaining privacy implications of enabling web search on encrypted models. The first two placeholders are the full model name (e.g. 'gpt-oss 120B'). The third and fourth placeholders wrap a clickable link reading 'zero provider visibility' that opens the privacy modal, please keep those around the link text in your translation. An example full sentence would be: Allows gpt-oss 120B to search the web to improve responses to relevant prompts. Only sends AI-generated queries to a search engine with limited data retention. Prompts and responses with gpt-oss 120B still have zero provider visibility.
@@ -1916,6 +1934,13 @@ msgid "Anonymous location enabled"
 msgstr "Анонімне розташування увімкнено"
 
 # smartling.placeholder_format=C
+msgctxt "settings"
+msgid ""
+"Anonymously generates answers for search queries based on web content. "
+"Choose how often you want it to appear, or disable it completely."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Instant Answer tab name
 msgid "Answer"
 msgstr "Відповідь"
@@ -2060,7 +2085,8 @@ msgstr "Ти ще тут?"
 msgctxt "Body text for clear all chats confirmation modal"
 msgid ""
 "Are you sure you want to clear all of your chats? This cannot be undone."
-msgstr "Ви впевнені, що бажаєте очистити всі ваші чати? Цю дію не можна скасувати."
+msgstr ""
+"Ви впевнені, що бажаєте очистити всі ваші чати? Цю дію не можна скасувати."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that asks the user if they want to clear the conversation.
@@ -2195,6 +2221,12 @@ msgid "Ask a follow-up with Duck.ai"
 msgstr "Запитайте додаткове запитання за допомогою Duck.ai"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
+msgctxt "Page suggestion chip label"
+msgid "Ask about this page"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
 msgctxt "Title for the page context onboarding modal"
 msgid "Ask about this page"
@@ -2259,10 +2291,11 @@ msgstr ""
 "Assist може анонімно генерувати відповіді ШІ на деякі пошукові запити, "
 "узагальнюючи релевантний веб-контент. Можна вибрати частоту відображення "
 "Assist: «Ніколи» (повністю приховує інтерфейс Assist із результатів пошуку), "
-"«На вимогу» (відображаються лише відповіді ШІ при натисканні кнопки «Assist» "
-"), «Іноді» (відображаються лише відповіді ШІ в разі високої релевантності) "
-"або «Часто» (відображається частіше у різних пошукових запитах). Наразі "
-"відповіді штучного інтелекту доступні лише в США (англійською)."
+"«На вимогу» (відображаються лише відповіді ШІ при натисканні кнопки "
+"«Assist» ), «Іноді» (відображаються лише відповіді ШІ в разі високої "
+"релевантності) або «Часто» (відображається частіше у різних пошукових "
+"запитах). Наразі відповіді штучного інтелекту доступні лише в США "
+"(англійською)."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2611,6 +2644,12 @@ msgid "Barcode"
 msgstr "Штрихкод"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Based on this page, is this course worth taking?"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Basic"
 msgstr "Загальні"
@@ -2649,6 +2688,14 @@ msgstr "Беттер"
 msgctxt "Assistant response placeholder"
 msgid "Before continuing..."
 msgstr "Перш ніж продовжувати..."
+
+# smartling.placeholder_format=C
+#. Explains that before storing the report, DuckDuckGo will anonymize the conversation by removing PII like names, email addresses, and identifying metadata.
+msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
+msgid ""
+"Before storing this report, DuckDuckGo will anonymize your conversation by "
+"removing PII like names, email addresses, and identifying metadata."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -2965,6 +3012,12 @@ msgstr "Бразилія"
 msgctxt "Sports module"
 msgid "Break Points Won"
 msgstr "Виграні брейк-пойнти"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Break this down into clear, numbered steps."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -3421,6 +3474,12 @@ msgstr "Кар'єра"
 msgctxt "Movie/TV Show Title instant answer"
 msgid "Cast"
 msgstr "Виконавці"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Cast & Crew"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -3887,7 +3946,8 @@ msgstr "Перевірте сабреддіт DuckDuckGo, щоб дізнати�
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
 msgctxt "noresults"
 msgid "Check the status page for updates on this outage."
-msgstr "Перевірте сторінку статусу на наявність оновлень щодо цього відключення."
+msgstr ""
+"Перевірте сторінку статусу на наявність оновлень щодо цього відключення."
 
 # smartling.placeholder_format=C
 #. Title shown to the host device (the one that is logged in) after it sends the pairing code. The host can't confirm the peer applied it, so this is a title-only screen (no body) prompting the user to finish on the other device.
@@ -4291,7 +4351,8 @@ msgstr "Оберіть %1$sНалаштування%2$s з меню вибору
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
-msgstr "Натисніть %1$sВикористати поточні сторінки%2$s, потім натисніть %3$sОК%4$s."
+msgstr ""
+"Натисніть %1$sВикористати поточні сторінки%2$s, потім натисніть %3$sОК%4$s."
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -4407,7 +4468,8 @@ msgstr "Натисніть на вкладку %1$sЗагальні%2$s."
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click the %sellipsis icon%s in the toolbar."
-msgstr "Клацніть на %1$sпіктограмі у вигляді трьох точок%2$s в панелі інструментів."
+msgstr ""
+"Клацніть на %1$sпіктограмі у вигляді трьох точок%2$s в панелі інструментів."
 
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to enable location service. Part of a list of instructions on how to enable location service.
@@ -4424,7 +4486,8 @@ msgstr "Натисніть %1$sзначок дозволів%2$s в адресн
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to search using DuckDuckGo.
 msgid "Click the Duck icon at the top of your browser to search!"
-msgstr "Натисніть на зображення качки у верхній частині браузера, щоб почати пошук!"
+msgstr ""
+"Натисніть на зображення качки у верхній частині браузера, щоб почати пошук!"
 
 #  UC Browser on Android
 # smartling.placeholder_format=C
@@ -5130,6 +5193,12 @@ msgid "Create Image"
 msgstr "Створити зображення"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Create a shopping list with quantities from this recipe."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text displayed in the input field when starting a new image generation session.
 msgctxt "Placeholder text for the image generation input field"
 msgid "Create an image of a cute duck..."
@@ -5772,6 +5841,11 @@ msgid "Dictation limit reached"
 msgstr "Досягнуто ліміту диктування"
 
 # smartling.placeholder_format=C
+#. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
+msgid "Dictation temporarily unavailable"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
@@ -6072,6 +6146,22 @@ msgid "Done"
 msgstr "Виконано"
 
 # smartling.placeholder_format=C
+#. Message shown in a modal after DuckDuckGo browser users disable AI features in Settings. The first two placeholders bold noai.duckduckgo.com. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
+"filtered out. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
+"and AI images filtered out. %sLearn more%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Double Faults"
@@ -6184,6 +6274,18 @@ msgid ""
 msgstr ""
 "Скласти стислий проте докладний електронний лист постачальнику із запитом "
 "кошторису на ремонт холодильника."
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Draft a cover letter"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Draft a cover letter for this job."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -6364,6 +6466,15 @@ msgstr ""
 "DuckDuckGo!"
 
 # smartling.placeholder_format=C
+#. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
+msgctxt "About section description on the Duck.ai settings page"
+msgid ""
+"Duck.ai is created by DuckDuckGo. We're an independent online protection "
+"company for anyone who wants to take back control of their personal "
+"information."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
 msgctxt "duckai_migration"
 msgid "Duck.ai is moving domains"
@@ -6407,6 +6518,13 @@ msgstr "Duck.ai тимчасово недоступний. Оновіть сто
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
 msgstr "Duck.ai тимчасово недоступний. Спробуйте пізніше."
+
+# smartling.placeholder_format=C
+msgctxt "settings"
+msgid ""
+"Duck.ai lets you chat privately with popular AI models. Disabling it hides "
+"Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6470,7 +6588,8 @@ msgstr "Duck.ai оновлено!"
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
-msgstr "Duck.ai найкраще працює в конфіденційному й безкоштовному додатку DuckDuckGo!"
+msgstr ""
+"Duck.ai найкраще працює в конфіденційному й безкоштовному додатку DuckDuckGo!"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -6514,10 +6633,10 @@ msgstr ""
 "У відповідь на деякі пошукові запити DuckAssist іноді анонімно шукає та "
 "узагальнює інформацію. Можна вибрати частоту відображення DuckAssist: "
 "«Ніколи» (повністю приховує інтерфейс DuckAssist із результатів пошуку), «На "
-"вимогу» (відображається лише при натисканні кнопки «Допомога»), «Іноді» "
-"(показується лише в разі високої релевантності) або «Часто» (відображається "
-"частіше у різних пошукових запитах). Наразі DuckAssist доступний лише у США "
-"(англійською)."
+"вимогу» (відображається лише при натисканні кнопки «Допомога»), "
+"«Іноді» (показується лише в разі високої релевантності) або "
+"«Часто» (відображається частіше у різних пошукових запитах). Наразі "
+"DuckAssist доступний лише у США (англійською)."
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6577,8 +6696,8 @@ msgstr ""
 "основі штучного інтелекту. Відповіді DuckAssist завжди містять пряме "
 "посилання на одне або два джерела відповіді, тому ви можете швидко знайти "
 "більш детальну інформацію. Важливо пам'ятати, що відповіді автоматично "
-"генеруються із зазначених джерел і ґрунтуються на %1$sвідсканованих "
-"веб-сторінках%2$s."
+"генеруються із зазначених джерел і ґрунтуються на %1$sвідсканованих веб-"
+"сторінках%2$s."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
@@ -6782,8 +6901,8 @@ msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid ""
 "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to Duck.ai's %s."
 msgstr ""
-"DuckDuckGo анонімізує чати. Натиснувши «%1$s», ви погоджуєтесь з %2$s "
-"Duck.ai."
+"DuckDuckGo анонімізує чати. Натиснувши «%1$s», ви погоджуєтесь з %2$s Duck."
+"ai."
 
 # smartling.placeholder_format=C
 #. Shown below the input on the empty state when the user has not yet accepted the terms of service. The first %s is the action button label ('Ask' for chat, 'Create' for image generation). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. Clicking the action button both accepts the terms and submits the prompt.
@@ -6791,7 +6910,8 @@ msgctxt ""
 "Inline terms-of-service disclaimer below chat or image-gen input for new "
 "users"
 msgid "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to our %s."
-msgstr "DuckDuckGo анонімізує чати. Натиснувши «%1$s», ви погоджуєтесь з нашими %2$s."
+msgstr ""
+"DuckDuckGo анонімізує чати. Натиснувши «%1$s», ви погоджуєтесь з нашими %2$s."
 
 # smartling.placeholder_format=C
 #. An information popup explaining that we block trackers
@@ -6980,7 +7100,8 @@ msgstr "Редагувати"
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
-msgstr "Відредаговане зображення. Вартість %1$s (лише для внутрішнього використання)"
+msgstr ""
+"Відредаговане зображення. Вартість %1$s (лише для внутрішнього використання)"
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is editing an image.
@@ -6993,7 +7114,8 @@ msgstr "Редагування зображення..."
 msgctxt "Info text for the editing message feature"
 msgid ""
 "Editing your message will remove the response below and generate a new one."
-msgstr "Редагування вашого повідомлення видалить відповідь нижче та згенерує нову."
+msgstr ""
+"Редагування вашого повідомлення видалить відповідь нижче та згенерує нову."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of an editor in its responses.
@@ -7249,7 +7371,8 @@ msgstr "Користуєтеся Duck.ai?"
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure %s'Allow'%s is selected for the 'Location' setting."
-msgstr "Переконайтеся, що для параметра 'Розташування' вибрано %1$s'Дозволити'%2$s."
+msgstr ""
+"Переконайтеся, що для параметра 'Розташування' вибрано %1$s'Дозволити'%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
@@ -7297,13 +7420,15 @@ msgstr "Переконайтеся, що доступ до розташуван�
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed %slocation access%s"
-msgstr "Переконайтеся, що вашому браузеру дозволено %1$sдоступ до розташування%2$s"
+msgstr ""
+"Переконайтеся, що вашому браузеру дозволено %1$sдоступ до розташування%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed %slocation access%s."
-msgstr "Переконайтеся, що вашому браузеру дозволено %1$sдоступ до розташування%2$s."
+msgstr ""
+"Переконайтеся, що вашому браузеру дозволено %1$sдоступ до розташування%2$s."
 
 # smartling.placeholder_format=C
 #. Tells how to enable location service. Part of a list of instructions on how to enable location service.
@@ -7413,6 +7538,18 @@ msgid "Eritrea"
 msgstr "Еритрея"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Estimate the nutrition"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Estimate the nutritional information for this recipe."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Estonia"
 msgstr "Естонія"
 
@@ -7467,11 +7604,60 @@ msgid "Expires in 1 day"
 msgstr "Термін дії закінчується через 1 день"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain the accepted answer in simple terms."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
-msgstr "Поясніть мені фундаментальні концепції чорних дір на рівні середньої школи."
+msgstr ""
+"Поясніть мені фундаментальні концепції чорних дір на рівні середньої школи."
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain the top answer"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this in simple, plain language."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this paper"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this repo"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this research paper in plain language."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this simply"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain what this repository does and how to use it."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label to show if song lyrics contain explicit content
@@ -7753,7 +7939,14 @@ msgstr "Відфільтровує створені ШІ зображення з
 msgctxt "settings"
 msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
-msgstr "Відфільтровує створені ШІ зображення з результатів пошуку. %1$sДокладніше%2$s"
+msgstr ""
+"Відфільтровує створені ШІ зображення з результатів пошуку. %1$sДокладніше%2$s"
+
+# smartling.placeholder_format=C
+msgctxt "settings"
+msgid ""
+"Filters out known AI spam sites from image search results. %sLearn More%s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the final score of a sporting event.
@@ -7782,7 +7975,8 @@ msgstr "Фінансовий радник"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Find %sDuckDuckGo%s and click%sMake default%s"
-msgstr "Знайдіть %1$sDuckDuckGo%2$s та натисніть%3$sВибрати за замовчуванням%4$s"
+msgstr ""
+"Знайдіть %1$sDuckDuckGo%2$s та натисніть%3$sВибрати за замовчуванням%4$s"
 
 # smartling.placeholder_format=C
 #. Sentence shown after export, includes a placeholder for one or more filenames with bold formatting for the filename(s).
@@ -7794,7 +7988,8 @@ msgstr "Знайдіть <b>%1$s</b> у папці завантажень"
 # smartling.placeholder_format=C
 #. Tells users how to change their default search engine to DuckDuckGo.
 msgid "Find DuckDuckGo in the displayed list and click %sMake Default%s"
-msgstr "Знайдіть DuckDuckGo у списку і натисніть %1$sОбрати за замовчуванням%2$s"
+msgstr ""
+"Знайдіть DuckDuckGo у списку і натисніть %1$sОбрати за замовчуванням%2$s"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for finding a better word.
@@ -7807,6 +8002,12 @@ msgstr "Знайдіть краще слово"
 msgctxt "Subtitle for the Web Search tool entry in the Tools dropdown menu"
 msgid "Find current information"
 msgstr "Знайти актуальну інформацію"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Find me alternatives"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button that searches for results closer to the user's current location.
@@ -8249,19 +8450,22 @@ msgstr "Загальне призначення"
 #. Text with short description for an AI (Artificial Intelligence) Model that has a high moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "General purpose AI with high built-in moderation"
-msgstr "Штучний інтелект загального призначення з вбудованою високою модерацією"
+msgstr ""
+"Штучний інтелект загального призначення з вбудованою високою модерацією"
 
 # smartling.placeholder_format=C
 #. Text with short description for an AI (Artificial Intelligence) Model that has a low moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "General purpose AI with low built-in moderation"
-msgstr "Штучний інтелект загального призначення з вбудованою низькою модерацією"
+msgstr ""
+"Штучний інтелект загального призначення з вбудованою низькою модерацією"
 
 # smartling.placeholder_format=C
 #. Text with short description for an AI (Artificial Intelligence) Model that has a medium moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "General purpose AI with medium built-in moderation"
-msgstr "Штучний інтелект загального призначення із вбудованою середньою модерацією"
+msgstr ""
+"Штучний інтелект загального призначення із вбудованою середньою модерацією"
 
 # smartling.placeholder_format=C
 #. Text indicating that the AI (Artificial Intelligence) model is a model for general purpose use. General-purpose AI refers to AI systems that can perform a wide range of tasks, rather than being specialized for a specific task.
@@ -8284,6 +8488,12 @@ msgstr "Згенерувати зображення"
 #. Text for the button that generates more of an answer from duckassist when the answer has come from a collapsed state
 msgid "Generate More"
 msgstr "Згенерувати більше"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Generate a shopping list"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
@@ -8316,7 +8526,8 @@ msgstr "Згенероване зображення"
 #. Title text shown for an assistant response that contains a generated image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Generated image. Cost %s (internal only)"
-msgstr "Згенероване зображення. Вартість %1$s (лише для внутрішнього використання)"
+msgstr ""
+"Згенероване зображення. Вартість %1$s (лише для внутрішнього використання)"
 
 # smartling.placeholder_format=C
 #. Aria label for the carousel (list of generated images) in the image generation mode.
@@ -8577,6 +8788,12 @@ msgstr "Спробувати"
 msgctxt "Onboarding welcome screen button text"
 msgid "Give it a Try"
 msgstr "Спробувати"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Give me a quick background on this person."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9025,6 +9242,18 @@ msgstr "Допоможіть поширити DuckDuckGo!"
 #. Link to a page with information about sharing DuckDuckGo with friends.
 msgid "Help Spread Privacy"
 msgstr "Допоможіть поширити приватність"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Help me prep for the interview"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Help me tailor my resume for this job."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title of a SERP popup that invites users to take a survey (desktop only)
@@ -9499,7 +9728,8 @@ msgctxt "Full sentence for preparing for a conversation"
 msgid ""
 "How should I tactfully approach a colleague about their constant pencil "
 "tapping and what should I say?"
-msgstr "Як тактовно попросити колегу перестати постійно стукати олівцем по столу?"
+msgstr ""
+"Як тактовно попросити колегу перестати постійно стукати олівцем по столу?"
 
 # smartling.placeholder_format=C
 #. The title for a feedback prompt that includes thumbs up and thumbs down buttons
@@ -9538,6 +9768,14 @@ msgstr "Ураган"
 msgctxt "Onboarding terms screen button text"
 msgid "I Agree"
 msgstr "Я згоден"
+
+# smartling.placeholder_format=C
+#. Text for the button that takes the user to the external DuckDuckGo login subscription page.
+msgctxt ""
+"Text for the I already have a subscription button in the Duck.ai settings "
+"page"
+msgid "I Already Have a Subscription"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the button that takes the user to the login subscription page.
@@ -10121,6 +10359,12 @@ msgid "Install Mac Browser"
 msgstr "Встановити браузер для Mac"
 
 # smartling.placeholder_format=C
+#. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
+msgctxt "settings"
+msgid "Install Now"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of a button to install the DuckDuckGo app
 msgctxt "Serp footer content"
 msgid "Install Our App"
@@ -10218,10 +10462,42 @@ msgid "Is deleted data really deleted?"
 msgstr "Чи дані справді видаляються?"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is it worth taking?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this place any good?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"Is this place any good? Summarize its reputation based on reviews and "
+"ratings."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "Is this video helpful?"
 msgstr "Чи корисне це відео?"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this worth watching?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Is this worth watching? Give me a spoiler-free take."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -10320,7 +10596,8 @@ msgstr "Приєднуйтесь до нашої команди!"
 # smartling.placeholder_format=C
 msgctxt "showcase_donate"
 msgid "Join our $500,000 Privacy Challenge"
-msgstr "Приєднуйтеся до нашого змагання з приватності із призовим фондом у $500 000"
+msgstr ""
+"Приєднуйтеся до нашого змагання з приватності із призовим фондом у $500 000"
 
 # smartling.placeholder_format=C
 msgid "Jordan"
@@ -10834,6 +11111,12 @@ msgid "Links:"
 msgstr "Посилання:"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "List the tools, materials, or prerequisites I need for this."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
 msgid "Listen"
 msgstr "Слухати"
@@ -10932,7 +11215,8 @@ msgstr "Завантаження..."
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Loads more image and video results when scrolling"
-msgstr "Завантаження інших результатів для зображень та відео при прокручуванні"
+msgstr ""
+"Завантаження інших результатів для зображень та відео при прокручуванні"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -11242,6 +11526,12 @@ msgstr "Керування підпискою"
 msgctxt "Exclusion message manage sites button"
 msgid "Manage blocked sites"
 msgstr "Керування заблокованими сайтами"
+
+# smartling.placeholder_format=C
+#. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
+msgctxt "setting"
+msgid "Manage in Browser Settings"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to the site exclusion settings page
@@ -13160,7 +13450,8 @@ msgstr "Відкрити вебсайт %1$s"
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open %sLocation%s, and ensure location is %senabled%s"
-msgstr "Відкрийте %1$s«Розташування»%2$s і переконайтеся, що воно %3$sувімкнене%4$s"
+msgstr ""
+"Відкрийте %1$s«Розташування»%2$s і переконайтеся, що воно %3$sувімкнене%4$s"
 
 #  Chrome/Firefox on Android/iOS
 # smartling.placeholder_format=C
@@ -13323,7 +13614,8 @@ msgstr "Відкрити панель «Як працює Duck.ai»"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open the Safari menu and select %sSettings for DuckDuckGo...%s"
-msgstr "Відкрийте меню Safari та виберіть %1$sНалаштування для DuckDuckGo...%2$s"
+msgstr ""
+"Відкрийте меню Safari та виберіть %1$sНалаштування для DuckDuckGo...%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the time a business opens. For example: 'Opens at 10am'
@@ -13702,8 +13994,8 @@ msgid ""
 "Passphrases cannot be recovered as we don't associate your IP address, "
 "browser fingerprint, or any other information with the file."
 msgstr ""
-"Неможливо відновити парольні фрази, оскільки ми не пов'язуємо вашу "
-"IP-адресу, відбиток браузера чи інші дані з файлом."
+"Неможливо відновити парольні фрази, оскільки ми не пов'язуємо вашу IP-"
+"адресу, відбиток браузера чи інші дані з файлом."
 
 # smartling.placeholder_format=C
 #. Label for the section of recent chats that were edited in the past 7 days.
@@ -14063,7 +14355,8 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this prompt was made by a "
 "human."
-msgstr "Виконайте наступне завдання, щоб підтвердити, що цей запит здійснено людиною."
+msgstr ""
+"Виконайте наступне завдання, щоб підтвердити, що цей запит здійснено людиною."
 
 # smartling.placeholder_format=C
 #. Bot challenge explanation
@@ -14071,13 +14364,21 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this search was made by a "
 "human."
-msgstr "Виконайте наступне завдання, щоб підтвердити, що цей пошук здійснено людиною."
+msgstr ""
+"Виконайте наступне завдання, щоб підтвердити, що цей пошук здійснено людиною."
+
+# smartling.placeholder_format=C
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
+msgctxt "Feedback prompt"
+msgid "Please describe why the chat response is harmful or illegal. (optional)"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
-msgstr "Поясніть, чому відповідь у чаті є незаконною або небезпечною. (Необов'язково)"
+msgstr ""
+"Поясніть, чому відповідь у чаті є незаконною або небезпечною. (Необов'язково)"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to enter their passphrase.
@@ -14100,6 +14401,14 @@ msgid ""
 msgstr ""
 "Зверніть увагу: якщо ви почнете новий чат з будь-якою моделлю, ваш поточний "
 "сеанс чату буде видалено."
+
+# smartling.placeholder_format=C
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
+msgctxt "Feedback prompt"
+msgid ""
+"Please paste your prompt and the problematic output (with any personal "
+"information removed) and describe why the content is harmful or illegal."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -14569,6 +14878,12 @@ msgid "Privacy"
 msgstr "Приватність"
 
 # smartling.placeholder_format=C
+#. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
+msgctxt "Section heading on the Duck.ai settings page"
+msgid "Privacy & Terms"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Privacy Blog"
 msgstr "Блог про приватність"
 
@@ -14637,6 +14952,12 @@ msgstr "Політика конфіденційності та умови вик
 msgctxt "Copy used to compose link in sentences"
 msgid "Privacy Policy and Terms of Service"
 msgstr "Політика конфіденційності та умови надання послуг"
+
+# smartling.placeholder_format=C
+#. Text for a button that links to the terms of use and privacy policy page.
+msgctxt "Secondary button text in active privacy modal"
+msgid "Privacy Policy and Terms of Service"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title displayed on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
@@ -15140,6 +15461,30 @@ msgid "Recommend a book"
 msgstr "Порекомендуйте книгу"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar books"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar books."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar movies or shows."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar titles"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
 msgid "Recording failed. Please try again."
 msgstr "Не вдалося записати. Повторіть спробу."
@@ -15363,7 +15708,8 @@ msgstr "Запам'ятати вибір"
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings
 msgid "Remember my choice (this can be changed in %s%s%sSettings%s)"
-msgstr "Запам'ятати мій вибір (це можна змінити в %1$s%2$s%3$sНалаштуваннях%4$s)"
+msgstr ""
+"Запам'ятати мій вибір (це можна змінити в %1$s%2$s%3$sНалаштуваннях%4$s)"
 
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
@@ -15538,6 +15884,15 @@ msgstr ""
 # smartling.placeholder_format=C
 msgid "Republic of Moldova"
 msgstr "Республіка Молдова"
+
+# smartling.placeholder_format=C
+#. Note indicating that sharing the conversation is mandatory when reporting harmful or illegal content. Rendered alongside the standard share label (DUCKCHAT_RESPONSE_FEEDBACK_SHARE_PROMPT_RESPONSE_LABEL), not replacing it.
+msgctxt ""
+"Note shown under the share-content switch label on the Duck.ai response "
+"feedback form when the user has selected Harmful or Illegal as the feedback "
+"reason"
+msgid "Required for harmful or illegal reports"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
@@ -15777,6 +16132,12 @@ msgstr "Відгуки"
 msgctxt "maps_places"
 msgid "Reviews"
 msgstr "Відгуки"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Rewrite this recipe scaled for a different number of servings."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Romania"
@@ -16231,7 +16592,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down to the %sServices%s section and click %sAddress bar%s."
-msgstr "Прокрутіть вниз до розділу %1$sСервіси%2$s та клацніть %3$sПанель адреси%4$s."
+msgstr ""
+"Прокрутіть вниз до розділу %1$sСервіси%2$s та клацніть %3$sПанель адреси%4$s."
 
 # smartling.placeholder_format=C
 #. Rugby match stats
@@ -16565,7 +16927,8 @@ msgstr "Тижні сезону"
 #. Description shown in the Sync & Backup settings section when sync is not yet enabled, explaining the feature.
 msgctxt "Description for sync and backup feature"
 msgid "Securely save and sync your chats across all your devices."
-msgstr "Безпечно зберігайте та синхронізуйте твої чати на всіх своїх пристроях."
+msgstr ""
+"Безпечно зберігайте та синхронізуйте твої чати на всіх своїх пристроях."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -16777,18 +17140,21 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
-msgstr "Оберіть %1$sDuckDuckGo%2$s та клацніть %3$sВстановити за замовчуванням%4$s!"
+msgstr ""
+"Оберіть %1$sDuckDuckGo%2$s та клацніть %3$sВстановити за замовчуванням%4$s!"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s"
-msgstr "Виберіть %1$sDuckDuckGo%2$s і натисніть %3$sВстановити за замовчуванням%4$s"
+msgstr ""
+"Виберіть %1$sDuckDuckGo%2$s і натисніть %3$sВстановити за замовчуванням%4$s"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s."
-msgstr "Виберіть %1$sDuckDuckGo%2$s і натисніть %3$sВстановити за замовчуванням%4$s."
+msgstr ""
+"Виберіть %1$sDuckDuckGo%2$s і натисніть %3$sВстановити за замовчуванням%4$s."
 
 #  Firefox 33
 # smartling.placeholder_format=C
@@ -16999,7 +17365,8 @@ msgstr "Вибраний текст із %1$s"
 #. Displayed when the user's text selection exceeds the maximum message size for AI tools (summary, translation, etc.).
 msgctxt "Error message for selection input limit"
 msgid "Selected text is too long. Try again with a shorter selection."
-msgstr "Вибраний текст занадто довгий. Спробуйте ще раз, вибравши коротший фрагмент."
+msgstr ""
+"Вибраний текст занадто довгий. Спробуйте ще раз, вибравши коротший фрагмент."
 
 # smartling.placeholder_format=C
 #. Label for the semi-finals knockout stage in e.g. the soccer World Cup
@@ -17120,6 +17487,12 @@ msgid "Set Up Now"
 msgstr "Налаштувати"
 
 # smartling.placeholder_format=C
+#. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
+msgctxt "Encrypted storage setup button shown in native browsers"
+msgid "Set Up Sync & Backup"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
 msgctxt "Title for the Sync & Backup intro screen"
 msgid "Set Up Sync & Backup"
@@ -17211,7 +17584,8 @@ msgstr "Поділитися"
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "Share DuckDuckGo and help friends take their privacy back!"
-msgstr "Розкажіть про DuckDuckGo та допоможіть вашим друзям повернути приватність!"
+msgstr ""
+"Розкажіть про DuckDuckGo та допоможіть вашим друзям повернути приватність!"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button that opens a feedback modal when clicked.
@@ -17299,6 +17673,13 @@ msgstr "Поділитися URL сторінки"
 msgctxt "feedback form"
 msgid "Share positive feedback"
 msgstr "Надіслати позитивний відгук"
+
+# smartling.placeholder_format=C
+#. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
+msgctxt ""
+"Label beside the share-content switch on the Duck.ai response feedback form"
+msgid "Share this conversation with DuckDuckGo"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -17703,12 +18084,14 @@ msgstr "Показує найпопулярніші посилання у нов
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your browser"
-msgstr "Показує періодичні нагадування про додавання DuckDuckGo до вашого браузера"
+msgstr ""
+"Показує періодичні нагадування про додавання DuckDuckGo до вашого браузера"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr "Показує періодичні нагадування про додавання DuckDuckGo на ваших пристроях"
+msgstr ""
+"Показує періодичні нагадування про додавання DuckDuckGo на ваших пристроях"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -17752,7 +18135,8 @@ msgstr "Показує привітальне повідомлення вгор�
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message to EU Android preference menu users"
-msgstr "Показує привітальне повідомлення користувачам з меню налаштувань Android в ЄС"
+msgstr ""
+"Показує привітальне повідомлення користувачам з меню налаштувань Android в ЄС"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers sometimes.
@@ -17974,7 +18358,8 @@ msgstr "Щось пішло не так при збереженні на сер�
 #. Body copy displayed under the Set Up Now button when the sync setup call fails.
 msgctxt "Generic error shown when sync setup fails"
 msgid "Something went wrong while enabling Sync & Backup. Please try again."
-msgstr "Сталася помилка під час увімкнення функції Sync & Backup. Повторіть спробу."
+msgstr ""
+"Сталася помилка під час увімкнення функції Sync & Backup. Повторіть спробу."
 
 # smartling.placeholder_format=C
 #. Displayed when the voice chat session ends with an unknown error.
@@ -18072,7 +18457,8 @@ msgstr ""
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr "На жаль, нам не вдалося надіслати ваш відгук. Будь ласка, спробуйте пізніше."
+msgstr ""
+"На жаль, нам не вдалося надіслати ваш відгук. Будь ласка, спробуйте пізніше."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -18558,6 +18944,24 @@ msgid "Suggest a title for a blog post"
 msgstr "Запропонуйте назву для публікації в блозі"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest related articles or topics worth exploring next."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Suggest related articles to explore"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest some alternatives to this product."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
 msgctxt "directions"
 msgid "Suggestions:"
@@ -18569,10 +18973,100 @@ msgid "Suggestions:"
 msgstr "Пропозиції:"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Sum up the reviews"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A short title for the a message asking the AI to summarize a text.
 msgctxt "Title for the summarize message"
 msgid "Summarize"
 msgstr "Підсумувати"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize the Q&As"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the background and notable work of this person."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the key details of this event."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the questions and answers on this page."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize their background"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this book"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this book."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this discussion"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this discussion thread."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this page"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this page."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this video"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this video."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize what the reviews say."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -18902,6 +19396,12 @@ msgid "Syria"
 msgstr "Сирія"
 
 # smartling.placeholder_format=C
+#. Text for a button that enables the theme to follow the operating system's color scheme preference.
+msgctxt "System theme button for theme selector"
+msgid "System"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Abbreviation indicating this is the total score for a game
 msgctxt "Sports module"
 msgid "T"
@@ -18928,6 +19428,12 @@ msgstr "ТБ"
 msgctxt "language_name"
 msgid "Tahitian"
 msgstr "Таїтянська"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Tailor my resume"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Taiwan"
@@ -18957,6 +19463,13 @@ msgstr "Контролюйте особисті дані"
 msgctxt "homepage ATB modal"
 msgid "Take control of your personal data!"
 msgstr "Контролюйте свої особисті дані!"
+
+# smartling.placeholder_format=C
+#. Description for the Feedback section of the Duck.ai settings page, asking the user to take an anonymous survey to let us know how we can make Duck.ai better.
+msgctxt "Feedback section description on the Duck.ai settings page"
+msgid ""
+"Take this anonymous survey to let us know how we can make Duck.ai better."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -19264,6 +19777,12 @@ msgid "Theme"
 msgstr "Тема"
 
 # smartling.placeholder_format=C
+#. Text for the theme selector label that allows users to switch between Light and dark theme.
+msgctxt "Label for the theme selector feature"
+msgid "Theme"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. http://i.imgur.com/LpFhb1e.png
 msgctxt "settings"
 msgid "Theme"
@@ -19367,7 +19886,8 @@ msgctxt "AI Chat: Error message for when a model is removed"
 msgid ""
 "This AI model is no longer available. Try starting a new chat with a "
 "different model."
-msgstr "Ця модель ШІ більше не доступна. Спробуйте почати новий чат з іншою моделлю."
+msgstr ""
+"Ця модель ШІ більше не доступна. Спробуйте почати новий чат з іншою моделлю."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is no longer supported because it has been upgraded to a newest version.
@@ -19512,14 +20032,16 @@ msgstr "Це зображення не вдалося створити."
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF"
-msgstr "Цей тип зображення не підтримується, прикріпіть файл JPG, PNG, WebP або GIF"
+msgstr ""
+"Цей тип зображення не підтримується, прикріпіть файл JPG, PNG, WebP або GIF"
 
 # smartling.placeholder_format=C
 #. Error message displayed when a file that the user tried to upload is not of a supported format
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF."
-msgstr "Цей тип зображення не підтримується. Додайте файл JPG, PNG, WebP або GIF."
+msgstr ""
+"Цей тип зображення не підтримується. Додайте файл JPG, PNG, WebP або GIF."
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
@@ -19572,7 +20094,8 @@ msgstr "Для роботи цієї сторінки необхідний Javas
 #. Information tooltip text explaining that the current page's content will be included with the chat message.
 msgctxt "Tooltip explaining that page content will be sent to Duck.ai"
 msgid "This page's content will be sent with your message to Duck.ai"
-msgstr "Вміст цієї сторінки буде надіслано до Duck.ai разом із вашим повідомленням"
+msgstr ""
+"Вміст цієї сторінки буде надіслано до Duck.ai разом із вашим повідомленням"
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -19647,7 +20170,8 @@ msgstr ""
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr "Ця вебсторінка не використовує захищене, зашифроване, з'єднання (HTTPS)."
+msgstr ""
+"Ця вебсторінка не використовує захищене, зашифроване, з'єднання (HTTPS)."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -19687,7 +20211,8 @@ msgstr "Це зітре усі налаштування. Продовжити?"
 #. Confirmation message asking if the user is sure they want to reset all of their settings.
 msgctxt "settings"
 msgid "This will reset your saved settings to default values. Continue?"
-msgstr "Це призведе до скидання ваших налаштувань до стандартних значень. Продовжити?"
+msgstr ""
+"Це призведе до скидання ваших налаштувань до стандартних значень. Продовжити?"
 
 # smartling.placeholder_format=C
 #. Golf leaderboard column: holes completed in current round
@@ -20095,6 +20620,18 @@ msgstr ""
 "кінотеатру?»"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Translate this page"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
+msgctxt "Page suggestion prompt"
+msgid "Translate this page into %s."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text for a region that will display translated text.
 msgctxt "translations_module"
 msgid "Translation"
@@ -20238,6 +20775,12 @@ msgid "Try Free"
 msgstr "Спробувати безкоштовно"
 
 # smartling.placeholder_format=C
+#. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
+msgctxt "settings"
+msgid "Try It Now"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
 msgctxt "Promotional CTA for new AI models"
 msgid "Try Now"
@@ -20308,7 +20851,8 @@ msgstr "Спробуйте увімкнути анонімне розташув�
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr "Спробуйте поекспериментувати з кожною моделлю — вони дадуть різні відповіді."
+msgstr ""
+"Спробуйте поекспериментувати з кожною моделлю — вони дадуть різні відповіді."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
@@ -20365,7 +20909,8 @@ msgstr "Спробуйте наш браузер,"
 # smartling.placeholder_format=C
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
-msgstr "Спробуйте нашу домашню сторінку, яка ніколи не показує ці повідомлення:"
+msgstr ""
+"Спробуйте нашу домашню сторінку, яка ніколи не показує ці повідомлення:"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with different words to get more results.
@@ -20388,7 +20933,8 @@ msgstr "Спробуйте налаштувати ваше розташуван�
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Try the %sDuckDuckGo Browser.%s Fast. Free. Private."
-msgstr "Спробуйте браузер %1$sDuckDuckGo.%2$s Швидко. Безплатно. Конфіденційно."
+msgstr ""
+"Спробуйте браузер %1$sDuckDuckGo.%2$s Швидко. Безплатно. Конфіденційно."
 
 # smartling.placeholder_format=C
 #. Link to a page where users can download the DuckDuckGo Browser for iOS or Android.
@@ -20474,6 +21020,22 @@ msgstr "Спробуйте: %1$s"
 msgctxt "new user poll"
 msgid "Trying DuckDuckGo again"
 msgstr "Повертаюся до користування DuckDuckGo"
+
+# smartling.placeholder_format=C
+#. Message shown in a modal after supported third-party browser users disable AI features in Settings. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -20575,7 +21137,8 @@ msgstr "Вимкнути:"
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on %sPrecise Location%s for more accurate results"
-msgstr "Увімкніть «%1$sТочне розташування%2$s» для отримання точніших результатів"
+msgstr ""
+"Увімкніть «%1$sТочне розташування%2$s» для отримання точніших результатів"
 
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
@@ -20800,7 +21363,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
-msgstr "В меню %1$sЗАПУСК > Домашня сторінка%2$s введіть: https://duckduckgo.com"
+msgstr ""
+"В меню %1$sЗАПУСК > Домашня сторінка%2$s введіть: https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -20810,7 +21374,8 @@ msgstr "В %1$sНалаштуваннях пошуку%2$s оберіть %3$sDu
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch in the address bar with%s select %sAdd New%s"
-msgstr "В розділі %1$sПошук в адресному рядку%2$s виберіть %3$sДодати новий%4$s"
+msgstr ""
+"В розділі %1$sПошук в адресному рядку%2$s виберіть %3$sДодати новий%4$s"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -20830,7 +21395,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine
 msgid "Under Search click the drop down and select %sDuckDuckGo%s"
-msgstr "Під рядком пошуку натисніть на випадне меню та виберіть %1$sDuckDuckGo%2$s"
+msgstr ""
+"Під рядком пошуку натисніть на випадне меню та виберіть %1$sDuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings" header
@@ -20963,7 +21529,8 @@ msgctxt ""
 "Text shown in the subscription promo card, with a trailing call-to-action "
 "link."
 msgid "Unlock more capable AI models with a DuckDuckGo subscription. %s"
-msgstr "Розблокуйте більше потужних моделей ШІ, підписавшись на DuckDuckGo. %1$s"
+msgstr ""
+"Розблокуйте більше потужних моделей ШІ, підписавшись на DuckDuckGo. %1$s"
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to unmute the microphone.
@@ -21176,7 +21743,8 @@ msgstr ""
 #. Upsell message shown in the voice chat limit and duration limit modals for Plus subscribers, encouraging them to upgrade to Pro.
 msgctxt "voice chat limit modal"
 msgid "Upgrade to Pro to unlock 2x higher usage limits than Plus"
-msgstr "Переходьте на план Pro, щоб розблокувати вдвічі вищі ліміти, ніж у плані Plus"
+msgstr ""
+"Переходьте на план Pro, щоб розблокувати вдвічі вищі ліміти, ніж у плані Plus"
 
 # smartling.placeholder_format=C
 #. Heading in a promotion for a desktop web browser
@@ -21223,6 +21791,12 @@ msgstr "Урду"
 # smartling.placeholder_format=C
 msgid "Uruguay"
 msgstr "Уругвай"
+
+# smartling.placeholder_format=C
+#. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
+msgctxt "Navigation label on the Duck.ai settings page"
+msgid "Usage"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -21457,7 +22031,8 @@ msgstr "Переглянути ціни на проживання"
 # smartling.placeholder_format=C
 #. A description for the ads tooltip that explains that viewing ads is privacy protected by DuckDuckGo.
 msgid "Viewing ads is privacy protected by DuckDuckGo."
-msgstr "Перегляд оголошень виконується із захистом конфіденційності DuckDuckGo."
+msgstr ""
+"Перегляд оголошень виконується із захистом конфіденційності DuckDuckGo."
 
 # smartling.placeholder_format=C
 msgctxt "Ads GDPR, internal use only. Do not change"
@@ -21564,8 +22139,8 @@ msgid ""
 msgstr ""
 "Відвідайте сайт Duck.ai в іншому браузері або в додатку DuckDuckGo та "
 "відкрийте налаштування Duck.ai. Виберіть «Увімкнути» у розділі «Sync & "
-"Backup» та виберіть «Синхронізувати з іншим пристроєм». Або відскануйте "
-"QR-код у PDF-файлі для відновлення."
+"Backup» та виберіть «Синхронізувати з іншим пристроєм». Або відскануйте QR-"
+"код у PDF-файлі для відновлення."
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -21678,6 +22253,12 @@ msgstr "Очікування розташування..."
 # smartling.placeholder_format=C
 msgid "Wales"
 msgstr "Уельс"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Walk me through the steps"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for walking directions on a map.
@@ -21797,6 +22378,17 @@ msgstr ""
 "більш точні результати."
 
 # smartling.placeholder_format=C
+#. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
+msgctxt ""
+"Inline warning shown below the share-content toggle when the user selects "
+"Harmful or Illegal but has not enabled sharing"
+msgid ""
+"We can only fix what we can see. To report a harmful or illegal response, "
+"please share this conversation with DuckDuckGo so we can investigate and "
+"address the issue."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
 msgctxt ""
 "Inline warning shown below the share-content toggle when the user selects "
@@ -21823,7 +22415,8 @@ msgstr ""
 msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
-msgstr "Не вдається зчитати додані файли, оскільки принаймні один із них зашифровано."
+msgstr ""
+"Не вдається зчитати додані файли, оскільки принаймні один із них зашифровано."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -21888,7 +22481,8 @@ msgstr "Ми ніколи не стежимо за вами."
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with a Continue button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don't track you. That's our Privacy Policy in a nutshell."
-msgstr "Ми не відстежуємо вас. Це наша Політика конфіденційності, якщо коротко."
+msgstr ""
+"Ми не відстежуємо вас. Це наша Політика конфіденційності, якщо коротко."
 
 # smartling.placeholder_format=C
 #. Description for the audio identification highlight in the dictation consent modal.
@@ -22019,7 +22613,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
-msgstr "Трекери, що намагаються збирати ваші дані під час перегляду, блокуватимуться."
+msgstr ""
+"Трекери, що намагаються збирати ваші дані під час перегляду, блокуватимуться."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -22348,6 +22943,103 @@ msgstr ""
 "так і без нього."
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the counterarguments?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the hours & location?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key contributions of this paper?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key contributions?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key details?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key points covered in this video?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key points?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key takeaways from this article?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key takeaways?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key things I will learn from this course?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main counterarguments or criticisms of this?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main questions this page answers?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the must-try dishes here?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"What are the opening hours, location, and contact details for this place?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the pros and cons of this product?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the pros and cons?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
 msgctxt "feedback form"
 msgid "What bothered you most?"
@@ -22448,6 +23140,12 @@ msgid "What does atria mean in the context of a medical article?"
 msgstr "Що передсердя означає у медичній статті?"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What does this answer?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
@@ -22460,20 +23158,32 @@ msgid "What information gets saved?"
 msgstr "Яка інформація зберігається?"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What interview questions might come up for this role?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
 msgid ""
 "What is the Cloud Save bookmarklet and how does it differ from the URL "
 "parameter bookmarklet?"
 msgstr ""
-"Що таке збережена в хмарі закладка і чим вона відрізняється від "
-"URL-параметрів?"
+"Що таке збережена в хмарі закладка і чим вона відрізняється від URL-"
+"параметрів?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for looking up the capital city of Albania.
 msgctxt "Full sentence for looking up basic facts"
 msgid "What is the capital city of Albania?"
 msgstr "Яка столиця Албанії?"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What is the overall verdict and rating for this?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to a page with additional information.
@@ -22498,6 +23208,12 @@ msgid "What people say:"
 msgstr "Що кажуть люди:"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What should I order?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
 msgctxt "feedback form"
 msgid "What stood out?"
@@ -22510,6 +23226,18 @@ msgid "What was wrong with the response? (optional)"
 msgstr "Що було не так із відповіддю? (Необов'язково)"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I learn?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I need?"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid "What would you like to provide feedback on?"
 msgstr "Про що б ви хотіли залишити відгук?"
@@ -22518,13 +23246,20 @@ msgstr "Про що б ви хотіли залишити відгук?"
 #. Explains the benefits of using our custom video player, the Duck Player
 msgid ""
 "What you watch in DuckDuckGo won't influence your recommendations on YouTube."
-msgstr "Те, що ви дивитеся в DuckDuckGo, не вплине на ваші рекомендації на YouTube."
+msgstr ""
+"Те, що ви дивитеся в DuckDuckGo, не вплине на ваші рекомендації на YouTube."
 
 # smartling.placeholder_format=C
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
 msgctxt "SERP footer content"
 msgid "What's New"
 msgstr "Що нового"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What's the verdict?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -22577,6 +23312,12 @@ msgid "Which features are missing? (Optional)"
 msgstr "Яких функцій не вистачає? (Необов'язково)"
 
 # smartling.placeholder_format=C
+#. An invitation for users to leave feedback
+msgctxt "Feedback prompt"
+msgid "Which features are missing? (optional)"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
 msgid "White"
 msgstr "Білий"
@@ -22591,6 +23332,18 @@ msgstr "Білий"
 #. Link to an about us page.
 msgid "Who We Are"
 msgstr "Хто ми такі"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Who are the main cast and crew, and what else are they known for?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Who is this person?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Header above a collection of privacy-related links.
@@ -23255,7 +24008,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
 msgid "You won't see this message again unless you clear your browser data."
-msgstr "Ви більше не побачите це повідомлення, якщо не очистите дані свого браузера."
+msgstr ""
+"Ви більше не побачите це повідомлення, якщо не очистите дані свого браузера."
 
 # smartling.placeholder_format=C
 #. The second paragraph of a pop up where we explain how to update the browser manually.
@@ -23513,7 +24267,8 @@ msgstr ""
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never used to train AI models"
-msgstr "Ваші чати є приватними і ніколи не використовуються для навчання моделей ШІ"
+msgstr ""
+"Ваші чати є приватними і ніколи не використовуються для навчання моделей ШІ"
 
 # smartling.placeholder_format=C
 #. Text for a description of the active privacy protection for DuckDuckGo's AI Chat feature.
@@ -23573,7 +24328,8 @@ msgctxt "duckai_migration"
 msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
-msgstr "Ваші чати імпортовано. Продовжуйте з того місця, де ви зупинилися у Duck.ai."
+msgstr ""
+"Ваші чати імпортовано. Продовжуйте з того місця, де ви зупинилися у Duck.ai."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.

--- a/locales/uk_UA/LC_MESSAGES/duckduckgo.po
+++ b/locales/uk_UA/LC_MESSAGES/duckduckgo.po
@@ -19048,7 +19048,7 @@ msgstr "Підсумуйте це відео."
 #. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize what the reviews say."
-msgstr "Надайте стислі дані, що показують відгуки."
+msgstr "Підсумуйте, що йдеться у відгуках."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -22926,7 +22926,7 @@ msgstr "Які є контраргументи?"
 #. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the hours & location?"
-msgstr "Які години роботи та де ви знаходитесь?"
+msgstr "Які години роботи та адреса?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.

--- a/locales/uk_UA/LC_MESSAGES/duckduckgo.po
+++ b/locales/uk_UA/LC_MESSAGES/duckduckgo.po
@@ -2,16 +2,15 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: uk_UA\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
-"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 
 # smartling.gettext_line_width = normalized : 79
 # smartling.placeholder_format=C
@@ -23,8 +22,7 @@ msgstr "Пошукові ярлики !Bang"
 msgctxt ""
 "Body copy for the Remove Device confirmation modal; %s is the device name"
 msgid "\"%s\" will no longer be able to access your synced data."
-msgstr ""
-"\"%1$s\" більше не зможе отримати доступ до ваших синхронізованих даних."
+msgstr "\"%1$s\" більше не зможе отримати доступ до ваших синхронізованих даних."
 
 # smartling.placeholder_format=C
 #. Used to specify the rank of a team/player in a specific ranking in short form. This should be interpreted as 'Ranked number <rankNumber> in the <rankingName> ranking. Here you only need to translate the # symbol for ranked number. If your language doesn't provide a single-letter convention, please leave #.
@@ -475,8 +473,7 @@ msgstr "%1$sДізнайтеся, як ми зберігаємо приватн�
 msgctxt "Footer text for About Sync modal"
 msgid ""
 "%sLearn more%s about how chats are stored privately on DuckDuckGo's server."
-msgstr ""
-"%1$sДокладніше%2$s про захищене зберігання чатів на сервері DuckDuckGo."
+msgstr "%1$sДокладніше%2$s про захищене зберігання чатів на сервері DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
@@ -886,8 +883,7 @@ msgstr ""
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of AI Chat is available! Please refresh this page to continue."
-msgstr ""
-"Доступна нова версія чату AI Chat! Оновіть цю сторінку, щоб продовжити."
+msgstr "Доступна нова версія чату AI Chat! Оновіть цю сторінку, щоб продовжити."
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of Duck.ai is available and they need to refresh the page.
@@ -997,9 +993,10 @@ msgid ""
 "models from OpenAI, and Anthropic, and more."
 msgstr ""
 "Наразі можливість ставити подальші запитання штучному інтелекту не "
-"підтримується. Однак ми також пропонуємо і часто посилаємось на %1$sDuck."
-"ai%2$s для отримання відповідей на уточнювальні запитання. Duck.ai — це наша "
-"служба приватних чатів із ШІ на базі моделей OpenAI, Anthropic тощо."
+"підтримується. Однак ми також пропонуємо і часто посилаємось на "
+"%1$sDuck.ai%2$s для отримання відповідей на уточнювальні запитання. Duck.ai "
+"— це наша служба приватних чатів із ШІ на базі моделей OpenAI, Anthropic "
+"тощо."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has turned off AI features and will no longer see AI-assisted answers.
@@ -1441,7 +1438,7 @@ msgstr "Неправильна адреса"
 #. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Adjust the servings"
-msgstr ""
+msgstr "Налаштувати кількість порцій"
 
 # smartling.placeholder_format=C
 #. as in multiple advertisements
@@ -1663,6 +1660,8 @@ msgid ""
 "All chats are anonymized by DuckDuckGo, and your conversations are not used "
 "to train chat models by DuckDuckGo or the model providers"
 msgstr ""
+"Усі чати анонімізуються DuckDuckGo, а ваші розмови не використовуються для "
+"навчання чат-моделей компанією DuckDuckGo або провайдерами моделей"
 
 # smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1753,8 +1752,7 @@ msgstr "Дозволити рекламу, що поважає приватні�
 # smartling.placeholder_format=C
 #. Title in a dialog informing the user how to disable their ad blocker for DuckDuckGo
 msgid "Allow privacy-respecting ads on DuckDuckGo Private Search"
-msgstr ""
-"Дозволити рекламу, що поважає конфіденційність, у DuckDuckGo Private Search"
+msgstr "Дозволити рекламу, що поважає конфіденційність, у DuckDuckGo Private Search"
 
 # smartling.placeholder_format=C
 #. Description explaining privacy implications of enabling web search on encrypted models. The first two placeholders are the full model name (e.g. 'gpt-oss 120B'). The third and fourth placeholders wrap a clickable link reading 'zero provider visibility' that opens the privacy modal, please keep those around the link text in your translation. An example full sentence would be: Allows gpt-oss 120B to search the web to improve responses to relevant prompts. Only sends AI-generated queries to a search engine with limited data retention. Prompts and responses with gpt-oss 120B still have zero provider visibility.
@@ -1939,6 +1937,8 @@ msgid ""
 "Anonymously generates answers for search queries based on web content. "
 "Choose how often you want it to appear, or disable it completely."
 msgstr ""
+"Анонімно генерує відповіді на пошукові запити на основі веб-контенту. "
+"Виберіть, як часто ви хочете бачити його, або вимкніть його повністю."
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -2085,8 +2085,7 @@ msgstr "Ти ще тут?"
 msgctxt "Body text for clear all chats confirmation modal"
 msgid ""
 "Are you sure you want to clear all of your chats? This cannot be undone."
-msgstr ""
-"Ви впевнені, що бажаєте очистити всі ваші чати? Цю дію не можна скасувати."
+msgstr "Ви впевнені, що бажаєте очистити всі ваші чати? Цю дію не можна скасувати."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that asks the user if they want to clear the conversation.
@@ -2224,7 +2223,7 @@ msgstr "Запитайте додаткове запитання за допом
 #. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
 msgctxt "Page suggestion chip label"
 msgid "Ask about this page"
-msgstr ""
+msgstr "Запитати про цю сторінку"
 
 # smartling.placeholder_format=C
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2291,11 +2290,10 @@ msgstr ""
 "Assist може анонімно генерувати відповіді ШІ на деякі пошукові запити, "
 "узагальнюючи релевантний веб-контент. Можна вибрати частоту відображення "
 "Assist: «Ніколи» (повністю приховує інтерфейс Assist із результатів пошуку), "
-"«На вимогу» (відображаються лише відповіді ШІ при натисканні кнопки "
-"«Assist» ), «Іноді» (відображаються лише відповіді ШІ в разі високої "
-"релевантності) або «Часто» (відображається частіше у різних пошукових "
-"запитах). Наразі відповіді штучного інтелекту доступні лише в США "
-"(англійською)."
+"«На вимогу» (відображаються лише відповіді ШІ при натисканні кнопки «Assist» "
+"), «Іноді» (відображаються лише відповіді ШІ в разі високої релевантності) "
+"або «Часто» (відображається частіше у різних пошукових запитах). Наразі "
+"відповіді штучного інтелекту доступні лише в США (англійською)."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2647,7 +2645,7 @@ msgstr "Штрихкод"
 #. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Based on this page, is this course worth taking?"
-msgstr ""
+msgstr "Чи варто проходити цей курс, судячи з цієї сторінки?"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2696,6 +2694,9 @@ msgid ""
 "Before storing this report, DuckDuckGo will anonymize your conversation by "
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
+"Перш ніж зберегти цю скаргу, DuckDuckGo анонімізує розмову, видаливши ваші "
+"персональні дані, як-от імена, адреси електронної пошти та ідентифікаційні "
+"метадані."
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -3017,7 +3018,7 @@ msgstr "Виграні брейк-пойнти"
 #. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Break this down into clear, numbered steps."
-msgstr ""
+msgstr "Розбийте на чіткі пронумеровані кроки."
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -3479,7 +3480,7 @@ msgstr "Виконавці"
 #. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Cast & Crew"
-msgstr ""
+msgstr "Актори та знімальна група"
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -3946,8 +3947,7 @@ msgstr "Перевірте сабреддіт DuckDuckGo, щоб дізнати�
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
 msgctxt "noresults"
 msgid "Check the status page for updates on this outage."
-msgstr ""
-"Перевірте сторінку статусу на наявність оновлень щодо цього відключення."
+msgstr "Перевірте сторінку статусу на наявність оновлень щодо цього відключення."
 
 # smartling.placeholder_format=C
 #. Title shown to the host device (the one that is logged in) after it sends the pairing code. The host can't confirm the peer applied it, so this is a title-only screen (no body) prompting the user to finish on the other device.
@@ -4351,8 +4351,7 @@ msgstr "Оберіть %1$sНалаштування%2$s з меню вибору
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
-msgstr ""
-"Натисніть %1$sВикористати поточні сторінки%2$s, потім натисніть %3$sОК%4$s."
+msgstr "Натисніть %1$sВикористати поточні сторінки%2$s, потім натисніть %3$sОК%4$s."
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -4468,8 +4467,7 @@ msgstr "Натисніть на вкладку %1$sЗагальні%2$s."
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click the %sellipsis icon%s in the toolbar."
-msgstr ""
-"Клацніть на %1$sпіктограмі у вигляді трьох точок%2$s в панелі інструментів."
+msgstr "Клацніть на %1$sпіктограмі у вигляді трьох точок%2$s в панелі інструментів."
 
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to enable location service. Part of a list of instructions on how to enable location service.
@@ -4486,8 +4484,7 @@ msgstr "Натисніть %1$sзначок дозволів%2$s в адресн
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to search using DuckDuckGo.
 msgid "Click the Duck icon at the top of your browser to search!"
-msgstr ""
-"Натисніть на зображення качки у верхній частині браузера, щоб почати пошук!"
+msgstr "Натисніть на зображення качки у верхній частині браузера, щоб почати пошук!"
 
 #  UC Browser on Android
 # smartling.placeholder_format=C
@@ -5196,7 +5193,7 @@ msgstr "Створити зображення"
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
-msgstr ""
+msgstr "Створи список покупок із кількістю інгредієнтів із цього рецепта."
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed in the input field when starting a new image generation session.
@@ -5843,7 +5840,7 @@ msgstr "Досягнуто ліміту диктування"
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
 msgid "Dictation temporarily unavailable"
-msgstr ""
+msgstr "Диктування тимчасово недоступне"
 
 # smartling.placeholder_format=C
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
@@ -6152,6 +6149,8 @@ msgid ""
 "Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
 "filtered out. %sLearn More%s"
 msgstr ""
+"Не потрібен ШІ? %1$snoai.duckduckgo.com%2$s не пропонує функції ШІ, а "
+"зображення, створені ШІ, відфільтровано. %3$sДокладніше%4$s"
 
 # smartling.placeholder_format=C
 #. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
@@ -6160,6 +6159,8 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
+"Не потрібен ШІ? Відвідайте %1$snoai.duckduckgo.com%2$s для пошуку без ШІ та "
+"з відфільтрованими зображеннями, створеними ШІ. %3$sДокладніше%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6279,13 +6280,13 @@ msgstr ""
 #. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Draft a cover letter"
-msgstr ""
+msgstr "Скласти супровідний лист"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Draft a cover letter for this job."
-msgstr ""
+msgstr "Напишіть супровідний лист для цієї посади."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -6473,6 +6474,9 @@ msgid ""
 "company for anyone who wants to take back control of their personal "
 "information."
 msgstr ""
+"Duck.ai створено компанією DuckDuckGo. Ми — незалежна компанія, що "
+"спеціалізується на захисті даних в Інтернеті для всіх, хто хоче повернути "
+"контроль над своєю особистою інформацією."
 
 # smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
@@ -6525,6 +6529,9 @@ msgid ""
 "Duck.ai lets you chat privately with popular AI models. Disabling it hides "
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
+"Duck.ai дозволяє спілкуватися приватно з популярними моделями ШІ. Вимкнення "
+"приховає кнопки та посилання Duck.ai, але ви все одно можете відвідати "
+"%1$sduck.ai%2$s безпосередньо."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6588,8 +6595,7 @@ msgstr "Duck.ai оновлено!"
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
-msgstr ""
-"Duck.ai найкраще працює в конфіденційному й безкоштовному додатку DuckDuckGo!"
+msgstr "Duck.ai найкраще працює в конфіденційному й безкоштовному додатку DuckDuckGo!"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -6633,10 +6639,10 @@ msgstr ""
 "У відповідь на деякі пошукові запити DuckAssist іноді анонімно шукає та "
 "узагальнює інформацію. Можна вибрати частоту відображення DuckAssist: "
 "«Ніколи» (повністю приховує інтерфейс DuckAssist із результатів пошуку), «На "
-"вимогу» (відображається лише при натисканні кнопки «Допомога»), "
-"«Іноді» (показується лише в разі високої релевантності) або "
-"«Часто» (відображається частіше у різних пошукових запитах). Наразі "
-"DuckAssist доступний лише у США (англійською)."
+"вимогу» (відображається лише при натисканні кнопки «Допомога»), «Іноді» "
+"(показується лише в разі високої релевантності) або «Часто» (відображається "
+"частіше у різних пошукових запитах). Наразі DuckAssist доступний лише у США "
+"(англійською)."
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6696,8 +6702,8 @@ msgstr ""
 "основі штучного інтелекту. Відповіді DuckAssist завжди містять пряме "
 "посилання на одне або два джерела відповіді, тому ви можете швидко знайти "
 "більш детальну інформацію. Важливо пам'ятати, що відповіді автоматично "
-"генеруються із зазначених джерел і ґрунтуються на %1$sвідсканованих веб-"
-"сторінках%2$s."
+"генеруються із зазначених джерел і ґрунтуються на %1$sвідсканованих "
+"веб-сторінках%2$s."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
@@ -6901,8 +6907,8 @@ msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid ""
 "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to Duck.ai's %s."
 msgstr ""
-"DuckDuckGo анонімізує чати. Натиснувши «%1$s», ви погоджуєтесь з %2$s Duck."
-"ai."
+"DuckDuckGo анонімізує чати. Натиснувши «%1$s», ви погоджуєтесь з %2$s "
+"Duck.ai."
 
 # smartling.placeholder_format=C
 #. Shown below the input on the empty state when the user has not yet accepted the terms of service. The first %s is the action button label ('Ask' for chat, 'Create' for image generation). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. Clicking the action button both accepts the terms and submits the prompt.
@@ -6910,8 +6916,7 @@ msgctxt ""
 "Inline terms-of-service disclaimer below chat or image-gen input for new "
 "users"
 msgid "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to our %s."
-msgstr ""
-"DuckDuckGo анонімізує чати. Натиснувши «%1$s», ви погоджуєтесь з нашими %2$s."
+msgstr "DuckDuckGo анонімізує чати. Натиснувши «%1$s», ви погоджуєтесь з нашими %2$s."
 
 # smartling.placeholder_format=C
 #. An information popup explaining that we block trackers
@@ -7100,8 +7105,7 @@ msgstr "Редагувати"
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
-msgstr ""
-"Відредаговане зображення. Вартість %1$s (лише для внутрішнього використання)"
+msgstr "Відредаговане зображення. Вартість %1$s (лише для внутрішнього використання)"
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is editing an image.
@@ -7114,8 +7118,7 @@ msgstr "Редагування зображення..."
 msgctxt "Info text for the editing message feature"
 msgid ""
 "Editing your message will remove the response below and generate a new one."
-msgstr ""
-"Редагування вашого повідомлення видалить відповідь нижче та згенерує нову."
+msgstr "Редагування вашого повідомлення видалить відповідь нижче та згенерує нову."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of an editor in its responses.
@@ -7371,8 +7374,7 @@ msgstr "Користуєтеся Duck.ai?"
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure %s'Allow'%s is selected for the 'Location' setting."
-msgstr ""
-"Переконайтеся, що для параметра 'Розташування' вибрано %1$s'Дозволити'%2$s."
+msgstr "Переконайтеся, що для параметра 'Розташування' вибрано %1$s'Дозволити'%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
@@ -7420,15 +7422,13 @@ msgstr "Переконайтеся, що доступ до розташуван�
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed %slocation access%s"
-msgstr ""
-"Переконайтеся, що вашому браузеру дозволено %1$sдоступ до розташування%2$s"
+msgstr "Переконайтеся, що вашому браузеру дозволено %1$sдоступ до розташування%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed %slocation access%s."
-msgstr ""
-"Переконайтеся, що вашому браузеру дозволено %1$sдоступ до розташування%2$s."
+msgstr "Переконайтеся, що вашому браузеру дозволено %1$sдоступ до розташування%2$s."
 
 # smartling.placeholder_format=C
 #. Tells how to enable location service. Part of a list of instructions on how to enable location service.
@@ -7541,13 +7541,13 @@ msgstr "Еритрея"
 #. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Estimate the nutrition"
-msgstr ""
+msgstr "Оцініть харчування"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Estimate the nutritional information for this recipe."
-msgstr ""
+msgstr "Оцініть харчову цінність цього рецепту."
 
 # smartling.placeholder_format=C
 msgid "Estonia"
@@ -7607,57 +7607,56 @@ msgstr "Термін дії закінчується через 1 день"
 #. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain the accepted answer in simple terms."
-msgstr ""
+msgstr "Поясніть прийняту відповідь простими словами."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
-msgstr ""
-"Поясніть мені фундаментальні концепції чорних дір на рівні середньої школи."
+msgstr "Поясніть мені фундаментальні концепції чорних дір на рівні середньої школи."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain the top answer"
-msgstr ""
+msgstr "Поясніть найкращу відповідь"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain this in simple, plain language."
-msgstr ""
+msgstr "Поясніть це простою, зрозумілою мовою."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain this paper"
-msgstr ""
+msgstr "Поясніть цей документ"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain this repo"
-msgstr ""
+msgstr "Поясніть мені цей репозиторій"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain this research paper in plain language."
-msgstr ""
+msgstr "Поясніть цю наукову статтю простою мовою."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain this simply"
-msgstr ""
+msgstr "Поясніть це простими словами"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain what this repository does and how to use it."
-msgstr ""
+msgstr "Поясніть, що робить цей репозиторій і як ним користуватися."
 
 # smartling.placeholder_format=C
 #. Label to show if song lyrics contain explicit content
@@ -7939,14 +7938,15 @@ msgstr "Відфільтровує створені ШІ зображення з
 msgctxt "settings"
 msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
-msgstr ""
-"Відфільтровує створені ШІ зображення з результатів пошуку. %1$sДокладніше%2$s"
+msgstr "Відфільтровує створені ШІ зображення з результатів пошуку. %1$sДокладніше%2$s"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Filters out known AI spam sites from image search results. %sLearn More%s"
 msgstr ""
+"Відфільтровує відомі створені ШІ сайти зі спамом з результатів пошуку "
+"зображень. %1$sДокладніше%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the final score of a sporting event.
@@ -7975,8 +7975,7 @@ msgstr "Фінансовий радник"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Find %sDuckDuckGo%s and click%sMake default%s"
-msgstr ""
-"Знайдіть %1$sDuckDuckGo%2$s та натисніть%3$sВибрати за замовчуванням%4$s"
+msgstr "Знайдіть %1$sDuckDuckGo%2$s та натисніть%3$sВибрати за замовчуванням%4$s"
 
 # smartling.placeholder_format=C
 #. Sentence shown after export, includes a placeholder for one or more filenames with bold formatting for the filename(s).
@@ -7988,8 +7987,7 @@ msgstr "Знайдіть <b>%1$s</b> у папці завантажень"
 # smartling.placeholder_format=C
 #. Tells users how to change their default search engine to DuckDuckGo.
 msgid "Find DuckDuckGo in the displayed list and click %sMake Default%s"
-msgstr ""
-"Знайдіть DuckDuckGo у списку і натисніть %1$sОбрати за замовчуванням%2$s"
+msgstr "Знайдіть DuckDuckGo у списку і натисніть %1$sОбрати за замовчуванням%2$s"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for finding a better word.
@@ -8007,7 +8005,7 @@ msgstr "Знайти актуальну інформацію"
 #. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Find me alternatives"
-msgstr ""
+msgstr "Знайдіть мені альтернативні варіанти"
 
 # smartling.placeholder_format=C
 #. Button that searches for results closer to the user's current location.
@@ -8450,22 +8448,19 @@ msgstr "Загальне призначення"
 #. Text with short description for an AI (Artificial Intelligence) Model that has a high moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "General purpose AI with high built-in moderation"
-msgstr ""
-"Штучний інтелект загального призначення з вбудованою високою модерацією"
+msgstr "Штучний інтелект загального призначення з вбудованою високою модерацією"
 
 # smartling.placeholder_format=C
 #. Text with short description for an AI (Artificial Intelligence) Model that has a low moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "General purpose AI with low built-in moderation"
-msgstr ""
-"Штучний інтелект загального призначення з вбудованою низькою модерацією"
+msgstr "Штучний інтелект загального призначення з вбудованою низькою модерацією"
 
 # smartling.placeholder_format=C
 #. Text with short description for an AI (Artificial Intelligence) Model that has a medium moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "General purpose AI with medium built-in moderation"
-msgstr ""
-"Штучний інтелект загального призначення із вбудованою середньою модерацією"
+msgstr "Штучний інтелект загального призначення із вбудованою середньою модерацією"
 
 # smartling.placeholder_format=C
 #. Text indicating that the AI (Artificial Intelligence) model is a model for general purpose use. General-purpose AI refers to AI systems that can perform a wide range of tasks, rather than being specialized for a specific task.
@@ -8493,7 +8488,7 @@ msgstr "Згенерувати більше"
 #. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Generate a shopping list"
-msgstr ""
+msgstr "Створити список покупок"
 
 # smartling.placeholder_format=C
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
@@ -8526,8 +8521,7 @@ msgstr "Згенероване зображення"
 #. Title text shown for an assistant response that contains a generated image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Generated image. Cost %s (internal only)"
-msgstr ""
-"Згенероване зображення. Вартість %1$s (лише для внутрішнього використання)"
+msgstr "Згенероване зображення. Вартість %1$s (лише для внутрішнього використання)"
 
 # smartling.placeholder_format=C
 #. Aria label for the carousel (list of generated images) in the image generation mode.
@@ -8793,7 +8787,7 @@ msgstr "Спробувати"
 #. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Give me a quick background on this person."
-msgstr ""
+msgstr "Дайте мені коротку довідку про цю особу."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9247,13 +9241,13 @@ msgstr "Допоможіть поширити приватність"
 #. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Help me prep for the interview"
-msgstr ""
+msgstr "Допоможіть підготуватися до співбесіди"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Help me tailor my resume for this job."
-msgstr ""
+msgstr "Допоможіть мені адаптувати моє резюме для цієї вакансії."
 
 # smartling.placeholder_format=C
 #. Title of a SERP popup that invites users to take a survey (desktop only)
@@ -9728,8 +9722,7 @@ msgctxt "Full sentence for preparing for a conversation"
 msgid ""
 "How should I tactfully approach a colleague about their constant pencil "
 "tapping and what should I say?"
-msgstr ""
-"Як тактовно попросити колегу перестати постійно стукати олівцем по столу?"
+msgstr "Як тактовно попросити колегу перестати постійно стукати олівцем по столу?"
 
 # smartling.placeholder_format=C
 #. The title for a feedback prompt that includes thumbs up and thumbs down buttons
@@ -9775,7 +9768,7 @@ msgctxt ""
 "Text for the I already have a subscription button in the Duck.ai settings "
 "page"
 msgid "I Already Have a Subscription"
-msgstr ""
+msgstr "У мене вже є підписка"
 
 # smartling.placeholder_format=C
 #. Text for the button that takes the user to the login subscription page.
@@ -10362,7 +10355,7 @@ msgstr "Встановити браузер для Mac"
 #. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
 msgctxt "settings"
 msgid "Install Now"
-msgstr ""
+msgstr "Встановити зараз"
 
 # smartling.placeholder_format=C
 #. Text of a button to install the DuckDuckGo app
@@ -10465,13 +10458,13 @@ msgstr "Чи дані справді видаляються?"
 #. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Is it worth taking?"
-msgstr ""
+msgstr "Чи варто це брати?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Is this place any good?"
-msgstr ""
+msgstr "Чи варте це місце уваги?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
@@ -10480,6 +10473,8 @@ msgid ""
 "Is this place any good? Summarize its reputation based on reviews and "
 "ratings."
 msgstr ""
+"Чи варте це місце уваги? Підсумуйте його репутацію на основі відгуків та "
+"оцінок."
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -10491,13 +10486,13 @@ msgstr "Чи корисне це відео?"
 #. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Is this worth watching?"
-msgstr ""
+msgstr "Чи варто це дивитися?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Is this worth watching? Give me a spoiler-free take."
-msgstr ""
+msgstr "Чи варто це дивитися? Дайте мені оцінку без спойлерів."
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -10596,8 +10591,7 @@ msgstr "Приєднуйтесь до нашої команди!"
 # smartling.placeholder_format=C
 msgctxt "showcase_donate"
 msgid "Join our $500,000 Privacy Challenge"
-msgstr ""
-"Приєднуйтеся до нашого змагання з приватності із призовим фондом у $500 000"
+msgstr "Приєднуйтеся до нашого змагання з приватності із призовим фондом у $500 000"
 
 # smartling.placeholder_format=C
 msgid "Jordan"
@@ -11115,6 +11109,8 @@ msgstr "Посилання:"
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
 msgstr ""
+"Перелічіть інструменти, матеріали або передумови, які мені для цього "
+"потрібні."
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -11215,8 +11211,7 @@ msgstr "Завантаження..."
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Loads more image and video results when scrolling"
-msgstr ""
-"Завантаження інших результатів для зображень та відео при прокручуванні"
+msgstr "Завантаження інших результатів для зображень та відео при прокручуванні"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -11531,7 +11526,7 @@ msgstr "Керування заблокованими сайтами"
 #. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
 msgctxt "setting"
 msgid "Manage in Browser Settings"
-msgstr ""
+msgstr "Керувати в налаштуваннях браузера"
 
 # smartling.placeholder_format=C
 #. Link to the site exclusion settings page
@@ -13450,8 +13445,7 @@ msgstr "Відкрити вебсайт %1$s"
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open %sLocation%s, and ensure location is %senabled%s"
-msgstr ""
-"Відкрийте %1$s«Розташування»%2$s і переконайтеся, що воно %3$sувімкнене%4$s"
+msgstr "Відкрийте %1$s«Розташування»%2$s і переконайтеся, що воно %3$sувімкнене%4$s"
 
 #  Chrome/Firefox on Android/iOS
 # smartling.placeholder_format=C
@@ -13614,8 +13608,7 @@ msgstr "Відкрити панель «Як працює Duck.ai»"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open the Safari menu and select %sSettings for DuckDuckGo...%s"
-msgstr ""
-"Відкрийте меню Safari та виберіть %1$sНалаштування для DuckDuckGo...%2$s"
+msgstr "Відкрийте меню Safari та виберіть %1$sНалаштування для DuckDuckGo...%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the time a business opens. For example: 'Opens at 10am'
@@ -13994,8 +13987,8 @@ msgid ""
 "Passphrases cannot be recovered as we don't associate your IP address, "
 "browser fingerprint, or any other information with the file."
 msgstr ""
-"Неможливо відновити парольні фрази, оскільки ми не пов'язуємо вашу IP-"
-"адресу, відбиток браузера чи інші дані з файлом."
+"Неможливо відновити парольні фрази, оскільки ми не пов'язуємо вашу "
+"IP-адресу, відбиток браузера чи інші дані з файлом."
 
 # smartling.placeholder_format=C
 #. Label for the section of recent chats that were edited in the past 7 days.
@@ -14355,8 +14348,7 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this prompt was made by a "
 "human."
-msgstr ""
-"Виконайте наступне завдання, щоб підтвердити, що цей запит здійснено людиною."
+msgstr "Виконайте наступне завдання, щоб підтвердити, що цей запит здійснено людиною."
 
 # smartling.placeholder_format=C
 #. Bot challenge explanation
@@ -14364,21 +14356,21 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this search was made by a "
 "human."
-msgstr ""
-"Виконайте наступне завдання, щоб підтвердити, що цей пошук здійснено людиною."
+msgstr "Виконайте наступне завдання, щоб підтвердити, що цей пошук здійснено людиною."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is harmful or illegal. (optional)"
 msgstr ""
+"Поясніть, чому Ви вважаєте відповідь у чаті шкідливою або протизаконною. "
+"(необов'язково)"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
-msgstr ""
-"Поясніть, чому відповідь у чаті є незаконною або небезпечною. (Необов'язково)"
+msgstr "Поясніть, чому відповідь у чаті є незаконною або небезпечною. (Необов'язково)"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to enter their passphrase.
@@ -14409,6 +14401,9 @@ msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is harmful or illegal."
 msgstr ""
+"Вставте свій запит і проблемний вивід (видаливши будь-яку особисту "
+"інформацію) та поясніть, чому на Вашу думку вміст є небезпечним або "
+"неприпустимим."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -14881,7 +14876,7 @@ msgstr "Приватність"
 #. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
 msgctxt "Section heading on the Duck.ai settings page"
 msgid "Privacy & Terms"
-msgstr ""
+msgstr "Конфіденційність та умови"
 
 # smartling.placeholder_format=C
 msgid "Privacy Blog"
@@ -14957,7 +14952,7 @@ msgstr "Політика конфіденційності та умови над
 #. Text for a button that links to the terms of use and privacy policy page.
 msgctxt "Secondary button text in active privacy modal"
 msgid "Privacy Policy and Terms of Service"
-msgstr ""
+msgstr "Політика конфіденційності та умови надання послуг"
 
 # smartling.placeholder_format=C
 #. Title displayed on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
@@ -15464,25 +15459,25 @@ msgstr "Порекомендуйте книгу"
 #. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Recommend similar books"
-msgstr ""
+msgstr "Порекомендуйте схожі книги"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Recommend similar books."
-msgstr ""
+msgstr "Порекомендуйте схожі книги."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Recommend similar movies or shows."
-msgstr ""
+msgstr "Порекомендуйте схожі фільми або телешоу."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Recommend similar titles"
-msgstr ""
+msgstr "Порекомендуйте схожі заголовки"
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
@@ -15708,8 +15703,7 @@ msgstr "Запам'ятати вибір"
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings
 msgid "Remember my choice (this can be changed in %s%s%sSettings%s)"
-msgstr ""
-"Запам'ятати мій вибір (це можна змінити в %1$s%2$s%3$sНалаштуваннях%4$s)"
+msgstr "Запам'ятати мій вибір (це можна змінити в %1$s%2$s%3$sНалаштуваннях%4$s)"
 
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
@@ -15892,7 +15886,7 @@ msgctxt ""
 "feedback form when the user has selected Harmful or Illegal as the feedback "
 "reason"
 msgid "Required for harmful or illegal reports"
-msgstr ""
+msgstr "Обов'язково для повідомлень про шкідливий або протизаконний вміст"
 
 # smartling.placeholder_format=C
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
@@ -16137,7 +16131,7 @@ msgstr "Відгуки"
 #. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Rewrite this recipe scaled for a different number of servings."
-msgstr ""
+msgstr "Перепишіть цей рецепт, змінивши кількість порцій."
 
 # smartling.placeholder_format=C
 msgid "Romania"
@@ -16592,8 +16586,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down to the %sServices%s section and click %sAddress bar%s."
-msgstr ""
-"Прокрутіть вниз до розділу %1$sСервіси%2$s та клацніть %3$sПанель адреси%4$s."
+msgstr "Прокрутіть вниз до розділу %1$sСервіси%2$s та клацніть %3$sПанель адреси%4$s."
 
 # smartling.placeholder_format=C
 #. Rugby match stats
@@ -16927,8 +16920,7 @@ msgstr "Тижні сезону"
 #. Description shown in the Sync & Backup settings section when sync is not yet enabled, explaining the feature.
 msgctxt "Description for sync and backup feature"
 msgid "Securely save and sync your chats across all your devices."
-msgstr ""
-"Безпечно зберігайте та синхронізуйте твої чати на всіх своїх пристроях."
+msgstr "Безпечно зберігайте та синхронізуйте твої чати на всіх своїх пристроях."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17140,21 +17132,18 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
-msgstr ""
-"Оберіть %1$sDuckDuckGo%2$s та клацніть %3$sВстановити за замовчуванням%4$s!"
+msgstr "Оберіть %1$sDuckDuckGo%2$s та клацніть %3$sВстановити за замовчуванням%4$s!"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s"
-msgstr ""
-"Виберіть %1$sDuckDuckGo%2$s і натисніть %3$sВстановити за замовчуванням%4$s"
+msgstr "Виберіть %1$sDuckDuckGo%2$s і натисніть %3$sВстановити за замовчуванням%4$s"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s."
-msgstr ""
-"Виберіть %1$sDuckDuckGo%2$s і натисніть %3$sВстановити за замовчуванням%4$s."
+msgstr "Виберіть %1$sDuckDuckGo%2$s і натисніть %3$sВстановити за замовчуванням%4$s."
 
 #  Firefox 33
 # smartling.placeholder_format=C
@@ -17365,8 +17354,7 @@ msgstr "Вибраний текст із %1$s"
 #. Displayed when the user's text selection exceeds the maximum message size for AI tools (summary, translation, etc.).
 msgctxt "Error message for selection input limit"
 msgid "Selected text is too long. Try again with a shorter selection."
-msgstr ""
-"Вибраний текст занадто довгий. Спробуйте ще раз, вибравши коротший фрагмент."
+msgstr "Вибраний текст занадто довгий. Спробуйте ще раз, вибравши коротший фрагмент."
 
 # smartling.placeholder_format=C
 #. Label for the semi-finals knockout stage in e.g. the soccer World Cup
@@ -17490,7 +17478,7 @@ msgstr "Налаштувати"
 #. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
 msgctxt "Encrypted storage setup button shown in native browsers"
 msgid "Set Up Sync & Backup"
-msgstr ""
+msgstr "Налаштування Sync & Backup"
 
 # smartling.placeholder_format=C
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
@@ -17584,8 +17572,7 @@ msgstr "Поділитися"
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "Share DuckDuckGo and help friends take their privacy back!"
-msgstr ""
-"Розкажіть про DuckDuckGo та допоможіть вашим друзям повернути приватність!"
+msgstr "Розкажіть про DuckDuckGo та допоможіть вашим друзям повернути приватність!"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button that opens a feedback modal when clicked.
@@ -17679,7 +17666,7 @@ msgstr "Надіслати позитивний відгук"
 msgctxt ""
 "Label beside the share-content switch on the Duck.ai response feedback form"
 msgid "Share this conversation with DuckDuckGo"
-msgstr ""
+msgstr "Поділитися цією розмовою з DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -18084,14 +18071,12 @@ msgstr "Показує найпопулярніші посилання у нов
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your browser"
-msgstr ""
-"Показує періодичні нагадування про додавання DuckDuckGo до вашого браузера"
+msgstr "Показує періодичні нагадування про додавання DuckDuckGo до вашого браузера"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr ""
-"Показує періодичні нагадування про додавання DuckDuckGo на ваших пристроях"
+msgstr "Показує періодичні нагадування про додавання DuckDuckGo на ваших пристроях"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18135,8 +18120,7 @@ msgstr "Показує привітальне повідомлення вгор�
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message to EU Android preference menu users"
-msgstr ""
-"Показує привітальне повідомлення користувачам з меню налаштувань Android в ЄС"
+msgstr "Показує привітальне повідомлення користувачам з меню налаштувань Android в ЄС"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers sometimes.
@@ -18358,8 +18342,7 @@ msgstr "Щось пішло не так при збереженні на сер�
 #. Body copy displayed under the Set Up Now button when the sync setup call fails.
 msgctxt "Generic error shown when sync setup fails"
 msgid "Something went wrong while enabling Sync & Backup. Please try again."
-msgstr ""
-"Сталася помилка під час увімкнення функції Sync & Backup. Повторіть спробу."
+msgstr "Сталася помилка під час увімкнення функції Sync & Backup. Повторіть спробу."
 
 # smartling.placeholder_format=C
 #. Displayed when the voice chat session ends with an unknown error.
@@ -18457,8 +18440,7 @@ msgstr ""
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr ""
-"На жаль, нам не вдалося надіслати ваш відгук. Будь ласка, спробуйте пізніше."
+msgstr "На жаль, нам не вдалося надіслати ваш відгук. Будь ласка, спробуйте пізніше."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -18947,19 +18929,19 @@ msgstr "Запропонуйте назву для публікації в бл�
 #. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Suggest related articles or topics worth exploring next."
-msgstr ""
+msgstr "Запропонуйте пов’язані статті або теми, які варто дослідити далі."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Suggest related articles to explore"
-msgstr ""
+msgstr "Запропонуйте пов'язані статті для ознайомлення"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Suggest some alternatives to this product."
-msgstr ""
+msgstr "Запропонуйте альтернативні варіанти цього продукту."
 
 # smartling.placeholder_format=C
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
@@ -18976,7 +18958,7 @@ msgstr "Пропозиції:"
 #. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Sum up the reviews"
-msgstr ""
+msgstr "Підсумуйте відгуки"
 
 # smartling.placeholder_format=C
 #. A short title for the a message asking the AI to summarize a text.
@@ -18988,85 +18970,85 @@ msgstr "Підсумувати"
 #. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize the Q&As"
-msgstr ""
+msgstr "Підсумуйте запитання та відповіді"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the background and notable work of this person."
-msgstr ""
+msgstr "Надайте короткі анкетні дані та визначні роботи цієї особи."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the key details of this event."
-msgstr ""
+msgstr "Надайте коротко ключові деталі цієї події."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the questions and answers on this page."
-msgstr ""
+msgstr "Підсумуйте запитання та відповіді на цій сторінці."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize their background"
-msgstr ""
+msgstr "Коротко опишіть їхню історію"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this book"
-msgstr ""
+msgstr "Коротко опишіть цю книгу"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this book."
-msgstr ""
+msgstr "Коротко опишіть цю книгу."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this discussion"
-msgstr ""
+msgstr "Підсумуйте це обговорення"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this discussion thread."
-msgstr ""
+msgstr "Підсумуйте цю гілку обговорення."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this page"
-msgstr ""
+msgstr "Підсумуйте цю сторінку"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this page."
-msgstr ""
+msgstr "Підсумуйте цю сторінку."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this video"
-msgstr ""
+msgstr "Підсумуйте це відео"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this video."
-msgstr ""
+msgstr "Підсумуйте це відео."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize what the reviews say."
-msgstr ""
+msgstr "Надайте стислі дані, що показують відгуки."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -19399,7 +19381,7 @@ msgstr "Сирія"
 #. Text for a button that enables the theme to follow the operating system's color scheme preference.
 msgctxt "System theme button for theme selector"
 msgid "System"
-msgstr ""
+msgstr "Система"
 
 # smartling.placeholder_format=C
 #. Abbreviation indicating this is the total score for a game
@@ -19433,7 +19415,7 @@ msgstr "Таїтянська"
 #. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Tailor my resume"
-msgstr ""
+msgstr "Адаптувати моє резюме"
 
 # smartling.placeholder_format=C
 msgid "Taiwan"
@@ -19470,6 +19452,8 @@ msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
+"Пройдіть це анонімне опитування, щоб повідомити нам, як ми можемо покращити "
+"Duck.ai."
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -19780,7 +19764,7 @@ msgstr "Тема"
 #. Text for the theme selector label that allows users to switch between Light and dark theme.
 msgctxt "Label for the theme selector feature"
 msgid "Theme"
-msgstr ""
+msgstr "Тема"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/LpFhb1e.png
@@ -19886,8 +19870,7 @@ msgctxt "AI Chat: Error message for when a model is removed"
 msgid ""
 "This AI model is no longer available. Try starting a new chat with a "
 "different model."
-msgstr ""
-"Ця модель ШІ більше не доступна. Спробуйте почати новий чат з іншою моделлю."
+msgstr "Ця модель ШІ більше не доступна. Спробуйте почати новий чат з іншою моделлю."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is no longer supported because it has been upgraded to a newest version.
@@ -20032,16 +20015,14 @@ msgstr "Це зображення не вдалося створити."
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF"
-msgstr ""
-"Цей тип зображення не підтримується, прикріпіть файл JPG, PNG, WebP або GIF"
+msgstr "Цей тип зображення не підтримується, прикріпіть файл JPG, PNG, WebP або GIF"
 
 # smartling.placeholder_format=C
 #. Error message displayed when a file that the user tried to upload is not of a supported format
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF."
-msgstr ""
-"Цей тип зображення не підтримується. Додайте файл JPG, PNG, WebP або GIF."
+msgstr "Цей тип зображення не підтримується. Додайте файл JPG, PNG, WebP або GIF."
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
@@ -20094,8 +20075,7 @@ msgstr "Для роботи цієї сторінки необхідний Javas
 #. Information tooltip text explaining that the current page's content will be included with the chat message.
 msgctxt "Tooltip explaining that page content will be sent to Duck.ai"
 msgid "This page's content will be sent with your message to Duck.ai"
-msgstr ""
-"Вміст цієї сторінки буде надіслано до Duck.ai разом із вашим повідомленням"
+msgstr "Вміст цієї сторінки буде надіслано до Duck.ai разом із вашим повідомленням"
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -20170,8 +20150,7 @@ msgstr ""
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr ""
-"Ця вебсторінка не використовує захищене, зашифроване, з'єднання (HTTPS)."
+msgstr "Ця вебсторінка не використовує захищене, зашифроване, з'єднання (HTTPS)."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -20211,8 +20190,7 @@ msgstr "Це зітре усі налаштування. Продовжити?"
 #. Confirmation message asking if the user is sure they want to reset all of their settings.
 msgctxt "settings"
 msgid "This will reset your saved settings to default values. Continue?"
-msgstr ""
-"Це призведе до скидання ваших налаштувань до стандартних значень. Продовжити?"
+msgstr "Це призведе до скидання ваших налаштувань до стандартних значень. Продовжити?"
 
 # smartling.placeholder_format=C
 #. Golf leaderboard column: holes completed in current round
@@ -20623,13 +20601,13 @@ msgstr ""
 #. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Translate this page"
-msgstr ""
+msgstr "Перекласти цю сторінку"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
 msgctxt "Page suggestion prompt"
 msgid "Translate this page into %s."
-msgstr ""
+msgstr "Перекласти цю сторінку на %1$s."
 
 # smartling.placeholder_format=C
 #. Placeholder text for a region that will display translated text.
@@ -20778,7 +20756,7 @@ msgstr "Спробувати безкоштовно"
 #. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
 msgctxt "settings"
 msgid "Try It Now"
-msgstr ""
+msgstr "Спробуйте зараз"
 
 # smartling.placeholder_format=C
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -20851,8 +20829,7 @@ msgstr "Спробуйте увімкнути анонімне розташув�
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr ""
-"Спробуйте поекспериментувати з кожною моделлю — вони дадуть різні відповіді."
+msgstr "Спробуйте поекспериментувати з кожною моделлю — вони дадуть різні відповіді."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
@@ -20909,8 +20886,7 @@ msgstr "Спробуйте наш браузер,"
 # smartling.placeholder_format=C
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
-msgstr ""
-"Спробуйте нашу домашню сторінку, яка ніколи не показує ці повідомлення:"
+msgstr "Спробуйте нашу домашню сторінку, яка ніколи не показує ці повідомлення:"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with different words to get more results.
@@ -20933,8 +20909,7 @@ msgstr "Спробуйте налаштувати ваше розташуван�
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Try the %sDuckDuckGo Browser.%s Fast. Free. Private."
-msgstr ""
-"Спробуйте браузер %1$sDuckDuckGo.%2$s Швидко. Безплатно. Конфіденційно."
+msgstr "Спробуйте браузер %1$sDuckDuckGo.%2$s Швидко. Безплатно. Конфіденційно."
 
 # smartling.placeholder_format=C
 #. Link to a page where users can download the DuckDuckGo Browser for iOS or Android.
@@ -21028,6 +21003,9 @@ msgid ""
 "Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
+"Намагаєтеся вимкнути можливості ШІ? Встановіть розширення для пошуку "
+"%1$sDuckDuckGo No AI%2$s, щоб запам'ятати свої налаштування. "
+"%3$sДокладніше%4$s"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -21036,6 +21014,9 @@ msgid ""
 "Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
+"Намагаєтеся вимкнути можливості ШІ? Перейдіть на розширення для пошуку "
+"%1$sDuckDuckGo No AI%2$s, щоб запам’ятати свої налаштування. "
+"%3$sДокладніше%4$s"
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -21137,8 +21118,7 @@ msgstr "Вимкнути:"
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on %sPrecise Location%s for more accurate results"
-msgstr ""
-"Увімкніть «%1$sТочне розташування%2$s» для отримання точніших результатів"
+msgstr "Увімкніть «%1$sТочне розташування%2$s» для отримання точніших результатів"
 
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
@@ -21363,8 +21343,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
-msgstr ""
-"В меню %1$sЗАПУСК > Домашня сторінка%2$s введіть: https://duckduckgo.com"
+msgstr "В меню %1$sЗАПУСК > Домашня сторінка%2$s введіть: https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -21374,8 +21353,7 @@ msgstr "В %1$sНалаштуваннях пошуку%2$s оберіть %3$sDu
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch in the address bar with%s select %sAdd New%s"
-msgstr ""
-"В розділі %1$sПошук в адресному рядку%2$s виберіть %3$sДодати новий%4$s"
+msgstr "В розділі %1$sПошук в адресному рядку%2$s виберіть %3$sДодати новий%4$s"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -21395,8 +21373,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine
 msgid "Under Search click the drop down and select %sDuckDuckGo%s"
-msgstr ""
-"Під рядком пошуку натисніть на випадне меню та виберіть %1$sDuckDuckGo%2$s"
+msgstr "Під рядком пошуку натисніть на випадне меню та виберіть %1$sDuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings" header
@@ -21529,8 +21506,7 @@ msgctxt ""
 "Text shown in the subscription promo card, with a trailing call-to-action "
 "link."
 msgid "Unlock more capable AI models with a DuckDuckGo subscription. %s"
-msgstr ""
-"Розблокуйте більше потужних моделей ШІ, підписавшись на DuckDuckGo. %1$s"
+msgstr "Розблокуйте більше потужних моделей ШІ, підписавшись на DuckDuckGo. %1$s"
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to unmute the microphone.
@@ -21743,8 +21719,7 @@ msgstr ""
 #. Upsell message shown in the voice chat limit and duration limit modals for Plus subscribers, encouraging them to upgrade to Pro.
 msgctxt "voice chat limit modal"
 msgid "Upgrade to Pro to unlock 2x higher usage limits than Plus"
-msgstr ""
-"Переходьте на план Pro, щоб розблокувати вдвічі вищі ліміти, ніж у плані Plus"
+msgstr "Переходьте на план Pro, щоб розблокувати вдвічі вищі ліміти, ніж у плані Plus"
 
 # smartling.placeholder_format=C
 #. Heading in a promotion for a desktop web browser
@@ -21796,7 +21771,7 @@ msgstr "Уругвай"
 #. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
 msgctxt "Navigation label on the Duck.ai settings page"
 msgid "Usage"
-msgstr ""
+msgstr "Використання"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -22031,8 +22006,7 @@ msgstr "Переглянути ціни на проживання"
 # smartling.placeholder_format=C
 #. A description for the ads tooltip that explains that viewing ads is privacy protected by DuckDuckGo.
 msgid "Viewing ads is privacy protected by DuckDuckGo."
-msgstr ""
-"Перегляд оголошень виконується із захистом конфіденційності DuckDuckGo."
+msgstr "Перегляд оголошень виконується із захистом конфіденційності DuckDuckGo."
 
 # smartling.placeholder_format=C
 msgctxt "Ads GDPR, internal use only. Do not change"
@@ -22139,8 +22113,8 @@ msgid ""
 msgstr ""
 "Відвідайте сайт Duck.ai в іншому браузері або в додатку DuckDuckGo та "
 "відкрийте налаштування Duck.ai. Виберіть «Увімкнути» у розділі «Sync & "
-"Backup» та виберіть «Синхронізувати з іншим пристроєм». Або відскануйте QR-"
-"код у PDF-файлі для відновлення."
+"Backup» та виберіть «Синхронізувати з іншим пристроєм». Або відскануйте "
+"QR-код у PDF-файлі для відновлення."
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -22258,7 +22232,7 @@ msgstr "Уельс"
 #. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Walk me through the steps"
-msgstr ""
+msgstr "Проведіть мене покроково"
 
 # smartling.placeholder_format=C
 #. Label for walking directions on a map.
@@ -22387,6 +22361,9 @@ msgid ""
 "please share this conversation with DuckDuckGo so we can investigate and "
 "address the issue."
 msgstr ""
+"Ми можемо виправити лише те, що бачимо. Щоб повідомити про небезпечну або "
+"протизаконну відповідь, поділіться цією розмовою з DuckDuckGo. Тоді ми "
+"зможемо провести розслідування і вирішити проблему."
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -22415,8 +22392,7 @@ msgstr ""
 msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
-msgstr ""
-"Не вдається зчитати додані файли, оскільки принаймні один із них зашифровано."
+msgstr "Не вдається зчитати додані файли, оскільки принаймні один із них зашифровано."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -22481,8 +22457,7 @@ msgstr "Ми ніколи не стежимо за вами."
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with a Continue button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don't track you. That's our Privacy Policy in a nutshell."
-msgstr ""
-"Ми не відстежуємо вас. Це наша Політика конфіденційності, якщо коротко."
+msgstr "Ми не відстежуємо вас. Це наша Політика конфіденційності, якщо коротко."
 
 # smartling.placeholder_format=C
 #. Description for the audio identification highlight in the dictation consent modal.
@@ -22613,8 +22588,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
-msgstr ""
-"Трекери, що намагаються збирати ваші дані під час перегляду, блокуватимуться."
+msgstr "Трекери, що намагаються збирати ваші дані під час перегляду, блокуватимуться."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -22946,98 +22920,98 @@ msgstr ""
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the counterarguments?"
-msgstr ""
+msgstr "Які є контраргументи?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the hours & location?"
-msgstr ""
+msgstr "Які години роботи та де ви знаходитесь?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key contributions of this paper?"
-msgstr ""
+msgstr "Які ключові досягнення цієї статті?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key contributions?"
-msgstr ""
+msgstr "В чому полягають ключові досягнення?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key details?"
-msgstr ""
+msgstr "В чому полягають ключові деталі?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key points covered in this video?"
-msgstr ""
+msgstr "Які ключові питання розглядаються в цьому відео?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key points?"
-msgstr ""
+msgstr "В чому полягають ключові питання?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key takeaways from this article?"
-msgstr ""
+msgstr "Які основні висновки з цієї статті?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key takeaways?"
-msgstr ""
+msgstr "В чому полягають ключові висновки?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key things I will learn from this course?"
-msgstr ""
+msgstr "Про які ключові питання я дізнаюся з цього курсу?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the main counterarguments or criticisms of this?"
-msgstr ""
+msgstr "Які основні контраргументи або критичні зауваження щодо цього?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the main questions this page answers?"
-msgstr ""
+msgstr "На які основні запитання відповідає ця сторінка?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the must-try dishes here?"
-msgstr ""
+msgstr "Які страви тут варто скуштувати?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid ""
 "What are the opening hours, location, and contact details for this place?"
-msgstr ""
+msgstr "Які години роботи, місцезнаходження та контактна інформація цього місця?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the pros and cons of this product?"
-msgstr ""
+msgstr "Які плюси та мінуси цього продукту?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the pros and cons?"
-msgstr ""
+msgstr "Які плюси та мінуси?"
 
 # smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
@@ -23143,7 +23117,7 @@ msgstr "Що передсердя означає у медичній статт�
 #. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What does this answer?"
-msgstr ""
+msgstr "На що це відповідає?"
 
 # smartling.placeholder_format=C
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
@@ -23161,7 +23135,7 @@ msgstr "Яка інформація зберігається?"
 #. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What interview questions might come up for this role?"
-msgstr ""
+msgstr "Які запитання на співбесіді можуть виникнути для цієї посади?"
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -23170,8 +23144,8 @@ msgid ""
 "What is the Cloud Save bookmarklet and how does it differ from the URL "
 "parameter bookmarklet?"
 msgstr ""
-"Що таке збережена в хмарі закладка і чим вона відрізняється від URL-"
-"параметрів?"
+"Що таке збережена в хмарі закладка і чим вона відрізняється від "
+"URL-параметрів?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for looking up the capital city of Albania.
@@ -23183,7 +23157,7 @@ msgstr "Яка столиця Албанії?"
 #. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What is the overall verdict and rating for this?"
-msgstr ""
+msgstr "Який загальний висновок та оцінка з цього приводу?"
 
 # smartling.placeholder_format=C
 #. Link to a page with additional information.
@@ -23211,7 +23185,7 @@ msgstr "Що кажуть люди:"
 #. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What should I order?"
-msgstr ""
+msgstr "Що мені замовити?"
 
 # smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
@@ -23229,13 +23203,13 @@ msgstr "Що було не так із відповіддю? (Необов'яз�
 #. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What will I learn?"
-msgstr ""
+msgstr "Чого я навчуся?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What will I need?"
-msgstr ""
+msgstr "Що мені знадобиться?"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -23246,8 +23220,7 @@ msgstr "Про що б ви хотіли залишити відгук?"
 #. Explains the benefits of using our custom video player, the Duck Player
 msgid ""
 "What you watch in DuckDuckGo won't influence your recommendations on YouTube."
-msgstr ""
-"Те, що ви дивитеся в DuckDuckGo, не вплине на ваші рекомендації на YouTube."
+msgstr "Те, що ви дивитеся в DuckDuckGo, не вплине на ваші рекомендації на YouTube."
 
 # smartling.placeholder_format=C
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
@@ -23259,7 +23232,7 @@ msgstr "Що нового"
 #. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What's the verdict?"
-msgstr ""
+msgstr "Який висновок?"
 
 # smartling.placeholder_format=C
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -23315,7 +23288,7 @@ msgstr "Яких функцій не вистачає? (Необов'язков�
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Which features are missing? (optional)"
-msgstr ""
+msgstr "Яких функцій бракує? (необов'язково)"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
@@ -23338,12 +23311,14 @@ msgstr "Хто ми такі"
 msgctxt "Page suggestion prompt"
 msgid "Who are the main cast and crew, and what else are they known for?"
 msgstr ""
+"Хто входить до основного акторського складу та знімальної групи і чим ще "
+"вони відомі?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Who is this person?"
-msgstr ""
+msgstr "Хто ця людина?"
 
 # smartling.placeholder_format=C
 #. Header above a collection of privacy-related links.
@@ -24008,8 +23983,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
 msgid "You won't see this message again unless you clear your browser data."
-msgstr ""
-"Ви більше не побачите це повідомлення, якщо не очистите дані свого браузера."
+msgstr "Ви більше не побачите це повідомлення, якщо не очистите дані свого браузера."
 
 # smartling.placeholder_format=C
 #. The second paragraph of a pop up where we explain how to update the browser manually.
@@ -24267,8 +24241,7 @@ msgstr ""
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never used to train AI models"
-msgstr ""
-"Ваші чати є приватними і ніколи не використовуються для навчання моделей ШІ"
+msgstr "Ваші чати є приватними і ніколи не використовуються для навчання моделей ШІ"
 
 # smartling.placeholder_format=C
 #. Text for a description of the active privacy protection for DuckDuckGo's AI Chat feature.
@@ -24328,8 +24301,7 @@ msgctxt "duckai_migration"
 msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
-msgstr ""
-"Ваші чати імпортовано. Продовжуйте з того місця, де ви зупинилися у Duck.ai."
+msgstr "Ваші чати імпортовано. Продовжуйте з того місця, де ви зупинилися у Duck.ai."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.

--- a/locales/ur_PK/LC_MESSAGES/duckduckgo.po
+++ b/locales/ur_PK/LC_MESSAGES/duckduckgo.po
@@ -1159,6 +1159,11 @@ msgctxt "feedback form"
 msgid "Address is incorrect"
 msgstr ""
 
+#. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Adjust the servings"
+msgstr ""
+
 #. as in multiple advertisements
 msgid "Ads"
 msgstr ""
@@ -1332,6 +1337,13 @@ msgstr ""
 #. Heading shown on the empty chat screen. The text between the two %s markers is displayed inside a clickable privacy button. First %s renders a shield icon, second %s is an invisible end marker. Keep the word 'private' between both %s markers.
 msgctxt "Empty state heading in Duck.ai chat mode"
 msgid "All chats are %sprivate%s"
+msgstr ""
+
+#. Paragraph in the Privacy & Terms section of the About & Legal page in Duck.ai settings, summarizing how chats are anonymized and are not stored or used to train chat models.
+msgctxt "Privacy & Terms section description on the Duck.ai settings page"
+msgid ""
+"All chats are anonymized by DuckDuckGo, and your conversations are not used "
+"to train chat models by DuckDuckGo or the model providers"
 msgstr ""
 
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1544,6 +1556,12 @@ msgstr ""
 #. Confirmation message after location service is enabled.
 msgctxt "precise_user_location"
 msgid "Anonymous location enabled"
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Anonymously generates answers for search queries based on web content. "
+"Choose how often you want it to appear, or disable it completely."
 msgstr ""
 
 #. Instant Answer tab name
@@ -1766,6 +1784,11 @@ msgstr ""
 
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse
 msgid "Ask a follow-up with Duck.ai"
+msgstr ""
+
+#. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
+msgctxt "Page suggestion chip label"
+msgid "Ask about this page"
 msgstr ""
 
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2090,6 +2113,11 @@ msgstr ""
 msgid "Barcode"
 msgstr "بارکوڈ"
 
+#. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Based on this page, is this course worth taking?"
+msgstr ""
+
 msgctxt "settings"
 msgid "Basic"
 msgstr "بیسک"
@@ -2121,6 +2149,13 @@ msgstr ""
 #. Placeholder text displayed while the assistant waits for the user to choose an action.
 msgctxt "Assistant response placeholder"
 msgid "Before continuing..."
+msgstr ""
+
+#. Explains that before storing the report, DuckDuckGo will anonymize the conversation by removing PII like names, email addresses, and identifying metadata.
+msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
+msgid ""
+"Before storing this report, DuckDuckGo will anonymize your conversation by "
+"removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
 #. Label that's displayed next to a past start date below a web search result.
@@ -2379,6 +2414,11 @@ msgstr ""
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Break Points Won"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Break this down into clear, numbered steps."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -2738,6 +2778,11 @@ msgstr ""
 #. Text of a button that performs a search for the cast of a particular movie or tv show
 msgctxt "Movie/TV Show Title instant answer"
 msgid "Cast"
+msgstr ""
+
+#. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Cast & Crew"
 msgstr ""
 
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -4089,6 +4134,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Create a shopping list with quantities from this recipe."
+msgstr ""
+
 #. Placeholder text displayed in the input field when starting a new image generation session.
 msgctxt "Placeholder text for the image generation input field"
 msgid "Create an image of a cute duck..."
@@ -4615,6 +4665,10 @@ msgstr ""
 msgid "Dictation limit reached"
 msgstr ""
 
+#. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
+msgid "Dictation temporarily unavailable"
+msgstr ""
+
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
@@ -4859,6 +4913,20 @@ msgctxt "precise_user_location"
 msgid "Done"
 msgstr ""
 
+#. Message shown in a modal after DuckDuckGo browser users disable AI features in Settings. The first two placeholders bold noai.duckduckgo.com. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
+"filtered out. %sLearn More%s"
+msgstr ""
+
+#. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
+"and AI images filtered out. %sLearn more%s"
+msgstr ""
+
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Double Faults"
@@ -4949,6 +5017,16 @@ msgctxt "Full sentence for writing an email"
 msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
+msgstr ""
+
+#. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Draft a cover letter"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Draft a cover letter for this job."
 msgstr ""
 
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -5088,6 +5166,14 @@ msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
 msgstr ""
 
+#. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
+msgctxt "About section description on the Duck.ai settings page"
+msgid ""
+"Duck.ai is created by DuckDuckGo. We're an independent online protection "
+"company for anyone who wants to take back control of their personal "
+"information."
+msgstr ""
+
 #. Title shown when an update is required before proceeding.
 msgctxt "duckai_migration"
 msgid "Duck.ai is moving domains"
@@ -5121,6 +5207,12 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Duck.ai lets you chat privately with popular AI models. Disabling it hides "
+"Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
 
 msgctxt "settings"
@@ -5886,6 +5978,16 @@ msgstr ""
 msgid "Eritrea"
 msgstr ""
 
+#. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Estimate the nutrition"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Estimate the nutritional information for this recipe."
+msgstr ""
+
 msgid "Estonia"
 msgstr ""
 
@@ -5930,10 +6032,50 @@ msgctxt "merchant promotion product ad extension"
 msgid "Expires in 1 day"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain the accepted answer in simple terms."
+msgstr ""
+
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
+msgstr ""
+
+#. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain the top answer"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this in simple, plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this paper"
+msgstr ""
+
+#. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this repo"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this research paper in plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this simply"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain what this repository does and how to use it."
 msgstr ""
 
 #. Label to show if song lyrics contain explicit content
@@ -6164,6 +6306,11 @@ msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
 msgstr ""
 
+msgctxt "settings"
+msgid ""
+"Filters out known AI spam sites from image search results. %sLearn More%s"
+msgstr ""
+
 #. Label for the final score of a sporting event.
 msgid "Final"
 msgstr ""
@@ -6203,6 +6350,11 @@ msgstr ""
 #. Short description shown below the 'Web Search' label in the Tools dropdown.
 msgctxt "Subtitle for the Web Search tool entry in the Tools dropdown menu"
 msgid "Find current information"
+msgstr ""
+
+#. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Find me alternatives"
 msgstr ""
 
 #. Button that searches for results closer to the user's current location.
@@ -6593,6 +6745,11 @@ msgstr ""
 msgid "Generate More"
 msgstr ""
 
+#. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Generate a shopping list"
+msgstr ""
+
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
 msgid "Generate a short answer from the web"
 msgstr ""
@@ -6827,6 +6984,11 @@ msgstr ""
 #. Text for a button inviting users to give it a try for the Duck.ai product. On click, they're taken to the Duck.ai page.
 msgctxt "Onboarding welcome screen button text"
 msgid "Give it a Try"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Give me a quick background on this person."
 msgstr ""
 
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -7189,6 +7351,16 @@ msgstr ""
 
 #. Link to a page with information about sharing DuckDuckGo with friends.
 msgid "Help Spread Privacy"
+msgstr ""
+
+#. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Help me prep for the interview"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Help me tailor my resume for this job."
 msgstr ""
 
 #. Title of a SERP popup that invites users to take a survey (desktop only)
@@ -7608,6 +7780,13 @@ msgstr ""
 #. Text displayed on the button on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
 msgctxt "Onboarding terms screen button text"
 msgid "I Agree"
+msgstr ""
+
+#. Text for the button that takes the user to the external DuckDuckGo login subscription page.
+msgctxt ""
+"Text for the I already have a subscription button in the Duck.ai settings "
+"page"
+msgid "I Already Have a Subscription"
 msgstr ""
 
 #. Text for the button that takes the user to the login subscription page.
@@ -8066,6 +8245,11 @@ msgctxt "Sidemenu browser promo"
 msgid "Install Mac Browser"
 msgstr ""
 
+#. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
+msgctxt "settings"
+msgid "Install Now"
+msgstr ""
+
 #. Text of a button to install the DuckDuckGo app
 msgctxt "Serp footer content"
 msgid "Install Our App"
@@ -8145,9 +8329,36 @@ msgctxt "cloudsave"
 msgid "Is deleted data really deleted?"
 msgstr "خارج کر دیا ڈیٹا واقعی خارج کر دیا جاتا ہے؟"
 
+#. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is it worth taking?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this place any good?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"Is this place any good? Summarize its reputation based on reviews and "
+"ratings."
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "Is this video helpful?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this worth watching?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Is this worth watching? Give me a spoiler-free take."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -8644,6 +8855,11 @@ msgstr "لنک فونٹ:"
 msgid "Links:"
 msgstr "روابط: "
 
+#. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "List the tools, materials, or prerequisites I need for this."
+msgstr ""
+
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
 msgid "Listen"
 msgstr "سنیں"
@@ -8976,6 +9192,11 @@ msgstr ""
 #. Label for linke navigating to site exclusion feature on Settings page
 msgctxt "Exclusion message manage sites button"
 msgid "Manage blocked sites"
+msgstr ""
+
+#. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
+msgctxt "setting"
+msgid "Manage in Browser Settings"
 msgstr ""
 
 #. Link to the site exclusion settings page
@@ -11275,6 +11496,11 @@ msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
+msgid "Please describe why the chat response is harmful or illegal. (optional)"
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
+msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
 msgstr ""
 
@@ -11293,6 +11519,13 @@ msgctxt "Modal disclaimer text"
 msgid ""
 "Please note: starting a new chat with any model will delete your current "
 "chat session."
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
+msgctxt "Feedback prompt"
+msgid ""
+"Please paste your prompt and the problematic output (with any personal "
+"information removed) and describe why the content is harmful or illegal."
 msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -11677,6 +11910,11 @@ msgctxt "settings"
 msgid "Privacy"
 msgstr "نجی معلومات کی حفاظتی"
 
+#. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
+msgctxt "Section heading on the Duck.ai settings page"
+msgid "Privacy & Terms"
+msgstr ""
+
 msgid "Privacy Blog"
 msgstr ""
 
@@ -11730,6 +11968,11 @@ msgstr ""
 
 #. Text used in other strings to link to the Privacy Policy and Terms of Service content.
 msgctxt "Copy used to compose link in sentences"
+msgid "Privacy Policy and Terms of Service"
+msgstr ""
+
+#. Text for a button that links to the terms of use and privacy policy page.
+msgctxt "Secondary button text in active privacy modal"
 msgid "Privacy Policy and Terms of Service"
 msgstr ""
 
@@ -12138,6 +12381,26 @@ msgctxt "Brief for recommending a book"
 msgid "Recommend a book"
 msgstr ""
 
+#. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar books"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar books."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar movies or shows."
+msgstr ""
+
+#. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar titles"
+msgstr ""
+
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
 msgid "Recording failed. Please try again."
 msgstr ""
@@ -12457,6 +12720,14 @@ msgstr ""
 msgid "Republic of Moldova"
 msgstr ""
 
+#. Note indicating that sharing the conversation is mandatory when reporting harmful or illegal content. Rendered alongside the standard share label (DUCKCHAT_RESPONSE_FEEDBACK_SHARE_PROMPT_RESPONSE_LABEL), not replacing it.
+msgctxt ""
+"Note shown under the share-content switch label on the Duck.ai response "
+"feedback form when the user has selected Harmful or Illegal as the feedback "
+"reason"
+msgid "Required for harmful or illegal reports"
+msgstr ""
+
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
 msgctxt "Description for extended reasoning mode in Duck.ai"
 msgid "Researches before responding"
@@ -12642,6 +12913,11 @@ msgstr "جائزہ"
 #. Label above a list of customer reviews of a business.
 msgctxt "maps_places"
 msgid "Reviews"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Rewrite this recipe scaled for a different number of servings."
 msgstr ""
 
 msgid "Romania"
@@ -13679,6 +13955,11 @@ msgctxt "Setup button for native sync flow"
 msgid "Set Up Now"
 msgstr ""
 
+#. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
+msgctxt "Encrypted storage setup button shown in native browsers"
+msgid "Set Up Sync & Backup"
+msgstr ""
+
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
 msgctxt "Title for the Sync & Backup intro screen"
 msgid "Set Up Sync & Backup"
@@ -13821,6 +14102,12 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
+msgctxt ""
+"Label beside the share-content switch on the Duck.ai response feedback form"
+msgid "Share this conversation with DuckDuckGo"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -14835,6 +15122,21 @@ msgctxt "Brief for suggesting a blog post title"
 msgid "Suggest a title for a blog post"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest related articles or topics worth exploring next."
+msgstr ""
+
+#. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Suggest related articles to explore"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest some alternatives to this product."
+msgstr ""
+
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
 msgctxt "directions"
 msgid "Suggestions:"
@@ -14844,9 +15146,84 @@ msgctxt "noresults"
 msgid "Suggestions:"
 msgstr ""
 
+#. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Sum up the reviews"
+msgstr ""
+
 #. A short title for the a message asking the AI to summarize a text.
 msgctxt "Title for the summarize message"
 msgid "Summarize"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize the Q&As"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the background and notable work of this person."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the key details of this event."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the questions and answers on this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize their background"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this book"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this book."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this discussion"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this discussion thread."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this video"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this video."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize what the reviews say."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -15101,6 +15478,11 @@ msgstr ""
 msgid "Syria"
 msgstr ""
 
+#. Text for a button that enables the theme to follow the operating system's color scheme preference.
+msgctxt "System theme button for theme selector"
+msgid "System"
+msgstr ""
+
 #. Abbreviation indicating this is the total score for a game
 msgctxt "Sports module"
 msgid "T"
@@ -15124,6 +15506,11 @@ msgctxt "language_name"
 msgid "Tahitian"
 msgstr ""
 
+#. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Tailor my resume"
+msgstr ""
+
 msgid "Taiwan"
 msgstr ""
 
@@ -15145,6 +15532,12 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "Take control of your personal data!"
+msgstr ""
+
+#. Description for the Feedback section of the Duck.ai settings page, asking the user to take an anonymous survey to let us know how we can make Duck.ai better.
+msgctxt "Feedback section description on the Duck.ai settings page"
+msgid ""
+"Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
 
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -15389,6 +15782,11 @@ msgstr ""
 #. https://duck.co/media/files/theme.png
 msgid "Theme"
 msgstr "تھیم"
+
+#. Text for the theme selector label that allows users to switch between Light and dark theme.
+msgctxt "Label for the theme selector feature"
+msgid "Theme"
+msgstr ""
 
 #. http://i.imgur.com/LpFhb1e.png
 msgctxt "settings"
@@ -16040,6 +16438,16 @@ msgid ""
 "movie theatre?”"
 msgstr ""
 
+#. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Translate this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
+msgctxt "Page suggestion prompt"
+msgid "Translate this page into %s."
+msgstr ""
+
 #. Placeholder text for a region that will display translated text.
 msgctxt "translations_module"
 msgid "Translation"
@@ -16154,6 +16562,11 @@ msgstr ""
 #. Call-to-action button for the subscription promo in the SERP sidemenu.
 msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
+msgstr ""
+
+#. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
+msgctxt "settings"
+msgid "Try It Now"
 msgstr ""
 
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -16347,6 +16760,20 @@ msgstr "اسے کوشش کرں: %s"
 #. Response a user can select in a feedback form, indicating that they're trying DuckDuckGo again.
 msgctxt "new user poll"
 msgid "Trying DuckDuckGo again"
+msgstr ""
+
+#. Message shown in a modal after supported third-party browser users disable AI features in Settings. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+#. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
 msgstr ""
 
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -16947,6 +17374,11 @@ msgstr ""
 msgid "Uruguay"
 msgstr ""
 
+#. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
+msgctxt "Navigation label on the Duck.ai settings page"
+msgid "Usage"
+msgstr ""
+
 #. A feedback suggestion
 msgctxt "Feedback prompt"
 msgid "Usage limit"
@@ -17295,6 +17727,11 @@ msgstr ""
 msgid "Wales"
 msgstr ""
 
+#. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Walk me through the steps"
+msgstr ""
+
 #. Label for walking directions on a map.
 msgctxt "directions"
 msgid "Walking"
@@ -17385,6 +17822,16 @@ msgstr ""
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
+msgstr ""
+
+#. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
+msgctxt ""
+"Inline warning shown below the share-content toggle when the user selects "
+"Harmful or Illegal but has not enabled sharing"
+msgid ""
+"We can only fix what we can see. To report a harmful or illegal response, "
+"please share this conversation with DuckDuckGo so we can investigate and "
+"address the issue."
 msgstr ""
 
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -17804,6 +18251,87 @@ msgid ""
 "experience."
 msgstr ""
 
+#. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the counterarguments?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the hours & location?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key contributions of this paper?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key contributions?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key details?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key points covered in this video?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key points?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key takeaways from this article?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key takeaways?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key things I will learn from this course?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main counterarguments or criticisms of this?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main questions this page answers?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the must-try dishes here?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"What are the opening hours, location, and contact details for this place?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the pros and cons of this product?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the pros and cons?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
 msgctxt "feedback form"
 msgid "What bothered you most?"
@@ -17887,6 +18415,11 @@ msgctxt "Full sentence for defining a term"
 msgid "What does atria mean in the context of a medical article?"
 msgstr ""
 
+#. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What does this answer?"
+msgstr ""
+
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
@@ -17896,6 +18429,11 @@ msgstr ""
 msgctxt "cloudsave"
 msgid "What information gets saved?"
 msgstr "کس قسم کی معلومات کو محفوظ کر لیا جاتا ہے؟ "
+
+#. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What interview questions might come up for this role?"
+msgstr ""
 
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
@@ -17907,6 +18445,11 @@ msgstr ""
 #. Text for a prompt suggestion for looking up the capital city of Albania.
 msgctxt "Full sentence for looking up basic facts"
 msgid "What is the capital city of Albania?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What is the overall verdict and rating for this?"
 msgstr ""
 
 #. Link to a page with additional information.
@@ -17927,6 +18470,11 @@ msgctxt "maps_places"
 msgid "What people say:"
 msgstr ""
 
+#. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What should I order?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
 msgctxt "feedback form"
 msgid "What stood out?"
@@ -17935,6 +18483,16 @@ msgstr ""
 #. Question on a feedback form for a negative feedback response.
 msgctxt "feedback form"
 msgid "What was wrong with the response? (optional)"
+msgstr ""
+
+#. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I learn?"
+msgstr ""
+
+#. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I need?"
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -17949,6 +18507,11 @@ msgstr ""
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
 msgctxt "SERP footer content"
 msgid "What's New"
+msgstr ""
+
+#. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What's the verdict?"
 msgstr ""
 
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -17990,6 +18553,11 @@ msgctxt "Feedback prompt"
 msgid "Which features are missing? (Optional)"
 msgstr ""
 
+#. An invitation for users to leave feedback
+msgctxt "Feedback prompt"
+msgid "Which features are missing? (optional)"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
 msgid "White"
 msgstr "سفید"
@@ -18001,6 +18569,16 @@ msgstr ""
 
 #. Link to an about us page.
 msgid "Who We Are"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Who are the main cast and crew, and what else are they known for?"
+msgstr ""
+
+#. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Who is this person?"
 msgstr ""
 
 #. Header above a collection of privacy-related links.

--- a/locales/vi_VN/LC_MESSAGES/duckduckgo.po
+++ b/locales/vi_VN/LC_MESSAGES/duckduckgo.po
@@ -1163,6 +1163,11 @@ msgctxt "feedback form"
 msgid "Address is incorrect"
 msgstr ""
 
+#. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Adjust the servings"
+msgstr ""
+
 #. as in multiple advertisements
 msgid "Ads"
 msgstr "Quảng cáo"
@@ -1334,6 +1339,13 @@ msgstr ""
 #. Heading shown on the empty chat screen. The text between the two %s markers is displayed inside a clickable privacy button. First %s renders a shield icon, second %s is an invisible end marker. Keep the word 'private' between both %s markers.
 msgctxt "Empty state heading in Duck.ai chat mode"
 msgid "All chats are %sprivate%s"
+msgstr ""
+
+#. Paragraph in the Privacy & Terms section of the About & Legal page in Duck.ai settings, summarizing how chats are anonymized and are not stored or used to train chat models.
+msgctxt "Privacy & Terms section description on the Duck.ai settings page"
+msgid ""
+"All chats are anonymized by DuckDuckGo, and your conversations are not used "
+"to train chat models by DuckDuckGo or the model providers"
 msgstr ""
 
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1549,6 +1561,12 @@ msgstr ""
 msgctxt "precise_user_location"
 msgid "Anonymous location enabled"
 msgstr "Đã bật vị trí ẩn danh"
+
+msgctxt "settings"
+msgid ""
+"Anonymously generates answers for search queries based on web content. "
+"Choose how often you want it to appear, or disable it completely."
+msgstr ""
 
 #. Instant Answer tab name
 msgid "Answer"
@@ -1772,6 +1790,11 @@ msgstr ""
 
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse
 msgid "Ask a follow-up with Duck.ai"
+msgstr ""
+
+#. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
+msgctxt "Page suggestion chip label"
+msgid "Ask about this page"
 msgstr ""
 
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2096,6 +2119,11 @@ msgstr ""
 msgid "Barcode"
 msgstr "Mã vạch"
 
+#. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Based on this page, is this course worth taking?"
+msgstr ""
+
 msgctxt "settings"
 msgid "Basic"
 msgstr "Cơ bản"
@@ -2127,6 +2155,13 @@ msgstr ""
 #. Placeholder text displayed while the assistant waits for the user to choose an action.
 msgctxt "Assistant response placeholder"
 msgid "Before continuing..."
+msgstr ""
+
+#. Explains that before storing the report, DuckDuckGo will anonymize the conversation by removing PII like names, email addresses, and identifying metadata.
+msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
+msgid ""
+"Before storing this report, DuckDuckGo will anonymize your conversation by "
+"removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
 #. Label that's displayed next to a past start date below a web search result.
@@ -2385,6 +2420,11 @@ msgstr "Bra-xin"
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Break Points Won"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Break this down into clear, numbered steps."
 msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -2758,6 +2798,11 @@ msgstr "Cơ hội nghề nghiệp"
 #. Text of a button that performs a search for the cast of a particular movie or tv show
 msgctxt "Movie/TV Show Title instant answer"
 msgid "Cast"
+msgstr ""
+
+#. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Cast & Crew"
 msgstr ""
 
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -4121,6 +4166,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Create a shopping list with quantities from this recipe."
+msgstr ""
+
 #. Placeholder text displayed in the input field when starting a new image generation session.
 msgctxt "Placeholder text for the image generation input field"
 msgid "Create an image of a cute duck..."
@@ -4647,6 +4697,10 @@ msgstr ""
 msgid "Dictation limit reached"
 msgstr ""
 
+#. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
+msgid "Dictation temporarily unavailable"
+msgstr ""
+
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
@@ -4891,6 +4945,20 @@ msgctxt "precise_user_location"
 msgid "Done"
 msgstr "Đã xong"
 
+#. Message shown in a modal after DuckDuckGo browser users disable AI features in Settings. The first two placeholders bold noai.duckduckgo.com. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
+"filtered out. %sLearn More%s"
+msgstr ""
+
+#. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
+"and AI images filtered out. %sLearn more%s"
+msgstr ""
+
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Double Faults"
@@ -4981,6 +5049,16 @@ msgctxt "Full sentence for writing an email"
 msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
+msgstr ""
+
+#. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Draft a cover letter"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Draft a cover letter for this job."
 msgstr ""
 
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -5120,6 +5198,14 @@ msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
 msgstr ""
 
+#. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
+msgctxt "About section description on the Duck.ai settings page"
+msgid ""
+"Duck.ai is created by DuckDuckGo. We're an independent online protection "
+"company for anyone who wants to take back control of their personal "
+"information."
+msgstr ""
+
 #. Title shown when an update is required before proceeding.
 msgctxt "duckai_migration"
 msgid "Duck.ai is moving domains"
@@ -5153,6 +5239,12 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Duck.ai lets you chat privately with popular AI models. Disabling it hides "
+"Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
 
 msgctxt "settings"
@@ -5934,6 +6026,16 @@ msgstr ""
 msgid "Eritrea"
 msgstr ""
 
+#. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Estimate the nutrition"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Estimate the nutritional information for this recipe."
+msgstr ""
+
 msgid "Estonia"
 msgstr "Estonia"
 
@@ -5978,10 +6080,50 @@ msgctxt "merchant promotion product ad extension"
 msgid "Expires in 1 day"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain the accepted answer in simple terms."
+msgstr ""
+
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
+msgstr ""
+
+#. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain the top answer"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this in simple, plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this paper"
+msgstr ""
+
+#. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this repo"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this research paper in plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this simply"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain what this repository does and how to use it."
 msgstr ""
 
 #. Label to show if song lyrics contain explicit content
@@ -6211,6 +6353,11 @@ msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
 msgstr ""
 
+msgctxt "settings"
+msgid ""
+"Filters out known AI spam sites from image search results. %sLearn More%s"
+msgstr ""
+
 #. Label for the final score of a sporting event.
 msgid "Final"
 msgstr "Lời cuối"
@@ -6250,6 +6397,11 @@ msgstr ""
 #. Short description shown below the 'Web Search' label in the Tools dropdown.
 msgctxt "Subtitle for the Web Search tool entry in the Tools dropdown menu"
 msgid "Find current information"
+msgstr ""
+
+#. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Find me alternatives"
 msgstr ""
 
 #. Button that searches for results closer to the user's current location.
@@ -6640,6 +6792,11 @@ msgstr ""
 msgid "Generate More"
 msgstr ""
 
+#. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Generate a shopping list"
+msgstr ""
+
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
 msgid "Generate a short answer from the web"
 msgstr ""
@@ -6874,6 +7031,11 @@ msgstr ""
 #. Text for a button inviting users to give it a try for the Duck.ai product. On click, they're taken to the Duck.ai page.
 msgctxt "Onboarding welcome screen button text"
 msgid "Give it a Try"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Give me a quick background on this person."
 msgstr ""
 
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -7237,6 +7399,16 @@ msgstr ""
 #. Link to a page with information about sharing DuckDuckGo with friends.
 msgid "Help Spread Privacy"
 msgstr "Giúp lan rộng quyền riêng tư"
+
+#. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Help me prep for the interview"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Help me tailor my resume for this job."
+msgstr ""
 
 #. Title of a SERP popup that invites users to take a survey (desktop only)
 msgctxt "User survey popup"
@@ -7659,6 +7831,13 @@ msgstr ""
 #. Text displayed on the button on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
 msgctxt "Onboarding terms screen button text"
 msgid "I Agree"
+msgstr ""
+
+#. Text for the button that takes the user to the external DuckDuckGo login subscription page.
+msgctxt ""
+"Text for the I already have a subscription button in the Duck.ai settings "
+"page"
+msgid "I Already Have a Subscription"
 msgstr ""
 
 #. Text for the button that takes the user to the login subscription page.
@@ -8122,6 +8301,11 @@ msgctxt "Sidemenu browser promo"
 msgid "Install Mac Browser"
 msgstr ""
 
+#. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
+msgctxt "settings"
+msgid "Install Now"
+msgstr ""
+
 #. Text of a button to install the DuckDuckGo app
 msgctxt "Serp footer content"
 msgid "Install Our App"
@@ -8201,10 +8385,37 @@ msgctxt "cloudsave"
 msgid "Is deleted data really deleted?"
 msgstr "Dữ liệu được xóa có thật sự được xóa?"
 
+#. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is it worth taking?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this place any good?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"Is this place any good? Summarize its reputation based on reviews and "
+"ratings."
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "Is this video helpful?"
 msgstr "Video này có giúp ích?"
+
+#. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this worth watching?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Is this worth watching? Give me a spoiler-free take."
+msgstr ""
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
 msgctxt "Weather IA"
@@ -8703,6 +8914,11 @@ msgstr "Phông chữ liên kết:"
 msgid "Links:"
 msgstr "Kết nối:"
 
+#. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "List the tools, materials, or prerequisites I need for this."
+msgstr ""
+
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
 msgid "Listen"
 msgstr "Nghe"
@@ -9035,6 +9251,11 @@ msgstr ""
 #. Label for linke navigating to site exclusion feature on Settings page
 msgctxt "Exclusion message manage sites button"
 msgid "Manage blocked sites"
+msgstr ""
+
+#. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
+msgctxt "setting"
+msgid "Manage in Browser Settings"
 msgstr ""
 
 #. Link to the site exclusion settings page
@@ -11347,6 +11568,11 @@ msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
+msgid "Please describe why the chat response is harmful or illegal. (optional)"
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
+msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
 msgstr ""
 
@@ -11365,6 +11591,13 @@ msgctxt "Modal disclaimer text"
 msgid ""
 "Please note: starting a new chat with any model will delete your current "
 "chat session."
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
+msgctxt "Feedback prompt"
+msgid ""
+"Please paste your prompt and the problematic output (with any personal "
+"information removed) and describe why the content is harmful or illegal."
 msgstr ""
 
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -11749,6 +11982,11 @@ msgctxt "settings"
 msgid "Privacy"
 msgstr "Quyền riêng tư"
 
+#. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
+msgctxt "Section heading on the Duck.ai settings page"
+msgid "Privacy & Terms"
+msgstr ""
+
 msgid "Privacy Blog"
 msgstr "Blog quyền riêng tư"
 
@@ -11802,6 +12040,11 @@ msgstr ""
 
 #. Text used in other strings to link to the Privacy Policy and Terms of Service content.
 msgctxt "Copy used to compose link in sentences"
+msgid "Privacy Policy and Terms of Service"
+msgstr ""
+
+#. Text for a button that links to the terms of use and privacy policy page.
+msgctxt "Secondary button text in active privacy modal"
 msgid "Privacy Policy and Terms of Service"
 msgstr ""
 
@@ -12210,6 +12453,26 @@ msgctxt "Brief for recommending a book"
 msgid "Recommend a book"
 msgstr ""
 
+#. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar books"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar books."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar movies or shows."
+msgstr ""
+
+#. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar titles"
+msgstr ""
+
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
 msgid "Recording failed. Please try again."
 msgstr ""
@@ -12529,6 +12792,14 @@ msgstr ""
 msgid "Republic of Moldova"
 msgstr ""
 
+#. Note indicating that sharing the conversation is mandatory when reporting harmful or illegal content. Rendered alongside the standard share label (DUCKCHAT_RESPONSE_FEEDBACK_SHARE_PROMPT_RESPONSE_LABEL), not replacing it.
+msgctxt ""
+"Note shown under the share-content switch label on the Duck.ai response "
+"feedback form when the user has selected Harmful or Illegal as the feedback "
+"reason"
+msgid "Required for harmful or illegal reports"
+msgstr ""
+
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
 msgctxt "Description for extended reasoning mode in Duck.ai"
 msgid "Researches before responding"
@@ -12715,6 +12986,11 @@ msgstr "Nhận xét"
 msgctxt "maps_places"
 msgid "Reviews"
 msgstr "Đánh giá"
+
+#. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Rewrite this recipe scaled for a different number of servings."
+msgstr ""
 
 msgid "Romania"
 msgstr "Romania"
@@ -13764,6 +14040,11 @@ msgctxt "Setup button for native sync flow"
 msgid "Set Up Now"
 msgstr ""
 
+#. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
+msgctxt "Encrypted storage setup button shown in native browsers"
+msgid "Set Up Sync & Backup"
+msgstr ""
+
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
 msgctxt "Title for the Sync & Backup intro screen"
 msgid "Set Up Sync & Backup"
@@ -13907,6 +14188,12 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
+msgctxt ""
+"Label beside the share-content switch on the Duck.ai response feedback form"
+msgid "Share this conversation with DuckDuckGo"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -14925,6 +15212,21 @@ msgctxt "Brief for suggesting a blog post title"
 msgid "Suggest a title for a blog post"
 msgstr ""
 
+#. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest related articles or topics worth exploring next."
+msgstr ""
+
+#. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Suggest related articles to explore"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest some alternatives to this product."
+msgstr ""
+
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
 msgctxt "directions"
 msgid "Suggestions:"
@@ -14934,9 +15236,84 @@ msgctxt "noresults"
 msgid "Suggestions:"
 msgstr "Gợi ý:"
 
+#. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Sum up the reviews"
+msgstr ""
+
 #. A short title for the a message asking the AI to summarize a text.
 msgctxt "Title for the summarize message"
 msgid "Summarize"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize the Q&As"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the background and notable work of this person."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the key details of this event."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the questions and answers on this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize their background"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this book"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this book."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this discussion"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this discussion thread."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this video"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this video."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize what the reviews say."
 msgstr ""
 
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -15192,6 +15569,11 @@ msgstr ""
 msgid "Syria"
 msgstr ""
 
+#. Text for a button that enables the theme to follow the operating system's color scheme preference.
+msgctxt "System theme button for theme selector"
+msgid "System"
+msgstr ""
+
 #. Abbreviation indicating this is the total score for a game
 msgctxt "Sports module"
 msgid "T"
@@ -15215,6 +15597,11 @@ msgctxt "language_name"
 msgid "Tahitian"
 msgstr "Tiếng Tahitian"
 
+#. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Tailor my resume"
+msgstr ""
+
 msgid "Taiwan"
 msgstr "Đài Loan"
 
@@ -15236,6 +15623,12 @@ msgstr ""
 
 msgctxt "homepage ATB modal"
 msgid "Take control of your personal data!"
+msgstr ""
+
+#. Description for the Feedback section of the Duck.ai settings page, asking the user to take an anonymous survey to let us know how we can make Duck.ai better.
+msgctxt "Feedback section description on the Duck.ai settings page"
+msgid ""
+"Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
 
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -15485,6 +15878,11 @@ msgstr ""
 #. https://duck.co/media/files/theme.png
 msgid "Theme"
 msgstr "Chủ đề"
+
+#. Text for the theme selector label that allows users to switch between Light and dark theme.
+msgctxt "Label for the theme selector feature"
+msgid "Theme"
+msgstr ""
 
 #. http://i.imgur.com/LpFhb1e.png
 msgctxt "settings"
@@ -16141,6 +16539,16 @@ msgid ""
 "movie theatre?”"
 msgstr ""
 
+#. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Translate this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
+msgctxt "Page suggestion prompt"
+msgid "Translate this page into %s."
+msgstr ""
+
 #. Placeholder text for a region that will display translated text.
 msgctxt "translations_module"
 msgid "Translation"
@@ -16255,6 +16663,11 @@ msgstr ""
 #. Call-to-action button for the subscription promo in the SERP sidemenu.
 msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
+msgstr ""
+
+#. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
+msgctxt "settings"
+msgid "Try It Now"
 msgstr ""
 
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -16451,6 +16864,20 @@ msgstr "Thử: %s"
 msgctxt "new user poll"
 msgid "Trying DuckDuckGo again"
 msgstr "Thử DuckDuckGo lại"
+
+#. Message shown in a modal after supported third-party browser users disable AI features in Settings. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+#. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
 
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
 msgctxt "Assistant response placeholder"
@@ -17054,6 +17481,11 @@ msgstr "Tiếng Urdu"
 msgid "Uruguay"
 msgstr ""
 
+#. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
+msgctxt "Navigation label on the Duck.ai settings page"
+msgid "Usage"
+msgstr ""
+
 #. A feedback suggestion
 msgctxt "Feedback prompt"
 msgid "Usage limit"
@@ -17404,6 +17836,11 @@ msgstr "Đang chờ vị trí..."
 msgid "Wales"
 msgstr ""
 
+#. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Walk me through the steps"
+msgstr ""
+
 #. Label for walking directions on a map.
 msgctxt "directions"
 msgid "Walking"
@@ -17494,6 +17931,16 @@ msgstr ""
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
+msgstr ""
+
+#. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
+msgctxt ""
+"Inline warning shown below the share-content toggle when the user selects "
+"Harmful or Illegal but has not enabled sharing"
+msgid ""
+"We can only fix what we can see. To report a harmful or illegal response, "
+"please share this conversation with DuckDuckGo so we can investigate and "
+"address the issue."
 msgstr ""
 
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -17927,6 +18374,87 @@ msgid ""
 "experience."
 msgstr ""
 
+#. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the counterarguments?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the hours & location?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key contributions of this paper?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key contributions?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key details?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key points covered in this video?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key points?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key takeaways from this article?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key takeaways?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key things I will learn from this course?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main counterarguments or criticisms of this?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main questions this page answers?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the must-try dishes here?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"What are the opening hours, location, and contact details for this place?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the pros and cons of this product?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the pros and cons?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
 msgctxt "feedback form"
 msgid "What bothered you most?"
@@ -18010,6 +18538,11 @@ msgctxt "Full sentence for defining a term"
 msgid "What does atria mean in the context of a medical article?"
 msgstr ""
 
+#. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What does this answer?"
+msgstr ""
+
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
@@ -18019,6 +18552,11 @@ msgstr ""
 msgctxt "cloudsave"
 msgid "What information gets saved?"
 msgstr "Những thông tin nào được lưu?"
+
+#. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What interview questions might come up for this role?"
+msgstr ""
 
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
@@ -18032,6 +18570,11 @@ msgstr ""
 #. Text for a prompt suggestion for looking up the capital city of Albania.
 msgctxt "Full sentence for looking up basic facts"
 msgid "What is the capital city of Albania?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What is the overall verdict and rating for this?"
 msgstr ""
 
 #. Link to a page with additional information.
@@ -18052,6 +18595,11 @@ msgctxt "maps_places"
 msgid "What people say:"
 msgstr "Mọi người nói gì:"
 
+#. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What should I order?"
+msgstr ""
+
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
 msgctxt "feedback form"
 msgid "What stood out?"
@@ -18060,6 +18608,16 @@ msgstr ""
 #. Question on a feedback form for a negative feedback response.
 msgctxt "feedback form"
 msgid "What was wrong with the response? (optional)"
+msgstr ""
+
+#. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I learn?"
+msgstr ""
+
+#. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I need?"
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -18074,6 +18632,11 @@ msgstr ""
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
 msgctxt "SERP footer content"
 msgid "What's New"
+msgstr ""
+
+#. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What's the verdict?"
 msgstr ""
 
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -18115,6 +18678,11 @@ msgctxt "Feedback prompt"
 msgid "Which features are missing? (Optional)"
 msgstr ""
 
+#. An invitation for users to leave feedback
+msgctxt "Feedback prompt"
+msgid "Which features are missing? (optional)"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
 msgid "White"
 msgstr "Trắng"
@@ -18127,6 +18695,16 @@ msgstr "Trắng"
 #. Link to an about us page.
 msgid "Who We Are"
 msgstr "Chúng tôi là ai"
+
+#. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Who are the main cast and crew, and what else are they known for?"
+msgstr ""
+
+#. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Who is this person?"
+msgstr ""
 
 #. Header above a collection of privacy-related links.
 msgid "Why Privacy"

--- a/locales/zh_CN/LC_MESSAGES/duckduckgo.po
+++ b/locales/zh_CN/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: zh_CN\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -175,9 +175,7 @@ msgctxt "Error message when a Plus subscriber tries to use a Pro-only model"
 msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
-msgstr ""
-"%1$s 仅限 Pro 订户使用。请在此浏览器中再次升级 DuckDuckGo 订阅以继续聊天，或"
-"者切换到 Plus 或免费模型。"
+msgstr "%1$s 仅限 Pro 订户使用。请在此浏览器中再次升级 DuckDuckGo 订阅以继续聊天，或者切换到 Plus 或免费模型。"
 
 # smartling.placeholder_format=C
 #. Text for the disclaimer message that appears when a Plus subscriber tries to use a Pro-only model. %s is replaced with the model name. Example: Claude Opus 4.6 is only available with Pro. Upgrade your DuckDuckGo subscription in this browser again to continue the chat, or switch to a Plus or free model.
@@ -186,9 +184,7 @@ msgctxt ""
 msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
-msgstr ""
-"%1$s 仅限 Pro 订户使用。请在此浏览器中再次升级 DuckDuckGo 订阅以继续聊天，或"
-"者切换到 Plus 或免费模型。"
+msgstr "%1$s 仅限 Pro 订户使用。请在此浏览器中再次升级 DuckDuckGo 订阅以继续聊天，或者切换到 Plus 或免费模型。"
 
 # smartling.placeholder_format=C
 #. Displayed when an AI (Artificial Intelligence) chat model is temporarily unavailable. Example: 'GPT 4o is only available with a DuckDuckGo subscription.'
@@ -203,9 +199,7 @@ msgid ""
 "%s is only available with a DuckDuckGo subscription. Activate your "
 "subscription in this browser again to continue the chat, or switch to a free "
 "model."
-msgstr ""
-"%1$s 仅限 DuckDuckGo 订阅用户使用。在这个浏览器中重新激活你的订阅以继续聊天，"
-"或切换到免费模式。"
+msgstr "%1$s 仅限 DuckDuckGo 订阅用户使用。在这个浏览器中重新激活你的订阅以继续聊天，或切换到免费模式。"
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is temporarily unavailable. Example: 'GPT 3.5 Turbo is temporarily unavailable. Please switch to a different model or try again later.'
@@ -303,9 +297,7 @@ msgid ""
 "%s runs in a Trusted Execution Environment. This means not even the model "
 "provider can see your prompts or the model’s responses, or save this chat on "
 "their servers."
-msgstr ""
-"%1$s 在可信执行环境中运行。这意味着即使是模型提供商也无法查看您的提示或模型的"
-"响应，也不会在其服务器上保存此聊天记录。"
+msgstr "%1$s 在可信执行环境中运行。这意味着即使是模型提供商也无法查看您的提示或模型的响应，也不会在其服务器上保存此聊天记录。"
 
 # smartling.placeholder_format=C
 #. Label shown in the batch selection toolbar when exactly one chat is selected. %s is replaced with 1. Use singular agreement where the language requires it.
@@ -413,8 +405,7 @@ msgstr "%1$s点击%2$s添加%3$s勾选%4$s允许%5$s，然后点击%6$s确定%7$
 #. Instructions on what buttons the user has to click in order to add the DuckDuckGo extension to their browser.
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAllow%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
-msgstr ""
-"%1$s点击%2$s允许%3$s点击%4$s添加%5$s勾选%6$s允许%7$s，然后点击%8$s确定%9$s"
+msgstr "%1$s点击%2$s允许%3$s点击%4$s添加%5$s勾选%6$s允许%7$s，然后点击%8$s确定%9$s"
 
 # Firefox
 # smartling.placeholder_format=C
@@ -423,9 +414,7 @@ msgctxt "install-duckduckgo"
 msgid ""
 "%sClick %sContinue To Installation%sClick %sAdd%sCheck %sAllow%s, then click "
 "%sOkay%s"
-msgstr ""
-"%1$s点击%2$s继续安装%3$s点击%4$s添加%5$s勾选%6$s允许%7$s，然后点击%8$s确"
-"定%9$s"
+msgstr "%1$s点击%2$s继续安装%3$s点击%4$s添加%5$s勾选%6$s允许%7$s，然后点击%8$s确定%9$s"
 
 # smartling.placeholder_format=C
 #. A button that reloads search results when an error occurs.
@@ -853,8 +842,7 @@ msgstr "客场"
 msgid ""
 "A network issue is preventing Search Assist from generating an answer. "
 "Please check your connection and try again."
-msgstr ""
-"网络问题导致 Search Assist 无法生成答案。请检查网络连接，然后再试一次。"
+msgstr "网络问题导致 Search Assist 无法生成答案。请检查网络连接，然后再试一次。"
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of AI Chat is available and they need to refresh the page.
@@ -906,9 +894,8 @@ msgid ""
 "still access AI Chat when this setting is off by visiting %sduckduckgo.com/"
 "aichat%s."
 msgstr ""
-"可以利用 AI Chat 与第三方人工智能聊天模型进行匿名对话。关闭此功能将隐藏 "
-"DuckDuckGo Search 中的 AI Chat 功能。关闭此设置后，仍可以通过访问 "
-"%1$sduckduckgo.com/aichat%2$s 来使用 AI Chat。"
+"可以利用 AI Chat 与第三方人工智能聊天模型进行匿名对话。关闭此功能将隐藏 DuckDuckGo Search 中的 AI Chat "
+"功能。关闭此设置后，仍可以通过访问 %1$sduckduckgo.com/aichat%2$s 来使用 AI Chat。"
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -969,9 +956,8 @@ msgid ""
 "questions, which is our private AI-powered chat service that supports chat "
 "models from OpenAI, and Anthropic, and more."
 msgstr ""
-"人工智能辅助的答案目前不直接支持后续问题。不过，我们还提供 %1$sDuck.ai%2$s 并"
-"通常会与其链接来解答后续问题，这是我们基于人工智能的私人聊天服务，支持 "
-"OpenAI 和 Anthropic 等公司的聊天模型。"
+"人工智能辅助的答案目前不直接支持后续问题。不过，我们还提供 %1$sDuck.ai%2$s "
+"并通常会与其链接来解答后续问题，这是我们基于人工智能的私人聊天服务，支持 OpenAI 和 Anthropic 等公司的聊天模型。"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has turned off AI features and will no longer see AI-assisted answers.
@@ -1405,7 +1391,7 @@ msgstr "地址有误"
 #. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Adjust the servings"
-msgstr ""
+msgstr "调整份量"
 
 # smartling.placeholder_format=C
 #. as in multiple advertisements
@@ -1624,7 +1610,7 @@ msgctxt "Privacy & Terms section description on the Duck.ai settings page"
 msgid ""
 "All chats are anonymized by DuckDuckGo, and your conversations are not used "
 "to train chat models by DuckDuckGo or the model providers"
-msgstr ""
+msgstr "DuckDuckGo 会对所有聊天内容进行匿名处理，并且 DuckDuckGo 或模型提供方不会使用你的对话来训练聊天模型"
 
 # smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1721,8 +1707,8 @@ msgid ""
 "sends AI-generated queries to a search engine with limited data retention. "
 "Prompts and responses with %s still have %szero provider visibility%s."
 msgstr ""
-"允许 %1$s 搜索网络，以改善对相关提示的回复质量。仅将人工智能生成的查询发送给"
-"数据留存期有限的搜索引擎。%2$s 的提示和回复仍然%3$s完全不会向提供商显示%4$s。"
+"允许 %1$s 搜索网络，以改善对相关提示的回复质量。仅将人工智能生成的查询发送给数据留存期有限的搜索引擎。%2$s "
+"的提示和回复仍然%3$s完全不会向提供商显示%4$s。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -1887,7 +1873,7 @@ msgctxt "settings"
 msgid ""
 "Anonymously generates answers for search queries based on web content. "
 "Choose how often you want it to appear, or disable it completely."
-msgstr ""
+msgstr "根据网页内容匿名生成搜索查询答案。你可以选择该功能的显示频率，或完全关闭它。"
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -2097,9 +2083,7 @@ msgstr "截至"
 msgid ""
 "As per our privacy policy, we do not collect or share any personal "
 "information ourselves. All of this privacy protection happens on your device."
-msgstr ""
-"根据我们的隐私协议，我们本身不会收集或传播任何隐私信息，仅会立足于你的设备保"
-"护隐私。"
+msgstr "根据我们的隐私协议，我们本身不会收集或传播任何隐私信息，仅会立足于你的设备保护隐私。"
 
 # smartling.placeholder_format=C
 #. A button to ask Duck.ai a question
@@ -2165,7 +2149,7 @@ msgstr "利用 Duck.ai 询问后续问题"
 #. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
 msgctxt "Page suggestion chip label"
 msgid "Ask about this page"
-msgstr ""
+msgstr "询问此页面相关信息"
 
 # smartling.placeholder_format=C
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2229,11 +2213,9 @@ msgid ""
 "(shows more frequently on a wider range of searches). For now, AI-assisted "
 "answers are only available in the U.S. (English) region."
 msgstr ""
-"Assist 可以在总结相关网页内容的基础上，为某些搜索匿名生成人工智能辅助答案。可"
-"以选择显示 Assist 的频率：从不（从搜索结果中完全移除 Assist 用户界面)、按需"
-"（仅在点击“Assist”按钮时显示人工智能辅助的答案）、有时（仅在高度相关时显示人"
-"工智能辅助的答案）或经常（在更广泛的搜索中更频繁地显示）。人工智能辅助的答案"
-"目前仅供美国（英语）地区使用。"
+"Assist 可以在总结相关网页内容的基础上，为某些搜索匿名生成人工智能辅助答案。可以选择显示 Assist 的频率：从不（从搜索结果中完全移除 "
+"Assist "
+"用户界面)、按需（仅在点击“Assist”按钮时显示人工智能辅助的答案）、有时（仅在高度相关时显示人工智能辅助的答案）或经常（在更广泛的搜索中更频繁地显示）。人工智能辅助的答案目前仅供美国（英语）地区使用。"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2245,10 +2227,8 @@ msgid ""
 "to remember that responses are auto-generated from cited sources and based "
 "on %scrawling the web%s."
 msgstr ""
-"Assist 是我们搜索结果中的一项可选功能，可以匿名生成人工智能辅助的搜索查询答"
-"案。为此，该功能会扫描网络上的相关内容，然后使用人工智能驱动的自然语言技术，"
-"根据找到的相关信息生成简短的答案。请务必记住，这些回复来自引用的资料来源，并"
-"通过%1$s爬取网络内容%2$s自动生成。"
+"Assist "
+"是我们搜索结果中的一项可选功能，可以匿名生成人工智能辅助的搜索查询答案。为此，该功能会扫描网络上的相关内容，然后使用人工智能驱动的自然语言技术，根据找到的相关信息生成简短的答案。请务必记住，这些回复来自引用的资料来源，并通过%1$s爬取网络内容%2$s自动生成。"
 
 # smartling.placeholder_format=C
 #. Title for the dropdown menu where users select the assistant's role. Example: 'Assistant role: Travel guide'
@@ -2410,9 +2390,7 @@ msgid ""
 "Automatically shows Assist for relevant searches. Assist can anonymously "
 "look up and summarize information in response to some searches. For now, "
 "Assist is only available in English regions."
-msgstr ""
-"为相关搜索自动显示 Assist。Assist 可以匿名查找和汇总信息，以响应某些搜索。"
-"Assist 目前仅供英语地区使用。"
+msgstr "为相关搜索自动显示 Assist。Assist 可以匿名查找和汇总信息，以响应某些搜索。Assist 目前仅供英语地区使用。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2420,9 +2398,7 @@ msgid ""
 "Automatically shows DuckAssist for relevant searches. DuckAssist can "
 "anonymously look up and summarize information in response to some searches. "
 "For now, DuckAssist is only available in English regions."
-msgstr ""
-"为相关搜索自动显示 DuckAssist。DuckAssist 可以匿名查找和汇总信息，以响应某些"
-"搜索。DuckAssist 目前仅供英语地区使用。"
+msgstr "为相关搜索自动显示 DuckAssist。DuckAssist 可以匿名查找和汇总信息，以响应某些搜索。DuckAssist 目前仅供英语地区使用。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2573,7 +2549,7 @@ msgstr "条形码"
 #. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Based on this page, is this course worth taking?"
-msgstr ""
+msgstr "根据这个页面来看，这门课程值得参加吗？"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2621,7 +2597,7 @@ msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
 msgid ""
 "Before storing this report, DuckDuckGo will anonymize your conversation by "
 "removing PII like names, email addresses, and identifying metadata."
-msgstr ""
+msgstr "在存储此报告之前，DuckDuckGo 会通过删除姓名、电子邮件地址和识别元数据等个人身份信息，对你的对话进行匿名化处理。"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -2943,7 +2919,7 @@ msgstr "破发成功率"
 #. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Break this down into clear, numbered steps."
-msgstr ""
+msgstr "把这个拆解成清晰的、带编号的步骤。"
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -3001,26 +2977,20 @@ msgstr "浏览文件"
 msgid ""
 "Browse as usual while we add privacy protection. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
-msgstr ""
-"正常上网，让我们来保护你的隐私。我们的 %1$s%2$s 扩展 %3$s 中预置了搜索引擎，"
-"还能屏蔽跟踪程序、开启网站加密。"
+msgstr "正常上网，让我们来保护你的隐私。我们的 %1$s%2$s 扩展 %3$s 中预置了搜索引擎，还能屏蔽跟踪程序、开启网站加密。"
 
 # smartling.placeholder_format=C
 msgid ""
 "Browse as usual, and we'll take care of the rest. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
-msgstr ""
-"正常上网，剩下的交给我们。我们的 %1$s%2$s 扩展 %3$s 中预置了搜索引擎，还能屏"
-"蔽跟踪程序、开启网站加密。"
+msgstr "正常上网，剩下的交给我们。我们的 %1$s%2$s 扩展 %3$s 中预置了搜索引擎，还能屏蔽跟踪程序、开启网站加密。"
 
 # smartling.placeholder_format=C
 msgid ""
 "Browse as usual, and we’ll take care of the rest. Get bundled private "
 "search, tracker blocking, and site encryption, all in one download, for "
 "%smajor browsers%s."
-msgstr ""
-"正常上网，剩下的交给我们。我们为 %1$s 主流浏览器 %2$s 提供了扩展，一键下载即"
-"可匿名搜索、屏蔽跟踪程序、开启网站加密。"
+msgstr "正常上网，剩下的交给我们。我们为 %1$s 主流浏览器 %2$s 提供了扩展，一键下载即可匿名搜索、屏蔽跟踪程序、开启网站加密。"
 
 # smartling.placeholder_format=C
 #. Header for a call to action to browse with the DuckDuckGo browser
@@ -3127,18 +3097,15 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"默认情况下，设置存储在浏览器 Cookie 中，不含隐私信息。你也可以使用匿名的 "
-"Cloud Save 功能把设置长期存放在我们的云服务器上，同样不会泄露隐私，使用的口令"
-"也只有浏览器知道。"
+"默认情况下，设置存储在浏览器 Cookie 中，不含隐私信息。你也可以使用匿名的 Cloud Save "
+"功能把设置长期存放在我们的云服务器上，同样不会泄露隐私，使用的口令也只有浏览器知道。"
 
 # smartling.placeholder_format=C
 #. Description for the consent highlight in the dictation consent modal. %s is replaced with a link to the help page.
 msgid ""
 "By enabling dictation, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
-msgstr ""
-"启用听写，即表示你同意将自己的语音数据发送给 OpenAI，以使用此功能。在开始使用"
-"之前，请参阅我们的%1$s。"
+msgstr "启用听写，即表示你同意将自己的语音数据发送给 OpenAI，以使用此功能。在开始使用之前，请参阅我们的%1$s。"
 
 # smartling.placeholder_format=C
 #. Description for the 'enable voice chat' section of the voice chat consent modal. Placeholder for the voice chat help page link and text. Example: 'By enabling voice chat, you consent to your voice data being sent to OpenAI for the use of this feature. See our voice chat help page before getting started.'
@@ -3146,9 +3113,7 @@ msgctxt "voice chat"
 msgid ""
 "By enabling voice chat, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
-msgstr ""
-"启用语音聊天，即表示你同意将自己的语音数据发送给 OpenAI，以使用此功能。在开始"
-"使用之前，请参阅我们的%1$s。"
+msgstr "启用语音聊天，即表示你同意将自己的语音数据发送给 OpenAI，以使用此功能。在开始使用之前，请参阅我们的%1$s。"
 
 # smartling.placeholder_format=C
 #. Golf leaderboard: player missed the cut
@@ -3397,7 +3362,7 @@ msgstr "演员表"
 #. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Cast & Crew"
-msgstr ""
+msgstr "演员与制作团队"
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -3632,10 +3597,9 @@ msgid ""
 "DuckDuckGo Search. However, you can still access Chat when this setting is "
 "off by visiting %shttps://duck.ai%s directly."
 msgstr ""
-"可以利用聊天功能（通过我们的 Duck.ai 服务提供）与第三方人工智能聊天模型进行匿"
-"名对话，该功能支持 OpenAI、Anthropic 等公司的模型。关闭此设置将隐藏 "
-"DuckDuckGo Search 上的聊天按钮和链接。不过，即使关闭该设置，仍然可以直接通过"
-"访问 %1$shttps://duck.ai%2$s 来使用聊天功能。 "
+"可以利用聊天功能（通过我们的 Duck.ai 服务提供）与第三方人工智能聊天模型进行匿名对话，该功能支持 OpenAI、Anthropic "
+"等公司的模型。关闭此设置将隐藏 DuckDuckGo Search 上的聊天按钮和链接。不过，即使关闭该设置，仍然可以直接通过访问 "
+"%1$shttps://duck.ai%2$s 来使用聊天功能。 "
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -3759,9 +3723,7 @@ msgctxt "Description for Chat History feature"
 msgid ""
 "Chats are stored locally on your device instead of on DuckDuckGo servers or "
 "remote servers. Disabling chat history will delete pinned chats."
-msgstr ""
-"聊天记录会存储在设备本机上，而非 DuckDuckGo 服务器或远程服务器上。禁用聊天历"
-"史记录会删除已置顶的聊天记录。"
+msgstr "聊天记录会存储在设备本机上，而非 DuckDuckGo 服务器或远程服务器上。禁用聊天历史记录会删除已置顶的聊天记录。"
 
 # smartling.placeholder_format=C
 #. Text explaining how the Chat History feature stores the user's chats locally to their device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection. Also explains that disabling chat history will delete pinned chats.
@@ -3773,9 +3735,8 @@ msgid ""
 "history will delete pinned chats, and disable the temporary storage of new "
 "prompts and responses."
 msgstr ""
-"聊天记录会存储在本地设备上。新的提示和回复在发送后会被加密并暂时存储在 "
-"DuckDuckGo 服务器上，以便在断开互联网连接时帮助恢复聊天记录。禁用聊天记录将删"
-"除置顶的聊天记录，并禁用新提示和回复的临时存储功能。"
+"聊天记录会存储在本地设备上。新的提示和回复在发送后会被加密并暂时存储在 DuckDuckGo "
+"服务器上，以便在断开互联网连接时帮助恢复聊天记录。禁用聊天记录将删除置顶的聊天记录，并禁用新提示和回复的临时存储功能。"
 
 # smartling.placeholder_format=C
 #. Title shown above the body copy in the Duck.ai recent chats IndexedDB unavailable notice.
@@ -4128,9 +4089,7 @@ msgctxt "Information about the effect of clearing browser data on recent chats"
 msgid ""
 "Clearing browser data deletes chats. Some browsers may keep recent chats "
 "indefinitely or auto-delete them after 7+ days of no AI Chat use."
-msgstr ""
-"清除浏览器数据会删除聊天记录。某些浏览器可能会无限期保留最近的聊天记录，或者"
-"在超过 7 天未使用 AI Chat 后自动将其删除。"
+msgstr "清除浏览器数据会删除聊天记录。某些浏览器可能会无限期保留最近的聊天记录，或者在超过 7 天未使用 AI Chat 后自动将其删除。"
 
 # smartling.placeholder_format=C
 #. Text explaining what happens to recent chats when browser data is cleared.
@@ -4139,9 +4098,7 @@ msgid ""
 "Clearing browser data deletes recent chats. Recent chats may be saved "
 "indefinitely or auto-deleted after 7 days without using Duck.ai, depending "
 "on your browser."
-msgstr ""
-"清除浏览器数据会删除近期聊天记录。在不使用 Duck.ai 的情况下，可以无限期保存近"
-"期聊天记录，或在 7 天后自动删除，具体取决于浏览器的设置。"
+msgstr "清除浏览器数据会删除近期聊天记录。在不使用 Duck.ai 的情况下，可以无限期保存近期聊天记录，或在 7 天后自动删除，具体取决于浏览器的设置。"
 
 # smartling.placeholder_format=C
 #. Warning message shown on the Block domain success modal. Blocked sites are stored in localStorage which is cleared alongside cookies when users clear browser data. Followed by a linked 'our free browser' text.
@@ -4158,8 +4115,8 @@ msgid ""
 "%sDuck.ai%s, our private AI chat service that supports chat models from "
 "OpenAI, Anthropic, and more."
 msgstr ""
-"点击“更多”以深入了解某个主题，并通过 %1$sDuck.ai%2$s 提出后续问题，我们的私密"
-"人工智能聊天服务支持 OpenAI、Anthropic 等聊天模型。"
+"点击“更多”以深入了解某个主题，并通过 %1$sDuck.ai%2$s 提出后续问题，我们的私密人工智能聊天服务支持 OpenAI、Anthropic "
+"等聊天模型。"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4200,9 +4157,7 @@ msgstr "在弹出的菜单中点击 %1$s更改搜索设置%2$s"
 msgid ""
 "Click %sEdit > Preferences%s (on Windows) %sSeaMonkey > Preferences%s (on "
 "Mac)"
-msgstr ""
-"Windows 系统点击 %1$s编辑 > 首选项%2$s，Mac 系统点击 %3$sSeaMonkey > 首选"
-"项%4$s"
+msgstr "Windows 系统点击 %1$s编辑 > 首选项%2$s，Mac 系统点击 %3$sSeaMonkey > 首选项%4$s"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -4232,9 +4187,7 @@ msgstr "在左侧的列表中点击 %1$s隐私和服务%2$s。"
 msgid ""
 "Click %sSafari%s in the top menu (On Windows, click the %sgears icon%s in "
 "the top right)"
-msgstr ""
-"在顶部菜单栏中点击 %1$sSafari 浏览器%2$s（Windows 系统点击右上角的 %3$s齿轮图"
-"标%4$s）"
+msgstr "在顶部菜单栏中点击 %1$sSafari 浏览器%2$s（Windows 系统点击右上角的 %3$s齿轮图标%4$s）"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4324,9 +4277,7 @@ msgctxt "cloudsave"
 msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Search Settings%s."
-msgstr ""
-"点击或轻触“%1$s删除我的数据%2$s”，即可删除来自云端的数据，但只要不点击／轻"
-"触“%3$s重置所有搜索设置%4$s”，相关数据就会一直保留在浏览器中。"
+msgstr "点击或轻触“%1$s删除我的数据%2$s”，即可删除来自云端的数据，但只要不点击／轻触“%3$s重置所有搜索设置%4$s”，相关数据就会一直保留在浏览器中。"
 
 # smartling.placeholder_format=C
 #. Tells users where to click in order to disable the cloud save feature and delete any data backed-up to the cloud.
@@ -4336,9 +4287,7 @@ msgctxt "cloudsave"
 msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Settings%s."
-msgstr ""
-"点击“%1$s删除我的数据%2$s”即可将云端的数据删除，但只要不点击“%3$s恢复初始设"
-"置%4$s”，从云端同步的设置就会一直保留在浏览器中。"
+msgstr "点击“%1$s删除我的数据%2$s”即可将云端的数据删除，但只要不点击“%3$s恢复初始设置%4$s”，从云端同步的设置就会一直保留在浏览器中。"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -4406,9 +4355,7 @@ msgstr "点击搜索栏中的下拉菜单"
 msgid ""
 "Click the dropdown menu beside %sSearch engine used in the address bar%s and "
 "select %sDuckDuckGo%s."
-msgstr ""
-"点击 %1$s在地址栏中使用的搜索引擎%2$s 旁边的下拉菜单，选择 "
-"%3$sDuckDuckGo%4$s。"
+msgstr "点击 %1$s在地址栏中使用的搜索引擎%2$s 旁边的下拉菜单，选择 %3$sDuckDuckGo%4$s。"
 
 # smartling.placeholder_format=C
 #. First step in a list of steps to take to disable the user's ad blocker
@@ -5081,7 +5028,7 @@ msgstr "创建图像"
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
-msgstr ""
+msgstr "根据这个食谱制作一份带有所需数量的购物清单。"
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed in the input field when starting a new image generation session.
@@ -5722,15 +5669,14 @@ msgstr "已达到听写限额"
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
 msgid "Dictation temporarily unavailable"
-msgstr ""
+msgstr "暂时无法使用听写功能"
 
 # smartling.placeholder_format=C
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
 "chat in Duck.ai without having to type."
-msgstr ""
-"听写功能使用 OpenAI 模型将语音转为文本，因此无需输入便可以在 Duck.ai 中聊天。"
+msgstr "听写功能使用 OpenAI 模型将语音转为文本，因此无需输入便可以在 Duck.ai 中聊天。"
 
 # smartling.placeholder_format=C
 #. In 0-click box -- link to definition.
@@ -6029,7 +5975,7 @@ msgctxt "settings"
 msgid ""
 "Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
 "filtered out. %sLearn More%s"
-msgstr ""
+msgstr "不想使用人工智能？%1$snoai.duckduckgo.com%2$s 不提供任何 AI 功能，并会筛选掉 AI 生成的图像。 %3$s了解详情%4$s"
 
 # smartling.placeholder_format=C
 #. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
@@ -6038,6 +5984,8 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
+"不想使用 AI？请访问 %1$snoai.duckduckgo.com%2$s 以在搜索时禁用 AI 功能并过滤掉 AI "
+"生成的图像。%3$s了解详情%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6153,13 +6101,13 @@ msgstr "起草一封简明扼要的电子邮件给供应商，要求提供家用
 #. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Draft a cover letter"
-msgstr ""
+msgstr "起草一封求职信"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Draft a cover letter for this job."
-msgstr ""
+msgstr "为这份工作起草一封求职信。"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -6300,9 +6248,7 @@ msgid ""
 "Duck.ai can now help answer questions about the page you're viewing. Page "
 "content is only included when you attach it, unless you choose to attach "
 "pages automatically in Settings."
-msgstr ""
-"Duck.ai 现在可以帮助回答你正在浏览的页面问题。页面内容仅在你附加时纳入，除非"
-"你选择在设置中自动附加页面。"
+msgstr "Duck.ai 现在可以帮助回答你正在浏览的页面问题。页面内容仅在你附加时纳入，除非你选择在设置中自动附加页面。"
 
 # smartling.placeholder_format=C
 #. Shown in the Duck.ai recent chats list on standalone when the browser API needed to store chats locally is missing or unavailable.
@@ -6311,9 +6257,7 @@ msgctxt ""
 msgid ""
 "Duck.ai can’t access local storage to save your chats. Please check your "
 "browser settings or disable any extensions and try again."
-msgstr ""
-"Duck.ai 无法访问本地存储来保存您的聊天记录。请检查浏览器设置或禁用任何扩展程"
-"序再试一次。"
+msgstr "Duck.ai 无法访问本地存储来保存您的聊天记录。请检查浏览器设置或禁用任何扩展程序再试一次。"
 
 # smartling.placeholder_format=C
 #. Displayed when the chat service has reached the maximum number of messages for one day.
@@ -6336,7 +6280,7 @@ msgid ""
 "Duck.ai is created by DuckDuckGo. We're an independent online protection "
 "company for anyone who wants to take back control of their personal "
 "information."
-msgstr ""
+msgstr "Duck.ai 由 DuckDuckGo 创建。我们是一家独立的在线安全保护公司，致力于帮助任何希望重新掌控自己个人信息的人。"
 
 # smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
@@ -6350,9 +6294,7 @@ msgctxt "duckai_migration"
 msgid ""
 "Duck.ai is still a DuckDuckGo product, but will now have an easier to "
 "remember home on the web: https://duck.ai"
-msgstr ""
-"Duck.ai 仍然是 DuckDuckGo 的产品，但现在将拥有一个更容易记住的网站主页："
-"https://duck.ai"
+msgstr "Duck.ai 仍然是 DuckDuckGo 的产品，但现在将拥有一个更容易记住的网站主页：https://duck.ai"
 
 # smartling.placeholder_format=C
 #. Headline for domain change notice.
@@ -6366,9 +6308,7 @@ msgctxt "Error message for BOTNET limit."
 msgid ""
 "Duck.ai is temporarily unavailable. If this persists, please email this "
 "anonymous code %s to %s"
-msgstr ""
-"暂时无法使用 Duck.ai。如果仍有问题，请通过电子邮件将此匿名代码 %1$s 发送到 "
-"%2$s"
+msgstr "暂时无法使用 Duck.ai。如果仍有问题，请通过电子邮件将此匿名代码 %1$s 发送到 %2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -6388,7 +6328,7 @@ msgctxt "settings"
 msgid ""
 "Duck.ai lets you chat privately with popular AI models. Disabling it hides "
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
-msgstr ""
+msgstr "Duck.ai 让你能够私密地与热门 AI 模型进行对话。禁用后将隐藏 Duck.ai 按钮和链接，但你仍然可以直接访问 %1$sduck.ai%2$s。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6399,10 +6339,9 @@ msgid ""
 "can still access Duck.ai when this setting is off by visiting %shttps://duck."
 "ai%s directly."
 msgstr ""
-"可以利用 Duck.ai 与第三方人工智能聊天模型进行匿名对话，包括来自 OpenAI、"
-"Anthropic 等公司的模型。关闭此设置将隐藏 DuckDuckGo Search 中的 Duck.ai 按钮"
-"和链接。不过，即使关闭该设置，仍然可以直接通过访问 %1$shttps://duck.ai%2$s 来"
-"使用 Duck.ai。"
+"可以利用 Duck.ai 与第三方人工智能聊天模型进行匿名对话，包括来自 OpenAI、Anthropic 等公司的模型。关闭此设置将隐藏 "
+"DuckDuckGo Search 中的 Duck.ai 按钮和链接。不过，即使关闭该设置，仍然可以直接通过访问 "
+"%1$shttps://duck.ai%2$s 来使用 Duck.ai。"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
@@ -6457,9 +6396,8 @@ msgid ""
 "AI chat no sign up, OpenAI, Anthropic, Llama, Mistral, open source AI "
 "models, privacy focused AI, no account AI chat"
 msgstr ""
-"Duck.ai、DuckDuckGo AI、私人 AI 聊天机器人、免费 AI 聊天、匿名 AI 聊天、无需"
-"注册的 AI 聊天、OpenAI、Anthropic、Llama、Mistral、开源 AI 模型、注重隐私的 "
-"AI、无需账户的 AI 聊天"
+"Duck.ai、DuckDuckGo AI、私人 AI 聊天机器人、免费 AI 聊天、匿名 AI 聊天、无需注册的 AI "
+"聊天、OpenAI、Anthropic、Llama、Mistral、开源 AI 模型、注重隐私的 AI、无需账户的 AI 聊天"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -6487,10 +6425,10 @@ msgid ""
 "relevant), or Often (shows more frequently on a wider range of searches). "
 "For now, DuckAssist is only available in the U.S. (English) region."
 msgstr ""
-"DuckAssist 可以匿名查找和汇总信息，以响应某些搜索。可以选择 DuckAssist 的显示"
-"频率：从不（从搜索结果中完全移除 DuckAssist 用户界面)、按需（仅在点击“协助”按"
-"钮时显示）、有时（仅在高度相关时显示）或经常（在更广泛的搜索中更频繁地显"
-"示）。DuckAssist 目前仅供美国（英语）地区使用。"
+"DuckAssist 可以匿名查找和汇总信息，以响应某些搜索。可以选择 DuckAssist 的显示频率：从不（从搜索结果中完全移除 "
+"DuckAssist "
+"用户界面)、按需（仅在点击“协助”按钮时显示）、有时（仅在高度相关时显示）或经常（在更广泛的搜索中更频繁地显示）。DuckAssist "
+"目前仅供美国（英语）地区使用。"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6499,9 +6437,8 @@ msgid ""
 "%sDuckDuckGo AI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI, and Anthropic, and more."
 msgstr ""
-"DuckAssist 无法回答后续问题，但是，我们还提供 %1$sDuckDuckGo AI Chat%2$s，这"
-"是一种人工智能驱动的私密聊天服务，支持包括 OpenAI 和 Anthropic 在内的多种聊天"
-"模型。"
+"DuckAssist 无法回答后续问题，但是，我们还提供 %1$sDuckDuckGo AI "
+"Chat%2$s，这是一种人工智能驱动的私密聊天服务，支持包括 OpenAI 和 Anthropic 在内的多种聊天模型。"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6510,8 +6447,8 @@ msgid ""
 "DuckDuckGo %sAI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI and Anthropic."
 msgstr ""
-"DuckAssist 无法回答后续问题，但是，我们还提供 DuckDuckGo %1$sAI Chat%2$s，这"
-"是一种人工智能驱动的私密聊天服务，支持 OpenAI 和 Anthropic 的聊天模型。"
+"DuckAssist 无法回答后续问题，但是，我们还提供 DuckDuckGo %1$sAI Chat%2$s，这是一种人工智能驱动的私密聊天服务，支持 "
+"OpenAI 和 Anthropic 的聊天模型。"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6523,10 +6460,10 @@ msgid ""
 "responses are currently based on Wikipedia and related content and are not "
 "checked for accuracy."
 msgstr ""
-"DuckAssist 是我们搜索结果中的一项新功能，可以匿名生成搜索查询的答案。为此，该"
-"功能会扫描维基百科和相关网站的相关内容，然后使用人工智能驱动的自然语言技术生"
-"成这些信息的摘要。 请注意，其回复目前基于维基百科和相关内容，其准确性未经核"
-"实。"
+"DuckAssist "
+""
+"是我们搜索结果中的一项新功能，可以匿名生成搜索查询的答案。为此，该功能会扫描维基百科和相关网站的相关内容，然后使用人工智能驱动的自然语言技术生成这些信息的摘要。 "
+"请注意，其回复目前基于维基百科和相关内容，其准确性未经核实。"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6540,11 +6477,10 @@ msgid ""
 "It’s important to remember that responses are auto-generated from cited "
 "sources and based on %scrawling the web%s."
 msgstr ""
-"DuckAssist 是我们搜索结果中的一项可选功能，可以匿名生成搜索查询的答案。为此，"
-"该功能会扫描网络上的相关内容，然后使用人工智能驱动的自然语言技术，根据找到的"
-"相关信息生成简短的答案。DuckAssist 的回复始终直接链接到一个或两个资料来源，并"
-"注明答案的出处，以便你轻松获取更详细的信息。请务必记住，这些回复来自引用的资"
-"料来源，并通过%1$s爬取网络内容%2$s自动生成。"
+"DuckAssist "
+""
+"是我们搜索结果中的一项可选功能，可以匿名生成搜索查询的答案。为此，该功能会扫描网络上的相关内容，然后使用人工智能驱动的自然语言技术，根据找到的相关信息生成简短的答案。DuckAssist "
+"的回复始终直接链接到一个或两个资料来源，并注明答案的出处，以便你轻松获取更详细的信息。请务必记住，这些回复来自引用的资料来源，并通过%1$s爬取网络内容%2$s自动生成。"
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
@@ -6567,9 +6503,7 @@ msgctxt "Modal body for information"
 msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
-msgstr ""
-"DuckDuckGo AI Chat 是一种私密人工智能驱动型聊天服务，目前支持 %1$s 的 %2$s "
-"和 %3$s 的 %4$s 聊天模型。"
+msgstr "DuckDuckGo AI Chat 是一种私密人工智能驱动型聊天服务，目前支持 %1$s 的 %2$s 和 %3$s 的 %4$s 聊天模型。"
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the welcome screen of the onboarding. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -6577,9 +6511,7 @@ msgctxt "Onboarding welcome screen subtitle"
 msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
-msgstr ""
-"DuckDuckGo AI Chat 是一种私密人工智能驱动型聊天服务，目前支持 %1$s 的 %2$s "
-"和 %3$s 的 %4$s 聊天模型。"
+msgstr "DuckDuckGo AI Chat 是一种私密人工智能驱动型聊天服务，目前支持 %1$s 的 %2$s 和 %3$s 的 %4$s 聊天模型。"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding DuckDuckGo AI Chat.
@@ -6595,9 +6527,7 @@ msgctxt "Error message for BOTNET limit."
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. If this persists, please "
 "email this anonymous code %s to %s"
-msgstr ""
-"暂时无法使用 DuckDuckGo AI Chat。如果仍有问题，请通过电子邮件将此匿名代码 "
-"%1$s 发送到 %2$s"
+msgstr "暂时无法使用 DuckDuckGo AI Chat。如果仍有问题，请通过电子邮件将此匿名代码 %1$s 发送到 %2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -6729,18 +6659,14 @@ msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
 msgid ""
 "DuckDuckGo anonymizes these reports by automatically removing PII like "
 "names, email addresses, phone numbers, and identifying metadata."
-msgstr ""
-"DuckDuckGo 通过自动删除姓名、电子邮件地址、电话号码和识别元数据等个人身份信息"
-"来对这些报告进行匿名化。"
+msgstr "DuckDuckGo 通过自动删除姓名、电子邮件地址、电话号码和识别元数据等个人身份信息来对这些报告进行匿名化。"
 
 # smartling.placeholder_format=C
 #. The first %s is the agree button label ('Agree'). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. The leading sentence mirrors the drawer-style inline disclaimer (DUCKCHAT_TOS_INLINE_DISCLAIMER).
 msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid ""
 "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to Duck.ai's %s."
-msgstr ""
-"DuckDuckGo 会对你的聊天内容进行匿名处理。点击“%1$s”即表示你同意 Duck.ai 的 "
-"%2$s。"
+msgstr "DuckDuckGo 会对你的聊天内容进行匿名处理。点击“%1$s”即表示你同意 Duck.ai 的 %2$s。"
 
 # smartling.placeholder_format=C
 #. Shown below the input on the empty state when the user has not yet accepted the terms of service. The first %s is the action button label ('Ask' for chat, 'Create' for image generation). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. Clicking the action button both accepts the terms and submits the prompt.
@@ -6748,8 +6674,7 @@ msgctxt ""
 "Inline terms-of-service disclaimer below chat or image-gen input for new "
 "users"
 msgid "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to our %s."
-msgstr ""
-"DuckDuckGo 会对你的聊天内容进行匿名处理。点击“%1$s”即表示你同意我们的 %2$s。"
+msgstr "DuckDuckGo 会对你的聊天内容进行匿名处理。点击“%1$s”即表示你同意我们的 %2$s。"
 
 # smartling.placeholder_format=C
 #. An information popup explaining that we block trackers
@@ -6757,9 +6682,7 @@ msgid ""
 "DuckDuckGo blocks trackers on websites you visit, including trackers from "
 "companies like Google and Facebook, who often try to track you on other "
 "websites."
-msgstr ""
-"DuckDuckGo 会屏蔽所访问网站的跟踪程序，包括来自 Google 和 Facebook 等公司的跟"
-"踪程序，这些公司经常试图在其他网站上跟踪你。"
+msgstr "DuckDuckGo 会屏蔽所访问网站的跟踪程序，包括来自 Google 和 Facebook 等公司的跟踪程序，这些公司经常试图在其他网站上跟踪你。"
 
 # smartling.placeholder_format=C
 #. Description of how DuckDuckGo keeps a user's location anonymous while the user searches on a map of their area.
@@ -6771,9 +6694,8 @@ msgid ""
 "away, such that you remain anonymous. %sLearn more about how we designed "
 "this technology to protect your privacy%s."
 msgstr ""
-"DuckDuckGo 的设计力图保护用户隐私，定位信息仅存储于你的设备中，只有发起搜索时"
-"会上传给我们用以优化搜索结果，搜索完成后我们也不会保留，以保证搜索匿名"
-"性。%1$s详细了解我们是如何设计这一功能来保护隐私的%2$s。"
+"DuckDuckGo "
+"的设计力图保护用户隐私，定位信息仅存储于你的设备中，只有发起搜索时会上传给我们用以优化搜索结果，搜索完成后我们也不会保留，以保证搜索匿名性。%1$s详细了解我们是如何设计这一功能来保护隐私的%2$s。"
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
@@ -6792,8 +6714,7 @@ msgctxt "settings"
 msgid ""
 "DuckDuckGo only uses your approximate location. That's all we need to "
 "deliver better results, closer to you. %sLearn more%s."
-msgstr ""
-"DuckDuckGo 只需了解你的大致位置即可优化你附近的搜索结果。%1$s了解详情%2$s。"
+msgstr "DuckDuckGo 只需了解你的大致位置即可优化你附近的搜索结果。%1$s了解详情%2$s。"
 
 # smartling.placeholder_format=C
 msgid "DuckDuckGo search"
@@ -6879,8 +6800,8 @@ msgid ""
 "random words from that list, ensuring that the passphrase is at least 18-20 "
 "characters long."
 msgstr ""
-"当你选择自动生成口令时，我们会从 DuckDuckGo 服务器获取一系列随机的英文词汇，"
-"并在浏览器端从中选取四五个，保证总长度至少有 18 到 20 个字符。"
+"当你选择自动生成口令时，我们会从 DuckDuckGo 服务器获取一系列随机的英文词汇，并在浏览器端从中选取四五个，保证总长度至少有 18 到 20 "
+"个字符。"
 
 # smartling.placeholder_format=C
 msgctxt "Sports module"
@@ -7117,9 +7038,7 @@ msgctxt "precise_user_location"
 msgid ""
 "Enabling anonymous location gives more accurate results but still keeps your "
 "searches and exact location private to DuckDuckGo."
-msgstr ""
-"启用匿名定位功能可获得更精确的结果，但 DuckDuckGo 仍会保密你的搜索和确切位置"
-"信息。"
+msgstr "启用匿名定位功能可获得更精确的结果，但 DuckDuckGo 仍会保密你的搜索和确切位置信息。"
 
 # smartling.placeholder_format=C
 msgid "Encrypt Connections"
@@ -7305,8 +7224,7 @@ msgstr "输入文本"
 #. Instructions for how to change the default search engine.
 msgid ""
 "Enter the following details: %sName%s: DuckDuckGo%s URL%s: %s Alias%s: d%s"
-msgstr ""
-"输入下列信息：%1$s名称%2$s：DuckDuckGo%3$s搜索串%4$s：%5$s快捷字%6$s：d%7$s"
+msgstr "输入下列信息：%1$s名称%2$s：DuckDuckGo%3$s搜索串%4$s：%5$s快捷字%6$s：d%7$s"
 
 # smartling.placeholder_format=C
 #. Prompt to enter a destination for driving directions.
@@ -7350,13 +7268,13 @@ msgstr "厄立特里亚"
 #. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Estimate the nutrition"
-msgstr ""
+msgstr "估算营养成分"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Estimate the nutritional information for this recipe."
-msgstr ""
+msgstr "估算这份食谱的营养成分信息。"
 
 # smartling.placeholder_format=C
 msgid "Estonia"
@@ -7416,7 +7334,7 @@ msgstr "1 天后失效"
 #. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain the accepted answer in simple terms."
-msgstr ""
+msgstr "用简单易懂的方式解释这个已采纳的答案。"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
@@ -7429,43 +7347,43 @@ msgstr "以高中生的水平向我解释黑洞的基本概念。"
 #. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain the top answer"
-msgstr ""
+msgstr "解释一下最受认可的答案"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain this in simple, plain language."
-msgstr ""
+msgstr "用简单易懂的语言解释一下。"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain this paper"
-msgstr ""
+msgstr "解释此篇论文"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain this repo"
-msgstr ""
+msgstr "解释此代码库"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain this research paper in plain language."
-msgstr ""
+msgstr "用简单易懂的语言解释这篇研究论文。"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain this simply"
-msgstr ""
+msgstr "简单解释一下"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain what this repository does and how to use it."
-msgstr ""
+msgstr "解释此代码库的功能及使用方法。"
 
 # smartling.placeholder_format=C
 #. Label to show if song lyrics contain explicit content
@@ -7650,9 +7568,7 @@ msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and "
 "improvements. Hopefully we can address the issue you shared too."
-msgstr ""
-"类似你这样的反馈会直接影响我们的产品更新和改进。希望我们也能解决你提出的问"
-"题。"
+msgstr "类似你这样的反馈会直接影响我们的产品更新和改进。希望我们也能解决你提出的问题。"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box
@@ -7748,7 +7664,7 @@ msgstr "从图像搜索结果中筛选掉人工智能生成的图像。%1$s了�
 msgctxt "settings"
 msgid ""
 "Filters out known AI spam sites from image search results. %sLearn More%s"
-msgstr ""
+msgstr "从图像搜索结果中筛选掉已知的 AI 垃圾网站。%1$s了解详情%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the final score of a sporting event.
@@ -7807,7 +7723,7 @@ msgstr "查找当前信息"
 #. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Find me alternatives"
-msgstr ""
+msgstr "寻找替代方案"
 
 # smartling.placeholder_format=C
 #. Button that searches for results closer to the user's current location.
@@ -8111,9 +8027,8 @@ msgid ""
 "<strong>Check for Updates...</strong>, then select <strong>Install Update</"
 "strong>."
 msgstr ""
-"在 Mac 的应用程序菜单栏中选择“<strong>DuckDuckGo</strong>” &gt; "
-"“<strong>Check for Updates...</strong>”（查看更新……），然后选"
-"择“<strong>Install Update</strong>”（安装更新）。"
+"在 Mac 的应用程序菜单栏中选择“<strong>DuckDuckGo</strong>” &gt; “<strong>Check for "
+"Updates...</strong>”（查看更新……），然后选择“<strong>Install Update</strong>”（安装更新）。"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -8284,7 +8199,7 @@ msgstr "生成更多内容"
 #. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Generate a shopping list"
-msgstr ""
+msgstr "生成购物清单"
 
 # smartling.placeholder_format=C
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
@@ -8463,9 +8378,7 @@ msgctxt "Description of the modal to upgrade the DuckDuckGo subscription"
 msgid ""
 "Get access to advanced AI models in Duck.ai by subscribing to DuckDuckGo, "
 "which also includes our VPN and other premium privacy protections."
-msgstr ""
-"订阅 DuckDuckGo 即可使用 Duck.ai 的高级人工智能模型，同时还包括我们的 VPN 和"
-"其他高级隐私保护功能。"
+msgstr "订阅 DuckDuckGo 即可使用 Duck.ai 的高级人工智能模型，同时还包括我们的 VPN 和其他高级隐私保护功能。"
 
 # smartling.placeholder_format=C
 #. Description for the subscription setting where users can subscribe to DuckDuckGo.
@@ -8475,9 +8388,7 @@ msgctxt ""
 msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
-msgstr ""
-"通过 DuckDuckGo 订阅使用 Duck.ai 的高级人工智能模型，其中还包括我们的 VPN 和"
-"其他高级隐私保护功能。"
+msgstr "通过 DuckDuckGo 订阅使用 Duck.ai 的高级人工智能模型，其中还包括我们的 VPN 和其他高级隐私保护功能。"
 
 # smartling.placeholder_format=C
 #. A button for users to generate an AI generated answer from their query on the duckassist module
@@ -8579,7 +8490,7 @@ msgstr "试试看"
 #. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Give me a quick background on this person."
-msgstr ""
+msgstr "简单介绍一下这个人的背景。"
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -8601,9 +8512,7 @@ msgctxt "precise_user_location"
 msgid ""
 "Go to %sSettings > Privacy > Permission manager > Location%s and scroll down "
 "to %sDuckDuckGo%s."
-msgstr ""
-"转到%1$s“设置” > “隐私” > “权限管理器” > “定位”%2$s，然后向下滚动至 "
-"%3$sDuckDuckGo%4$s。"
+msgstr "转到%1$s“设置” > “隐私” > “权限管理器” > “定位”%2$s，然后向下滚动至 %3$sDuckDuckGo%4$s。"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9029,13 +8938,13 @@ msgstr "协助推广隐私保护"
 #. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Help me prep for the interview"
-msgstr ""
+msgstr "帮我准备面试"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Help me tailor my resume for this job."
-msgstr ""
+msgstr "帮我根据这份工作优化我的简历。"
 
 # smartling.placeholder_format=C
 #. Title of a SERP popup that invites users to take a survey (desktop only)
@@ -9299,9 +9208,7 @@ msgstr "历史"
 msgid ""
 "Hit %sReturn%s on your keyboard to %ssave DuckDuckGo to the list. %sThen "
 "click %sMake Default%s"
-msgstr ""
-"按下键盘上的 %1$s回车键%2$s%3$s将 DuckDuckGo 添加到列表中，%4$s然后点击 %5$s"
-"设为默认搜索引擎%6$s"
+msgstr "按下键盘上的 %1$s回车键%2$s%3$s将 DuckDuckGo 添加到列表中，%4$s然后点击 %5$s设为默认搜索引擎%6$s"
 
 # smartling.placeholder_format=C
 #. The name of the Hmong Daw language
@@ -9314,9 +9221,7 @@ msgstr "白苗语"
 msgid ""
 "Hold on! Changing it back will disable the DuckDuckGo extension and you'll "
 "lose our privacy protection."
-msgstr ""
-"稍等！将其改回默认搜索引擎将禁用 DuckDuckGo 扩展程序，并将失去我们的隐私保"
-"护。"
+msgstr "稍等！将其改回默认搜索引擎将禁用 DuckDuckGo 扩展程序，并将失去我们的隐私保护。"
 
 # smartling.placeholder_format=C
 #. Heading shown above warning messages in the AI chat, for non-critical issues like unsupported file formats or file size limits. Analogous to 'Oops...' for error messages.
@@ -9552,7 +9457,7 @@ msgctxt ""
 "Text for the I already have a subscription button in the Duck.ai settings "
 "page"
 msgid "I Already Have a Subscription"
-msgstr ""
+msgstr "我已经有一个订阅"
 
 # smartling.placeholder_format=C
 #. Text for the button that takes the user to the login subscription page.
@@ -9661,9 +9566,7 @@ msgctxt "precise_user_location"
 msgid ""
 "If the browser location remains unavailable, then go to %sSettings > General "
 "> Reset > 'Reset Location & Privacy'%s."
-msgstr ""
-"如果仍然无法使用浏览器定位，请前往%1$s“设置” > “通用” > “还原” > “还原位置与"
-"隐私”%2$s。"
+msgstr "如果仍然无法使用浏览器定位，请前往%1$s“设置” > “通用” > “还原” > “还原位置与隐私”%2$s。"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -9673,8 +9576,8 @@ msgid ""
 "> Menu > Settings > Site settings > Location%s, and ensure DuckDuckGo is "
 "allowed location access."
 msgstr ""
-"如果仍然无法使用浏览器定位，请在浏览器中转到%1$s“⋮” > “菜单” > “设置” > “网站"
-"设置” > “位置”%2$s，并确认已允许 DuckDuckGo 使用定位信息。"
+"如果仍然无法使用浏览器定位，请在浏览器中转到%1$s“⋮” > “菜单” > “设置” > “网站设置” > “位置”%2$s，并确认已允许 "
+"DuckDuckGo 使用定位信息。"
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -9688,8 +9591,7 @@ msgstr "如果你继续看到此错误，请联系 %1$s。"
 msgid ""
 "If you don't see %sDuckDuckGo,%s you will need to add it to the list of "
 "%sOther Search Engines%s"
-msgstr ""
-"如果找不到 %1$sDuckDuckGo%2$s，你需要手动将其添加到 %3$s其他搜索引擎%4$s 中"
+msgstr "如果找不到 %1$sDuckDuckGo%2$s，你需要手动将其添加到 %3$s其他搜索引擎%4$s 中"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding the AI model providers and links to their support pages. Example: 'If you have concerns about our chat providers or any particular chat response, you can also reach out directly to OpenAI and Anthropic support pages.'
@@ -9697,9 +9599,7 @@ msgctxt "Disclaimer text at the bottom of the feedback form."
 msgid ""
 "If you have concerns about our chat providers or any particular chat "
 "response, you can also reach out directly to %s and %s support pages."
-msgstr ""
-"如果你对我们的聊天提供商或任何特定的聊天回复有疑虑，也可以直接联系 %1$s 和 "
-"%2$s 支持页面。"
+msgstr "如果你对我们的聊天提供商或任何特定的聊天回复有疑虑，也可以直接联系 %1$s 和 %2$s 支持页面。"
 
 # smartling.placeholder_format=C
 #. Body copy explaining what the recovery code is for and how it can be saved.
@@ -9707,9 +9607,7 @@ msgctxt "Body for the Sync & Backup recovery code screen"
 msgid ""
 "If you lose access to your devices, you will need this code to recover your "
 "saved chats. You can save this code to your device as a text file."
-msgstr ""
-"如果您无法访问自己的设备，则将需要此代码来恢复保存的聊天记录。您可以将此代码"
-"以文本文件的形式保存到设备中。"
+msgstr "如果您无法访问自己的设备，则将需要此代码来恢复保存的聊天记录。您可以将此代码以文本文件的形式保存到设备中。"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/ReKkJtU.png
@@ -9724,9 +9622,7 @@ msgstr "如果你仍愿支持我们，可%1$s协助推广 DuckDuckGo%2$s"
 msgid ""
 "If you want to use DuckDuckGo without JavaScript, please use our %s or %s "
 "versions."
-msgstr ""
-"如需在关闭 JavaScript 的情况下使用 DuckDuckGo，请使用我们的 %1$s 或者 %2$s 版"
-"本。"
+msgstr "如需在关闭 JavaScript 的情况下使用 DuckDuckGo，请使用我们的 %1$s 或者 %2$s 版本。"
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -9873,9 +9769,7 @@ msgctxt "settings"
 msgid ""
 "In some older browsers, it's necessary to redirect your clicks through our "
 "server to prevent search leakage. %sLearn more%s."
-msgstr ""
-"如果使用某些过时的浏览器，点击搜索结果后需要经过我们的服务器重定向才能避免泄"
-"露搜索内容。%1$s了解详情%2$s。"
+msgstr "如果使用某些过时的浏览器，点击搜索结果后需要经过我们的服务器重定向才能避免泄露搜索内容。%1$s了解详情%2$s。"
 
 # smartling.placeholder_format=C
 #. Instructions accompanying DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE; tells the user where to use the code on a DuckDuckGo browser.
@@ -9885,8 +9779,7 @@ msgctxt ""
 msgid ""
 "In the DuckDuckGo browser, go to Settings › Sync & Backup, and then “Sync "
 "with another device”."
-msgstr ""
-"在 DuckDuckGo 浏览器中，前往设置 › Sync & Backup，然后选择“与其他设备同步”。"
+msgstr "在 DuckDuckGo 浏览器中，前往设置 › Sync & Backup，然后选择“与其他设备同步”。"
 
 #  SeaMonkey default search engine instruction
 # smartling.placeholder_format=C
@@ -9900,9 +9793,7 @@ msgctxt "cloudsave"
 msgid ""
 "In the interest of transparency, this data is not encrypted: You can see "
 "exactly what information we store."
-msgstr ""
-"本着透明公开的原则，上传的信息也没有加密处理，如果你感兴趣的话可以看到我们具"
-"体都存了什么。"
+msgstr "本着透明公开的原则，上传的信息也没有加密处理，如果你感兴趣的话可以看到我们具体都存了什么。"
 
 # smartling.placeholder_format=C
 msgid "In the menu at the top select %sTools%s > %sSettings%s"
@@ -10121,7 +10012,7 @@ msgstr "安装 Mac 浏览器"
 #. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
 msgctxt "settings"
 msgid "Install Now"
-msgstr ""
+msgstr "立即安装"
 
 # smartling.placeholder_format=C
 #. Text of a button to install the DuckDuckGo app
@@ -10224,13 +10115,13 @@ msgstr "数据真的已被删除掉吗？"
 #. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Is it worth taking?"
-msgstr ""
+msgstr "值得采纳吗？"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Is this place any good?"
-msgstr ""
+msgstr "这个地方怎么样？"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
@@ -10238,7 +10129,7 @@ msgctxt "Page suggestion prompt"
 msgid ""
 "Is this place any good? Summarize its reputation based on reviews and "
 "ratings."
-msgstr ""
+msgstr "这个地方怎么样？结合评论和评分，总结一下大家对它的评价。"
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -10250,13 +10141,13 @@ msgstr "此视频有用吗？"
 #. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Is this worth watching?"
-msgstr ""
+msgstr "值得看吗？"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Is this worth watching? Give me a spoiler-free take."
-msgstr ""
+msgstr "值得看吗？请给个不剧透的评价。"
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -10307,8 +10198,8 @@ msgid ""
 "through Microsoft's Ad Network. Clicks lead directly to merchant landing "
 "pages and unlike ads, DuckDuckGo is not compensated for these results."
 msgstr ""
-"结果根据与搜索词的相关程度排序，并通过 Microsoft 的广告网络提供。链接直接指向"
-"商户页面，与广告不同，DuckDuckGo 不会通过这些搜索结果获得收益。"
+"结果根据与搜索词的相关程度排序，并通过 Microsoft 的广告网络提供。链接直接指向商户页面，与广告不同，DuckDuckGo "
+"不会通过这些搜索结果获得收益。"
 
 # smartling.placeholder_format=C
 #. Text explaining why passphrases use a series of words instead of random numbers and letters.
@@ -10866,7 +10757,7 @@ msgstr "链接："
 #. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
-msgstr ""
+msgstr "完成这个项目需要哪些工具、材料或准备工作？"
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -11278,7 +11169,7 @@ msgstr "管理已屏蔽网站"
 #. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
 msgctxt "setting"
 msgid "Manage in Browser Settings"
-msgstr ""
+msgstr "在浏览器设置中管理"
 
 # smartling.placeholder_format=C
 #. Link to the site exclusion settings page
@@ -12251,9 +12142,8 @@ msgid ""
 "internet connection. Disabling chat history will delete pinned chats, and "
 "disable the temporary storage of new prompts and responses."
 msgstr ""
-"新的提示和回复在发送后会被加密并暂时存储在 DuckDuckGo 服务器上，以便在断开互"
-"联网连接时帮助恢复聊天记录。禁用聊天记录将删除置顶的聊天记录，并禁用新提示和"
-"回复的临时存储功能。"
+"新的提示和回复在发送后会被加密并暂时存储在 DuckDuckGo "
+"服务器上，以便在断开互联网连接时帮助恢复聊天记录。禁用聊天记录将删除置顶的聊天记录，并禁用新提示和回复的临时存储功能。"
 
 # smartling.placeholder_format=C
 #. Question in a feedback form.
@@ -13068,9 +12958,7 @@ msgstr "按需"
 msgid ""
 "On Mac, %sClick Maxthon > Preferences%s, On Windows, %sClick the %s icon > "
 "Settings%s"
-msgstr ""
-"Mac 系统 %1$s点击 Maxthon > 设置%2$s，Windows 系统 %3$s点击 %4$s 图标 > 设"
-"置%5$s"
+msgstr "Mac 系统 %1$s点击 Maxthon > 设置%2$s，Windows 系统 %3$s点击 %4$s 图标 > 设置%5$s"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
@@ -13447,9 +13335,7 @@ msgctxt "homepage onboarding"
 msgid ""
 "Other search engines track your searches even when you’re in private "
 "browsing mode. We don’t track you &mdash; period."
-msgstr ""
-"即使在隐私浏览模式中，某些搜索引擎照样会跟踪你。而我们不会跟踪你，就这么简"
-"单。"
+msgstr "即使在隐私浏览模式中，某些搜索引擎照样会跟踪你。而我们不会跟踪你，就这么简单。"
 
 # smartling.placeholder_format=C
 msgctxt "SERP footer content"
@@ -13468,9 +13354,7 @@ msgid ""
 "Our private browser for mobile comes equipped with our search engine, "
 "tracker blocker, encryption enforcer, and more. Available on %siOS & "
 "Android%s."
-msgstr ""
-"我们的移动端隐私浏览器预置了搜索引擎，还可以屏蔽跟踪程序、开启网站加密等等。"
-"现已支持 %1$siOS 和 Android%2$s。"
+msgstr "我们的移动端隐私浏览器预置了搜索引擎，还可以屏蔽跟踪程序、开启网站加密等等。现已支持 %1$siOS 和 Android%2$s。"
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the information was out of date.
@@ -13722,9 +13606,7 @@ msgctxt "cloudsave"
 msgid ""
 "Passphrases cannot be recovered as we don't associate your IP address, "
 "browser fingerprint, or any other information with the file."
-msgstr ""
-"我们存储设置时并未记录你的 IP 地址、浏览器指纹或任何其他信息，因此无法找回口"
-"令。"
+msgstr "我们存储设置时并未记录你的 IP 地址、浏览器指纹或任何其他信息，因此无法找回口令。"
 
 # smartling.placeholder_format=C
 #. Label for the section of recent chats that were edited in the past 7 days.
@@ -13917,9 +13799,7 @@ msgid ""
 "assisted answers more likely to appear automatically and often yields better "
 "answers. To turn them off and hide the Assist button visit %sSearch "
 "Settings%s."
-msgstr ""
-"以问题和完整的句子进行搜索，会更有可能自动显示人工智能辅助的答案，通常也能获"
-"得更佳答案。若要将其关闭并隐藏“Assist”按钮，请访问“%1$s搜索设置%2$s”。"
+msgstr "以问题和完整的句子进行搜索，会更有可能自动显示人工智能辅助的答案，通常也能获得更佳答案。若要将其关闭并隐藏“Assist”按钮，请访问“%1$s搜索设置%2$s”。"
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -13928,8 +13808,8 @@ msgid ""
 "DuckAssist more likely to appear and often yields better answers. To adjust "
 "how this feature works, or to turn it off, visit %sDuckAssist Settings%s."
 msgstr ""
-"以问题和完整的句子进行搜索，会更有可能显示 DuckAssist，通常也能获得更佳答"
-"案。 如需调整此功能的工作方式或将其关闭，请访问 %1$sDuckAssist 设置%2$s。"
+"以问题和完整的句子进行搜索，会更有可能显示 DuckAssist，通常也能获得更佳答案。 如需调整此功能的工作方式或将其关闭，请访问 "
+"%1$sDuckAssist 设置%2$s。"
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -13939,8 +13819,8 @@ msgid ""
 "answers. To turn it off and hide the Assist button visit %sDuckAssist "
 "Settings%s."
 msgstr ""
-"以问题和完整的句子进行搜索，会更有可能自动显示 DuckAssist，通常也能获得更佳答"
-"案。若要将其关闭并隐藏“协助”按钮，请访问 %1$sDuckAssist 设置%2$s。"
+"以问题和完整的句子进行搜索，会更有可能自动显示 DuckAssist，通常也能获得更佳答案。若要将其关闭并隐藏“协助”按钮，请访问 "
+"%1$sDuckAssist 设置%2$s。"
 
 # smartling.placeholder_format=C
 #. Button that allows users to manually select a location on a map.
@@ -13980,8 +13860,7 @@ msgctxt "Body copy for the chat card in the How Duck.ai Works panel"
 msgid ""
 "Pick a popular AI to chat with, like GPT-5 mini, Claude Haiku 4.5, "
 "Mistral, etc."
-msgstr ""
-"选择热门 AI 并与之对话，比如 GPT-5 mini、Claude Haiku 4.5、Mistral 等。"
+msgstr "选择热门 AI 并与之对话，比如 GPT-5 mini、Claude Haiku 4.5、Mistral 等。"
 
 # smartling.placeholder_format=C
 #. The description of the third party map app picker, shown on iOS when a user is given an option of which app to navigate to a destination with
@@ -14085,7 +13964,7 @@ msgstr "请完成以下挑战，以确认这项搜索由真人进行。"
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is harmful or illegal. (optional)"
-msgstr ""
+msgstr "请说明该聊天回复为何属于有害或非法内容。（可选）"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
@@ -14119,7 +13998,7 @@ msgctxt "Feedback prompt"
 msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is harmful or illegal."
-msgstr ""
+msgstr "请粘贴你的提示和有问题的输出内容（删除所有个人信息），并说明相关内容为何有害或非法。"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -14127,9 +14006,7 @@ msgctxt "Feedback prompt"
 msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is illegal or harmful."
-msgstr ""
-"请粘贴你的提示和有问题的输出内容（删除任何个人信息），并说明相关内容为何违法"
-"或有害。"
+msgstr "请粘贴你的提示和有问题的输出内容（删除任何个人信息），并说明相关内容为何违法或有害。"
 
 # smartling.placeholder_format=C
 #. Title on a feedback form.
@@ -14590,7 +14467,7 @@ msgstr "隐私"
 #. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
 msgctxt "Section heading on the Duck.ai settings page"
 msgid "Privacy & Terms"
-msgstr ""
+msgstr "隐私与条款"
 
 # smartling.placeholder_format=C
 msgid "Privacy Blog"
@@ -14666,7 +14543,7 @@ msgstr "隐私政策和服务条款"
 #. Text for a button that links to the terms of use and privacy policy page.
 msgctxt "Secondary button text in active privacy modal"
 msgid "Privacy Policy and Terms of Service"
-msgstr ""
+msgstr "隐私政策和服务条款"
 
 # smartling.placeholder_format=C
 #. Title displayed on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
@@ -15118,8 +14995,7 @@ msgctxt "Description for recent chats feature"
 msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
-msgstr ""
-"近期聊天记录会存储在设备本机上，而非 DuckDuckGo 服务器或其他远程服务器上。"
+msgstr "近期聊天记录会存储在设备本机上，而非 DuckDuckGo 服务器或其他远程服务器上。"
 
 # smartling.placeholder_format=C
 #. Text explaining that recent chats are stored locally on the user's device.
@@ -15127,8 +15003,7 @@ msgctxt "Description of where recent chats are stored"
 msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
-msgstr ""
-"近期聊天记录会存储在设备本机上，而非 DuckDuckGo 服务器或其他远程服务器上。"
+msgstr "近期聊天记录会存储在设备本机上，而非 DuckDuckGo 服务器或其他远程服务器上。"
 
 # smartling.placeholder_format=C
 #. Text explaining how recent chats are stored locally on the user's device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection.
@@ -15137,9 +15012,7 @@ msgid ""
 "Recent chats are stored locally on your device. New prompts and responses "
 "are encrypted and temporarily stored on a DuckDuckGo server after being "
 "sent, to help recover a chat if you lose your internet connection."
-msgstr ""
-"最近的聊天记录会存储在本地设备上。新的提示和回复在发送后会被加密并暂时存储在 "
-"DuckDuckGo 服务器上，以便在断开互联网连接时帮助恢复聊天记录。"
+msgstr "最近的聊天记录会存储在本地设备上。新的提示和回复在发送后会被加密并暂时存储在 DuckDuckGo 服务器上，以便在断开互联网连接时帮助恢复聊天记录。"
 
 # smartling.placeholder_format=C
 msgctxt "region filter"
@@ -15166,25 +15039,25 @@ msgstr "推荐一本书"
 #. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Recommend similar books"
-msgstr ""
+msgstr "推荐类似书籍"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Recommend similar books."
-msgstr ""
+msgstr "推荐类似书籍。"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Recommend similar movies or shows."
-msgstr ""
+msgstr "推荐相似的电影或节目。"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Recommend similar titles"
-msgstr ""
+msgstr "推荐相似标题"
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
@@ -15396,9 +15269,7 @@ msgstr "重新加载 Duck.ai"
 msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
-msgstr ""
-"请按照说明重新加载 DuckDuckGo，或点击浏览器的“Refresh”（刷新）或“Reload”（重"
-"新加载）按钮。"
+msgstr "请按照说明重新加载 DuckDuckGo，或点击浏览器的“Refresh”（刷新）或“Reload”（重新加载）按钮。"
 
 # smartling.placeholder_format=C
 #. checkbox label that allows the user to save the setting
@@ -15487,18 +15358,14 @@ msgctxt "settings"
 msgid ""
 "Removes the \"Ask\" button so answers appear automatically in response to "
 "relevant searches. Cached answers always display automatically."
-msgstr ""
-"移除“Ask”（询问）按钮，以便在相关搜索的响应中自动显示答案。一律自动显示缓存的"
-"答案。"
+msgstr "移除“Ask”（询问）按钮，以便在相关搜索的响应中自动显示答案。一律自动显示缓存的答案。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Removes the \"Generate\" button so answers appear automatically in response "
 "to relevant searches. Cached answers always display automatically."
-msgstr ""
-"移除“Generate”（生成）按钮，以便在相关搜索的响应中自动显示答案。一律自动显示"
-"缓存的答案。"
+msgstr "移除“Generate”（生成）按钮，以便在相关搜索的响应中自动显示答案。一律自动显示缓存的答案。"
 
 # smartling.placeholder_format=C
 #. Text for a button to rename a chat, as in it will allow the user to change the title of the chat.
@@ -15555,18 +15422,14 @@ msgid ""
 "Reports are anonymous and sent to DuckDuckGo to help improve our search "
 "service. Your anonymous feedback is also shared with %s to help improve "
 "their services."
-msgstr ""
-"你的反馈将以匿名方式发送至 DuckDuckGo，以帮助我们改进搜索服务，同时也将匿名提"
-"供给 %1$s，以便共同提高服务质量。"
+msgstr "你的反馈将以匿名方式发送至 DuckDuckGo，以帮助我们改进搜索服务，同时也将匿名提供给 %1$s，以便共同提高服务质量。"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "Reports sent to DuckDuckGo are anonymous. Please do not include any personal "
 "or identifying information in your feedback."
-msgstr ""
-"发给 DuckDuckGo 的报告均为匿名。请不要在反馈中包含任何个人或可识别身份的信"
-"息。"
+msgstr "发给 DuckDuckGo 的报告均为匿名。请不要在反馈中包含任何个人或可识别身份的信息。"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -15574,9 +15437,7 @@ msgid ""
 "Reports sent to DuckDuckGo include all of the text you've asked us to "
 "translate during this page load, and are anonymous. Please do not include "
 "any personal or identifying information in your feedback."
-msgstr ""
-"发送给 DuckDuckGo 的报告包括你在此页面加载过程中要求我们翻译的所有文本，且是"
-"匿名形式。请不要在反馈中包含任何个人或可识别身份的信息。"
+msgstr "发送给 DuckDuckGo 的报告包括你在此页面加载过程中要求我们翻译的所有文本，且是匿名形式。请不要在反馈中包含任何个人或可识别身份的信息。"
 
 # smartling.placeholder_format=C
 msgid "Republic of Moldova"
@@ -15589,7 +15450,7 @@ msgctxt ""
 "feedback form when the user has selected Harmful or Illegal as the feedback "
 "reason"
 msgid "Required for harmful or illegal reports"
-msgstr ""
+msgstr "举报有害或非法内容时必须提供"
 
 # smartling.placeholder_format=C
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
@@ -15655,9 +15516,7 @@ msgid ""
 "Responses are for educational purposes only and are not intended as medical, "
 "legal, financial, investment, or other professional advice. AI-assisted "
 "answers are subject to our %sTerms of Service%s."
-msgstr ""
-"回复仅供教育用途，不应视为医疗、法律、财务、投资或其他专业建议。人工智能辅助"
-"的答案受我们的%1$s服务条款%2$s约束。"
+msgstr "回复仅供教育用途，不应视为医疗、法律、财务、投资或其他专业建议。人工智能辅助的答案受我们的%1$s服务条款%2$s约束。"
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -15665,9 +15524,7 @@ msgid ""
 "Responses are for educational purposes only and are not intended as medical, "
 "legal, financial, investment, or other professional advice. DuckAssist is "
 "subject to our %sTerms of Service%s."
-msgstr ""
-"回复仅供教育用途，不应视为医疗、法律、财务、投资或其他专业建议。DuckAssist 受"
-"我们的%1$s服务条款%2$s约束。"
+msgstr "回复仅供教育用途，不应视为医疗、法律、财务、投资或其他专业建议。DuckAssist 受我们的%1$s服务条款%2$s约束。"
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -15677,8 +15534,8 @@ msgid ""
 "generated based on web content and may contain inaccuracies. Search Assist "
 "is subject to our %sTerms of Service%s."
 msgstr ""
-"回复仅供教育用途，不应视为医疗、法律、财务、投资或其他专业建议，且根据网络内"
-"容生成，可能包含不准确的信息。Search Assist 受我们的%1$s服务条款%2$s约束。"
+"回复仅供教育用途，不应视为医疗、法律、财务、投资或其他专业建议，且根据网络内容生成，可能包含不准确的信息。Search Assist "
+"受我们的%1$s服务条款%2$s约束。"
 
 # smartling.placeholder_format=C
 #. Label on the button for restoring all previous website data.
@@ -15825,7 +15682,7 @@ msgstr "评价"
 #. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Rewrite this recipe scaled for a different number of servings."
-msgstr ""
+msgstr "根据不同的份数，重新调整并改写这份食谱。"
 
 # smartling.placeholder_format=C
 msgid "Romania"
@@ -16096,9 +15953,7 @@ msgctxt "Description for Chat History feature with Encrypted Storage option"
 msgid ""
 "Save up to 30 of your most recent chats locally on your device, with the "
 "option for more with Encrypted Storage."
-msgstr ""
-"在本地设备上保存多达 30 条最新聊天记录，还可使用加密存储功能保存更多聊天记"
-"录。"
+msgstr "在本地设备上保存多达 30 条最新聊天记录，还可使用加密存储功能保存更多聊天记录。"
 
 # smartling.placeholder_format=C
 #. Short text for native DDG browser users explaining how Chat History stores up to 30 of their most recent chats locally on their device.
@@ -16240,9 +16095,7 @@ msgstr "向下滚动并点击 %1$s查看高级设置%2$s。"
 msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)"
-msgstr ""
-"向下滚动并找到%1$s地址栏使用的搜索引擎%2$s，点击%3$s更改搜索引擎%4$s（或%5$s"
-"添加搜索引擎%6$s）"
+msgstr "向下滚动并找到%1$s地址栏使用的搜索引擎%2$s，点击%3$s更改搜索引擎%4$s（或%5$s添加搜索引擎%6$s）"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
@@ -16250,9 +16103,7 @@ msgstr ""
 msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)."
-msgstr ""
-"向下滚动并找到 %1$s地址栏使用的搜索引擎%2$s，点击 %3$s更改搜索引擎%4$s（或 "
-"%5$s添加搜索引擎%6$s）。"
+msgstr "向下滚动并找到 %1$s地址栏使用的搜索引擎%2$s，点击 %3$s更改搜索引擎%4$s（或 %5$s添加搜索引擎%6$s）。"
 
 # smartling.placeholder_format=C
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -16324,10 +16175,10 @@ msgid ""
 "(on a wide range of searches). For now, Search Assist is only available in a "
 "subset of English speaking regions."
 msgstr ""
-"Search Assist 匿名生成搜索查询的答案。为此，该功能会扫描网络以查找相关内容，"
-"然后使用人工智能生成简短的答案。可以选择其出现的频率：从不、按需（仅在点"
-"击“Assist”时显示）、有时（仅在高度相关时显示）或经常（在更广泛的搜索中显"
-"示）。Search Assist 目前仅供部分英语地区使用。"
+"Search Assist "
+""
+"匿名生成搜索查询的答案。为此，该功能会扫描网络以查找相关内容，然后使用人工智能生成简短的答案。可以选择其出现的频率：从不、按需（仅在点击“Assist”时显示）、有时（仅在高度相关时显示）或经常（在更广泛的搜索中显示）。Search "
+"Assist 目前仅供部分英语地区使用。"
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI) when the answer is not found and the answer is unsourced or with no sources
@@ -16343,8 +16194,8 @@ msgid ""
 "search queries. To do this, it %sscans the web%s for relevant content and "
 "then uses AI to generate a brief answer based on information found."
 msgstr ""
-"Search Assist 是一项可选功能，可以匿名生成搜索查询的答案。为此，该功能会%1$s"
-"扫描网络%2$s以查找相关内容，然后使用人工智能根据找到的信息生成简短的答案。"
+"Search Assist "
+"是一项可选功能，可以匿名生成搜索查询的答案。为此，该功能会%1$s扫描网络%2$s以查找相关内容，然后使用人工智能根据找到的信息生成简短的答案。"
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/search_box. top header
@@ -16464,8 +16315,7 @@ msgctxt "noresults"
 msgid ""
 "Search other sites with %s shortcuts: a search for ”!w ducks” will search "
 "for “ducks” directly on Wikipedia."
-msgstr ""
-"使用 %1$s 快捷键搜索其他网站：搜索“!w ducks”将直接在维基百科上搜索“ducks”。"
+msgstr "使用 %1$s 快捷键搜索其他网站：搜索“!w ducks”将直接在维基百科上搜索“ducks”。"
 
 # smartling.placeholder_format=C
 #. Placeholder text for the search form when no text has been entered
@@ -16483,9 +16333,7 @@ msgstr "匿名搜索并屏蔽跟踪程序"
 msgid ""
 "Search privately with our app or extension, add private web search to your "
 "favorite browser, or search directly at %sduckduckgo.com%s."
-msgstr ""
-"通过我们的移动应用或扩展程序匿名搜索，或将搜索引擎加入浏览器，抑或直接打开 "
-"%1$sduckduckgo.com%2$s 发起搜索。"
+msgstr "通过我们的移动应用或扩展程序匿名搜索，或将搜索引擎加入浏览器，抑或直接打开 %1$sduckduckgo.com%2$s 发起搜索。"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/6LZAoqH.png
@@ -16504,9 +16352,8 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"搜索设置会存储在非个人浏览器 Cookie 和浏览器的本地存储中，但也可以使用 Cloud "
-"Save 将设置匿名存储在云端的远程服务器上。系统不会在云端存储任何个人身份信息，"
-"且你的口令仅限在你的浏览器中使用。"
+"搜索设置会存储在非个人浏览器 Cookie 和浏览器的本地存储中，但也可以使用 Cloud Save "
+"将设置匿名存储在云端的远程服务器上。系统不会在云端存储任何个人身份信息，且你的口令仅限在你的浏览器中使用。"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -16602,9 +16449,7 @@ msgctxt "Description explaining how native users can enable sync"
 msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
-msgstr ""
-"使用端到端加密安全地在我们的服务器上存储几乎无限量的聊天记录，并可从所有设备"
-"访问。"
+msgstr "使用端到端加密安全地在我们的服务器上存储几乎无限量的聊天记录，并可从所有设备访问。"
 
 # smartling.placeholder_format=C
 #. Text explaining that the Encrypted Storage feature stores the user's chats encrypted on their device.
@@ -16612,9 +16457,7 @@ msgctxt "Description for encrypted storage feature"
 msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
-msgstr ""
-"使用端到端加密安全地在我们的服务器上存储几乎无限量的聊天记录，并可从所有设备"
-"访问。"
+msgstr "使用端到端加密安全地在我们的服务器上存储几乎无限量的聊天记录，并可从所有设备访问。"
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -16622,9 +16465,7 @@ msgctxt "Description explaining how native users can enable sync"
 msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your synced devices."
-msgstr ""
-"使用端到端加密安全地在我们的服务器上存储几乎无限量的聊天记录，并可从所有已同"
-"步的设备访问。"
+msgstr "使用端到端加密安全地在我们的服务器上存储几乎无限量的聊天记录，并可从所有已同步的设备访问。"
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -16632,9 +16473,7 @@ msgctxt "Description explaining how native users can enable sync"
 msgid ""
 "Securely store your chats on our server using end-to-end encryption, and "
 "access them from all your devices."
-msgstr ""
-"利用端到端加密功能将聊天记录安全地存储在我们的服务器上，并可从所有设备访问相"
-"关内容。"
+msgstr "利用端到端加密功能将聊天记录安全地存储在我们的服务器上，并可从所有设备访问相关内容。"
 
 # smartling.placeholder_format=C
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
@@ -16648,9 +16487,7 @@ msgctxt "Chat history with sync modal list item"
 msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
-msgstr ""
-"采用端到端加密技术，安全存储在 DuckDuckGo 服务器上。除了你之外，没有人可以看"
-"到你的数据，甚至我们也不行。"
+msgstr "采用端到端加密技术，安全存储在 DuckDuckGo 服务器上。除了你之外，没有人可以看到你的数据，甚至我们也不行。"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -16858,16 +16695,14 @@ msgstr "在弹出的菜单中点击 %1$s管理加载项%2$s"
 #. Tells users where in the settings menu they can change their default search engine.
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sMenu > Settings%s (on Windows)"
-msgstr ""
-"Mac 系统点击 %1$sOpera > 设置%2$s，Windows 系统点击 %3$s菜单 > 设置%4$s"
+msgstr "Mac 系统点击 %1$sOpera > 设置%2$s，Windows 系统点击 %3$s菜单 > 设置%4$s"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sOpera > Options%s (on Windows)"
-msgstr ""
-"Mac 系统点击 %1$sOpera > 设置%2$s，Windows 系统点击 %3$sOpera > 选项%4$s"
+msgstr "Mac 系统点击 %1$sOpera > 设置%2$s，Windows 系统点击 %3$sOpera > 选项%4$s"
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -17052,9 +16887,7 @@ msgid ""
 "Sends a prompt to AI models with your messages with instructions on how to "
 "respond. These instructions will apply to all of your conversations going "
 "forward."
-msgstr ""
-"向人工智能模型发送包含你的消息的提示，并附带回复说明。这些说明将适用于你今后"
-"的所有对话。"
+msgstr "向人工智能模型发送包含你的消息的提示，并附带回复说明。这些说明将适用于你今后的所有对话。"
 
 # smartling.placeholder_format=C
 msgid "Senegal"
@@ -17133,7 +16966,7 @@ msgstr "立即设置"
 #. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
 msgctxt "Encrypted storage setup button shown in native browsers"
 msgid "Set Up Sync & Backup"
-msgstr ""
+msgstr "设置 Sync & Backup"
 
 # smartling.placeholder_format=C
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
@@ -17249,9 +17082,7 @@ msgctxt "Description for Approximate Location feature"
 msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
-msgstr ""
-"与人工智能模型共享城市级位置信息，以提升相关性。Duck.ai 绝不会向我们或人工智"
-"能模型透露你的精确位置。"
+msgstr "与人工智能模型共享城市级位置信息，以提升相关性。Duck.ai 绝不会向我们或人工智能模型透露你的精确位置。"
 
 # smartling.placeholder_format=C
 #. Menu option to share feedback about a result
@@ -17316,7 +17147,7 @@ msgstr "分享正面反馈"
 msgctxt ""
 "Label beside the share-content switch on the Duck.ai response feedback form"
 msgid "Share this conversation with DuckDuckGo"
-msgstr ""
+msgstr "与 DuckDuckGo 分享此对话"
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -17333,8 +17164,7 @@ msgctxt ""
 msgid ""
 "Share your prompt and chat response with DuckDuckGo (required for illegal "
 "and harmful report)"
-msgstr ""
-"将您的提示和聊天回复分享给 DuckDuckGo（举报非法和有害内容时需要执行此步骤）"
+msgstr "将您的提示和聊天回复分享给 DuckDuckGo（举报非法和有害内容时需要执行此步骤）"
 
 # smartling.placeholder_format=C
 #. An invitation for users to leave feedback
@@ -17679,18 +17509,14 @@ msgctxt "settings"
 msgid ""
 "Shows a reminder that searches on DuckDuckGo are always private. Turning "
 "this off hides the reminder and never affects search privacy."
-msgstr ""
-"提醒：在 DuckDuckGo 上进行的所有搜索均为匿名搜索。关闭此功能可隐藏提醒，且不"
-"会影响搜索隐私。"
+msgstr "提醒：在 DuckDuckGo 上进行的所有搜索均为匿名搜索。关闭此功能可隐藏提醒，且不会影响搜索隐私。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Shows a reminder that searches on DuckDuckGo are always protected. Turning "
 "this off hides the reminder and never affects search protection."
-msgstr ""
-"提醒：在 DuckDuckGo 上进行的所有搜索始终受到保护。关闭此功能可隐藏提醒，且不"
-"会影响搜索保护。"
+msgstr "提醒：在 DuckDuckGo 上进行的所有搜索始终受到保护。关闭此功能可隐藏提醒，且不会影响搜索保护。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18552,19 +18378,19 @@ msgstr "为博客文章建议标题"
 #. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Suggest related articles or topics worth exploring next."
-msgstr ""
+msgstr "推荐一些值得进一步了解的相关文章或主题。"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Suggest related articles to explore"
-msgstr ""
+msgstr "推荐值得阅读的相关文章"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Suggest some alternatives to this product."
-msgstr ""
+msgstr "推荐这款产品的一些替代品。"
 
 # smartling.placeholder_format=C
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
@@ -18581,7 +18407,7 @@ msgstr "搜索建议："
 #. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Sum up the reviews"
-msgstr ""
+msgstr "总结一下这些评价"
 
 # smartling.placeholder_format=C
 #. A short title for the a message asking the AI to summarize a text.
@@ -18593,85 +18419,85 @@ msgstr "总结"
 #. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize the Q&As"
-msgstr ""
+msgstr "总结问答内容"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the background and notable work of this person."
-msgstr ""
+msgstr "概述此人的背景经历及其重要成就。"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the key details of this event."
-msgstr ""
+msgstr "总结此事件的关键细节。"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the questions and answers on this page."
-msgstr ""
+msgstr "总结此页面上的问题和答案。"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize their background"
-msgstr ""
+msgstr "总结他们的背景"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this book"
-msgstr ""
+msgstr "总结这本书"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this book."
-msgstr ""
+msgstr "总结这本书。"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this discussion"
-msgstr ""
+msgstr "总结这段讨论"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this discussion thread."
-msgstr ""
+msgstr "总结这条讨论帖的主要内容。"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this page"
-msgstr ""
+msgstr "总结此页面"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this page."
-msgstr ""
+msgstr "总结此页面。"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this video"
-msgstr ""
+msgstr "总结此视频"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this video."
-msgstr ""
+msgstr "总结此视频。"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize what the reviews say."
-msgstr ""
+msgstr "总结一下大众评价。"
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -18935,8 +18761,7 @@ msgid ""
 msgstr ""
 "同步恢复代码\n"
 "\n"
-"恢复代码允许你在多个设备之间同步密码、自动填充数据和 Duck.ai 聊天记录，并在无"
-"法访问某个设备时恢复已同步的数据。\n"
+"恢复代码允许你在多个设备之间同步密码、自动填充数据和 Duck.ai 聊天记录，并在无法访问某个设备时恢复已同步的数据。\n"
 "\n"
 "请妥善保管此信息。\n"
 "任何可访问此代码的人都可以访问你的同步数据。\n"
@@ -18948,8 +18773,7 @@ msgstr ""
 "2. 选择“开启 Sync & Backup”，然后选择“恢复同步数据”\n"
 " 3. 复制上方的恢复代码，并将其粘贴到“在此处粘贴代码”处\n"
 "\n"
-"如果你超过 18 个月未使用启用 Sync & Backup 功能的 DuckDuckGo 浏览器，你的数据"
-"将从服务器中删除且无法恢复。"
+"如果你超过 18 个月未使用启用 Sync & Backup 功能的 DuckDuckGo 浏览器，你的数据将从服务器中删除且无法恢复。"
 
 # smartling.placeholder_format=C
 #. Secondary button label on the Sync & Backup intro screen that takes the user to the camera scan screen to pair with another device.
@@ -18995,7 +18819,7 @@ msgstr "叙利亚"
 #. Text for a button that enables the theme to follow the operating system's color scheme preference.
 msgctxt "System theme button for theme selector"
 msgid "System"
-msgstr ""
+msgstr "系统"
 
 # smartling.placeholder_format=C
 #. Abbreviation indicating this is the total score for a game
@@ -19029,7 +18853,7 @@ msgstr "塔希提语"
 #. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Tailor my resume"
-msgstr ""
+msgstr "定制我的简历"
 
 # smartling.placeholder_format=C
 msgid "Taiwan"
@@ -19065,7 +18889,7 @@ msgstr "掌控个人数据！"
 msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
-msgstr ""
+msgstr "参加这项匿名调查，告诉我们如何改进 Duck.ai。"
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -19279,9 +19103,7 @@ msgid ""
 "That means information sent between your device and the webpage behind this "
 "link is at increased risk of being intercepted by a third party. In rare "
 "cases this includes passwords, or payment details."
-msgstr ""
-"这意味着你与网站之间传输的信息更有可能被第三方截获，其中甚至包括你的密码和银"
-"行账号。"
+msgstr "这意味着你与网站之间传输的信息更有可能被第三方截获，其中甚至包括你的密码和银行账号。"
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -19367,7 +19189,7 @@ msgstr "配色"
 #. Text for the theme selector label that allows users to switch between Light and dark theme.
 msgctxt "Label for the theme selector feature"
 msgid "Theme"
-msgstr ""
+msgstr "配色"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/LpFhb1e.png
@@ -19397,8 +19219,7 @@ msgctxt "Error message when there was an issue saving a chat to the browser"
 msgid ""
 "There was an error saving this chat locally. Please check your browser "
 "settings to make sure local data storage is enabled."
-msgstr ""
-"在本地保存此聊天时出现了错误。请检查你的浏览器设置以确保已启用本地数据存储。"
+msgstr "在本地保存此聊天时出现了错误。请检查你的浏览器设置以确保已启用本地数据存储。"
 
 # smartling.placeholder_format=C
 #. Error modal body line 1.
@@ -19430,9 +19251,7 @@ msgid ""
 "These browser permissions are used to add privacy protection on websites you "
 "visit by blocking hidden trackers, encrypting connections where possible, "
 "and by making DuckDuckGo your default search engine."
-msgstr ""
-"所需的浏览器权限用于屏蔽网页跟踪程序、尽可能建立加密连接，并将 DuckDuckGo 设"
-"为默认搜索引擎，从而保护你的隐私。"
+msgstr "所需的浏览器权限用于屏蔽网页跟踪程序、尽可能建立加密连接，并将 DuckDuckGo 设为默认搜索引擎，从而保护你的隐私。"
 
 # smartling.placeholder_format=C
 #. Secondary line under DUCKCHAT_SYNC_PAIRING_ALREADY_SYNCED_TITLE.
@@ -19503,9 +19322,7 @@ msgctxt "Export chat feature in AI Chat"
 msgid ""
 "This conversation was generated with Duck.ai (%s) using %s's %s Model. AI "
 "chats may display inaccurate or offensive information (see %s for more info)."
-msgstr ""
-"此对话由 Duck.ai (%1$s) 使用 %2$s 的 %3$s 模型生成。人工智能聊天可能会显示不"
-"准确或令人反感的信息（详情请参阅%4$s）。"
+msgstr "此对话由 Duck.ai (%1$s) 使用 %2$s 的 %3$s 模型生成。人工智能聊天可能会显示不准确或令人反感的信息（详情请参阅%4$s）。"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with multiple AI models in the same chat, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using multiple chat models. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -19514,9 +19331,7 @@ msgid ""
 "This conversation was generated with Duck.ai (%s) using multiple chat "
 "models. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
-msgstr ""
-"此对话由 Duck.ai (%1$s) 使用多个聊天模型生成。人工智能聊天可能会显示不准确或"
-"令人反感的信息（详情请参阅%2$s）。"
+msgstr "此对话由 Duck.ai (%1$s) 使用多个聊天模型生成。人工智能聊天可能会显示不准确或令人反感的信息（详情请参阅%2$s）。"
 
 # smartling.placeholder_format=C
 #. When a user exports a transcript of a voice chat they had with the AI. This text goes at the very top of the downloaded file as a header. Placeholders are for links. Example: 'This conversation was generated with Duck.ai voice chat (https://duck.ai). AI may provide inaccurate or offensive information. (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -19524,9 +19339,7 @@ msgctxt "Export chat feature in AI Chat"
 msgid ""
 "This conversation was generated with Duck.ai voice chat (%s). AI may provide "
 "inaccurate or offensive information. (see %s for more info)."
-msgstr ""
-"这段对话通过 Duck.ai 语音聊天生成 (%1$s)。人工智能可能会提供不准确或令人反感"
-"的信息。（详情请参见 %2$s）。"
+msgstr "这段对话通过 Duck.ai 语音聊天生成 (%1$s)。人工智能可能会提供不准确或令人反感的信息。（详情请参见 %2$s）。"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with DuckDuckGo AI Chat (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/aichat/privacy-terms for more info).'
@@ -19536,8 +19349,8 @@ msgid ""
 "Model. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
 msgstr ""
-"此对话由 DuckDuckGo AI Chat (%1$s) 使用 %2$s 的 %3$s 模型生成。人工智能聊天可"
-"能会显示不准确或令人反感的信息（详情请参阅%4$s）。"
+"此对话由 DuckDuckGo AI Chat (%1$s) 使用 %2$s 的 %3$s "
+"模型生成。人工智能聊天可能会显示不准确或令人反感的信息（详情请参阅%4$s）。"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
@@ -19640,9 +19453,7 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "This model provider deletes data associated with this chat within 30 days. "
 "Other model providers follow a zero data retention model."
-msgstr ""
-"该模型提供商会在 30 天内删除与此聊天记录相关的数据。其他模型提供商遵循零数据"
-"保留模式。"
+msgstr "该模型提供商会在 30 天内删除与此聊天记录相关的数据。其他模型提供商遵循零数据保留模式。"
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers, and that other providers may retain chat data for a limited time instead.
@@ -19650,9 +19461,7 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "This model provider does not store any data associated with this chat. Other "
 "model providers follow a limited data retention model."
-msgstr ""
-"该模型提供商不会存储与此聊天记录相关的任何数据。其他模型提供商遵循有限的数据"
-"保留模式。"
+msgstr "该模型提供商不会存储与此聊天记录相关的任何数据。其他模型提供商遵循有限的数据保留模式。"
 
 # smartling.placeholder_format=C
 #. Info that page may refresh during update.
@@ -19688,9 +19497,7 @@ msgctxt "First paragraph for the Sync & Backup intro screen"
 msgid ""
 "This saves your chats with end-to-end encryption on DuckDuckGo's secure "
 "server, which later can be accessed from any browser."
-msgstr ""
-"这将使用端到端加密技术将您的聊天记录安全地存储在 DuckDuckGo 的安全服务器上，"
-"之后可以通过任何浏览器访问这些记录。"
+msgstr "这将使用端到端加密技术将您的聊天记录安全地存储在 DuckDuckGo 的安全服务器上，之后可以通过任何浏览器访问这些记录。"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -19698,9 +19505,7 @@ msgctxt "duckassist"
 msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again."
-msgstr ""
-"此设置存储在你的浏览器中，这意味着如果清除了 duckduckgo.com 的浏览器数据，那"
-"么你可能会再次看到 AI 辅助的答案。"
+msgstr "此设置存储在你的浏览器中，这意味着如果清除了 duckduckgo.com 的浏览器数据，那么你可能会再次看到 AI 辅助的答案。"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -19710,9 +19515,8 @@ msgid ""
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
 msgstr ""
-"此设置存储在你的浏览器中，这意味着如果清除了 duckduckgo.com 的浏览器数据，那"
-"么你可能会再次看到 AI 辅助的答案。不过，我们还有一个起始页，它从不在 %1$s 显"
-"示 AI 辅助答案。"
+"此设置存储在你的浏览器中，这意味着如果清除了 duckduckgo.com 的浏览器数据，那么你可能会再次看到 AI "
+"辅助的答案。不过，我们还有一个起始页，它从不在 %1$s 显示 AI 辅助答案。"
 
 # smartling.placeholder_format=C
 #. User feedback indicating that a translation is helpful
@@ -19751,8 +19555,8 @@ msgid ""
 "Sync & Backup. You'll still be able to access your chats in other browsers "
 "connected to Sync & Backup."
 msgstr ""
-"这将删除你在此浏览器中的所有 Duck.ai 聊天记录，并断开 Sync & Backup 连接。你"
-"仍然可以在连接到 Sync & Backup 的其他浏览器中浏览你的聊天记录。"
+"这将删除你在此浏览器中的所有 Duck.ai 聊天记录，并断开 Sync & Backup 连接。你仍然可以在连接到 Sync & Backup "
+"的其他浏览器中浏览你的聊天记录。"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to clear all recentchats, with a warning that this action cannot be undone.
@@ -19897,8 +19701,7 @@ msgctxt "directions"
 msgid ""
 "To print directions:%sGo back to the map.%sSelect the route you want to "
 "print.%sClick the print icon.%s"
-msgstr ""
-"打印路线具体操作：%1$s返回地图。%2$s选择要打印的路线。%3$s点击打印图标。%4$s"
+msgstr "打印路线具体操作：%1$s返回地图。%2$s选择要打印的路线。%3$s点击打印图标。%4$s"
 
 # smartling.placeholder_format=C
 #. Explains where the user can find their recovery code. Figma frame 3703-44420.
@@ -19907,9 +19710,7 @@ msgid ""
 "To restore your synced data, you'll need the Recovery Code you saved when "
 "you first set up Sync. This code may have been saved as a PDF on the device "
 "you originally used to set up Sync."
-msgstr ""
-"需要使用首次设置同步时保存的恢复代码来还原已同步的数据。此代码可能已以 PDF 格"
-"式保存到最初用于设置同步的设备上。"
+msgstr "需要使用首次设置同步时保存的恢复代码来还原已同步的数据。此代码可能已以 PDF 格式保存到最初用于设置同步的设备上。"
 
 # smartling.placeholder_format=C
 #. Body text explaining that the user needs to update their DDG browser before migration can proceed.
@@ -19917,9 +19718,7 @@ msgctxt "duckai_migration"
 msgid ""
 "To transfer your chat history to Duck.ai, please update your DuckDuckGo "
 "browser to the latest version and try again."
-msgstr ""
-"如需将聊天记录转移到 Duck.ai，请先将 DuckDuckGo 浏览器升级至最新版本，然后再"
-"试一次。"
+msgstr "如需将聊天记录转移到 Duck.ai，请先将 DuckDuckGo 浏览器升级至最新版本，然后再试一次。"
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
@@ -20115,8 +19914,7 @@ msgctxt "tracker_stats"
 msgid ""
 "Tracking attempts blocked by DuckDuckGo appear here. Keep browsing to see "
 "how many we block."
-msgstr ""
-"此处将显示被 DuckDuckGo 阻止的跟踪企图。继续浏览以查看我们阻止了多少次。"
+msgstr "此处将显示被 DuckDuckGo 阻止的跟踪企图。继续浏览以查看我们阻止了多少次。"
 
 # smartling.placeholder_format=C
 #. Placeholder for when we cannot report any blocked trackers yet
@@ -20177,13 +19975,13 @@ msgstr "将这句中文翻译成英语：“我怎么去最近的电影院？”
 #. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Translate this page"
-msgstr ""
+msgstr "翻译此页面"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
 msgctxt "Page suggestion prompt"
 msgid "Translate this page into %s."
-msgstr ""
+msgstr "将此页面翻译成 %1$s。"
 
 # smartling.placeholder_format=C
 #. Placeholder text for a region that will display translated text.
@@ -20330,7 +20128,7 @@ msgstr "免费试用"
 #. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
 msgctxt "settings"
 msgid "Try It Now"
-msgstr ""
+msgstr "立即试用"
 
 # smartling.placeholder_format=C
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -20570,7 +20368,7 @@ msgctxt "settings"
 msgid ""
 "Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
-msgstr ""
+msgstr "想要禁用 AI 功能？安装 %1$sDuckDuckGo No AI%2$s 搜索扩展程序，以便记住你的设置。%3$s了解详情%4$s"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -20578,7 +20376,7 @@ msgctxt "settings"
 msgid ""
 "Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
-msgstr ""
+msgstr "想要禁用 AI 功能？切换到 %1$sDuckDuckGo No AI%2$s 搜索扩展程序，以便记住你的设置。%3$s了解详情%4$s"
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -20748,9 +20546,7 @@ msgctxt "settings"
 msgid ""
 "Types out DuckAssist answers as they're generated. Turning this off may "
 "result in a short delay between a search and the answer being displayed."
-msgstr ""
-"在生成 DuckAssist 答案时键入相关内容。关闭此功能可能会导致搜索与显示答案之间"
-"出现短暂的延迟。"
+msgstr "在生成 DuckAssist 答案时键入相关内容。关闭此功能可能会导致搜索与显示答案之间出现短暂的延迟。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -20879,16 +20675,14 @@ msgstr "了解优点和缺点"
 msgid ""
 "Under %sOn startup%s, click %sOpen a specific page%s then click %sSet "
 "Pages%s."
-msgstr ""
-"在%1$s启动时%2$s下，点击%3$s打开特定页面%4$s，然后点击 %5$s设置页面%6$s。"
+msgstr "在%1$s启动时%2$s下，点击%3$s打开特定页面%4$s，然后点击 %5$s设置页面%6$s。"
 
 #  Maxthon homepage instruction
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
-msgstr ""
-"在%1$s启动时%2$s下，选择%3$s主页%4$s并将主页设为 https://duckduckgo.com"
+msgstr "在%1$s启动时%2$s下，选择%3$s主页%4$s并将主页设为 https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -21003,9 +20797,7 @@ msgctxt "Description of the modal to upgrade to Pro"
 msgid ""
 "Unlock %s, higher AI reasoning, and 2x higher usage limits than the Plus "
 "plan by upgrading to Pro."
-msgstr ""
-"升级至 Pro 计划，即可解锁 %1$s、更强大的 AI 推理能力，以及比 Plus 计划高 2 倍"
-"的使用限额。"
+msgstr "升级至 Pro 计划，即可解锁 %1$s、更强大的 AI 推理能力，以及比 Plus 计划高 2 倍的使用限额。"
 
 # smartling.placeholder_format=C
 #. Title for the subscription promo shown in the SERP sidemenu.
@@ -21320,7 +21112,7 @@ msgstr "乌拉圭"
 #. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
 msgctxt "Navigation label on the Duck.ai settings page"
 msgid "Usage"
-msgstr ""
+msgstr "使用情况"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -21363,9 +21155,7 @@ msgctxt "duckai_seo"
 msgid ""
 "Use ChatGPT, Claude, and other AIs, privately. Protect chats from hackers, "
 "scammers, and companies. Keep info confidential. Free. No account required."
-msgstr ""
-"私密地使用 ChatGPT、Claude 和其他人工智能工具。保护聊天内容免受黑客、骗子和公"
-"司的侵害。确保信息保密。免费。无需账户。"
+msgstr "私密地使用 ChatGPT、Claude 和其他人工智能工具。保护聊天内容免受黑客、骗子和公司的侵害。确保信息保密。免费。无需账户。"
 
 # smartling.placeholder_format=C
 #. Header above instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -21563,8 +21353,7 @@ msgctxt "Single Place Hotel Offers Module"
 msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "TripAdvisor's ad network."
-msgstr ""
-"DuckDuckGo 会保护观看广告的隐私。广告点击量由 TripAdvisor 广告网络管理。"
+msgstr "DuckDuckGo 会保护观看广告的隐私。广告点击量由 TripAdvisor 广告网络管理。"
 
 # smartling.placeholder_format=C
 msgid "Virgin Islands"
@@ -21606,8 +21395,8 @@ msgid ""
 "Visit Duck.ai in your other browser and go to %sDuck.ai Settings%s > %sSync "
 "& Backup%s > %sManage%s then select %sSync With Another Device%s."
 msgstr ""
-"在您的另一个浏览器中访问 Duck.ai，然后前往 %1$sDuck.ai 设置%2$s > %3$sSync & "
-"Backup%4$s > %5$s管理%6$s，然后选择%7$s与另一台设备同步%8$s。"
+"在您的另一个浏览器中访问 Duck.ai，然后前往 %1$sDuck.ai 设置%2$s > %3$sSync & Backup%4$s > "
+"%5$s管理%6$s，然后选择%7$s与另一台设备同步%8$s。"
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -21617,8 +21406,8 @@ msgid ""
 "On” under Sync & Backup and select “Sync With Another Device”. Or scan the "
 "QR on your Recovery PDF."
 msgstr ""
-"在其他浏览器中访问 Duck.ai 并打开 Duck.ai 设置。在 Sync & Backup 栏下选择“开"
-"启”，然后选择“与其他设备同步”。或者扫描恢复 PDF 中的二维码。"
+"在其他浏览器中访问 Duck.ai 并打开 Duck.ai 设置。在 Sync & Backup "
+"栏下选择“开启”，然后选择“与其他设备同步”。或者扫描恢复 PDF 中的二维码。"
 
 # smartling.placeholder_format=C
 #. Shared body copy for every screen in the Sync Another Device flow (QR display, camera scan, camera-unavailable fallback, manual entry). Bold tags wrap navigation breadcrumbs. Render with <Translate /> so the HTML is interpreted; plain `translate()` will trip the html-string warning.
@@ -21628,9 +21417,8 @@ msgid ""
 "ai Settings%s > %sSync & Backup%s > %sManage%s then select %sSync With "
 "Another Device%s."
 msgstr ""
-"在另一个浏览器或 DuckDuckGo 应用程序中访问 Duck.ai，然后前往“%1$sDuck.ai 设"
-"置%2$s > %3$sSync & Backup%4$s > %5$s管理%6$s”，然后选择“%7$s与其他设备同"
-"步%8$s”。"
+"在另一个浏览器或 DuckDuckGo 应用程序中访问 Duck.ai，然后前往“%1$sDuck.ai 设置%2$s > %3$sSync & "
+"Backup%4$s > %5$s管理%6$s”，然后选择“%7$s与其他设备同步%8$s”。"
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -21640,9 +21428,8 @@ msgid ""
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
 msgstr ""
-"在另一个浏览器或 DuckDuckGo 应用程序中访问 Duck.ai，然后打开 Duck.ai 设置。"
-"在 Sync & Backup 栏下选择“开启”，然后选择“与其他设备同步”。或者扫描恢复 PDF "
-"中的二维码。"
+"在另一个浏览器或 DuckDuckGo 应用程序中访问 Duck.ai，然后打开 Duck.ai 设置。在 Sync & Backup "
+"栏下选择“开启”，然后选择“与其他设备同步”。或者扫描恢复 PDF 中的二维码。"
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -21758,7 +21545,7 @@ msgstr "威尔士"
 #. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Walk me through the steps"
-msgstr ""
+msgstr "指导我完成这些步骤"
 
 # smartling.placeholder_format=C
 #. Label for walking directions on a map.
@@ -21837,9 +21624,7 @@ msgstr "在 Duck Player 中观看"
 msgid ""
 "Watch in Duck Player to block personalized ads on YouTube and prevent your "
 "viewing activity from influencing YouTube recommendations."
-msgstr ""
-"在 Duck Player 中观看，以屏蔽 YouTube 上的个性化广告，并防止你的观看活动影响 "
-"YouTube 推荐。"
+msgstr "在 Duck Player 中观看，以屏蔽 YouTube 上的个性化广告，并防止你的观看活动影响 YouTube 推荐。"
 
 # smartling.placeholder_format=C
 #. A button that takes a user to another site in order to watch a video. The placeholder is the name of the video site. For example: 'Watch on Vimeo'
@@ -21859,8 +21644,8 @@ msgid ""
 "independent company and has no relationship with YouTube, where most videos "
 "are hosted."
 msgstr ""
-"在此处观看视频意味着其托管网站可以跟踪你，因为我们必须从该网站流式传输内容。"
-"DuckDuckGo 是一家独立公司，与托管大多数视频的 YouTube 没有任何关系。"
+"在此处观看视频意味着其托管网站可以跟踪你，因为我们必须从该网站流式传输内容。DuckDuckGo 是一家独立公司，与托管大多数视频的 YouTube "
+"没有任何关系。"
 
 # smartling.placeholder_format=C
 #. Heading for the highlight card explaining anonymized prompt delivery.
@@ -21883,7 +21668,7 @@ msgid ""
 "We can only fix what we can see. To report a harmful or illegal response, "
 "please share this conversation with DuckDuckGo so we can investigate and "
 "address the issue."
-msgstr ""
+msgstr "我们只能处理我们看得到的问题。要举报有害或非法的回复，请分享此对话给 DuckDuckGo，这样我们才能调查并处理这个问题。"
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -21894,9 +21679,7 @@ msgid ""
 "We can only fix what we can see. To report a harmful or illegal response, "
 "please share your prompt and response so we can investigate and address the "
 "issue."
-msgstr ""
-"我们只能处理我们看得到的问题。要举报有害或非法的回复，请先分享您的提示词和回"
-"复，这样我们才能调查并处理这个问题。"
+msgstr "我们只能处理我们看得到的问题。要举报有害或非法的回复，请先分享您的提示词和回复，这样我们才能调查并处理这个问题。"
 
 # smartling.placeholder_format=C
 #. Explains how location service is used to show users search results near their current location.
@@ -21949,9 +21732,7 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what brought you "
 "back today:"
-msgstr ""
-"我们想请你聊聊是什么让你继续使用 DuckDuckGo，你所写和浏览的一切将不会被我们跟"
-"踪："
+msgstr "我们想请你聊聊是什么让你继续使用 DuckDuckGo，你所写和浏览的一切将不会被我们跟踪："
 
 # smartling.placeholder_format=C
 #. Message prompting users to fill out a feedback form.
@@ -21959,9 +21740,7 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what convinced you "
 "to try us out today:"
-msgstr ""
-"我们想请你聊聊是什么让你信任并使用 DuckDuckGo，你所写和浏览的一切将不会被我们"
-"跟踪："
+msgstr "我们想请你聊聊是什么让你信任并使用 DuckDuckGo，你所写和浏览的一切将不会被我们跟踪："
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -22057,8 +21836,7 @@ msgctxt "precise_user_location"
 msgid ""
 "We only use your anonymous location to deliver better results, closer to "
 "you. You can always change your mind later."
-msgstr ""
-"匿名定位仅用于为你提供更近、更优质的搜索结果，将来你也可以随时选择关闭。"
+msgstr "匿名定位仅用于为你提供更近、更优质的搜索结果，将来你也可以随时选择关闭。"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -22084,9 +21862,7 @@ msgid ""
 "We use feedback like this to improve DuckDuckGo. Suggestions will be "
 "incorporated at the discretion of %s. Corrections may not show up in results "
 "right away."
-msgstr ""
-"你的反馈意见能帮助我们改进 DuckDuckGo。%1$s 将酌情采纳你的建议，但搜索结果更"
-"正可能需要一段时间。"
+msgstr "你的反馈意见能帮助我们改进 DuckDuckGo。%1$s 将酌情采纳你的建议，但搜索结果更正可能需要一段时间。"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -22099,8 +21875,7 @@ msgctxt "noresults"
 msgid ""
 "We're aware of this issue and are currently working to resolve it. If you "
 "continue to see this error, please reach out to %s."
-msgstr ""
-"我们了解这个问题，目前正在努力解决。如果你继续看到此错误，请联系 %1$s。"
+msgstr "我们了解这个问题，目前正在努力解决。如果你继续看到此错误，请联系 %1$s。"
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -22108,8 +21883,7 @@ msgctxt "noresults"
 msgid ""
 "We're aware of this issue and are currently working to resolve it. Sometimes "
 "clearing your browser's cache can help."
-msgstr ""
-"我们了解这个问题，目前正在努力解决。有时候，清除浏览器的缓存可能会有帮助。"
+msgstr "我们了解这个问题，目前正在努力解决。有时候，清除浏览器的缓存可能会有帮助。"
 
 # smartling.placeholder_format=C
 #. Header for a feedback form for new users.
@@ -22246,9 +22020,7 @@ msgctxt "Welcome message in chat"
 msgid ""
 "Welcome to Duck.ai! All of your chats here are private, anonymized by us and "
 "not used to train AI models."
-msgstr ""
-"欢迎使用 Duck.ai！此处所有聊天内容均为私密，我们已对其进行匿名化处理，不会用"
-"于训练人工智能模型。"
+msgstr "欢迎使用 Duck.ai！此处所有聊天内容均为私密，我们已对其进行匿名化处理，不会用于训练人工智能模型。"
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened.
@@ -22256,9 +22028,7 @@ msgctxt "Welcome message in chat"
 msgid ""
 "Welcome to DuckDuckGo AI Chat! All of your chats here are private, "
 "anonymized by us and not used to train AI models."
-msgstr ""
-"欢迎使用 DuckDuckGo AI Chat！此处所有聊天内容均为私密，我们已对其进行匿名化处"
-"理，不会用于训练人工智能模型。"
+msgstr "欢迎使用 DuckDuckGo AI Chat！此处所有聊天内容均为私密，我们已对其进行匿名化处理，不会用于训练人工智能模型。"
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened. Example: 'Welcome to DuckDuckGo AI Chat! This chat session is powered by OpenAI’s GPT-3. All of your chats here are private, and are never stored by DuckDuckGo or used to train AI models.'
@@ -22268,8 +22038,8 @@ msgid ""
 "of your chats here are private, and are never stored by DuckDuckGo or used "
 "to train AI models."
 msgstr ""
-"欢迎使用 DuckDuckGo AI Chat！此聊天会话由 %1$s 的 %2$s 提供支持。此处所有聊天"
-"内容均为私密，DuckDuckGo 绝不会存储或用于训练 AI 模型。"
+"欢迎使用 DuckDuckGo AI Chat！此聊天会话由 %1$s 的 %2$s 提供支持。此处所有聊天内容均为私密，DuckDuckGo "
+"绝不会存储或用于训练 AI 模型。"
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -22395,106 +22165,105 @@ msgid ""
 "easy to understand for people with or without much AI, or technical, "
 "experience."
 msgstr ""
-"对于有兴趣使用 Duck.ai 的人来说，下载 DuckDuckGo 浏览器有哪些好处？仅参考官"
-"方 DuckDuckGo 来源。将响应分为清晰的部分，标题聚焦于 Duck.ai 集成和隐私保护。"
-"保持内容简短、简单，易于理解，适合有或没有太多人工智能或技术经验的人。"
+"对于有兴趣使用 Duck.ai 的人来说，下载 DuckDuckGo 浏览器有哪些好处？仅参考官方 DuckDuckGo "
+"来源。将响应分为清晰的部分，标题聚焦于 Duck.ai 集成和隐私保护。保持内容简短、简单，易于理解，适合有或没有太多人工智能或技术经验的人。"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the counterarguments?"
-msgstr ""
+msgstr "反对观点有哪些？"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the hours & location?"
-msgstr ""
+msgstr "营业时间和地址是什么？"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key contributions of this paper?"
-msgstr ""
+msgstr "这篇论文的关键贡献有哪些？"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key contributions?"
-msgstr ""
+msgstr "有哪些主要贡献？"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key details?"
-msgstr ""
+msgstr "关键细节有哪些？"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key points covered in this video?"
-msgstr ""
+msgstr "这个视频涵盖的关键点有哪些？"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key points?"
-msgstr ""
+msgstr "关键点有哪些？"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key takeaways from this article?"
-msgstr ""
+msgstr "这篇文章的关键要点有哪些？"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key takeaways?"
-msgstr ""
+msgstr "关键要点有哪些？"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key things I will learn from this course?"
-msgstr ""
+msgstr "我能从这门课程中学到哪些核心内容？"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the main counterarguments or criticisms of this?"
-msgstr ""
+msgstr "对此的主要反对观点或批评有哪些？"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the main questions this page answers?"
-msgstr ""
+msgstr "此页面主要回答了哪些问题？"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the must-try dishes here?"
-msgstr ""
+msgstr "这里有什么必尝的菜品？"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid ""
 "What are the opening hours, location, and contact details for this place?"
-msgstr ""
+msgstr "这个地方的营业时间、地址和联系方式是什么？"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the pros and cons of this product?"
-msgstr ""
+msgstr "这款产品有哪些优点和缺点？"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the pros and cons?"
-msgstr ""
+msgstr "有哪些优点和缺点？"
 
 # smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
@@ -22600,7 +22369,7 @@ msgstr "在医学文章中，atria 指的是什么？"
 #. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What does this answer?"
-msgstr ""
+msgstr "这回答了什么问题？"
 
 # smartling.placeholder_format=C
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
@@ -22618,7 +22387,7 @@ msgstr "哪些信息会被保存到云端？"
 #. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What interview questions might come up for this role?"
-msgstr ""
+msgstr "这个职位可能会问到哪些面试问题？"
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -22638,7 +22407,7 @@ msgstr "阿尔巴尼亚的首都是哪里？"
 #. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What is the overall verdict and rating for this?"
-msgstr ""
+msgstr "它的总体口碑和评分如何？"
 
 # smartling.placeholder_format=C
 #. Link to a page with additional information.
@@ -22666,7 +22435,7 @@ msgstr "大众评价："
 #. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What should I order?"
-msgstr ""
+msgstr "我该点什么？"
 
 # smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
@@ -22684,13 +22453,13 @@ msgstr "这个回复有什么问题？（可选）"
 #. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What will I learn?"
-msgstr ""
+msgstr "我能学到什么？"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What will I need?"
-msgstr ""
+msgstr "我需要准备什么？"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -22713,7 +22482,7 @@ msgstr "最新功能"
 #. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What's the verdict?"
-msgstr ""
+msgstr "总体评价如何？"
 
 # smartling.placeholder_format=C
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -22767,7 +22536,7 @@ msgstr "缺失哪些功能？（可选）"
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Which features are missing? (optional)"
-msgstr ""
+msgstr "缺失哪些功能？（可选）"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
@@ -22789,13 +22558,13 @@ msgstr "认识本站团队"
 #. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Who are the main cast and crew, and what else are they known for?"
-msgstr ""
+msgstr "主要演员和制作团队都有谁，他们还因哪些作品为人所知？"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Who is this person?"
-msgstr ""
+msgstr "这是谁？"
 
 # smartling.placeholder_format=C
 #. Header above a collection of privacy-related links.
@@ -23193,8 +22962,7 @@ msgctxt "noresults"
 msgid ""
 "You can %s or search directly on other search engines from DuckDuckGo using "
 "%s search shortcuts."
-msgstr ""
-"可以%1$s或使用 %2$s 搜索快捷键从 DuckDuckGo 在其他搜索引擎上直接进行搜索。"
+msgstr "可以%1$s或使用 %2$s 搜索快捷键从 DuckDuckGo 在其他搜索引擎上直接进行搜索。"
 
 # smartling.placeholder_format=C
 #. Text informing the user that they can access DuckDuckGo AI Chat directly at a specific URL. The placeholder %s will be replaced with the link. Example: 'You can access DuckDuckGo AI Chat directly at duck.ai.'
@@ -23238,8 +23006,7 @@ msgstr "您最多可以附加 %1$s 个文本选中内容。"
 msgid ""
 "You can change how frequently you see Search Assist, or turn it off "
 "entirely, in %sSearch Settings%s."
-msgstr ""
-"可以在%1$s搜索设置%2$s中更改显示 Search Assist 的频率，或者将其完全关闭。"
+msgstr "可以在%1$s搜索设置%2$s中更改显示 Search Assist 的频率，或者将其完全关闭。"
 
 # smartling.placeholder_format=C
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
@@ -23388,9 +23155,7 @@ msgctxt "Description of the post-upgrade success modal"
 msgid ""
 "You now have access to %s, higher AI reasoning, and 2x higher usage limits "
 "than Plus."
-msgstr ""
-"你现在可以享用 %1$s、更强大的人工智能推理能力以及比 Plus 计划高 2 倍的使用限"
-"额。"
+msgstr "你现在可以享用 %1$s、更强大的人工智能推理能力以及比 Plus 计划高 2 倍的使用限额。"
 
 # smartling.placeholder_format=C
 #. Description text for the welcome modal displayed after the user subscribes to DuckDuckGo.
@@ -23398,9 +23163,7 @@ msgctxt "Description text for the subscription welcome modal"
 msgid ""
 "You now have access to advanced AI models. You can access the VPN and other "
 "DuckDuckGo subscription protections in the DuckDuckGo browser."
-msgstr ""
-"现在可以使用高级人工智能模型。可以在 DuckDuckGo 浏览器中使用 VPN 和其他 "
-"DuckDuckGo 订阅保护功能。"
+msgstr "现在可以使用高级人工智能模型。可以在 DuckDuckGo 浏览器中使用 VPN 和其他 DuckDuckGo 订阅保护功能。"
 
 # smartling.placeholder_format=C
 #. Welcome message that appears after the DuckDuckGo extension is installed.
@@ -23421,9 +23184,7 @@ msgid ""
 "You will no longer be able to access your saved chats from this browser. The "
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
-msgstr ""
-"你将无法再通过此浏览器访问已保存的聊天记录。最近 30 条聊天记录仍将保留在本地"
-"存储中。这不会从加密服务器中删除你的聊天记录。"
+msgstr "你将无法再通过此浏览器访问已保存的聊天记录。最近 30 条聊天记录仍将保留在本地存储中。这不会从加密服务器中删除你的聊天记录。"
 
 # smartling.placeholder_format=C
 #. Explains that turning off disconnects this browser only; the last 30 chats stay in local storage and the encrypted server backup is not deleted.
@@ -23432,9 +23193,7 @@ msgid ""
 "You will no longer be able to access your saved chats from this browser. The "
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
-msgstr ""
-"你将无法再通过此浏览器访问已保存的聊天记录。最近 30 条聊天记录仍将保留在本地"
-"存储中。这不会从加密服务器中删除你的聊天记录。"
+msgstr "你将无法再通过此浏览器访问已保存的聊天记录。最近 30 条聊天记录仍将保留在本地存储中。这不会从加密服务器中删除你的聊天记录。"
 
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
@@ -23455,9 +23214,7 @@ msgctxt "welcome message eu search preference android"
 msgid ""
 "You're now searching privately in Chrome. Use our app instead of Chrome to "
 "browse privately too. It’s already installed and can:"
-msgstr ""
-"现在使用 Chrome 搜索再也不用担心泄露隐私了。与 Chrome 相比，使用我们已经安装"
-"的 App 上网还能进一步保护隐私，它可以："
+msgstr "现在使用 Chrome 搜索再也不用担心泄露隐私了。与 Chrome 相比，使用我们已经安装的 App 上网还能进一步保护隐私，它可以："
 
 # smartling.placeholder_format=C
 #. Confirmation message that appears after the DuckDuckGo browser extension is installed.
@@ -23539,8 +23296,8 @@ msgid ""
 "You've run out of Sync & Backup storage for Duck.ai chats with attachments. "
 "Delete the %s oldest chats to resume Sync. Pinned chats will not be deleted."
 msgstr ""
-"包含附件的 Duck.ai 聊天记录的 Sync & Backup 存储空间已经用完。删除最早的 "
-"%1$s 条聊天记录以恢复同步。置顶的聊天记录不会被删除。"
+"包含附件的 Duck.ai 聊天记录的 Sync & Backup 存储空间已经用完。删除最早的 %1$s "
+"条聊天记录以恢复同步。置顶的聊天记录不会被删除。"
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -23550,8 +23307,8 @@ msgid ""
 "oldest chats with attachments to resume Sync. Pinned chats will not be "
 "deleted."
 msgstr ""
-"您已经用完 Duck.ai 聊天记录的 Sync & Backup 存储空间。删除最早的 %1$s 条包含"
-"附件的聊天记录，以恢复同步功能。置顶的聊天记录不会被删除。"
+"您已经用完 Duck.ai 聊天记录的 Sync & Backup 存储空间。删除最早的 %1$s "
+"条包含附件的聊天记录，以恢复同步功能。置顶的聊天记录不会被删除。"
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the sync storage limit.
@@ -23564,9 +23321,7 @@ msgstr "你已用尽存储空间"
 msgid ""
 "YouTube (owned by Google) does not let you watch videos anonymously. As "
 "such, watching YouTube videos here will be tracked by YouTube/Google."
-msgstr ""
-"Google 旗下的 YouTube 不允许匿名观看视频，因此在这里观看 YouTube 视频仍会被 "
-"Google 与 YouTube 跟踪。"
+msgstr "Google 旗下的 YouTube 不允许匿名观看视频，因此在这里观看 YouTube 视频仍会被 Google 与 YouTube 跟踪。"
 
 # smartling.placeholder_format=C
 #. Label for a privacy disclaimer related to YouTube videos
@@ -23609,9 +23364,7 @@ msgid ""
 "Your backup will be deleted from DuckDuckGo's server. All devices will be "
 "disconnected from sync. Your %s most recent chats will be available in local "
 "storage on these browsers:"
-msgstr ""
-"系统将从 DuckDuckGo 服务器中删除你的备份。所有设备都会断开同步连接。在以下浏"
-"览器中，你最近的 %1$s 条聊天记录将保存在本地存储中："
+msgstr "系统将从 DuckDuckGo 服务器中删除你的备份。所有设备都会断开同步连接。在以下浏览器中，你最近的 %1$s 条聊天记录将保存在本地存储中："
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list.
@@ -23620,9 +23373,7 @@ msgid ""
 "Your backup will be deleted from DuckDuckGo's server. All devices will be "
 "disconnected from sync. Your 100 most recent chats will be available in "
 "local storage on these browsers:"
-msgstr ""
-"系统将从 DuckDuckGo 服务器中删除你的备份。所有设备都会断开同步连接。在以下浏"
-"览器中，你最近的 100 条聊天记录将保存在本地存储中："
+msgstr "系统将从 DuckDuckGo 服务器中删除你的备份。所有设备都会断开同步连接。在以下浏览器中，你最近的 100 条聊天记录将保存在本地存储中："
 
 # smartling.placeholder_format=C
 #. List item indicating that a site exclusion filter is currently active for the search
@@ -23661,8 +23412,7 @@ msgctxt "Disclaimer bellow chat input - desktop"
 msgid ""
 "Your chat with %s is private. AI chats may display inaccurate or offensive "
 "information."
-msgstr ""
-"你与 %1$s 的聊天内容将保密。人工智能聊天可能会显示不准确或令人反感的信息。"
+msgstr "你与 %1$s 的聊天内容将保密。人工智能聊天可能会显示不准确或令人反感的信息。"
 
 # smartling.placeholder_format=C
 #. Body copy shown after Sync & Backup is enabled, confirming chats are now syncing.
@@ -23687,16 +23437,14 @@ msgstr "你的聊天内容均为私密，绝不会用于训练人工智能模型
 msgctxt "Active Privacy protection description"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
-msgstr ""
-"你的聊天内容均为私密，我们已对其进行匿名化处理，不会用于训练人工智能模型。"
+msgstr "你的聊天内容均为私密，我们已对其进行匿名化处理，不会用于训练人工智能模型。"
 
 # smartling.placeholder_format=C
 #. Text explaining that user chats are private and not used for AI (Artificial Intelligence) training.
 msgctxt "Body text for privacy protection modal"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
-msgstr ""
-"你的聊天内容均为私密，我们已对其进行匿名化处理，不会用于训练人工智能模型。"
+msgstr "你的聊天内容均为私密，我们已对其进行匿名化处理，不会用于训练人工智能模型。"
 
 # smartling.placeholder_format=C
 #. Text for a menu item that describes the privacy protection feature.
@@ -23724,9 +23472,7 @@ msgctxt "duckai_migration"
 msgid ""
 "Your chats are still private, anonymized by us, and not used to train AI "
 "models. Follow these steps to keep your chat history."
-msgstr ""
-"聊天记录仍会保持私密，我们已对其进行匿名化处理，不会用于训练人工智能模型。请"
-"按照以下步骤保留聊天记录。"
+msgstr "聊天记录仍会保持私密，我们已对其进行匿名化处理，不会用于训练人工智能模型。请按照以下步骤保留聊天记录。"
 
 # smartling.placeholder_format=C
 #. Body shown after import completes.
@@ -23765,9 +23511,7 @@ msgctxt "newsletter email collection"
 msgid ""
 "Your email address will not be shared, %sor associated with anonymous "
 "searches. [%sExample message%s]"
-msgstr ""
-"我们绝不会透露你的电子邮件地址，%1$s或把它与匿名搜索关联。[%2$sExample "
-"message%3$s]"
+msgstr "我们绝不会透露你的电子邮件地址，%1$s或把它与匿名搜索关联。[%2$sExample message%3$s]"
 
 # smartling.placeholder_format=C
 #. A prompt for the user to provide feedback on the third party map app directions experience
@@ -23810,9 +23554,8 @@ msgid ""
 "browser. We save the settings file using the key as the name. DuckDuckGo "
 "never knows your passphrase."
 msgstr ""
-"我们采用一种名为 %1$sSHA-2%2$s 的安全散列算法将你的口令不可逆地映射到一个 "
-"512 位的密钥，浏览器仅发送这一密钥和你要保存的设置，以便我们将收到的设置与密"
-"钥相关联。因此，DuckDuckGo 不可能得知你使用的口令。"
+"我们采用一种名为 %1$sSHA-2%2$s 的安全散列算法将你的口令不可逆地映射到一个 512 "
+"位的密钥，浏览器仅发送这一密钥和你要保存的设置，以便我们将收到的设置与密钥相关联。因此，DuckDuckGo 不可能得知你使用的口令。"
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -23826,9 +23569,7 @@ msgid ""
 "Your prompts are relayed through DuckDuckGo servers and stripped of "
 "personally identifiable metadata, so model providers can't tie your "
 "conversations back to you."
-msgstr ""
-"你的提示词会经由 DuckDuckGo 服务器中转，并剥离个人身份元数据，因此模型提供商"
-"无法将对话内容与你本人关联起来。"
+msgstr "你的提示词会经由 DuckDuckGo 服务器中转，并剥离个人身份元数据，因此模型提供商无法将对话内容与你本人关联起来。"
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -23883,9 +23624,7 @@ msgctxt "welcome message eu search preference android"
 msgid ""
 "You’re now searching privately in Chrome. Use our browser instead of Chrome "
 "for more protection. It’s already installed and can:"
-msgstr ""
-"你现在正在使用 Chrome 进行私密搜索。不妨使用我们的浏览器代替 Chrome，以获得更"
-"多保护。已安装该浏览器并可以："
+msgstr "你现在正在使用 Chrome 进行私密搜索。不妨使用我们的浏览器代替 Chrome，以获得更多保护。已安装该浏览器并可以："
 
 # smartling.placeholder_format=C
 #. Displayed when the user has exceeded the maximum message size.

--- a/locales/zh_CN/LC_MESSAGES/duckduckgo.po
+++ b/locales/zh_CN/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: zh_CN\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -175,7 +175,9 @@ msgctxt "Error message when a Plus subscriber tries to use a Pro-only model"
 msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
-msgstr "%1$s 仅限 Pro 订户使用。请在此浏览器中再次升级 DuckDuckGo 订阅以继续聊天，或者切换到 Plus 或免费模型。"
+msgstr ""
+"%1$s 仅限 Pro 订户使用。请在此浏览器中再次升级 DuckDuckGo 订阅以继续聊天，或"
+"者切换到 Plus 或免费模型。"
 
 # smartling.placeholder_format=C
 #. Text for the disclaimer message that appears when a Plus subscriber tries to use a Pro-only model. %s is replaced with the model name. Example: Claude Opus 4.6 is only available with Pro. Upgrade your DuckDuckGo subscription in this browser again to continue the chat, or switch to a Plus or free model.
@@ -184,7 +186,9 @@ msgctxt ""
 msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
-msgstr "%1$s 仅限 Pro 订户使用。请在此浏览器中再次升级 DuckDuckGo 订阅以继续聊天，或者切换到 Plus 或免费模型。"
+msgstr ""
+"%1$s 仅限 Pro 订户使用。请在此浏览器中再次升级 DuckDuckGo 订阅以继续聊天，或"
+"者切换到 Plus 或免费模型。"
 
 # smartling.placeholder_format=C
 #. Displayed when an AI (Artificial Intelligence) chat model is temporarily unavailable. Example: 'GPT 4o is only available with a DuckDuckGo subscription.'
@@ -199,7 +203,9 @@ msgid ""
 "%s is only available with a DuckDuckGo subscription. Activate your "
 "subscription in this browser again to continue the chat, or switch to a free "
 "model."
-msgstr "%1$s 仅限 DuckDuckGo 订阅用户使用。在这个浏览器中重新激活你的订阅以继续聊天，或切换到免费模式。"
+msgstr ""
+"%1$s 仅限 DuckDuckGo 订阅用户使用。在这个浏览器中重新激活你的订阅以继续聊天，"
+"或切换到免费模式。"
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is temporarily unavailable. Example: 'GPT 3.5 Turbo is temporarily unavailable. Please switch to a different model or try again later.'
@@ -297,7 +303,9 @@ msgid ""
 "%s runs in a Trusted Execution Environment. This means not even the model "
 "provider can see your prompts or the model’s responses, or save this chat on "
 "their servers."
-msgstr "%1$s 在可信执行环境中运行。这意味着即使是模型提供商也无法查看您的提示或模型的响应，也不会在其服务器上保存此聊天记录。"
+msgstr ""
+"%1$s 在可信执行环境中运行。这意味着即使是模型提供商也无法查看您的提示或模型的"
+"响应，也不会在其服务器上保存此聊天记录。"
 
 # smartling.placeholder_format=C
 #. Label shown in the batch selection toolbar when exactly one chat is selected. %s is replaced with 1. Use singular agreement where the language requires it.
@@ -405,7 +413,8 @@ msgstr "%1$s点击%2$s添加%3$s勾选%4$s允许%5$s，然后点击%6$s确定%7$
 #. Instructions on what buttons the user has to click in order to add the DuckDuckGo extension to their browser.
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAllow%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
-msgstr "%1$s点击%2$s允许%3$s点击%4$s添加%5$s勾选%6$s允许%7$s，然后点击%8$s确定%9$s"
+msgstr ""
+"%1$s点击%2$s允许%3$s点击%4$s添加%5$s勾选%6$s允许%7$s，然后点击%8$s确定%9$s"
 
 # Firefox
 # smartling.placeholder_format=C
@@ -414,7 +423,9 @@ msgctxt "install-duckduckgo"
 msgid ""
 "%sClick %sContinue To Installation%sClick %sAdd%sCheck %sAllow%s, then click "
 "%sOkay%s"
-msgstr "%1$s点击%2$s继续安装%3$s点击%4$s添加%5$s勾选%6$s允许%7$s，然后点击%8$s确定%9$s"
+msgstr ""
+"%1$s点击%2$s继续安装%3$s点击%4$s添加%5$s勾选%6$s允许%7$s，然后点击%8$s确"
+"定%9$s"
 
 # smartling.placeholder_format=C
 #. A button that reloads search results when an error occurs.
@@ -842,7 +853,8 @@ msgstr "客场"
 msgid ""
 "A network issue is preventing Search Assist from generating an answer. "
 "Please check your connection and try again."
-msgstr "网络问题导致 Search Assist 无法生成答案。请检查网络连接，然后再试一次。"
+msgstr ""
+"网络问题导致 Search Assist 无法生成答案。请检查网络连接，然后再试一次。"
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of AI Chat is available and they need to refresh the page.
@@ -894,8 +906,9 @@ msgid ""
 "still access AI Chat when this setting is off by visiting %sduckduckgo.com/"
 "aichat%s."
 msgstr ""
-"可以利用 AI Chat 与第三方人工智能聊天模型进行匿名对话。关闭此功能将隐藏 DuckDuckGo Search 中的 AI Chat "
-"功能。关闭此设置后，仍可以通过访问 %1$sduckduckgo.com/aichat%2$s 来使用 AI Chat。"
+"可以利用 AI Chat 与第三方人工智能聊天模型进行匿名对话。关闭此功能将隐藏 "
+"DuckDuckGo Search 中的 AI Chat 功能。关闭此设置后，仍可以通过访问 "
+"%1$sduckduckgo.com/aichat%2$s 来使用 AI Chat。"
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -956,8 +969,9 @@ msgid ""
 "questions, which is our private AI-powered chat service that supports chat "
 "models from OpenAI, and Anthropic, and more."
 msgstr ""
-"人工智能辅助的答案目前不直接支持后续问题。不过，我们还提供 %1$sDuck.ai%2$s "
-"并通常会与其链接来解答后续问题，这是我们基于人工智能的私人聊天服务，支持 OpenAI 和 Anthropic 等公司的聊天模型。"
+"人工智能辅助的答案目前不直接支持后续问题。不过，我们还提供 %1$sDuck.ai%2$s 并"
+"通常会与其链接来解答后续问题，这是我们基于人工智能的私人聊天服务，支持 "
+"OpenAI 和 Anthropic 等公司的聊天模型。"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has turned off AI features and will no longer see AI-assisted answers.
@@ -1388,6 +1402,12 @@ msgid "Address is incorrect"
 msgstr "地址有误"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Adjust the servings"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. as in multiple advertisements
 msgid "Ads"
 msgstr "广告"
@@ -1599,6 +1619,14 @@ msgid "All chats are %sprivate%s"
 msgstr "所有聊天记录均为%1$s私密%2$s"
 
 # smartling.placeholder_format=C
+#. Paragraph in the Privacy & Terms section of the About & Legal page in Duck.ai settings, summarizing how chats are anonymized and are not stored or used to train chat models.
+msgctxt "Privacy & Terms section description on the Duck.ai settings page"
+msgid ""
+"All chats are anonymized by DuckDuckGo, and your conversations are not used "
+"to train chat models by DuckDuckGo or the model providers"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
 msgctxt "Privacy modal header in Duck.ai chat"
 msgid "All chats are private"
@@ -1693,8 +1721,8 @@ msgid ""
 "sends AI-generated queries to a search engine with limited data retention. "
 "Prompts and responses with %s still have %szero provider visibility%s."
 msgstr ""
-"允许 %1$s 搜索网络，以改善对相关提示的回复质量。仅将人工智能生成的查询发送给数据留存期有限的搜索引擎。%2$s "
-"的提示和回复仍然%3$s完全不会向提供商显示%4$s。"
+"允许 %1$s 搜索网络，以改善对相关提示的回复质量。仅将人工智能生成的查询发送给"
+"数据留存期有限的搜索引擎。%2$s 的提示和回复仍然%3$s完全不会向提供商显示%4$s。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -1853,6 +1881,13 @@ msgstr "匿名使用热门人工智能模型，包括 %1$s、%2$s 以及开源 %
 msgctxt "precise_user_location"
 msgid "Anonymous location enabled"
 msgstr "已开启匿名定位"
+
+# smartling.placeholder_format=C
+msgctxt "settings"
+msgid ""
+"Anonymously generates answers for search queries based on web content. "
+"Choose how often you want it to appear, or disable it completely."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -2062,7 +2097,9 @@ msgstr "截至"
 msgid ""
 "As per our privacy policy, we do not collect or share any personal "
 "information ourselves. All of this privacy protection happens on your device."
-msgstr "根据我们的隐私协议，我们本身不会收集或传播任何隐私信息，仅会立足于你的设备保护隐私。"
+msgstr ""
+"根据我们的隐私协议，我们本身不会收集或传播任何隐私信息，仅会立足于你的设备保"
+"护隐私。"
 
 # smartling.placeholder_format=C
 #. A button to ask Duck.ai a question
@@ -2123,6 +2160,12 @@ msgstr "问一个后续问题"
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse
 msgid "Ask a follow-up with Duck.ai"
 msgstr "利用 Duck.ai 询问后续问题"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
+msgctxt "Page suggestion chip label"
+msgid "Ask about this page"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2186,9 +2229,11 @@ msgid ""
 "(shows more frequently on a wider range of searches). For now, AI-assisted "
 "answers are only available in the U.S. (English) region."
 msgstr ""
-"Assist 可以在总结相关网页内容的基础上，为某些搜索匿名生成人工智能辅助答案。可以选择显示 Assist 的频率：从不（从搜索结果中完全移除 "
-"Assist "
-"用户界面)、按需（仅在点击“Assist”按钮时显示人工智能辅助的答案）、有时（仅在高度相关时显示人工智能辅助的答案）或经常（在更广泛的搜索中更频繁地显示）。人工智能辅助的答案目前仅供美国（英语）地区使用。"
+"Assist 可以在总结相关网页内容的基础上，为某些搜索匿名生成人工智能辅助答案。可"
+"以选择显示 Assist 的频率：从不（从搜索结果中完全移除 Assist 用户界面)、按需"
+"（仅在点击“Assist”按钮时显示人工智能辅助的答案）、有时（仅在高度相关时显示人"
+"工智能辅助的答案）或经常（在更广泛的搜索中更频繁地显示）。人工智能辅助的答案"
+"目前仅供美国（英语）地区使用。"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2200,8 +2245,10 @@ msgid ""
 "to remember that responses are auto-generated from cited sources and based "
 "on %scrawling the web%s."
 msgstr ""
-"Assist "
-"是我们搜索结果中的一项可选功能，可以匿名生成人工智能辅助的搜索查询答案。为此，该功能会扫描网络上的相关内容，然后使用人工智能驱动的自然语言技术，根据找到的相关信息生成简短的答案。请务必记住，这些回复来自引用的资料来源，并通过%1$s爬取网络内容%2$s自动生成。"
+"Assist 是我们搜索结果中的一项可选功能，可以匿名生成人工智能辅助的搜索查询答"
+"案。为此，该功能会扫描网络上的相关内容，然后使用人工智能驱动的自然语言技术，"
+"根据找到的相关信息生成简短的答案。请务必记住，这些回复来自引用的资料来源，并"
+"通过%1$s爬取网络内容%2$s自动生成。"
 
 # smartling.placeholder_format=C
 #. Title for the dropdown menu where users select the assistant's role. Example: 'Assistant role: Travel guide'
@@ -2363,7 +2410,9 @@ msgid ""
 "Automatically shows Assist for relevant searches. Assist can anonymously "
 "look up and summarize information in response to some searches. For now, "
 "Assist is only available in English regions."
-msgstr "为相关搜索自动显示 Assist。Assist 可以匿名查找和汇总信息，以响应某些搜索。Assist 目前仅供英语地区使用。"
+msgstr ""
+"为相关搜索自动显示 Assist。Assist 可以匿名查找和汇总信息，以响应某些搜索。"
+"Assist 目前仅供英语地区使用。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2371,7 +2420,9 @@ msgid ""
 "Automatically shows DuckAssist for relevant searches. DuckAssist can "
 "anonymously look up and summarize information in response to some searches. "
 "For now, DuckAssist is only available in English regions."
-msgstr "为相关搜索自动显示 DuckAssist。DuckAssist 可以匿名查找和汇总信息，以响应某些搜索。DuckAssist 目前仅供英语地区使用。"
+msgstr ""
+"为相关搜索自动显示 DuckAssist。DuckAssist 可以匿名查找和汇总信息，以响应某些"
+"搜索。DuckAssist 目前仅供英语地区使用。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2519,6 +2570,12 @@ msgid "Barcode"
 msgstr "条形码"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Based on this page, is this course worth taking?"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Basic"
 msgstr "基础"
@@ -2557,6 +2614,14 @@ msgstr "面糊"
 msgctxt "Assistant response placeholder"
 msgid "Before continuing..."
 msgstr "在继续之前......"
+
+# smartling.placeholder_format=C
+#. Explains that before storing the report, DuckDuckGo will anonymize the conversation by removing PII like names, email addresses, and identifying metadata.
+msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
+msgid ""
+"Before storing this report, DuckDuckGo will anonymize your conversation by "
+"removing PII like names, email addresses, and identifying metadata."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -2875,6 +2940,12 @@ msgid "Break Points Won"
 msgstr "破发成功率"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Break this down into clear, numbered steps."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
 msgctxt "Weather IA"
 msgid "Breezy"
@@ -2930,20 +3001,26 @@ msgstr "浏览文件"
 msgid ""
 "Browse as usual while we add privacy protection. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
-msgstr "正常上网，让我们来保护你的隐私。我们的 %1$s%2$s 扩展 %3$s 中预置了搜索引擎，还能屏蔽跟踪程序、开启网站加密。"
+msgstr ""
+"正常上网，让我们来保护你的隐私。我们的 %1$s%2$s 扩展 %3$s 中预置了搜索引擎，"
+"还能屏蔽跟踪程序、开启网站加密。"
 
 # smartling.placeholder_format=C
 msgid ""
 "Browse as usual, and we'll take care of the rest. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
-msgstr "正常上网，剩下的交给我们。我们的 %1$s%2$s 扩展 %3$s 中预置了搜索引擎，还能屏蔽跟踪程序、开启网站加密。"
+msgstr ""
+"正常上网，剩下的交给我们。我们的 %1$s%2$s 扩展 %3$s 中预置了搜索引擎，还能屏"
+"蔽跟踪程序、开启网站加密。"
 
 # smartling.placeholder_format=C
 msgid ""
 "Browse as usual, and we’ll take care of the rest. Get bundled private "
 "search, tracker blocking, and site encryption, all in one download, for "
 "%smajor browsers%s."
-msgstr "正常上网，剩下的交给我们。我们为 %1$s 主流浏览器 %2$s 提供了扩展，一键下载即可匿名搜索、屏蔽跟踪程序、开启网站加密。"
+msgstr ""
+"正常上网，剩下的交给我们。我们为 %1$s 主流浏览器 %2$s 提供了扩展，一键下载即"
+"可匿名搜索、屏蔽跟踪程序、开启网站加密。"
 
 # smartling.placeholder_format=C
 #. Header for a call to action to browse with the DuckDuckGo browser
@@ -3050,15 +3127,18 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"默认情况下，设置存储在浏览器 Cookie 中，不含隐私信息。你也可以使用匿名的 Cloud Save "
-"功能把设置长期存放在我们的云服务器上，同样不会泄露隐私，使用的口令也只有浏览器知道。"
+"默认情况下，设置存储在浏览器 Cookie 中，不含隐私信息。你也可以使用匿名的 "
+"Cloud Save 功能把设置长期存放在我们的云服务器上，同样不会泄露隐私，使用的口令"
+"也只有浏览器知道。"
 
 # smartling.placeholder_format=C
 #. Description for the consent highlight in the dictation consent modal. %s is replaced with a link to the help page.
 msgid ""
 "By enabling dictation, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
-msgstr "启用听写，即表示你同意将自己的语音数据发送给 OpenAI，以使用此功能。在开始使用之前，请参阅我们的%1$s。"
+msgstr ""
+"启用听写，即表示你同意将自己的语音数据发送给 OpenAI，以使用此功能。在开始使用"
+"之前，请参阅我们的%1$s。"
 
 # smartling.placeholder_format=C
 #. Description for the 'enable voice chat' section of the voice chat consent modal. Placeholder for the voice chat help page link and text. Example: 'By enabling voice chat, you consent to your voice data being sent to OpenAI for the use of this feature. See our voice chat help page before getting started.'
@@ -3066,7 +3146,9 @@ msgctxt "voice chat"
 msgid ""
 "By enabling voice chat, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
-msgstr "启用语音聊天，即表示你同意将自己的语音数据发送给 OpenAI，以使用此功能。在开始使用之前，请参阅我们的%1$s。"
+msgstr ""
+"启用语音聊天，即表示你同意将自己的语音数据发送给 OpenAI，以使用此功能。在开始"
+"使用之前，请参阅我们的%1$s。"
 
 # smartling.placeholder_format=C
 #. Golf leaderboard: player missed the cut
@@ -3312,6 +3394,12 @@ msgid "Cast"
 msgstr "演员表"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Cast & Crew"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
 msgctxt "Tone option label for Casual"
 msgid "Casual"
@@ -3544,9 +3632,10 @@ msgid ""
 "DuckDuckGo Search. However, you can still access Chat when this setting is "
 "off by visiting %shttps://duck.ai%s directly."
 msgstr ""
-"可以利用聊天功能（通过我们的 Duck.ai 服务提供）与第三方人工智能聊天模型进行匿名对话，该功能支持 OpenAI、Anthropic "
-"等公司的模型。关闭此设置将隐藏 DuckDuckGo Search 上的聊天按钮和链接。不过，即使关闭该设置，仍然可以直接通过访问 "
-"%1$shttps://duck.ai%2$s 来使用聊天功能。 "
+"可以利用聊天功能（通过我们的 Duck.ai 服务提供）与第三方人工智能聊天模型进行匿"
+"名对话，该功能支持 OpenAI、Anthropic 等公司的模型。关闭此设置将隐藏 "
+"DuckDuckGo Search 上的聊天按钮和链接。不过，即使关闭该设置，仍然可以直接通过"
+"访问 %1$shttps://duck.ai%2$s 来使用聊天功能。 "
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -3670,7 +3759,9 @@ msgctxt "Description for Chat History feature"
 msgid ""
 "Chats are stored locally on your device instead of on DuckDuckGo servers or "
 "remote servers. Disabling chat history will delete pinned chats."
-msgstr "聊天记录会存储在设备本机上，而非 DuckDuckGo 服务器或远程服务器上。禁用聊天历史记录会删除已置顶的聊天记录。"
+msgstr ""
+"聊天记录会存储在设备本机上，而非 DuckDuckGo 服务器或远程服务器上。禁用聊天历"
+"史记录会删除已置顶的聊天记录。"
 
 # smartling.placeholder_format=C
 #. Text explaining how the Chat History feature stores the user's chats locally to their device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection. Also explains that disabling chat history will delete pinned chats.
@@ -3682,8 +3773,9 @@ msgid ""
 "history will delete pinned chats, and disable the temporary storage of new "
 "prompts and responses."
 msgstr ""
-"聊天记录会存储在本地设备上。新的提示和回复在发送后会被加密并暂时存储在 DuckDuckGo "
-"服务器上，以便在断开互联网连接时帮助恢复聊天记录。禁用聊天记录将删除置顶的聊天记录，并禁用新提示和回复的临时存储功能。"
+"聊天记录会存储在本地设备上。新的提示和回复在发送后会被加密并暂时存储在 "
+"DuckDuckGo 服务器上，以便在断开互联网连接时帮助恢复聊天记录。禁用聊天记录将删"
+"除置顶的聊天记录，并禁用新提示和回复的临时存储功能。"
 
 # smartling.placeholder_format=C
 #. Title shown above the body copy in the Duck.ai recent chats IndexedDB unavailable notice.
@@ -4036,7 +4128,9 @@ msgctxt "Information about the effect of clearing browser data on recent chats"
 msgid ""
 "Clearing browser data deletes chats. Some browsers may keep recent chats "
 "indefinitely or auto-delete them after 7+ days of no AI Chat use."
-msgstr "清除浏览器数据会删除聊天记录。某些浏览器可能会无限期保留最近的聊天记录，或者在超过 7 天未使用 AI Chat 后自动将其删除。"
+msgstr ""
+"清除浏览器数据会删除聊天记录。某些浏览器可能会无限期保留最近的聊天记录，或者"
+"在超过 7 天未使用 AI Chat 后自动将其删除。"
 
 # smartling.placeholder_format=C
 #. Text explaining what happens to recent chats when browser data is cleared.
@@ -4045,7 +4139,9 @@ msgid ""
 "Clearing browser data deletes recent chats. Recent chats may be saved "
 "indefinitely or auto-deleted after 7 days without using Duck.ai, depending "
 "on your browser."
-msgstr "清除浏览器数据会删除近期聊天记录。在不使用 Duck.ai 的情况下，可以无限期保存近期聊天记录，或在 7 天后自动删除，具体取决于浏览器的设置。"
+msgstr ""
+"清除浏览器数据会删除近期聊天记录。在不使用 Duck.ai 的情况下，可以无限期保存近"
+"期聊天记录，或在 7 天后自动删除，具体取决于浏览器的设置。"
 
 # smartling.placeholder_format=C
 #. Warning message shown on the Block domain success modal. Blocked sites are stored in localStorage which is cleared alongside cookies when users clear browser data. Followed by a linked 'our free browser' text.
@@ -4062,8 +4158,8 @@ msgid ""
 "%sDuck.ai%s, our private AI chat service that supports chat models from "
 "OpenAI, Anthropic, and more."
 msgstr ""
-"点击“更多”以深入了解某个主题，并通过 %1$sDuck.ai%2$s 提出后续问题，我们的私密人工智能聊天服务支持 OpenAI、Anthropic "
-"等聊天模型。"
+"点击“更多”以深入了解某个主题，并通过 %1$sDuck.ai%2$s 提出后续问题，我们的私密"
+"人工智能聊天服务支持 OpenAI、Anthropic 等聊天模型。"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4104,7 +4200,9 @@ msgstr "在弹出的菜单中点击 %1$s更改搜索设置%2$s"
 msgid ""
 "Click %sEdit > Preferences%s (on Windows) %sSeaMonkey > Preferences%s (on "
 "Mac)"
-msgstr "Windows 系统点击 %1$s编辑 > 首选项%2$s，Mac 系统点击 %3$sSeaMonkey > 首选项%4$s"
+msgstr ""
+"Windows 系统点击 %1$s编辑 > 首选项%2$s，Mac 系统点击 %3$sSeaMonkey > 首选"
+"项%4$s"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -4134,7 +4232,9 @@ msgstr "在左侧的列表中点击 %1$s隐私和服务%2$s。"
 msgid ""
 "Click %sSafari%s in the top menu (On Windows, click the %sgears icon%s in "
 "the top right)"
-msgstr "在顶部菜单栏中点击 %1$sSafari 浏览器%2$s（Windows 系统点击右上角的 %3$s齿轮图标%4$s）"
+msgstr ""
+"在顶部菜单栏中点击 %1$sSafari 浏览器%2$s（Windows 系统点击右上角的 %3$s齿轮图"
+"标%4$s）"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4224,7 +4324,9 @@ msgctxt "cloudsave"
 msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Search Settings%s."
-msgstr "点击或轻触“%1$s删除我的数据%2$s”，即可删除来自云端的数据，但只要不点击／轻触“%3$s重置所有搜索设置%4$s”，相关数据就会一直保留在浏览器中。"
+msgstr ""
+"点击或轻触“%1$s删除我的数据%2$s”，即可删除来自云端的数据，但只要不点击／轻"
+"触“%3$s重置所有搜索设置%4$s”，相关数据就会一直保留在浏览器中。"
 
 # smartling.placeholder_format=C
 #. Tells users where to click in order to disable the cloud save feature and delete any data backed-up to the cloud.
@@ -4234,7 +4336,9 @@ msgctxt "cloudsave"
 msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Settings%s."
-msgstr "点击“%1$s删除我的数据%2$s”即可将云端的数据删除，但只要不点击“%3$s恢复初始设置%4$s”，从云端同步的设置就会一直保留在浏览器中。"
+msgstr ""
+"点击“%1$s删除我的数据%2$s”即可将云端的数据删除，但只要不点击“%3$s恢复初始设"
+"置%4$s”，从云端同步的设置就会一直保留在浏览器中。"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -4302,7 +4406,9 @@ msgstr "点击搜索栏中的下拉菜单"
 msgid ""
 "Click the dropdown menu beside %sSearch engine used in the address bar%s and "
 "select %sDuckDuckGo%s."
-msgstr "点击 %1$s在地址栏中使用的搜索引擎%2$s 旁边的下拉菜单，选择 %3$sDuckDuckGo%4$s。"
+msgstr ""
+"点击 %1$s在地址栏中使用的搜索引擎%2$s 旁边的下拉菜单，选择 "
+"%3$sDuckDuckGo%4$s。"
 
 # smartling.placeholder_format=C
 #. First step in a list of steps to take to disable the user's ad blocker
@@ -4972,6 +5078,12 @@ msgid "Create Image"
 msgstr "创建图像"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Create a shopping list with quantities from this recipe."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text displayed in the input field when starting a new image generation session.
 msgctxt "Placeholder text for the image generation input field"
 msgid "Create an image of a cute duck..."
@@ -5608,11 +5720,17 @@ msgid "Dictation limit reached"
 msgstr "已达到听写限额"
 
 # smartling.placeholder_format=C
+#. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
+msgid "Dictation temporarily unavailable"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
 "chat in Duck.ai without having to type."
-msgstr "听写功能使用 OpenAI 模型将语音转为文本，因此无需输入便可以在 Duck.ai 中聊天。"
+msgstr ""
+"听写功能使用 OpenAI 模型将语音转为文本，因此无需输入便可以在 Duck.ai 中聊天。"
 
 # smartling.placeholder_format=C
 #. In 0-click box -- link to definition.
@@ -5906,6 +6024,22 @@ msgid "Done"
 msgstr "完成"
 
 # smartling.placeholder_format=C
+#. Message shown in a modal after DuckDuckGo browser users disable AI features in Settings. The first two placeholders bold noai.duckduckgo.com. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
+"filtered out. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
+"and AI images filtered out. %sLearn more%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Double Faults"
@@ -6014,6 +6148,18 @@ msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
 msgstr "起草一封简明扼要的电子邮件给供应商，要求提供家用冰箱维修服务的报价。"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Draft a cover letter"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Draft a cover letter for this job."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -6154,7 +6300,9 @@ msgid ""
 "Duck.ai can now help answer questions about the page you're viewing. Page "
 "content is only included when you attach it, unless you choose to attach "
 "pages automatically in Settings."
-msgstr "Duck.ai 现在可以帮助回答你正在浏览的页面问题。页面内容仅在你附加时纳入，除非你选择在设置中自动附加页面。"
+msgstr ""
+"Duck.ai 现在可以帮助回答你正在浏览的页面问题。页面内容仅在你附加时纳入，除非"
+"你选择在设置中自动附加页面。"
 
 # smartling.placeholder_format=C
 #. Shown in the Duck.ai recent chats list on standalone when the browser API needed to store chats locally is missing or unavailable.
@@ -6163,7 +6311,9 @@ msgctxt ""
 msgid ""
 "Duck.ai can’t access local storage to save your chats. Please check your "
 "browser settings or disable any extensions and try again."
-msgstr "Duck.ai 无法访问本地存储来保存您的聊天记录。请检查浏览器设置或禁用任何扩展程序再试一次。"
+msgstr ""
+"Duck.ai 无法访问本地存储来保存您的聊天记录。请检查浏览器设置或禁用任何扩展程"
+"序再试一次。"
 
 # smartling.placeholder_format=C
 #. Displayed when the chat service has reached the maximum number of messages for one day.
@@ -6180,6 +6330,15 @@ msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
 msgstr "Duck.ai 在我们私密且免费的 DuckDuckGo 浏览器中表现最佳！"
 
 # smartling.placeholder_format=C
+#. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
+msgctxt "About section description on the Duck.ai settings page"
+msgid ""
+"Duck.ai is created by DuckDuckGo. We're an independent online protection "
+"company for anyone who wants to take back control of their personal "
+"information."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
 msgctxt "duckai_migration"
 msgid "Duck.ai is moving domains"
@@ -6191,7 +6350,9 @@ msgctxt "duckai_migration"
 msgid ""
 "Duck.ai is still a DuckDuckGo product, but will now have an easier to "
 "remember home on the web: https://duck.ai"
-msgstr "Duck.ai 仍然是 DuckDuckGo 的产品，但现在将拥有一个更容易记住的网站主页：https://duck.ai"
+msgstr ""
+"Duck.ai 仍然是 DuckDuckGo 的产品，但现在将拥有一个更容易记住的网站主页："
+"https://duck.ai"
 
 # smartling.placeholder_format=C
 #. Headline for domain change notice.
@@ -6205,7 +6366,9 @@ msgctxt "Error message for BOTNET limit."
 msgid ""
 "Duck.ai is temporarily unavailable. If this persists, please email this "
 "anonymous code %s to %s"
-msgstr "暂时无法使用 Duck.ai。如果仍有问题，请通过电子邮件将此匿名代码 %1$s 发送到 %2$s"
+msgstr ""
+"暂时无法使用 Duck.ai。如果仍有问题，请通过电子邮件将此匿名代码 %1$s 发送到 "
+"%2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -6223,15 +6386,23 @@ msgstr "暂时无法使用 Duck.ai。请稍后重试。"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
+"Duck.ai lets you chat privately with popular AI models. Disabling it hides "
+"Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
+msgstr ""
+
+# smartling.placeholder_format=C
+msgctxt "settings"
+msgid ""
 "Duck.ai lets you have anonymous conversations with 3rd-party AI chat models, "
 "including models from OpenAI, Anthropic, and others. Turning this setting "
 "off will hide Duck.ai buttons and links on DuckDuckGo Search. However, you "
 "can still access Duck.ai when this setting is off by visiting %shttps://duck."
 "ai%s directly."
 msgstr ""
-"可以利用 Duck.ai 与第三方人工智能聊天模型进行匿名对话，包括来自 OpenAI、Anthropic 等公司的模型。关闭此设置将隐藏 "
-"DuckDuckGo Search 中的 Duck.ai 按钮和链接。不过，即使关闭该设置，仍然可以直接通过访问 "
-"%1$shttps://duck.ai%2$s 来使用 Duck.ai。"
+"可以利用 Duck.ai 与第三方人工智能聊天模型进行匿名对话，包括来自 OpenAI、"
+"Anthropic 等公司的模型。关闭此设置将隐藏 DuckDuckGo Search 中的 Duck.ai 按钮"
+"和链接。不过，即使关闭该设置，仍然可以直接通过访问 %1$shttps://duck.ai%2$s 来"
+"使用 Duck.ai。"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
@@ -6286,8 +6457,9 @@ msgid ""
 "AI chat no sign up, OpenAI, Anthropic, Llama, Mistral, open source AI "
 "models, privacy focused AI, no account AI chat"
 msgstr ""
-"Duck.ai、DuckDuckGo AI、私人 AI 聊天机器人、免费 AI 聊天、匿名 AI 聊天、无需注册的 AI "
-"聊天、OpenAI、Anthropic、Llama、Mistral、开源 AI 模型、注重隐私的 AI、无需账户的 AI 聊天"
+"Duck.ai、DuckDuckGo AI、私人 AI 聊天机器人、免费 AI 聊天、匿名 AI 聊天、无需"
+"注册的 AI 聊天、OpenAI、Anthropic、Llama、Mistral、开源 AI 模型、注重隐私的 "
+"AI、无需账户的 AI 聊天"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -6315,10 +6487,10 @@ msgid ""
 "relevant), or Often (shows more frequently on a wider range of searches). "
 "For now, DuckAssist is only available in the U.S. (English) region."
 msgstr ""
-"DuckAssist 可以匿名查找和汇总信息，以响应某些搜索。可以选择 DuckAssist 的显示频率：从不（从搜索结果中完全移除 "
-"DuckAssist "
-"用户界面)、按需（仅在点击“协助”按钮时显示）、有时（仅在高度相关时显示）或经常（在更广泛的搜索中更频繁地显示）。DuckAssist "
-"目前仅供美国（英语）地区使用。"
+"DuckAssist 可以匿名查找和汇总信息，以响应某些搜索。可以选择 DuckAssist 的显示"
+"频率：从不（从搜索结果中完全移除 DuckAssist 用户界面)、按需（仅在点击“协助”按"
+"钮时显示）、有时（仅在高度相关时显示）或经常（在更广泛的搜索中更频繁地显"
+"示）。DuckAssist 目前仅供美国（英语）地区使用。"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6327,8 +6499,9 @@ msgid ""
 "%sDuckDuckGo AI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI, and Anthropic, and more."
 msgstr ""
-"DuckAssist 无法回答后续问题，但是，我们还提供 %1$sDuckDuckGo AI "
-"Chat%2$s，这是一种人工智能驱动的私密聊天服务，支持包括 OpenAI 和 Anthropic 在内的多种聊天模型。"
+"DuckAssist 无法回答后续问题，但是，我们还提供 %1$sDuckDuckGo AI Chat%2$s，这"
+"是一种人工智能驱动的私密聊天服务，支持包括 OpenAI 和 Anthropic 在内的多种聊天"
+"模型。"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6337,8 +6510,8 @@ msgid ""
 "DuckDuckGo %sAI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI and Anthropic."
 msgstr ""
-"DuckAssist 无法回答后续问题，但是，我们还提供 DuckDuckGo %1$sAI Chat%2$s，这是一种人工智能驱动的私密聊天服务，支持 "
-"OpenAI 和 Anthropic 的聊天模型。"
+"DuckAssist 无法回答后续问题，但是，我们还提供 DuckDuckGo %1$sAI Chat%2$s，这"
+"是一种人工智能驱动的私密聊天服务，支持 OpenAI 和 Anthropic 的聊天模型。"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6350,10 +6523,10 @@ msgid ""
 "responses are currently based on Wikipedia and related content and are not "
 "checked for accuracy."
 msgstr ""
-"DuckAssist "
-""
-"是我们搜索结果中的一项新功能，可以匿名生成搜索查询的答案。为此，该功能会扫描维基百科和相关网站的相关内容，然后使用人工智能驱动的自然语言技术生成这些信息的摘要。 "
-"请注意，其回复目前基于维基百科和相关内容，其准确性未经核实。"
+"DuckAssist 是我们搜索结果中的一项新功能，可以匿名生成搜索查询的答案。为此，该"
+"功能会扫描维基百科和相关网站的相关内容，然后使用人工智能驱动的自然语言技术生"
+"成这些信息的摘要。 请注意，其回复目前基于维基百科和相关内容，其准确性未经核"
+"实。"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6367,10 +6540,11 @@ msgid ""
 "It’s important to remember that responses are auto-generated from cited "
 "sources and based on %scrawling the web%s."
 msgstr ""
-"DuckAssist "
-""
-"是我们搜索结果中的一项可选功能，可以匿名生成搜索查询的答案。为此，该功能会扫描网络上的相关内容，然后使用人工智能驱动的自然语言技术，根据找到的相关信息生成简短的答案。DuckAssist "
-"的回复始终直接链接到一个或两个资料来源，并注明答案的出处，以便你轻松获取更详细的信息。请务必记住，这些回复来自引用的资料来源，并通过%1$s爬取网络内容%2$s自动生成。"
+"DuckAssist 是我们搜索结果中的一项可选功能，可以匿名生成搜索查询的答案。为此，"
+"该功能会扫描网络上的相关内容，然后使用人工智能驱动的自然语言技术，根据找到的"
+"相关信息生成简短的答案。DuckAssist 的回复始终直接链接到一个或两个资料来源，并"
+"注明答案的出处，以便你轻松获取更详细的信息。请务必记住，这些回复来自引用的资"
+"料来源，并通过%1$s爬取网络内容%2$s自动生成。"
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
@@ -6393,7 +6567,9 @@ msgctxt "Modal body for information"
 msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
-msgstr "DuckDuckGo AI Chat 是一种私密人工智能驱动型聊天服务，目前支持 %1$s 的 %2$s 和 %3$s 的 %4$s 聊天模型。"
+msgstr ""
+"DuckDuckGo AI Chat 是一种私密人工智能驱动型聊天服务，目前支持 %1$s 的 %2$s "
+"和 %3$s 的 %4$s 聊天模型。"
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the welcome screen of the onboarding. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -6401,7 +6577,9 @@ msgctxt "Onboarding welcome screen subtitle"
 msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
-msgstr "DuckDuckGo AI Chat 是一种私密人工智能驱动型聊天服务，目前支持 %1$s 的 %2$s 和 %3$s 的 %4$s 聊天模型。"
+msgstr ""
+"DuckDuckGo AI Chat 是一种私密人工智能驱动型聊天服务，目前支持 %1$s 的 %2$s "
+"和 %3$s 的 %4$s 聊天模型。"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding DuckDuckGo AI Chat.
@@ -6417,7 +6595,9 @@ msgctxt "Error message for BOTNET limit."
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. If this persists, please "
 "email this anonymous code %s to %s"
-msgstr "暂时无法使用 DuckDuckGo AI Chat。如果仍有问题，请通过电子邮件将此匿名代码 %1$s 发送到 %2$s"
+msgstr ""
+"暂时无法使用 DuckDuckGo AI Chat。如果仍有问题，请通过电子邮件将此匿名代码 "
+"%1$s 发送到 %2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -6549,14 +6729,18 @@ msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
 msgid ""
 "DuckDuckGo anonymizes these reports by automatically removing PII like "
 "names, email addresses, phone numbers, and identifying metadata."
-msgstr "DuckDuckGo 通过自动删除姓名、电子邮件地址、电话号码和识别元数据等个人身份信息来对这些报告进行匿名化。"
+msgstr ""
+"DuckDuckGo 通过自动删除姓名、电子邮件地址、电话号码和识别元数据等个人身份信息"
+"来对这些报告进行匿名化。"
 
 # smartling.placeholder_format=C
 #. The first %s is the agree button label ('Agree'). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. The leading sentence mirrors the drawer-style inline disclaimer (DUCKCHAT_TOS_INLINE_DISCLAIMER).
 msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid ""
 "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to Duck.ai's %s."
-msgstr "DuckDuckGo 会对你的聊天内容进行匿名处理。点击“%1$s”即表示你同意 Duck.ai 的 %2$s。"
+msgstr ""
+"DuckDuckGo 会对你的聊天内容进行匿名处理。点击“%1$s”即表示你同意 Duck.ai 的 "
+"%2$s。"
 
 # smartling.placeholder_format=C
 #. Shown below the input on the empty state when the user has not yet accepted the terms of service. The first %s is the action button label ('Ask' for chat, 'Create' for image generation). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. Clicking the action button both accepts the terms and submits the prompt.
@@ -6564,7 +6748,8 @@ msgctxt ""
 "Inline terms-of-service disclaimer below chat or image-gen input for new "
 "users"
 msgid "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to our %s."
-msgstr "DuckDuckGo 会对你的聊天内容进行匿名处理。点击“%1$s”即表示你同意我们的 %2$s。"
+msgstr ""
+"DuckDuckGo 会对你的聊天内容进行匿名处理。点击“%1$s”即表示你同意我们的 %2$s。"
 
 # smartling.placeholder_format=C
 #. An information popup explaining that we block trackers
@@ -6572,7 +6757,9 @@ msgid ""
 "DuckDuckGo blocks trackers on websites you visit, including trackers from "
 "companies like Google and Facebook, who often try to track you on other "
 "websites."
-msgstr "DuckDuckGo 会屏蔽所访问网站的跟踪程序，包括来自 Google 和 Facebook 等公司的跟踪程序，这些公司经常试图在其他网站上跟踪你。"
+msgstr ""
+"DuckDuckGo 会屏蔽所访问网站的跟踪程序，包括来自 Google 和 Facebook 等公司的跟"
+"踪程序，这些公司经常试图在其他网站上跟踪你。"
 
 # smartling.placeholder_format=C
 #. Description of how DuckDuckGo keeps a user's location anonymous while the user searches on a map of their area.
@@ -6584,8 +6771,9 @@ msgid ""
 "away, such that you remain anonymous. %sLearn more about how we designed "
 "this technology to protect your privacy%s."
 msgstr ""
-"DuckDuckGo "
-"的设计力图保护用户隐私，定位信息仅存储于你的设备中，只有发起搜索时会上传给我们用以优化搜索结果，搜索完成后我们也不会保留，以保证搜索匿名性。%1$s详细了解我们是如何设计这一功能来保护隐私的%2$s。"
+"DuckDuckGo 的设计力图保护用户隐私，定位信息仅存储于你的设备中，只有发起搜索时"
+"会上传给我们用以优化搜索结果，搜索完成后我们也不会保留，以保证搜索匿名"
+"性。%1$s详细了解我们是如何设计这一功能来保护隐私的%2$s。"
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
@@ -6604,7 +6792,8 @@ msgctxt "settings"
 msgid ""
 "DuckDuckGo only uses your approximate location. That's all we need to "
 "deliver better results, closer to you. %sLearn more%s."
-msgstr "DuckDuckGo 只需了解你的大致位置即可优化你附近的搜索结果。%1$s了解详情%2$s。"
+msgstr ""
+"DuckDuckGo 只需了解你的大致位置即可优化你附近的搜索结果。%1$s了解详情%2$s。"
 
 # smartling.placeholder_format=C
 msgid "DuckDuckGo search"
@@ -6690,8 +6879,8 @@ msgid ""
 "random words from that list, ensuring that the passphrase is at least 18-20 "
 "characters long."
 msgstr ""
-"当你选择自动生成口令时，我们会从 DuckDuckGo 服务器获取一系列随机的英文词汇，并在浏览器端从中选取四五个，保证总长度至少有 18 到 20 "
-"个字符。"
+"当你选择自动生成口令时，我们会从 DuckDuckGo 服务器获取一系列随机的英文词汇，"
+"并在浏览器端从中选取四五个，保证总长度至少有 18 到 20 个字符。"
 
 # smartling.placeholder_format=C
 msgctxt "Sports module"
@@ -6928,7 +7117,9 @@ msgctxt "precise_user_location"
 msgid ""
 "Enabling anonymous location gives more accurate results but still keeps your "
 "searches and exact location private to DuckDuckGo."
-msgstr "启用匿名定位功能可获得更精确的结果，但 DuckDuckGo 仍会保密你的搜索和确切位置信息。"
+msgstr ""
+"启用匿名定位功能可获得更精确的结果，但 DuckDuckGo 仍会保密你的搜索和确切位置"
+"信息。"
 
 # smartling.placeholder_format=C
 msgid "Encrypt Connections"
@@ -7114,7 +7305,8 @@ msgstr "输入文本"
 #. Instructions for how to change the default search engine.
 msgid ""
 "Enter the following details: %sName%s: DuckDuckGo%s URL%s: %s Alias%s: d%s"
-msgstr "输入下列信息：%1$s名称%2$s：DuckDuckGo%3$s搜索串%4$s：%5$s快捷字%6$s：d%7$s"
+msgstr ""
+"输入下列信息：%1$s名称%2$s：DuckDuckGo%3$s搜索串%4$s：%5$s快捷字%6$s：d%7$s"
 
 # smartling.placeholder_format=C
 #. Prompt to enter a destination for driving directions.
@@ -7153,6 +7345,18 @@ msgstr "使用我们的 %1$sFire Button%2$s 瞬间清除你的浏览数据"
 # smartling.placeholder_format=C
 msgid "Eritrea"
 msgstr "厄立特里亚"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Estimate the nutrition"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Estimate the nutritional information for this recipe."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Estonia"
@@ -7209,11 +7413,59 @@ msgid "Expires in 1 day"
 msgstr "1 天后失效"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain the accepted answer in simple terms."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
 msgstr "以高中生的水平向我解释黑洞的基本概念。"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain the top answer"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this in simple, plain language."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this paper"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this repo"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this research paper in plain language."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this simply"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain what this repository does and how to use it."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label to show if song lyrics contain explicit content
@@ -7398,7 +7650,9 @@ msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and "
 "improvements. Hopefully we can address the issue you shared too."
-msgstr "类似你这样的反馈会直接影响我们的产品更新和改进。希望我们也能解决你提出的问题。"
+msgstr ""
+"类似你这样的反馈会直接影响我们的产品更新和改进。希望我们也能解决你提出的问"
+"题。"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box
@@ -7491,6 +7745,12 @@ msgid ""
 msgstr "从图像搜索结果中筛选掉人工智能生成的图像。%1$s了解详情%2$s"
 
 # smartling.placeholder_format=C
+msgctxt "settings"
+msgid ""
+"Filters out known AI spam sites from image search results. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the final score of a sporting event.
 msgid "Final"
 msgstr "最终比分"
@@ -7542,6 +7802,12 @@ msgstr "查找更好的用词"
 msgctxt "Subtitle for the Web Search tool entry in the Tools dropdown menu"
 msgid "Find current information"
 msgstr "查找当前信息"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Find me alternatives"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button that searches for results closer to the user's current location.
@@ -7845,8 +8111,9 @@ msgid ""
 "<strong>Check for Updates...</strong>, then select <strong>Install Update</"
 "strong>."
 msgstr ""
-"在 Mac 的应用程序菜单栏中选择“<strong>DuckDuckGo</strong>” &gt; “<strong>Check for "
-"Updates...</strong>”（查看更新……），然后选择“<strong>Install Update</strong>”（安装更新）。"
+"在 Mac 的应用程序菜单栏中选择“<strong>DuckDuckGo</strong>” &gt; "
+"“<strong>Check for Updates...</strong>”（查看更新……），然后选"
+"择“<strong>Install Update</strong>”（安装更新）。"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -8012,6 +8279,12 @@ msgstr "生成图像"
 #. Text for the button that generates more of an answer from duckassist when the answer has come from a collapsed state
 msgid "Generate More"
 msgstr "生成更多内容"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Generate a shopping list"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
@@ -8190,7 +8463,9 @@ msgctxt "Description of the modal to upgrade the DuckDuckGo subscription"
 msgid ""
 "Get access to advanced AI models in Duck.ai by subscribing to DuckDuckGo, "
 "which also includes our VPN and other premium privacy protections."
-msgstr "订阅 DuckDuckGo 即可使用 Duck.ai 的高级人工智能模型，同时还包括我们的 VPN 和其他高级隐私保护功能。"
+msgstr ""
+"订阅 DuckDuckGo 即可使用 Duck.ai 的高级人工智能模型，同时还包括我们的 VPN 和"
+"其他高级隐私保护功能。"
 
 # smartling.placeholder_format=C
 #. Description for the subscription setting where users can subscribe to DuckDuckGo.
@@ -8200,7 +8475,9 @@ msgctxt ""
 msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
-msgstr "通过 DuckDuckGo 订阅使用 Duck.ai 的高级人工智能模型，其中还包括我们的 VPN 和其他高级隐私保护功能。"
+msgstr ""
+"通过 DuckDuckGo 订阅使用 Duck.ai 的高级人工智能模型，其中还包括我们的 VPN 和"
+"其他高级隐私保护功能。"
 
 # smartling.placeholder_format=C
 #. A button for users to generate an AI generated answer from their query on the duckassist module
@@ -8299,6 +8576,12 @@ msgid "Give it a Try"
 msgstr "试试看"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Give me a quick background on this person."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
@@ -8318,7 +8601,9 @@ msgctxt "precise_user_location"
 msgid ""
 "Go to %sSettings > Privacy > Permission manager > Location%s and scroll down "
 "to %sDuckDuckGo%s."
-msgstr "转到%1$s“设置” > “隐私” > “权限管理器” > “定位”%2$s，然后向下滚动至 %3$sDuckDuckGo%4$s。"
+msgstr ""
+"转到%1$s“设置” > “隐私” > “权限管理器” > “定位”%2$s，然后向下滚动至 "
+"%3$sDuckDuckGo%4$s。"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -8741,6 +9026,18 @@ msgid "Help Spread Privacy"
 msgstr "协助推广隐私保护"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Help me prep for the interview"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Help me tailor my resume for this job."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title of a SERP popup that invites users to take a survey (desktop only)
 msgctxt "User survey popup"
 msgid "Help us improve DuckDuckGo"
@@ -9002,7 +9299,9 @@ msgstr "历史"
 msgid ""
 "Hit %sReturn%s on your keyboard to %ssave DuckDuckGo to the list. %sThen "
 "click %sMake Default%s"
-msgstr "按下键盘上的 %1$s回车键%2$s%3$s将 DuckDuckGo 添加到列表中，%4$s然后点击 %5$s设为默认搜索引擎%6$s"
+msgstr ""
+"按下键盘上的 %1$s回车键%2$s%3$s将 DuckDuckGo 添加到列表中，%4$s然后点击 %5$s"
+"设为默认搜索引擎%6$s"
 
 # smartling.placeholder_format=C
 #. The name of the Hmong Daw language
@@ -9015,7 +9314,9 @@ msgstr "白苗语"
 msgid ""
 "Hold on! Changing it back will disable the DuckDuckGo extension and you'll "
 "lose our privacy protection."
-msgstr "稍等！将其改回默认搜索引擎将禁用 DuckDuckGo 扩展程序，并将失去我们的隐私保护。"
+msgstr ""
+"稍等！将其改回默认搜索引擎将禁用 DuckDuckGo 扩展程序，并将失去我们的隐私保"
+"护。"
 
 # smartling.placeholder_format=C
 #. Heading shown above warning messages in the AI chat, for non-critical issues like unsupported file formats or file size limits. Analogous to 'Oops...' for error messages.
@@ -9246,6 +9547,14 @@ msgid "I Agree"
 msgstr "我同意"
 
 # smartling.placeholder_format=C
+#. Text for the button that takes the user to the external DuckDuckGo login subscription page.
+msgctxt ""
+"Text for the I already have a subscription button in the Duck.ai settings "
+"page"
+msgid "I Already Have a Subscription"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for the button that takes the user to the login subscription page.
 msgctxt "Text for the I have a subscription button"
 msgid "I Have a Subscription"
@@ -9352,7 +9661,9 @@ msgctxt "precise_user_location"
 msgid ""
 "If the browser location remains unavailable, then go to %sSettings > General "
 "> Reset > 'Reset Location & Privacy'%s."
-msgstr "如果仍然无法使用浏览器定位，请前往%1$s“设置” > “通用” > “还原” > “还原位置与隐私”%2$s。"
+msgstr ""
+"如果仍然无法使用浏览器定位，请前往%1$s“设置” > “通用” > “还原” > “还原位置与"
+"隐私”%2$s。"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -9362,8 +9673,8 @@ msgid ""
 "> Menu > Settings > Site settings > Location%s, and ensure DuckDuckGo is "
 "allowed location access."
 msgstr ""
-"如果仍然无法使用浏览器定位，请在浏览器中转到%1$s“⋮” > “菜单” > “设置” > “网站设置” > “位置”%2$s，并确认已允许 "
-"DuckDuckGo 使用定位信息。"
+"如果仍然无法使用浏览器定位，请在浏览器中转到%1$s“⋮” > “菜单” > “设置” > “网站"
+"设置” > “位置”%2$s，并确认已允许 DuckDuckGo 使用定位信息。"
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -9377,7 +9688,8 @@ msgstr "如果你继续看到此错误，请联系 %1$s。"
 msgid ""
 "If you don't see %sDuckDuckGo,%s you will need to add it to the list of "
 "%sOther Search Engines%s"
-msgstr "如果找不到 %1$sDuckDuckGo%2$s，你需要手动将其添加到 %3$s其他搜索引擎%4$s 中"
+msgstr ""
+"如果找不到 %1$sDuckDuckGo%2$s，你需要手动将其添加到 %3$s其他搜索引擎%4$s 中"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding the AI model providers and links to their support pages. Example: 'If you have concerns about our chat providers or any particular chat response, you can also reach out directly to OpenAI and Anthropic support pages.'
@@ -9385,7 +9697,9 @@ msgctxt "Disclaimer text at the bottom of the feedback form."
 msgid ""
 "If you have concerns about our chat providers or any particular chat "
 "response, you can also reach out directly to %s and %s support pages."
-msgstr "如果你对我们的聊天提供商或任何特定的聊天回复有疑虑，也可以直接联系 %1$s 和 %2$s 支持页面。"
+msgstr ""
+"如果你对我们的聊天提供商或任何特定的聊天回复有疑虑，也可以直接联系 %1$s 和 "
+"%2$s 支持页面。"
 
 # smartling.placeholder_format=C
 #. Body copy explaining what the recovery code is for and how it can be saved.
@@ -9393,7 +9707,9 @@ msgctxt "Body for the Sync & Backup recovery code screen"
 msgid ""
 "If you lose access to your devices, you will need this code to recover your "
 "saved chats. You can save this code to your device as a text file."
-msgstr "如果您无法访问自己的设备，则将需要此代码来恢复保存的聊天记录。您可以将此代码以文本文件的形式保存到设备中。"
+msgstr ""
+"如果您无法访问自己的设备，则将需要此代码来恢复保存的聊天记录。您可以将此代码"
+"以文本文件的形式保存到设备中。"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/ReKkJtU.png
@@ -9408,7 +9724,9 @@ msgstr "如果你仍愿支持我们，可%1$s协助推广 DuckDuckGo%2$s"
 msgid ""
 "If you want to use DuckDuckGo without JavaScript, please use our %s or %s "
 "versions."
-msgstr "如需在关闭 JavaScript 的情况下使用 DuckDuckGo，请使用我们的 %1$s 或者 %2$s 版本。"
+msgstr ""
+"如需在关闭 JavaScript 的情况下使用 DuckDuckGo，请使用我们的 %1$s 或者 %2$s 版"
+"本。"
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -9555,7 +9873,9 @@ msgctxt "settings"
 msgid ""
 "In some older browsers, it's necessary to redirect your clicks through our "
 "server to prevent search leakage. %sLearn more%s."
-msgstr "如果使用某些过时的浏览器，点击搜索结果后需要经过我们的服务器重定向才能避免泄露搜索内容。%1$s了解详情%2$s。"
+msgstr ""
+"如果使用某些过时的浏览器，点击搜索结果后需要经过我们的服务器重定向才能避免泄"
+"露搜索内容。%1$s了解详情%2$s。"
 
 # smartling.placeholder_format=C
 #. Instructions accompanying DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE; tells the user where to use the code on a DuckDuckGo browser.
@@ -9565,7 +9885,8 @@ msgctxt ""
 msgid ""
 "In the DuckDuckGo browser, go to Settings › Sync & Backup, and then “Sync "
 "with another device”."
-msgstr "在 DuckDuckGo 浏览器中，前往设置 › Sync & Backup，然后选择“与其他设备同步”。"
+msgstr ""
+"在 DuckDuckGo 浏览器中，前往设置 › Sync & Backup，然后选择“与其他设备同步”。"
 
 #  SeaMonkey default search engine instruction
 # smartling.placeholder_format=C
@@ -9579,7 +9900,9 @@ msgctxt "cloudsave"
 msgid ""
 "In the interest of transparency, this data is not encrypted: You can see "
 "exactly what information we store."
-msgstr "本着透明公开的原则，上传的信息也没有加密处理，如果你感兴趣的话可以看到我们具体都存了什么。"
+msgstr ""
+"本着透明公开的原则，上传的信息也没有加密处理，如果你感兴趣的话可以看到我们具"
+"体都存了什么。"
 
 # smartling.placeholder_format=C
 msgid "In the menu at the top select %sTools%s > %sSettings%s"
@@ -9795,6 +10118,12 @@ msgid "Install Mac Browser"
 msgstr "安装 Mac 浏览器"
 
 # smartling.placeholder_format=C
+#. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
+msgctxt "settings"
+msgid "Install Now"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of a button to install the DuckDuckGo app
 msgctxt "Serp footer content"
 msgid "Install Our App"
@@ -9892,10 +10221,42 @@ msgid "Is deleted data really deleted?"
 msgstr "数据真的已被删除掉吗？"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is it worth taking?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this place any good?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"Is this place any good? Summarize its reputation based on reviews and "
+"ratings."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "Is this video helpful?"
 msgstr "此视频有用吗？"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this worth watching?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Is this worth watching? Give me a spoiler-free take."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -9946,8 +10307,8 @@ msgid ""
 "through Microsoft's Ad Network. Clicks lead directly to merchant landing "
 "pages and unlike ads, DuckDuckGo is not compensated for these results."
 msgstr ""
-"结果根据与搜索词的相关程度排序，并通过 Microsoft 的广告网络提供。链接直接指向商户页面，与广告不同，DuckDuckGo "
-"不会通过这些搜索结果获得收益。"
+"结果根据与搜索词的相关程度排序，并通过 Microsoft 的广告网络提供。链接直接指向"
+"商户页面，与广告不同，DuckDuckGo 不会通过这些搜索结果获得收益。"
 
 # smartling.placeholder_format=C
 #. Text explaining why passphrases use a series of words instead of random numbers and letters.
@@ -10502,6 +10863,12 @@ msgid "Links:"
 msgstr "链接："
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "List the tools, materials, or prerequisites I need for this."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
 msgid "Listen"
 msgstr "收听"
@@ -10906,6 +11273,12 @@ msgstr "管理你的订阅"
 msgctxt "Exclusion message manage sites button"
 msgid "Manage blocked sites"
 msgstr "管理已屏蔽网站"
+
+# smartling.placeholder_format=C
+#. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
+msgctxt "setting"
+msgid "Manage in Browser Settings"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to the site exclusion settings page
@@ -11878,8 +12251,9 @@ msgid ""
 "internet connection. Disabling chat history will delete pinned chats, and "
 "disable the temporary storage of new prompts and responses."
 msgstr ""
-"新的提示和回复在发送后会被加密并暂时存储在 DuckDuckGo "
-"服务器上，以便在断开互联网连接时帮助恢复聊天记录。禁用聊天记录将删除置顶的聊天记录，并禁用新提示和回复的临时存储功能。"
+"新的提示和回复在发送后会被加密并暂时存储在 DuckDuckGo 服务器上，以便在断开互"
+"联网连接时帮助恢复聊天记录。禁用聊天记录将删除置顶的聊天记录，并禁用新提示和"
+"回复的临时存储功能。"
 
 # smartling.placeholder_format=C
 #. Question in a feedback form.
@@ -12694,7 +13068,9 @@ msgstr "按需"
 msgid ""
 "On Mac, %sClick Maxthon > Preferences%s, On Windows, %sClick the %s icon > "
 "Settings%s"
-msgstr "Mac 系统 %1$s点击 Maxthon > 设置%2$s，Windows 系统 %3$s点击 %4$s 图标 > 设置%5$s"
+msgstr ""
+"Mac 系统 %1$s点击 Maxthon > 设置%2$s，Windows 系统 %3$s点击 %4$s 图标 > 设"
+"置%5$s"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
@@ -13071,7 +13447,9 @@ msgctxt "homepage onboarding"
 msgid ""
 "Other search engines track your searches even when you’re in private "
 "browsing mode. We don’t track you &mdash; period."
-msgstr "即使在隐私浏览模式中，某些搜索引擎照样会跟踪你。而我们不会跟踪你，就这么简单。"
+msgstr ""
+"即使在隐私浏览模式中，某些搜索引擎照样会跟踪你。而我们不会跟踪你，就这么简"
+"单。"
 
 # smartling.placeholder_format=C
 msgctxt "SERP footer content"
@@ -13090,7 +13468,9 @@ msgid ""
 "Our private browser for mobile comes equipped with our search engine, "
 "tracker blocker, encryption enforcer, and more. Available on %siOS & "
 "Android%s."
-msgstr "我们的移动端隐私浏览器预置了搜索引擎，还可以屏蔽跟踪程序、开启网站加密等等。现已支持 %1$siOS 和 Android%2$s。"
+msgstr ""
+"我们的移动端隐私浏览器预置了搜索引擎，还可以屏蔽跟踪程序、开启网站加密等等。"
+"现已支持 %1$siOS 和 Android%2$s。"
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the information was out of date.
@@ -13342,7 +13722,9 @@ msgctxt "cloudsave"
 msgid ""
 "Passphrases cannot be recovered as we don't associate your IP address, "
 "browser fingerprint, or any other information with the file."
-msgstr "我们存储设置时并未记录你的 IP 地址、浏览器指纹或任何其他信息，因此无法找回口令。"
+msgstr ""
+"我们存储设置时并未记录你的 IP 地址、浏览器指纹或任何其他信息，因此无法找回口"
+"令。"
 
 # smartling.placeholder_format=C
 #. Label for the section of recent chats that were edited in the past 7 days.
@@ -13535,7 +13917,9 @@ msgid ""
 "assisted answers more likely to appear automatically and often yields better "
 "answers. To turn them off and hide the Assist button visit %sSearch "
 "Settings%s."
-msgstr "以问题和完整的句子进行搜索，会更有可能自动显示人工智能辅助的答案，通常也能获得更佳答案。若要将其关闭并隐藏“Assist”按钮，请访问“%1$s搜索设置%2$s”。"
+msgstr ""
+"以问题和完整的句子进行搜索，会更有可能自动显示人工智能辅助的答案，通常也能获"
+"得更佳答案。若要将其关闭并隐藏“Assist”按钮，请访问“%1$s搜索设置%2$s”。"
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -13544,8 +13928,8 @@ msgid ""
 "DuckAssist more likely to appear and often yields better answers. To adjust "
 "how this feature works, or to turn it off, visit %sDuckAssist Settings%s."
 msgstr ""
-"以问题和完整的句子进行搜索，会更有可能显示 DuckAssist，通常也能获得更佳答案。 如需调整此功能的工作方式或将其关闭，请访问 "
-"%1$sDuckAssist 设置%2$s。"
+"以问题和完整的句子进行搜索，会更有可能显示 DuckAssist，通常也能获得更佳答"
+"案。 如需调整此功能的工作方式或将其关闭，请访问 %1$sDuckAssist 设置%2$s。"
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -13555,8 +13939,8 @@ msgid ""
 "answers. To turn it off and hide the Assist button visit %sDuckAssist "
 "Settings%s."
 msgstr ""
-"以问题和完整的句子进行搜索，会更有可能自动显示 DuckAssist，通常也能获得更佳答案。若要将其关闭并隐藏“协助”按钮，请访问 "
-"%1$sDuckAssist 设置%2$s。"
+"以问题和完整的句子进行搜索，会更有可能自动显示 DuckAssist，通常也能获得更佳答"
+"案。若要将其关闭并隐藏“协助”按钮，请访问 %1$sDuckAssist 设置%2$s。"
 
 # smartling.placeholder_format=C
 #. Button that allows users to manually select a location on a map.
@@ -13596,7 +13980,8 @@ msgctxt "Body copy for the chat card in the How Duck.ai Works panel"
 msgid ""
 "Pick a popular AI to chat with, like GPT-5 mini, Claude Haiku 4.5, "
 "Mistral, etc."
-msgstr "选择热门 AI 并与之对话，比如 GPT-5 mini、Claude Haiku 4.5、Mistral 等。"
+msgstr ""
+"选择热门 AI 并与之对话，比如 GPT-5 mini、Claude Haiku 4.5、Mistral 等。"
 
 # smartling.placeholder_format=C
 #. The description of the third party map app picker, shown on iOS when a user is given an option of which app to navigate to a destination with
@@ -13699,6 +14084,12 @@ msgstr "请完成以下挑战，以确认这项搜索由真人进行。"
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
+msgid "Please describe why the chat response is harmful or illegal. (optional)"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
+msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
 msgstr "请说明该聊天回复为何属于非法或有害内容。（可选）"
 
@@ -13727,8 +14118,18 @@ msgstr "请注意：与任何模型开始新的聊天都会删除当前的聊天
 msgctxt "Feedback prompt"
 msgid ""
 "Please paste your prompt and the problematic output (with any personal "
+"information removed) and describe why the content is harmful or illegal."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
+msgctxt "Feedback prompt"
+msgid ""
+"Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is illegal or harmful."
-msgstr "请粘贴你的提示和有问题的输出内容（删除任何个人信息），并说明相关内容为何违法或有害。"
+msgstr ""
+"请粘贴你的提示和有问题的输出内容（删除任何个人信息），并说明相关内容为何违法"
+"或有害。"
 
 # smartling.placeholder_format=C
 #. Title on a feedback form.
@@ -14186,6 +14587,12 @@ msgid "Privacy"
 msgstr "隐私"
 
 # smartling.placeholder_format=C
+#. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
+msgctxt "Section heading on the Duck.ai settings page"
+msgid "Privacy & Terms"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Privacy Blog"
 msgstr "隐私播报"
 
@@ -14254,6 +14661,12 @@ msgstr "隐私政策和使用条款"
 msgctxt "Copy used to compose link in sentences"
 msgid "Privacy Policy and Terms of Service"
 msgstr "隐私政策和服务条款"
+
+# smartling.placeholder_format=C
+#. Text for a button that links to the terms of use and privacy policy page.
+msgctxt "Secondary button text in active privacy modal"
+msgid "Privacy Policy and Terms of Service"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title displayed on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
@@ -14705,7 +15118,8 @@ msgctxt "Description for recent chats feature"
 msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
-msgstr "近期聊天记录会存储在设备本机上，而非 DuckDuckGo 服务器或其他远程服务器上。"
+msgstr ""
+"近期聊天记录会存储在设备本机上，而非 DuckDuckGo 服务器或其他远程服务器上。"
 
 # smartling.placeholder_format=C
 #. Text explaining that recent chats are stored locally on the user's device.
@@ -14713,7 +15127,8 @@ msgctxt "Description of where recent chats are stored"
 msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
-msgstr "近期聊天记录会存储在设备本机上，而非 DuckDuckGo 服务器或其他远程服务器上。"
+msgstr ""
+"近期聊天记录会存储在设备本机上，而非 DuckDuckGo 服务器或其他远程服务器上。"
 
 # smartling.placeholder_format=C
 #. Text explaining how recent chats are stored locally on the user's device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection.
@@ -14722,7 +15137,9 @@ msgid ""
 "Recent chats are stored locally on your device. New prompts and responses "
 "are encrypted and temporarily stored on a DuckDuckGo server after being "
 "sent, to help recover a chat if you lose your internet connection."
-msgstr "最近的聊天记录会存储在本地设备上。新的提示和回复在发送后会被加密并暂时存储在 DuckDuckGo 服务器上，以便在断开互联网连接时帮助恢复聊天记录。"
+msgstr ""
+"最近的聊天记录会存储在本地设备上。新的提示和回复在发送后会被加密并暂时存储在 "
+"DuckDuckGo 服务器上，以便在断开互联网连接时帮助恢复聊天记录。"
 
 # smartling.placeholder_format=C
 msgctxt "region filter"
@@ -14744,6 +15161,30 @@ msgstr "%1$s%2$s%3$s食谱"
 msgctxt "Brief for recommending a book"
 msgid "Recommend a book"
 msgstr "推荐一本书"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar books"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar books."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar movies or shows."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar titles"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
@@ -14955,7 +15396,9 @@ msgstr "重新加载 Duck.ai"
 msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
-msgstr "请按照说明重新加载 DuckDuckGo，或点击浏览器的“Refresh”（刷新）或“Reload”（重新加载）按钮。"
+msgstr ""
+"请按照说明重新加载 DuckDuckGo，或点击浏览器的“Refresh”（刷新）或“Reload”（重"
+"新加载）按钮。"
 
 # smartling.placeholder_format=C
 #. checkbox label that allows the user to save the setting
@@ -15044,14 +15487,18 @@ msgctxt "settings"
 msgid ""
 "Removes the \"Ask\" button so answers appear automatically in response to "
 "relevant searches. Cached answers always display automatically."
-msgstr "移除“Ask”（询问）按钮，以便在相关搜索的响应中自动显示答案。一律自动显示缓存的答案。"
+msgstr ""
+"移除“Ask”（询问）按钮，以便在相关搜索的响应中自动显示答案。一律自动显示缓存的"
+"答案。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Removes the \"Generate\" button so answers appear automatically in response "
 "to relevant searches. Cached answers always display automatically."
-msgstr "移除“Generate”（生成）按钮，以便在相关搜索的响应中自动显示答案。一律自动显示缓存的答案。"
+msgstr ""
+"移除“Generate”（生成）按钮，以便在相关搜索的响应中自动显示答案。一律自动显示"
+"缓存的答案。"
 
 # smartling.placeholder_format=C
 #. Text for a button to rename a chat, as in it will allow the user to change the title of the chat.
@@ -15108,14 +15555,18 @@ msgid ""
 "Reports are anonymous and sent to DuckDuckGo to help improve our search "
 "service. Your anonymous feedback is also shared with %s to help improve "
 "their services."
-msgstr "你的反馈将以匿名方式发送至 DuckDuckGo，以帮助我们改进搜索服务，同时也将匿名提供给 %1$s，以便共同提高服务质量。"
+msgstr ""
+"你的反馈将以匿名方式发送至 DuckDuckGo，以帮助我们改进搜索服务，同时也将匿名提"
+"供给 %1$s，以便共同提高服务质量。"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "Reports sent to DuckDuckGo are anonymous. Please do not include any personal "
 "or identifying information in your feedback."
-msgstr "发给 DuckDuckGo 的报告均为匿名。请不要在反馈中包含任何个人或可识别身份的信息。"
+msgstr ""
+"发给 DuckDuckGo 的报告均为匿名。请不要在反馈中包含任何个人或可识别身份的信"
+"息。"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -15123,11 +15574,22 @@ msgid ""
 "Reports sent to DuckDuckGo include all of the text you've asked us to "
 "translate during this page load, and are anonymous. Please do not include "
 "any personal or identifying information in your feedback."
-msgstr "发送给 DuckDuckGo 的报告包括你在此页面加载过程中要求我们翻译的所有文本，且是匿名形式。请不要在反馈中包含任何个人或可识别身份的信息。"
+msgstr ""
+"发送给 DuckDuckGo 的报告包括你在此页面加载过程中要求我们翻译的所有文本，且是"
+"匿名形式。请不要在反馈中包含任何个人或可识别身份的信息。"
 
 # smartling.placeholder_format=C
 msgid "Republic of Moldova"
 msgstr "摩尔多瓦共和国"
+
+# smartling.placeholder_format=C
+#. Note indicating that sharing the conversation is mandatory when reporting harmful or illegal content. Rendered alongside the standard share label (DUCKCHAT_RESPONSE_FEEDBACK_SHARE_PROMPT_RESPONSE_LABEL), not replacing it.
+msgctxt ""
+"Note shown under the share-content switch label on the Duck.ai response "
+"feedback form when the user has selected Harmful or Illegal as the feedback "
+"reason"
+msgid "Required for harmful or illegal reports"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
@@ -15193,7 +15655,9 @@ msgid ""
 "Responses are for educational purposes only and are not intended as medical, "
 "legal, financial, investment, or other professional advice. AI-assisted "
 "answers are subject to our %sTerms of Service%s."
-msgstr "回复仅供教育用途，不应视为医疗、法律、财务、投资或其他专业建议。人工智能辅助的答案受我们的%1$s服务条款%2$s约束。"
+msgstr ""
+"回复仅供教育用途，不应视为医疗、法律、财务、投资或其他专业建议。人工智能辅助"
+"的答案受我们的%1$s服务条款%2$s约束。"
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -15201,7 +15665,9 @@ msgid ""
 "Responses are for educational purposes only and are not intended as medical, "
 "legal, financial, investment, or other professional advice. DuckAssist is "
 "subject to our %sTerms of Service%s."
-msgstr "回复仅供教育用途，不应视为医疗、法律、财务、投资或其他专业建议。DuckAssist 受我们的%1$s服务条款%2$s约束。"
+msgstr ""
+"回复仅供教育用途，不应视为医疗、法律、财务、投资或其他专业建议。DuckAssist 受"
+"我们的%1$s服务条款%2$s约束。"
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -15211,8 +15677,8 @@ msgid ""
 "generated based on web content and may contain inaccuracies. Search Assist "
 "is subject to our %sTerms of Service%s."
 msgstr ""
-"回复仅供教育用途，不应视为医疗、法律、财务、投资或其他专业建议，且根据网络内容生成，可能包含不准确的信息。Search Assist "
-"受我们的%1$s服务条款%2$s约束。"
+"回复仅供教育用途，不应视为医疗、法律、财务、投资或其他专业建议，且根据网络内"
+"容生成，可能包含不准确的信息。Search Assist 受我们的%1$s服务条款%2$s约束。"
 
 # smartling.placeholder_format=C
 #. Label on the button for restoring all previous website data.
@@ -15354,6 +15820,12 @@ msgstr "评价"
 msgctxt "maps_places"
 msgid "Reviews"
 msgstr "评价"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Rewrite this recipe scaled for a different number of servings."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Romania"
@@ -15624,7 +16096,9 @@ msgctxt "Description for Chat History feature with Encrypted Storage option"
 msgid ""
 "Save up to 30 of your most recent chats locally on your device, with the "
 "option for more with Encrypted Storage."
-msgstr "在本地设备上保存多达 30 条最新聊天记录，还可使用加密存储功能保存更多聊天记录。"
+msgstr ""
+"在本地设备上保存多达 30 条最新聊天记录，还可使用加密存储功能保存更多聊天记"
+"录。"
 
 # smartling.placeholder_format=C
 #. Short text for native DDG browser users explaining how Chat History stores up to 30 of their most recent chats locally on their device.
@@ -15766,7 +16240,9 @@ msgstr "向下滚动并点击 %1$s查看高级设置%2$s。"
 msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)"
-msgstr "向下滚动并找到%1$s地址栏使用的搜索引擎%2$s，点击%3$s更改搜索引擎%4$s（或%5$s添加搜索引擎%6$s）"
+msgstr ""
+"向下滚动并找到%1$s地址栏使用的搜索引擎%2$s，点击%3$s更改搜索引擎%4$s（或%5$s"
+"添加搜索引擎%6$s）"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
@@ -15774,7 +16250,9 @@ msgstr "向下滚动并找到%1$s地址栏使用的搜索引擎%2$s，点击%3$s
 msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)."
-msgstr "向下滚动并找到 %1$s地址栏使用的搜索引擎%2$s，点击 %3$s更改搜索引擎%4$s（或 %5$s添加搜索引擎%6$s）。"
+msgstr ""
+"向下滚动并找到 %1$s地址栏使用的搜索引擎%2$s，点击 %3$s更改搜索引擎%4$s（或 "
+"%5$s添加搜索引擎%6$s）。"
 
 # smartling.placeholder_format=C
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -15846,10 +16324,10 @@ msgid ""
 "(on a wide range of searches). For now, Search Assist is only available in a "
 "subset of English speaking regions."
 msgstr ""
-"Search Assist "
-""
-"匿名生成搜索查询的答案。为此，该功能会扫描网络以查找相关内容，然后使用人工智能生成简短的答案。可以选择其出现的频率：从不、按需（仅在点击“Assist”时显示）、有时（仅在高度相关时显示）或经常（在更广泛的搜索中显示）。Search "
-"Assist 目前仅供部分英语地区使用。"
+"Search Assist 匿名生成搜索查询的答案。为此，该功能会扫描网络以查找相关内容，"
+"然后使用人工智能生成简短的答案。可以选择其出现的频率：从不、按需（仅在点"
+"击“Assist”时显示）、有时（仅在高度相关时显示）或经常（在更广泛的搜索中显"
+"示）。Search Assist 目前仅供部分英语地区使用。"
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI) when the answer is not found and the answer is unsourced or with no sources
@@ -15865,8 +16343,8 @@ msgid ""
 "search queries. To do this, it %sscans the web%s for relevant content and "
 "then uses AI to generate a brief answer based on information found."
 msgstr ""
-"Search Assist "
-"是一项可选功能，可以匿名生成搜索查询的答案。为此，该功能会%1$s扫描网络%2$s以查找相关内容，然后使用人工智能根据找到的信息生成简短的答案。"
+"Search Assist 是一项可选功能，可以匿名生成搜索查询的答案。为此，该功能会%1$s"
+"扫描网络%2$s以查找相关内容，然后使用人工智能根据找到的信息生成简短的答案。"
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/search_box. top header
@@ -15986,7 +16464,8 @@ msgctxt "noresults"
 msgid ""
 "Search other sites with %s shortcuts: a search for ”!w ducks” will search "
 "for “ducks” directly on Wikipedia."
-msgstr "使用 %1$s 快捷键搜索其他网站：搜索“!w ducks”将直接在维基百科上搜索“ducks”。"
+msgstr ""
+"使用 %1$s 快捷键搜索其他网站：搜索“!w ducks”将直接在维基百科上搜索“ducks”。"
 
 # smartling.placeholder_format=C
 #. Placeholder text for the search form when no text has been entered
@@ -16004,7 +16483,9 @@ msgstr "匿名搜索并屏蔽跟踪程序"
 msgid ""
 "Search privately with our app or extension, add private web search to your "
 "favorite browser, or search directly at %sduckduckgo.com%s."
-msgstr "通过我们的移动应用或扩展程序匿名搜索，或将搜索引擎加入浏览器，抑或直接打开 %1$sduckduckgo.com%2$s 发起搜索。"
+msgstr ""
+"通过我们的移动应用或扩展程序匿名搜索，或将搜索引擎加入浏览器，抑或直接打开 "
+"%1$sduckduckgo.com%2$s 发起搜索。"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/6LZAoqH.png
@@ -16023,8 +16504,9 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"搜索设置会存储在非个人浏览器 Cookie 和浏览器的本地存储中，但也可以使用 Cloud Save "
-"将设置匿名存储在云端的远程服务器上。系统不会在云端存储任何个人身份信息，且你的口令仅限在你的浏览器中使用。"
+"搜索设置会存储在非个人浏览器 Cookie 和浏览器的本地存储中，但也可以使用 Cloud "
+"Save 将设置匿名存储在云端的远程服务器上。系统不会在云端存储任何个人身份信息，"
+"且你的口令仅限在你的浏览器中使用。"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -16120,7 +16602,9 @@ msgctxt "Description explaining how native users can enable sync"
 msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
-msgstr "使用端到端加密安全地在我们的服务器上存储几乎无限量的聊天记录，并可从所有设备访问。"
+msgstr ""
+"使用端到端加密安全地在我们的服务器上存储几乎无限量的聊天记录，并可从所有设备"
+"访问。"
 
 # smartling.placeholder_format=C
 #. Text explaining that the Encrypted Storage feature stores the user's chats encrypted on their device.
@@ -16128,7 +16612,9 @@ msgctxt "Description for encrypted storage feature"
 msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
-msgstr "使用端到端加密安全地在我们的服务器上存储几乎无限量的聊天记录，并可从所有设备访问。"
+msgstr ""
+"使用端到端加密安全地在我们的服务器上存储几乎无限量的聊天记录，并可从所有设备"
+"访问。"
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -16136,7 +16622,9 @@ msgctxt "Description explaining how native users can enable sync"
 msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your synced devices."
-msgstr "使用端到端加密安全地在我们的服务器上存储几乎无限量的聊天记录，并可从所有已同步的设备访问。"
+msgstr ""
+"使用端到端加密安全地在我们的服务器上存储几乎无限量的聊天记录，并可从所有已同"
+"步的设备访问。"
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -16144,7 +16632,9 @@ msgctxt "Description explaining how native users can enable sync"
 msgid ""
 "Securely store your chats on our server using end-to-end encryption, and "
 "access them from all your devices."
-msgstr "利用端到端加密功能将聊天记录安全地存储在我们的服务器上，并可从所有设备访问相关内容。"
+msgstr ""
+"利用端到端加密功能将聊天记录安全地存储在我们的服务器上，并可从所有设备访问相"
+"关内容。"
 
 # smartling.placeholder_format=C
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
@@ -16158,7 +16648,9 @@ msgctxt "Chat history with sync modal list item"
 msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
-msgstr "采用端到端加密技术，安全存储在 DuckDuckGo 服务器上。除了你之外，没有人可以看到你的数据，甚至我们也不行。"
+msgstr ""
+"采用端到端加密技术，安全存储在 DuckDuckGo 服务器上。除了你之外，没有人可以看"
+"到你的数据，甚至我们也不行。"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -16366,14 +16858,16 @@ msgstr "在弹出的菜单中点击 %1$s管理加载项%2$s"
 #. Tells users where in the settings menu they can change their default search engine.
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sMenu > Settings%s (on Windows)"
-msgstr "Mac 系统点击 %1$sOpera > 设置%2$s，Windows 系统点击 %3$s菜单 > 设置%4$s"
+msgstr ""
+"Mac 系统点击 %1$sOpera > 设置%2$s，Windows 系统点击 %3$s菜单 > 设置%4$s"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sOpera > Options%s (on Windows)"
-msgstr "Mac 系统点击 %1$sOpera > 设置%2$s，Windows 系统点击 %3$sOpera > 选项%4$s"
+msgstr ""
+"Mac 系统点击 %1$sOpera > 设置%2$s，Windows 系统点击 %3$sOpera > 选项%4$s"
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -16558,7 +17052,9 @@ msgid ""
 "Sends a prompt to AI models with your messages with instructions on how to "
 "respond. These instructions will apply to all of your conversations going "
 "forward."
-msgstr "向人工智能模型发送包含你的消息的提示，并附带回复说明。这些说明将适用于你今后的所有对话。"
+msgstr ""
+"向人工智能模型发送包含你的消息的提示，并附带回复说明。这些说明将适用于你今后"
+"的所有对话。"
 
 # smartling.placeholder_format=C
 msgid "Senegal"
@@ -16632,6 +17128,12 @@ msgstr "立即设置"
 msgctxt "Setup button for native sync flow"
 msgid "Set Up Now"
 msgstr "立即设置"
+
+# smartling.placeholder_format=C
+#. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
+msgctxt "Encrypted storage setup button shown in native browsers"
+msgid "Set Up Sync & Backup"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
@@ -16747,7 +17249,9 @@ msgctxt "Description for Approximate Location feature"
 msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
-msgstr "与人工智能模型共享城市级位置信息，以提升相关性。Duck.ai 绝不会向我们或人工智能模型透露你的精确位置。"
+msgstr ""
+"与人工智能模型共享城市级位置信息，以提升相关性。Duck.ai 绝不会向我们或人工智"
+"能模型透露你的精确位置。"
 
 # smartling.placeholder_format=C
 #. Menu option to share feedback about a result
@@ -16808,6 +17312,13 @@ msgid "Share positive feedback"
 msgstr "分享正面反馈"
 
 # smartling.placeholder_format=C
+#. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
+msgctxt ""
+"Label beside the share-content switch on the Duck.ai response feedback form"
+msgid "Share this conversation with DuckDuckGo"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
 msgctxt ""
 "Label beside the share-content switch on the Duck.ai response feedback form"
@@ -16822,7 +17333,8 @@ msgctxt ""
 msgid ""
 "Share your prompt and chat response with DuckDuckGo (required for illegal "
 "and harmful report)"
-msgstr "将您的提示和聊天回复分享给 DuckDuckGo（举报非法和有害内容时需要执行此步骤）"
+msgstr ""
+"将您的提示和聊天回复分享给 DuckDuckGo（举报非法和有害内容时需要执行此步骤）"
 
 # smartling.placeholder_format=C
 #. An invitation for users to leave feedback
@@ -17167,14 +17679,18 @@ msgctxt "settings"
 msgid ""
 "Shows a reminder that searches on DuckDuckGo are always private. Turning "
 "this off hides the reminder and never affects search privacy."
-msgstr "提醒：在 DuckDuckGo 上进行的所有搜索均为匿名搜索。关闭此功能可隐藏提醒，且不会影响搜索隐私。"
+msgstr ""
+"提醒：在 DuckDuckGo 上进行的所有搜索均为匿名搜索。关闭此功能可隐藏提醒，且不"
+"会影响搜索隐私。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Shows a reminder that searches on DuckDuckGo are always protected. Turning "
 "this off hides the reminder and never affects search protection."
-msgstr "提醒：在 DuckDuckGo 上进行的所有搜索始终受到保护。关闭此功能可隐藏提醒，且不会影响搜索保护。"
+msgstr ""
+"提醒：在 DuckDuckGo 上进行的所有搜索始终受到保护。关闭此功能可隐藏提醒，且不"
+"会影响搜索保护。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18033,6 +18549,24 @@ msgid "Suggest a title for a blog post"
 msgstr "为博客文章建议标题"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest related articles or topics worth exploring next."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Suggest related articles to explore"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest some alternatives to this product."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
 msgctxt "directions"
 msgid "Suggestions:"
@@ -18044,10 +18578,100 @@ msgid "Suggestions:"
 msgstr "搜索建议："
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Sum up the reviews"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A short title for the a message asking the AI to summarize a text.
 msgctxt "Title for the summarize message"
 msgid "Summarize"
 msgstr "总结"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize the Q&As"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the background and notable work of this person."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the key details of this event."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the questions and answers on this page."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize their background"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this book"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this book."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this discussion"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this discussion thread."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this page"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this page."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this video"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this video."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize what the reviews say."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -18311,7 +18935,8 @@ msgid ""
 msgstr ""
 "同步恢复代码\n"
 "\n"
-"恢复代码允许你在多个设备之间同步密码、自动填充数据和 Duck.ai 聊天记录，并在无法访问某个设备时恢复已同步的数据。\n"
+"恢复代码允许你在多个设备之间同步密码、自动填充数据和 Duck.ai 聊天记录，并在无"
+"法访问某个设备时恢复已同步的数据。\n"
 "\n"
 "请妥善保管此信息。\n"
 "任何可访问此代码的人都可以访问你的同步数据。\n"
@@ -18323,7 +18948,8 @@ msgstr ""
 "2. 选择“开启 Sync & Backup”，然后选择“恢复同步数据”\n"
 " 3. 复制上方的恢复代码，并将其粘贴到“在此处粘贴代码”处\n"
 "\n"
-"如果你超过 18 个月未使用启用 Sync & Backup 功能的 DuckDuckGo 浏览器，你的数据将从服务器中删除且无法恢复。"
+"如果你超过 18 个月未使用启用 Sync & Backup 功能的 DuckDuckGo 浏览器，你的数据"
+"将从服务器中删除且无法恢复。"
 
 # smartling.placeholder_format=C
 #. Secondary button label on the Sync & Backup intro screen that takes the user to the camera scan screen to pair with another device.
@@ -18366,6 +18992,12 @@ msgid "Syria"
 msgstr "叙利亚"
 
 # smartling.placeholder_format=C
+#. Text for a button that enables the theme to follow the operating system's color scheme preference.
+msgctxt "System theme button for theme selector"
+msgid "System"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Abbreviation indicating this is the total score for a game
 msgctxt "Sports module"
 msgid "T"
@@ -18392,6 +19024,12 @@ msgstr "电视"
 msgctxt "language_name"
 msgid "Tahitian"
 msgstr "塔希提语"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Tailor my resume"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Taiwan"
@@ -18421,6 +19059,13 @@ msgstr "掌控个人数据"
 msgctxt "homepage ATB modal"
 msgid "Take control of your personal data!"
 msgstr "掌控个人数据！"
+
+# smartling.placeholder_format=C
+#. Description for the Feedback section of the Duck.ai settings page, asking the user to take an anonymous survey to let us know how we can make Duck.ai better.
+msgctxt "Feedback section description on the Duck.ai settings page"
+msgid ""
+"Take this anonymous survey to let us know how we can make Duck.ai better."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -18634,7 +19279,9 @@ msgid ""
 "That means information sent between your device and the webpage behind this "
 "link is at increased risk of being intercepted by a third party. In rare "
 "cases this includes passwords, or payment details."
-msgstr "这意味着你与网站之间传输的信息更有可能被第三方截获，其中甚至包括你的密码和银行账号。"
+msgstr ""
+"这意味着你与网站之间传输的信息更有可能被第三方截获，其中甚至包括你的密码和银"
+"行账号。"
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -18717,6 +19364,12 @@ msgid "Theme"
 msgstr "配色"
 
 # smartling.placeholder_format=C
+#. Text for the theme selector label that allows users to switch between Light and dark theme.
+msgctxt "Label for the theme selector feature"
+msgid "Theme"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. http://i.imgur.com/LpFhb1e.png
 msgctxt "settings"
 msgid "Theme"
@@ -18744,7 +19397,8 @@ msgctxt "Error message when there was an issue saving a chat to the browser"
 msgid ""
 "There was an error saving this chat locally. Please check your browser "
 "settings to make sure local data storage is enabled."
-msgstr "在本地保存此聊天时出现了错误。请检查你的浏览器设置以确保已启用本地数据存储。"
+msgstr ""
+"在本地保存此聊天时出现了错误。请检查你的浏览器设置以确保已启用本地数据存储。"
 
 # smartling.placeholder_format=C
 #. Error modal body line 1.
@@ -18776,7 +19430,9 @@ msgid ""
 "These browser permissions are used to add privacy protection on websites you "
 "visit by blocking hidden trackers, encrypting connections where possible, "
 "and by making DuckDuckGo your default search engine."
-msgstr "所需的浏览器权限用于屏蔽网页跟踪程序、尽可能建立加密连接，并将 DuckDuckGo 设为默认搜索引擎，从而保护你的隐私。"
+msgstr ""
+"所需的浏览器权限用于屏蔽网页跟踪程序、尽可能建立加密连接，并将 DuckDuckGo 设"
+"为默认搜索引擎，从而保护你的隐私。"
 
 # smartling.placeholder_format=C
 #. Secondary line under DUCKCHAT_SYNC_PAIRING_ALREADY_SYNCED_TITLE.
@@ -18847,7 +19503,9 @@ msgctxt "Export chat feature in AI Chat"
 msgid ""
 "This conversation was generated with Duck.ai (%s) using %s's %s Model. AI "
 "chats may display inaccurate or offensive information (see %s for more info)."
-msgstr "此对话由 Duck.ai (%1$s) 使用 %2$s 的 %3$s 模型生成。人工智能聊天可能会显示不准确或令人反感的信息（详情请参阅%4$s）。"
+msgstr ""
+"此对话由 Duck.ai (%1$s) 使用 %2$s 的 %3$s 模型生成。人工智能聊天可能会显示不"
+"准确或令人反感的信息（详情请参阅%4$s）。"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with multiple AI models in the same chat, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using multiple chat models. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -18856,7 +19514,9 @@ msgid ""
 "This conversation was generated with Duck.ai (%s) using multiple chat "
 "models. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
-msgstr "此对话由 Duck.ai (%1$s) 使用多个聊天模型生成。人工智能聊天可能会显示不准确或令人反感的信息（详情请参阅%2$s）。"
+msgstr ""
+"此对话由 Duck.ai (%1$s) 使用多个聊天模型生成。人工智能聊天可能会显示不准确或"
+"令人反感的信息（详情请参阅%2$s）。"
 
 # smartling.placeholder_format=C
 #. When a user exports a transcript of a voice chat they had with the AI. This text goes at the very top of the downloaded file as a header. Placeholders are for links. Example: 'This conversation was generated with Duck.ai voice chat (https://duck.ai). AI may provide inaccurate or offensive information. (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -18864,7 +19524,9 @@ msgctxt "Export chat feature in AI Chat"
 msgid ""
 "This conversation was generated with Duck.ai voice chat (%s). AI may provide "
 "inaccurate or offensive information. (see %s for more info)."
-msgstr "这段对话通过 Duck.ai 语音聊天生成 (%1$s)。人工智能可能会提供不准确或令人反感的信息。（详情请参见 %2$s）。"
+msgstr ""
+"这段对话通过 Duck.ai 语音聊天生成 (%1$s)。人工智能可能会提供不准确或令人反感"
+"的信息。（详情请参见 %2$s）。"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with DuckDuckGo AI Chat (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/aichat/privacy-terms for more info).'
@@ -18874,8 +19536,8 @@ msgid ""
 "Model. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
 msgstr ""
-"此对话由 DuckDuckGo AI Chat (%1$s) 使用 %2$s 的 %3$s "
-"模型生成。人工智能聊天可能会显示不准确或令人反感的信息（详情请参阅%4$s）。"
+"此对话由 DuckDuckGo AI Chat (%1$s) 使用 %2$s 的 %3$s 模型生成。人工智能聊天可"
+"能会显示不准确或令人反感的信息（详情请参阅%4$s）。"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
@@ -18978,7 +19640,9 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "This model provider deletes data associated with this chat within 30 days. "
 "Other model providers follow a zero data retention model."
-msgstr "该模型提供商会在 30 天内删除与此聊天记录相关的数据。其他模型提供商遵循零数据保留模式。"
+msgstr ""
+"该模型提供商会在 30 天内删除与此聊天记录相关的数据。其他模型提供商遵循零数据"
+"保留模式。"
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers, and that other providers may retain chat data for a limited time instead.
@@ -18986,7 +19650,9 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "This model provider does not store any data associated with this chat. Other "
 "model providers follow a limited data retention model."
-msgstr "该模型提供商不会存储与此聊天记录相关的任何数据。其他模型提供商遵循有限的数据保留模式。"
+msgstr ""
+"该模型提供商不会存储与此聊天记录相关的任何数据。其他模型提供商遵循有限的数据"
+"保留模式。"
 
 # smartling.placeholder_format=C
 #. Info that page may refresh during update.
@@ -19022,7 +19688,9 @@ msgctxt "First paragraph for the Sync & Backup intro screen"
 msgid ""
 "This saves your chats with end-to-end encryption on DuckDuckGo's secure "
 "server, which later can be accessed from any browser."
-msgstr "这将使用端到端加密技术将您的聊天记录安全地存储在 DuckDuckGo 的安全服务器上，之后可以通过任何浏览器访问这些记录。"
+msgstr ""
+"这将使用端到端加密技术将您的聊天记录安全地存储在 DuckDuckGo 的安全服务器上，"
+"之后可以通过任何浏览器访问这些记录。"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -19030,7 +19698,9 @@ msgctxt "duckassist"
 msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again."
-msgstr "此设置存储在你的浏览器中，这意味着如果清除了 duckduckgo.com 的浏览器数据，那么你可能会再次看到 AI 辅助的答案。"
+msgstr ""
+"此设置存储在你的浏览器中，这意味着如果清除了 duckduckgo.com 的浏览器数据，那"
+"么你可能会再次看到 AI 辅助的答案。"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -19040,8 +19710,9 @@ msgid ""
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
 msgstr ""
-"此设置存储在你的浏览器中，这意味着如果清除了 duckduckgo.com 的浏览器数据，那么你可能会再次看到 AI "
-"辅助的答案。不过，我们还有一个起始页，它从不在 %1$s 显示 AI 辅助答案。"
+"此设置存储在你的浏览器中，这意味着如果清除了 duckduckgo.com 的浏览器数据，那"
+"么你可能会再次看到 AI 辅助的答案。不过，我们还有一个起始页，它从不在 %1$s 显"
+"示 AI 辅助答案。"
 
 # smartling.placeholder_format=C
 #. User feedback indicating that a translation is helpful
@@ -19080,8 +19751,8 @@ msgid ""
 "Sync & Backup. You'll still be able to access your chats in other browsers "
 "connected to Sync & Backup."
 msgstr ""
-"这将删除你在此浏览器中的所有 Duck.ai 聊天记录，并断开 Sync & Backup 连接。你仍然可以在连接到 Sync & Backup "
-"的其他浏览器中浏览你的聊天记录。"
+"这将删除你在此浏览器中的所有 Duck.ai 聊天记录，并断开 Sync & Backup 连接。你"
+"仍然可以在连接到 Sync & Backup 的其他浏览器中浏览你的聊天记录。"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to clear all recentchats, with a warning that this action cannot be undone.
@@ -19226,7 +19897,8 @@ msgctxt "directions"
 msgid ""
 "To print directions:%sGo back to the map.%sSelect the route you want to "
 "print.%sClick the print icon.%s"
-msgstr "打印路线具体操作：%1$s返回地图。%2$s选择要打印的路线。%3$s点击打印图标。%4$s"
+msgstr ""
+"打印路线具体操作：%1$s返回地图。%2$s选择要打印的路线。%3$s点击打印图标。%4$s"
 
 # smartling.placeholder_format=C
 #. Explains where the user can find their recovery code. Figma frame 3703-44420.
@@ -19235,7 +19907,9 @@ msgid ""
 "To restore your synced data, you'll need the Recovery Code you saved when "
 "you first set up Sync. This code may have been saved as a PDF on the device "
 "you originally used to set up Sync."
-msgstr "需要使用首次设置同步时保存的恢复代码来还原已同步的数据。此代码可能已以 PDF 格式保存到最初用于设置同步的设备上。"
+msgstr ""
+"需要使用首次设置同步时保存的恢复代码来还原已同步的数据。此代码可能已以 PDF 格"
+"式保存到最初用于设置同步的设备上。"
 
 # smartling.placeholder_format=C
 #. Body text explaining that the user needs to update their DDG browser before migration can proceed.
@@ -19243,7 +19917,9 @@ msgctxt "duckai_migration"
 msgid ""
 "To transfer your chat history to Duck.ai, please update your DuckDuckGo "
 "browser to the latest version and try again."
-msgstr "如需将聊天记录转移到 Duck.ai，请先将 DuckDuckGo 浏览器升级至最新版本，然后再试一次。"
+msgstr ""
+"如需将聊天记录转移到 Duck.ai，请先将 DuckDuckGo 浏览器升级至最新版本，然后再"
+"试一次。"
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
@@ -19439,7 +20115,8 @@ msgctxt "tracker_stats"
 msgid ""
 "Tracking attempts blocked by DuckDuckGo appear here. Keep browsing to see "
 "how many we block."
-msgstr "此处将显示被 DuckDuckGo 阻止的跟踪企图。继续浏览以查看我们阻止了多少次。"
+msgstr ""
+"此处将显示被 DuckDuckGo 阻止的跟踪企图。继续浏览以查看我们阻止了多少次。"
 
 # smartling.placeholder_format=C
 #. Placeholder for when we cannot report any blocked trackers yet
@@ -19495,6 +20172,18 @@ msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
 msgstr "将这句中文翻译成英语：“我怎么去最近的电影院？”"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Translate this page"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
+msgctxt "Page suggestion prompt"
+msgid "Translate this page into %s."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder text for a region that will display translated text.
@@ -19636,6 +20325,12 @@ msgstr "再试一次"
 msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
 msgstr "免费试用"
+
+# smartling.placeholder_format=C
+#. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
+msgctxt "settings"
+msgid "Try It Now"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -19870,6 +20565,22 @@ msgid "Trying DuckDuckGo again"
 msgstr "再用用看 DuckDuckGo"
 
 # smartling.placeholder_format=C
+#. Message shown in a modal after supported third-party browser users disable AI features in Settings. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
 msgctxt "Assistant response placeholder"
 msgid "Trying with %s"
@@ -20037,7 +20748,9 @@ msgctxt "settings"
 msgid ""
 "Types out DuckAssist answers as they're generated. Turning this off may "
 "result in a short delay between a search and the answer being displayed."
-msgstr "在生成 DuckAssist 答案时键入相关内容。关闭此功能可能会导致搜索与显示答案之间出现短暂的延迟。"
+msgstr ""
+"在生成 DuckAssist 答案时键入相关内容。关闭此功能可能会导致搜索与显示答案之间"
+"出现短暂的延迟。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -20166,14 +20879,16 @@ msgstr "了解优点和缺点"
 msgid ""
 "Under %sOn startup%s, click %sOpen a specific page%s then click %sSet "
 "Pages%s."
-msgstr "在%1$s启动时%2$s下，点击%3$s打开特定页面%4$s，然后点击 %5$s设置页面%6$s。"
+msgstr ""
+"在%1$s启动时%2$s下，点击%3$s打开特定页面%4$s，然后点击 %5$s设置页面%6$s。"
 
 #  Maxthon homepage instruction
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
-msgstr "在%1$s启动时%2$s下，选择%3$s主页%4$s并将主页设为 https://duckduckgo.com"
+msgstr ""
+"在%1$s启动时%2$s下，选择%3$s主页%4$s并将主页设为 https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -20288,7 +21003,9 @@ msgctxt "Description of the modal to upgrade to Pro"
 msgid ""
 "Unlock %s, higher AI reasoning, and 2x higher usage limits than the Plus "
 "plan by upgrading to Pro."
-msgstr "升级至 Pro 计划，即可解锁 %1$s、更强大的 AI 推理能力，以及比 Plus 计划高 2 倍的使用限额。"
+msgstr ""
+"升级至 Pro 计划，即可解锁 %1$s、更强大的 AI 推理能力，以及比 Plus 计划高 2 倍"
+"的使用限额。"
 
 # smartling.placeholder_format=C
 #. Title for the subscription promo shown in the SERP sidemenu.
@@ -20600,6 +21317,12 @@ msgid "Uruguay"
 msgstr "乌拉圭"
 
 # smartling.placeholder_format=C
+#. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
+msgctxt "Navigation label on the Duck.ai settings page"
+msgid "Usage"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A feedback suggestion
 msgctxt "Feedback prompt"
 msgid "Usage limit"
@@ -20640,7 +21363,9 @@ msgctxt "duckai_seo"
 msgid ""
 "Use ChatGPT, Claude, and other AIs, privately. Protect chats from hackers, "
 "scammers, and companies. Keep info confidential. Free. No account required."
-msgstr "私密地使用 ChatGPT、Claude 和其他人工智能工具。保护聊天内容免受黑客、骗子和公司的侵害。确保信息保密。免费。无需账户。"
+msgstr ""
+"私密地使用 ChatGPT、Claude 和其他人工智能工具。保护聊天内容免受黑客、骗子和公"
+"司的侵害。确保信息保密。免费。无需账户。"
 
 # smartling.placeholder_format=C
 #. Header above instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -20838,7 +21563,8 @@ msgctxt "Single Place Hotel Offers Module"
 msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "TripAdvisor's ad network."
-msgstr "DuckDuckGo 会保护观看广告的隐私。广告点击量由 TripAdvisor 广告网络管理。"
+msgstr ""
+"DuckDuckGo 会保护观看广告的隐私。广告点击量由 TripAdvisor 广告网络管理。"
 
 # smartling.placeholder_format=C
 msgid "Virgin Islands"
@@ -20880,8 +21606,8 @@ msgid ""
 "Visit Duck.ai in your other browser and go to %sDuck.ai Settings%s > %sSync "
 "& Backup%s > %sManage%s then select %sSync With Another Device%s."
 msgstr ""
-"在您的另一个浏览器中访问 Duck.ai，然后前往 %1$sDuck.ai 设置%2$s > %3$sSync & Backup%4$s > "
-"%5$s管理%6$s，然后选择%7$s与另一台设备同步%8$s。"
+"在您的另一个浏览器中访问 Duck.ai，然后前往 %1$sDuck.ai 设置%2$s > %3$sSync & "
+"Backup%4$s > %5$s管理%6$s，然后选择%7$s与另一台设备同步%8$s。"
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -20891,8 +21617,8 @@ msgid ""
 "On” under Sync & Backup and select “Sync With Another Device”. Or scan the "
 "QR on your Recovery PDF."
 msgstr ""
-"在其他浏览器中访问 Duck.ai 并打开 Duck.ai 设置。在 Sync & Backup "
-"栏下选择“开启”，然后选择“与其他设备同步”。或者扫描恢复 PDF 中的二维码。"
+"在其他浏览器中访问 Duck.ai 并打开 Duck.ai 设置。在 Sync & Backup 栏下选择“开"
+"启”，然后选择“与其他设备同步”。或者扫描恢复 PDF 中的二维码。"
 
 # smartling.placeholder_format=C
 #. Shared body copy for every screen in the Sync Another Device flow (QR display, camera scan, camera-unavailable fallback, manual entry). Bold tags wrap navigation breadcrumbs. Render with <Translate /> so the HTML is interpreted; plain `translate()` will trip the html-string warning.
@@ -20902,8 +21628,9 @@ msgid ""
 "ai Settings%s > %sSync & Backup%s > %sManage%s then select %sSync With "
 "Another Device%s."
 msgstr ""
-"在另一个浏览器或 DuckDuckGo 应用程序中访问 Duck.ai，然后前往“%1$sDuck.ai 设置%2$s > %3$sSync & "
-"Backup%4$s > %5$s管理%6$s”，然后选择“%7$s与其他设备同步%8$s”。"
+"在另一个浏览器或 DuckDuckGo 应用程序中访问 Duck.ai，然后前往“%1$sDuck.ai 设"
+"置%2$s > %3$sSync & Backup%4$s > %5$s管理%6$s”，然后选择“%7$s与其他设备同"
+"步%8$s”。"
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -20913,8 +21640,9 @@ msgid ""
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
 msgstr ""
-"在另一个浏览器或 DuckDuckGo 应用程序中访问 Duck.ai，然后打开 Duck.ai 设置。在 Sync & Backup "
-"栏下选择“开启”，然后选择“与其他设备同步”。或者扫描恢复 PDF 中的二维码。"
+"在另一个浏览器或 DuckDuckGo 应用程序中访问 Duck.ai，然后打开 Duck.ai 设置。"
+"在 Sync & Backup 栏下选择“开启”，然后选择“与其他设备同步”。或者扫描恢复 PDF "
+"中的二维码。"
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -21027,6 +21755,12 @@ msgid "Wales"
 msgstr "威尔士"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Walk me through the steps"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for walking directions on a map.
 msgctxt "directions"
 msgid "Walking"
@@ -21103,7 +21837,9 @@ msgstr "在 Duck Player 中观看"
 msgid ""
 "Watch in Duck Player to block personalized ads on YouTube and prevent your "
 "viewing activity from influencing YouTube recommendations."
-msgstr "在 Duck Player 中观看，以屏蔽 YouTube 上的个性化广告，并防止你的观看活动影响 YouTube 推荐。"
+msgstr ""
+"在 Duck Player 中观看，以屏蔽 YouTube 上的个性化广告，并防止你的观看活动影响 "
+"YouTube 推荐。"
 
 # smartling.placeholder_format=C
 #. A button that takes a user to another site in order to watch a video. The placeholder is the name of the video site. For example: 'Watch on Vimeo'
@@ -21123,8 +21859,8 @@ msgid ""
 "independent company and has no relationship with YouTube, where most videos "
 "are hosted."
 msgstr ""
-"在此处观看视频意味着其托管网站可以跟踪你，因为我们必须从该网站流式传输内容。DuckDuckGo 是一家独立公司，与托管大多数视频的 YouTube "
-"没有任何关系。"
+"在此处观看视频意味着其托管网站可以跟踪你，因为我们必须从该网站流式传输内容。"
+"DuckDuckGo 是一家独立公司，与托管大多数视频的 YouTube 没有任何关系。"
 
 # smartling.placeholder_format=C
 #. Heading for the highlight card explaining anonymized prompt delivery.
@@ -21139,6 +21875,17 @@ msgid "We can anonymize%s your location%s to show you more accurate results."
 msgstr "我们可以通过匿名%1$s你的定位%2$s显示更精准的搜索结果。"
 
 # smartling.placeholder_format=C
+#. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
+msgctxt ""
+"Inline warning shown below the share-content toggle when the user selects "
+"Harmful or Illegal but has not enabled sharing"
+msgid ""
+"We can only fix what we can see. To report a harmful or illegal response, "
+"please share this conversation with DuckDuckGo so we can investigate and "
+"address the issue."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
 msgctxt ""
 "Inline warning shown below the share-content toggle when the user selects "
@@ -21147,7 +21894,9 @@ msgid ""
 "We can only fix what we can see. To report a harmful or illegal response, "
 "please share your prompt and response so we can investigate and address the "
 "issue."
-msgstr "我们只能处理我们看得到的问题。要举报有害或非法的回复，请先分享您的提示词和回复，这样我们才能调查并处理这个问题。"
+msgstr ""
+"我们只能处理我们看得到的问题。要举报有害或非法的回复，请先分享您的提示词和回"
+"复，这样我们才能调查并处理这个问题。"
 
 # smartling.placeholder_format=C
 #. Explains how location service is used to show users search results near their current location.
@@ -21200,7 +21949,9 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what brought you "
 "back today:"
-msgstr "我们想请你聊聊是什么让你继续使用 DuckDuckGo，你所写和浏览的一切将不会被我们跟踪："
+msgstr ""
+"我们想请你聊聊是什么让你继续使用 DuckDuckGo，你所写和浏览的一切将不会被我们跟"
+"踪："
 
 # smartling.placeholder_format=C
 #. Message prompting users to fill out a feedback form.
@@ -21208,7 +21959,9 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what convinced you "
 "to try us out today:"
-msgstr "我们想请你聊聊是什么让你信任并使用 DuckDuckGo，你所写和浏览的一切将不会被我们跟踪："
+msgstr ""
+"我们想请你聊聊是什么让你信任并使用 DuckDuckGo，你所写和浏览的一切将不会被我们"
+"跟踪："
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -21304,7 +22057,8 @@ msgctxt "precise_user_location"
 msgid ""
 "We only use your anonymous location to deliver better results, closer to "
 "you. You can always change your mind later."
-msgstr "匿名定位仅用于为你提供更近、更优质的搜索结果，将来你也可以随时选择关闭。"
+msgstr ""
+"匿名定位仅用于为你提供更近、更优质的搜索结果，将来你也可以随时选择关闭。"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -21330,7 +22084,9 @@ msgid ""
 "We use feedback like this to improve DuckDuckGo. Suggestions will be "
 "incorporated at the discretion of %s. Corrections may not show up in results "
 "right away."
-msgstr "你的反馈意见能帮助我们改进 DuckDuckGo。%1$s 将酌情采纳你的建议，但搜索结果更正可能需要一段时间。"
+msgstr ""
+"你的反馈意见能帮助我们改进 DuckDuckGo。%1$s 将酌情采纳你的建议，但搜索结果更"
+"正可能需要一段时间。"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -21343,7 +22099,8 @@ msgctxt "noresults"
 msgid ""
 "We're aware of this issue and are currently working to resolve it. If you "
 "continue to see this error, please reach out to %s."
-msgstr "我们了解这个问题，目前正在努力解决。如果你继续看到此错误，请联系 %1$s。"
+msgstr ""
+"我们了解这个问题，目前正在努力解决。如果你继续看到此错误，请联系 %1$s。"
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -21351,7 +22108,8 @@ msgctxt "noresults"
 msgid ""
 "We're aware of this issue and are currently working to resolve it. Sometimes "
 "clearing your browser's cache can help."
-msgstr "我们了解这个问题，目前正在努力解决。有时候，清除浏览器的缓存可能会有帮助。"
+msgstr ""
+"我们了解这个问题，目前正在努力解决。有时候，清除浏览器的缓存可能会有帮助。"
 
 # smartling.placeholder_format=C
 #. Header for a feedback form for new users.
@@ -21488,7 +22246,9 @@ msgctxt "Welcome message in chat"
 msgid ""
 "Welcome to Duck.ai! All of your chats here are private, anonymized by us and "
 "not used to train AI models."
-msgstr "欢迎使用 Duck.ai！此处所有聊天内容均为私密，我们已对其进行匿名化处理，不会用于训练人工智能模型。"
+msgstr ""
+"欢迎使用 Duck.ai！此处所有聊天内容均为私密，我们已对其进行匿名化处理，不会用"
+"于训练人工智能模型。"
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened.
@@ -21496,7 +22256,9 @@ msgctxt "Welcome message in chat"
 msgid ""
 "Welcome to DuckDuckGo AI Chat! All of your chats here are private, "
 "anonymized by us and not used to train AI models."
-msgstr "欢迎使用 DuckDuckGo AI Chat！此处所有聊天内容均为私密，我们已对其进行匿名化处理，不会用于训练人工智能模型。"
+msgstr ""
+"欢迎使用 DuckDuckGo AI Chat！此处所有聊天内容均为私密，我们已对其进行匿名化处"
+"理，不会用于训练人工智能模型。"
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened. Example: 'Welcome to DuckDuckGo AI Chat! This chat session is powered by OpenAI’s GPT-3. All of your chats here are private, and are never stored by DuckDuckGo or used to train AI models.'
@@ -21506,8 +22268,8 @@ msgid ""
 "of your chats here are private, and are never stored by DuckDuckGo or used "
 "to train AI models."
 msgstr ""
-"欢迎使用 DuckDuckGo AI Chat！此聊天会话由 %1$s 的 %2$s 提供支持。此处所有聊天内容均为私密，DuckDuckGo "
-"绝不会存储或用于训练 AI 模型。"
+"欢迎使用 DuckDuckGo AI Chat！此聊天会话由 %1$s 的 %2$s 提供支持。此处所有聊天"
+"内容均为私密，DuckDuckGo 绝不会存储或用于训练 AI 模型。"
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -21633,8 +22395,106 @@ msgid ""
 "easy to understand for people with or without much AI, or technical, "
 "experience."
 msgstr ""
-"对于有兴趣使用 Duck.ai 的人来说，下载 DuckDuckGo 浏览器有哪些好处？仅参考官方 DuckDuckGo "
-"来源。将响应分为清晰的部分，标题聚焦于 Duck.ai 集成和隐私保护。保持内容简短、简单，易于理解，适合有或没有太多人工智能或技术经验的人。"
+"对于有兴趣使用 Duck.ai 的人来说，下载 DuckDuckGo 浏览器有哪些好处？仅参考官"
+"方 DuckDuckGo 来源。将响应分为清晰的部分，标题聚焦于 Duck.ai 集成和隐私保护。"
+"保持内容简短、简单，易于理解，适合有或没有太多人工智能或技术经验的人。"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the counterarguments?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the hours & location?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key contributions of this paper?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key contributions?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key details?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key points covered in this video?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key points?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key takeaways from this article?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key takeaways?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key things I will learn from this course?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main counterarguments or criticisms of this?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main questions this page answers?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the must-try dishes here?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"What are the opening hours, location, and contact details for this place?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the pros and cons of this product?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the pros and cons?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
@@ -21737,6 +22597,12 @@ msgid "What does atria mean in the context of a medical article?"
 msgstr "在医学文章中，atria 指的是什么？"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What does this answer?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
@@ -21747,6 +22613,12 @@ msgstr "你希望我们添加什么功能？（可选）"
 msgctxt "cloudsave"
 msgid "What information gets saved?"
 msgstr "哪些信息会被保存到云端？"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What interview questions might come up for this role?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -21761,6 +22633,12 @@ msgstr "Cloud Save 链接是什么？和参数设置链接有何不同？"
 msgctxt "Full sentence for looking up basic facts"
 msgid "What is the capital city of Albania?"
 msgstr "阿尔巴尼亚的首都是哪里？"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What is the overall verdict and rating for this?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to a page with additional information.
@@ -21785,6 +22663,12 @@ msgid "What people say:"
 msgstr "大众评价："
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What should I order?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
 msgctxt "feedback form"
 msgid "What stood out?"
@@ -21795,6 +22679,18 @@ msgstr "最令人印象深刻的是什么？"
 msgctxt "feedback form"
 msgid "What was wrong with the response? (optional)"
 msgstr "这个回复有什么问题？（可选）"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I learn?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I need?"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -21812,6 +22708,12 @@ msgstr "在 DuckDuckGo 中观看的内容不会影响 YouTube 上的推荐。"
 msgctxt "SERP footer content"
 msgid "What's New"
 msgstr "最新功能"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What's the verdict?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -21862,6 +22764,12 @@ msgid "Which features are missing? (Optional)"
 msgstr "缺失哪些功能？（可选）"
 
 # smartling.placeholder_format=C
+#. An invitation for users to leave feedback
+msgctxt "Feedback prompt"
+msgid "Which features are missing? (optional)"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
 msgid "White"
 msgstr "白色"
@@ -21876,6 +22784,18 @@ msgstr "白色"
 #. Link to an about us page.
 msgid "Who We Are"
 msgstr "认识本站团队"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Who are the main cast and crew, and what else are they known for?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Who is this person?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Header above a collection of privacy-related links.
@@ -22273,7 +23193,8 @@ msgctxt "noresults"
 msgid ""
 "You can %s or search directly on other search engines from DuckDuckGo using "
 "%s search shortcuts."
-msgstr "可以%1$s或使用 %2$s 搜索快捷键从 DuckDuckGo 在其他搜索引擎上直接进行搜索。"
+msgstr ""
+"可以%1$s或使用 %2$s 搜索快捷键从 DuckDuckGo 在其他搜索引擎上直接进行搜索。"
 
 # smartling.placeholder_format=C
 #. Text informing the user that they can access DuckDuckGo AI Chat directly at a specific URL. The placeholder %s will be replaced with the link. Example: 'You can access DuckDuckGo AI Chat directly at duck.ai.'
@@ -22317,7 +23238,8 @@ msgstr "您最多可以附加 %1$s 个文本选中内容。"
 msgid ""
 "You can change how frequently you see Search Assist, or turn it off "
 "entirely, in %sSearch Settings%s."
-msgstr "可以在%1$s搜索设置%2$s中更改显示 Search Assist 的频率，或者将其完全关闭。"
+msgstr ""
+"可以在%1$s搜索设置%2$s中更改显示 Search Assist 的频率，或者将其完全关闭。"
 
 # smartling.placeholder_format=C
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
@@ -22466,7 +23388,9 @@ msgctxt "Description of the post-upgrade success modal"
 msgid ""
 "You now have access to %s, higher AI reasoning, and 2x higher usage limits "
 "than Plus."
-msgstr "你现在可以享用 %1$s、更强大的人工智能推理能力以及比 Plus 计划高 2 倍的使用限额。"
+msgstr ""
+"你现在可以享用 %1$s、更强大的人工智能推理能力以及比 Plus 计划高 2 倍的使用限"
+"额。"
 
 # smartling.placeholder_format=C
 #. Description text for the welcome modal displayed after the user subscribes to DuckDuckGo.
@@ -22474,7 +23398,9 @@ msgctxt "Description text for the subscription welcome modal"
 msgid ""
 "You now have access to advanced AI models. You can access the VPN and other "
 "DuckDuckGo subscription protections in the DuckDuckGo browser."
-msgstr "现在可以使用高级人工智能模型。可以在 DuckDuckGo 浏览器中使用 VPN 和其他 DuckDuckGo 订阅保护功能。"
+msgstr ""
+"现在可以使用高级人工智能模型。可以在 DuckDuckGo 浏览器中使用 VPN 和其他 "
+"DuckDuckGo 订阅保护功能。"
 
 # smartling.placeholder_format=C
 #. Welcome message that appears after the DuckDuckGo extension is installed.
@@ -22495,7 +23421,9 @@ msgid ""
 "You will no longer be able to access your saved chats from this browser. The "
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
-msgstr "你将无法再通过此浏览器访问已保存的聊天记录。最近 30 条聊天记录仍将保留在本地存储中。这不会从加密服务器中删除你的聊天记录。"
+msgstr ""
+"你将无法再通过此浏览器访问已保存的聊天记录。最近 30 条聊天记录仍将保留在本地"
+"存储中。这不会从加密服务器中删除你的聊天记录。"
 
 # smartling.placeholder_format=C
 #. Explains that turning off disconnects this browser only; the last 30 chats stay in local storage and the encrypted server backup is not deleted.
@@ -22504,7 +23432,9 @@ msgid ""
 "You will no longer be able to access your saved chats from this browser. The "
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
-msgstr "你将无法再通过此浏览器访问已保存的聊天记录。最近 30 条聊天记录仍将保留在本地存储中。这不会从加密服务器中删除你的聊天记录。"
+msgstr ""
+"你将无法再通过此浏览器访问已保存的聊天记录。最近 30 条聊天记录仍将保留在本地"
+"存储中。这不会从加密服务器中删除你的聊天记录。"
 
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
@@ -22525,7 +23455,9 @@ msgctxt "welcome message eu search preference android"
 msgid ""
 "You're now searching privately in Chrome. Use our app instead of Chrome to "
 "browse privately too. It’s already installed and can:"
-msgstr "现在使用 Chrome 搜索再也不用担心泄露隐私了。与 Chrome 相比，使用我们已经安装的 App 上网还能进一步保护隐私，它可以："
+msgstr ""
+"现在使用 Chrome 搜索再也不用担心泄露隐私了。与 Chrome 相比，使用我们已经安装"
+"的 App 上网还能进一步保护隐私，它可以："
 
 # smartling.placeholder_format=C
 #. Confirmation message that appears after the DuckDuckGo browser extension is installed.
@@ -22607,8 +23539,8 @@ msgid ""
 "You've run out of Sync & Backup storage for Duck.ai chats with attachments. "
 "Delete the %s oldest chats to resume Sync. Pinned chats will not be deleted."
 msgstr ""
-"包含附件的 Duck.ai 聊天记录的 Sync & Backup 存储空间已经用完。删除最早的 %1$s "
-"条聊天记录以恢复同步。置顶的聊天记录不会被删除。"
+"包含附件的 Duck.ai 聊天记录的 Sync & Backup 存储空间已经用完。删除最早的 "
+"%1$s 条聊天记录以恢复同步。置顶的聊天记录不会被删除。"
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -22618,8 +23550,8 @@ msgid ""
 "oldest chats with attachments to resume Sync. Pinned chats will not be "
 "deleted."
 msgstr ""
-"您已经用完 Duck.ai 聊天记录的 Sync & Backup 存储空间。删除最早的 %1$s "
-"条包含附件的聊天记录，以恢复同步功能。置顶的聊天记录不会被删除。"
+"您已经用完 Duck.ai 聊天记录的 Sync & Backup 存储空间。删除最早的 %1$s 条包含"
+"附件的聊天记录，以恢复同步功能。置顶的聊天记录不会被删除。"
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the sync storage limit.
@@ -22632,7 +23564,9 @@ msgstr "你已用尽存储空间"
 msgid ""
 "YouTube (owned by Google) does not let you watch videos anonymously. As "
 "such, watching YouTube videos here will be tracked by YouTube/Google."
-msgstr "Google 旗下的 YouTube 不允许匿名观看视频，因此在这里观看 YouTube 视频仍会被 Google 与 YouTube 跟踪。"
+msgstr ""
+"Google 旗下的 YouTube 不允许匿名观看视频，因此在这里观看 YouTube 视频仍会被 "
+"Google 与 YouTube 跟踪。"
 
 # smartling.placeholder_format=C
 #. Label for a privacy disclaimer related to YouTube videos
@@ -22675,7 +23609,9 @@ msgid ""
 "Your backup will be deleted from DuckDuckGo's server. All devices will be "
 "disconnected from sync. Your %s most recent chats will be available in local "
 "storage on these browsers:"
-msgstr "系统将从 DuckDuckGo 服务器中删除你的备份。所有设备都会断开同步连接。在以下浏览器中，你最近的 %1$s 条聊天记录将保存在本地存储中："
+msgstr ""
+"系统将从 DuckDuckGo 服务器中删除你的备份。所有设备都会断开同步连接。在以下浏"
+"览器中，你最近的 %1$s 条聊天记录将保存在本地存储中："
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list.
@@ -22684,7 +23620,9 @@ msgid ""
 "Your backup will be deleted from DuckDuckGo's server. All devices will be "
 "disconnected from sync. Your 100 most recent chats will be available in "
 "local storage on these browsers:"
-msgstr "系统将从 DuckDuckGo 服务器中删除你的备份。所有设备都会断开同步连接。在以下浏览器中，你最近的 100 条聊天记录将保存在本地存储中："
+msgstr ""
+"系统将从 DuckDuckGo 服务器中删除你的备份。所有设备都会断开同步连接。在以下浏"
+"览器中，你最近的 100 条聊天记录将保存在本地存储中："
 
 # smartling.placeholder_format=C
 #. List item indicating that a site exclusion filter is currently active for the search
@@ -22723,7 +23661,8 @@ msgctxt "Disclaimer bellow chat input - desktop"
 msgid ""
 "Your chat with %s is private. AI chats may display inaccurate or offensive "
 "information."
-msgstr "你与 %1$s 的聊天内容将保密。人工智能聊天可能会显示不准确或令人反感的信息。"
+msgstr ""
+"你与 %1$s 的聊天内容将保密。人工智能聊天可能会显示不准确或令人反感的信息。"
 
 # smartling.placeholder_format=C
 #. Body copy shown after Sync & Backup is enabled, confirming chats are now syncing.
@@ -22748,14 +23687,16 @@ msgstr "你的聊天内容均为私密，绝不会用于训练人工智能模型
 msgctxt "Active Privacy protection description"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
-msgstr "你的聊天内容均为私密，我们已对其进行匿名化处理，不会用于训练人工智能模型。"
+msgstr ""
+"你的聊天内容均为私密，我们已对其进行匿名化处理，不会用于训练人工智能模型。"
 
 # smartling.placeholder_format=C
 #. Text explaining that user chats are private and not used for AI (Artificial Intelligence) training.
 msgctxt "Body text for privacy protection modal"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
-msgstr "你的聊天内容均为私密，我们已对其进行匿名化处理，不会用于训练人工智能模型。"
+msgstr ""
+"你的聊天内容均为私密，我们已对其进行匿名化处理，不会用于训练人工智能模型。"
 
 # smartling.placeholder_format=C
 #. Text for a menu item that describes the privacy protection feature.
@@ -22783,7 +23724,9 @@ msgctxt "duckai_migration"
 msgid ""
 "Your chats are still private, anonymized by us, and not used to train AI "
 "models. Follow these steps to keep your chat history."
-msgstr "聊天记录仍会保持私密，我们已对其进行匿名化处理，不会用于训练人工智能模型。请按照以下步骤保留聊天记录。"
+msgstr ""
+"聊天记录仍会保持私密，我们已对其进行匿名化处理，不会用于训练人工智能模型。请"
+"按照以下步骤保留聊天记录。"
 
 # smartling.placeholder_format=C
 #. Body shown after import completes.
@@ -22822,7 +23765,9 @@ msgctxt "newsletter email collection"
 msgid ""
 "Your email address will not be shared, %sor associated with anonymous "
 "searches. [%sExample message%s]"
-msgstr "我们绝不会透露你的电子邮件地址，%1$s或把它与匿名搜索关联。[%2$sExample message%3$s]"
+msgstr ""
+"我们绝不会透露你的电子邮件地址，%1$s或把它与匿名搜索关联。[%2$sExample "
+"message%3$s]"
 
 # smartling.placeholder_format=C
 #. A prompt for the user to provide feedback on the third party map app directions experience
@@ -22865,8 +23810,9 @@ msgid ""
 "browser. We save the settings file using the key as the name. DuckDuckGo "
 "never knows your passphrase."
 msgstr ""
-"我们采用一种名为 %1$sSHA-2%2$s 的安全散列算法将你的口令不可逆地映射到一个 512 "
-"位的密钥，浏览器仅发送这一密钥和你要保存的设置，以便我们将收到的设置与密钥相关联。因此，DuckDuckGo 不可能得知你使用的口令。"
+"我们采用一种名为 %1$sSHA-2%2$s 的安全散列算法将你的口令不可逆地映射到一个 "
+"512 位的密钥，浏览器仅发送这一密钥和你要保存的设置，以便我们将收到的设置与密"
+"钥相关联。因此，DuckDuckGo 不可能得知你使用的口令。"
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -22880,7 +23826,9 @@ msgid ""
 "Your prompts are relayed through DuckDuckGo servers and stripped of "
 "personally identifiable metadata, so model providers can't tie your "
 "conversations back to you."
-msgstr "你的提示词会经由 DuckDuckGo 服务器中转，并剥离个人身份元数据，因此模型提供商无法将对话内容与你本人关联起来。"
+msgstr ""
+"你的提示词会经由 DuckDuckGo 服务器中转，并剥离个人身份元数据，因此模型提供商"
+"无法将对话内容与你本人关联起来。"
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -22935,7 +23883,9 @@ msgctxt "welcome message eu search preference android"
 msgid ""
 "You’re now searching privately in Chrome. Use our browser instead of Chrome "
 "for more protection. It’s already installed and can:"
-msgstr "你现在正在使用 Chrome 进行私密搜索。不妨使用我们的浏览器代替 Chrome，以获得更多保护。已安装该浏览器并可以："
+msgstr ""
+"你现在正在使用 Chrome 进行私密搜索。不妨使用我们的浏览器代替 Chrome，以获得更"
+"多保护。已安装该浏览器并可以："
 
 # smartling.placeholder_format=C
 #. Displayed when the user has exceeded the maximum message size.

--- a/locales/zh_TW/LC_MESSAGES/duckduckgo.po
+++ b/locales/zh_TW/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: zh_TW\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -175,9 +175,7 @@ msgctxt "Error message when a Plus subscriber tries to use a Pro-only model"
 msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
-msgstr ""
-"%1$s 只適用於 Pro。在此瀏覽器中再次升級你的 DuckDuckGo 訂閱以繼續聊天，或切換"
-"至 Plus 或免費模式。"
+msgstr "%1$s 只適用於 Pro。在此瀏覽器中再次升級你的 DuckDuckGo 訂閱以繼續聊天，或切換至 Plus 或免費模式。"
 
 # smartling.placeholder_format=C
 #. Text for the disclaimer message that appears when a Plus subscriber tries to use a Pro-only model. %s is replaced with the model name. Example: Claude Opus 4.6 is only available with Pro. Upgrade your DuckDuckGo subscription in this browser again to continue the chat, or switch to a Plus or free model.
@@ -186,9 +184,7 @@ msgctxt ""
 msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
-msgstr ""
-"%1$s 只適用於 Pro。請在此瀏覽器中再次升級你的 DuckDuckGo 訂閱以繼續聊天，或切"
-"換至 Plus 或免費模式。"
+msgstr "%1$s 只適用於 Pro。請在此瀏覽器中再次升級你的 DuckDuckGo 訂閱以繼續聊天，或切換至 Plus 或免費模式。"
 
 # smartling.placeholder_format=C
 #. Displayed when an AI (Artificial Intelligence) chat model is temporarily unavailable. Example: 'GPT 4o is only available with a DuckDuckGo subscription.'
@@ -203,9 +199,7 @@ msgid ""
 "%s is only available with a DuckDuckGo subscription. Activate your "
 "subscription in this browser again to continue the chat, or switch to a free "
 "model."
-msgstr ""
-"%1$s 只有訂閱 DuckDuckGo 才能使用。在此瀏覽器中再次啟用你的訂閱以繼續聊天，或"
-"切換至免費模式。"
+msgstr "%1$s 只有訂閱 DuckDuckGo 才能使用。在此瀏覽器中再次啟用你的訂閱以繼續聊天，或切換至免費模式。"
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is temporarily unavailable. Example: 'GPT 3.5 Turbo is temporarily unavailable. Please switch to a different model or try again later.'
@@ -304,8 +298,8 @@ msgid ""
 "provider can see your prompts or the model’s responses, or save this chat on "
 "their servers."
 msgstr ""
-"%1$s 運行於受信任執行環境（Trusted Execution Environment）。這表示即使是模型"
-"提供商也無法看到您的提示或模型的回應，也不會在其伺服器上儲存此聊天。"
+"%1$s 運行於受信任執行環境（Trusted Execution "
+"Environment）。這表示即使是模型提供商也無法看到您的提示或模型的回應，也不會在其伺服器上儲存此聊天。"
 
 # smartling.placeholder_format=C
 #. Label shown in the batch selection toolbar when exactly one chat is selected. %s is replaced with 1. Use singular agreement where the language requires it.
@@ -384,8 +378,7 @@ msgctxt ""
 msgid ""
 "%s will be leaving Duck.ai in %s days (%s). After that, you can switch "
 "models to continue this chat."
-msgstr ""
-"%1$s 將在 %2$s 天後離開 Duck.ai (%3$s)。之後，您可以切換模型以繼續此聊天。"
+msgstr "%1$s 將在 %2$s 天後離開 Duck.ai (%3$s)。之後，您可以切換模型以繼續此聊天。"
 
 # smartling.placeholder_format=C
 #. Displayed in a saved chat when its AI model is about to be retired tomorrow. First placeholder is the friendly model name, second placeholder is the removal date formatted in the user's browser locale (e.g., 'June 15, 2026' in en-US). Singular-day form.
@@ -395,8 +388,7 @@ msgctxt ""
 msgid ""
 "%s will be leaving Duck.ai in 1 day (%s). After that, you can switch models "
 "to continue this chat."
-msgstr ""
-"%1$s 將在 1 天後 (%2$s) 離開 Duck.ai。之後，您可以切換模型以繼續此聊天。"
+msgstr "%1$s 將在 1 天後 (%2$s) 離開 Duck.ai。之後，您可以切換模型以繼續此聊天。"
 
 # smartling.placeholder_format=C
 #. Shown in a text selection chip when the selection contains multiple words. %s is replaced with the number of words, e.g. '142 words'.
@@ -424,8 +416,7 @@ msgctxt "install-duckduckgo"
 msgid ""
 "%sClick %sContinue To Installation%sClick %sAdd%sCheck %sAllow%s, then click "
 "%sOkay%s"
-msgstr ""
-"%1$s按%2$s繼續安裝%3$s按%4$s新增%5$s勾選%6$s允許%7$s，然後按%8$s確定%9$s"
+msgstr "%1$s按%2$s繼續安裝%3$s按%4$s新增%5$s勾選%6$s允許%7$s，然後按%8$s確定%9$s"
 
 # smartling.placeholder_format=C
 #. A button that reloads search results when an error occurs.
@@ -853,8 +844,7 @@ msgstr "客場戰績"
 msgid ""
 "A network issue is preventing Search Assist from generating an answer. "
 "Please check your connection and try again."
-msgstr ""
-"網路問題導致 Search Assist 無法生成答案。請檢查你的連線，接著再試一次。"
+msgstr "網路問題導致 Search Assist 無法生成答案。請檢查你的連線，接著再試一次。"
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of AI Chat is available and they need to refresh the page.
@@ -906,9 +896,8 @@ msgid ""
 "still access AI Chat when this setting is off by visiting %sduckduckgo.com/"
 "aichat%s."
 msgstr ""
-"AI Chat 能讓您與第三方 AI Chat 模型匿名對話。關閉此功能將隱藏 DuckDuckGo "
-"Search 上的 AI Chat 功能。關閉此設定後，您仍可透過造訪 %1$sduckduckgo.com/"
-"aichat%2$s 使用 AI Chat 功能。"
+"AI Chat 能讓您與第三方 AI Chat 模型匿名對話。關閉此功能將隱藏 DuckDuckGo Search 上的 AI Chat "
+"功能。關閉此設定後，您仍可透過造訪 %1$sduckduckgo.com/aichat%2$s 使用 AI Chat 功能。"
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -969,9 +958,8 @@ msgid ""
 "questions, which is our private AI-powered chat service that supports chat "
 "models from OpenAI, and Anthropic, and more."
 msgstr ""
-"AI 輔助的答案目前不直接支援後續問題。不過，我們也提供並經常連結到 %1$sDuck."
-"ai%2$s 以回答後續問題，這是我們的私密 AI 驅動的聊天服務，支援來自 OpenAI、"
-"Anthropic 等的聊天模型。"
+"AI 輔助的答案目前不直接支援後續問題。不過，我們也提供並經常連結到 %1$sDuck.ai%2$s 以回答後續問題，這是我們的私密 AI "
+"驅動的聊天服務，支援來自 OpenAI、Anthropic 等的聊天模型。"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has turned off AI features and will no longer see AI-assisted answers.
@@ -1405,7 +1393,7 @@ msgstr "地址錯誤"
 #. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Adjust the servings"
-msgstr ""
+msgstr "調整份量"
 
 # smartling.placeholder_format=C
 #. as in multiple advertisements
@@ -1624,7 +1612,7 @@ msgctxt "Privacy & Terms section description on the Duck.ai settings page"
 msgid ""
 "All chats are anonymized by DuckDuckGo, and your conversations are not used "
 "to train chat models by DuckDuckGo or the model providers"
-msgstr ""
+msgstr "所有聊天內容均由 DuckDuckGo 進行匿名處理，且你的對話不會由 DuckDuckGo 或模型供應商用於訓練聊天模型"
 
 # smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1670,9 +1658,7 @@ msgctxt "Body copy for the anonymized card in the How Duck.ai Works panel"
 msgid ""
 "All personal metadata (for example, your IP address) is removed before "
 "sending a chat to the AI provider."
-msgstr ""
-"在將聊天內容傳送給 AI 服務提供者之前，所有個人元資料（例如您的 IP 位址）都會"
-"被移除。"
+msgstr "在將聊天內容傳送給 AI 服務提供者之前，所有個人元資料（例如您的 IP 位址）都會被移除。"
 
 # smartling.placeholder_format=C
 #. A filter that shows search results from all countries.
@@ -1723,8 +1709,8 @@ msgid ""
 "sends AI-generated queries to a search engine with limited data retention. "
 "Prompts and responses with %s still have %szero provider visibility%s."
 msgstr ""
-"允許 %1$s 搜尋網頁，以調整相關提示的回應。僅將 AI 生成的查詢傳送到資料保留期"
-"限有限的搜尋引擎。%2$s 的提示和回應仍具有%3$s零提供者可見度%4$s。"
+"允許 %1$s 搜尋網頁，以調整相關提示的回應。僅將 AI 生成的查詢傳送到資料保留期限有限的搜尋引擎。%2$s "
+"的提示和回應仍具有%3$s零提供者可見度%4$s。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -1889,7 +1875,7 @@ msgctxt "settings"
 msgid ""
 "Anonymously generates answers for search queries based on web content. "
 "Choose how often you want it to appear, or disable it completely."
-msgstr ""
+msgstr "根據網頁內容匿名生成搜尋查詢的答案。你可以選擇它出現的頻率，或完全停用它。"
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -2062,9 +2048,7 @@ msgctxt "Body text for disable recent chats confirmation modal"
 msgid ""
 "Are you sure you want to disable recent chats? This will also delete any "
 "recent chats that are currently saved."
-msgstr ""
-"你是否確定要停用「最近的聊天記錄」？這麽做的話，也會將最近儲存下來的所有聊天"
-"記錄一併刪除。"
+msgstr "你是否確定要停用「最近的聊天記錄」？這麽做的話，也會將最近儲存下來的所有聊天記錄一併刪除。"
 
 # smartling.placeholder_format=C
 #. Question asking user if they want to share the URL of the page they were on when giving feedback
@@ -2101,9 +2085,7 @@ msgstr "更新時間："
 msgid ""
 "As per our privacy policy, we do not collect or share any personal "
 "information ourselves. All of this privacy protection happens on your device."
-msgstr ""
-"根據我們的隱私政策規範，我們不會主動收集或分享任何個人資訊。這些隱私保護作業"
-"皆於你的裝置上進行。"
+msgstr "根據我們的隱私政策規範，我們不會主動收集或分享任何個人資訊。這些隱私保護作業皆於你的裝置上進行。"
 
 # smartling.placeholder_format=C
 #. A button to ask Duck.ai a question
@@ -2169,7 +2151,7 @@ msgstr "請向 Duck.ai 提出後續問題"
 #. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
 msgctxt "Page suggestion chip label"
 msgid "Ask about this page"
-msgstr ""
+msgstr "詢問關於此頁面的問題"
 
 # smartling.placeholder_format=C
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2233,10 +2215,9 @@ msgid ""
 "(shows more frequently on a wider range of searches). For now, AI-assisted "
 "answers are only available in the U.S. (English) region."
 msgstr ""
-"Assist 可匿名根據相關網頁內容的摘要，生成某些搜尋的 AI 輔助答案。您可以選擇想"
-"要 Assist 出現的頻率：從不 (從搜尋結果中完全移除 Assist 使用介面)、隨選 (僅在"
-"點按 Assist 按鈕後顯示)、有時 (僅在高度相關時顯示) 或經常 (在更廣泛的搜尋中更"
-"頻繁地顯示)。目前，AI 輔助答案僅在美國 (英文) 地區提供。"
+"Assist 可匿名根據相關網頁內容的摘要，生成某些搜尋的 AI 輔助答案。您可以選擇想要 Assist 出現的頻率：從不 (從搜尋結果中完全移除 "
+"Assist 使用介面)、隨選 (僅在點按 Assist 按鈕後顯示)、有時 (僅在高度相關時顯示) 或經常 "
+"(在更廣泛的搜尋中更頻繁地顯示)。目前，AI 輔助答案僅在美國 (英文) 地區提供。"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2248,10 +2229,8 @@ msgid ""
 "to remember that responses are auto-generated from cited sources and based "
 "on %scrawling the web%s."
 msgstr ""
-"Assist 是我們搜尋結果中的一項選用功能，能夠匿名產生由 AI 協助的搜尋查詢答案。"
-"為了完成此任務，它將掃描網路以便查詢相關內容，接著使用人工智慧支援的自然語言"
-"技術，根據找到的相關資訊產生簡短的答案。重要的是要記住，回應是從引用的來源並"
-"根據%1$s搜耙網路%2$s自動產生的。"
+"Assist 是我們搜尋結果中的一項選用功能，能夠匿名產生由 AI "
+"協助的搜尋查詢答案。為了完成此任務，它將掃描網路以便查詢相關內容，接著使用人工智慧支援的自然語言技術，根據找到的相關資訊產生簡短的答案。重要的是要記住，回應是從引用的來源並根據%1$s搜耙網路%2$s自動產生的。"
 
 # smartling.placeholder_format=C
 #. Title for the dropdown menu where users select the assistant's role. Example: 'Assistant role: Travel guide'
@@ -2413,9 +2392,7 @@ msgid ""
 "Automatically shows Assist for relevant searches. Assist can anonymously "
 "look up and summarize information in response to some searches. For now, "
 "Assist is only available in English regions."
-msgstr ""
-"自動顯示相關搜尋的 Assist 功能。Assist 能夠匿名搜尋與摘要資訊，以便回應某些搜"
-"尋結果。目前，Assist 僅供英語地區使用。"
+msgstr "自動顯示相關搜尋的 Assist 功能。Assist 能夠匿名搜尋與摘要資訊，以便回應某些搜尋結果。目前，Assist 僅供英語地區使用。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2424,8 +2401,8 @@ msgid ""
 "anonymously look up and summarize information in response to some searches. "
 "For now, DuckAssist is only available in English regions."
 msgstr ""
-"對相關的搜尋自動顯示 DuckAssist。DuckAssist 能夠匿名搜尋與摘要資訊，以便回應"
-"某些搜尋結果。目前，DuckAssist 僅供說英文的地區使用。"
+"對相關的搜尋自動顯示 DuckAssist。DuckAssist 能夠匿名搜尋與摘要資訊，以便回應某些搜尋結果。目前，DuckAssist "
+"僅供說英文的地區使用。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2576,7 +2553,7 @@ msgstr "條碼"
 #. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Based on this page, is this course worth taking?"
-msgstr ""
+msgstr "根據此頁面，這門課程值得參加嗎？"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2624,7 +2601,7 @@ msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
 msgid ""
 "Before storing this report, DuckDuckGo will anonymize your conversation by "
 "removing PII like names, email addresses, and identifying metadata."
-msgstr ""
+msgstr "在儲存此報告前，DuckDuckGo 會透過移除姓名、電子郵件地址及識別中繼資料等個人身份資訊，將你的對話匿名化。"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -2946,7 +2923,7 @@ msgstr "破發成功率"
 #. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Break this down into clear, numbered steps."
-msgstr ""
+msgstr "將此拆解為清晰的編號步驟。"
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -3004,26 +2981,20 @@ msgstr "瀏覽檔案"
 msgid ""
 "Browse as usual while we add privacy protection. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
-msgstr ""
-"享受隱私保護，只管放心瀏覽。我們將搜尋引擎、追蹤器封鎖程式以及加密執行程式組"
-"合為一項%1$s%2$s延伸模組%3$s。"
+msgstr "享受隱私保護，只管放心瀏覽。我們將搜尋引擎、追蹤器封鎖程式以及加密執行程式組合為一項%1$s%2$s延伸模組%3$s。"
 
 # smartling.placeholder_format=C
 msgid ""
 "Browse as usual, and we'll take care of the rest. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
-msgstr ""
-"你盡可放心瀏覽，其餘的交給我們處理。我們將搜尋引擎、追蹤器封鎖程式以及加密執"
-"行程式組合為一項%1$s%2$s延伸模組%3$s。"
+msgstr "你盡可放心瀏覽，其餘的交給我們處理。我們將搜尋引擎、追蹤器封鎖程式以及加密執行程式組合為一項%1$s%2$s延伸模組%3$s。"
 
 # smartling.placeholder_format=C
 msgid ""
 "Browse as usual, and we’ll take care of the rest. Get bundled private "
 "search, tracker blocking, and site encryption, all in one download, for "
 "%smajor browsers%s."
-msgstr ""
-"你盡可放心瀏覽，其餘的交給我們處理。只需下載一次，即可取得為%1$s主要瀏覽"
-"器%2$s設計的私密搜尋、追蹤器封鎖、網站加密等多合一功能。"
+msgstr "你盡可放心瀏覽，其餘的交給我們處理。只需下載一次，即可取得為%1$s主要瀏覽器%2$s設計的私密搜尋、追蹤器封鎖、網站加密等多合一功能。"
 
 # smartling.placeholder_format=C
 #. Header for a call to action to browse with the DuckDuckGo browser
@@ -3130,18 +3101,15 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"預設情況下，所有的設定都使用非個人的 Cookie 儲存（在你的瀏覽器）。你也可以使"
-"用匿名的 Could Save 以更持久的方式來將設定儲存在雲端的遠端伺服器。所有可識別"
-"的個人資訊都不會儲存在雲端，你的通關密語也不會從瀏覽器洩漏。"
+"預設情況下，所有的設定都使用非個人的 Cookie 儲存（在你的瀏覽器）。你也可以使用匿名的 Could Save "
+"以更持久的方式來將設定儲存在雲端的遠端伺服器。所有可識別的個人資訊都不會儲存在雲端，你的通關密語也不會從瀏覽器洩漏。"
 
 # smartling.placeholder_format=C
 #. Description for the consent highlight in the dictation consent modal. %s is replaced with a link to the help page.
 msgid ""
 "By enabling dictation, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
-msgstr ""
-"啟用語音輸入功能即表示您同意將您的語音資料傳送至 OpenAI 以使用此功能。在開始"
-"之前，請先查看我們的%1$s。"
+msgstr "啟用語音輸入功能即表示您同意將您的語音資料傳送至 OpenAI 以使用此功能。在開始之前，請先查看我們的%1$s。"
 
 # smartling.placeholder_format=C
 #. Description for the 'enable voice chat' section of the voice chat consent modal. Placeholder for the voice chat help page link and text. Example: 'By enabling voice chat, you consent to your voice data being sent to OpenAI for the use of this feature. See our voice chat help page before getting started.'
@@ -3149,9 +3117,7 @@ msgctxt "voice chat"
 msgid ""
 "By enabling voice chat, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
-msgstr ""
-"啟用語音聊天功能，即表示您同意將您的語音資料傳送至 OpenAI 以使用此功能。在開"
-"始之前，請先查看我們的%1$s。"
+msgstr "啟用語音聊天功能，即表示您同意將您的語音資料傳送至 OpenAI 以使用此功能。在開始之前，請先查看我們的%1$s。"
 
 # smartling.placeholder_format=C
 #. Golf leaderboard: player missed the cut
@@ -3400,7 +3366,7 @@ msgstr "演員"
 #. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Cast & Crew"
-msgstr ""
+msgstr "演職人員"
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
@@ -3635,10 +3601,9 @@ msgid ""
 "DuckDuckGo Search. However, you can still access Chat when this setting is "
 "off by visiting %shttps://duck.ai%s directly."
 msgstr ""
-"聊天 (透過我們的 Duck.ai 服務) 能讓你與第三方 AI 聊天模型進行匿名對話，支援 "
-"OpenAI、Anthropic 等模型。關閉此設定將隱藏 DuckDuckGo Search 上的聊天按鈕和連"
-"結。不過，關閉此設定後，您仍可透過造訪 %1$shttps://duck.ai%2$s 直接使用聊天功"
-"能。"
+"聊天 (透過我們的 Duck.ai 服務) 能讓你與第三方 AI 聊天模型進行匿名對話，支援 OpenAI、Anthropic 等模型。關閉此設定將隱藏 "
+"DuckDuckGo Search 上的聊天按鈕和連結。不過，關閉此設定後，您仍可透過造訪 %1$shttps://duck.ai%2$s "
+"直接使用聊天功能。"
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -3762,9 +3727,7 @@ msgctxt "Description for Chat History feature"
 msgid ""
 "Chats are stored locally on your device instead of on DuckDuckGo servers or "
 "remote servers. Disabling chat history will delete pinned chats."
-msgstr ""
-"聊天記錄會儲存在你的裝置本機上，而非 DuckDuckGo 伺服器或其他遠端伺服器。停用"
-"聊天記錄將刪除置頂的聊天。"
+msgstr "聊天記錄會儲存在你的裝置本機上，而非 DuckDuckGo 伺服器或其他遠端伺服器。停用聊天記錄將刪除置頂的聊天。"
 
 # smartling.placeholder_format=C
 #. Text explaining how the Chat History feature stores the user's chats locally to their device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection. Also explains that disabling chat history will delete pinned chats.
@@ -3776,9 +3739,8 @@ msgid ""
 "history will delete pinned chats, and disable the temporary storage of new "
 "prompts and responses."
 msgstr ""
-"聊天記錄將儲存在你的裝置本地。新的提示和回應在傳送後會被加密並暫時儲存在 "
-"DuckDuckGo 伺服器上，以便在你失去網路連線時協助恢復聊天。停用聊天紀錄會刪除置"
-"頂的聊天記錄，並停用新提示和回應的暫時儲存功能。"
+"聊天記錄將儲存在你的裝置本地。新的提示和回應在傳送後會被加密並暫時儲存在 DuckDuckGo "
+"伺服器上，以便在你失去網路連線時協助恢復聊天。停用聊天紀錄會刪除置頂的聊天記錄，並停用新提示和回應的暫時儲存功能。"
 
 # smartling.placeholder_format=C
 #. Title shown above the body copy in the Duck.ai recent chats IndexedDB unavailable notice.
@@ -4131,9 +4093,7 @@ msgctxt "Information about the effect of clearing browser data on recent chats"
 msgid ""
 "Clearing browser data deletes chats. Some browsers may keep recent chats "
 "indefinitely or auto-delete them after 7+ days of no AI Chat use."
-msgstr ""
-"清除瀏覽器資料的話，也會將聊天記錄一併刪除。特定的瀏覽器可能會無限期保留最近"
-"的聊天記錄，或是在你超過 7 天未使用 AI Chat 後自動將聊天記錄刪除。"
+msgstr "清除瀏覽器資料的話，也會將聊天記錄一併刪除。特定的瀏覽器可能會無限期保留最近的聊天記錄，或是在你超過 7 天未使用 AI Chat 後自動將聊天記錄刪除。"
 
 # smartling.placeholder_format=C
 #. Text explaining what happens to recent chats when browser data is cleared.
@@ -4143,8 +4103,8 @@ msgid ""
 "indefinitely or auto-deleted after 7 days without using Duck.ai, depending "
 "on your browser."
 msgstr ""
-"清除瀏覽器資料的話，也會將最近的聊天記錄一併刪除。最近的聊天記錄可能會無限期"
-"保存，或在不使用 Duck.ai 的情況下 7 天後自動刪除，視您的瀏覽器而定。"
+"清除瀏覽器資料的話，也會將最近的聊天記錄一併刪除。最近的聊天記錄可能會無限期保存，或在不使用 Duck.ai 的情況下 7 "
+"天後自動刪除，視您的瀏覽器而定。"
 
 # smartling.placeholder_format=C
 #. Warning message shown on the Block domain success modal. Blocked sites are stored in localStorage which is cleared alongside cookies when users clear browser data. Followed by a linked 'our free browser' text.
@@ -4161,8 +4121,8 @@ msgid ""
 "%sDuck.ai%s, our private AI chat service that supports chat models from "
 "OpenAI, Anthropic, and more."
 msgstr ""
-"按一下「更多」深入瞭解主題，並透過 %1$sDuck.ai%2$s 提出後續問題，這是我們的私"
-"人 AI 聊天服務，支援來自 OpenAI、Anthropic 等的聊天模型。"
+"按一下「更多」深入瞭解主題，並透過 %1$sDuck.ai%2$s 提出後續問題，這是我們的私人 AI 聊天服務，支援來自 "
+"OpenAI、Anthropic 等的聊天模型。"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4323,9 +4283,7 @@ msgctxt "cloudsave"
 msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Search Settings%s."
-msgstr ""
-"按一下或點擊 %1$s刪除我的資料%2$s。這將從雲端移除資料，但資料仍將留存於您的瀏"
-"覽器中，等您按一下/點擊%3$s重設所有搜尋設定%4$s才會刪除。"
+msgstr "按一下或點擊 %1$s刪除我的資料%2$s。這將從雲端移除資料，但資料仍將留存於您的瀏覽器中，等您按一下/點擊%3$s重設所有搜尋設定%4$s才會刪除。"
 
 # smartling.placeholder_format=C
 #. Tells users where to click in order to disable the cloud save feature and delete any data backed-up to the cloud.
@@ -4335,9 +4293,7 @@ msgctxt "cloudsave"
 msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Settings%s."
-msgstr ""
-"按一下或點按%1$s刪除我的資料%2$s。這即會從雲端移除資料，但資料仍會留存於你的"
-"瀏覽器中，等你按一下/點按%3$s重設所有設定%4$s才會刪除。"
+msgstr "按一下或點按%1$s刪除我的資料%2$s。這即會從雲端移除資料，但資料仍會留存於你的瀏覽器中，等你按一下/點按%3$s重設所有設定%4$s才會刪除。"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -4600,8 +4556,7 @@ msgctxt "cloudsave"
 msgid ""
 "Cloud Save lets you save your settings more permanently by entering a "
 "passphrase. It is entirely optional."
-msgstr ""
-"Cloud Save將更長久地保留你的設定，只要輸入通關密語即可套用。此項純屬自願。"
+msgstr "Cloud Save將更長久地保留你的設定，只要輸入通關密語即可套用。此項純屬自願。"
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -5079,7 +5034,7 @@ msgstr "建立圖像"
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
-msgstr ""
+msgstr "根據這份食譜建立包含份量的購物清單。"
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed in the input field when starting a new image generation session.
@@ -5720,16 +5675,14 @@ msgstr "語音輸入次數已達上限"
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
 msgid "Dictation temporarily unavailable"
-msgstr ""
+msgstr "聽寫功能暫時無法使用"
 
 # smartling.placeholder_format=C
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
 "chat in Duck.ai without having to type."
-msgstr ""
-"語音輸入功能使用 OpenAI 模型將您的語音轉換為文字，因此您不用輸入文字也能在 "
-"Duck.ai 中聊天。"
+msgstr "語音輸入功能使用 OpenAI 模型將您的語音轉換為文字，因此您不用輸入文字也能在 Duck.ai 中聊天。"
 
 # smartling.placeholder_format=C
 #. In 0-click box -- link to definition.
@@ -6028,7 +5981,7 @@ msgctxt "settings"
 msgid ""
 "Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
 "filtered out. %sLearn More%s"
-msgstr ""
+msgstr "不想要 AI？%1$snoai.duckduckgo.com%2$s 不提供 AI 功能，且已過濾 AI 生成的圖片。 %3$s瞭解更多%4$s"
 
 # smartling.placeholder_format=C
 #. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
@@ -6036,7 +5989,7 @@ msgctxt "settings"
 msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
-msgstr ""
+msgstr "不想要 AI？請造訪 %1$snoai.duckduckgo.com%2$s 以進行無 AI 功能且過濾掉 AI 圖片的搜尋。%3$s瞭解更多%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6152,13 +6105,13 @@ msgstr "撰寫一封給供應商的簡明扼要的電子郵件，要求提供家
 #. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Draft a cover letter"
-msgstr ""
+msgstr "起草求職信"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Draft a cover letter for this job."
-msgstr ""
+msgstr "為這份工作起草一封求職信。"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -6299,9 +6252,7 @@ msgid ""
 "Duck.ai can now help answer questions about the page you're viewing. Page "
 "content is only included when you attach it, unless you choose to attach "
 "pages automatically in Settings."
-msgstr ""
-"Duck.ai 現在可以幫助回答你正在檢視的頁面上的問題。頁面內容僅在你附加它時包"
-"含，除非你在設定中選擇自動附加頁面。"
+msgstr "Duck.ai 現在可以幫助回答你正在檢視的頁面上的問題。頁面內容僅在你附加它時包含，除非你在設定中選擇自動附加頁面。"
 
 # smartling.placeholder_format=C
 #. Shown in the Duck.ai recent chats list on standalone when the browser API needed to store chats locally is missing or unavailable.
@@ -6310,9 +6261,7 @@ msgctxt ""
 msgid ""
 "Duck.ai can’t access local storage to save your chats. Please check your "
 "browser settings or disable any extensions and try again."
-msgstr ""
-"Duck.ai 無法存取本機儲存空間來儲存你的聊天記錄。請檢查您的瀏覽器設定或停用任"
-"何擴充套件，然後再試一次。"
+msgstr "Duck.ai 無法存取本機儲存空間來儲存你的聊天記錄。請檢查您的瀏覽器設定或停用任何擴充套件，然後再試一次。"
 
 # smartling.placeholder_format=C
 #. Displayed when the chat service has reached the maximum number of messages for one day.
@@ -6335,7 +6284,7 @@ msgid ""
 "Duck.ai is created by DuckDuckGo. We're an independent online protection "
 "company for anyone who wants to take back control of their personal "
 "information."
-msgstr ""
+msgstr "Duck.ai 由 DuckDuckGo 建立。 我們是一間獨立的線上保護公司，旨在協助任何想要重新掌控個人資訊的人。"
 
 # smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
@@ -6349,9 +6298,7 @@ msgctxt "duckai_migration"
 msgid ""
 "Duck.ai is still a DuckDuckGo product, but will now have an easier to "
 "remember home on the web: https://duck.ai"
-msgstr ""
-"Duck.ai 仍然是 DuckDuckGo 產品，但現在將在網絡上有一個更容易記住的主頁："
-"https://duck.ai"
+msgstr "Duck.ai 仍然是 DuckDuckGo 產品，但現在將在網絡上有一個更容易記住的主頁：https://duck.ai"
 
 # smartling.placeholder_format=C
 #. Headline for domain change notice.
@@ -6365,8 +6312,7 @@ msgctxt "Error message for BOTNET limit."
 msgid ""
 "Duck.ai is temporarily unavailable. If this persists, please email this "
 "anonymous code %s to %s"
-msgstr ""
-"Duck.ai 暫時無法使用。若問題仍存在，請將此匿名代碼%1$s透過電子郵件傳送至%2$s"
+msgstr "Duck.ai 暫時無法使用。若問題仍存在，請將此匿名代碼%1$s透過電子郵件傳送至%2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -6387,6 +6333,8 @@ msgid ""
 "Duck.ai lets you chat privately with popular AI models. Disabling it hides "
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
+"Duck.ai 讓你與熱門的 AI 模型進行私密聊天。 停用後將隱藏 Duck.ai 按鈕和連結，但你仍然可以造訪 %1$sduck.ai%2$s "
+"直接使用。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6397,9 +6345,9 @@ msgid ""
 "can still access Duck.ai when this setting is off by visiting %shttps://duck."
 "ai%s directly."
 msgstr ""
-"Duck.ai 讓你與第三方 AI 聊天模型進行匿名對話，支援 OpenAI、Anthropic 等模型。"
-"關閉此設定將隱藏 DuckDuckGo Search 上的 Duck.ai 按鈕和連結。不過，關閉此設定"
-"後，您仍可透過造訪 %1$shttps://duck.ai%2$s 來存取 Duck.ai使用聊天功能。"
+"Duck.ai 讓你與第三方 AI 聊天模型進行匿名對話，支援 OpenAI、Anthropic 等模型。關閉此設定將隱藏 DuckDuckGo "
+"Search 上的 Duck.ai 按鈕和連結。不過，關閉此設定後，您仍可透過造訪 %1$shttps://duck.ai%2$s 來存取 "
+"Duck.ai使用聊天功能。"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
@@ -6454,9 +6402,8 @@ msgid ""
 "AI chat no sign up, OpenAI, Anthropic, Llama, Mistral, open source AI "
 "models, privacy focused AI, no account AI chat"
 msgstr ""
-"Duck.ai、DuckDuckGo AI、私密 AI 聊天機器人、免費 AI 聊天、匿名 AI 聊天、無需"
-"註冊的 AI 聊天、OpenAI、Anthropic、Llama、Mistral、開源 AI 模型、以隱私為重點"
-"的 AI、無需帳號的 AI 聊天"
+"Duck.ai、DuckDuckGo AI、私密 AI 聊天機器人、免費 AI 聊天、匿名 AI 聊天、無需註冊的 AI "
+"聊天、OpenAI、Anthropic、Llama、Mistral、開源 AI 模型、以隱私為重點的 AI、無需帳號的 AI 聊天"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -6484,10 +6431,9 @@ msgid ""
 "relevant), or Often (shows more frequently on a wider range of searches). "
 "For now, DuckAssist is only available in the U.S. (English) region."
 msgstr ""
-"DuckAssist 可匿名搜尋資訊並做成摘要，以便回應某些搜尋結果。您可以選擇想要 "
-"DuckAssist 出現的頻率：從不 (從搜尋結果中完全移除 DuckAssist UI)、隨選 (僅在"
-"點按協助按鈕後顯示)、有時 (僅在高度相關時顯示) 或經常 (在更廣泛的搜尋中更頻繁"
-"地顯示)。目前 DuckAssist 僅供美國 (英文) 地區使用。"
+"DuckAssist 可匿名搜尋資訊並做成摘要，以便回應某些搜尋結果。您可以選擇想要 DuckAssist 出現的頻率：從不 (從搜尋結果中完全移除 "
+"DuckAssist UI)、隨選 (僅在點按協助按鈕後顯示)、有時 (僅在高度相關時顯示) 或經常 (在更廣泛的搜尋中更頻繁地顯示)。目前 "
+"DuckAssist 僅供美國 (英文) 地區使用。"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6496,8 +6442,8 @@ msgid ""
 "%sDuckDuckGo AI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI, and Anthropic, and more."
 msgstr ""
-"DuckAssist 無法回答後續問題，但是，我們亦提供%1$s DuckDuckGo AI Chat%2$s，這"
-"是一款私密 AI 驅動的聊天服務，支援 OpenAI 和 Anthropic 等聊天模型。"
+"DuckAssist 無法回答後續問題，但是，我們亦提供%1$s DuckDuckGo AI Chat%2$s，這是一款私密 AI 驅動的聊天服務，支援 "
+"OpenAI 和 Anthropic 等聊天模型。"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6506,8 +6452,8 @@ msgid ""
 "DuckDuckGo %sAI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI and Anthropic."
 msgstr ""
-"DuckAssist 無法回答後續問題，但是，我們亦提供 DuckDuckGo %1$sAI Chat%2$s，這"
-"是一款私密 AI 驅動的聊天服務，支援 OpenAI 和 Anthropic 的聊天模型。"
+"DuckAssist 無法回答後續問題，但是，我們亦提供 DuckDuckGo %1$sAI Chat%2$s，這是一款私密 AI 驅動的聊天服務，支援 "
+"OpenAI 和 Anthropic 的聊天模型。"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6519,10 +6465,8 @@ msgid ""
 "responses are currently based on Wikipedia and related content and are not "
 "checked for accuracy."
 msgstr ""
-"DuckAssist 是我們搜尋結果中的一項全新功能，能夠匿名產生搜尋查詢的答案。 為了"
-"完成此任務，它將掃描維基百科與相關網站以便查詢相關內容，接著使用 AI 驅動的自"
-"然語言處理技術產生該資訊的摘要。 請注意，目前的回應僅根據維基百科與相關內容，"
-"尚未確認準確性。"
+"DuckAssist 是我們搜尋結果中的一項全新功能，能夠匿名產生搜尋查詢的答案。 為了完成此任務，它將掃描維基百科與相關網站以便查詢相關內容，接著使用 "
+"AI 驅動的自然語言處理技術產生該資訊的摘要。 請注意，目前的回應僅根據維基百科與相關內容，尚未確認準確性。"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6536,11 +6480,10 @@ msgid ""
 "It’s important to remember that responses are auto-generated from cited "
 "sources and based on %scrawling the web%s."
 msgstr ""
-"DuckAssist 是我們搜尋結果中的一項選用功能，能夠匿名產生搜尋查詢的答案。為了完"
-"成此任務，它將掃描網路以便查詢相關內容，接著使用人工智慧支援的自然語言技術，"
-"根據找到的相關資訊產生簡短的答案。DuckAssist 的回應始終直接連結至一個或兩個來"
-"源，並引用答案的來源，因此您能夠輕鬆取得更詳盡的資料。重要的是要記住，回應是"
-"從引用的來源並根據%1$s搜耙網路%2$s自動產生的，"
+"DuckAssist "
+""
+"是我們搜尋結果中的一項選用功能，能夠匿名產生搜尋查詢的答案。為了完成此任務，它將掃描網路以便查詢相關內容，接著使用人工智慧支援的自然語言技術，根據找到的相關資訊產生簡短的答案。DuckAssist "
+"的回應始終直接連結至一個或兩個來源，並引用答案的來源，因此您能夠輕鬆取得更詳盡的資料。重要的是要記住，回應是從引用的來源並根據%1$s搜耙網路%2$s自動產生的，"
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
@@ -6563,9 +6506,7 @@ msgctxt "Modal body for information"
 msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
-msgstr ""
-"DuckDuckGo AI Chat 是一款私密 AI 驅動的聊天服務，目前支援 %1$s 的 %2$s 與 "
-"%3$s 的 %4$s 聊天模型。"
+msgstr "DuckDuckGo AI Chat 是一款私密 AI 驅動的聊天服務，目前支援 %1$s 的 %2$s 與 %3$s 的 %4$s 聊天模型。"
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the welcome screen of the onboarding. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -6573,9 +6514,7 @@ msgctxt "Onboarding welcome screen subtitle"
 msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
-msgstr ""
-"DuckDuckGo AI Chat 是一款私密 AI 驅動的聊天服務，目前支援 %1$s 的 %2$s 與 "
-"%3$s 的 %4$s 聊天模型。"
+msgstr "DuckDuckGo AI Chat 是一款私密 AI 驅動的聊天服務，目前支援 %1$s 的 %2$s 與 %3$s 的 %4$s 聊天模型。"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding DuckDuckGo AI Chat.
@@ -6591,9 +6530,7 @@ msgctxt "Error message for BOTNET limit."
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. If this persists, please "
 "email this anonymous code %s to %s"
-msgstr ""
-"DuckDuckGo AI Chat 暫時無法使用。若問題仍存在，請將此匿名代碼%1$s透過電子郵件"
-"傳送至%2$s"
+msgstr "DuckDuckGo AI Chat 暫時無法使用。若問題仍存在，請將此匿名代碼%1$s透過電子郵件傳送至%2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -6725,17 +6662,14 @@ msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
 msgid ""
 "DuckDuckGo anonymizes these reports by automatically removing PII like "
 "names, email addresses, phone numbers, and identifying metadata."
-msgstr ""
-"DuckDuckGo 透過自動移除姓名、電子郵件地址、電話號碼及識別中繼資料等個人身份資"
-"訊來匿名化這些報告。"
+msgstr "DuckDuckGo 透過自動移除姓名、電子郵件地址、電話號碼及識別中繼資料等個人身份資訊來匿名化這些報告。"
 
 # smartling.placeholder_format=C
 #. The first %s is the agree button label ('Agree'). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. The leading sentence mirrors the drawer-style inline disclaimer (DUCKCHAT_TOS_INLINE_DISCLAIMER).
 msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid ""
 "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to Duck.ai's %s."
-msgstr ""
-"DuckDuckGo 將您的聊天匿名化。點擊「%1$s」，即表示你同意 Duck.ai 的%2$s。"
+msgstr "DuckDuckGo 將您的聊天匿名化。點擊「%1$s」，即表示你同意 Duck.ai 的%2$s。"
 
 # smartling.placeholder_format=C
 #. Shown below the input on the empty state when the user has not yet accepted the terms of service. The first %s is the action button label ('Ask' for chat, 'Create' for image generation). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. Clicking the action button both accepts the terms and submits the prompt.
@@ -6751,9 +6685,7 @@ msgid ""
 "DuckDuckGo blocks trackers on websites you visit, including trackers from "
 "companies like Google and Facebook, who often try to track you on other "
 "websites."
-msgstr ""
-"DuckDuckGo將封鎖你造訪網站上的追蹤器，包括來自Google和Facebook等公司的追蹤"
-"器，它們經常試圖在你造訪其他網站時追蹤你。"
+msgstr "DuckDuckGo將封鎖你造訪網站上的追蹤器，包括來自Google和Facebook等公司的追蹤器，它們經常試圖在你造訪其他網站時追蹤你。"
 
 # smartling.placeholder_format=C
 #. Description of how DuckDuckGo keeps a user's location anonymous while the user searches on a map of their area.
@@ -6764,11 +6696,7 @@ msgid ""
 "use it to improve results for that search, and then we promptly throw it "
 "away, such that you remain anonymous. %sLearn more about how we designed "
 "this technology to protect your privacy%s."
-msgstr ""
-"DuckDuckGo的設計以隱私為主要考量。當你啟用定位功能時，只會儲存於你的本機裝置"
-"上。當你搜尋時，你的裝置會將位置傳送給我們，讓我們改善該次的搜尋結果，然後我"
-"們會立即將其丟棄，讓你繼續保持匿名。%1$s進一步瞭解我們如何設計了這項技術來保"
-"護你的隱私%2$s。"
+msgstr "DuckDuckGo的設計以隱私為主要考量。當你啟用定位功能時，只會儲存於你的本機裝置上。當你搜尋時，你的裝置會將位置傳送給我們，讓我們改善該次的搜尋結果，然後我們會立即將其丟棄，讓你繼續保持匿名。%1$s進一步瞭解我們如何設計了這項技術來保護你的隱私%2$s。"
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
@@ -6787,9 +6715,7 @@ msgctxt "settings"
 msgid ""
 "DuckDuckGo only uses your approximate location. That's all we need to "
 "deliver better results, closer to you. %sLearn more%s."
-msgstr ""
-"DuckDuckGo只會使用你的大概位置。我們只需要這麼一點點資訊，就能呈現更好、也更"
-"接近你的搜尋結果。%1$s瞭解更多%2$s。"
+msgstr "DuckDuckGo只會使用你的大概位置。我們只需要這麼一點點資訊，就能呈現更好、也更接近你的搜尋結果。%1$s瞭解更多%2$s。"
 
 # smartling.placeholder_format=C
 msgid "DuckDuckGo search"
@@ -6874,10 +6800,7 @@ msgid ""
 "random words from the DuckDuckGo servers. In the browser, we then select 4-5 "
 "random words from that list, ensuring that the passphrase is at least 18-20 "
 "characters long."
-msgstr ""
-"當你需要通關密語建議時，我們會從DuckDuckGo伺服器收到一長串隨機單字的清單。我"
-"們會在瀏覽器中從該清單隨機挑選出4至5個單字，確認每個通關密語的長度都至少有18"
-"至20個字元。"
+msgstr "當你需要通關密語建議時，我們會從DuckDuckGo伺服器收到一長串隨機單字的清單。我們會在瀏覽器中從該清單隨機挑選出4至5個單字，確認每個通關密語的長度都至少有18至20個字元。"
 
 # smartling.placeholder_format=C
 msgctxt "Sports module"
@@ -7114,9 +7037,7 @@ msgctxt "precise_user_location"
 msgid ""
 "Enabling anonymous location gives more accurate results but still keeps your "
 "searches and exact location private to DuckDuckGo."
-msgstr ""
-"啟用匿名位置可提供更準確的結果，但 DuckDuckGo 仍會對你的搜尋與確切位置進行保"
-"密。"
+msgstr "啟用匿名位置可提供更準確的結果，但 DuckDuckGo 仍會對你的搜尋與確切位置進行保密。"
 
 # smartling.placeholder_format=C
 msgid "Encrypt Connections"
@@ -7277,9 +7198,7 @@ msgctxt "cloudsave"
 msgid ""
 "Enter a new passphrase and click/tap %sSave Settings%s. This will save your "
 "data under your new passphrase."
-msgstr ""
-"輸入新的通關密語，再按一下/點按%1$s儲存設定%2$s。這會將你的資料儲存在新的通關"
-"密語下。"
+msgstr "輸入新的通關密語，再按一下/點按%1$s儲存設定%2$s。這會將你的資料儲存在新的通關密語下。"
 
 # smartling.placeholder_format=C
 #. Label for the field where a user enters their passphrase.
@@ -7304,8 +7223,7 @@ msgstr "輸入文字"
 #. Instructions for how to change the default search engine.
 msgid ""
 "Enter the following details: %sName%s: DuckDuckGo%s URL%s: %s Alias%s: d%s"
-msgstr ""
-"輸入以下細節：%1$s名稱%2$s：DuckDuckGo%3$s URL%4$s：%5$s暱稱%6$s：d%7$s"
+msgstr "輸入以下細節：%1$s名稱%2$s：DuckDuckGo%3$s URL%4$s：%5$s暱稱%6$s：d%7$s"
 
 # smartling.placeholder_format=C
 #. Prompt to enter a destination for driving directions.
@@ -7349,13 +7267,13 @@ msgstr "厄利垂亞"
 #. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Estimate the nutrition"
-msgstr ""
+msgstr "估算營養"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Estimate the nutritional information for this recipe."
-msgstr ""
+msgstr "估算這份食譜的營養資訊。"
 
 # smartling.placeholder_format=C
 msgid "Estonia"
@@ -7415,7 +7333,7 @@ msgstr "到期日為 1 天"
 #. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain the accepted answer in simple terms."
-msgstr ""
+msgstr "用簡單的話解釋一下被採納的答案。"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
@@ -7428,43 +7346,43 @@ msgstr "向我解釋高中等級黑洞的基本概念。"
 #. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain the top answer"
-msgstr ""
+msgstr "解釋最佳答案"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain this in simple, plain language."
-msgstr ""
+msgstr "用簡單易懂的語言解釋一下。"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain this paper"
-msgstr ""
+msgstr "解釋這篇論文"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain this repo"
-msgstr ""
+msgstr "解釋此儲存庫"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain this research paper in plain language."
-msgstr ""
+msgstr "用簡單易懂的語言解釋這篇研究論文。"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Explain this simply"
-msgstr ""
+msgstr "簡單解釋一下"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain what this repository does and how to use it."
-msgstr ""
+msgstr "說明此儲存庫的功能以及如何使用它。"
 
 # smartling.placeholder_format=C
 #. Label to show if song lyrics contain explicit content
@@ -7649,9 +7567,7 @@ msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and "
 "improvements. Hopefully we can address the issue you shared too."
-msgstr ""
-"像你提供的的意見回饋會直接影響我們的產品更新和改善。希望我們也能解決你分享的"
-"問題。"
+msgstr "像你提供的的意見回饋會直接影響我們的產品更新和改善。希望我們也能解決你分享的問題。"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box
@@ -7747,7 +7663,7 @@ msgstr "從圖片搜尋結果中過篩選 AI 生成的圖片。%1$s瞭解更多%
 msgctxt "settings"
 msgid ""
 "Filters out known AI spam sites from image search results. %sLearn More%s"
-msgstr ""
+msgstr "從圖片搜尋結果中過濾掉已知的 AI 垃圾網站。 %1$s瞭解更多%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the final score of a sporting event.
@@ -7806,7 +7722,7 @@ msgstr "尋找目前資訊"
 #. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Find me alternatives"
-msgstr ""
+msgstr "尋找替代方案"
 
 # smartling.placeholder_format=C
 #. Button that searches for results closer to the user's current location.
@@ -7888,8 +7804,7 @@ msgstr "多霧"
 msgid ""
 "Follow the instructions for turning off the ad blocker for DuckDuckGo. You "
 "may have to select a menu option or click a button."
-msgstr ""
-"按照指示關閉 DuckDuckGo 的廣告封鎖程式。你可能需要選取一個選項或按一下按鈕。"
+msgstr "按照指示關閉 DuckDuckGo 的廣告封鎖程式。你可能需要選取一個選項或按一下按鈕。"
 
 # smartling.placeholder_format=C
 #. Privacy reassurance and instructions intro.
@@ -8111,8 +8026,8 @@ msgid ""
 "<strong>Check for Updates...</strong>, then select <strong>Install Update</"
 "strong>."
 msgstr ""
-"從 Mac 上的應用程式功能表工具列中，選取<strong>DuckDuckGo</strong> &gt;"
-"<strong>檢查更新...</strong> ，然後選取<strong>安裝更新</strong>。"
+"從 Mac 上的應用程式功能表工具列中，選取<strong>DuckDuckGo</strong> "
+"&gt;<strong>檢查更新...</strong> ，然後選取<strong>安裝更新</strong>。"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -8283,7 +8198,7 @@ msgstr "生成更多"
 #. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Generate a shopping list"
-msgstr ""
+msgstr "產生購物清單"
 
 # smartling.placeholder_format=C
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
@@ -8462,9 +8377,7 @@ msgctxt "Description of the modal to upgrade the DuckDuckGo subscription"
 msgid ""
 "Get access to advanced AI models in Duck.ai by subscribing to DuckDuckGo, "
 "which also includes our VPN and other premium privacy protections."
-msgstr ""
-"訂閱 DuckDuckGo，即可存取 Duck.ai 的進階 AI 模型，還包括我們的 VPN 和其他頂級"
-"隱私權保護。"
+msgstr "訂閱 DuckDuckGo，即可存取 Duck.ai 的進階 AI 模型，還包括我們的 VPN 和其他頂級隱私權保護。"
 
 # smartling.placeholder_format=C
 #. Description for the subscription setting where users can subscribe to DuckDuckGo.
@@ -8474,9 +8387,7 @@ msgctxt ""
 msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
-msgstr ""
-"訂閱 DuckDuckGo，即可存取 Duck.ai 的進階 AI 模型，還包括我們的 VPN 和其他頂級"
-"隱私權保護。"
+msgstr "訂閱 DuckDuckGo，即可存取 Duck.ai 的進階 AI 模型，還包括我們的 VPN 和其他頂級隱私權保護。"
 
 # smartling.placeholder_format=C
 #. A button for users to generate an AI generated answer from their query on the duckassist module
@@ -8578,7 +8489,7 @@ msgstr "來試試看吧"
 #. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Give me a quick background on this person."
-msgstr ""
+msgstr "給我這個人的快速背景介紹。"
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -8592,8 +8503,7 @@ msgctxt "precise_user_location"
 msgid ""
 "Go to %sSettings > Privacy & Security > Location Services%s, and make sure "
 "“Location Services” is turned on."
-msgstr ""
-"前往 %1$s 設定 > 隱私權和安全性 > 位置服務 %2$s，並確定「位置服務」已開啟。"
+msgstr "前往 %1$s 設定 > 隱私權和安全性 > 位置服務 %2$s，並確定「位置服務」已開啟。"
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -8601,8 +8511,7 @@ msgctxt "precise_user_location"
 msgid ""
 "Go to %sSettings > Privacy > Permission manager > Location%s and scroll down "
 "to %sDuckDuckGo%s."
-msgstr ""
-"前往%1$s設定>隱私權>權限管理>位置%2$s ，接著往下捲動至 %3$sDuckDuckGo%4$s。"
+msgstr "前往%1$s設定>隱私權>權限管理>位置%2$s ，接著往下捲動至 %3$sDuckDuckGo%4$s。"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9028,13 +8937,13 @@ msgstr "協助推廣隱私保護"
 #. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Help me prep for the interview"
-msgstr ""
+msgstr "幫我準備面試"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Help me tailor my resume for this job."
-msgstr ""
+msgstr "幫我針對這份工作調整我的簡歷。"
 
 # smartling.placeholder_format=C
 #. Title of a SERP popup that invites users to take a survey (desktop only)
@@ -9298,9 +9207,7 @@ msgstr "最近活動"
 msgid ""
 "Hit %sReturn%s on your keyboard to %ssave DuckDuckGo to the list. %sThen "
 "click %sMake Default%s"
-msgstr ""
-"在鍵盤上點擊%1$s返回%2$s即可將DuckDuckGo%3$s儲存至清單。%4$s接著點擊%5$s設定"
-"為預設%6$s"
+msgstr "在鍵盤上點擊%1$s返回%2$s即可將DuckDuckGo%3$s儲存至清單。%4$s接著點擊%5$s設定為預設%6$s"
 
 # smartling.placeholder_format=C
 #. The name of the Hmong Daw language
@@ -9549,7 +9456,7 @@ msgctxt ""
 "Text for the I already have a subscription button in the Duck.ai settings "
 "page"
 msgid "I Already Have a Subscription"
-msgstr ""
+msgstr "我已經有訂閱"
 
 # smartling.placeholder_format=C
 #. Text for the button that takes the user to the login subscription page.
@@ -9658,9 +9565,7 @@ msgctxt "precise_user_location"
 msgid ""
 "If the browser location remains unavailable, then go to %sSettings > General "
 "> Reset > 'Reset Location & Privacy'%s."
-msgstr ""
-"如果仍然沒有可用的瀏覽器位置，那麼請前往%1$s設定 > 一般 > 重設 >「重設位置與"
-"隱私」%2$s。"
+msgstr "如果仍然沒有可用的瀏覽器位置，那麼請前往%1$s設定 > 一般 > 重設 >「重設位置與隱私」%2$s。"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -9670,8 +9575,8 @@ msgid ""
 "> Menu > Settings > Site settings > Location%s, and ensure DuckDuckGo is "
 "allowed location access."
 msgstr ""
-"如果仍然沒有可用的瀏覽器位置，那麼請在你的瀏覽器中前往 %1$s⋮ > 選單 > 設定 > "
-"網站設定 > 位置%2$s，確認DuckDuckGo是被允許的存取位置。"
+"如果仍然沒有可用的瀏覽器位置，那麼請在你的瀏覽器中前往 %1$s⋮ > 選單 > 設定 > 網站設定 > "
+"位置%2$s，確認DuckDuckGo是被允許的存取位置。"
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -9685,8 +9590,7 @@ msgstr "如果你繼續看到此錯誤，請聯絡 %1$s。"
 msgid ""
 "If you don't see %sDuckDuckGo,%s you will need to add it to the list of "
 "%sOther Search Engines%s"
-msgstr ""
-"如果你沒看見%1$sDuckDuckGo，%2$s必須先將其新增至%3$s其他搜尋引擎%4$s的清單中"
+msgstr "如果你沒看見%1$sDuckDuckGo，%2$s必須先將其新增至%3$s其他搜尋引擎%4$s的清單中"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding the AI model providers and links to their support pages. Example: 'If you have concerns about our chat providers or any particular chat response, you can also reach out directly to OpenAI and Anthropic support pages.'
@@ -9694,9 +9598,7 @@ msgctxt "Disclaimer text at the bottom of the feedback form."
 msgid ""
 "If you have concerns about our chat providers or any particular chat "
 "response, you can also reach out directly to %s and %s support pages."
-msgstr ""
-"若您對我們的聊天供應商或任何特定的聊天回覆有任何疑問，也能夠直接聯絡 %1$s 與 "
-"%2$s 支援頁面。"
+msgstr "若您對我們的聊天供應商或任何特定的聊天回覆有任何疑問，也能夠直接聯絡 %1$s 與 %2$s 支援頁面。"
 
 # smartling.placeholder_format=C
 #. Body copy explaining what the recovery code is for and how it can be saved.
@@ -9704,9 +9606,7 @@ msgctxt "Body for the Sync & Backup recovery code screen"
 msgid ""
 "If you lose access to your devices, you will need this code to recover your "
 "saved chats. You can save this code to your device as a text file."
-msgstr ""
-"如果您無法存取裝置，需要使用此恢復碼才能恢復您儲存的聊天記錄。您可以把這個恢"
-"復碼儲存成文字檔，儲存至您的裝置。"
+msgstr "如果您無法存取裝置，需要使用此恢復碼才能恢復您儲存的聊天記錄。您可以把這個恢復碼儲存成文字檔，儲存至您的裝置。"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/ReKkJtU.png
@@ -9868,9 +9768,7 @@ msgctxt "settings"
 msgid ""
 "In some older browsers, it's necessary to redirect your clicks through our "
 "server to prevent search leakage. %sLearn more%s."
-msgstr ""
-"若你使用的瀏覽器較舊，在你點擊連結時，必須透過我們的伺服器來重新導向，才能避"
-"免搜尋記錄外洩。%1$s瞭解更多%2$s。"
+msgstr "若你使用的瀏覽器較舊，在你點擊連結時，必須透過我們的伺服器來重新導向，才能避免搜尋記錄外洩。%1$s瞭解更多%2$s。"
 
 # smartling.placeholder_format=C
 #. Instructions accompanying DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE; tells the user where to use the code on a DuckDuckGo browser.
@@ -9880,9 +9778,7 @@ msgctxt ""
 msgid ""
 "In the DuckDuckGo browser, go to Settings › Sync & Backup, and then “Sync "
 "with another device”."
-msgstr ""
-"在 DuckDuckGo 瀏覽器中，點選設定 › Sync & Backup，然後選擇「與另一裝置同"
-"步」。"
+msgstr "在 DuckDuckGo 瀏覽器中，點選設定 › Sync & Backup，然後選擇「與另一裝置同步」。"
 
 #  SeaMonkey default search engine instruction
 # smartling.placeholder_format=C
@@ -10115,7 +10011,7 @@ msgstr "安裝 Mac 瀏覽器"
 #. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
 msgctxt "settings"
 msgid "Install Now"
-msgstr ""
+msgstr "立即安裝"
 
 # smartling.placeholder_format=C
 #. Text of a button to install the DuckDuckGo app
@@ -10218,13 +10114,13 @@ msgstr "我要求刪除的資料是真的刪掉了嗎？"
 #. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Is it worth taking?"
-msgstr ""
+msgstr "值得一試嗎？"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Is this place any good?"
-msgstr ""
+msgstr "這個地方好嗎？"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
@@ -10232,7 +10128,7 @@ msgctxt "Page suggestion prompt"
 msgid ""
 "Is this place any good? Summarize its reputation based on reviews and "
 "ratings."
-msgstr ""
+msgstr "這個地方怎麼樣？ 根據評論與評分總結其評價。"
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -10244,13 +10140,13 @@ msgstr "這部影片有幫助嗎？"
 #. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Is this worth watching?"
-msgstr ""
+msgstr "這值得看嗎？"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Is this worth watching? Give me a spoiler-free take."
-msgstr ""
+msgstr "這值得看嗎？給我一個無雷的看法。"
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -10301,9 +10197,8 @@ msgid ""
 "through Microsoft's Ad Network. Clicks lead directly to merchant landing "
 "pages and unlike ads, DuckDuckGo is not compensated for these results."
 msgstr ""
-"物品排序是依照你的搜尋關鍵字為依據，並經由Microsoft's Ad Network播送。點擊後"
-"會立即連接到商家的登陸頁面，但與廣告不同的是，DuckDuckGo並不會因這些結果而收"
-"到任何報酬。"
+"物品排序是依照你的搜尋關鍵字為依據，並經由Microsoft's Ad "
+"Network播送。點擊後會立即連接到商家的登陸頁面，但與廣告不同的是，DuckDuckGo並不會因這些結果而收到任何報酬。"
 
 # smartling.placeholder_format=C
 #. Text explaining why passphrases use a series of words instead of random numbers and letters.
@@ -10311,9 +10206,7 @@ msgctxt "cloudsave"
 msgid ""
 "It’s easier to remember 4-5 words than 10 random letters and numbers, and "
 "far more secure."
-msgstr ""
-"比起強記 10 個隨機的字母與數字，只記住 4 至 5 個單字要容易許多，而且也更加安"
-"全。"
+msgstr "比起強記 10 個隨機的字母與數字，只記住 4 至 5 個單字要容易許多，而且也更加安全。"
 
 # smartling.placeholder_format=C
 msgid "Ivory Coast"
@@ -10863,7 +10756,7 @@ msgstr "連結："
 #. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
-msgstr ""
+msgstr "列出我需要用到的工具、材料或先決條件。"
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -11275,7 +11168,7 @@ msgstr "管理被封鎖的網站"
 #. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
 msgctxt "setting"
 msgid "Manage in Browser Settings"
-msgstr ""
+msgstr "在瀏覽器設定中管理"
 
 # smartling.placeholder_format=C
 #. Link to the site exclusion settings page
@@ -12248,9 +12141,8 @@ msgid ""
 "internet connection. Disabling chat history will delete pinned chats, and "
 "disable the temporary storage of new prompts and responses."
 msgstr ""
-"新的提示和回應在傳送後會被加密並暫時儲存在 DuckDuckGo 伺服器上，以便在你失去"
-"網路連線時協助恢復聊天。停用聊天紀錄會刪除置頂的聊天記錄，並停用新提示和回應"
-"的暫時儲存功能。"
+"新的提示和回應在傳送後會被加密並暫時儲存在 DuckDuckGo "
+"伺服器上，以便在你失去網路連線時協助恢復聊天。停用聊天紀錄會刪除置頂的聊天記錄，並停用新提示和回應的暫時儲存功能。"
 
 # smartling.placeholder_format=C
 #. Question in a feedback form.
@@ -13065,9 +12957,7 @@ msgstr "隨需"
 msgid ""
 "On Mac, %sClick Maxthon > Preferences%s, On Windows, %sClick the %s icon > "
 "Settings%s"
-msgstr ""
-"在Mac系統中，%1$s按Maxthon > 偏好設定%2$s，在Windows中，%3$s按%4$s 圖示 > 設"
-"定%5$s"
+msgstr "在Mac系統中，%1$s按Maxthon > 偏好設定%2$s，在Windows中，%3$s按%4$s 圖示 > 設定%5$s"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
@@ -13088,8 +12978,7 @@ msgctxt ""
 msgid ""
 "One of the files attached has more pages than we support. Please upload "
 "files with %s pages or fewer."
-msgstr ""
-"附上的其中一個檔案頁數超過了我們的支援範圍。請上傳頁數不超過 %1$s 的檔案。"
+msgstr "附上的其中一個檔案頁數超過了我們的支援範圍。請上傳頁數不超過 %1$s 的檔案。"
 
 # smartling.placeholder_format=C
 #. Response a user can select in a feedback form, indicating that they heard about DuckDuckGo in an online article.
@@ -13445,8 +13334,7 @@ msgctxt "homepage onboarding"
 msgid ""
 "Other search engines track your searches even when you’re in private "
 "browsing mode. We don’t track you &mdash; period."
-msgstr ""
-"即使你處於隱身瀏覽模式，其他搜尋引擎也會追蹤你的搜尋。我們在這期間不追蹤你。"
+msgstr "即使你處於隱身瀏覽模式，其他搜尋引擎也會追蹤你的搜尋。我們在這期間不追蹤你。"
 
 # smartling.placeholder_format=C
 msgctxt "SERP footer content"
@@ -13465,9 +13353,7 @@ msgid ""
 "Our private browser for mobile comes equipped with our search engine, "
 "tracker blocker, encryption enforcer, and more. Available on %siOS & "
 "Android%s."
-msgstr ""
-"我們的行動裝置私密瀏覽器配備搜尋引擎、追蹤器封鎖程式、加密執行程式等眾多功"
-"能。提供%1$siOS及Android%2$s版本。"
+msgstr "我們的行動裝置私密瀏覽器配備搜尋引擎、追蹤器封鎖程式、加密執行程式等眾多功能。提供%1$siOS及Android%2$s版本。"
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the information was out of date.
@@ -13719,9 +13605,7 @@ msgctxt "cloudsave"
 msgid ""
 "Passphrases cannot be recovered as we don't associate your IP address, "
 "browser fingerprint, or any other information with the file."
-msgstr ""
-"我們並未將你的IP位址、瀏覽器指紋或其他相關資訊連結至通關密語檔案，因此無法找"
-"回通關密語。"
+msgstr "我們並未將你的IP位址、瀏覽器指紋或其他相關資訊連結至通關密語檔案，因此無法找回通關密語。"
 
 # smartling.placeholder_format=C
 #. Label for the section of recent chats that were edited in the past 7 days.
@@ -13915,8 +13799,8 @@ msgid ""
 "answers. To turn them off and hide the Assist button visit %sSearch "
 "Settings%s."
 msgstr ""
-"將您的搜尋以問句形式完整地表達出來，能提高 AI 輔助答案自動顯示的機率，且通常"
-"能得到更好的答案。欲關閉並隱藏「Assist」按鈕，請造訪 %1$s搜尋設定%2$s。"
+"將您的搜尋以問句形式完整地表達出來，能提高 AI 輔助答案自動顯示的機率，且通常能得到更好的答案。欲關閉並隱藏「Assist」按鈕，請造訪 "
+"%1$s搜尋設定%2$s。"
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -13925,9 +13809,8 @@ msgid ""
 "DuckAssist more likely to appear and often yields better answers. To adjust "
 "how this feature works, or to turn it off, visit %sDuckAssist Settings%s."
 msgstr ""
-"將您的搜尋作為一個問題表述，並且用一個完整的句子為形式，讓 DuckAssist 更可能"
-"顯示並且通常能得出更好的答案。 欲調整此功能的運作方式或將其關閉，請造訪 "
-"%1$sDuckAssist 設定%2$s。"
+"將您的搜尋作為一個問題表述，並且用一個完整的句子為形式，讓 DuckAssist 更可能顯示並且通常能得出更好的答案。 "
+"欲調整此功能的運作方式或將其關閉，請造訪 %1$sDuckAssist 設定%2$s。"
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -13937,9 +13820,8 @@ msgid ""
 "answers. To turn it off and hide the Assist button visit %sDuckAssist "
 "Settings%s."
 msgstr ""
-"將您的搜尋作為一個問題表述，並且用一個完整的句子為形式，讓 DuckAssist 更可能"
-"自動顯示並且通常能得出更好的答案。欲關閉並隱藏「協助」按鈕，請造訪 %1$s "
-"DuckAssist 設定 %2$s。"
+"將您的搜尋作為一個問題表述，並且用一個完整的句子為形式，讓 DuckAssist "
+"更可能自動顯示並且通常能得出更好的答案。欲關閉並隱藏「協助」按鈕，請造訪 %1$s DuckAssist 設定 %2$s。"
 
 # smartling.placeholder_format=C
 #. Button that allows users to manually select a location on a map.
@@ -13971,8 +13853,7 @@ msgctxt "Body copy for the chat card in the How Duck.ai Works panel"
 msgid ""
 "Pick a popular AI to chat with, like GPT-5 mini, Claude Haiku 4.5, Mistral, "
 "etc."
-msgstr ""
-"選擇流行的 AI 進行聊天，例如 GPT-5 迷你、克勞德海庫 4.5、米斯特拉爾等。"
+msgstr "選擇流行的 AI 進行聊天，例如 GPT-5 迷你、克勞德海庫 4.5、米斯特拉爾等。"
 
 # smartling.placeholder_format=C
 #. Describes the ability to choose from popular AI models. Pairs with a chat-bubble pictogram.
@@ -13988,8 +13869,7 @@ msgctxt "Third party map app picker"
 msgid ""
 "Pick a service to navigate to your destination. External apps won’t come "
 "with DuckDuckGo protections."
-msgstr ""
-"選擇一項服務來導覽到你的目的地。外部應用程式不會受到 DuckDuckGo 的保護。"
+msgstr "選擇一項服務來導覽到你的目的地。外部應用程式不會受到 DuckDuckGo 的保護。"
 
 # smartling.placeholder_format=C
 #. Label for a list of problems on a feedback form.
@@ -14085,7 +13965,7 @@ msgstr "請完成以下挑戰，確認此搜尋是由真人所進行。"
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is harmful or illegal. (optional)"
-msgstr ""
+msgstr "請說明聊天回覆有害或非法的原因。(選填)"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
@@ -14119,7 +13999,7 @@ msgctxt "Feedback prompt"
 msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is harmful or illegal."
-msgstr ""
+msgstr "請貼上你的提示和有問題的輸出（請移除任何個人資訊），並描述為何該內容有害或非法。"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -14127,9 +14007,7 @@ msgctxt "Feedback prompt"
 msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is illegal or harmful."
-msgstr ""
-"請貼上你的提示和有問題的輸出（請移除任何個人資訊），並描述為何該內容非法或有"
-"害。"
+msgstr "請貼上你的提示和有問題的輸出（請移除任何個人資訊），並描述為何該內容非法或有害。"
 
 # smartling.placeholder_format=C
 #. Title on a feedback form.
@@ -14590,7 +14468,7 @@ msgstr "隱私"
 #. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
 msgctxt "Section heading on the Duck.ai settings page"
 msgid "Privacy & Terms"
-msgstr ""
+msgstr "隱私權與條款"
 
 # smartling.placeholder_format=C
 msgid "Privacy Blog"
@@ -14666,7 +14544,7 @@ msgstr "隱私權政策與服務條款"
 #. Text for a button that links to the terms of use and privacy policy page.
 msgctxt "Secondary button text in active privacy modal"
 msgid "Privacy Policy and Terms of Service"
-msgstr ""
+msgstr "隱私權政策與服務條款"
 
 # smartling.placeholder_format=C
 #. Title displayed on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
@@ -15118,9 +14996,7 @@ msgctxt "Description for recent chats feature"
 msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
-msgstr ""
-"最近的聊天記錄會儲存在你的裝置本機上，而非在 DuckDuckGo 或其他的遠端伺服器"
-"中。"
+msgstr "最近的聊天記錄會儲存在你的裝置本機上，而非在 DuckDuckGo 或其他的遠端伺服器中。"
 
 # smartling.placeholder_format=C
 #. Text explaining that recent chats are stored locally on the user's device.
@@ -15128,9 +15004,7 @@ msgctxt "Description of where recent chats are stored"
 msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
-msgstr ""
-"最近的聊天記錄會儲存在你的裝置本機上，而非在 DuckDuckGo 或其他的遠端伺服器"
-"中。"
+msgstr "最近的聊天記錄會儲存在你的裝置本機上，而非在 DuckDuckGo 或其他的遠端伺服器中。"
 
 # smartling.placeholder_format=C
 #. Text explaining how recent chats are stored locally on the user's device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection.
@@ -15139,9 +15013,7 @@ msgid ""
 "Recent chats are stored locally on your device. New prompts and responses "
 "are encrypted and temporarily stored on a DuckDuckGo server after being "
 "sent, to help recover a chat if you lose your internet connection."
-msgstr ""
-"最近的聊天記錄會儲存在你的裝置本機上。新的提示和回應在傳送後會被加密並暫時儲"
-"存在 DuckDuckGo 伺服器上，以便在你斷線時協助恢復聊天。"
+msgstr "最近的聊天記錄會儲存在你的裝置本機上。新的提示和回應在傳送後會被加密並暫時儲存在 DuckDuckGo 伺服器上，以便在你斷線時協助恢復聊天。"
 
 # smartling.placeholder_format=C
 msgctxt "region filter"
@@ -15168,25 +15040,25 @@ msgstr "推薦一本書"
 #. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Recommend similar books"
-msgstr ""
+msgstr "推薦類似書籍"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Recommend similar books."
-msgstr ""
+msgstr "推薦類似書籍。"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Recommend similar movies or shows."
-msgstr ""
+msgstr "推薦類似的電影或節目。"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Recommend similar titles"
-msgstr ""
+msgstr "推薦類似標題"
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
@@ -15398,8 +15270,7 @@ msgstr "重新載入 Duck.ai。"
 msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
-msgstr ""
-"按照說明重新載入 DuckDuckGo，或者點擊瀏覽器的「重新整理」或「重新載入」按鈕。"
+msgstr "按照說明重新載入 DuckDuckGo，或者點擊瀏覽器的「重新整理」或「重新載入」按鈕。"
 
 # smartling.placeholder_format=C
 #. checkbox label that allows the user to save the setting
@@ -15552,18 +15423,14 @@ msgid ""
 "Reports are anonymous and sent to DuckDuckGo to help improve our search "
 "service. Your anonymous feedback is also shared with %s to help improve "
 "their services."
-msgstr ""
-"報告會匿名傳送給DuckDuckGo，幫助我們改善搜尋服務。你的匿名回饋意見也會分享"
-"給%1$s來協助改善其服務。"
+msgstr "報告會匿名傳送給DuckDuckGo，幫助我們改善搜尋服務。你的匿名回饋意見也會分享給%1$s來協助改善其服務。"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "Reports sent to DuckDuckGo are anonymous. Please do not include any personal "
 "or identifying information in your feedback."
-msgstr ""
-"傳送給 DuckDuckGo 的檢舉採匿名制。請不要在你的意見回饋中包含任何個人或可識別"
-"身分的資訊。"
+msgstr "傳送給 DuckDuckGo 的檢舉採匿名制。請不要在你的意見回饋中包含任何個人或可識別身分的資訊。"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -15571,9 +15438,7 @@ msgid ""
 "Reports sent to DuckDuckGo include all of the text you've asked us to "
 "translate during this page load, and are anonymous. Please do not include "
 "any personal or identifying information in your feedback."
-msgstr ""
-"傳送給 DuckDuckGo 的報告包括你在此頁面載入時要求我們翻譯的所有文字，並且是匿"
-"名的。請不要在你的意見回饋中包含任何個人或可識別身分的資訊。"
+msgstr "傳送給 DuckDuckGo 的報告包括你在此頁面載入時要求我們翻譯的所有文字，並且是匿名的。請不要在你的意見回饋中包含任何個人或可識別身分的資訊。"
 
 # smartling.placeholder_format=C
 msgid "Republic of Moldova"
@@ -15586,7 +15451,7 @@ msgctxt ""
 "feedback form when the user has selected Harmful or Illegal as the feedback "
 "reason"
 msgid "Required for harmful or illegal reports"
-msgstr ""
+msgstr "有害或非法報告必填"
 
 # smartling.placeholder_format=C
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
@@ -15652,9 +15517,7 @@ msgid ""
 "Responses are for educational purposes only and are not intended as medical, "
 "legal, financial, investment, or other professional advice. AI-assisted "
 "answers are subject to our %sTerms of Service%s."
-msgstr ""
-"回覆僅用於教育用途，並不構成醫療、法律、財務、投資或其他專業建議。AI 輔助的回"
-"答受我們的 %1$s 服務條款%2$s約束。"
+msgstr "回覆僅用於教育用途，並不構成醫療、法律、財務、投資或其他專業建議。AI 輔助的回答受我們的 %1$s 服務條款%2$s約束。"
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -15662,9 +15525,7 @@ msgid ""
 "Responses are for educational purposes only and are not intended as medical, "
 "legal, financial, investment, or other professional advice. DuckAssist is "
 "subject to our %sTerms of Service%s."
-msgstr ""
-"回覆僅用於教育用途，並不構成醫療、法律、財務、投資或其他專業建議。DuckAssist "
-"受我們的%1$s服務條款%2$s約束。"
+msgstr "回覆僅用於教育用途，並不構成醫療、法律、財務、投資或其他專業建議。DuckAssist 受我們的%1$s服務條款%2$s約束。"
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -15674,8 +15535,8 @@ msgid ""
 "generated based on web content and may contain inaccuracies. Search Assist "
 "is subject to our %sTerms of Service%s."
 msgstr ""
-"回覆僅用於教育用途，並不構成醫療、法律、財務、投資或其他專業建議。係根據網頁"
-"內容生成，可能會有不準確之處。Search Assist 受我們的 %1$s服務條款%2$s 約束。"
+"回覆僅用於教育用途，並不構成醫療、法律、財務、投資或其他專業建議。係根據網頁內容生成，可能會有不準確之處。Search Assist 受我們的 "
+"%1$s服務條款%2$s 約束。"
 
 # smartling.placeholder_format=C
 #. Label on the button for restoring all previous website data.
@@ -15822,7 +15683,7 @@ msgstr "評論"
 #. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Rewrite this recipe scaled for a different number of servings."
-msgstr ""
+msgstr "重新編寫此食譜，以調整為不同的份量。"
 
 # smartling.placeholder_format=C
 msgid "Romania"
@@ -16093,9 +15954,7 @@ msgctxt "Description for Chat History feature with Encrypted Storage option"
 msgid ""
 "Save up to 30 of your most recent chats locally on your device, with the "
 "option for more with Encrypted Storage."
-msgstr ""
-"你最多可在裝置本機儲存多達 30 筆近期聊天記錄，並可選擇透過加密儲存功能儲存更"
-"多內容。"
+msgstr "你最多可在裝置本機儲存多達 30 筆近期聊天記錄，並可選擇透過加密儲存功能儲存更多內容。"
 
 # smartling.placeholder_format=C
 #. Short text for native DDG browser users explaining how Chat History stores up to 30 of their most recent chats locally on their device.
@@ -16317,18 +16176,16 @@ msgid ""
 "(on a wide range of searches). For now, Search Assist is only available in a "
 "subset of English speaking regions."
 msgstr ""
-"Search Assist 會匿名生成搜尋查詢的答案。為了達成這個目的，它會掃描網路尋找相"
-"關內容，然後使用 AI 生成簡短的回答。你可以選擇它出現的頻率：從不、隨需 (僅在"
-"點按 Assist 時)、有時 (在高度相關時)，或經常 (在廣泛的搜尋中)。目前，Search "
-"Assist 功能僅供部分英語地區使用。"
+"Search Assist 會匿名生成搜尋查詢的答案。為了達成這個目的，它會掃描網路尋找相關內容，然後使用 AI "
+"生成簡短的回答。你可以選擇它出現的頻率：從不、隨需 (僅在點按 Assist 時)、有時 (在高度相關時)，或經常 "
+"(在廣泛的搜尋中)。目前，Search Assist 功能僅供部分英語地區使用。"
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI) when the answer is not found and the answer is unsourced or with no sources
 msgid ""
 "Search Assist couldn't find enough reliable information to generate an "
 "answer for this question. Try another search."
-msgstr ""
-"Search Assist 找不到足夠的可靠資訊以產生這個問題的答案。嘗試另一個搜尋。"
+msgstr "Search Assist 找不到足夠的可靠資訊以產生這個問題的答案。嘗試另一個搜尋。"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -16337,8 +16194,8 @@ msgid ""
 "search queries. To do this, it %sscans the web%s for relevant content and "
 "then uses AI to generate a brief answer based on information found."
 msgstr ""
-"Search Assist 是一項選用功能，可匿名生成搜尋查詢的答案。為此，它%1$s掃描網"
-"路%2$s以尋找相關內容，然後使用 AI 根據找到的資訊生成簡短的答案。"
+"Search Assist 是一項選用功能，可匿名生成搜尋查詢的答案。為此，它%1$s掃描網路%2$s以尋找相關內容，然後使用 AI "
+"根據找到的資訊生成簡短的答案。"
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/search_box. top header
@@ -16458,9 +16315,7 @@ msgctxt "noresults"
 msgid ""
 "Search other sites with %s shortcuts: a search for ”!w ducks” will search "
 "for “ducks” directly on Wikipedia."
-msgstr ""
-"使用 %1$s 快捷方式搜尋其他網站：搜尋「!w ducks」將直接在維基百科上搜尋"
-"「ducks」。"
+msgstr "使用 %1$s 快捷方式搜尋其他網站：搜尋「!w ducks」將直接在維基百科上搜尋「ducks」。"
 
 # smartling.placeholder_format=C
 #. Placeholder text for the search form when no text has been entered
@@ -16478,9 +16333,7 @@ msgstr "私密搜尋與封鎖追蹤器"
 msgid ""
 "Search privately with our app or extension, add private web search to your "
 "favorite browser, or search directly at %sduckduckgo.com%s."
-msgstr ""
-"使用我們的應用程式或延伸模組進行私密搜尋，為你最常用的瀏覽器新增隱身網路搜尋"
-"功能，或直接在%1$sduckduckgo.com%2$s搜尋。"
+msgstr "使用我們的應用程式或延伸模組進行私密搜尋，為你最常用的瀏覽器新增隱身網路搜尋功能，或直接在%1$sduckduckgo.com%2$s搜尋。"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/6LZAoqH.png
@@ -16499,9 +16352,8 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"搜尋設定會儲存在瀏覽器中的非個人瀏覽器 cookie 和本機儲存空間，但你也可以使用 "
-"Cloud Save 將設定匿名儲存在雲端的遠端伺服器上。不會在雲端中儲存任何個人身分資"
-"料，且你的通關密語永遠不會離開你的瀏覽器。"
+"搜尋設定會儲存在瀏覽器中的非個人瀏覽器 cookie 和本機儲存空間，但你也可以使用 Cloud Save "
+"將設定匿名儲存在雲端的遠端伺服器上。不會在雲端中儲存任何個人身分資料，且你的通關密語永遠不會離開你的瀏覽器。"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -16613,9 +16465,7 @@ msgctxt "Description explaining how native users can enable sync"
 msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your synced devices."
-msgstr ""
-"以端對端加密安全地將幾乎無限的聊天內容儲存在我們的伺服器上，並可從所有已同步"
-"的裝置存取。"
+msgstr "以端對端加密安全地將幾乎無限的聊天內容儲存在我們的伺服器上，並可從所有已同步的裝置存取。"
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -16623,9 +16473,7 @@ msgctxt "Description explaining how native users can enable sync"
 msgid ""
 "Securely store your chats on our server using end-to-end encryption, and "
 "access them from all your devices."
-msgstr ""
-"以端對端加密安全地將您的聊天內容儲存在我們的伺服器上，並可從您所有的裝置存"
-"取。"
+msgstr "以端對端加密安全地將您的聊天內容儲存在我們的伺服器上，並可從您所有的裝置存取。"
 
 # smartling.placeholder_format=C
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
@@ -16639,9 +16487,7 @@ msgctxt "Chat history with sync modal list item"
 msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
-msgstr ""
-"採用端對端加密，安全儲存在 DuckDuckGo 的伺服器上。除了你之外，沒有人可以看到"
-"你的資料，連我們也不行。"
+msgstr "採用端對端加密，安全儲存在 DuckDuckGo 的伺服器上。除了你之外，沒有人可以看到你的資料，連我們也不行。"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -17041,9 +16887,7 @@ msgid ""
 "Sends a prompt to AI models with your messages with instructions on how to "
 "respond. These instructions will apply to all of your conversations going "
 "forward."
-msgstr ""
-"向 AI 模型發送提示，包含你的訊息和回應指示說明。這些只是將自動套用至往後所有"
-"對話。"
+msgstr "向 AI 模型發送提示，包含你的訊息和回應指示說明。這些只是將自動套用至往後所有對話。"
 
 # smartling.placeholder_format=C
 msgid "Senegal"
@@ -17122,7 +16966,7 @@ msgstr "立即設定"
 #. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
 msgctxt "Encrypted storage setup button shown in native browsers"
 msgid "Set Up Sync & Backup"
-msgstr ""
+msgstr "設定 Sync & Backup"
 
 # smartling.placeholder_format=C
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
@@ -17152,8 +16996,7 @@ msgctxt "Chat history about modal list item"
 msgid ""
 "Set up Sync & Backup after turning on Chat History to keep your chats synced "
 "across devices."
-msgstr ""
-"開啟聊天記錄後，請設定 Sync & Backup 以確保您的聊天記錄能在各裝置間保持同步。"
+msgstr "開啟聊天記錄後，請設定 Sync & Backup 以確保您的聊天記錄能在各裝置間保持同步。"
 
 # smartling.placeholder_format=C
 #. Prompt for the user to indicate their location on a map, to enable more relevant search results.
@@ -17239,9 +17082,7 @@ msgctxt "Description for Approximate Location feature"
 msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
-msgstr ""
-"與 AI 模型分享城市等級的位置，以提升相關性。Duck.ai 絕不會向我們或 AI 模型透"
-"露你的精確位置。"
+msgstr "與 AI 模型分享城市等級的位置，以提升相關性。Duck.ai 絕不會向我們或 AI 模型透露你的精確位置。"
 
 # smartling.placeholder_format=C
 #. Menu option to share feedback about a result
@@ -17306,7 +17147,7 @@ msgstr "分享正面意見回饋"
 msgctxt ""
 "Label beside the share-content switch on the Duck.ai response feedback form"
 msgid "Share this conversation with DuckDuckGo"
-msgstr ""
+msgstr "與 DuckDuckGo 分享此對話"
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -17668,18 +17509,14 @@ msgctxt "settings"
 msgid ""
 "Shows a reminder that searches on DuckDuckGo are always private. Turning "
 "this off hides the reminder and never affects search privacy."
-msgstr ""
-"提醒您，DuckDuckGo 上的所有搜尋都是私密的。關閉此功能會隱藏提醒，且永遠不會影"
-"響私密搜尋。"
+msgstr "提醒您，DuckDuckGo 上的所有搜尋都是私密的。關閉此功能會隱藏提醒，且永遠不會影響私密搜尋。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Shows a reminder that searches on DuckDuckGo are always protected. Turning "
 "this off hides the reminder and never affects search protection."
-msgstr ""
-"提醒您，DuckDuckGo 上的所有搜尋都受到保護。關閉此功能會隱藏提醒，且永遠不會影"
-"響搜尋保護。"
+msgstr "提醒您，DuckDuckGo 上的所有搜尋都受到保護。關閉此功能會隱藏提醒，且永遠不會影響搜尋保護。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18541,19 +18378,19 @@ msgstr "建議部落格文章的標題"
 #. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Suggest related articles or topics worth exploring next."
-msgstr ""
+msgstr "推薦接下來值得探索的相關文章或話題。"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Suggest related articles to explore"
-msgstr ""
+msgstr "建議探索相關文章"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Suggest some alternatives to this product."
-msgstr ""
+msgstr "建議一些這項產品的替代方案。"
 
 # smartling.placeholder_format=C
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
@@ -18570,7 +18407,7 @@ msgstr "建議："
 #. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Sum up the reviews"
-msgstr ""
+msgstr "總結評論"
 
 # smartling.placeholder_format=C
 #. A short title for the a message asking the AI to summarize a text.
@@ -18582,85 +18419,85 @@ msgstr "總結"
 #. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize the Q&As"
-msgstr ""
+msgstr "總結問答"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the background and notable work of this person."
-msgstr ""
+msgstr "總結這個人的背景與重要事蹟。"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the key details of this event."
-msgstr ""
+msgstr "總結此活動的關鍵細節。"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the questions and answers on this page."
-msgstr ""
+msgstr "摘要此頁面上的問題與解答。"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize their background"
-msgstr ""
+msgstr "總結他們的背景"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this book"
-msgstr ""
+msgstr "總結這本書"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this book."
-msgstr ""
+msgstr "總結這本書。"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this discussion"
-msgstr ""
+msgstr "總結此討論"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this discussion thread."
-msgstr ""
+msgstr "總結這個討論串。"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this page"
-msgstr ""
+msgstr "總結此頁面"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this page."
-msgstr ""
+msgstr "總結這個頁面。"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Summarize this video"
-msgstr ""
+msgstr "總結這部影片"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize this video."
-msgstr ""
+msgstr "總結這部影片。"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize what the reviews say."
-msgstr ""
+msgstr "總結評論內容。"
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -18924,19 +18761,16 @@ msgid ""
 msgstr ""
 "同步恢復碼\n"
 "\n"
-"恢復碼允許你在多個裝置之間同步您的密碼、自動填入資料和 Duck.ai 聊天記錄，並在"
-"你無法存取某個裝置時恢復你的同步資料。\n"
+"恢復碼允許你在多個裝置之間同步您的密碼、自動填入資料和 Duck.ai 聊天記錄，並在你無法存取某個裝置時恢復你的同步資料。\n"
 "\n"
 "確保此資訊安全無虞。\n"
 "任何有權限存取此代碼的人都能存取你同步的資料。%1$s\n"
 "\n"
 "這段代碼是如何運作的？\n"
-"1. 在瀏覽器中造訪 Duck.ai 並開啟 Duck.ai 設定。2. 選取「開啟 Sync & "
-"Backup」，然後選擇「恢復已同步的資料」\n"
+"1. 在瀏覽器中造訪 Duck.ai 並開啟 Duck.ai 設定。2. 選取「開啟 Sync & Backup」，然後選擇「恢復已同步的資料」\n"
 "3. 複製上方的恢復代碼，並貼到顯示「將你的代碼貼在這裡」的地方\n"
 "\n"
-"如果你超過 18 個月未使用已啟用 Sync & Backup 的 DuckDuckGo 瀏覽器，你的資料將"
-"從伺服器上刪除，且無法恢復。"
+"如果你超過 18 個月未使用已啟用 Sync & Backup 的 DuckDuckGo 瀏覽器，你的資料將從伺服器上刪除，且無法恢復。"
 
 # smartling.placeholder_format=C
 #. Secondary button label on the Sync & Backup intro screen that takes the user to the camera scan screen to pair with another device.
@@ -18982,7 +18816,7 @@ msgstr "敘利亞"
 #. Text for a button that enables the theme to follow the operating system's color scheme preference.
 msgctxt "System theme button for theme selector"
 msgid "System"
-msgstr ""
+msgstr "系統"
 
 # smartling.placeholder_format=C
 #. Abbreviation indicating this is the total score for a game
@@ -19016,7 +18850,7 @@ msgstr "大溪地語"
 #. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Tailor my resume"
-msgstr ""
+msgstr "調整我的簡歷"
 
 # smartling.placeholder_format=C
 msgid "Taiwan"
@@ -19052,7 +18886,7 @@ msgstr "讓你確實掌控自己的個人資料！"
 msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
-msgstr ""
+msgstr "填寫這份匿名問卷，讓我們知道該如何改善 Duck.ai。"
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -19266,9 +19100,7 @@ msgid ""
 "That means information sent between your device and the webpage behind this "
 "link is at increased risk of being intercepted by a third party. In rare "
 "cases this includes passwords, or payment details."
-msgstr ""
-"這代表在你的裝置與此連結通往的網頁之間傳遞的資訊處於高風險中，有可能會遭到第"
-"三方攔截。雖然極少發生，但該資訊可能包含密碼或付款詳情。"
+msgstr "這代表在你的裝置與此連結通往的網頁之間傳遞的資訊處於高風險中，有可能會遭到第三方攔截。雖然極少發生，但該資訊可能包含密碼或付款詳情。"
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -19354,7 +19186,7 @@ msgstr "佈景主題"
 #. Text for the theme selector label that allows users to switch between Light and dark theme.
 msgctxt "Label for the theme selector feature"
 msgid "Theme"
-msgstr ""
+msgstr "佈景主題"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/LpFhb1e.png
@@ -19384,8 +19216,7 @@ msgctxt "Error message when there was an issue saving a chat to the browser"
 msgid ""
 "There was an error saving this chat locally. Please check your browser "
 "settings to make sure local data storage is enabled."
-msgstr ""
-"在本機儲存此聊天時發生錯誤。請檢查你的瀏覽器設定，確保已啟用本機資料儲存。"
+msgstr "在本機儲存此聊天時發生錯誤。請檢查你的瀏覽器設定，確保已啟用本機資料儲存。"
 
 # smartling.placeholder_format=C
 #. Error modal body line 1.
@@ -19417,9 +19248,7 @@ msgid ""
 "These browser permissions are used to add privacy protection on websites you "
 "visit by blocking hidden trackers, encrypting connections where possible, "
 "and by making DuckDuckGo your default search engine."
-msgstr ""
-"這些瀏覽器權限可封鎖隱藏的追蹤器，並盡可能加密資訊，並將DuckDuckGo設定為預設"
-"搜尋引擎，藉此為你造訪的網站新增隱私保護。"
+msgstr "這些瀏覽器權限可封鎖隱藏的追蹤器，並盡可能加密資訊，並將DuckDuckGo設定為預設搜尋引擎，藉此為你造訪的網站新增隱私保護。"
 
 # smartling.placeholder_format=C
 #. Secondary line under DUCKCHAT_SYNC_PAIRING_ALREADY_SYNCED_TITLE.
@@ -19491,8 +19320,8 @@ msgid ""
 "This conversation was generated with Duck.ai (%s) using %s's %s Model. AI "
 "chats may display inaccurate or offensive information (see %s for more info)."
 msgstr ""
-"此對話是使用 %2$s 的 %3$s 模型與 Duck.ai (%1$s) 產生的。AI 聊天可能會顯示不準"
-"確或令人反感的資訊 (請參閱 %4$s 取得更多資訊)。"
+"此對話是使用 %2$s 的 %3$s 模型與 Duck.ai (%1$s) 產生的。AI 聊天可能會顯示不準確或令人反感的資訊 (請參閱 %4$s "
+"取得更多資訊)。"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with multiple AI models in the same chat, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using multiple chat models. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -19501,9 +19330,7 @@ msgid ""
 "This conversation was generated with Duck.ai (%s) using multiple chat "
 "models. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
-msgstr ""
-"此對話是使用多個聊天模型與 Duck.ai (%1$s) 產生的。AI 聊天可能會顯示不準確或令"
-"人反感的資訊 (請參閱 %2$s 取得更多資訊)。"
+msgstr "此對話是使用多個聊天模型與 Duck.ai (%1$s) 產生的。AI 聊天可能會顯示不準確或令人反感的資訊 (請參閱 %2$s 取得更多資訊)。"
 
 # smartling.placeholder_format=C
 #. When a user exports a transcript of a voice chat they had with the AI. This text goes at the very top of the downloaded file as a header. Placeholders are for links. Example: 'This conversation was generated with Duck.ai voice chat (https://duck.ai). AI may provide inaccurate or offensive information. (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -19511,9 +19338,7 @@ msgctxt "Export chat feature in AI Chat"
 msgid ""
 "This conversation was generated with Duck.ai voice chat (%s). AI may provide "
 "inaccurate or offensive information. (see %s for more info)."
-msgstr ""
-"這段對話是透過 Duck.ai 語音聊天產生的（%1$s）。AI 可能會提供不準確或令人反感"
-"的資訊。（更多資訊請參見%2$s）。"
+msgstr "這段對話是透過 Duck.ai 語音聊天產生的（%1$s）。AI 可能會提供不準確或令人反感的資訊。（更多資訊請參見%2$s）。"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with DuckDuckGo AI Chat (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/aichat/privacy-terms for more info).'
@@ -19523,8 +19348,8 @@ msgid ""
 "Model. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
 msgstr ""
-"此對話是使用 %2$s的%3$s 模型與 DuckDuckGo AI Chat (%1$s) 產生的。AI 聊天可能"
-"會顯示不準確或令人反感的資訊 (請參閱 %4$s 取得更多資訊)。"
+"此對話是使用 %2$s的%3$s 模型與 DuckDuckGo AI Chat (%1$s) 產生的。AI 聊天可能會顯示不準確或令人反感的資訊 "
+"(請參閱 %4$s 取得更多資訊)。"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
@@ -19627,9 +19452,7 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "This model provider deletes data associated with this chat within 30 days. "
 "Other model providers follow a zero data retention model."
-msgstr ""
-"此模型供應商會在 30 天內刪除與此聊天相關的資料。其他模型供應商遵循零資料保留"
-"模式。"
+msgstr "此模型供應商會在 30 天內刪除與此聊天相關的資料。其他模型供應商遵循零資料保留模式。"
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers, and that other providers may retain chat data for a limited time instead.
@@ -19637,9 +19460,7 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "This model provider does not store any data associated with this chat. Other "
 "model providers follow a limited data retention model."
-msgstr ""
-"此模型供應商不會儲存與此聊天相關的任何資料。其他模型供應商遵循限制資料保留模"
-"式。"
+msgstr "此模型供應商不會儲存與此聊天相關的任何資料。其他模型供應商遵循限制資料保留模式。"
 
 # smartling.placeholder_format=C
 #. Info that page may refresh during update.
@@ -19675,9 +19496,7 @@ msgctxt "First paragraph for the Sync & Backup intro screen"
 msgid ""
 "This saves your chats with end-to-end encryption on DuckDuckGo's secure "
 "server, which later can be accessed from any browser."
-msgstr ""
-"這會將您的聊天內容以端對端加密方式儲存在 DuckDuckGo 的安全伺服器，之後您可從"
-"任何瀏覽器存取。"
+msgstr "這會將您的聊天內容以端對端加密方式儲存在 DuckDuckGo 的安全伺服器，之後您可從任何瀏覽器存取。"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -19685,9 +19504,7 @@ msgctxt "duckassist"
 msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again."
-msgstr ""
-"此設定儲存在你的瀏覽器中，這表示如果你清除 duckduckgo.com 的瀏覽器資料，那麼"
-"可能會再次看到 AI 輔助的答案。"
+msgstr "此設定儲存在你的瀏覽器中，這表示如果你清除 duckduckgo.com 的瀏覽器資料，那麼可能會再次看到 AI 輔助的答案。"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -19697,9 +19514,8 @@ msgid ""
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
 msgstr ""
-"此設定儲存在你的瀏覽器中，這表示如果你清除 duckduckgo.com 的瀏覽器資料，那麼"
-"可能會再次看到 AI 輔助的答案。不過，我們也有一個起始頁面，從不在 %1$s 顯示 "
-"AI 輔助答案。"
+"此設定儲存在你的瀏覽器中，這表示如果你清除 duckduckgo.com 的瀏覽器資料，那麼可能會再次看到 AI "
+"輔助的答案。不過，我們也有一個起始頁面，從不在 %1$s 顯示 AI 輔助答案。"
 
 # smartling.placeholder_format=C
 #. User feedback indicating that a translation is helpful
@@ -19738,8 +19554,8 @@ msgid ""
 "Sync & Backup. You'll still be able to access your chats in other browsers "
 "connected to Sync & Backup."
 msgstr ""
-"這將刪除此瀏覽器中所有 Duck.ai 聊天記錄，並與 Sync & Backup 中斷連線。您仍然"
-"可以在連接到 Sync & Backup 的其他瀏覽器中存取您的聊天記錄。"
+"這將刪除此瀏覽器中所有 Duck.ai 聊天記錄，並與 Sync & Backup 中斷連線。您仍然可以在連接到 Sync & Backup "
+"的其他瀏覽器中存取您的聊天記錄。"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to clear all recentchats, with a warning that this action cannot be undone.
@@ -19884,9 +19700,7 @@ msgctxt "directions"
 msgid ""
 "To print directions:%sGo back to the map.%sSelect the route you want to "
 "print.%sClick the print icon.%s"
-msgstr ""
-"如要列印導航指引：%1$s返回地圖。%2$s選取你想列印的路線。%3$s按一下「列印」圖"
-"示。%4$s"
+msgstr "如要列印導航指引：%1$s返回地圖。%2$s選取你想列印的路線。%3$s按一下「列印」圖示。%4$s"
 
 # smartling.placeholder_format=C
 #. Explains where the user can find their recovery code. Figma frame 3703-44420.
@@ -19895,9 +19709,7 @@ msgid ""
 "To restore your synced data, you'll need the Recovery Code you saved when "
 "you first set up Sync. This code may have been saved as a PDF on the device "
 "you originally used to set up Sync."
-msgstr ""
-"若要恢復同步資料，請在第一次設定同步時儲存的恢復碼。此代碼可能已以 PDF 格式儲"
-"存在您最初用於設定同步的裝置上。"
+msgstr "若要恢復同步資料，請在第一次設定同步時儲存的恢復碼。此代碼可能已以 PDF 格式儲存在您最初用於設定同步的裝置上。"
 
 # smartling.placeholder_format=C
 #. Body text explaining that the user needs to update their DDG browser before migration can proceed.
@@ -19905,9 +19717,7 @@ msgctxt "duckai_migration"
 msgid ""
 "To transfer your chat history to Duck.ai, please update your DuckDuckGo "
 "browser to the latest version and try again."
-msgstr ""
-"欲將你的聊天紀錄轉移至 Duck.ai，請將你的 DuckDuckGo 瀏覽器更新至最新版本並再"
-"試一次。"
+msgstr "欲將你的聊天紀錄轉移至 Duck.ai，請將你的 DuckDuckGo 瀏覽器更新至最新版本並再試一次。"
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
@@ -20150,8 +19960,7 @@ msgctxt "Full sentence for translating text"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr ""
-"將這段英文句子翻譯成法語：“How do I get to the nearest movie theatre？”"
+msgstr "將這段英文句子翻譯成法語：“How do I get to the nearest movie theatre？”"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for translating a sentence into another language. Translate the whole sentence and please use target language instead of 'English' and modify the sentence to translate into 'English' instead of 'French'. Example: 'Translate this {target language} sentence into English: “How do I get to the nearest movie theatre?”'
@@ -20159,20 +19968,19 @@ msgctxt "Full sentence for translating text prompt"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr ""
-"將這段英文句子翻譯成中文：“How do I get to the nearest movie theatre？”"
+msgstr "將這段英文句子翻譯成中文：“How do I get to the nearest movie theatre？”"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Translate this page"
-msgstr ""
+msgstr "翻譯此頁面"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
 msgctxt "Page suggestion prompt"
 msgid "Translate this page into %s."
-msgstr ""
+msgstr "將此頁面翻譯為 %1$s。"
 
 # smartling.placeholder_format=C
 #. Placeholder text for a region that will display translated text.
@@ -20319,7 +20127,7 @@ msgstr "免費試用"
 #. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
 msgctxt "settings"
 msgid "Try It Now"
-msgstr ""
+msgstr "立即試用"
 
 # smartling.placeholder_format=C
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -20559,7 +20367,7 @@ msgctxt "settings"
 msgid ""
 "Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
-msgstr ""
+msgstr "想要停用 AI 功能嗎？ 安裝 %1$sDuckDuckGo No AI%2$s 搜尋擴充套件以儲存你的設定。 %3$s瞭解更多%4$s"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -20567,7 +20375,7 @@ msgctxt "settings"
 msgid ""
 "Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
-msgstr ""
+msgstr "想要停用 AI 功能嗎？ 切換至 %1$sDuckDuckGo No AI%2$s 搜尋擴充功能以儲存你的設定。 %3$s瞭解更多%4$s"
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -20737,9 +20545,7 @@ msgctxt "settings"
 msgid ""
 "Types out DuckAssist answers as they're generated. Turning this off may "
 "result in a short delay between a search and the answer being displayed."
-msgstr ""
-"在產生時輸入 DuckAssist 答案。關閉此功能可能會導致搜尋與顯示答案之間的短暫延"
-"遲。"
+msgstr "在產生時輸入 DuckAssist 答案。關閉此功能可能會導致搜尋與顯示答案之間的短暫延遲。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -20990,9 +20796,7 @@ msgctxt "Description of the modal to upgrade to Pro"
 msgid ""
 "Unlock %s, higher AI reasoning, and 2x higher usage limits than the Plus "
 "plan by upgrading to Pro."
-msgstr ""
-"透過升級至 Pro，解鎖 %1$s、比 Plus 方案更高的 AI 推理能力，以及 2 倍於 Plus "
-"方案的使用上限。"
+msgstr "透過升級至 Pro，解鎖 %1$s、比 Plus 方案更高的 AI 推理能力，以及 2 倍於 Plus 方案的使用上限。"
 
 # smartling.placeholder_format=C
 #. Title for the subscription promo shown in the SERP sidemenu.
@@ -21307,7 +21111,7 @@ msgstr "烏拉圭"
 #. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
 msgctxt "Navigation label on the Duck.ai settings page"
 msgid "Usage"
-msgstr ""
+msgstr "使用情況"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -21350,9 +21154,7 @@ msgctxt "duckai_seo"
 msgid ""
 "Use ChatGPT, Claude, and other AIs, privately. Protect chats from hackers, "
 "scammers, and companies. Keep info confidential. Free. No account required."
-msgstr ""
-"私下使用 ChatGPT、Claude 及其他 AI。保護聊天內容，防止駭客、詐騙者和公司的侵"
-"害。對資訊保密。免費。不需要帳戶。"
+msgstr "私下使用 ChatGPT、Claude 及其他 AI。保護聊天內容，防止駭客、詐騙者和公司的侵害。對資訊保密。免費。不需要帳戶。"
 
 # smartling.placeholder_format=C
 #. Header above instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -21542,8 +21344,7 @@ msgctxt "Ads GDPR, internal use only. Do not change"
 msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Microsoft's ad network"
-msgstr ""
-"DuckDuckGo 會保護你在觀看廣告時的隱私。點擊廣告則由 Microsoft 的廣告網路管理"
+msgstr "DuckDuckGo 會保護你在觀看廣告時的隱私。點擊廣告則由 Microsoft 的廣告網路管理"
 
 # smartling.placeholder_format=C
 #. Information about TripAdvisor ads for DuckDuckGo's users. This appears in a tooltip.
@@ -21551,9 +21352,7 @@ msgctxt "Single Place Hotel Offers Module"
 msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "TripAdvisor's ad network."
-msgstr ""
-"DuckDuckGo 會保護你在觀看廣告時的隱私。點擊廣告則由 TripAdvisor 的廣告網路管"
-"理。"
+msgstr "DuckDuckGo 會保護你在觀看廣告時的隱私。點擊廣告則由 TripAdvisor 的廣告網路管理。"
 
 # smartling.placeholder_format=C
 msgid "Virgin Islands"
@@ -21595,8 +21394,8 @@ msgid ""
 "Visit Duck.ai in your other browser and go to %sDuck.ai Settings%s > %sSync "
 "& Backup%s > %sManage%s then select %sSync With Another Device%s."
 msgstr ""
-"請用其他瀏覽器造訪 Duck.ai，並前往 %1$sDuck.ai 設定%2$s > %3$sSync & "
-"Backup%4$s > %5$s管理%6$s，再選取%7$s與其他裝置同步%8$s。"
+"請用其他瀏覽器造訪 Duck.ai，並前往 %1$sDuck.ai 設定%2$s > %3$sSync & Backup%4$s > "
+"%5$s管理%6$s，再選取%7$s與其他裝置同步%8$s。"
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -21606,8 +21405,8 @@ msgid ""
 "On” under Sync & Backup and select “Sync With Another Device”. Or scan the "
 "QR on your Recovery PDF."
 msgstr ""
-"在您的其他瀏覽器中造訪 Duck.ai 並開啟 Duck.ai 設定。在「Sync & Backup」下選取"
-"「開啟」，然後選取「與另一裝置同步」。或掃描您的恢復 PDF 上的二維碼。"
+"在您的其他瀏覽器中造訪 Duck.ai 並開啟 Duck.ai 設定。在「Sync & "
+"Backup」下選取「開啟」，然後選取「與另一裝置同步」。或掃描您的恢復 PDF 上的二維碼。"
 
 # smartling.placeholder_format=C
 #. Shared body copy for every screen in the Sync Another Device flow (QR display, camera scan, camera-unavailable fallback, manual entry). Bold tags wrap navigation breadcrumbs. Render with <Translate /> so the HTML is interpreted; plain `translate()` will trip the html-string warning.
@@ -21617,8 +21416,8 @@ msgid ""
 "ai Settings%s > %sSync & Backup%s > %sManage%s then select %sSync With "
 "Another Device%s."
 msgstr ""
-"請用其他瀏覽器或 DuckDuckGo 應用程式造訪 Duck.ai，並前往 %1$sDuck.ai 設"
-"定%2$s > %3$sSync & Backup%4$s > %5$s管理%6$s，再選取%7$s與其他裝置同步%8$s。"
+"請用其他瀏覽器或 DuckDuckGo 應用程式造訪 Duck.ai，並前往 %1$sDuck.ai 設定%2$s > %3$sSync & "
+"Backup%4$s > %5$s管理%6$s，再選取%7$s與其他裝置同步%8$s。"
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -21628,9 +21427,8 @@ msgid ""
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
 msgstr ""
-"使用其他瀏覽器或 DuckDuckGo 應用程式造訪 Duck.ai，然後開啟 Duck.ai 設定。在"
-"「Sync & Backup」下選取「開啟」，然後選取「與另一裝置同步」。或掃描您的恢復 "
-"PDF 上的二維碼。"
+"使用其他瀏覽器或 DuckDuckGo 應用程式造訪 Duck.ai，然後開啟 Duck.ai 設定。在「Sync & "
+"Backup」下選取「開啟」，然後選取「與另一裝置同步」。或掃描您的恢復 PDF 上的二維碼。"
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -21746,7 +21544,7 @@ msgstr "威爾斯"
 #. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Walk me through the steps"
-msgstr ""
+msgstr "帶我逐步操作"
 
 # smartling.placeholder_format=C
 #. Label for walking directions on a map.
@@ -21825,9 +21623,7 @@ msgstr "在 Duck Player 中觀看"
 msgid ""
 "Watch in Duck Player to block personalized ads on YouTube and prevent your "
 "viewing activity from influencing YouTube recommendations."
-msgstr ""
-"在 Duck Player 中觀看，阻擋 YouTube 上的個人化廣告，避免觀看體驗受 YouTube 推"
-"播干擾。"
+msgstr "在 Duck Player 中觀看，阻擋 YouTube 上的個人化廣告，避免觀看體驗受 YouTube 推播干擾。"
 
 # smartling.placeholder_format=C
 #. A button that takes a user to another site in order to watch a video. The placeholder is the name of the video site. For example: 'Watch on Vimeo'
@@ -21847,8 +21643,8 @@ msgid ""
 "independent company and has no relationship with YouTube, where most videos "
 "are hosted."
 msgstr ""
-"在此處觀看影片即代表託管影片的網站能夠追蹤您，因為我們必須從那邊串流傳輸內"
-"容。DuckDuckGo 是一間獨立公司，與託管大多數影片的 YouTube 沒有任何關係。"
+"在此處觀看影片即代表託管影片的網站能夠追蹤您，因為我們必須從那邊串流傳輸內容。DuckDuckGo 是一間獨立公司，與託管大多數影片的 YouTube "
+"沒有任何關係。"
 
 # smartling.placeholder_format=C
 #. Heading for the highlight card explaining anonymized prompt delivery.
@@ -21871,7 +21667,7 @@ msgid ""
 "We can only fix what we can see. To report a harmful or illegal response, "
 "please share this conversation with DuckDuckGo so we can investigate and "
 "address the issue."
-msgstr ""
+msgstr "我們必須先察覺問題，才能修正問題。若要檢舉有害或非法的回覆，請與 DuckDuckGo 分享此對話，以便我們調查並處理該問題。"
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -21882,9 +21678,7 @@ msgid ""
 "We can only fix what we can see. To report a harmful or illegal response, "
 "please share your prompt and response so we can investigate and address the "
 "issue."
-msgstr ""
-"我們必須先察覺問題，才能修正問題。若要檢舉有害或非法的回覆，請與我們分享您的"
-"提示詞與回覆內容，以便我們調查並處理該問題。"
+msgstr "我們必須先察覺問題，才能修正問題。若要檢舉有害或非法的回覆，請與我們分享您的提示詞與回覆內容，以便我們調查並處理該問題。"
 
 # smartling.placeholder_format=C
 #. Explains how location service is used to show users search results near their current location.
@@ -21924,8 +21718,7 @@ msgstr "我們不會儲存你的個人資訊。"
 msgid ""
 "We don't store your personal info. We don't follow you around with ads. We "
 "don't track you. Ever."
-msgstr ""
-"我們不會儲存你的個人資訊。我們不會用廣告到處煩你。我們不會追蹤你。絕對不會。"
+msgstr "我們不會儲存你的個人資訊。我們不會用廣告到處煩你。我們不會追蹤你。絕對不會。"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -21946,8 +21739,7 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what convinced you "
 "to try us out today:"
-msgstr ""
-"本站不追蹤任何用戶，請告訴我們為何你願意試用我們的服務，以讓我們不斷完善："
+msgstr "本站不追蹤任何用戶，請告訴我們為何你願意試用我們的服務，以讓我們不斷完善："
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -21986,9 +21778,7 @@ msgctxt "homepage onboarding"
 msgid ""
 "We don’t store your search history. We therefore have nothing to sell to "
 "advertisers that track you across the Internet."
-msgstr ""
-"我們不會儲存你的搜尋紀錄。因此，我們沒有東西能夠賣給網路上那些追蹤你的廣告"
-"商。"
+msgstr "我們不會儲存你的搜尋紀錄。因此，我們沒有東西能夠賣給網路上那些追蹤你的廣告商。"
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -22013,9 +21803,7 @@ msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
 "We have agreements with all AI providers to ensure your chats aren't used to "
 "train AIs."
-msgstr ""
-"我們與所有人工智慧提供者都簽訂了協議，以確保你的聊天記錄不會用於訓練人工智"
-"慧。"
+msgstr "我們與所有人工智慧提供者都簽訂了協議，以確保你的聊天記錄不會用於訓練人工智慧。"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -22047,9 +21835,7 @@ msgctxt "precise_user_location"
 msgid ""
 "We only use your anonymous location to deliver better results, closer to "
 "you. You can always change your mind later."
-msgstr ""
-"我們僅會將你的匿名位置用於提供更優質、離你更近的結果。你之後可以隨時改變主"
-"意。"
+msgstr "我們僅會將你的匿名位置用於提供更優質、離你更近的結果。你之後可以隨時改變主意。"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -22075,9 +21861,7 @@ msgid ""
 "We use feedback like this to improve DuckDuckGo. Suggestions will be "
 "incorporated at the discretion of %s. Corrections may not show up in results "
 "right away."
-msgstr ""
-"我們運用這樣的回饋來完善DuckDuckGo。%1$s將視情況採納建議。修改內容可能不會立"
-"刻出現。"
+msgstr "我們運用這樣的回饋來完善DuckDuckGo。%1$s將視情況採納建議。修改內容可能不會立刻出現。"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -22235,9 +22019,7 @@ msgctxt "Welcome message in chat"
 msgid ""
 "Welcome to Duck.ai! All of your chats here are private, anonymized by us and "
 "not used to train AI models."
-msgstr ""
-"歡迎來到 Duck.ai！您在這裡的所有聊天內容都是私密的，我們會將其匿名化，且不會"
-"用來訓練人工智慧模型。"
+msgstr "歡迎來到 Duck.ai！您在這裡的所有聊天內容都是私密的，我們會將其匿名化，且不會用來訓練人工智慧模型。"
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened.
@@ -22245,9 +22027,7 @@ msgctxt "Welcome message in chat"
 msgid ""
 "Welcome to DuckDuckGo AI Chat! All of your chats here are private, "
 "anonymized by us and not used to train AI models."
-msgstr ""
-"歡迎來到 DuckDuckGo AI Chat！您在這裡的所有聊天內容都是私密的，我們會將其匿名"
-"化，且不會用來訓練人工智慧模型。"
+msgstr "歡迎來到 DuckDuckGo AI Chat！您在這裡的所有聊天內容都是私密的，我們會將其匿名化，且不會用來訓練人工智慧模型。"
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened. Example: 'Welcome to DuckDuckGo AI Chat! This chat session is powered by OpenAI’s GPT-3. All of your chats here are private, and are never stored by DuckDuckGo or used to train AI models.'
@@ -22257,8 +22037,8 @@ msgid ""
 "of your chats here are private, and are never stored by DuckDuckGo or used "
 "to train AI models."
 msgstr ""
-"歡迎來到 DuckDuckGo AI Chat！此聊天會話由 %1$s 的 %2$s 提供技術支援。 您在這"
-"裡的所有聊天內容都是私密的，且永遠不會被 DuckDuckGo 儲存或用來訓練 AI 模型。"
+"歡迎來到 DuckDuckGo AI Chat！此聊天會話由 %1$s 的 %2$s 提供技術支援。 您在這裡的所有聊天內容都是私密的，且永遠不會被 "
+"DuckDuckGo 儲存或用來訓練 AI 模型。"
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -22384,106 +22164,105 @@ msgid ""
 "easy to understand for people with or without much AI, or technical, "
 "experience."
 msgstr ""
-"下載 DuckDuckGo 瀏覽器對於有興趣使用 Duck.ai 的人有哪些好處？僅參考官方 "
-"DuckDuckGo 來源。將回應分成清晰的部分，並以 Duck.ai 整合和隱私保護為重點。對"
-"於具有或沒有太多 AI 或技術經驗的人來說，保持內容相當簡短、簡單且易於理解。"
+"下載 DuckDuckGo 瀏覽器對於有興趣使用 Duck.ai 的人有哪些好處？僅參考官方 DuckDuckGo 來源。將回應分成清晰的部分，並以 "
+"Duck.ai 整合和隱私保護為重點。對於具有或沒有太多 AI 或技術經驗的人來說，保持內容相當簡短、簡單且易於理解。"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the counterarguments?"
-msgstr ""
+msgstr "有哪些反對意見？"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the hours & location?"
-msgstr ""
+msgstr "營業時間與地點為何？"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key contributions of this paper?"
-msgstr ""
+msgstr "這篇論文的主要貢獻是什麼？"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key contributions?"
-msgstr ""
+msgstr "主要貢獻是什麼？"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key details?"
-msgstr ""
+msgstr "重點詳情是什麼？"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key points covered in this video?"
-msgstr ""
+msgstr "這部影片涵蓋了哪些重點？"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key points?"
-msgstr ""
+msgstr "重點是什麼？"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key takeaways from this article?"
-msgstr ""
+msgstr "這篇文章的重點是什麼？"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the key takeaways?"
-msgstr ""
+msgstr "重點是什麼？"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key things I will learn from this course?"
-msgstr ""
+msgstr "我從這門課程中會學到哪些重點？"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the main counterarguments or criticisms of this?"
-msgstr ""
+msgstr "對此有哪些主要的反對意見或批評？"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the main questions this page answers?"
-msgstr ""
+msgstr "此頁面回答了哪些主要問題？"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the must-try dishes here?"
-msgstr ""
+msgstr "這裡有哪些必嚐料理？"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid ""
 "What are the opening hours, location, and contact details for this place?"
-msgstr ""
+msgstr "這個地方的營業時間、地點和聯絡資訊是什麼？"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the pros and cons of this product?"
-msgstr ""
+msgstr "這項產品的優缺點是什麼？"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What are the pros and cons?"
-msgstr ""
+msgstr "優缺點是什麼？"
 
 # smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
@@ -22589,7 +22368,7 @@ msgstr "在醫學文章中，心房一詞的含義是？"
 #. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What does this answer?"
-msgstr ""
+msgstr "這回答了什麼？"
 
 # smartling.placeholder_format=C
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
@@ -22607,7 +22386,7 @@ msgstr "甚麼資訊會被儲存？"
 #. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What interview questions might come up for this role?"
-msgstr ""
+msgstr "這個職位可能會問到哪些面試問題？"
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -22627,7 +22406,7 @@ msgstr "阿爾巴尼亞的首都是哪座城市？"
 #. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What is the overall verdict and rating for this?"
-msgstr ""
+msgstr "這項目的整體評價和評分如何？"
 
 # smartling.placeholder_format=C
 #. Link to a page with additional information.
@@ -22655,7 +22434,7 @@ msgstr "評論："
 #. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What should I order?"
-msgstr ""
+msgstr "我該點什麼？"
 
 # smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
@@ -22673,13 +22452,13 @@ msgstr "回覆有什麼問題？(選填)"
 #. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What will I learn?"
-msgstr ""
+msgstr "我會學到什麼？"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What will I need?"
-msgstr ""
+msgstr "我需要準備什麼？"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -22702,7 +22481,7 @@ msgstr "最新消息"
 #. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "What's the verdict?"
-msgstr ""
+msgstr "結論是什麼？"
 
 # smartling.placeholder_format=C
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -22756,7 +22535,7 @@ msgstr "缺少哪些功能？（選填）"
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Which features are missing? (optional)"
-msgstr ""
+msgstr "缺少哪些功能？(選填)"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
@@ -22778,13 +22557,13 @@ msgstr "關於我們"
 #. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Who are the main cast and crew, and what else are they known for?"
-msgstr ""
+msgstr "主要演員和製作團隊有哪些人，他們還以哪些作品聞名？"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
 msgctxt "Page suggestion chip label"
 msgid "Who is this person?"
-msgstr ""
+msgstr "這人是誰？"
 
 # smartling.placeholder_format=C
 #. Header above a collection of privacy-related links.
@@ -23226,8 +23005,7 @@ msgstr "你最多可以附加 %1$s 個文字選擇。"
 msgid ""
 "You can change how frequently you see Search Assist, or turn it off "
 "entirely, in %sSearch Settings%s."
-msgstr ""
-"你可以在 %1$s搜尋設定%2$s 中變更 Search Assist 的顯示頻率，或將其完全關閉。"
+msgstr "你可以在 %1$s搜尋設定%2$s 中變更 Search Assist 的顯示頻率，或將其完全關閉。"
 
 # smartling.placeholder_format=C
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
@@ -23241,8 +23019,7 @@ msgctxt "cloudsave"
 msgid ""
 "You can do this by saving your settings under a different passphrase, "
 "optionally deleting the first set."
-msgstr ""
-"你可以將你的設定以另一通關密語儲存，你亦可同時刪除以舊通關密語儲存的設定。"
+msgstr "你可以將你的設定以另一通關密語儲存，你亦可同時刪除以舊通關密語儲存的設定。"
 
 # smartling.placeholder_format=C
 #. Prefix for filename location sentence.
@@ -23377,9 +23154,7 @@ msgctxt "Description of the post-upgrade success modal"
 msgid ""
 "You now have access to %s, higher AI reasoning, and 2x higher usage limits "
 "than Plus."
-msgstr ""
-"您現在已獲得 %1$s 的存取權限，具備更高階的 AI 推理能力，並享有比 Plus 方案高"
-"出 2 倍的使用上限。"
+msgstr "您現在已獲得 %1$s 的存取權限，具備更高階的 AI 推理能力，並享有比 Plus 方案高出 2 倍的使用上限。"
 
 # smartling.placeholder_format=C
 #. Description text for the welcome modal displayed after the user subscribes to DuckDuckGo.
@@ -23387,9 +23162,7 @@ msgctxt "Description text for the subscription welcome modal"
 msgid ""
 "You now have access to advanced AI models. You can access the VPN and other "
 "DuckDuckGo subscription protections in the DuckDuckGo browser."
-msgstr ""
-"你現在可以使用進階的 AI 模型。你可以在 DuckDuckGo 瀏覽器中存取 VPN 和其他 "
-"DuckDuckGo 訂閱保護功能。"
+msgstr "你現在可以使用進階的 AI 模型。你可以在 DuckDuckGo 瀏覽器中存取 VPN 和其他 DuckDuckGo 訂閱保護功能。"
 
 # smartling.placeholder_format=C
 #. Welcome message that appears after the DuckDuckGo extension is installed.
@@ -23410,9 +23183,7 @@ msgid ""
 "You will no longer be able to access your saved chats from this browser. The "
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
-msgstr ""
-"您將無法再從此瀏覽器存取已儲存的聊天記錄。最近的 30 個聊天記錄仍將保留在本地"
-"儲存空間中。這不會刪除您在加密伺服器上的聊天記錄。"
+msgstr "您將無法再從此瀏覽器存取已儲存的聊天記錄。最近的 30 個聊天記錄仍將保留在本地儲存空間中。這不會刪除您在加密伺服器上的聊天記錄。"
 
 # smartling.placeholder_format=C
 #. Explains that turning off disconnects this browser only; the last 30 chats stay in local storage and the encrypted server backup is not deleted.
@@ -23421,9 +23192,7 @@ msgid ""
 "You will no longer be able to access your saved chats from this browser. The "
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
-msgstr ""
-"您將無法再從此瀏覽器存取已儲存的聊天記錄。最近的 30 個聊天記錄仍將保留在本地"
-"儲存空間中。這不會刪除您在加密伺服器上的聊天記錄。"
+msgstr "您將無法再從此瀏覽器存取已儲存的聊天記錄。最近的 30 個聊天記錄仍將保留在本地儲存空間中。這不會刪除您在加密伺服器上的聊天記錄。"
 
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
@@ -23444,9 +23213,7 @@ msgctxt "welcome message eu search preference android"
 msgid ""
 "You're now searching privately in Chrome. Use our app instead of Chrome to "
 "browse privately too. It’s already installed and can:"
-msgstr ""
-"你目前正在Chrome進行私密搜尋。不用Chrome，在我們的應用程式中也可以進行隱身瀏"
-"覽。應用程式已經安裝完畢，而且可以："
+msgstr "你目前正在Chrome進行私密搜尋。不用Chrome，在我們的應用程式中也可以進行隱身瀏覽。應用程式已經安裝完畢，而且可以："
 
 # smartling.placeholder_format=C
 #. Confirmation message that appears after the DuckDuckGo browser extension is installed.
@@ -23527,9 +23294,7 @@ msgctxt "Sync file storage limit modal description"
 msgid ""
 "You've run out of Sync & Backup storage for Duck.ai chats with attachments. "
 "Delete the %s oldest chats to resume Sync. Pinned chats will not be deleted."
-msgstr ""
-"您 Duck.ai 聊天 (含附件) 的 Sync & Backup 儲存空間已用完。刪除 %1$s 則最舊的"
-"聊天記錄以恢復同步。置頂聊天不會刪除。"
+msgstr "您 Duck.ai 聊天 (含附件) 的 Sync & Backup 儲存空間已用完。刪除 %1$s 則最舊的聊天記錄以恢復同步。置頂聊天不會刪除。"
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -23538,9 +23303,7 @@ msgid ""
 "You've run out of Sync & Backup storage for Duck.ai chats. Delete the %s "
 "oldest chats with attachments to resume Sync. Pinned chats will not be "
 "deleted."
-msgstr ""
-"您已用完 Duck.ai 聊天記錄的 Sync & Backup 儲存空間。刪除 %1$s 則最舊的含附件"
-"聊天記錄以恢復同步。置頂聊天不會刪除。"
+msgstr "您已用完 Duck.ai 聊天記錄的 Sync & Backup 儲存空間。刪除 %1$s 則最舊的含附件聊天記錄以恢復同步。置頂聊天不會刪除。"
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the sync storage limit.
@@ -23553,9 +23316,7 @@ msgstr "你的儲存空間已用完"
 msgid ""
 "YouTube (owned by Google) does not let you watch videos anonymously. As "
 "such, watching YouTube videos here will be tracked by YouTube/Google."
-msgstr ""
-"YouTube(Google所擁有的公司)不允許匿名看影片。觀看YouTube影片還是會被Youtube/"
-"Google追蹤。"
+msgstr "YouTube(Google所擁有的公司)不允許匿名看影片。觀看YouTube影片還是會被Youtube/Google追蹤。"
 
 # smartling.placeholder_format=C
 #. Label for a privacy disclaimer related to YouTube videos
@@ -23598,9 +23359,7 @@ msgid ""
 "Your backup will be deleted from DuckDuckGo's server. All devices will be "
 "disconnected from sync. Your %s most recent chats will be available in local "
 "storage on these browsers:"
-msgstr ""
-"您的備份將從 DuckDuckGo 的伺服器中刪除。所有裝置都將中斷同步。在以下瀏覽器"
-"中，您最近的 %1$s 筆聊天記錄將保存在本機儲存空間中："
+msgstr "您的備份將從 DuckDuckGo 的伺服器中刪除。所有裝置都將中斷同步。在以下瀏覽器中，您最近的 %1$s 筆聊天記錄將保存在本機儲存空間中："
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list.
@@ -23609,9 +23368,7 @@ msgid ""
 "Your backup will be deleted from DuckDuckGo's server. All devices will be "
 "disconnected from sync. Your 100 most recent chats will be available in "
 "local storage on these browsers:"
-msgstr ""
-"您的備份將從 DuckDuckGo 的伺服器中刪除。所有裝置都將中斷同步。在以下瀏覽器"
-"中，您最近的 100 筆聊天記錄將保存在本機儲存空間中："
+msgstr "您的備份將從 DuckDuckGo 的伺服器中刪除。所有裝置都將中斷同步。在以下瀏覽器中，您最近的 100 筆聊天記錄將保存在本機儲存空間中："
 
 # smartling.placeholder_format=C
 #. List item indicating that a site exclusion filter is currently active for the search
@@ -23675,16 +23432,14 @@ msgstr "您的聊天內容是私密的，且絕不會用於訓練 AI 模型"
 msgctxt "Active Privacy protection description"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
-msgstr ""
-"您的聊天內容是私密的，我們會對其進行匿名處理，且不會用來訓練人工智慧模型。"
+msgstr "您的聊天內容是私密的，我們會對其進行匿名處理，且不會用來訓練人工智慧模型。"
 
 # smartling.placeholder_format=C
 #. Text explaining that user chats are private and not used for AI (Artificial Intelligence) training.
 msgctxt "Body text for privacy protection modal"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
-msgstr ""
-"您的聊天內容是私密的，我們會對其進行匿名處理，且不會用來訓練人工智慧模型。"
+msgstr "您的聊天內容是私密的，我們會對其進行匿名處理，且不會用來訓練人工智慧模型。"
 
 # smartling.placeholder_format=C
 #. Text for a menu item that describes the privacy protection feature.
@@ -23712,9 +23467,7 @@ msgctxt "duckai_migration"
 msgid ""
 "Your chats are still private, anonymized by us, and not used to train AI "
 "models. Follow these steps to keep your chat history."
-msgstr ""
-"您的聊天內容是私密的，我們會進行匿名處理，且不會用來訓練 AI 模型。請依照這些"
-"步驟保留您的聊天記錄。"
+msgstr "您的聊天內容是私密的，我們會進行匿名處理，且不會用來訓練 AI 模型。請依照這些步驟保留您的聊天記錄。"
 
 # smartling.placeholder_format=C
 #. Body shown after import completes.
@@ -23753,8 +23506,7 @@ msgctxt "newsletter email collection"
 msgid ""
 "Your email address will not be shared, %sor associated with anonymous "
 "searches. [%sExample message%s]"
-msgstr ""
-"你的電子信箱將不會被公開分享，%1$s或與匿名搜尋有任何關聯。[%2$s範例訊息%3$s]"
+msgstr "你的電子信箱將不會被公開分享，%1$s或與匿名搜尋有任何關聯。[%2$s範例訊息%3$s]"
 
 # smartling.placeholder_format=C
 #. A prompt for the user to provide feedback on the third party map app directions experience
@@ -23796,10 +23548,7 @@ msgid ""
 "known as %sSHA-2%s. Only the key and associated settings file leave your "
 "browser. We save the settings file using the key as the name. DuckDuckGo "
 "never knows your passphrase."
-msgstr ""
-"我們將使用%1$sSHA-2%2$s安全雜湊演算法，根據你的通關密語產生一組512位的金鑰。"
-"只有金鑰及其相關設定檔案會傳至你的瀏覽器之外。我們將以該金鑰為檔名儲存設定檔"
-"案。DuckDuckGo不會知道你的通關密語。"
+msgstr "我們將使用%1$sSHA-2%2$s安全雜湊演算法，根據你的通關密語產生一組512位的金鑰。只有金鑰及其相關設定檔案會傳至你的瀏覽器之外。我們將以該金鑰為檔名儲存設定檔案。DuckDuckGo不會知道你的通關密語。"
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -23813,9 +23562,7 @@ msgid ""
 "Your prompts are relayed through DuckDuckGo servers and stripped of "
 "personally identifiable metadata, so model providers can't tie your "
 "conversations back to you."
-msgstr ""
-"你的提示會透過 DuckDuckGo 伺服器轉發，並移除個人識別的元資料，因此模型提供者"
-"無法將你的對話與你連結起來。"
+msgstr "你的提示會透過 DuckDuckGo 伺服器轉發，並移除個人識別的元資料，因此模型提供者無法將你的對話與你連結起來。"
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -23870,9 +23617,7 @@ msgctxt "welcome message eu search preference android"
 msgid ""
 "You’re now searching privately in Chrome. Use our browser instead of Chrome "
 "for more protection. It’s already installed and can:"
-msgstr ""
-"你目前正在 Chrome 使用隱私搜尋。使用我們的瀏覽器而非 Chrome，如此一來即可取得"
-"更全面的保護。應用程式已經安裝完畢，而且可以："
+msgstr "你目前正在 Chrome 使用隱私搜尋。使用我們的瀏覽器而非 Chrome，如此一來即可取得更全面的保護。應用程式已經安裝完畢，而且可以："
 
 # smartling.placeholder_format=C
 #. Displayed when the user has exceeded the maximum message size.
@@ -23888,8 +23633,7 @@ msgctxt "Error message for conversation limit"
 msgid ""
 "You’ve reached the maximum chat length in this conversation. Clear this "
 "conversation with the Fire Button to continue."
-msgstr ""
-"您已達到此對話的最長聊天長度。 使用「Fire Button」按鈕清除此對話以繼續。"
+msgstr "您已達到此對話的最長聊天長度。 使用「Fire Button」按鈕清除此對話以繼續。"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.

--- a/locales/zh_TW/LC_MESSAGES/duckduckgo.po
+++ b/locales/zh_TW/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: zh_TW\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -175,7 +175,9 @@ msgctxt "Error message when a Plus subscriber tries to use a Pro-only model"
 msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
-msgstr "%1$s 只適用於 Pro。在此瀏覽器中再次升級你的 DuckDuckGo 訂閱以繼續聊天，或切換至 Plus 或免費模式。"
+msgstr ""
+"%1$s 只適用於 Pro。在此瀏覽器中再次升級你的 DuckDuckGo 訂閱以繼續聊天，或切換"
+"至 Plus 或免費模式。"
 
 # smartling.placeholder_format=C
 #. Text for the disclaimer message that appears when a Plus subscriber tries to use a Pro-only model. %s is replaced with the model name. Example: Claude Opus 4.6 is only available with Pro. Upgrade your DuckDuckGo subscription in this browser again to continue the chat, or switch to a Plus or free model.
@@ -184,7 +186,9 @@ msgctxt ""
 msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
-msgstr "%1$s 只適用於 Pro。請在此瀏覽器中再次升級你的 DuckDuckGo 訂閱以繼續聊天，或切換至 Plus 或免費模式。"
+msgstr ""
+"%1$s 只適用於 Pro。請在此瀏覽器中再次升級你的 DuckDuckGo 訂閱以繼續聊天，或切"
+"換至 Plus 或免費模式。"
 
 # smartling.placeholder_format=C
 #. Displayed when an AI (Artificial Intelligence) chat model is temporarily unavailable. Example: 'GPT 4o is only available with a DuckDuckGo subscription.'
@@ -199,7 +203,9 @@ msgid ""
 "%s is only available with a DuckDuckGo subscription. Activate your "
 "subscription in this browser again to continue the chat, or switch to a free "
 "model."
-msgstr "%1$s 只有訂閱 DuckDuckGo 才能使用。在此瀏覽器中再次啟用你的訂閱以繼續聊天，或切換至免費模式。"
+msgstr ""
+"%1$s 只有訂閱 DuckDuckGo 才能使用。在此瀏覽器中再次啟用你的訂閱以繼續聊天，或"
+"切換至免費模式。"
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is temporarily unavailable. Example: 'GPT 3.5 Turbo is temporarily unavailable. Please switch to a different model or try again later.'
@@ -298,8 +304,8 @@ msgid ""
 "provider can see your prompts or the model’s responses, or save this chat on "
 "their servers."
 msgstr ""
-"%1$s 運行於受信任執行環境（Trusted Execution "
-"Environment）。這表示即使是模型提供商也無法看到您的提示或模型的回應，也不會在其伺服器上儲存此聊天。"
+"%1$s 運行於受信任執行環境（Trusted Execution Environment）。這表示即使是模型"
+"提供商也無法看到您的提示或模型的回應，也不會在其伺服器上儲存此聊天。"
 
 # smartling.placeholder_format=C
 #. Label shown in the batch selection toolbar when exactly one chat is selected. %s is replaced with 1. Use singular agreement where the language requires it.
@@ -378,7 +384,8 @@ msgctxt ""
 msgid ""
 "%s will be leaving Duck.ai in %s days (%s). After that, you can switch "
 "models to continue this chat."
-msgstr "%1$s 將在 %2$s 天後離開 Duck.ai (%3$s)。之後，您可以切換模型以繼續此聊天。"
+msgstr ""
+"%1$s 將在 %2$s 天後離開 Duck.ai (%3$s)。之後，您可以切換模型以繼續此聊天。"
 
 # smartling.placeholder_format=C
 #. Displayed in a saved chat when its AI model is about to be retired tomorrow. First placeholder is the friendly model name, second placeholder is the removal date formatted in the user's browser locale (e.g., 'June 15, 2026' in en-US). Singular-day form.
@@ -388,7 +395,8 @@ msgctxt ""
 msgid ""
 "%s will be leaving Duck.ai in 1 day (%s). After that, you can switch models "
 "to continue this chat."
-msgstr "%1$s 將在 1 天後 (%2$s) 離開 Duck.ai。之後，您可以切換模型以繼續此聊天。"
+msgstr ""
+"%1$s 將在 1 天後 (%2$s) 離開 Duck.ai。之後，您可以切換模型以繼續此聊天。"
 
 # smartling.placeholder_format=C
 #. Shown in a text selection chip when the selection contains multiple words. %s is replaced with the number of words, e.g. '142 words'.
@@ -416,7 +424,8 @@ msgctxt "install-duckduckgo"
 msgid ""
 "%sClick %sContinue To Installation%sClick %sAdd%sCheck %sAllow%s, then click "
 "%sOkay%s"
-msgstr "%1$s按%2$s繼續安裝%3$s按%4$s新增%5$s勾選%6$s允許%7$s，然後按%8$s確定%9$s"
+msgstr ""
+"%1$s按%2$s繼續安裝%3$s按%4$s新增%5$s勾選%6$s允許%7$s，然後按%8$s確定%9$s"
 
 # smartling.placeholder_format=C
 #. A button that reloads search results when an error occurs.
@@ -844,7 +853,8 @@ msgstr "客場戰績"
 msgid ""
 "A network issue is preventing Search Assist from generating an answer. "
 "Please check your connection and try again."
-msgstr "網路問題導致 Search Assist 無法生成答案。請檢查你的連線，接著再試一次。"
+msgstr ""
+"網路問題導致 Search Assist 無法生成答案。請檢查你的連線，接著再試一次。"
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of AI Chat is available and they need to refresh the page.
@@ -896,8 +906,9 @@ msgid ""
 "still access AI Chat when this setting is off by visiting %sduckduckgo.com/"
 "aichat%s."
 msgstr ""
-"AI Chat 能讓您與第三方 AI Chat 模型匿名對話。關閉此功能將隱藏 DuckDuckGo Search 上的 AI Chat "
-"功能。關閉此設定後，您仍可透過造訪 %1$sduckduckgo.com/aichat%2$s 使用 AI Chat 功能。"
+"AI Chat 能讓您與第三方 AI Chat 模型匿名對話。關閉此功能將隱藏 DuckDuckGo "
+"Search 上的 AI Chat 功能。關閉此設定後，您仍可透過造訪 %1$sduckduckgo.com/"
+"aichat%2$s 使用 AI Chat 功能。"
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -958,8 +969,9 @@ msgid ""
 "questions, which is our private AI-powered chat service that supports chat "
 "models from OpenAI, and Anthropic, and more."
 msgstr ""
-"AI 輔助的答案目前不直接支援後續問題。不過，我們也提供並經常連結到 %1$sDuck.ai%2$s 以回答後續問題，這是我們的私密 AI "
-"驅動的聊天服務，支援來自 OpenAI、Anthropic 等的聊天模型。"
+"AI 輔助的答案目前不直接支援後續問題。不過，我們也提供並經常連結到 %1$sDuck."
+"ai%2$s 以回答後續問題，這是我們的私密 AI 驅動的聊天服務，支援來自 OpenAI、"
+"Anthropic 等的聊天模型。"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has turned off AI features and will no longer see AI-assisted answers.
@@ -1390,6 +1402,12 @@ msgid "Address is incorrect"
 msgstr "地址錯誤"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Adjust the servings"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. as in multiple advertisements
 msgid "Ads"
 msgstr "廣告"
@@ -1601,6 +1619,14 @@ msgid "All chats are %sprivate%s"
 msgstr "所有聊天均為%1$s私密%2$s"
 
 # smartling.placeholder_format=C
+#. Paragraph in the Privacy & Terms section of the About & Legal page in Duck.ai settings, summarizing how chats are anonymized and are not stored or used to train chat models.
+msgctxt "Privacy & Terms section description on the Duck.ai settings page"
+msgid ""
+"All chats are anonymized by DuckDuckGo, and your conversations are not used "
+"to train chat models by DuckDuckGo or the model providers"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
 msgctxt "Privacy modal header in Duck.ai chat"
 msgid "All chats are private"
@@ -1644,7 +1670,9 @@ msgctxt "Body copy for the anonymized card in the How Duck.ai Works panel"
 msgid ""
 "All personal metadata (for example, your IP address) is removed before "
 "sending a chat to the AI provider."
-msgstr "在將聊天內容傳送給 AI 服務提供者之前，所有個人元資料（例如您的 IP 位址）都會被移除。"
+msgstr ""
+"在將聊天內容傳送給 AI 服務提供者之前，所有個人元資料（例如您的 IP 位址）都會"
+"被移除。"
 
 # smartling.placeholder_format=C
 #. A filter that shows search results from all countries.
@@ -1695,8 +1723,8 @@ msgid ""
 "sends AI-generated queries to a search engine with limited data retention. "
 "Prompts and responses with %s still have %szero provider visibility%s."
 msgstr ""
-"允許 %1$s 搜尋網頁，以調整相關提示的回應。僅將 AI 生成的查詢傳送到資料保留期限有限的搜尋引擎。%2$s "
-"的提示和回應仍具有%3$s零提供者可見度%4$s。"
+"允許 %1$s 搜尋網頁，以調整相關提示的回應。僅將 AI 生成的查詢傳送到資料保留期"
+"限有限的搜尋引擎。%2$s 的提示和回應仍具有%3$s零提供者可見度%4$s。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -1855,6 +1883,13 @@ msgstr "匿名存取熱門的 AI 模型，包括 %1$s、 %2$s以及開放原始�
 msgctxt "precise_user_location"
 msgid "Anonymous location enabled"
 msgstr "已啟用匿名位置"
+
+# smartling.placeholder_format=C
+msgctxt "settings"
+msgid ""
+"Anonymously generates answers for search queries based on web content. "
+"Choose how often you want it to appear, or disable it completely."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -2027,7 +2062,9 @@ msgctxt "Body text for disable recent chats confirmation modal"
 msgid ""
 "Are you sure you want to disable recent chats? This will also delete any "
 "recent chats that are currently saved."
-msgstr "你是否確定要停用「最近的聊天記錄」？這麽做的話，也會將最近儲存下來的所有聊天記錄一併刪除。"
+msgstr ""
+"你是否確定要停用「最近的聊天記錄」？這麽做的話，也會將最近儲存下來的所有聊天"
+"記錄一併刪除。"
 
 # smartling.placeholder_format=C
 #. Question asking user if they want to share the URL of the page they were on when giving feedback
@@ -2064,7 +2101,9 @@ msgstr "更新時間："
 msgid ""
 "As per our privacy policy, we do not collect or share any personal "
 "information ourselves. All of this privacy protection happens on your device."
-msgstr "根據我們的隱私政策規範，我們不會主動收集或分享任何個人資訊。這些隱私保護作業皆於你的裝置上進行。"
+msgstr ""
+"根據我們的隱私政策規範，我們不會主動收集或分享任何個人資訊。這些隱私保護作業"
+"皆於你的裝置上進行。"
 
 # smartling.placeholder_format=C
 #. A button to ask Duck.ai a question
@@ -2125,6 +2164,12 @@ msgstr "提出後續問題"
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse
 msgid "Ask a follow-up with Duck.ai"
 msgstr "請向 Duck.ai 提出後續問題"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
+msgctxt "Page suggestion chip label"
+msgid "Ask about this page"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title for the modal displayed to first-time sidebar users explaining the page context feature.
@@ -2188,9 +2233,10 @@ msgid ""
 "(shows more frequently on a wider range of searches). For now, AI-assisted "
 "answers are only available in the U.S. (English) region."
 msgstr ""
-"Assist 可匿名根據相關網頁內容的摘要，生成某些搜尋的 AI 輔助答案。您可以選擇想要 Assist 出現的頻率：從不 (從搜尋結果中完全移除 "
-"Assist 使用介面)、隨選 (僅在點按 Assist 按鈕後顯示)、有時 (僅在高度相關時顯示) 或經常 "
-"(在更廣泛的搜尋中更頻繁地顯示)。目前，AI 輔助答案僅在美國 (英文) 地區提供。"
+"Assist 可匿名根據相關網頁內容的摘要，生成某些搜尋的 AI 輔助答案。您可以選擇想"
+"要 Assist 出現的頻率：從不 (從搜尋結果中完全移除 Assist 使用介面)、隨選 (僅在"
+"點按 Assist 按鈕後顯示)、有時 (僅在高度相關時顯示) 或經常 (在更廣泛的搜尋中更"
+"頻繁地顯示)。目前，AI 輔助答案僅在美國 (英文) 地區提供。"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2202,8 +2248,10 @@ msgid ""
 "to remember that responses are auto-generated from cited sources and based "
 "on %scrawling the web%s."
 msgstr ""
-"Assist 是我們搜尋結果中的一項選用功能，能夠匿名產生由 AI "
-"協助的搜尋查詢答案。為了完成此任務，它將掃描網路以便查詢相關內容，接著使用人工智慧支援的自然語言技術，根據找到的相關資訊產生簡短的答案。重要的是要記住，回應是從引用的來源並根據%1$s搜耙網路%2$s自動產生的。"
+"Assist 是我們搜尋結果中的一項選用功能，能夠匿名產生由 AI 協助的搜尋查詢答案。"
+"為了完成此任務，它將掃描網路以便查詢相關內容，接著使用人工智慧支援的自然語言"
+"技術，根據找到的相關資訊產生簡短的答案。重要的是要記住，回應是從引用的來源並"
+"根據%1$s搜耙網路%2$s自動產生的。"
 
 # smartling.placeholder_format=C
 #. Title for the dropdown menu where users select the assistant's role. Example: 'Assistant role: Travel guide'
@@ -2365,7 +2413,9 @@ msgid ""
 "Automatically shows Assist for relevant searches. Assist can anonymously "
 "look up and summarize information in response to some searches. For now, "
 "Assist is only available in English regions."
-msgstr "自動顯示相關搜尋的 Assist 功能。Assist 能夠匿名搜尋與摘要資訊，以便回應某些搜尋結果。目前，Assist 僅供英語地區使用。"
+msgstr ""
+"自動顯示相關搜尋的 Assist 功能。Assist 能夠匿名搜尋與摘要資訊，以便回應某些搜"
+"尋結果。目前，Assist 僅供英語地區使用。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2374,8 +2424,8 @@ msgid ""
 "anonymously look up and summarize information in response to some searches. "
 "For now, DuckAssist is only available in English regions."
 msgstr ""
-"對相關的搜尋自動顯示 DuckAssist。DuckAssist 能夠匿名搜尋與摘要資訊，以便回應某些搜尋結果。目前，DuckAssist "
-"僅供說英文的地區使用。"
+"對相關的搜尋自動顯示 DuckAssist。DuckAssist 能夠匿名搜尋與摘要資訊，以便回應"
+"某些搜尋結果。目前，DuckAssist 僅供說英文的地區使用。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2523,6 +2573,12 @@ msgid "Barcode"
 msgstr "條碼"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Based on this page, is this course worth taking?"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Basic"
 msgstr "基本"
@@ -2561,6 +2617,14 @@ msgstr "擊球手"
 msgctxt "Assistant response placeholder"
 msgid "Before continuing..."
 msgstr "在繼續之前……"
+
+# smartling.placeholder_format=C
+#. Explains that before storing the report, DuckDuckGo will anonymize the conversation by removing PII like names, email addresses, and identifying metadata.
+msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
+msgid ""
+"Before storing this report, DuckDuckGo will anonymize your conversation by "
+"removing PII like names, email addresses, and identifying metadata."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -2879,6 +2943,12 @@ msgid "Break Points Won"
 msgstr "破發成功率"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Break this down into clear, numbered steps."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
 msgctxt "Weather IA"
 msgid "Breezy"
@@ -2934,20 +3004,26 @@ msgstr "瀏覽檔案"
 msgid ""
 "Browse as usual while we add privacy protection. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
-msgstr "享受隱私保護，只管放心瀏覽。我們將搜尋引擎、追蹤器封鎖程式以及加密執行程式組合為一項%1$s%2$s延伸模組%3$s。"
+msgstr ""
+"享受隱私保護，只管放心瀏覽。我們將搜尋引擎、追蹤器封鎖程式以及加密執行程式組"
+"合為一項%1$s%2$s延伸模組%3$s。"
 
 # smartling.placeholder_format=C
 msgid ""
 "Browse as usual, and we'll take care of the rest. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
-msgstr "你盡可放心瀏覽，其餘的交給我們處理。我們將搜尋引擎、追蹤器封鎖程式以及加密執行程式組合為一項%1$s%2$s延伸模組%3$s。"
+msgstr ""
+"你盡可放心瀏覽，其餘的交給我們處理。我們將搜尋引擎、追蹤器封鎖程式以及加密執"
+"行程式組合為一項%1$s%2$s延伸模組%3$s。"
 
 # smartling.placeholder_format=C
 msgid ""
 "Browse as usual, and we’ll take care of the rest. Get bundled private "
 "search, tracker blocking, and site encryption, all in one download, for "
 "%smajor browsers%s."
-msgstr "你盡可放心瀏覽，其餘的交給我們處理。只需下載一次，即可取得為%1$s主要瀏覽器%2$s設計的私密搜尋、追蹤器封鎖、網站加密等多合一功能。"
+msgstr ""
+"你盡可放心瀏覽，其餘的交給我們處理。只需下載一次，即可取得為%1$s主要瀏覽"
+"器%2$s設計的私密搜尋、追蹤器封鎖、網站加密等多合一功能。"
 
 # smartling.placeholder_format=C
 #. Header for a call to action to browse with the DuckDuckGo browser
@@ -3054,15 +3130,18 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"預設情況下，所有的設定都使用非個人的 Cookie 儲存（在你的瀏覽器）。你也可以使用匿名的 Could Save "
-"以更持久的方式來將設定儲存在雲端的遠端伺服器。所有可識別的個人資訊都不會儲存在雲端，你的通關密語也不會從瀏覽器洩漏。"
+"預設情況下，所有的設定都使用非個人的 Cookie 儲存（在你的瀏覽器）。你也可以使"
+"用匿名的 Could Save 以更持久的方式來將設定儲存在雲端的遠端伺服器。所有可識別"
+"的個人資訊都不會儲存在雲端，你的通關密語也不會從瀏覽器洩漏。"
 
 # smartling.placeholder_format=C
 #. Description for the consent highlight in the dictation consent modal. %s is replaced with a link to the help page.
 msgid ""
 "By enabling dictation, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
-msgstr "啟用語音輸入功能即表示您同意將您的語音資料傳送至 OpenAI 以使用此功能。在開始之前，請先查看我們的%1$s。"
+msgstr ""
+"啟用語音輸入功能即表示您同意將您的語音資料傳送至 OpenAI 以使用此功能。在開始"
+"之前，請先查看我們的%1$s。"
 
 # smartling.placeholder_format=C
 #. Description for the 'enable voice chat' section of the voice chat consent modal. Placeholder for the voice chat help page link and text. Example: 'By enabling voice chat, you consent to your voice data being sent to OpenAI for the use of this feature. See our voice chat help page before getting started.'
@@ -3070,7 +3149,9 @@ msgctxt "voice chat"
 msgid ""
 "By enabling voice chat, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
-msgstr "啟用語音聊天功能，即表示您同意將您的語音資料傳送至 OpenAI 以使用此功能。在開始之前，請先查看我們的%1$s。"
+msgstr ""
+"啟用語音聊天功能，即表示您同意將您的語音資料傳送至 OpenAI 以使用此功能。在開"
+"始之前，請先查看我們的%1$s。"
 
 # smartling.placeholder_format=C
 #. Golf leaderboard: player missed the cut
@@ -3316,6 +3397,12 @@ msgid "Cast"
 msgstr "演員"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Cast & Crew"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use casual tone in its responses.
 msgctxt "Tone option label for Casual"
 msgid "Casual"
@@ -3548,9 +3635,10 @@ msgid ""
 "DuckDuckGo Search. However, you can still access Chat when this setting is "
 "off by visiting %shttps://duck.ai%s directly."
 msgstr ""
-"聊天 (透過我們的 Duck.ai 服務) 能讓你與第三方 AI 聊天模型進行匿名對話，支援 OpenAI、Anthropic 等模型。關閉此設定將隱藏 "
-"DuckDuckGo Search 上的聊天按鈕和連結。不過，關閉此設定後，您仍可透過造訪 %1$shttps://duck.ai%2$s "
-"直接使用聊天功能。"
+"聊天 (透過我們的 Duck.ai 服務) 能讓你與第三方 AI 聊天模型進行匿名對話，支援 "
+"OpenAI、Anthropic 等模型。關閉此設定將隱藏 DuckDuckGo Search 上的聊天按鈕和連"
+"結。不過，關閉此設定後，您仍可透過造訪 %1$shttps://duck.ai%2$s 直接使用聊天功"
+"能。"
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -3674,7 +3762,9 @@ msgctxt "Description for Chat History feature"
 msgid ""
 "Chats are stored locally on your device instead of on DuckDuckGo servers or "
 "remote servers. Disabling chat history will delete pinned chats."
-msgstr "聊天記錄會儲存在你的裝置本機上，而非 DuckDuckGo 伺服器或其他遠端伺服器。停用聊天記錄將刪除置頂的聊天。"
+msgstr ""
+"聊天記錄會儲存在你的裝置本機上，而非 DuckDuckGo 伺服器或其他遠端伺服器。停用"
+"聊天記錄將刪除置頂的聊天。"
 
 # smartling.placeholder_format=C
 #. Text explaining how the Chat History feature stores the user's chats locally to their device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection. Also explains that disabling chat history will delete pinned chats.
@@ -3686,8 +3776,9 @@ msgid ""
 "history will delete pinned chats, and disable the temporary storage of new "
 "prompts and responses."
 msgstr ""
-"聊天記錄將儲存在你的裝置本地。新的提示和回應在傳送後會被加密並暫時儲存在 DuckDuckGo "
-"伺服器上，以便在你失去網路連線時協助恢復聊天。停用聊天紀錄會刪除置頂的聊天記錄，並停用新提示和回應的暫時儲存功能。"
+"聊天記錄將儲存在你的裝置本地。新的提示和回應在傳送後會被加密並暫時儲存在 "
+"DuckDuckGo 伺服器上，以便在你失去網路連線時協助恢復聊天。停用聊天紀錄會刪除置"
+"頂的聊天記錄，並停用新提示和回應的暫時儲存功能。"
 
 # smartling.placeholder_format=C
 #. Title shown above the body copy in the Duck.ai recent chats IndexedDB unavailable notice.
@@ -4040,7 +4131,9 @@ msgctxt "Information about the effect of clearing browser data on recent chats"
 msgid ""
 "Clearing browser data deletes chats. Some browsers may keep recent chats "
 "indefinitely or auto-delete them after 7+ days of no AI Chat use."
-msgstr "清除瀏覽器資料的話，也會將聊天記錄一併刪除。特定的瀏覽器可能會無限期保留最近的聊天記錄，或是在你超過 7 天未使用 AI Chat 後自動將聊天記錄刪除。"
+msgstr ""
+"清除瀏覽器資料的話，也會將聊天記錄一併刪除。特定的瀏覽器可能會無限期保留最近"
+"的聊天記錄，或是在你超過 7 天未使用 AI Chat 後自動將聊天記錄刪除。"
 
 # smartling.placeholder_format=C
 #. Text explaining what happens to recent chats when browser data is cleared.
@@ -4050,8 +4143,8 @@ msgid ""
 "indefinitely or auto-deleted after 7 days without using Duck.ai, depending "
 "on your browser."
 msgstr ""
-"清除瀏覽器資料的話，也會將最近的聊天記錄一併刪除。最近的聊天記錄可能會無限期保存，或在不使用 Duck.ai 的情況下 7 "
-"天後自動刪除，視您的瀏覽器而定。"
+"清除瀏覽器資料的話，也會將最近的聊天記錄一併刪除。最近的聊天記錄可能會無限期"
+"保存，或在不使用 Duck.ai 的情況下 7 天後自動刪除，視您的瀏覽器而定。"
 
 # smartling.placeholder_format=C
 #. Warning message shown on the Block domain success modal. Blocked sites are stored in localStorage which is cleared alongside cookies when users clear browser data. Followed by a linked 'our free browser' text.
@@ -4068,8 +4161,8 @@ msgid ""
 "%sDuck.ai%s, our private AI chat service that supports chat models from "
 "OpenAI, Anthropic, and more."
 msgstr ""
-"按一下「更多」深入瞭解主題，並透過 %1$sDuck.ai%2$s 提出後續問題，這是我們的私人 AI 聊天服務，支援來自 "
-"OpenAI、Anthropic 等的聊天模型。"
+"按一下「更多」深入瞭解主題，並透過 %1$sDuck.ai%2$s 提出後續問題，這是我們的私"
+"人 AI 聊天服務，支援來自 OpenAI、Anthropic 等的聊天模型。"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4230,7 +4323,9 @@ msgctxt "cloudsave"
 msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Search Settings%s."
-msgstr "按一下或點擊 %1$s刪除我的資料%2$s。這將從雲端移除資料，但資料仍將留存於您的瀏覽器中，等您按一下/點擊%3$s重設所有搜尋設定%4$s才會刪除。"
+msgstr ""
+"按一下或點擊 %1$s刪除我的資料%2$s。這將從雲端移除資料，但資料仍將留存於您的瀏"
+"覽器中，等您按一下/點擊%3$s重設所有搜尋設定%4$s才會刪除。"
 
 # smartling.placeholder_format=C
 #. Tells users where to click in order to disable the cloud save feature and delete any data backed-up to the cloud.
@@ -4240,7 +4335,9 @@ msgctxt "cloudsave"
 msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Settings%s."
-msgstr "按一下或點按%1$s刪除我的資料%2$s。這即會從雲端移除資料，但資料仍會留存於你的瀏覽器中，等你按一下/點按%3$s重設所有設定%4$s才會刪除。"
+msgstr ""
+"按一下或點按%1$s刪除我的資料%2$s。這即會從雲端移除資料，但資料仍會留存於你的"
+"瀏覽器中，等你按一下/點按%3$s重設所有設定%4$s才會刪除。"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -4503,7 +4600,8 @@ msgctxt "cloudsave"
 msgid ""
 "Cloud Save lets you save your settings more permanently by entering a "
 "passphrase. It is entirely optional."
-msgstr "Cloud Save將更長久地保留你的設定，只要輸入通關密語即可套用。此項純屬自願。"
+msgstr ""
+"Cloud Save將更長久地保留你的設定，只要輸入通關密語即可套用。此項純屬自願。"
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -4976,6 +5074,12 @@ msgstr "建立圖像"
 msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr "建立圖像"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Create a shopping list with quantities from this recipe."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed in the input field when starting a new image generation session.
@@ -5614,11 +5718,18 @@ msgid "Dictation limit reached"
 msgstr "語音輸入次數已達上限"
 
 # smartling.placeholder_format=C
+#. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
+msgid "Dictation temporarily unavailable"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Subtitle text in the dictation privacy consent modal explaining the feature.
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
 "chat in Duck.ai without having to type."
-msgstr "語音輸入功能使用 OpenAI 模型將您的語音轉換為文字，因此您不用輸入文字也能在 Duck.ai 中聊天。"
+msgstr ""
+"語音輸入功能使用 OpenAI 模型將您的語音轉換為文字，因此您不用輸入文字也能在 "
+"Duck.ai 中聊天。"
 
 # smartling.placeholder_format=C
 #. In 0-click box -- link to definition.
@@ -5912,6 +6023,22 @@ msgid "Done"
 msgstr "完成"
 
 # smartling.placeholder_format=C
+#. Message shown in a modal after DuckDuckGo browser users disable AI features in Settings. The first two placeholders bold noai.duckduckgo.com. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
+"filtered out. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
+"and AI images filtered out. %sLearn more%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tennis match stats
 msgctxt "Sports module"
 msgid "Double Faults"
@@ -6020,6 +6147,18 @@ msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
 msgstr "撰寫一封給供應商的簡明扼要的電子郵件，要求提供家用冰箱維修服務的報價。"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Draft a cover letter"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Draft a cover letter for this job."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
@@ -6160,7 +6299,9 @@ msgid ""
 "Duck.ai can now help answer questions about the page you're viewing. Page "
 "content is only included when you attach it, unless you choose to attach "
 "pages automatically in Settings."
-msgstr "Duck.ai 現在可以幫助回答你正在檢視的頁面上的問題。頁面內容僅在你附加它時包含，除非你在設定中選擇自動附加頁面。"
+msgstr ""
+"Duck.ai 現在可以幫助回答你正在檢視的頁面上的問題。頁面內容僅在你附加它時包"
+"含，除非你在設定中選擇自動附加頁面。"
 
 # smartling.placeholder_format=C
 #. Shown in the Duck.ai recent chats list on standalone when the browser API needed to store chats locally is missing or unavailable.
@@ -6169,7 +6310,9 @@ msgctxt ""
 msgid ""
 "Duck.ai can’t access local storage to save your chats. Please check your "
 "browser settings or disable any extensions and try again."
-msgstr "Duck.ai 無法存取本機儲存空間來儲存你的聊天記錄。請檢查您的瀏覽器設定或停用任何擴充套件，然後再試一次。"
+msgstr ""
+"Duck.ai 無法存取本機儲存空間來儲存你的聊天記錄。請檢查您的瀏覽器設定或停用任"
+"何擴充套件，然後再試一次。"
 
 # smartling.placeholder_format=C
 #. Displayed when the chat service has reached the maximum number of messages for one day.
@@ -6186,6 +6329,15 @@ msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
 msgstr "Duck.ai 在我們私密且免費的 DuckDuckGo 瀏覽器中表現最佳！"
 
 # smartling.placeholder_format=C
+#. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
+msgctxt "About section description on the Duck.ai settings page"
+msgid ""
+"Duck.ai is created by DuckDuckGo. We're an independent online protection "
+"company for anyone who wants to take back control of their personal "
+"information."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
 msgctxt "duckai_migration"
 msgid "Duck.ai is moving domains"
@@ -6197,7 +6349,9 @@ msgctxt "duckai_migration"
 msgid ""
 "Duck.ai is still a DuckDuckGo product, but will now have an easier to "
 "remember home on the web: https://duck.ai"
-msgstr "Duck.ai 仍然是 DuckDuckGo 產品，但現在將在網絡上有一個更容易記住的主頁：https://duck.ai"
+msgstr ""
+"Duck.ai 仍然是 DuckDuckGo 產品，但現在將在網絡上有一個更容易記住的主頁："
+"https://duck.ai"
 
 # smartling.placeholder_format=C
 #. Headline for domain change notice.
@@ -6211,7 +6365,8 @@ msgctxt "Error message for BOTNET limit."
 msgid ""
 "Duck.ai is temporarily unavailable. If this persists, please email this "
 "anonymous code %s to %s"
-msgstr "Duck.ai 暫時無法使用。若問題仍存在，請將此匿名代碼%1$s透過電子郵件傳送至%2$s"
+msgstr ""
+"Duck.ai 暫時無法使用。若問題仍存在，請將此匿名代碼%1$s透過電子郵件傳送至%2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -6229,15 +6384,22 @@ msgstr "Duck.ai 暫時無法使用。請稍後再試。"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
+"Duck.ai lets you chat privately with popular AI models. Disabling it hides "
+"Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
+msgstr ""
+
+# smartling.placeholder_format=C
+msgctxt "settings"
+msgid ""
 "Duck.ai lets you have anonymous conversations with 3rd-party AI chat models, "
 "including models from OpenAI, Anthropic, and others. Turning this setting "
 "off will hide Duck.ai buttons and links on DuckDuckGo Search. However, you "
 "can still access Duck.ai when this setting is off by visiting %shttps://duck."
 "ai%s directly."
 msgstr ""
-"Duck.ai 讓你與第三方 AI 聊天模型進行匿名對話，支援 OpenAI、Anthropic 等模型。關閉此設定將隱藏 DuckDuckGo "
-"Search 上的 Duck.ai 按鈕和連結。不過，關閉此設定後，您仍可透過造訪 %1$shttps://duck.ai%2$s 來存取 "
-"Duck.ai使用聊天功能。"
+"Duck.ai 讓你與第三方 AI 聊天模型進行匿名對話，支援 OpenAI、Anthropic 等模型。"
+"關閉此設定將隱藏 DuckDuckGo Search 上的 Duck.ai 按鈕和連結。不過，關閉此設定"
+"後，您仍可透過造訪 %1$shttps://duck.ai%2$s 來存取 Duck.ai使用聊天功能。"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
@@ -6292,8 +6454,9 @@ msgid ""
 "AI chat no sign up, OpenAI, Anthropic, Llama, Mistral, open source AI "
 "models, privacy focused AI, no account AI chat"
 msgstr ""
-"Duck.ai、DuckDuckGo AI、私密 AI 聊天機器人、免費 AI 聊天、匿名 AI 聊天、無需註冊的 AI "
-"聊天、OpenAI、Anthropic、Llama、Mistral、開源 AI 模型、以隱私為重點的 AI、無需帳號的 AI 聊天"
+"Duck.ai、DuckDuckGo AI、私密 AI 聊天機器人、免費 AI 聊天、匿名 AI 聊天、無需"
+"註冊的 AI 聊天、OpenAI、Anthropic、Llama、Mistral、開源 AI 模型、以隱私為重點"
+"的 AI、無需帳號的 AI 聊天"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -6321,9 +6484,10 @@ msgid ""
 "relevant), or Often (shows more frequently on a wider range of searches). "
 "For now, DuckAssist is only available in the U.S. (English) region."
 msgstr ""
-"DuckAssist 可匿名搜尋資訊並做成摘要，以便回應某些搜尋結果。您可以選擇想要 DuckAssist 出現的頻率：從不 (從搜尋結果中完全移除 "
-"DuckAssist UI)、隨選 (僅在點按協助按鈕後顯示)、有時 (僅在高度相關時顯示) 或經常 (在更廣泛的搜尋中更頻繁地顯示)。目前 "
-"DuckAssist 僅供美國 (英文) 地區使用。"
+"DuckAssist 可匿名搜尋資訊並做成摘要，以便回應某些搜尋結果。您可以選擇想要 "
+"DuckAssist 出現的頻率：從不 (從搜尋結果中完全移除 DuckAssist UI)、隨選 (僅在"
+"點按協助按鈕後顯示)、有時 (僅在高度相關時顯示) 或經常 (在更廣泛的搜尋中更頻繁"
+"地顯示)。目前 DuckAssist 僅供美國 (英文) 地區使用。"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6332,8 +6496,8 @@ msgid ""
 "%sDuckDuckGo AI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI, and Anthropic, and more."
 msgstr ""
-"DuckAssist 無法回答後續問題，但是，我們亦提供%1$s DuckDuckGo AI Chat%2$s，這是一款私密 AI 驅動的聊天服務，支援 "
-"OpenAI 和 Anthropic 等聊天模型。"
+"DuckAssist 無法回答後續問題，但是，我們亦提供%1$s DuckDuckGo AI Chat%2$s，這"
+"是一款私密 AI 驅動的聊天服務，支援 OpenAI 和 Anthropic 等聊天模型。"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6342,8 +6506,8 @@ msgid ""
 "DuckDuckGo %sAI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI and Anthropic."
 msgstr ""
-"DuckAssist 無法回答後續問題，但是，我們亦提供 DuckDuckGo %1$sAI Chat%2$s，這是一款私密 AI 驅動的聊天服務，支援 "
-"OpenAI 和 Anthropic 的聊天模型。"
+"DuckAssist 無法回答後續問題，但是，我們亦提供 DuckDuckGo %1$sAI Chat%2$s，這"
+"是一款私密 AI 驅動的聊天服務，支援 OpenAI 和 Anthropic 的聊天模型。"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6355,8 +6519,10 @@ msgid ""
 "responses are currently based on Wikipedia and related content and are not "
 "checked for accuracy."
 msgstr ""
-"DuckAssist 是我們搜尋結果中的一項全新功能，能夠匿名產生搜尋查詢的答案。 為了完成此任務，它將掃描維基百科與相關網站以便查詢相關內容，接著使用 "
-"AI 驅動的自然語言處理技術產生該資訊的摘要。 請注意，目前的回應僅根據維基百科與相關內容，尚未確認準確性。"
+"DuckAssist 是我們搜尋結果中的一項全新功能，能夠匿名產生搜尋查詢的答案。 為了"
+"完成此任務，它將掃描維基百科與相關網站以便查詢相關內容，接著使用 AI 驅動的自"
+"然語言處理技術產生該資訊的摘要。 請注意，目前的回應僅根據維基百科與相關內容，"
+"尚未確認準確性。"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6370,10 +6536,11 @@ msgid ""
 "It’s important to remember that responses are auto-generated from cited "
 "sources and based on %scrawling the web%s."
 msgstr ""
-"DuckAssist "
-""
-"是我們搜尋結果中的一項選用功能，能夠匿名產生搜尋查詢的答案。為了完成此任務，它將掃描網路以便查詢相關內容，接著使用人工智慧支援的自然語言技術，根據找到的相關資訊產生簡短的答案。DuckAssist "
-"的回應始終直接連結至一個或兩個來源，並引用答案的來源，因此您能夠輕鬆取得更詳盡的資料。重要的是要記住，回應是從引用的來源並根據%1$s搜耙網路%2$s自動產生的，"
+"DuckAssist 是我們搜尋結果中的一項選用功能，能夠匿名產生搜尋查詢的答案。為了完"
+"成此任務，它將掃描網路以便查詢相關內容，接著使用人工智慧支援的自然語言技術，"
+"根據找到的相關資訊產生簡短的答案。DuckAssist 的回應始終直接連結至一個或兩個來"
+"源，並引用答案的來源，因此您能夠輕鬆取得更詳盡的資料。重要的是要記住，回應是"
+"從引用的來源並根據%1$s搜耙網路%2$s自動產生的，"
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
@@ -6396,7 +6563,9 @@ msgctxt "Modal body for information"
 msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
-msgstr "DuckDuckGo AI Chat 是一款私密 AI 驅動的聊天服務，目前支援 %1$s 的 %2$s 與 %3$s 的 %4$s 聊天模型。"
+msgstr ""
+"DuckDuckGo AI Chat 是一款私密 AI 驅動的聊天服務，目前支援 %1$s 的 %2$s 與 "
+"%3$s 的 %4$s 聊天模型。"
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the welcome screen of the onboarding. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -6404,7 +6573,9 @@ msgctxt "Onboarding welcome screen subtitle"
 msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
-msgstr "DuckDuckGo AI Chat 是一款私密 AI 驅動的聊天服務，目前支援 %1$s 的 %2$s 與 %3$s 的 %4$s 聊天模型。"
+msgstr ""
+"DuckDuckGo AI Chat 是一款私密 AI 驅動的聊天服務，目前支援 %1$s 的 %2$s 與 "
+"%3$s 的 %4$s 聊天模型。"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding DuckDuckGo AI Chat.
@@ -6420,7 +6591,9 @@ msgctxt "Error message for BOTNET limit."
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. If this persists, please "
 "email this anonymous code %s to %s"
-msgstr "DuckDuckGo AI Chat 暫時無法使用。若問題仍存在，請將此匿名代碼%1$s透過電子郵件傳送至%2$s"
+msgstr ""
+"DuckDuckGo AI Chat 暫時無法使用。若問題仍存在，請將此匿名代碼%1$s透過電子郵件"
+"傳送至%2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -6552,14 +6725,17 @@ msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
 msgid ""
 "DuckDuckGo anonymizes these reports by automatically removing PII like "
 "names, email addresses, phone numbers, and identifying metadata."
-msgstr "DuckDuckGo 透過自動移除姓名、電子郵件地址、電話號碼及識別中繼資料等個人身份資訊來匿名化這些報告。"
+msgstr ""
+"DuckDuckGo 透過自動移除姓名、電子郵件地址、電話號碼及識別中繼資料等個人身份資"
+"訊來匿名化這些報告。"
 
 # smartling.placeholder_format=C
 #. The first %s is the agree button label ('Agree'). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. The leading sentence mirrors the drawer-style inline disclaimer (DUCKCHAT_TOS_INLINE_DISCLAIMER).
 msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid ""
 "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to Duck.ai's %s."
-msgstr "DuckDuckGo 將您的聊天匿名化。點擊「%1$s」，即表示你同意 Duck.ai 的%2$s。"
+msgstr ""
+"DuckDuckGo 將您的聊天匿名化。點擊「%1$s」，即表示你同意 Duck.ai 的%2$s。"
 
 # smartling.placeholder_format=C
 #. Shown below the input on the empty state when the user has not yet accepted the terms of service. The first %s is the action button label ('Ask' for chat, 'Create' for image generation). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. Clicking the action button both accepts the terms and submits the prompt.
@@ -6575,7 +6751,9 @@ msgid ""
 "DuckDuckGo blocks trackers on websites you visit, including trackers from "
 "companies like Google and Facebook, who often try to track you on other "
 "websites."
-msgstr "DuckDuckGo將封鎖你造訪網站上的追蹤器，包括來自Google和Facebook等公司的追蹤器，它們經常試圖在你造訪其他網站時追蹤你。"
+msgstr ""
+"DuckDuckGo將封鎖你造訪網站上的追蹤器，包括來自Google和Facebook等公司的追蹤"
+"器，它們經常試圖在你造訪其他網站時追蹤你。"
 
 # smartling.placeholder_format=C
 #. Description of how DuckDuckGo keeps a user's location anonymous while the user searches on a map of their area.
@@ -6586,7 +6764,11 @@ msgid ""
 "use it to improve results for that search, and then we promptly throw it "
 "away, such that you remain anonymous. %sLearn more about how we designed "
 "this technology to protect your privacy%s."
-msgstr "DuckDuckGo的設計以隱私為主要考量。當你啟用定位功能時，只會儲存於你的本機裝置上。當你搜尋時，你的裝置會將位置傳送給我們，讓我們改善該次的搜尋結果，然後我們會立即將其丟棄，讓你繼續保持匿名。%1$s進一步瞭解我們如何設計了這項技術來保護你的隱私%2$s。"
+msgstr ""
+"DuckDuckGo的設計以隱私為主要考量。當你啟用定位功能時，只會儲存於你的本機裝置"
+"上。當你搜尋時，你的裝置會將位置傳送給我們，讓我們改善該次的搜尋結果，然後我"
+"們會立即將其丟棄，讓你繼續保持匿名。%1$s進一步瞭解我們如何設計了這項技術來保"
+"護你的隱私%2$s。"
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
@@ -6605,7 +6787,9 @@ msgctxt "settings"
 msgid ""
 "DuckDuckGo only uses your approximate location. That's all we need to "
 "deliver better results, closer to you. %sLearn more%s."
-msgstr "DuckDuckGo只會使用你的大概位置。我們只需要這麼一點點資訊，就能呈現更好、也更接近你的搜尋結果。%1$s瞭解更多%2$s。"
+msgstr ""
+"DuckDuckGo只會使用你的大概位置。我們只需要這麼一點點資訊，就能呈現更好、也更"
+"接近你的搜尋結果。%1$s瞭解更多%2$s。"
 
 # smartling.placeholder_format=C
 msgid "DuckDuckGo search"
@@ -6690,7 +6874,10 @@ msgid ""
 "random words from the DuckDuckGo servers. In the browser, we then select 4-5 "
 "random words from that list, ensuring that the passphrase is at least 18-20 "
 "characters long."
-msgstr "當你需要通關密語建議時，我們會從DuckDuckGo伺服器收到一長串隨機單字的清單。我們會在瀏覽器中從該清單隨機挑選出4至5個單字，確認每個通關密語的長度都至少有18至20個字元。"
+msgstr ""
+"當你需要通關密語建議時，我們會從DuckDuckGo伺服器收到一長串隨機單字的清單。我"
+"們會在瀏覽器中從該清單隨機挑選出4至5個單字，確認每個通關密語的長度都至少有18"
+"至20個字元。"
 
 # smartling.placeholder_format=C
 msgctxt "Sports module"
@@ -6927,7 +7114,9 @@ msgctxt "precise_user_location"
 msgid ""
 "Enabling anonymous location gives more accurate results but still keeps your "
 "searches and exact location private to DuckDuckGo."
-msgstr "啟用匿名位置可提供更準確的結果，但 DuckDuckGo 仍會對你的搜尋與確切位置進行保密。"
+msgstr ""
+"啟用匿名位置可提供更準確的結果，但 DuckDuckGo 仍會對你的搜尋與確切位置進行保"
+"密。"
 
 # smartling.placeholder_format=C
 msgid "Encrypt Connections"
@@ -7088,7 +7277,9 @@ msgctxt "cloudsave"
 msgid ""
 "Enter a new passphrase and click/tap %sSave Settings%s. This will save your "
 "data under your new passphrase."
-msgstr "輸入新的通關密語，再按一下/點按%1$s儲存設定%2$s。這會將你的資料儲存在新的通關密語下。"
+msgstr ""
+"輸入新的通關密語，再按一下/點按%1$s儲存設定%2$s。這會將你的資料儲存在新的通關"
+"密語下。"
 
 # smartling.placeholder_format=C
 #. Label for the field where a user enters their passphrase.
@@ -7113,7 +7304,8 @@ msgstr "輸入文字"
 #. Instructions for how to change the default search engine.
 msgid ""
 "Enter the following details: %sName%s: DuckDuckGo%s URL%s: %s Alias%s: d%s"
-msgstr "輸入以下細節：%1$s名稱%2$s：DuckDuckGo%3$s URL%4$s：%5$s暱稱%6$s：d%7$s"
+msgstr ""
+"輸入以下細節：%1$s名稱%2$s：DuckDuckGo%3$s URL%4$s：%5$s暱稱%6$s：d%7$s"
 
 # smartling.placeholder_format=C
 #. Prompt to enter a destination for driving directions.
@@ -7152,6 +7344,18 @@ msgstr "使用我們的%1$sFire Button%2$s立即清除您的瀏覽數據"
 # smartling.placeholder_format=C
 msgid "Eritrea"
 msgstr "厄利垂亞"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Estimate the nutrition"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Estimate the nutritional information for this recipe."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Estonia"
@@ -7208,11 +7412,59 @@ msgid "Expires in 1 day"
 msgstr "到期日為 1 天"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain the accepted answer in simple terms."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
 msgstr "向我解釋高中等級黑洞的基本概念。"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain the top answer"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this in simple, plain language."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this paper"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this repo"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this research paper in plain language."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this simply"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain what this repository does and how to use it."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label to show if song lyrics contain explicit content
@@ -7397,7 +7649,9 @@ msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and "
 "improvements. Hopefully we can address the issue you shared too."
-msgstr "像你提供的的意見回饋會直接影響我們的產品更新和改善。希望我們也能解決你分享的問題。"
+msgstr ""
+"像你提供的的意見回饋會直接影響我們的產品更新和改善。希望我們也能解決你分享的"
+"問題。"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box
@@ -7490,6 +7744,12 @@ msgid ""
 msgstr "從圖片搜尋結果中過篩選 AI 生成的圖片。%1$s瞭解更多%2$s"
 
 # smartling.placeholder_format=C
+msgctxt "settings"
+msgid ""
+"Filters out known AI spam sites from image search results. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the final score of a sporting event.
 msgid "Final"
 msgstr "最後得分"
@@ -7541,6 +7801,12 @@ msgstr "尋找更好的字詞"
 msgctxt "Subtitle for the Web Search tool entry in the Tools dropdown menu"
 msgid "Find current information"
 msgstr "尋找目前資訊"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Find me alternatives"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button that searches for results closer to the user's current location.
@@ -7622,7 +7888,8 @@ msgstr "多霧"
 msgid ""
 "Follow the instructions for turning off the ad blocker for DuckDuckGo. You "
 "may have to select a menu option or click a button."
-msgstr "按照指示關閉 DuckDuckGo 的廣告封鎖程式。你可能需要選取一個選項或按一下按鈕。"
+msgstr ""
+"按照指示關閉 DuckDuckGo 的廣告封鎖程式。你可能需要選取一個選項或按一下按鈕。"
 
 # smartling.placeholder_format=C
 #. Privacy reassurance and instructions intro.
@@ -7844,8 +8111,8 @@ msgid ""
 "<strong>Check for Updates...</strong>, then select <strong>Install Update</"
 "strong>."
 msgstr ""
-"從 Mac 上的應用程式功能表工具列中，選取<strong>DuckDuckGo</strong> "
-"&gt;<strong>檢查更新...</strong> ，然後選取<strong>安裝更新</strong>。"
+"從 Mac 上的應用程式功能表工具列中，選取<strong>DuckDuckGo</strong> &gt;"
+"<strong>檢查更新...</strong> ，然後選取<strong>安裝更新</strong>。"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -8011,6 +8278,12 @@ msgstr "生成圖片"
 #. Text for the button that generates more of an answer from duckassist when the answer has come from a collapsed state
 msgid "Generate More"
 msgstr "生成更多"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Generate a shopping list"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
@@ -8189,7 +8462,9 @@ msgctxt "Description of the modal to upgrade the DuckDuckGo subscription"
 msgid ""
 "Get access to advanced AI models in Duck.ai by subscribing to DuckDuckGo, "
 "which also includes our VPN and other premium privacy protections."
-msgstr "訂閱 DuckDuckGo，即可存取 Duck.ai 的進階 AI 模型，還包括我們的 VPN 和其他頂級隱私權保護。"
+msgstr ""
+"訂閱 DuckDuckGo，即可存取 Duck.ai 的進階 AI 模型，還包括我們的 VPN 和其他頂級"
+"隱私權保護。"
 
 # smartling.placeholder_format=C
 #. Description for the subscription setting where users can subscribe to DuckDuckGo.
@@ -8199,7 +8474,9 @@ msgctxt ""
 msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
-msgstr "訂閱 DuckDuckGo，即可存取 Duck.ai 的進階 AI 模型，還包括我們的 VPN 和其他頂級隱私權保護。"
+msgstr ""
+"訂閱 DuckDuckGo，即可存取 Duck.ai 的進階 AI 模型，還包括我們的 VPN 和其他頂級"
+"隱私權保護。"
 
 # smartling.placeholder_format=C
 #. A button for users to generate an AI generated answer from their query on the duckassist module
@@ -8298,6 +8575,12 @@ msgid "Give it a Try"
 msgstr "來試試看吧"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Give me a quick background on this person."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
@@ -8309,7 +8592,8 @@ msgctxt "precise_user_location"
 msgid ""
 "Go to %sSettings > Privacy & Security > Location Services%s, and make sure "
 "“Location Services” is turned on."
-msgstr "前往 %1$s 設定 > 隱私權和安全性 > 位置服務 %2$s，並確定「位置服務」已開啟。"
+msgstr ""
+"前往 %1$s 設定 > 隱私權和安全性 > 位置服務 %2$s，並確定「位置服務」已開啟。"
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -8317,7 +8601,8 @@ msgctxt "precise_user_location"
 msgid ""
 "Go to %sSettings > Privacy > Permission manager > Location%s and scroll down "
 "to %sDuckDuckGo%s."
-msgstr "前往%1$s設定>隱私權>權限管理>位置%2$s ，接著往下捲動至 %3$sDuckDuckGo%4$s。"
+msgstr ""
+"前往%1$s設定>隱私權>權限管理>位置%2$s ，接著往下捲動至 %3$sDuckDuckGo%4$s。"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -8740,6 +9025,18 @@ msgid "Help Spread Privacy"
 msgstr "協助推廣隱私保護"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Help me prep for the interview"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Help me tailor my resume for this job."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title of a SERP popup that invites users to take a survey (desktop only)
 msgctxt "User survey popup"
 msgid "Help us improve DuckDuckGo"
@@ -9001,7 +9298,9 @@ msgstr "最近活動"
 msgid ""
 "Hit %sReturn%s on your keyboard to %ssave DuckDuckGo to the list. %sThen "
 "click %sMake Default%s"
-msgstr "在鍵盤上點擊%1$s返回%2$s即可將DuckDuckGo%3$s儲存至清單。%4$s接著點擊%5$s設定為預設%6$s"
+msgstr ""
+"在鍵盤上點擊%1$s返回%2$s即可將DuckDuckGo%3$s儲存至清單。%4$s接著點擊%5$s設定"
+"為預設%6$s"
 
 # smartling.placeholder_format=C
 #. The name of the Hmong Daw language
@@ -9245,6 +9544,14 @@ msgid "I Agree"
 msgstr "我同意"
 
 # smartling.placeholder_format=C
+#. Text for the button that takes the user to the external DuckDuckGo login subscription page.
+msgctxt ""
+"Text for the I already have a subscription button in the Duck.ai settings "
+"page"
+msgid "I Already Have a Subscription"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for the button that takes the user to the login subscription page.
 msgctxt "Text for the I have a subscription button"
 msgid "I Have a Subscription"
@@ -9351,7 +9658,9 @@ msgctxt "precise_user_location"
 msgid ""
 "If the browser location remains unavailable, then go to %sSettings > General "
 "> Reset > 'Reset Location & Privacy'%s."
-msgstr "如果仍然沒有可用的瀏覽器位置，那麼請前往%1$s設定 > 一般 > 重設 >「重設位置與隱私」%2$s。"
+msgstr ""
+"如果仍然沒有可用的瀏覽器位置，那麼請前往%1$s設定 > 一般 > 重設 >「重設位置與"
+"隱私」%2$s。"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -9361,8 +9670,8 @@ msgid ""
 "> Menu > Settings > Site settings > Location%s, and ensure DuckDuckGo is "
 "allowed location access."
 msgstr ""
-"如果仍然沒有可用的瀏覽器位置，那麼請在你的瀏覽器中前往 %1$s⋮ > 選單 > 設定 > 網站設定 > "
-"位置%2$s，確認DuckDuckGo是被允許的存取位置。"
+"如果仍然沒有可用的瀏覽器位置，那麼請在你的瀏覽器中前往 %1$s⋮ > 選單 > 設定 > "
+"網站設定 > 位置%2$s，確認DuckDuckGo是被允許的存取位置。"
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -9376,7 +9685,8 @@ msgstr "如果你繼續看到此錯誤，請聯絡 %1$s。"
 msgid ""
 "If you don't see %sDuckDuckGo,%s you will need to add it to the list of "
 "%sOther Search Engines%s"
-msgstr "如果你沒看見%1$sDuckDuckGo，%2$s必須先將其新增至%3$s其他搜尋引擎%4$s的清單中"
+msgstr ""
+"如果你沒看見%1$sDuckDuckGo，%2$s必須先將其新增至%3$s其他搜尋引擎%4$s的清單中"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding the AI model providers and links to their support pages. Example: 'If you have concerns about our chat providers or any particular chat response, you can also reach out directly to OpenAI and Anthropic support pages.'
@@ -9384,7 +9694,9 @@ msgctxt "Disclaimer text at the bottom of the feedback form."
 msgid ""
 "If you have concerns about our chat providers or any particular chat "
 "response, you can also reach out directly to %s and %s support pages."
-msgstr "若您對我們的聊天供應商或任何特定的聊天回覆有任何疑問，也能夠直接聯絡 %1$s 與 %2$s 支援頁面。"
+msgstr ""
+"若您對我們的聊天供應商或任何特定的聊天回覆有任何疑問，也能夠直接聯絡 %1$s 與 "
+"%2$s 支援頁面。"
 
 # smartling.placeholder_format=C
 #. Body copy explaining what the recovery code is for and how it can be saved.
@@ -9392,7 +9704,9 @@ msgctxt "Body for the Sync & Backup recovery code screen"
 msgid ""
 "If you lose access to your devices, you will need this code to recover your "
 "saved chats. You can save this code to your device as a text file."
-msgstr "如果您無法存取裝置，需要使用此恢復碼才能恢復您儲存的聊天記錄。您可以把這個恢復碼儲存成文字檔，儲存至您的裝置。"
+msgstr ""
+"如果您無法存取裝置，需要使用此恢復碼才能恢復您儲存的聊天記錄。您可以把這個恢"
+"復碼儲存成文字檔，儲存至您的裝置。"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/ReKkJtU.png
@@ -9554,7 +9868,9 @@ msgctxt "settings"
 msgid ""
 "In some older browsers, it's necessary to redirect your clicks through our "
 "server to prevent search leakage. %sLearn more%s."
-msgstr "若你使用的瀏覽器較舊，在你點擊連結時，必須透過我們的伺服器來重新導向，才能避免搜尋記錄外洩。%1$s瞭解更多%2$s。"
+msgstr ""
+"若你使用的瀏覽器較舊，在你點擊連結時，必須透過我們的伺服器來重新導向，才能避"
+"免搜尋記錄外洩。%1$s瞭解更多%2$s。"
 
 # smartling.placeholder_format=C
 #. Instructions accompanying DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE; tells the user where to use the code on a DuckDuckGo browser.
@@ -9564,7 +9880,9 @@ msgctxt ""
 msgid ""
 "In the DuckDuckGo browser, go to Settings › Sync & Backup, and then “Sync "
 "with another device”."
-msgstr "在 DuckDuckGo 瀏覽器中，點選設定 › Sync & Backup，然後選擇「與另一裝置同步」。"
+msgstr ""
+"在 DuckDuckGo 瀏覽器中，點選設定 › Sync & Backup，然後選擇「與另一裝置同"
+"步」。"
 
 #  SeaMonkey default search engine instruction
 # smartling.placeholder_format=C
@@ -9794,6 +10112,12 @@ msgid "Install Mac Browser"
 msgstr "安裝 Mac 瀏覽器"
 
 # smartling.placeholder_format=C
+#. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
+msgctxt "settings"
+msgid "Install Now"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of a button to install the DuckDuckGo app
 msgctxt "Serp footer content"
 msgid "Install Our App"
@@ -9891,10 +10215,42 @@ msgid "Is deleted data really deleted?"
 msgstr "我要求刪除的資料是真的刪掉了嗎？"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is it worth taking?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this place any good?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"Is this place any good? Summarize its reputation based on reviews and "
+"ratings."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "Is this video helpful?"
 msgstr "這部影片有幫助嗎？"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this worth watching?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Is this worth watching? Give me a spoiler-free take."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -9945,8 +10301,9 @@ msgid ""
 "through Microsoft's Ad Network. Clicks lead directly to merchant landing "
 "pages and unlike ads, DuckDuckGo is not compensated for these results."
 msgstr ""
-"物品排序是依照你的搜尋關鍵字為依據，並經由Microsoft's Ad "
-"Network播送。點擊後會立即連接到商家的登陸頁面，但與廣告不同的是，DuckDuckGo並不會因這些結果而收到任何報酬。"
+"物品排序是依照你的搜尋關鍵字為依據，並經由Microsoft's Ad Network播送。點擊後"
+"會立即連接到商家的登陸頁面，但與廣告不同的是，DuckDuckGo並不會因這些結果而收"
+"到任何報酬。"
 
 # smartling.placeholder_format=C
 #. Text explaining why passphrases use a series of words instead of random numbers and letters.
@@ -9954,7 +10311,9 @@ msgctxt "cloudsave"
 msgid ""
 "It’s easier to remember 4-5 words than 10 random letters and numbers, and "
 "far more secure."
-msgstr "比起強記 10 個隨機的字母與數字，只記住 4 至 5 個單字要容易許多，而且也更加安全。"
+msgstr ""
+"比起強記 10 個隨機的字母與數字，只記住 4 至 5 個單字要容易許多，而且也更加安"
+"全。"
 
 # smartling.placeholder_format=C
 msgid "Ivory Coast"
@@ -10501,6 +10860,12 @@ msgid "Links:"
 msgstr "連結："
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "List the tools, materials, or prerequisites I need for this."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
 msgid "Listen"
 msgstr "傾聽"
@@ -10905,6 +11270,12 @@ msgstr "管理您的訂閱"
 msgctxt "Exclusion message manage sites button"
 msgid "Manage blocked sites"
 msgstr "管理被封鎖的網站"
+
+# smartling.placeholder_format=C
+#. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
+msgctxt "setting"
+msgid "Manage in Browser Settings"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to the site exclusion settings page
@@ -11877,8 +12248,9 @@ msgid ""
 "internet connection. Disabling chat history will delete pinned chats, and "
 "disable the temporary storage of new prompts and responses."
 msgstr ""
-"新的提示和回應在傳送後會被加密並暫時儲存在 DuckDuckGo "
-"伺服器上，以便在你失去網路連線時協助恢復聊天。停用聊天紀錄會刪除置頂的聊天記錄，並停用新提示和回應的暫時儲存功能。"
+"新的提示和回應在傳送後會被加密並暫時儲存在 DuckDuckGo 伺服器上，以便在你失去"
+"網路連線時協助恢復聊天。停用聊天紀錄會刪除置頂的聊天記錄，並停用新提示和回應"
+"的暫時儲存功能。"
 
 # smartling.placeholder_format=C
 #. Question in a feedback form.
@@ -12693,7 +13065,9 @@ msgstr "隨需"
 msgid ""
 "On Mac, %sClick Maxthon > Preferences%s, On Windows, %sClick the %s icon > "
 "Settings%s"
-msgstr "在Mac系統中，%1$s按Maxthon > 偏好設定%2$s，在Windows中，%3$s按%4$s 圖示 > 設定%5$s"
+msgstr ""
+"在Mac系統中，%1$s按Maxthon > 偏好設定%2$s，在Windows中，%3$s按%4$s 圖示 > 設"
+"定%5$s"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
@@ -12714,7 +13088,8 @@ msgctxt ""
 msgid ""
 "One of the files attached has more pages than we support. Please upload "
 "files with %s pages or fewer."
-msgstr "附上的其中一個檔案頁數超過了我們的支援範圍。請上傳頁數不超過 %1$s 的檔案。"
+msgstr ""
+"附上的其中一個檔案頁數超過了我們的支援範圍。請上傳頁數不超過 %1$s 的檔案。"
 
 # smartling.placeholder_format=C
 #. Response a user can select in a feedback form, indicating that they heard about DuckDuckGo in an online article.
@@ -13070,7 +13445,8 @@ msgctxt "homepage onboarding"
 msgid ""
 "Other search engines track your searches even when you’re in private "
 "browsing mode. We don’t track you &mdash; period."
-msgstr "即使你處於隱身瀏覽模式，其他搜尋引擎也會追蹤你的搜尋。我們在這期間不追蹤你。"
+msgstr ""
+"即使你處於隱身瀏覽模式，其他搜尋引擎也會追蹤你的搜尋。我們在這期間不追蹤你。"
 
 # smartling.placeholder_format=C
 msgctxt "SERP footer content"
@@ -13089,7 +13465,9 @@ msgid ""
 "Our private browser for mobile comes equipped with our search engine, "
 "tracker blocker, encryption enforcer, and more. Available on %siOS & "
 "Android%s."
-msgstr "我們的行動裝置私密瀏覽器配備搜尋引擎、追蹤器封鎖程式、加密執行程式等眾多功能。提供%1$siOS及Android%2$s版本。"
+msgstr ""
+"我們的行動裝置私密瀏覽器配備搜尋引擎、追蹤器封鎖程式、加密執行程式等眾多功"
+"能。提供%1$siOS及Android%2$s版本。"
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the information was out of date.
@@ -13341,7 +13719,9 @@ msgctxt "cloudsave"
 msgid ""
 "Passphrases cannot be recovered as we don't associate your IP address, "
 "browser fingerprint, or any other information with the file."
-msgstr "我們並未將你的IP位址、瀏覽器指紋或其他相關資訊連結至通關密語檔案，因此無法找回通關密語。"
+msgstr ""
+"我們並未將你的IP位址、瀏覽器指紋或其他相關資訊連結至通關密語檔案，因此無法找"
+"回通關密語。"
 
 # smartling.placeholder_format=C
 #. Label for the section of recent chats that were edited in the past 7 days.
@@ -13535,8 +13915,8 @@ msgid ""
 "answers. To turn them off and hide the Assist button visit %sSearch "
 "Settings%s."
 msgstr ""
-"將您的搜尋以問句形式完整地表達出來，能提高 AI 輔助答案自動顯示的機率，且通常能得到更好的答案。欲關閉並隱藏「Assist」按鈕，請造訪 "
-"%1$s搜尋設定%2$s。"
+"將您的搜尋以問句形式完整地表達出來，能提高 AI 輔助答案自動顯示的機率，且通常"
+"能得到更好的答案。欲關閉並隱藏「Assist」按鈕，請造訪 %1$s搜尋設定%2$s。"
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -13545,8 +13925,9 @@ msgid ""
 "DuckAssist more likely to appear and often yields better answers. To adjust "
 "how this feature works, or to turn it off, visit %sDuckAssist Settings%s."
 msgstr ""
-"將您的搜尋作為一個問題表述，並且用一個完整的句子為形式，讓 DuckAssist 更可能顯示並且通常能得出更好的答案。 "
-"欲調整此功能的運作方式或將其關閉，請造訪 %1$sDuckAssist 設定%2$s。"
+"將您的搜尋作為一個問題表述，並且用一個完整的句子為形式，讓 DuckAssist 更可能"
+"顯示並且通常能得出更好的答案。 欲調整此功能的運作方式或將其關閉，請造訪 "
+"%1$sDuckAssist 設定%2$s。"
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -13556,8 +13937,9 @@ msgid ""
 "answers. To turn it off and hide the Assist button visit %sDuckAssist "
 "Settings%s."
 msgstr ""
-"將您的搜尋作為一個問題表述，並且用一個完整的句子為形式，讓 DuckAssist "
-"更可能自動顯示並且通常能得出更好的答案。欲關閉並隱藏「協助」按鈕，請造訪 %1$s DuckAssist 設定 %2$s。"
+"將您的搜尋作為一個問題表述，並且用一個完整的句子為形式，讓 DuckAssist 更可能"
+"自動顯示並且通常能得出更好的答案。欲關閉並隱藏「協助」按鈕，請造訪 %1$s "
+"DuckAssist 設定 %2$s。"
 
 # smartling.placeholder_format=C
 #. Button that allows users to manually select a location on a map.
@@ -13589,7 +13971,8 @@ msgctxt "Body copy for the chat card in the How Duck.ai Works panel"
 msgid ""
 "Pick a popular AI to chat with, like GPT-5 mini, Claude Haiku 4.5, Mistral, "
 "etc."
-msgstr "選擇流行的 AI 進行聊天，例如 GPT-5 迷你、克勞德海庫 4.5、米斯特拉爾等。"
+msgstr ""
+"選擇流行的 AI 進行聊天，例如 GPT-5 迷你、克勞德海庫 4.5、米斯特拉爾等。"
 
 # smartling.placeholder_format=C
 #. Describes the ability to choose from popular AI models. Pairs with a chat-bubble pictogram.
@@ -13605,7 +13988,8 @@ msgctxt "Third party map app picker"
 msgid ""
 "Pick a service to navigate to your destination. External apps won’t come "
 "with DuckDuckGo protections."
-msgstr "選擇一項服務來導覽到你的目的地。外部應用程式不會受到 DuckDuckGo 的保護。"
+msgstr ""
+"選擇一項服務來導覽到你的目的地。外部應用程式不會受到 DuckDuckGo 的保護。"
 
 # smartling.placeholder_format=C
 #. Label for a list of problems on a feedback form.
@@ -13700,6 +14084,12 @@ msgstr "請完成以下挑戰，確認此搜尋是由真人所進行。"
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
+msgid "Please describe why the chat response is harmful or illegal. (optional)"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
+msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
 msgstr "請說明聊天回覆違法或有害的原因。（選填）"
 
@@ -13728,8 +14118,18 @@ msgstr "請注意：以任何模型開始全新聊天將會刪除您目前的聊
 msgctxt "Feedback prompt"
 msgid ""
 "Please paste your prompt and the problematic output (with any personal "
+"information removed) and describe why the content is harmful or illegal."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
+msgctxt "Feedback prompt"
+msgid ""
+"Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is illegal or harmful."
-msgstr "請貼上你的提示和有問題的輸出（請移除任何個人資訊），並描述為何該內容非法或有害。"
+msgstr ""
+"請貼上你的提示和有問題的輸出（請移除任何個人資訊），並描述為何該內容非法或有"
+"害。"
 
 # smartling.placeholder_format=C
 #. Title on a feedback form.
@@ -14187,6 +14587,12 @@ msgid "Privacy"
 msgstr "隱私"
 
 # smartling.placeholder_format=C
+#. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
+msgctxt "Section heading on the Duck.ai settings page"
+msgid "Privacy & Terms"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Privacy Blog"
 msgstr "隱私部落格"
 
@@ -14255,6 +14661,12 @@ msgstr "隱私權政策與使用條款"
 msgctxt "Copy used to compose link in sentences"
 msgid "Privacy Policy and Terms of Service"
 msgstr "隱私權政策與服務條款"
+
+# smartling.placeholder_format=C
+#. Text for a button that links to the terms of use and privacy policy page.
+msgctxt "Secondary button text in active privacy modal"
+msgid "Privacy Policy and Terms of Service"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title displayed on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
@@ -14706,7 +15118,9 @@ msgctxt "Description for recent chats feature"
 msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
-msgstr "最近的聊天記錄會儲存在你的裝置本機上，而非在 DuckDuckGo 或其他的遠端伺服器中。"
+msgstr ""
+"最近的聊天記錄會儲存在你的裝置本機上，而非在 DuckDuckGo 或其他的遠端伺服器"
+"中。"
 
 # smartling.placeholder_format=C
 #. Text explaining that recent chats are stored locally on the user's device.
@@ -14714,7 +15128,9 @@ msgctxt "Description of where recent chats are stored"
 msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
-msgstr "最近的聊天記錄會儲存在你的裝置本機上，而非在 DuckDuckGo 或其他的遠端伺服器中。"
+msgstr ""
+"最近的聊天記錄會儲存在你的裝置本機上，而非在 DuckDuckGo 或其他的遠端伺服器"
+"中。"
 
 # smartling.placeholder_format=C
 #. Text explaining how recent chats are stored locally on the user's device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection.
@@ -14723,7 +15139,9 @@ msgid ""
 "Recent chats are stored locally on your device. New prompts and responses "
 "are encrypted and temporarily stored on a DuckDuckGo server after being "
 "sent, to help recover a chat if you lose your internet connection."
-msgstr "最近的聊天記錄會儲存在你的裝置本機上。新的提示和回應在傳送後會被加密並暫時儲存在 DuckDuckGo 伺服器上，以便在你斷線時協助恢復聊天。"
+msgstr ""
+"最近的聊天記錄會儲存在你的裝置本機上。新的提示和回應在傳送後會被加密並暫時儲"
+"存在 DuckDuckGo 伺服器上，以便在你斷線時協助恢復聊天。"
 
 # smartling.placeholder_format=C
 msgctxt "region filter"
@@ -14745,6 +15163,30 @@ msgstr "%1$s %2$s %3$s 的食譜"
 msgctxt "Brief for recommending a book"
 msgid "Recommend a book"
 msgstr "推薦一本書"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar books"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar books."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar movies or shows."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar titles"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
@@ -14956,7 +15398,8 @@ msgstr "重新載入 Duck.ai。"
 msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
-msgstr "按照說明重新載入 DuckDuckGo，或者點擊瀏覽器的「重新整理」或「重新載入」按鈕。"
+msgstr ""
+"按照說明重新載入 DuckDuckGo，或者點擊瀏覽器的「重新整理」或「重新載入」按鈕。"
 
 # smartling.placeholder_format=C
 #. checkbox label that allows the user to save the setting
@@ -15109,14 +15552,18 @@ msgid ""
 "Reports are anonymous and sent to DuckDuckGo to help improve our search "
 "service. Your anonymous feedback is also shared with %s to help improve "
 "their services."
-msgstr "報告會匿名傳送給DuckDuckGo，幫助我們改善搜尋服務。你的匿名回饋意見也會分享給%1$s來協助改善其服務。"
+msgstr ""
+"報告會匿名傳送給DuckDuckGo，幫助我們改善搜尋服務。你的匿名回饋意見也會分享"
+"給%1$s來協助改善其服務。"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "Reports sent to DuckDuckGo are anonymous. Please do not include any personal "
 "or identifying information in your feedback."
-msgstr "傳送給 DuckDuckGo 的檢舉採匿名制。請不要在你的意見回饋中包含任何個人或可識別身分的資訊。"
+msgstr ""
+"傳送給 DuckDuckGo 的檢舉採匿名制。請不要在你的意見回饋中包含任何個人或可識別"
+"身分的資訊。"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -15124,11 +15571,22 @@ msgid ""
 "Reports sent to DuckDuckGo include all of the text you've asked us to "
 "translate during this page load, and are anonymous. Please do not include "
 "any personal or identifying information in your feedback."
-msgstr "傳送給 DuckDuckGo 的報告包括你在此頁面載入時要求我們翻譯的所有文字，並且是匿名的。請不要在你的意見回饋中包含任何個人或可識別身分的資訊。"
+msgstr ""
+"傳送給 DuckDuckGo 的報告包括你在此頁面載入時要求我們翻譯的所有文字，並且是匿"
+"名的。請不要在你的意見回饋中包含任何個人或可識別身分的資訊。"
 
 # smartling.placeholder_format=C
 msgid "Republic of Moldova"
 msgstr "摩爾多瓦共和國"
+
+# smartling.placeholder_format=C
+#. Note indicating that sharing the conversation is mandatory when reporting harmful or illegal content. Rendered alongside the standard share label (DUCKCHAT_RESPONSE_FEEDBACK_SHARE_PROMPT_RESPONSE_LABEL), not replacing it.
+msgctxt ""
+"Note shown under the share-content switch label on the Duck.ai response "
+"feedback form when the user has selected Harmful or Illegal as the feedback "
+"reason"
+msgid "Required for harmful or illegal reports"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
@@ -15194,7 +15652,9 @@ msgid ""
 "Responses are for educational purposes only and are not intended as medical, "
 "legal, financial, investment, or other professional advice. AI-assisted "
 "answers are subject to our %sTerms of Service%s."
-msgstr "回覆僅用於教育用途，並不構成醫療、法律、財務、投資或其他專業建議。AI 輔助的回答受我們的 %1$s 服務條款%2$s約束。"
+msgstr ""
+"回覆僅用於教育用途，並不構成醫療、法律、財務、投資或其他專業建議。AI 輔助的回"
+"答受我們的 %1$s 服務條款%2$s約束。"
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -15202,7 +15662,9 @@ msgid ""
 "Responses are for educational purposes only and are not intended as medical, "
 "legal, financial, investment, or other professional advice. DuckAssist is "
 "subject to our %sTerms of Service%s."
-msgstr "回覆僅用於教育用途，並不構成醫療、法律、財務、投資或其他專業建議。DuckAssist 受我們的%1$s服務條款%2$s約束。"
+msgstr ""
+"回覆僅用於教育用途，並不構成醫療、法律、財務、投資或其他專業建議。DuckAssist "
+"受我們的%1$s服務條款%2$s約束。"
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -15212,8 +15674,8 @@ msgid ""
 "generated based on web content and may contain inaccuracies. Search Assist "
 "is subject to our %sTerms of Service%s."
 msgstr ""
-"回覆僅用於教育用途，並不構成醫療、法律、財務、投資或其他專業建議。係根據網頁內容生成，可能會有不準確之處。Search Assist 受我們的 "
-"%1$s服務條款%2$s 約束。"
+"回覆僅用於教育用途，並不構成醫療、法律、財務、投資或其他專業建議。係根據網頁"
+"內容生成，可能會有不準確之處。Search Assist 受我們的 %1$s服務條款%2$s 約束。"
 
 # smartling.placeholder_format=C
 #. Label on the button for restoring all previous website data.
@@ -15355,6 +15817,12 @@ msgstr "評論"
 msgctxt "maps_places"
 msgid "Reviews"
 msgstr "評論"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Rewrite this recipe scaled for a different number of servings."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Romania"
@@ -15625,7 +16093,9 @@ msgctxt "Description for Chat History feature with Encrypted Storage option"
 msgid ""
 "Save up to 30 of your most recent chats locally on your device, with the "
 "option for more with Encrypted Storage."
-msgstr "你最多可在裝置本機儲存多達 30 筆近期聊天記錄，並可選擇透過加密儲存功能儲存更多內容。"
+msgstr ""
+"你最多可在裝置本機儲存多達 30 筆近期聊天記錄，並可選擇透過加密儲存功能儲存更"
+"多內容。"
 
 # smartling.placeholder_format=C
 #. Short text for native DDG browser users explaining how Chat History stores up to 30 of their most recent chats locally on their device.
@@ -15847,16 +16317,18 @@ msgid ""
 "(on a wide range of searches). For now, Search Assist is only available in a "
 "subset of English speaking regions."
 msgstr ""
-"Search Assist 會匿名生成搜尋查詢的答案。為了達成這個目的，它會掃描網路尋找相關內容，然後使用 AI "
-"生成簡短的回答。你可以選擇它出現的頻率：從不、隨需 (僅在點按 Assist 時)、有時 (在高度相關時)，或經常 "
-"(在廣泛的搜尋中)。目前，Search Assist 功能僅供部分英語地區使用。"
+"Search Assist 會匿名生成搜尋查詢的答案。為了達成這個目的，它會掃描網路尋找相"
+"關內容，然後使用 AI 生成簡短的回答。你可以選擇它出現的頻率：從不、隨需 (僅在"
+"點按 Assist 時)、有時 (在高度相關時)，或經常 (在廣泛的搜尋中)。目前，Search "
+"Assist 功能僅供部分英語地區使用。"
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI) when the answer is not found and the answer is unsourced or with no sources
 msgid ""
 "Search Assist couldn't find enough reliable information to generate an "
 "answer for this question. Try another search."
-msgstr "Search Assist 找不到足夠的可靠資訊以產生這個問題的答案。嘗試另一個搜尋。"
+msgstr ""
+"Search Assist 找不到足夠的可靠資訊以產生這個問題的答案。嘗試另一個搜尋。"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -15865,8 +16337,8 @@ msgid ""
 "search queries. To do this, it %sscans the web%s for relevant content and "
 "then uses AI to generate a brief answer based on information found."
 msgstr ""
-"Search Assist 是一項選用功能，可匿名生成搜尋查詢的答案。為此，它%1$s掃描網路%2$s以尋找相關內容，然後使用 AI "
-"根據找到的資訊生成簡短的答案。"
+"Search Assist 是一項選用功能，可匿名生成搜尋查詢的答案。為此，它%1$s掃描網"
+"路%2$s以尋找相關內容，然後使用 AI 根據找到的資訊生成簡短的答案。"
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/search_box. top header
@@ -15986,7 +16458,9 @@ msgctxt "noresults"
 msgid ""
 "Search other sites with %s shortcuts: a search for ”!w ducks” will search "
 "for “ducks” directly on Wikipedia."
-msgstr "使用 %1$s 快捷方式搜尋其他網站：搜尋「!w ducks」將直接在維基百科上搜尋「ducks」。"
+msgstr ""
+"使用 %1$s 快捷方式搜尋其他網站：搜尋「!w ducks」將直接在維基百科上搜尋"
+"「ducks」。"
 
 # smartling.placeholder_format=C
 #. Placeholder text for the search form when no text has been entered
@@ -16004,7 +16478,9 @@ msgstr "私密搜尋與封鎖追蹤器"
 msgid ""
 "Search privately with our app or extension, add private web search to your "
 "favorite browser, or search directly at %sduckduckgo.com%s."
-msgstr "使用我們的應用程式或延伸模組進行私密搜尋，為你最常用的瀏覽器新增隱身網路搜尋功能，或直接在%1$sduckduckgo.com%2$s搜尋。"
+msgstr ""
+"使用我們的應用程式或延伸模組進行私密搜尋，為你最常用的瀏覽器新增隱身網路搜尋"
+"功能，或直接在%1$sduckduckgo.com%2$s搜尋。"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/6LZAoqH.png
@@ -16023,8 +16499,9 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"搜尋設定會儲存在瀏覽器中的非個人瀏覽器 cookie 和本機儲存空間，但你也可以使用 Cloud Save "
-"將設定匿名儲存在雲端的遠端伺服器上。不會在雲端中儲存任何個人身分資料，且你的通關密語永遠不會離開你的瀏覽器。"
+"搜尋設定會儲存在瀏覽器中的非個人瀏覽器 cookie 和本機儲存空間，但你也可以使用 "
+"Cloud Save 將設定匿名儲存在雲端的遠端伺服器上。不會在雲端中儲存任何個人身分資"
+"料，且你的通關密語永遠不會離開你的瀏覽器。"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -16136,7 +16613,9 @@ msgctxt "Description explaining how native users can enable sync"
 msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your synced devices."
-msgstr "以端對端加密安全地將幾乎無限的聊天內容儲存在我們的伺服器上，並可從所有已同步的裝置存取。"
+msgstr ""
+"以端對端加密安全地將幾乎無限的聊天內容儲存在我們的伺服器上，並可從所有已同步"
+"的裝置存取。"
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -16144,7 +16623,9 @@ msgctxt "Description explaining how native users can enable sync"
 msgid ""
 "Securely store your chats on our server using end-to-end encryption, and "
 "access them from all your devices."
-msgstr "以端對端加密安全地將您的聊天內容儲存在我們的伺服器上，並可從您所有的裝置存取。"
+msgstr ""
+"以端對端加密安全地將您的聊天內容儲存在我們的伺服器上，並可從您所有的裝置存"
+"取。"
 
 # smartling.placeholder_format=C
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
@@ -16158,7 +16639,9 @@ msgctxt "Chat history with sync modal list item"
 msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
-msgstr "採用端對端加密，安全儲存在 DuckDuckGo 的伺服器上。除了你之外，沒有人可以看到你的資料，連我們也不行。"
+msgstr ""
+"採用端對端加密，安全儲存在 DuckDuckGo 的伺服器上。除了你之外，沒有人可以看到"
+"你的資料，連我們也不行。"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -16558,7 +17041,9 @@ msgid ""
 "Sends a prompt to AI models with your messages with instructions on how to "
 "respond. These instructions will apply to all of your conversations going "
 "forward."
-msgstr "向 AI 模型發送提示，包含你的訊息和回應指示說明。這些只是將自動套用至往後所有對話。"
+msgstr ""
+"向 AI 模型發送提示，包含你的訊息和回應指示說明。這些只是將自動套用至往後所有"
+"對話。"
 
 # smartling.placeholder_format=C
 msgid "Senegal"
@@ -16634,6 +17119,12 @@ msgid "Set Up Now"
 msgstr "立即設定"
 
 # smartling.placeholder_format=C
+#. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
+msgctxt "Encrypted storage setup button shown in native browsers"
+msgid "Set Up Sync & Backup"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
 msgctxt "Title for the Sync & Backup intro screen"
 msgid "Set Up Sync & Backup"
@@ -16661,7 +17152,8 @@ msgctxt "Chat history about modal list item"
 msgid ""
 "Set up Sync & Backup after turning on Chat History to keep your chats synced "
 "across devices."
-msgstr "開啟聊天記錄後，請設定 Sync & Backup 以確保您的聊天記錄能在各裝置間保持同步。"
+msgstr ""
+"開啟聊天記錄後，請設定 Sync & Backup 以確保您的聊天記錄能在各裝置間保持同步。"
 
 # smartling.placeholder_format=C
 #. Prompt for the user to indicate their location on a map, to enable more relevant search results.
@@ -16747,7 +17239,9 @@ msgctxt "Description for Approximate Location feature"
 msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
-msgstr "與 AI 模型分享城市等級的位置，以提升相關性。Duck.ai 絕不會向我們或 AI 模型透露你的精確位置。"
+msgstr ""
+"與 AI 模型分享城市等級的位置，以提升相關性。Duck.ai 絕不會向我們或 AI 模型透"
+"露你的精確位置。"
 
 # smartling.placeholder_format=C
 #. Menu option to share feedback about a result
@@ -16806,6 +17300,13 @@ msgstr "分享頁面網址"
 msgctxt "feedback form"
 msgid "Share positive feedback"
 msgstr "分享正面意見回饋"
+
+# smartling.placeholder_format=C
+#. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
+msgctxt ""
+"Label beside the share-content switch on the Duck.ai response feedback form"
+msgid "Share this conversation with DuckDuckGo"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
@@ -17167,14 +17668,18 @@ msgctxt "settings"
 msgid ""
 "Shows a reminder that searches on DuckDuckGo are always private. Turning "
 "this off hides the reminder and never affects search privacy."
-msgstr "提醒您，DuckDuckGo 上的所有搜尋都是私密的。關閉此功能會隱藏提醒，且永遠不會影響私密搜尋。"
+msgstr ""
+"提醒您，DuckDuckGo 上的所有搜尋都是私密的。關閉此功能會隱藏提醒，且永遠不會影"
+"響私密搜尋。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Shows a reminder that searches on DuckDuckGo are always protected. Turning "
 "this off hides the reminder and never affects search protection."
-msgstr "提醒您，DuckDuckGo 上的所有搜尋都受到保護。關閉此功能會隱藏提醒，且永遠不會影響搜尋保護。"
+msgstr ""
+"提醒您，DuckDuckGo 上的所有搜尋都受到保護。關閉此功能會隱藏提醒，且永遠不會影"
+"響搜尋保護。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18033,6 +18538,24 @@ msgid "Suggest a title for a blog post"
 msgstr "建議部落格文章的標題"
 
 # smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest related articles or topics worth exploring next."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Suggest related articles to explore"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest some alternatives to this product."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
 msgctxt "directions"
 msgid "Suggestions:"
@@ -18044,10 +18567,100 @@ msgid "Suggestions:"
 msgstr "建議："
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Sum up the reviews"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A short title for the a message asking the AI to summarize a text.
 msgctxt "Title for the summarize message"
 msgid "Summarize"
 msgstr "總結"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize the Q&As"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the background and notable work of this person."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the key details of this event."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the questions and answers on this page."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize their background"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this book"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this book."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this discussion"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this discussion thread."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this page"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this page."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this video"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this video."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize what the reviews say."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
@@ -18311,16 +18924,19 @@ msgid ""
 msgstr ""
 "同步恢復碼\n"
 "\n"
-"恢復碼允許你在多個裝置之間同步您的密碼、自動填入資料和 Duck.ai 聊天記錄，並在你無法存取某個裝置時恢復你的同步資料。\n"
+"恢復碼允許你在多個裝置之間同步您的密碼、自動填入資料和 Duck.ai 聊天記錄，並在"
+"你無法存取某個裝置時恢復你的同步資料。\n"
 "\n"
 "確保此資訊安全無虞。\n"
 "任何有權限存取此代碼的人都能存取你同步的資料。%1$s\n"
 "\n"
 "這段代碼是如何運作的？\n"
-"1. 在瀏覽器中造訪 Duck.ai 並開啟 Duck.ai 設定。2. 選取「開啟 Sync & Backup」，然後選擇「恢復已同步的資料」\n"
+"1. 在瀏覽器中造訪 Duck.ai 並開啟 Duck.ai 設定。2. 選取「開啟 Sync & "
+"Backup」，然後選擇「恢復已同步的資料」\n"
 "3. 複製上方的恢復代碼，並貼到顯示「將你的代碼貼在這裡」的地方\n"
 "\n"
-"如果你超過 18 個月未使用已啟用 Sync & Backup 的 DuckDuckGo 瀏覽器，你的資料將從伺服器上刪除，且無法恢復。"
+"如果你超過 18 個月未使用已啟用 Sync & Backup 的 DuckDuckGo 瀏覽器，你的資料將"
+"從伺服器上刪除，且無法恢復。"
 
 # smartling.placeholder_format=C
 #. Secondary button label on the Sync & Backup intro screen that takes the user to the camera scan screen to pair with another device.
@@ -18363,6 +18979,12 @@ msgid "Syria"
 msgstr "敘利亞"
 
 # smartling.placeholder_format=C
+#. Text for a button that enables the theme to follow the operating system's color scheme preference.
+msgctxt "System theme button for theme selector"
+msgid "System"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Abbreviation indicating this is the total score for a game
 msgctxt "Sports module"
 msgid "T"
@@ -18389,6 +19011,12 @@ msgstr "電視"
 msgctxt "language_name"
 msgid "Tahitian"
 msgstr "大溪地語"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Tailor my resume"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Taiwan"
@@ -18418,6 +19046,13 @@ msgstr "讓你確實掌控自己的個人資料"
 msgctxt "homepage ATB modal"
 msgid "Take control of your personal data!"
 msgstr "讓你確實掌控自己的個人資料！"
+
+# smartling.placeholder_format=C
+#. Description for the Feedback section of the Duck.ai settings page, asking the user to take an anonymous survey to let us know how we can make Duck.ai better.
+msgctxt "Feedback section description on the Duck.ai settings page"
+msgid ""
+"Take this anonymous survey to let us know how we can make Duck.ai better."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -18631,7 +19266,9 @@ msgid ""
 "That means information sent between your device and the webpage behind this "
 "link is at increased risk of being intercepted by a third party. In rare "
 "cases this includes passwords, or payment details."
-msgstr "這代表在你的裝置與此連結通往的網頁之間傳遞的資訊處於高風險中，有可能會遭到第三方攔截。雖然極少發生，但該資訊可能包含密碼或付款詳情。"
+msgstr ""
+"這代表在你的裝置與此連結通往的網頁之間傳遞的資訊處於高風險中，有可能會遭到第"
+"三方攔截。雖然極少發生，但該資訊可能包含密碼或付款詳情。"
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -18714,6 +19351,12 @@ msgid "Theme"
 msgstr "佈景主題"
 
 # smartling.placeholder_format=C
+#. Text for the theme selector label that allows users to switch between Light and dark theme.
+msgctxt "Label for the theme selector feature"
+msgid "Theme"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. http://i.imgur.com/LpFhb1e.png
 msgctxt "settings"
 msgid "Theme"
@@ -18741,7 +19384,8 @@ msgctxt "Error message when there was an issue saving a chat to the browser"
 msgid ""
 "There was an error saving this chat locally. Please check your browser "
 "settings to make sure local data storage is enabled."
-msgstr "在本機儲存此聊天時發生錯誤。請檢查你的瀏覽器設定，確保已啟用本機資料儲存。"
+msgstr ""
+"在本機儲存此聊天時發生錯誤。請檢查你的瀏覽器設定，確保已啟用本機資料儲存。"
 
 # smartling.placeholder_format=C
 #. Error modal body line 1.
@@ -18773,7 +19417,9 @@ msgid ""
 "These browser permissions are used to add privacy protection on websites you "
 "visit by blocking hidden trackers, encrypting connections where possible, "
 "and by making DuckDuckGo your default search engine."
-msgstr "這些瀏覽器權限可封鎖隱藏的追蹤器，並盡可能加密資訊，並將DuckDuckGo設定為預設搜尋引擎，藉此為你造訪的網站新增隱私保護。"
+msgstr ""
+"這些瀏覽器權限可封鎖隱藏的追蹤器，並盡可能加密資訊，並將DuckDuckGo設定為預設"
+"搜尋引擎，藉此為你造訪的網站新增隱私保護。"
 
 # smartling.placeholder_format=C
 #. Secondary line under DUCKCHAT_SYNC_PAIRING_ALREADY_SYNCED_TITLE.
@@ -18845,8 +19491,8 @@ msgid ""
 "This conversation was generated with Duck.ai (%s) using %s's %s Model. AI "
 "chats may display inaccurate or offensive information (see %s for more info)."
 msgstr ""
-"此對話是使用 %2$s 的 %3$s 模型與 Duck.ai (%1$s) 產生的。AI 聊天可能會顯示不準確或令人反感的資訊 (請參閱 %4$s "
-"取得更多資訊)。"
+"此對話是使用 %2$s 的 %3$s 模型與 Duck.ai (%1$s) 產生的。AI 聊天可能會顯示不準"
+"確或令人反感的資訊 (請參閱 %4$s 取得更多資訊)。"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with multiple AI models in the same chat, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using multiple chat models. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -18855,7 +19501,9 @@ msgid ""
 "This conversation was generated with Duck.ai (%s) using multiple chat "
 "models. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
-msgstr "此對話是使用多個聊天模型與 Duck.ai (%1$s) 產生的。AI 聊天可能會顯示不準確或令人反感的資訊 (請參閱 %2$s 取得更多資訊)。"
+msgstr ""
+"此對話是使用多個聊天模型與 Duck.ai (%1$s) 產生的。AI 聊天可能會顯示不準確或令"
+"人反感的資訊 (請參閱 %2$s 取得更多資訊)。"
 
 # smartling.placeholder_format=C
 #. When a user exports a transcript of a voice chat they had with the AI. This text goes at the very top of the downloaded file as a header. Placeholders are for links. Example: 'This conversation was generated with Duck.ai voice chat (https://duck.ai). AI may provide inaccurate or offensive information. (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -18863,7 +19511,9 @@ msgctxt "Export chat feature in AI Chat"
 msgid ""
 "This conversation was generated with Duck.ai voice chat (%s). AI may provide "
 "inaccurate or offensive information. (see %s for more info)."
-msgstr "這段對話是透過 Duck.ai 語音聊天產生的（%1$s）。AI 可能會提供不準確或令人反感的資訊。（更多資訊請參見%2$s）。"
+msgstr ""
+"這段對話是透過 Duck.ai 語音聊天產生的（%1$s）。AI 可能會提供不準確或令人反感"
+"的資訊。（更多資訊請參見%2$s）。"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with DuckDuckGo AI Chat (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/aichat/privacy-terms for more info).'
@@ -18873,8 +19523,8 @@ msgid ""
 "Model. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
 msgstr ""
-"此對話是使用 %2$s的%3$s 模型與 DuckDuckGo AI Chat (%1$s) 產生的。AI 聊天可能會顯示不準確或令人反感的資訊 "
-"(請參閱 %4$s 取得更多資訊)。"
+"此對話是使用 %2$s的%3$s 模型與 DuckDuckGo AI Chat (%1$s) 產生的。AI 聊天可能"
+"會顯示不準確或令人反感的資訊 (請參閱 %4$s 取得更多資訊)。"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
@@ -18977,7 +19627,9 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "This model provider deletes data associated with this chat within 30 days. "
 "Other model providers follow a zero data retention model."
-msgstr "此模型供應商會在 30 天內刪除與此聊天相關的資料。其他模型供應商遵循零資料保留模式。"
+msgstr ""
+"此模型供應商會在 30 天內刪除與此聊天相關的資料。其他模型供應商遵循零資料保留"
+"模式。"
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers, and that other providers may retain chat data for a limited time instead.
@@ -18985,7 +19637,9 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "This model provider does not store any data associated with this chat. Other "
 "model providers follow a limited data retention model."
-msgstr "此模型供應商不會儲存與此聊天相關的任何資料。其他模型供應商遵循限制資料保留模式。"
+msgstr ""
+"此模型供應商不會儲存與此聊天相關的任何資料。其他模型供應商遵循限制資料保留模"
+"式。"
 
 # smartling.placeholder_format=C
 #. Info that page may refresh during update.
@@ -19021,7 +19675,9 @@ msgctxt "First paragraph for the Sync & Backup intro screen"
 msgid ""
 "This saves your chats with end-to-end encryption on DuckDuckGo's secure "
 "server, which later can be accessed from any browser."
-msgstr "這會將您的聊天內容以端對端加密方式儲存在 DuckDuckGo 的安全伺服器，之後您可從任何瀏覽器存取。"
+msgstr ""
+"這會將您的聊天內容以端對端加密方式儲存在 DuckDuckGo 的安全伺服器，之後您可從"
+"任何瀏覽器存取。"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -19029,7 +19685,9 @@ msgctxt "duckassist"
 msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again."
-msgstr "此設定儲存在你的瀏覽器中，這表示如果你清除 duckduckgo.com 的瀏覽器資料，那麼可能會再次看到 AI 輔助的答案。"
+msgstr ""
+"此設定儲存在你的瀏覽器中，這表示如果你清除 duckduckgo.com 的瀏覽器資料，那麼"
+"可能會再次看到 AI 輔助的答案。"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -19039,8 +19697,9 @@ msgid ""
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
 msgstr ""
-"此設定儲存在你的瀏覽器中，這表示如果你清除 duckduckgo.com 的瀏覽器資料，那麼可能會再次看到 AI "
-"輔助的答案。不過，我們也有一個起始頁面，從不在 %1$s 顯示 AI 輔助答案。"
+"此設定儲存在你的瀏覽器中，這表示如果你清除 duckduckgo.com 的瀏覽器資料，那麼"
+"可能會再次看到 AI 輔助的答案。不過，我們也有一個起始頁面，從不在 %1$s 顯示 "
+"AI 輔助答案。"
 
 # smartling.placeholder_format=C
 #. User feedback indicating that a translation is helpful
@@ -19079,8 +19738,8 @@ msgid ""
 "Sync & Backup. You'll still be able to access your chats in other browsers "
 "connected to Sync & Backup."
 msgstr ""
-"這將刪除此瀏覽器中所有 Duck.ai 聊天記錄，並與 Sync & Backup 中斷連線。您仍然可以在連接到 Sync & Backup "
-"的其他瀏覽器中存取您的聊天記錄。"
+"這將刪除此瀏覽器中所有 Duck.ai 聊天記錄，並與 Sync & Backup 中斷連線。您仍然"
+"可以在連接到 Sync & Backup 的其他瀏覽器中存取您的聊天記錄。"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to clear all recentchats, with a warning that this action cannot be undone.
@@ -19225,7 +19884,9 @@ msgctxt "directions"
 msgid ""
 "To print directions:%sGo back to the map.%sSelect the route you want to "
 "print.%sClick the print icon.%s"
-msgstr "如要列印導航指引：%1$s返回地圖。%2$s選取你想列印的路線。%3$s按一下「列印」圖示。%4$s"
+msgstr ""
+"如要列印導航指引：%1$s返回地圖。%2$s選取你想列印的路線。%3$s按一下「列印」圖"
+"示。%4$s"
 
 # smartling.placeholder_format=C
 #. Explains where the user can find their recovery code. Figma frame 3703-44420.
@@ -19234,7 +19895,9 @@ msgid ""
 "To restore your synced data, you'll need the Recovery Code you saved when "
 "you first set up Sync. This code may have been saved as a PDF on the device "
 "you originally used to set up Sync."
-msgstr "若要恢復同步資料，請在第一次設定同步時儲存的恢復碼。此代碼可能已以 PDF 格式儲存在您最初用於設定同步的裝置上。"
+msgstr ""
+"若要恢復同步資料，請在第一次設定同步時儲存的恢復碼。此代碼可能已以 PDF 格式儲"
+"存在您最初用於設定同步的裝置上。"
 
 # smartling.placeholder_format=C
 #. Body text explaining that the user needs to update their DDG browser before migration can proceed.
@@ -19242,7 +19905,9 @@ msgctxt "duckai_migration"
 msgid ""
 "To transfer your chat history to Duck.ai, please update your DuckDuckGo "
 "browser to the latest version and try again."
-msgstr "欲將你的聊天紀錄轉移至 Duck.ai，請將你的 DuckDuckGo 瀏覽器更新至最新版本並再試一次。"
+msgstr ""
+"欲將你的聊天紀錄轉移至 Duck.ai，請將你的 DuckDuckGo 瀏覽器更新至最新版本並再"
+"試一次。"
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
@@ -19485,7 +20150,8 @@ msgctxt "Full sentence for translating text"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr "將這段英文句子翻譯成法語：“How do I get to the nearest movie theatre？”"
+msgstr ""
+"將這段英文句子翻譯成法語：“How do I get to the nearest movie theatre？”"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for translating a sentence into another language. Translate the whole sentence and please use target language instead of 'English' and modify the sentence to translate into 'English' instead of 'French'. Example: 'Translate this {target language} sentence into English: “How do I get to the nearest movie theatre?”'
@@ -19493,7 +20159,20 @@ msgctxt "Full sentence for translating text prompt"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr "將這段英文句子翻譯成中文：“How do I get to the nearest movie theatre？”"
+msgstr ""
+"將這段英文句子翻譯成中文：“How do I get to the nearest movie theatre？”"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Translate this page"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
+msgctxt "Page suggestion prompt"
+msgid "Translate this page into %s."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder text for a region that will display translated text.
@@ -19635,6 +20314,12 @@ msgstr "請再試一次"
 msgctxt "Sidemenu subscription promo"
 msgid "Try Free"
 msgstr "免費試用"
+
+# smartling.placeholder_format=C
+#. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
+msgctxt "settings"
+msgid "Try It Now"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. CTA for a promotional card that encourages users to try new AI model that was added recently
@@ -19869,6 +20554,22 @@ msgid "Trying DuckDuckGo again"
 msgstr "再試一次DuckDuckGo"
 
 # smartling.placeholder_format=C
+#. Message shown in a modal after supported third-party browser users disable AI features in Settings. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
 msgctxt "Assistant response placeholder"
 msgid "Trying with %s"
@@ -20036,7 +20737,9 @@ msgctxt "settings"
 msgid ""
 "Types out DuckAssist answers as they're generated. Turning this off may "
 "result in a short delay between a search and the answer being displayed."
-msgstr "在產生時輸入 DuckAssist 答案。關閉此功能可能會導致搜尋與顯示答案之間的短暫延遲。"
+msgstr ""
+"在產生時輸入 DuckAssist 答案。關閉此功能可能會導致搜尋與顯示答案之間的短暫延"
+"遲。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -20287,7 +20990,9 @@ msgctxt "Description of the modal to upgrade to Pro"
 msgid ""
 "Unlock %s, higher AI reasoning, and 2x higher usage limits than the Plus "
 "plan by upgrading to Pro."
-msgstr "透過升級至 Pro，解鎖 %1$s、比 Plus 方案更高的 AI 推理能力，以及 2 倍於 Plus 方案的使用上限。"
+msgstr ""
+"透過升級至 Pro，解鎖 %1$s、比 Plus 方案更高的 AI 推理能力，以及 2 倍於 Plus "
+"方案的使用上限。"
 
 # smartling.placeholder_format=C
 #. Title for the subscription promo shown in the SERP sidemenu.
@@ -20599,6 +21304,12 @@ msgid "Uruguay"
 msgstr "烏拉圭"
 
 # smartling.placeholder_format=C
+#. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
+msgctxt "Navigation label on the Duck.ai settings page"
+msgid "Usage"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A feedback suggestion
 msgctxt "Feedback prompt"
 msgid "Usage limit"
@@ -20639,7 +21350,9 @@ msgctxt "duckai_seo"
 msgid ""
 "Use ChatGPT, Claude, and other AIs, privately. Protect chats from hackers, "
 "scammers, and companies. Keep info confidential. Free. No account required."
-msgstr "私下使用 ChatGPT、Claude 及其他 AI。保護聊天內容，防止駭客、詐騙者和公司的侵害。對資訊保密。免費。不需要帳戶。"
+msgstr ""
+"私下使用 ChatGPT、Claude 及其他 AI。保護聊天內容，防止駭客、詐騙者和公司的侵"
+"害。對資訊保密。免費。不需要帳戶。"
 
 # smartling.placeholder_format=C
 #. Header above instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -20829,7 +21542,8 @@ msgctxt "Ads GDPR, internal use only. Do not change"
 msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Microsoft's ad network"
-msgstr "DuckDuckGo 會保護你在觀看廣告時的隱私。點擊廣告則由 Microsoft 的廣告網路管理"
+msgstr ""
+"DuckDuckGo 會保護你在觀看廣告時的隱私。點擊廣告則由 Microsoft 的廣告網路管理"
 
 # smartling.placeholder_format=C
 #. Information about TripAdvisor ads for DuckDuckGo's users. This appears in a tooltip.
@@ -20837,7 +21551,9 @@ msgctxt "Single Place Hotel Offers Module"
 msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "TripAdvisor's ad network."
-msgstr "DuckDuckGo 會保護你在觀看廣告時的隱私。點擊廣告則由 TripAdvisor 的廣告網路管理。"
+msgstr ""
+"DuckDuckGo 會保護你在觀看廣告時的隱私。點擊廣告則由 TripAdvisor 的廣告網路管"
+"理。"
 
 # smartling.placeholder_format=C
 msgid "Virgin Islands"
@@ -20879,8 +21595,8 @@ msgid ""
 "Visit Duck.ai in your other browser and go to %sDuck.ai Settings%s > %sSync "
 "& Backup%s > %sManage%s then select %sSync With Another Device%s."
 msgstr ""
-"請用其他瀏覽器造訪 Duck.ai，並前往 %1$sDuck.ai 設定%2$s > %3$sSync & Backup%4$s > "
-"%5$s管理%6$s，再選取%7$s與其他裝置同步%8$s。"
+"請用其他瀏覽器造訪 Duck.ai，並前往 %1$sDuck.ai 設定%2$s > %3$sSync & "
+"Backup%4$s > %5$s管理%6$s，再選取%7$s與其他裝置同步%8$s。"
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -20890,8 +21606,8 @@ msgid ""
 "On” under Sync & Backup and select “Sync With Another Device”. Or scan the "
 "QR on your Recovery PDF."
 msgstr ""
-"在您的其他瀏覽器中造訪 Duck.ai 並開啟 Duck.ai 設定。在「Sync & "
-"Backup」下選取「開啟」，然後選取「與另一裝置同步」。或掃描您的恢復 PDF 上的二維碼。"
+"在您的其他瀏覽器中造訪 Duck.ai 並開啟 Duck.ai 設定。在「Sync & Backup」下選取"
+"「開啟」，然後選取「與另一裝置同步」。或掃描您的恢復 PDF 上的二維碼。"
 
 # smartling.placeholder_format=C
 #. Shared body copy for every screen in the Sync Another Device flow (QR display, camera scan, camera-unavailable fallback, manual entry). Bold tags wrap navigation breadcrumbs. Render with <Translate /> so the HTML is interpreted; plain `translate()` will trip the html-string warning.
@@ -20901,8 +21617,8 @@ msgid ""
 "ai Settings%s > %sSync & Backup%s > %sManage%s then select %sSync With "
 "Another Device%s."
 msgstr ""
-"請用其他瀏覽器或 DuckDuckGo 應用程式造訪 Duck.ai，並前往 %1$sDuck.ai 設定%2$s > %3$sSync & "
-"Backup%4$s > %5$s管理%6$s，再選取%7$s與其他裝置同步%8$s。"
+"請用其他瀏覽器或 DuckDuckGo 應用程式造訪 Duck.ai，並前往 %1$sDuck.ai 設"
+"定%2$s > %3$sSync & Backup%4$s > %5$s管理%6$s，再選取%7$s與其他裝置同步%8$s。"
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -20912,8 +21628,9 @@ msgid ""
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
 msgstr ""
-"使用其他瀏覽器或 DuckDuckGo 應用程式造訪 Duck.ai，然後開啟 Duck.ai 設定。在「Sync & "
-"Backup」下選取「開啟」，然後選取「與另一裝置同步」。或掃描您的恢復 PDF 上的二維碼。"
+"使用其他瀏覽器或 DuckDuckGo 應用程式造訪 Duck.ai，然後開啟 Duck.ai 設定。在"
+"「Sync & Backup」下選取「開啟」，然後選取「與另一裝置同步」。或掃描您的恢復 "
+"PDF 上的二維碼。"
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -21026,6 +21743,12 @@ msgid "Wales"
 msgstr "威爾斯"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Walk me through the steps"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for walking directions on a map.
 msgctxt "directions"
 msgid "Walking"
@@ -21102,7 +21825,9 @@ msgstr "在 Duck Player 中觀看"
 msgid ""
 "Watch in Duck Player to block personalized ads on YouTube and prevent your "
 "viewing activity from influencing YouTube recommendations."
-msgstr "在 Duck Player 中觀看，阻擋 YouTube 上的個人化廣告，避免觀看體驗受 YouTube 推播干擾。"
+msgstr ""
+"在 Duck Player 中觀看，阻擋 YouTube 上的個人化廣告，避免觀看體驗受 YouTube 推"
+"播干擾。"
 
 # smartling.placeholder_format=C
 #. A button that takes a user to another site in order to watch a video. The placeholder is the name of the video site. For example: 'Watch on Vimeo'
@@ -21122,8 +21847,8 @@ msgid ""
 "independent company and has no relationship with YouTube, where most videos "
 "are hosted."
 msgstr ""
-"在此處觀看影片即代表託管影片的網站能夠追蹤您，因為我們必須從那邊串流傳輸內容。DuckDuckGo 是一間獨立公司，與託管大多數影片的 YouTube "
-"沒有任何關係。"
+"在此處觀看影片即代表託管影片的網站能夠追蹤您，因為我們必須從那邊串流傳輸內"
+"容。DuckDuckGo 是一間獨立公司，與託管大多數影片的 YouTube 沒有任何關係。"
 
 # smartling.placeholder_format=C
 #. Heading for the highlight card explaining anonymized prompt delivery.
@@ -21138,6 +21863,17 @@ msgid "We can anonymize%s your location%s to show you more accurate results."
 msgstr "我們可以將你的%1$s位置%2$s匿名，來顯示更精確的結果。"
 
 # smartling.placeholder_format=C
+#. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
+msgctxt ""
+"Inline warning shown below the share-content toggle when the user selects "
+"Harmful or Illegal but has not enabled sharing"
+msgid ""
+"We can only fix what we can see. To report a harmful or illegal response, "
+"please share this conversation with DuckDuckGo so we can investigate and "
+"address the issue."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
 msgctxt ""
 "Inline warning shown below the share-content toggle when the user selects "
@@ -21146,7 +21882,9 @@ msgid ""
 "We can only fix what we can see. To report a harmful or illegal response, "
 "please share your prompt and response so we can investigate and address the "
 "issue."
-msgstr "我們必須先察覺問題，才能修正問題。若要檢舉有害或非法的回覆，請與我們分享您的提示詞與回覆內容，以便我們調查並處理該問題。"
+msgstr ""
+"我們必須先察覺問題，才能修正問題。若要檢舉有害或非法的回覆，請與我們分享您的"
+"提示詞與回覆內容，以便我們調查並處理該問題。"
 
 # smartling.placeholder_format=C
 #. Explains how location service is used to show users search results near their current location.
@@ -21186,7 +21924,8 @@ msgstr "我們不會儲存你的個人資訊。"
 msgid ""
 "We don't store your personal info. We don't follow you around with ads. We "
 "don't track you. Ever."
-msgstr "我們不會儲存你的個人資訊。我們不會用廣告到處煩你。我們不會追蹤你。絕對不會。"
+msgstr ""
+"我們不會儲存你的個人資訊。我們不會用廣告到處煩你。我們不會追蹤你。絕對不會。"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -21207,7 +21946,8 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what convinced you "
 "to try us out today:"
-msgstr "本站不追蹤任何用戶，請告訴我們為何你願意試用我們的服務，以讓我們不斷完善："
+msgstr ""
+"本站不追蹤任何用戶，請告訴我們為何你願意試用我們的服務，以讓我們不斷完善："
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -21246,7 +21986,9 @@ msgctxt "homepage onboarding"
 msgid ""
 "We don’t store your search history. We therefore have nothing to sell to "
 "advertisers that track you across the Internet."
-msgstr "我們不會儲存你的搜尋紀錄。因此，我們沒有東西能夠賣給網路上那些追蹤你的廣告商。"
+msgstr ""
+"我們不會儲存你的搜尋紀錄。因此，我們沒有東西能夠賣給網路上那些追蹤你的廣告"
+"商。"
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -21271,7 +22013,9 @@ msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
 "We have agreements with all AI providers to ensure your chats aren't used to "
 "train AIs."
-msgstr "我們與所有人工智慧提供者都簽訂了協議，以確保你的聊天記錄不會用於訓練人工智慧。"
+msgstr ""
+"我們與所有人工智慧提供者都簽訂了協議，以確保你的聊天記錄不會用於訓練人工智"
+"慧。"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -21303,7 +22047,9 @@ msgctxt "precise_user_location"
 msgid ""
 "We only use your anonymous location to deliver better results, closer to "
 "you. You can always change your mind later."
-msgstr "我們僅會將你的匿名位置用於提供更優質、離你更近的結果。你之後可以隨時改變主意。"
+msgstr ""
+"我們僅會將你的匿名位置用於提供更優質、離你更近的結果。你之後可以隨時改變主"
+"意。"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -21329,7 +22075,9 @@ msgid ""
 "We use feedback like this to improve DuckDuckGo. Suggestions will be "
 "incorporated at the discretion of %s. Corrections may not show up in results "
 "right away."
-msgstr "我們運用這樣的回饋來完善DuckDuckGo。%1$s將視情況採納建議。修改內容可能不會立刻出現。"
+msgstr ""
+"我們運用這樣的回饋來完善DuckDuckGo。%1$s將視情況採納建議。修改內容可能不會立"
+"刻出現。"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -21487,7 +22235,9 @@ msgctxt "Welcome message in chat"
 msgid ""
 "Welcome to Duck.ai! All of your chats here are private, anonymized by us and "
 "not used to train AI models."
-msgstr "歡迎來到 Duck.ai！您在這裡的所有聊天內容都是私密的，我們會將其匿名化，且不會用來訓練人工智慧模型。"
+msgstr ""
+"歡迎來到 Duck.ai！您在這裡的所有聊天內容都是私密的，我們會將其匿名化，且不會"
+"用來訓練人工智慧模型。"
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened.
@@ -21495,7 +22245,9 @@ msgctxt "Welcome message in chat"
 msgid ""
 "Welcome to DuckDuckGo AI Chat! All of your chats here are private, "
 "anonymized by us and not used to train AI models."
-msgstr "歡迎來到 DuckDuckGo AI Chat！您在這裡的所有聊天內容都是私密的，我們會將其匿名化，且不會用來訓練人工智慧模型。"
+msgstr ""
+"歡迎來到 DuckDuckGo AI Chat！您在這裡的所有聊天內容都是私密的，我們會將其匿名"
+"化，且不會用來訓練人工智慧模型。"
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened. Example: 'Welcome to DuckDuckGo AI Chat! This chat session is powered by OpenAI’s GPT-3. All of your chats here are private, and are never stored by DuckDuckGo or used to train AI models.'
@@ -21505,8 +22257,8 @@ msgid ""
 "of your chats here are private, and are never stored by DuckDuckGo or used "
 "to train AI models."
 msgstr ""
-"歡迎來到 DuckDuckGo AI Chat！此聊天會話由 %1$s 的 %2$s 提供技術支援。 您在這裡的所有聊天內容都是私密的，且永遠不會被 "
-"DuckDuckGo 儲存或用來訓練 AI 模型。"
+"歡迎來到 DuckDuckGo AI Chat！此聊天會話由 %1$s 的 %2$s 提供技術支援。 您在這"
+"裡的所有聊天內容都是私密的，且永遠不會被 DuckDuckGo 儲存或用來訓練 AI 模型。"
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -21632,8 +22384,106 @@ msgid ""
 "easy to understand for people with or without much AI, or technical, "
 "experience."
 msgstr ""
-"下載 DuckDuckGo 瀏覽器對於有興趣使用 Duck.ai 的人有哪些好處？僅參考官方 DuckDuckGo 來源。將回應分成清晰的部分，並以 "
-"Duck.ai 整合和隱私保護為重點。對於具有或沒有太多 AI 或技術經驗的人來說，保持內容相當簡短、簡單且易於理解。"
+"下載 DuckDuckGo 瀏覽器對於有興趣使用 Duck.ai 的人有哪些好處？僅參考官方 "
+"DuckDuckGo 來源。將回應分成清晰的部分，並以 Duck.ai 整合和隱私保護為重點。對"
+"於具有或沒有太多 AI 或技術經驗的人來說，保持內容相當簡短、簡單且易於理解。"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the counterarguments?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the hours & location?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key contributions of this paper?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key contributions?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key details?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key points covered in this video?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key points?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key takeaways from this article?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key takeaways?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key things I will learn from this course?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main counterarguments or criticisms of this?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main questions this page answers?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the must-try dishes here?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"What are the opening hours, location, and contact details for this place?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the pros and cons of this product?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the pros and cons?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
@@ -21736,6 +22586,12 @@ msgid "What does atria mean in the context of a medical article?"
 msgstr "在醫學文章中，心房一詞的含義是？"
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What does this answer?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
@@ -21746,6 +22602,12 @@ msgstr "希望我們新增什麼功能呢？ (選填)"
 msgctxt "cloudsave"
 msgid "What information gets saved?"
 msgstr "甚麼資訊會被儲存？"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What interview questions might come up for this role?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -21760,6 +22622,12 @@ msgstr "甚麼是Cloud Save書籤小工具，以及它跟網址參數書籤小�
 msgctxt "Full sentence for looking up basic facts"
 msgid "What is the capital city of Albania?"
 msgstr "阿爾巴尼亞的首都是哪座城市？"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What is the overall verdict and rating for this?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to a page with additional information.
@@ -21784,6 +22652,12 @@ msgid "What people say:"
 msgstr "評論："
 
 # smartling.placeholder_format=C
+#. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What should I order?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
 msgctxt "feedback form"
 msgid "What stood out?"
@@ -21794,6 +22668,18 @@ msgstr "有什麼特別突出的地方？"
 msgctxt "feedback form"
 msgid "What was wrong with the response? (optional)"
 msgstr "回覆有什麼問題？(選填)"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I learn?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I need?"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -21811,6 +22697,12 @@ msgstr "您在 DuckDuckGo 中觀看的內容不會影響您在 YouTube 上的推
 msgctxt "SERP footer content"
 msgid "What's New"
 msgstr "最新消息"
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What's the verdict?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to a page featuring the most recent updates from DuckDuckGo.
@@ -21861,6 +22753,12 @@ msgid "Which features are missing? (Optional)"
 msgstr "缺少哪些功能？（選填）"
 
 # smartling.placeholder_format=C
+#. An invitation for users to leave feedback
+msgctxt "Feedback prompt"
+msgid "Which features are missing? (optional)"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
 msgid "White"
 msgstr "白色"
@@ -21875,6 +22773,18 @@ msgstr "白色"
 #. Link to an about us page.
 msgid "Who We Are"
 msgstr "關於我們"
+
+# smartling.placeholder_format=C
+#. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Who are the main cast and crew, and what else are they known for?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Who is this person?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Header above a collection of privacy-related links.
@@ -22316,7 +23226,8 @@ msgstr "你最多可以附加 %1$s 個文字選擇。"
 msgid ""
 "You can change how frequently you see Search Assist, or turn it off "
 "entirely, in %sSearch Settings%s."
-msgstr "你可以在 %1$s搜尋設定%2$s 中變更 Search Assist 的顯示頻率，或將其完全關閉。"
+msgstr ""
+"你可以在 %1$s搜尋設定%2$s 中變更 Search Assist 的顯示頻率，或將其完全關閉。"
 
 # smartling.placeholder_format=C
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
@@ -22330,7 +23241,8 @@ msgctxt "cloudsave"
 msgid ""
 "You can do this by saving your settings under a different passphrase, "
 "optionally deleting the first set."
-msgstr "你可以將你的設定以另一通關密語儲存，你亦可同時刪除以舊通關密語儲存的設定。"
+msgstr ""
+"你可以將你的設定以另一通關密語儲存，你亦可同時刪除以舊通關密語儲存的設定。"
 
 # smartling.placeholder_format=C
 #. Prefix for filename location sentence.
@@ -22465,7 +23377,9 @@ msgctxt "Description of the post-upgrade success modal"
 msgid ""
 "You now have access to %s, higher AI reasoning, and 2x higher usage limits "
 "than Plus."
-msgstr "您現在已獲得 %1$s 的存取權限，具備更高階的 AI 推理能力，並享有比 Plus 方案高出 2 倍的使用上限。"
+msgstr ""
+"您現在已獲得 %1$s 的存取權限，具備更高階的 AI 推理能力，並享有比 Plus 方案高"
+"出 2 倍的使用上限。"
 
 # smartling.placeholder_format=C
 #. Description text for the welcome modal displayed after the user subscribes to DuckDuckGo.
@@ -22473,7 +23387,9 @@ msgctxt "Description text for the subscription welcome modal"
 msgid ""
 "You now have access to advanced AI models. You can access the VPN and other "
 "DuckDuckGo subscription protections in the DuckDuckGo browser."
-msgstr "你現在可以使用進階的 AI 模型。你可以在 DuckDuckGo 瀏覽器中存取 VPN 和其他 DuckDuckGo 訂閱保護功能。"
+msgstr ""
+"你現在可以使用進階的 AI 模型。你可以在 DuckDuckGo 瀏覽器中存取 VPN 和其他 "
+"DuckDuckGo 訂閱保護功能。"
 
 # smartling.placeholder_format=C
 #. Welcome message that appears after the DuckDuckGo extension is installed.
@@ -22494,7 +23410,9 @@ msgid ""
 "You will no longer be able to access your saved chats from this browser. The "
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
-msgstr "您將無法再從此瀏覽器存取已儲存的聊天記錄。最近的 30 個聊天記錄仍將保留在本地儲存空間中。這不會刪除您在加密伺服器上的聊天記錄。"
+msgstr ""
+"您將無法再從此瀏覽器存取已儲存的聊天記錄。最近的 30 個聊天記錄仍將保留在本地"
+"儲存空間中。這不會刪除您在加密伺服器上的聊天記錄。"
 
 # smartling.placeholder_format=C
 #. Explains that turning off disconnects this browser only; the last 30 chats stay in local storage and the encrypted server backup is not deleted.
@@ -22503,7 +23421,9 @@ msgid ""
 "You will no longer be able to access your saved chats from this browser. The "
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
-msgstr "您將無法再從此瀏覽器存取已儲存的聊天記錄。最近的 30 個聊天記錄仍將保留在本地儲存空間中。這不會刪除您在加密伺服器上的聊天記錄。"
+msgstr ""
+"您將無法再從此瀏覽器存取已儲存的聊天記錄。最近的 30 個聊天記錄仍將保留在本地"
+"儲存空間中。這不會刪除您在加密伺服器上的聊天記錄。"
 
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
@@ -22524,7 +23444,9 @@ msgctxt "welcome message eu search preference android"
 msgid ""
 "You're now searching privately in Chrome. Use our app instead of Chrome to "
 "browse privately too. It’s already installed and can:"
-msgstr "你目前正在Chrome進行私密搜尋。不用Chrome，在我們的應用程式中也可以進行隱身瀏覽。應用程式已經安裝完畢，而且可以："
+msgstr ""
+"你目前正在Chrome進行私密搜尋。不用Chrome，在我們的應用程式中也可以進行隱身瀏"
+"覽。應用程式已經安裝完畢，而且可以："
 
 # smartling.placeholder_format=C
 #. Confirmation message that appears after the DuckDuckGo browser extension is installed.
@@ -22605,7 +23527,9 @@ msgctxt "Sync file storage limit modal description"
 msgid ""
 "You've run out of Sync & Backup storage for Duck.ai chats with attachments. "
 "Delete the %s oldest chats to resume Sync. Pinned chats will not be deleted."
-msgstr "您 Duck.ai 聊天 (含附件) 的 Sync & Backup 儲存空間已用完。刪除 %1$s 則最舊的聊天記錄以恢復同步。置頂聊天不會刪除。"
+msgstr ""
+"您 Duck.ai 聊天 (含附件) 的 Sync & Backup 儲存空間已用完。刪除 %1$s 則最舊的"
+"聊天記錄以恢復同步。置頂聊天不會刪除。"
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -22614,7 +23538,9 @@ msgid ""
 "You've run out of Sync & Backup storage for Duck.ai chats. Delete the %s "
 "oldest chats with attachments to resume Sync. Pinned chats will not be "
 "deleted."
-msgstr "您已用完 Duck.ai 聊天記錄的 Sync & Backup 儲存空間。刪除 %1$s 則最舊的含附件聊天記錄以恢復同步。置頂聊天不會刪除。"
+msgstr ""
+"您已用完 Duck.ai 聊天記錄的 Sync & Backup 儲存空間。刪除 %1$s 則最舊的含附件"
+"聊天記錄以恢復同步。置頂聊天不會刪除。"
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the sync storage limit.
@@ -22627,7 +23553,9 @@ msgstr "你的儲存空間已用完"
 msgid ""
 "YouTube (owned by Google) does not let you watch videos anonymously. As "
 "such, watching YouTube videos here will be tracked by YouTube/Google."
-msgstr "YouTube(Google所擁有的公司)不允許匿名看影片。觀看YouTube影片還是會被Youtube/Google追蹤。"
+msgstr ""
+"YouTube(Google所擁有的公司)不允許匿名看影片。觀看YouTube影片還是會被Youtube/"
+"Google追蹤。"
 
 # smartling.placeholder_format=C
 #. Label for a privacy disclaimer related to YouTube videos
@@ -22670,7 +23598,9 @@ msgid ""
 "Your backup will be deleted from DuckDuckGo's server. All devices will be "
 "disconnected from sync. Your %s most recent chats will be available in local "
 "storage on these browsers:"
-msgstr "您的備份將從 DuckDuckGo 的伺服器中刪除。所有裝置都將中斷同步。在以下瀏覽器中，您最近的 %1$s 筆聊天記錄將保存在本機儲存空間中："
+msgstr ""
+"您的備份將從 DuckDuckGo 的伺服器中刪除。所有裝置都將中斷同步。在以下瀏覽器"
+"中，您最近的 %1$s 筆聊天記錄將保存在本機儲存空間中："
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list.
@@ -22679,7 +23609,9 @@ msgid ""
 "Your backup will be deleted from DuckDuckGo's server. All devices will be "
 "disconnected from sync. Your 100 most recent chats will be available in "
 "local storage on these browsers:"
-msgstr "您的備份將從 DuckDuckGo 的伺服器中刪除。所有裝置都將中斷同步。在以下瀏覽器中，您最近的 100 筆聊天記錄將保存在本機儲存空間中："
+msgstr ""
+"您的備份將從 DuckDuckGo 的伺服器中刪除。所有裝置都將中斷同步。在以下瀏覽器"
+"中，您最近的 100 筆聊天記錄將保存在本機儲存空間中："
 
 # smartling.placeholder_format=C
 #. List item indicating that a site exclusion filter is currently active for the search
@@ -22743,14 +23675,16 @@ msgstr "您的聊天內容是私密的，且絕不會用於訓練 AI 模型"
 msgctxt "Active Privacy protection description"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
-msgstr "您的聊天內容是私密的，我們會對其進行匿名處理，且不會用來訓練人工智慧模型。"
+msgstr ""
+"您的聊天內容是私密的，我們會對其進行匿名處理，且不會用來訓練人工智慧模型。"
 
 # smartling.placeholder_format=C
 #. Text explaining that user chats are private and not used for AI (Artificial Intelligence) training.
 msgctxt "Body text for privacy protection modal"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
-msgstr "您的聊天內容是私密的，我們會對其進行匿名處理，且不會用來訓練人工智慧模型。"
+msgstr ""
+"您的聊天內容是私密的，我們會對其進行匿名處理，且不會用來訓練人工智慧模型。"
 
 # smartling.placeholder_format=C
 #. Text for a menu item that describes the privacy protection feature.
@@ -22778,7 +23712,9 @@ msgctxt "duckai_migration"
 msgid ""
 "Your chats are still private, anonymized by us, and not used to train AI "
 "models. Follow these steps to keep your chat history."
-msgstr "您的聊天內容是私密的，我們會進行匿名處理，且不會用來訓練 AI 模型。請依照這些步驟保留您的聊天記錄。"
+msgstr ""
+"您的聊天內容是私密的，我們會進行匿名處理，且不會用來訓練 AI 模型。請依照這些"
+"步驟保留您的聊天記錄。"
 
 # smartling.placeholder_format=C
 #. Body shown after import completes.
@@ -22817,7 +23753,8 @@ msgctxt "newsletter email collection"
 msgid ""
 "Your email address will not be shared, %sor associated with anonymous "
 "searches. [%sExample message%s]"
-msgstr "你的電子信箱將不會被公開分享，%1$s或與匿名搜尋有任何關聯。[%2$s範例訊息%3$s]"
+msgstr ""
+"你的電子信箱將不會被公開分享，%1$s或與匿名搜尋有任何關聯。[%2$s範例訊息%3$s]"
 
 # smartling.placeholder_format=C
 #. A prompt for the user to provide feedback on the third party map app directions experience
@@ -22859,7 +23796,10 @@ msgid ""
 "known as %sSHA-2%s. Only the key and associated settings file leave your "
 "browser. We save the settings file using the key as the name. DuckDuckGo "
 "never knows your passphrase."
-msgstr "我們將使用%1$sSHA-2%2$s安全雜湊演算法，根據你的通關密語產生一組512位的金鑰。只有金鑰及其相關設定檔案會傳至你的瀏覽器之外。我們將以該金鑰為檔名儲存設定檔案。DuckDuckGo不會知道你的通關密語。"
+msgstr ""
+"我們將使用%1$sSHA-2%2$s安全雜湊演算法，根據你的通關密語產生一組512位的金鑰。"
+"只有金鑰及其相關設定檔案會傳至你的瀏覽器之外。我們將以該金鑰為檔名儲存設定檔"
+"案。DuckDuckGo不會知道你的通關密語。"
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -22873,7 +23813,9 @@ msgid ""
 "Your prompts are relayed through DuckDuckGo servers and stripped of "
 "personally identifiable metadata, so model providers can't tie your "
 "conversations back to you."
-msgstr "你的提示會透過 DuckDuckGo 伺服器轉發，並移除個人識別的元資料，因此模型提供者無法將你的對話與你連結起來。"
+msgstr ""
+"你的提示會透過 DuckDuckGo 伺服器轉發，並移除個人識別的元資料，因此模型提供者"
+"無法將你的對話與你連結起來。"
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -22928,7 +23870,9 @@ msgctxt "welcome message eu search preference android"
 msgid ""
 "You’re now searching privately in Chrome. Use our browser instead of Chrome "
 "for more protection. It’s already installed and can:"
-msgstr "你目前正在 Chrome 使用隱私搜尋。使用我們的瀏覽器而非 Chrome，如此一來即可取得更全面的保護。應用程式已經安裝完畢，而且可以："
+msgstr ""
+"你目前正在 Chrome 使用隱私搜尋。使用我們的瀏覽器而非 Chrome，如此一來即可取得"
+"更全面的保護。應用程式已經安裝完畢，而且可以："
 
 # smartling.placeholder_format=C
 #. Displayed when the user has exceeded the maximum message size.
@@ -22944,7 +23888,8 @@ msgctxt "Error message for conversation limit"
 msgid ""
 "You’ve reached the maximum chat length in this conversation. Clear this "
 "conversation with the Fire Button to continue."
-msgstr "您已達到此對話的最長聊天長度。 使用「Fire Button」按鈕清除此對話以繼續。"
+msgstr ""
+"您已達到此對話的最長聊天長度。 使用「Fire Button」按鈕清除此對話以繼續。"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> String-catalog only; no application logic changes. Risk is limited to missing or incorrect translations affecting displayed UI text.
> 
> **Overview**
> Adds a large batch of new **gettext/Smartling strings** to the master template `duckduckgo.pot` and syncs locale `.po` files (e.g. **af_ZA** with Afrikaans translations, **ar_DZ** with new entries pending translation).
> 
> The new copy mainly supports **Duck.ai sidebar page-context chips** (`Page suggestion chip label` / `Page suggestion prompt` pairs for summarize, translate, recipes, jobs, reviews, etc.), plus **Duck.ai settings** (About & Legal, Privacy & Terms, Usage, theme selector, feedback/share flows), **search settings** (Search Assist description, AI image/spam filters, no-AI / `noai.duckduckgo.com` modals and extension CTAs), and smaller UX strings (dictation kill-switch tooltip, harmful/illegal report sharing requirements).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6fa951ad01fe623d4190ad49b044dcf59b2985ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->